### PR TITLE
fix(protocol-engine): Update location after `liquidProbe` and `tryLiquidProbe`

### DIFF
--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -12,10 +12,6 @@ from opentrons.hardware_control.nozzle_manager import (
     NozzleMap,
 )
 from opentrons.protocol_engine.actions.actions import FailCommandAction
-from opentrons.protocol_engine.commands.aspirate import Aspirate
-from opentrons.protocol_engine.commands.dispense import Dispense
-from opentrons.protocol_engine.commands.aspirate_in_place import AspirateInPlace
-from opentrons.protocol_engine.commands.dispense_in_place import DispenseInPlace
 from opentrons.protocol_engine.commands.command import DefinedErrorData
 from opentrons.protocol_engine.commands.pipetting_common import (
     OverpressureError,
@@ -23,6 +19,7 @@ from opentrons.protocol_engine.commands.pipetting_common import (
 )
 from opentrons.types import MountType, Mount as HwMount, Point
 
+from .. import commands
 from .. import errors
 from ..types import (
     LoadedPipette,
@@ -33,31 +30,6 @@ from ..types import (
     CurrentAddressableArea,
     CurrentPipetteLocation,
     TipGeometry,
-)
-from ..commands import (
-    LoadPipetteResult,
-    AspirateResult,
-    AspirateInPlaceResult,
-    DispenseResult,
-    DispenseInPlaceResult,
-    MoveLabwareResult,
-    MoveToCoordinatesResult,
-    MoveToWellResult,
-    MoveRelativeResult,
-    MoveToAddressableAreaResult,
-    MoveToAddressableAreaForDropTipResult,
-    PickUpTipResult,
-    DropTipResult,
-    DropTipInPlaceResult,
-    HomeResult,
-    RetractAxisResult,
-    BlowOutResult,
-    BlowOutInPlaceResult,
-    unsafe,
-    TouchTipResult,
-    thermocycler,
-    heater_shaker,
-    PrepareToAspirateResult,
 )
 from ..commands.configuring_common import (
     PipetteConfigUpdateResultMixin,
@@ -227,7 +199,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 private_result.pipette_id
             ] = private_result.nozzle_map
 
-        if isinstance(command.result, LoadPipetteResult):
+        if isinstance(command.result, commands.LoadPipetteResult):
             pipette_id = command.result.pipetteId
 
             self._state.pipettes_by_id[pipette_id] = LoadedPipette(
@@ -247,7 +219,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                     pipette_id
                 ] = static_config.default_nozzle_map
 
-        elif isinstance(command.result, PickUpTipResult):
+        elif isinstance(command.result, commands.PickUpTipResult):
             pipette_id = command.params.pipetteId
             attached_tip = TipGeometry(
                 length=command.result.tipLength,
@@ -281,7 +253,11 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
         elif isinstance(
             command.result,
-            (DropTipResult, DropTipInPlaceResult, unsafe.UnsafeDropTipInPlaceResult),
+            (
+                commands.DropTipResult,
+                commands.DropTipInPlaceResult,
+                commands.unsafe.UnsafeDropTipInPlaceResult,
+            ),
         ):
             pipette_id = command.params.pipetteId
             self._state.aspirated_volume_by_id[pipette_id] = None
@@ -307,13 +283,13 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                MoveToWellResult,
-                PickUpTipResult,
-                DropTipResult,
-                AspirateResult,
-                DispenseResult,
-                BlowOutResult,
-                TouchTipResult,
+                commands.MoveToWellResult,
+                commands.PickUpTipResult,
+                commands.DropTipResult,
+                commands.AspirateResult,
+                commands.DispenseResult,
+                commands.BlowOutResult,
+                commands.TouchTipResult,
             ),
         ):
             self._state.current_location = CurrentWell(
@@ -323,7 +299,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             )
         elif (
             isinstance(action, FailCommandAction)
-            and isinstance(action.running_command, (Aspirate, Dispense))
+            and isinstance(
+                action.running_command, (commands.Aspirate, commands.Dispense)
+            )
             and isinstance(action.error, DefinedErrorData)
             and isinstance(action.error.public, OverpressureError)
         ):
@@ -334,7 +312,10 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             )
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
-            (MoveToAddressableAreaResult, MoveToAddressableAreaForDropTipResult),
+            (
+                commands.MoveToAddressableAreaResult,
+                commands.MoveToAddressableAreaForDropTipResult,
+            ),
         ):
             self._state.current_location = CurrentAddressableArea(
                 pipette_id=action.command.params.pipetteId,
@@ -349,11 +330,11 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                HomeResult,
-                RetractAxisResult,
-                MoveToCoordinatesResult,
-                thermocycler.OpenLidResult,
-                thermocycler.CloseLidResult,
+                commands.HomeResult,
+                commands.RetractAxisResult,
+                commands.MoveToCoordinatesResult,
+                commands.thermocycler.OpenLidResult,
+                commands.thermocycler.CloseLidResult,
             ),
         ):
             self._state.current_location = None
@@ -363,8 +344,8 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                heater_shaker.SetAndWaitForShakeSpeedResult,
-                heater_shaker.OpenLabwareLatchResult,
+                commands.heater_shaker.SetAndWaitForShakeSpeedResult,
+                commands.heater_shaker.OpenLabwareLatchResult,
             ),
         ):
             if action.command.result.pipetteRetracted:
@@ -377,7 +358,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         # This is necessary for safe motion planning in case the next movement
         # goes to the same labware (now in a new place).
         elif isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, MoveLabwareResult
+            action.command.result, commands.MoveLabwareResult
         ):
             moved_labware_id = action.command.params.labwareId
             if action.command.params.strategy == "usingGripper":
@@ -398,17 +379,17 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                MoveToWellResult,
-                MoveToCoordinatesResult,
-                MoveRelativeResult,
-                MoveToAddressableAreaResult,
-                MoveToAddressableAreaForDropTipResult,
-                PickUpTipResult,
-                DropTipResult,
-                AspirateResult,
-                DispenseResult,
-                BlowOutResult,
-                TouchTipResult,
+                commands.MoveToWellResult,
+                commands.MoveToCoordinatesResult,
+                commands.MoveRelativeResult,
+                commands.MoveToAddressableAreaResult,
+                commands.MoveToAddressableAreaForDropTipResult,
+                commands.PickUpTipResult,
+                commands.DropTipResult,
+                commands.AspirateResult,
+                commands.DispenseResult,
+                commands.BlowOutResult,
+                commands.TouchTipResult,
             ),
         ):
             pipette_id = action.command.params.pipetteId
@@ -421,7 +402,12 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             isinstance(action, FailCommandAction)
             and isinstance(
                 action.running_command,
-                (Aspirate, Dispense, AspirateInPlace, DispenseInPlace),
+                (
+                    commands.Aspirate,
+                    commands.Dispense,
+                    commands.AspirateInPlace,
+                    commands.DispenseInPlace,
+                ),
             )
             and isinstance(action.error, DefinedErrorData)
             and isinstance(action.error.public, OverpressureError)
@@ -437,10 +423,10 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                HomeResult,
-                RetractAxisResult,
-                thermocycler.OpenLidResult,
-                thermocycler.CloseLidResult,
+                commands.HomeResult,
+                commands.RetractAxisResult,
+                commands.thermocycler.OpenLidResult,
+                commands.thermocycler.CloseLidResult,
             ),
         ):
             self._clear_deck_point()
@@ -448,15 +434,15 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                heater_shaker.SetAndWaitForShakeSpeedResult,
-                heater_shaker.OpenLabwareLatchResult,
+                commands.heater_shaker.SetAndWaitForShakeSpeedResult,
+                commands.heater_shaker.OpenLabwareLatchResult,
             ),
         ):
             if action.command.result.pipetteRetracted:
                 self._clear_deck_point()
 
         elif isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, MoveLabwareResult
+            action.command.result, commands.MoveLabwareResult
         ):
             if action.command.params.strategy == "usingGripper":
                 # All mounts will have been retracted.
@@ -466,7 +452,8 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         self, action: Union[SucceedCommandAction, FailCommandAction]
     ) -> None:
         if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, (AspirateResult, AspirateInPlaceResult)
+            action.command.result,
+            (commands.AspirateResult, commands.AspirateInPlaceResult),
         ):
             pipette_id = action.command.params.pipetteId
             previous_volume = self._state.aspirated_volume_by_id[pipette_id] or 0
@@ -477,7 +464,8 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.aspirated_volume_by_id[pipette_id] = next_volume
 
         elif isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, (DispenseResult, DispenseInPlaceResult)
+            action.command.result,
+            (commands.DispenseResult, commands.DispenseInPlaceResult),
         ):
             pipette_id = action.command.params.pipetteId
             previous_volume = self._state.aspirated_volume_by_id[pipette_id] or 0
@@ -488,13 +476,17 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
-            (BlowOutResult, BlowOutInPlaceResult, unsafe.UnsafeBlowOutInPlaceResult),
+            (
+                commands.BlowOutResult,
+                commands.BlowOutInPlaceResult,
+                commands.unsafe.UnsafeBlowOutInPlaceResult,
+            ),
         ):
             pipette_id = action.command.params.pipetteId
             self._state.aspirated_volume_by_id[pipette_id] = None
 
         elif isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, PrepareToAspirateResult
+            action.command.result, commands.PrepareToAspirateResult
         ):
             pipette_id = action.command.params.pipetteId
             self._state.aspirated_volume_by_id[pipette_id] = 0

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -10,6 +10,8 @@ from opentrons.types import DeckSlotName, MountType, Point
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine.commands.command import DefinedErrorData
 from opentrons.protocol_engine.commands.pipetting_common import (
+    LiquidNotFoundError,
+    LiquidNotFoundErrorInternalData,
     OverpressureError,
     OverpressureErrorInternalData,
 )
@@ -500,6 +502,95 @@ def test_blow_out_clears_volume(
                 pipette_id="pipette-id",
                 labware_id="dispense-labware-id",
                 well_name="dispense-well-name",
+            ),
+        ),
+        # liquidProbe and tryLiquidProbe succeeding and with overpressure error
+        (
+            SucceedCommandAction(
+                command=cmd.LiquidProbe(
+                    id="command-id",
+                    createdAt=datetime.now(),
+                    startedAt=datetime.now(),
+                    completedAt=datetime.now(),
+                    key="command-key",
+                    status=cmd.CommandStatus.SUCCEEDED,
+                    params=cmd.LiquidProbeParams(
+                        labwareId="liquid-probe-labware-id",
+                        wellName="liquid-probe-well-name",
+                        pipetteId="pipette-id",
+                    ),
+                    result=cmd.LiquidProbeResult(
+                        position=DeckPoint(x=0, y=0, z=0), z_position=0
+                    ),
+                ),
+                private_result=None,
+            ),
+            CurrentWell(
+                pipette_id="pipette-id",
+                labware_id="liquid-probe-labware-id",
+                well_name="liquid-probe-well-name",
+            ),
+        ),
+        (
+            FailCommandAction(
+                running_command=cmd.LiquidProbe(
+                    id="command-id",
+                    createdAt=datetime.now(),
+                    startedAt=datetime.now(),
+                    key="command-key",
+                    status=cmd.CommandStatus.RUNNING,
+                    params=cmd.LiquidProbeParams(
+                        labwareId="liquid-probe-labware-id",
+                        wellName="liquid-probe-well-name",
+                        pipetteId="pipette-id",
+                    ),
+                ),
+                error=DefinedErrorData(
+                    public=LiquidNotFoundError(
+                        id="error-id",
+                        createdAt=datetime.now(),
+                    ),
+                    private=LiquidNotFoundErrorInternalData(
+                        position=DeckPoint(x=0, y=0, z=0)
+                    ),
+                ),
+                command_id="command-id",
+                error_id="error-id",
+                failed_at=datetime.now(),
+                notes=[],
+                type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
+            ),
+            CurrentWell(
+                pipette_id="pipette-id",
+                labware_id="liquid-probe-labware-id",
+                well_name="liquid-probe-well-name",
+            ),
+        ),
+        (
+            SucceedCommandAction(
+                command=cmd.TryLiquidProbe(
+                    id="command-id",
+                    createdAt=datetime.now(),
+                    startedAt=datetime.now(),
+                    completedAt=datetime.now(),
+                    key="command-key",
+                    status=cmd.CommandStatus.SUCCEEDED,
+                    params=cmd.TryLiquidProbeParams(
+                        labwareId="try-liquid-probe-labware-id",
+                        wellName="try-liquid-probe-well-name",
+                        pipetteId="pipette-id",
+                    ),
+                    result=cmd.TryLiquidProbeResult(
+                        position=DeckPoint(x=0, y=0, z=0),
+                        z_position=0,
+                    ),
+                ),
+                private_result=None,
+            ),
+            CurrentWell(
+                pipette_id="pipette-id",
+                labware_id="try-liquid-probe-labware-id",
+                well_name="try-liquid-probe-well-name",
             ),
         ),
     ),


### PR DESCRIPTION
# Overview

Fixes EXEC-611.

## Test Plan and Hands on Testing

Here's a test protocol:

```py
from opentrons import protocol_api

requirements = {"robotType": "Flex", "apiLevel": "2.20"}


def run(ctx: protocol_api.ProtocolContext):
    tip_rack = ctx.load_labware("opentrons_flex_96_tiprack_1000ul", "C2")
    instrument = ctx.load_instrument(
        "flex_1channel_1000", mount="left", tip_racks=[tip_rack]
    )

    movement_plate = ctx.load_labware("nest_96_wellplate_200ul_flat", "C3")
    liquid_probe_plate = ctx.load_labware("nest_96_wellplate_200ul_flat", "D3")

    instrument.pick_up_tip()
    instrument.move_to(movement_plate["A1"].top(z=0))
    instrument.require_liquid_presence(liquid_probe_plate["A1"])
    instrument.move_to(movement_plate["A1"].top(z=-1))
    instrument.return_tip()
```

~~If you run this without any liquid, and then choose to ignore the liquid probe error, I'm expecting the robot to physically crash into labware without this PR, and expecting it to not do that with this PR.~~ [Edit] Because error recovery begins with a home, it hides the problem, so there's no observable difference in this case.

If you run this with liquid, so the probe succeeds:

* [ ] I'm expecting the robot to physically crash into labware without this PR
    * I don't think we need to actually run this unless we really want to knock water all over the Flex deck. I've done `breakpoint()` debugging and confirmed that this will happen in simulation.
* [x] I'm expecting it to not do that with this PR.

## Review requests

None.

## Risk assessment

Low.