### PR TITLE
fix(app): send runTimeParameterFiles to POST /runs

### DIFF
--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -7,6 +7,7 @@ import { simpleAnalysisFileFixture } from '@opentrons/api-client'
 import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
+import { useFeatureFlag } from '../../../redux/config'
 import { getStoredProtocols } from '../../../redux/protocol-storage'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import {
@@ -18,6 +19,7 @@ import { useCreateRunFromProtocol } from '../../ChooseRobotToRunProtocolSlideout
 import { ChooseProtocolSlideout } from '../'
 import { useNotifyDataReady } from '../../../resources/useNotifyDataReady'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
+import { when } from 'vitest-when'
 
 vi.mock('../../ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol')
 vi.mock('../../../redux/protocol-storage')
@@ -67,6 +69,7 @@ describe('ChooseProtocolSlideout', () => {
       trackCreateProtocolRunEvent: mockTrackCreateProtocolRunEvent,
     })
     vi.mocked(useNotifyDataReady).mockReturnValue({} as any)
+    when(vi.mocked(useFeatureFlag)).calledWith('enableCsvFile').thenReturn(true)
   })
 
   it('renders slideout if showSlideout true', () => {
@@ -127,6 +130,7 @@ describe('ChooseProtocolSlideout', () => {
         files: [expect.any(File)],
         protocolKey: storedProtocolDataFixture.protocolKey,
         runTimeParameterValues: expect.any(Object),
+        runTimeParameterFiles: expect.any(Object),
       })
     )
     expect(mockTrackCreateProtocolRunEvent).toHaveBeenCalled()

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -9,6 +9,7 @@ import { i18n } from '../../../i18n'
 import { useTrackCreateProtocolRunEvent } from '../../../organisms/Devices/hooks'
 import { useCloseCurrentRun } from '../../../organisms/ProtocolUpload/hooks'
 import { useCurrentRunStatus } from '../../../organisms/RunTimeControl/hooks'
+import { useFeatureFlag } from '../../../redux/config'
 import {
   getConnectableRobots,
   getReachableRobots,
@@ -38,6 +39,7 @@ import type { State } from '../../../redux/types'
 vi.mock('../../../organisms/Devices/hooks')
 vi.mock('../../../organisms/ProtocolUpload/hooks')
 vi.mock('../../../organisms/RunTimeControl/hooks')
+vi.mock('../../../redux/config')
 vi.mock('../../../redux/discovery')
 vi.mock('../../../redux/robot-update')
 vi.mock('../../../redux/networking')
@@ -190,6 +192,8 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
       { ...mockConnectableRobot, name: 'otherRobot', ip: 'otherIp' },
       mockConnectableRobot,
     ])
+    vi.mocked(useFeatureFlag).mockReturnValue(true)
+
     provideNullCurrentRunIdFor('otherIp')
     render({
       storedProtocolData: storedProtocolDataFixture,
@@ -213,6 +217,7 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
         files: [expect.any(File)],
         protocolKey: storedProtocolDataFixture.protocolKey,
         runTimeParameterValues: expect.any(Object),
+        runTimeParameterFiles: expect.any(Object),
       })
     )
     expect(mockTrackCreateProtocolRunEvent).toHaveBeenCalled()

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -71,11 +71,12 @@ export function useCreateRunFromProtocol(
     reset: resetProtocolMutation,
   } = useCreateProtocolMutation(
     {
-      onSuccess: (data, { runTimeParameterValues }) => {
+      onSuccess: (data, { runTimeParameterValues, runTimeParameterFiles }) => {
         createRun({
           protocolId: data.data.id,
           labwareOffsets,
           runTimeParameterValues,
+          runTimeParameterFiles,
         })
       },
     },


### PR DESCRIPTION
# Overview

From both `ChooseRobotToRunProtocolSlideout` and `ChooseProtocolSlideout` components, we render a hook `useCreateRunFromProtocol`, which synchronously handles posting to /protocols and /runs. This PR fixes a bug where `runTimeParameterFiles` overrides were being passed to /protocols, but not to /runs in this hook.

## Test Plan and Hands on Testing

- run a CSV RTP protocol from end to end and ensure you can start a run successfully

## Changelog

- pass `runTimeParameterFiles` to `createRun` in `useCreateRunFromProtocol`
- update tests

## Review requests

see test plan

## Risk assessment

low