### PR TITLE
fix(app): fix "return to dashboard" not returning to dashboard

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -22,7 +22,7 @@ import {
 
 import { checkShellUpdate } from '../redux/shell'
 import { useToaster } from '../organisms/ToasterOven'
-import { useNotifyAllRunsQuery, useNotifyRunQuery } from '../resources/runs'
+import { useCurrentRunId, useNotifyRunQuery } from '../resources/runs'
 
 import type { SetStatusBarCreateCommand } from '@opentrons/shared-data'
 import type { Dispatch } from '../redux/types'
@@ -125,20 +125,7 @@ export function useProtocolReceiptToast(): void {
 }
 
 export function useCurrentRunRoute(): string | null {
-  const { data: allRuns } = useNotifyAllRunsQuery(
-    { pageLength: 1 },
-    { refetchInterval: CURRENT_RUN_POLL }
-  )
-  const currentRunLink = allRuns?.links?.current ?? null
-  const currentRun =
-    currentRunLink != null &&
-    typeof currentRunLink !== 'string' &&
-    'href' in currentRunLink
-      ? allRuns?.data.find(
-          run => run.id === currentRunLink.href.replace('/runs/', '')
-        ) // trim link path down to only runId
-      : null
-  const currentRunId = currentRun?.id ?? null
+  const currentRunId = useCurrentRunId({ refetchInterval: CURRENT_RUN_POLL })
   const { data: runRecord } = useNotifyRunQuery(currentRunId, {
     staleTime: Infinity,
     enabled: currentRunId != null,

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
+import { useQueryClient } from 'react-query'
 
 import {
   ALIGN_CENTER,
@@ -155,8 +156,12 @@ export function RunSummary(): JSX.Element {
     determineTipStatus()
   }, [])
 
+  // TODO(jh, 08-02-24): Revisit useCurrentRunRoute and top level redirects.
+  const queryClient = useQueryClient()
   const returnToDash = (): void => {
     closeCurrentRun()
+    // Eagerly clear the query cache to prevent top level redirecting back to this page.
+    queryClient.setQueryData([host, 'runs', runId, 'details'], () => undefined)
     navigate('/')
   }
   // TODO(jh, 07-24-24): After EXEC-504, add reportRecoveredRunResult here.


### PR DESCRIPTION
Closes [RQA-2886](https://opentrons.atlassian.net/browse/RQA-2886)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

After clicking "return to dashboard" on the ODD, the run context is closed, and then a navigate to dashboard is issued. However, the top level redirects logic keeps the ODD on the runs summary page as long as there is an active run record, which is always the case when the network request hasn't yet completed. 

By the time the user clicks "return to dashboard" a second time, the run has (most likely) closed, and the user can actually navigate away. Unfortunately, throwing this `navigate` behind an onSuccess callback is insufficient, because the top level redirects hook correctly uses a different endpoint to determine whether it should redirect. 

To solve this, let's eagerly clear the query cache on the ODD for the run record. Any future refetches of that run record simply repopulate the cache. It's worth revisiting our approach to top level redirects in the future, but this solution is adequate for now.


### Current Behavior

https://github.com/user-attachments/assets/c6f9b2ca-21bc-4e52-a638-fc385e36c1ff

### Fixed Behavior

https://github.com/user-attachments/assets/6938ac2d-7ec4-4ec2-82ed-dea766c03d9c

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed clicking "return to dashboard" on the ODD not returning to the dashboard until the second click.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low - the blast radius is just the `RunSummary` page with this approach, and we redirect off it immediately.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2886]: https://opentrons.atlassian.net/browse/RQA-2886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ