### PR TITLE
feat(app): Implement `hasEverEnteredErrorRecovery`

### DIFF
--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -150,10 +150,13 @@ export function RunSummary(): JSX.Element {
     isFlex: true,
   })
 
-  // Determine tip status on initial render only.
+  // Determine tip status on initial render only. Error Recovery always handles tip status, so don't show it twice.
+  const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
   React.useEffect(() => {
-    determineTipStatus()
-  }, [])
+    if (isRunCurrent && enteredER === false) {
+      void determineTipStatus()
+    }
+  }, [isRunCurrent, enteredER])
 
   const returnToDash = (): void => {
     closeCurrentRun()
@@ -185,6 +188,7 @@ export function RunSummary(): JSX.Element {
     trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.AGAIN })
   }
 
+  //TOME: I'm willing to bet this is at least part of the problem!
   // If no pipettes have tips attached, execute the routing callback.
   const setTipStatusResolvedAndRoute = (
     routeCb: (pipettesWithTip: PipetteWithTip[]) => void
@@ -210,7 +214,7 @@ export function RunSummary(): JSX.Element {
   }
 
   const handleRunAgain = (pipettesWithTip: PipetteWithTip[]): void => {
-    if (isRunCurrent && pipettesWithTip.length > 0) {
+    if (mostRecentRunId === runId && pipettesWithTip.length > 0) {
       void handleTipsAttachedModal({
         setTipStatusResolved: setTipStatusResolvedAndRoute(handleRunAgain),
         host,

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -109,10 +109,6 @@ export function RunSummary(): JSX.Element {
   )
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name ?? 'no name'
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(
-    runId,
-    robotName as string
-  )
 
   const onCloneRunSuccess = (): void => {
     if (isQuickTransfer) {
@@ -120,6 +116,10 @@ export function RunSummary(): JSX.Element {
     }
   }
 
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(
+    runId,
+    robotName as string
+  )
   const robotAnalyticsData = useRobotAnalyticsData(robotName as string)
   const { reportRecoveredRunResult } = useRecoveryAnalytics()
 


### PR DESCRIPTION
Closes [EXEC-636](https://opentrons.atlassian.net/browse/EXEC-636) and [EXEC-637](https://opentrons.atlassian.net/browse/EXEC-637) and [RQA-2900](https://opentrons.atlassian.net/browse/RQA-2900)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Now that the run can tell us if we've entered Error Recovery, we can:

### Show drop tip CTAs conditionally

Because ER always requires the users to go through drop tip flows, it's redundant and mildly annoying for users to see a second set of now irrelevant CTAs. Now, we only show the CTAs at the end of the run if the run did not enter error recovery (and the conditions for detecting potential tip attachment occur).

I earlier hacked something together to make this work on the desktop, but it wasn't possible to do this on the ODD based on how routing logic works. I've cleaned up the desktop to use the same logic that the ODD uses. 

### Use ODD recovery analytics

There was one analytic that was impossible to implement on the ODD without `hasEverEnteredErrorRecovery` (again, due to the way we handle routing), so that is added here, too. 


### Current Behavior

https://github.com/user-attachments/assets/a87502e4-d7e8-4112-a104-15da870567ce

### New Behavior

https://github.com/user-attachments/assets/9aa0dc7e-b560-49f0-a7f3-b0b90937a317



<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- End of run drop tip CTAs will not appear if the user handled tips during Error Recovery. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-636]: https://opentrons.atlassian.net/browse/EXEC-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-637]: https://opentrons.atlassian.net/browse/EXEC-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-2900]: https://opentrons.atlassian.net/browse/RQA-2900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ