### PR TITLE
fix(app): fix desktop post-run drop tip wiz crash after tip removal

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -205,7 +205,7 @@ export function ProtocolRunHeader({
     determineTipStatus,
     resetTipStatus,
     setTipStatusResolved,
-    pipettesWithTip,
+    aPipetteWithTip,
   } = useTipAttachmentStatus({
     runId,
     runRecord,
@@ -421,7 +421,7 @@ export function ProtocolRunHeader({
           <ProtocolDropTipModal
             onSkip={onDTModalSkip}
             onBeginRemoval={onDTModalRemoval}
-            mount={pipettesWithTip[0]?.mount}
+            mount={aPipetteWithTip?.mount}
           />
         ) : null}
         <Box display="grid" gridTemplateColumns="4fr 3fr 3fr 4fr">
@@ -496,11 +496,11 @@ export function ProtocolRunHeader({
             robotName={robotName}
           />
         ) : null}
-        {showDTWiz && mostRecentRunId === runId ? (
+        {showDTWiz && aPipetteWithTip != null ? (
           <DropTipWizardFlows
             robotType={isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE}
-            mount={pipettesWithTip[0]?.mount}
-            instrumentModelSpecs={pipettesWithTip[0].specs}
+            mount={aPipetteWithTip.mount}
+            instrumentModelSpecs={aPipetteWithTip.specs}
             closeFlow={() => setTipStatusResolved().then(toggleDTWiz)}
           />
         ) : null}

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -14,7 +14,6 @@ import {
   RUN_STATUS_SUCCEEDED,
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
   instrumentsResponseLeftPipetteFixture,
-  instrumentsResponseRightPipetteFixture,
 } from '@opentrons/api-client'
 import {
   useHost,
@@ -88,6 +87,7 @@ import { useNotifyRunQuery, useCurrentRunId } from '../../../../resources/runs'
 import {
   useDropTipWizardFlows,
   useTipAttachmentStatus,
+  DropTipWizardFlows,
 } from '../../../DropTipWizardFlows'
 import {
   useErrorRecoveryFlows,
@@ -340,10 +340,7 @@ describe('ProtocolRunHeader', () => {
     vi.mocked(useInstrumentsQuery).mockReturnValue({ data: {} } as any)
     vi.mocked(useHost).mockReturnValue({} as any)
     vi.mocked(useTipAttachmentStatus).mockReturnValue({
-      pipettesWithTip: [
-        instrumentsResponseLeftPipetteFixture,
-        instrumentsResponseRightPipetteFixture,
-      ],
+      aPipetteWithTip: instrumentsResponseLeftPipetteFixture,
       areTipsAttached: true,
       determineTipStatus: mockDetermineTipStatus,
       resetTipStatus: vi.fn(),
@@ -383,6 +380,9 @@ describe('ProtocolRunHeader', () => {
     } as any)
     vi.mocked(ProtocolDropTipModal).mockReturnValue(
       <div>MOCK_DROP_TIP_MODAL</div>
+    )
+    vi.mocked(DropTipWizardFlows).mockReturnValue(
+      <div>MOCK_DROP_TIP_WIZARD_FLOWS</div>
     )
   })
 
@@ -1075,5 +1075,15 @@ describe('ProtocolRunHeader', () => {
 
     render()
     screen.getByText('MOCK_ERROR_RECOVERY')
+  })
+
+  it('renders DropTipWizardFlows when conditions are met', () => {
+    vi.mocked(useDropTipWizardFlows).mockReturnValue({
+      showDTWiz: true,
+      toggleDTWiz: vi.fn(),
+    })
+
+    render()
+    screen.getByText('MOCK_DROP_TIP_WIZARD_FLOWS')
   })
 })

--- a/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
+++ b/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import capitalize from 'lodash/capitalize'
-import head from 'lodash/head'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -23,7 +22,7 @@ import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { PipetteWithTip } from '.'
 
 interface TipsAttachedModalProps {
-  pipettesWithTip: PipetteWithTip[]
+  aPipetteWithTip: PipetteWithTip
   host: HostConfig | null
   setTipStatusResolved: (onEmpty?: () => void) => Promise<void>
 }
@@ -38,11 +37,11 @@ export const handleTipsAttachedModal = (
 
 const TipsAttachedModal = NiceModal.create(
   (props: TipsAttachedModalProps): JSX.Element => {
-    const { pipettesWithTip, host, setTipStatusResolved } = props
+    const { aPipetteWithTip, host, setTipStatusResolved } = props
     const { t } = useTranslation(['drop_tip_wizard'])
     const modal = useModal()
 
-    const { mount, specs } = head(pipettesWithTip) as PipetteWithTip
+    const { mount, specs } = aPipetteWithTip
     const { showDTWiz, toggleDTWiz } = useDropTipWizardFlows()
 
     const tipsAttachedHeader: ModalHeaderBaseProps = {
@@ -57,7 +56,9 @@ const TipsAttachedModal = NiceModal.create(
     }
 
     const is96Channel = specs.channels === 96
-    const displayMountText = is96Channel ? '96-Channel' : capitalize(mount)
+    const displayMountText = is96Channel
+      ? '96-Channel'
+      : capitalize(mount as string)
 
     return (
       <ApiHostProvider {...host} hostname={host?.hostname ?? null}>

--- a/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardFlows.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardFlows.test.tsx
@@ -37,6 +37,21 @@ const MOCK_ACTUAL_PIPETTE = {
   },
 } as PipetteModelSpecs
 
+const mockPipetteWithTip: PipetteWithTip = {
+  mount: 'left',
+  specs: MOCK_ACTUAL_PIPETTE,
+}
+
+const mockSecondPipetteWithTip: PipetteWithTip = {
+  mount: 'right',
+  specs: MOCK_ACTUAL_PIPETTE,
+}
+
+const mockPipettesWithTip: PipetteWithTip[] = [
+  mockPipetteWithTip,
+  mockSecondPipetteWithTip,
+]
+
 describe('useTipAttachmentStatus', () => {
   let mockGetPipettesWithTipAttached: Mock
 
@@ -44,6 +59,7 @@ describe('useTipAttachmentStatus', () => {
     mockGetPipettesWithTipAttached = vi.mocked(getPipettesWithTipAttached)
     vi.mocked(getPipetteModelSpecs).mockReturnValue(MOCK_ACTUAL_PIPETTE)
     vi.mocked(DropTipWizard).mockReturnValue(<div>MOCK DROP TIP WIZ</div>)
+    mockGetPipettesWithTipAttached.mockResolvedValue(mockPipettesWithTip)
   })
 
   afterEach(() => {
@@ -54,16 +70,10 @@ describe('useTipAttachmentStatus', () => {
     const { result } = renderHook(() => useTipAttachmentStatus({} as any))
 
     expect(result.current.areTipsAttached).toBe(false)
-    expect(result.current.pipettesWithTip).toEqual([])
+    expect(result.current.aPipetteWithTip).toEqual(null)
   })
 
   it('should determine tip status and update state accordingly', async () => {
-    const mockPipettesWithTip: PipetteWithTip[] = [
-      { mount: 'left', specs: MOCK_ACTUAL_PIPETTE },
-      { mount: 'right', specs: MOCK_ACTUAL_PIPETTE },
-    ]
-    mockGetPipettesWithTipAttached.mockResolvedValueOnce(mockPipettesWithTip)
-
     const { result } = renderHook(() => useTipAttachmentStatus({} as any))
 
     await act(async () => {
@@ -71,15 +81,10 @@ describe('useTipAttachmentStatus', () => {
     })
 
     expect(result.current.areTipsAttached).toBe(true)
-    expect(result.current.pipettesWithTip).toEqual(mockPipettesWithTip)
+    expect(result.current.aPipetteWithTip).toEqual(mockPipetteWithTip)
   })
 
   it('should reset tip status', async () => {
-    const mockPipettesWithTip: PipetteWithTip[] = [
-      { mount: 'left', specs: MOCK_ACTUAL_PIPETTE },
-    ]
-    mockGetPipettesWithTipAttached.mockResolvedValueOnce(mockPipettesWithTip)
-
     const { result } = renderHook(() => useTipAttachmentStatus({} as any))
 
     await act(async () => {
@@ -88,16 +93,10 @@ describe('useTipAttachmentStatus', () => {
     })
 
     expect(result.current.areTipsAttached).toBe(false)
-    expect(result.current.pipettesWithTip).toEqual([])
+    expect(result.current.aPipetteWithTip).toEqual(null)
   })
 
   it('should set tip status resolved and update state', async () => {
-    const mockPipettesWithTip: PipetteWithTip[] = [
-      { mount: 'left', specs: MOCK_ACTUAL_PIPETTE },
-      { mount: 'right', specs: MOCK_ACTUAL_PIPETTE },
-    ]
-    mockGetPipettesWithTipAttached.mockResolvedValueOnce(mockPipettesWithTip)
-
     const { result } = renderHook(() => useTipAttachmentStatus({} as any))
 
     await act(async () => {
@@ -105,14 +104,11 @@ describe('useTipAttachmentStatus', () => {
       result.current.setTipStatusResolved()
     })
 
-    expect(result.current.pipettesWithTip).toEqual([mockPipettesWithTip[1]])
+    expect(result.current.aPipetteWithTip).toEqual(mockSecondPipetteWithTip)
   })
 
   it('should call onEmptyCache callback when cache becomes empty', async () => {
-    const mockPipettesWithTip: PipetteWithTip[] = [
-      { mount: 'left', specs: MOCK_ACTUAL_PIPETTE },
-    ]
-    mockGetPipettesWithTipAttached.mockResolvedValueOnce(mockPipettesWithTip)
+    mockGetPipettesWithTipAttached.mockResolvedValueOnce([mockPipetteWithTip])
 
     const onEmptyCacheMock = vi.fn()
     const { result } = renderHook(() => useTipAttachmentStatus({} as any))

--- a/app/src/organisms/DropTipWizardFlows/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/TipsAttachedModal.test.tsx
@@ -33,24 +33,24 @@ const ninetySixSpecs = {
   channels: 96,
 } as PipetteModelSpecs
 
-const MOCK_PIPETTES_WITH_TIP: PipetteWithTip[] = [
-  { mount: LEFT, specs: MOCK_ACTUAL_PIPETTE },
-]
-const MOCK_96_WITH_TIP: PipetteWithTip[] = [
-  { mount: LEFT, specs: ninetySixSpecs },
-]
+const MOCK_A_PIPETTE_WITH_TIP: PipetteWithTip = {
+  mount: LEFT,
+  specs: MOCK_ACTUAL_PIPETTE,
+}
+
+const MOCK_96_WITH_TIP: PipetteWithTip = { mount: LEFT, specs: ninetySixSpecs }
 
 const mockSetTipStatusResolved = vi.fn()
 const MOCK_HOST: HostConfig = { hostname: 'MOCK_HOST' }
 
-const render = (pipettesWithTips: PipetteWithTip[]) => {
+const render = (aPipetteWithTip: PipetteWithTip) => {
   return renderWithProviders(
     <NiceModal.Provider>
       <button
         onClick={() =>
           handleTipsAttachedModal({
             host: MOCK_HOST,
-            pipettesWithTip: pipettesWithTips,
+            aPipetteWithTip,
             setTipStatusResolved: mockSetTipStatusResolved,
           })
         }
@@ -79,7 +79,7 @@ describe('TipsAttachedModal', () => {
   })
 
   it('renders appropriate warning given the pipette mount', () => {
-    render(MOCK_PIPETTES_WITH_TIP)
+    render(MOCK_A_PIPETTE_WITH_TIP)
     const btn = screen.getByTestId('testButton')
     fireEvent.click(btn)
 
@@ -89,7 +89,7 @@ describe('TipsAttachedModal', () => {
     )
   })
   it('clicking the skip button properly closes the modal', () => {
-    render(MOCK_PIPETTES_WITH_TIP)
+    render(MOCK_A_PIPETTE_WITH_TIP)
     const btn = screen.getByTestId('testButton')
     fireEvent.click(btn)
 
@@ -98,7 +98,7 @@ describe('TipsAttachedModal', () => {
     expect(mockSetTipStatusResolved).toHaveBeenCalled()
   })
   it('clicking the launch wizard button properly launches the wizard', () => {
-    render(MOCK_PIPETTES_WITH_TIP)
+    render(MOCK_A_PIPETTE_WITH_TIP)
     const btn = screen.getByTestId('testButton')
     fireEvent.click(btn)
 

--- a/app/src/organisms/DropTipWizardFlows/index.tsx
+++ b/app/src/organisms/DropTipWizardFlows/index.tsx
@@ -75,9 +75,9 @@ export interface TipAttachmentStatusResult {
    * NOTE: Use responsibly! This function can potentially (but not likely) iterate over the entire length of a protocol run.
    * */
   determineTipStatus: () => Promise<PipetteWithTip[]>
-  /** Whether tips are likely attached on *any* pipette. Typically called after determineTipStatus() */
+  /* Whether tips are likely attached on *any* pipette. Typically called after determineTipStatus() */
   areTipsAttached: boolean
-  /** Resets the cached pipettes with tip statuses to null.  */
+  /* Resets the cached pipettes with tip statuses to null.  */
   resetTipStatus: () => void
   /** Removes the first element from the tip attached cache if present.
    * @param {Function} onEmptyCache After removing the pipette from the cache, if the attached tip cache is empty, invoke this callback.
@@ -86,9 +86,9 @@ export interface TipAttachmentStatusResult {
   setTipStatusResolved: (
     onEmptyCache?: () => void,
     onTipsDetected?: () => void
-  ) => Promise<PipetteWithTip[]>
-  /** Relevant pipette information for those pipettes with tips attached. */
-  pipettesWithTip: PipetteWithTip[]
+  ) => Promise<PipetteWithTip>
+  /* Relevant pipette information for a pipette with a tip attached. If both pipettes have tips attached, return the left pipette. */
+  aPipetteWithTip: PipetteWithTip | null
 }
 
 // Returns various utilities for interacting with the cache of pipettes with tips attached.
@@ -98,6 +98,8 @@ export function useTipAttachmentStatus(
   const [pipettesWithTip, setPipettesWithTip] = React.useState<
     PipetteWithTip[]
   >([])
+
+  const aPipetteWithTip = head(pipettesWithTip) ?? null
 
   const areTipsAttached =
     pipettesWithTip.length != null && head(pipettesWithTip)?.specs != null
@@ -130,8 +132,8 @@ export function useTipAttachmentStatus(
   const setTipStatusResolved = (
     onEmptyCache?: () => void,
     onTipsDetected?: () => void
-  ): Promise<PipetteWithTip[]> => {
-    return new Promise<PipetteWithTip[]>(resolve => {
+  ): Promise<PipetteWithTip> => {
+    return new Promise<PipetteWithTip>(resolve => {
       setPipettesWithTip(prevPipettesWithTip => {
         const newState = [...prevPipettesWithTip.slice(1)]
         if (newState.length === 0) {
@@ -140,7 +142,7 @@ export function useTipAttachmentStatus(
           onTipsDetected?.()
         }
 
-        resolve(newState)
+        resolve(newState[0])
         return newState
       })
     })
@@ -150,7 +152,7 @@ export function useTipAttachmentStatus(
     areTipsAttached,
     determineTipStatus,
     resetTipStatus,
-    pipettesWithTip,
+    aPipetteWithTip,
     setTipStatusResolved,
   }
 }

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import head from 'lodash/head'
 
 import {
   DIRECTION_COLUMN,
@@ -60,7 +59,7 @@ export function BeginRemoval({
   currentRecoveryOptionUtils,
 }: RecoveryContentProps): JSX.Element | null {
   const { t } = useTranslation('error_recovery')
-  const { pipettesWithTip } = tipStatusUtils
+  const { aPipetteWithTip } = tipStatusUtils
   const {
     proceedNextStep,
     setRobotInMotion,
@@ -69,7 +68,7 @@ export function BeginRemoval({
   const { cancelRun } = recoveryCommands
   const { selectedRecoveryOption } = currentRecoveryOptionUtils
   const { ROBOT_CANCELING, RETRY_NEW_TIPS } = RECOVERY_MAP
-  const mount = head(pipettesWithTip)?.mount
+  const mount = aPipetteWithTip?.mount
 
   const primaryOnClick = (): void => {
     void proceedNextStep()
@@ -155,9 +154,7 @@ function DropTipFlowsContainer(
   const { setTipStatusResolved } = tipStatusUtils
   const { cancelRun } = recoveryCommands
 
-  const { mount, specs } = head(
-    tipStatusUtils.pipettesWithTip
-  ) as PipetteWithTip // Safe as we have to have tips to get to this point in the flow.
+  const { mount, specs } = tipStatusUtils.aPipetteWithTip as PipetteWithTip // Safe as we have to have tips to get to this point in the flow.
 
   const onCloseFlow = (): void => {
     if (selectedRecoveryOption === RETRY_NEW_TIPS.ROUTE) {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/ManageTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/ManageTips.test.tsx
@@ -58,7 +58,7 @@ describe('ManageTips', () => {
         step: DROP_TIP_FLOWS.STEPS.BEGIN_REMOVAL,
       },
       tipStatusUtils: {
-        pipettesWithTip: [{ mount: 'left', specs: MOCK_ACTUAL_PIPETTE }],
+        aPipetteWithTip: { mount: 'left', specs: MOCK_ACTUAL_PIPETTE },
       } as any,
       routeUpdateActions: {
         proceedNextStep: mockProceedNextStep,

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -155,7 +155,7 @@ export function RunSummary(): JSX.Element {
   const {
     determineTipStatus,
     setTipStatusResolved,
-    pipettesWithTip,
+    aPipetteWithTip,
   } = useTipAttachmentStatus({
     runId,
     runRecord,
@@ -206,7 +206,7 @@ export function RunSummary(): JSX.Element {
 
   // If no pipettes have tips attached, execute the routing callback.
   const setTipStatusResolvedAndRoute = (
-    routeCb: (pipettesWithTip: PipetteWithTip[]) => void
+    routeCb: (aPipetteWithTip: PipetteWithTip) => void
   ): (() => Promise<void>) => {
     return () =>
       setTipStatusResolved().then(newPipettesWithTip => {
@@ -214,12 +214,12 @@ export function RunSummary(): JSX.Element {
       })
   }
 
-  const handleReturnToDash = (pipettesWithTip: PipetteWithTip[]): void => {
-    if (mostRecentRunId === runId && pipettesWithTip.length > 0) {
+  const handleReturnToDash = (aPipetteWithTip: PipetteWithTip | null): void => {
+    if (mostRecentRunId === runId && aPipetteWithTip != null) {
       void handleTipsAttachedModal({
         setTipStatusResolved: setTipStatusResolvedAndRoute(handleReturnToDash),
         host,
-        pipettesWithTip,
+        aPipetteWithTip,
       })
     } else if (isQuickTransfer) {
       returnToQuickTransfer()
@@ -228,12 +228,12 @@ export function RunSummary(): JSX.Element {
     }
   }
 
-  const handleRunAgain = (pipettesWithTip: PipetteWithTip[]): void => {
-    if (mostRecentRunId === runId && pipettesWithTip.length > 0) {
+  const handleRunAgain = (aPipetteWithTip: PipetteWithTip | null): void => {
+    if (mostRecentRunId === runId && aPipetteWithTip != null) {
       void handleTipsAttachedModal({
         setTipStatusResolved: setTipStatusResolvedAndRoute(handleRunAgain),
         host,
-        pipettesWithTip,
+        aPipetteWithTip,
       })
     } else {
       if (!isResetRunLoading) {
@@ -367,7 +367,7 @@ export function RunSummary(): JSX.Element {
               iconName="arrow-left"
               buttonType="secondary"
               onClick={() => {
-                handleReturnToDash(pipettesWithTip)
+                handleReturnToDash(aPipetteWithTip)
               }}
               buttonText={
                 isQuickTransfer
@@ -380,7 +380,7 @@ export function RunSummary(): JSX.Element {
               flex="1"
               iconName="play-round-corners"
               onClick={() => {
-                handleRunAgain(pipettesWithTip)
+                handleRunAgain(aPipetteWithTip)
               }}
               buttonText={
                 showRunAgainSpinner ? RUN_AGAIN_SPINNER_TEXT : t('run_again')


### PR DESCRIPTION
Closes [RQA-2902](https://opentrons.atlassian.net/browse/RQA-2902)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

After a drop-tip event (post run, not during error recovery), the desktop app did not properly check if `pipettesWithTip` was defined before accessing `specs`. While there is a simple solution here, the problem points to an issue with typing and likely warrants revisiting how the app commonly utilizes the `useTipAttachmentStatus` hook. 

When `useTipAttachmentStatus` was first created, it seemed likely that the components that would use the hook would likely want details about _all_ the pipettes with tips attached. In practice, the opposite has proven to be the case: the API is only ever used to retrieve information about a single pipette at a time, and because of that, there's a lot of extra .`length` checks and weirdness that doesn't really need to exist.

This is a long-winded way of saying that we can reduce some of the clunkiness when using `useTipAttachementStatus` by just providing one pipette with a tip at a time. 

### Current Behavior 

![Screenshot 2024-08-02 150026](https://github.com/user-attachments/assets/9579dccf-dbd4-4ecc-8cb3-75ad8bb57c7f)

### Fixed Behavior

https://github.com/user-attachments/assets/05b8052c-4c1d-48c2-baa6-57c4abd91a32

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The desktop app no longer crashes when completing Drop Tip Wizard after a protocol run.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2902]: https://opentrons.atlassian.net/browse/RQA-2902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ