### PR TITLE
fix(app): Correction for manual move tiprack not shown in tiprack adapter 

### DIFF
--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -223,7 +223,11 @@ export function MoveLabwareInterventionContent({
                     )
                   )}
                   {labwareRenderInfo
-                    .filter(l => l.labwareId !== command.params.labwareId)
+                    .filter(
+                      l =>
+                        l.labwareId !== command.params.labwareId &&
+                        !l.labwareDef.allowedRoles?.includes('adapter')
+                    )
                     .map(({ x, y, labwareDef, labwareId }) => (
                       <g key={labwareId} transform={`translate(${x},${y})`}>
                         {labwareDef != null &&


### PR DESCRIPTION


# Overview
Covers RQA-2899

The app handler for move labware intervention content previously would utilize the labware renderer filtering only by labware ID. The addition of a filter to remove adapters from the move labware intervention content modal would seek to solve the issue detailed in the bug for the ticket above. Adapters are not meant to be moved, so their exclusion appears to be the most reasonable approach.

## Test Plan and Hands on Testing

- [x] Test to ensure when a manual move labware occurs the proper labware is rendered on the app view for the modal shown to the user.

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
