### PR TITLE
refactor(app): change map view action button behavior

### DIFF
--- a/app/src/atoms/buttons/FloatingActionButton.tsx
+++ b/app/src/atoms/buttons/FloatingActionButton.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
@@ -12,29 +11,21 @@ import {
   Icon,
   POSITION_FIXED,
   SPACING,
-  LegacyStyledText,
-  TYPOGRAPHY,
+  StyledText,
 } from '@opentrons/components'
 
-import type { IconName, StyleProps } from '@opentrons/components'
+import type { IconName } from '@opentrons/components'
 
-interface FloatingActionButtonProps extends StyleProps {
-  buttonText?: React.ReactNode
+interface FloatingActionButtonProps extends React.ComponentProps<typeof Btn> {
+  buttonText: string
   disabled?: boolean
   iconName?: IconName
-  onClick: React.MouseEventHandler
 }
 
 export function FloatingActionButton(
   props: FloatingActionButtonProps
 ): JSX.Element {
-  const { t } = useTranslation('protocol_setup')
-  const {
-    buttonText = t('map_view'),
-    disabled = false,
-    iconName = 'deck-map',
-    ...buttonProps
-  } = props
+  const { buttonText, disabled = false, iconName, ...buttonProps } = props
 
   const contentColor = disabled ? COLORS.grey50 : COLORS.white
   const FLOATING_ACTION_BUTTON_STYLE = css`
@@ -65,9 +56,6 @@ export function FloatingActionButton(
       bottom={SPACING.spacing24}
       css={FLOATING_ACTION_BUTTON_STYLE}
       disabled={disabled}
-      fontSize={TYPOGRAPHY.fontSize28}
-      fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-      lineHeight={TYPOGRAPHY.lineHeight36}
       padding={`${SPACING.spacing12} ${SPACING.spacing24}`}
       position={POSITION_FIXED}
       right={SPACING.spacing24}
@@ -78,13 +66,15 @@ export function FloatingActionButton(
         flexDirection={DIRECTION_ROW}
         gridGap={SPACING.spacing8}
       >
-        <Icon
-          color={contentColor}
-          height="3rem"
-          name={iconName}
-          width="3.75rem"
-        />
-        <LegacyStyledText>{buttonText}</LegacyStyledText>
+        {iconName != null ? (
+          <Icon
+            color={contentColor}
+            height="3rem"
+            name={iconName}
+            width="3.75rem"
+          />
+        ) : null}
+        <StyledText oddStyle="level4HeaderSemiBold">{buttonText}</StyledText>
       </Flex>
     </Btn>
   )

--- a/app/src/atoms/buttons/__tests__/FloatingActionButton.test.tsx
+++ b/app/src/atoms/buttons/__tests__/FloatingActionButton.test.tsx
@@ -31,9 +31,6 @@ describe('FloatingActionButton', () => {
       `padding: ${SPACING.spacing12} ${SPACING.spacing24}`
     )
     expect(button).toHaveStyle(`background-color: ${COLORS.purple50}`)
-    expect(button).toHaveStyle(`font-size: ${TYPOGRAPHY.fontSize28}`)
-    expect(button).toHaveStyle(`font-weight: ${TYPOGRAPHY.fontWeightSemiBold}`)
-    expect(button).toHaveStyle(`line-height: ${TYPOGRAPHY.lineHeight36}`)
     expect(button).toHaveStyle(`border-radius: ${BORDERS.borderRadius40}`)
     expect(button).toHaveStyle(
       `text-transform: ${TYPOGRAPHY.textTransformNone}`

--- a/app/src/organisms/ProtocolSetupLabware/LabwareMapView.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/LabwareMapView.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react'
 import map from 'lodash/map'
-import { useTranslation } from 'react-i18next'
-import { BaseDeck } from '@opentrons/components'
+import { BaseDeck, Flex } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
   getSimplestDeckConfigForProtocol,
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 
-import { Modal } from '../../molecules/Modal'
 import { getStandardDeckViewLayerBlockList } from '../Devices/ProtocolRun/utils/getStandardDeckViewLayerBlockList'
 import { getLabwareRenderInfo } from '../Devices/ProtocolRun/utils/getLabwareRenderInfo'
 
@@ -18,43 +16,32 @@ import type {
   LabwareDefinition2,
 } from '@opentrons/shared-data'
 import type { LoadedLabwareByAdapter } from '@opentrons/api-client'
-import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { AttachedProtocolModuleMatch } from '../ProtocolSetupModulesAndDeck/utils'
 
-interface LabwareMapViewModalProps {
+interface LabwareMapViewProps {
   attachedProtocolModuleMatches: AttachedProtocolModuleMatch[]
   handleLabwareClick: (
     labwareDef: LabwareDefinition2,
     labwareId: string
   ) => void
-  onCloseClick: () => void
   initialLoadedLabwareByAdapter: LoadedLabwareByAdapter
   deckDef: DeckDefinition
   mostRecentAnalysis: CompletedProtocolAnalysis | null
 }
 
-export function LabwareMapViewModal(
-  props: LabwareMapViewModalProps
-): JSX.Element {
+export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
   const {
     handleLabwareClick,
-    onCloseClick,
     attachedProtocolModuleMatches,
     initialLoadedLabwareByAdapter,
     deckDef,
     mostRecentAnalysis,
   } = props
-  const { t } = useTranslation('protocol_setup')
   const deckConfig = getSimplestDeckConfigForProtocol(mostRecentAnalysis)
   const labwareRenderInfo =
     mostRecentAnalysis != null
       ? getLabwareRenderInfo(mostRecentAnalysis, deckDef)
       : {}
-
-  const modalHeader: ModalHeaderBaseProps = {
-    title: t('map_view'),
-    hasExitIcon: true,
-  }
 
   const modulesOnDeck = attachedProtocolModuleMatches.map(module => {
     const { moduleDef, nestedLabwareDef, nestedLabwareId, slotName } = module
@@ -112,7 +99,7 @@ export function LabwareMapViewModal(
   )
 
   return (
-    <Modal header={modalHeader} modalSize="large" onOutsideClick={onCloseClick}>
+    <Flex height="27.75rem">
       <BaseDeck
         deckConfig={deckConfig}
         deckLayerBlocklist={getStandardDeckViewLayerBlockList(FLEX_ROBOT_TYPE)}
@@ -120,6 +107,6 @@ export function LabwareMapViewModal(
         labwareOnDeck={labwareLocations}
         modulesOnDeck={modulesOnDeck}
       />
-    </Modal>
+    </Flex>
   )
 }

--- a/app/src/organisms/ProtocolSetupLabware/__tests__/LabwareMapView.test.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/__tests__/LabwareMapView.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { when } from 'vitest-when'
-import { fireEvent, screen } from '@testing-library/react'
 import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest'
 
 import { BaseDeck, EXTENDED_DECK_CONFIG_FIXTURE } from '@opentrons/components'
@@ -16,7 +15,7 @@ import { i18n } from '../../../i18n'
 import { getLabwareRenderInfo } from '../../Devices/ProtocolRun/utils/getLabwareRenderInfo'
 import { getStandardDeckViewLayerBlockList } from '../../Devices/ProtocolRun/utils/getStandardDeckViewLayerBlockList'
 import { mockProtocolModuleInfo } from '../__fixtures__'
-import { LabwareMapViewModal } from '../LabwareMapViewModal'
+import { LabwareMapView } from '../LabwareMapView'
 
 import type {
   getSimplestDeckConfigForProtocol,
@@ -51,10 +50,10 @@ vi.mock('@opentrons/components', async importOriginal => {
   }
 })
 
-const render = (props: React.ComponentProps<typeof LabwareMapViewModal>) => {
+const render = (props: React.ComponentProps<typeof LabwareMapView>) => {
   return renderWithProviders(
     <MemoryRouter>
-      <LabwareMapViewModal {...props} />
+      <LabwareMapView {...props} />
     </MemoryRouter>,
     {
       i18nInstance: i18n,
@@ -62,36 +61,13 @@ const render = (props: React.ComponentProps<typeof LabwareMapViewModal>) => {
   )[0]
 }
 
-describe('LabwareMapViewModal', () => {
+describe('LabwareMapView', () => {
   beforeEach(() => {
     vi.mocked(getLabwareRenderInfo).mockReturnValue({})
-    // vi.mocked(getSimplestDeckConfigForProtocol).mockReturnValue([])
   })
 
   afterEach(() => {
     vi.resetAllMocks()
-  })
-
-  it('should render nothing on the deck and calls exit button', () => {
-    vi.mocked(BaseDeck).mockReturnValue(<div>mock base deck</div>)
-
-    const props = {
-      handleLabwareClick: vi.fn(),
-      onCloseClick: vi.fn(),
-      deckDef: (deckDefFixture as unknown) as DeckDefinition,
-      mostRecentAnalysis: ({
-        commands: [],
-        labware: [],
-      } as unknown) as CompletedProtocolAnalysis,
-      initialLoadedLabwareByAdapter: {},
-      attachedProtocolModuleMatches: [],
-    }
-
-    render(props)
-    screen.getByText('Map View')
-    screen.getByText('mock base deck')
-    fireEvent.click(screen.getByLabelText('closeIcon'))
-    expect(props.onCloseClick).toHaveBeenCalled()
   })
 
   it('should render a deck with modules and labware', () => {
@@ -136,7 +112,6 @@ describe('LabwareMapViewModal', () => {
     })
     render({
       handleLabwareClick: vi.fn(),
-      onCloseClick: vi.fn(),
       deckDef: (deckDefFixture as unknown) as DeckDefinition,
       mostRecentAnalysis: ({} as unknown) as CompletedProtocolAnalysis,
       initialLoadedLabwareByAdapter: {},

--- a/app/src/organisms/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
@@ -110,10 +110,12 @@ describe('ProtocolSetupLabware', () => {
     expect(mockSetSetupScreen).toHaveBeenCalledWith('prepare to run')
   })
 
-  it('should launch and close the deck map', () => {
+  it('should toggle between map view and list view', () => {
     render()
+    expect(screen.queryByText('List View')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Map View' }))
-    fireEvent.click(screen.getByLabelText('closeIcon'))
+    expect(screen.queryByText('Map View')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     screen.getByText('Labware')
   })
 

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/ModulesAndDeckMapView.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/ModulesAndDeckMapView.tsx
@@ -1,41 +1,28 @@
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 
-import { BaseDeck } from '@opentrons/components'
+import { BaseDeck, Flex } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
   getSimplestDeckConfigForProtocol,
 } from '@opentrons/shared-data'
 
-import { Modal } from '../../molecules/Modal'
 import { ModuleInfo } from '../Devices/ModuleInfo'
 import { getStandardDeckViewLayerBlockList } from '../Devices/ProtocolRun/utils/getStandardDeckViewLayerBlockList'
 
 import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
-import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { AttachedProtocolModuleMatch } from './utils'
 
-// Note (kk:10/26/2023) once we are ready for removing ff, we will be able to update props
-interface ModulesAndDeckMapViewModalProps {
-  setShowDeckMapModal: (showDeckMapModal: boolean) => void
+interface ModulesAndDeckMapViewProps {
   attachedProtocolModuleMatches: AttachedProtocolModuleMatch[]
   runId: string
   protocolAnalysis: CompletedProtocolAnalysis | null
 }
 
-export function ModulesAndDeckMapViewModal({
-  setShowDeckMapModal,
+export function ModulesAndDeckMapView({
   attachedProtocolModuleMatches,
   runId,
   protocolAnalysis,
-}: ModulesAndDeckMapViewModalProps): JSX.Element | null {
-  const { t } = useTranslation('protocol_setup')
-
-  const modalHeader: ModalHeaderBaseProps = {
-    title: t('map_view'),
-    hasExitIcon: true,
-  }
-
+}: ModulesAndDeckMapViewProps): JSX.Element | null {
   if (protocolAnalysis == null) return null
 
   const deckConfig = getSimplestDeckConfigForProtocol(protocolAnalysis)
@@ -54,13 +41,7 @@ export function ModulesAndDeckMapViewModal({
   }))
 
   return (
-    <Modal
-      header={modalHeader}
-      modalSize="large"
-      onOutsideClick={() => {
-        setShowDeckMapModal(false)
-      }}
-    >
+    <Flex height="27.75rem">
       <BaseDeck
         deckConfig={deckConfig}
         deckLayerBlocklist={getStandardDeckViewLayerBlockList(FLEX_ROBOT_TYPE)}
@@ -68,6 +49,6 @@ export function ModulesAndDeckMapViewModal({
         labwareOnDeck={[]}
         modulesOnDeck={modulesOnDeck}
       />
-    </Modal>
+    </Flex>
   )
 }

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ModulesAndDeckMapView.test.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ModulesAndDeckMapView.test.tsx
@@ -10,7 +10,7 @@ import {
 
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
-import { ModulesAndDeckMapViewModal } from '../ModulesAndDeckMapViewModal'
+import { ModulesAndDeckMapView } from '../ModulesAndDeckMapView'
 
 vi.mock('@opentrons/components/src/hardware-sim/BaseDeck')
 vi.mock('@opentrons/api-client')
@@ -22,7 +22,6 @@ vi.mock('../../Devices/ModuleInfo')
 vi.mock('../../Devices/ProtocolRun/utils/getLabwareRenderInfo')
 
 const mockRunId = 'mockRunId'
-const mockSetShowDeckMapModal = vi.fn()
 const PROTOCOL_ANALYSIS = {
   id: 'fake analysis',
   status: 'completed',
@@ -101,20 +100,17 @@ vi.mock('@opentrons/components', async importOriginal => {
   }
 })
 
-const render = (
-  props: React.ComponentProps<typeof ModulesAndDeckMapViewModal>
-) => {
-  return renderWithProviders(<ModulesAndDeckMapViewModal {...props} />, {
+const render = (props: React.ComponentProps<typeof ModulesAndDeckMapView>) => {
+  return renderWithProviders(<ModulesAndDeckMapView {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
 
-describe('ModulesAndDeckMapViewModal', () => {
-  let props: React.ComponentProps<typeof ModulesAndDeckMapViewModal>
+describe('ModulesAndDeckMapView', () => {
+  let props: React.ComponentProps<typeof ModulesAndDeckMapView>
 
   beforeEach(() => {
     props = {
-      setShowDeckMapModal: mockSetShowDeckMapModal,
       attachedProtocolModuleMatches: mockAttachedProtocolModuleMatches,
       runId: mockRunId,
       protocolAnalysis: PROTOCOL_ANALYSIS,
@@ -131,7 +127,6 @@ describe('ModulesAndDeckMapViewModal', () => {
 
   it('should render BaseDeck map view', () => {
     render(props)
-    screen.getByText('Map View')
     screen.getByText('mock BaseDeck')
   })
 })

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
@@ -33,7 +33,7 @@ import { LocationConflictModal } from '../../Devices/ProtocolRun/SetupModuleAndD
 import { ModuleWizardFlows } from '../../ModuleWizardFlows'
 import { SetupInstructionsModal } from '../SetupInstructionsModal'
 import { FixtureTable } from '../FixtureTable'
-import { ModulesAndDeckMapViewModal } from '../ModulesAndDeckMapViewModal'
+import { ModulesAndDeckMapView } from '../ModulesAndDeckMapView'
 import { ProtocolSetupModulesAndDeck } from '..'
 import { useNotifyDeckConfigurationQuery } from '../../../resources/deck_configuration'
 import { useRunStatus } from '../../RunTimeControl/hooks'
@@ -54,7 +54,7 @@ vi.mock('../SetupInstructionsModal')
 vi.mock('../../ModuleWizardFlows')
 vi.mock('../FixtureTable')
 vi.mock('../../Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal')
-vi.mock('../ModulesAndDeckMapViewModal')
+vi.mock('../ModulesAndDeckMapView')
 vi.mock('../../RunTimeControl/hooks')
 
 const ROBOT_NAME = 'otie'
@@ -327,10 +327,10 @@ describe('ProtocolSetupModulesAndDeck', () => {
     screen.getByText('mock location conflict modal')
   })
 
-  it('should render ModulesAndDeckMapViewModal when tapping map view button', () => {
+  it('should render ModulesAndDeckMapView when tapping map view button', () => {
     render()
     fireEvent.click(screen.getByText('Map View'))
     screen.debug()
-    expect(vi.mocked(ModulesAndDeckMapViewModal)).toHaveBeenCalled()
+    expect(vi.mocked(ModulesAndDeckMapView)).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
@@ -31,7 +31,7 @@ import {
 import { SetupInstructionsModal } from './SetupInstructionsModal'
 import { FixtureTable } from './FixtureTable'
 import { ModuleTable } from './ModuleTable'
-import { ModulesAndDeckMapViewModal } from './ModulesAndDeckMapViewModal'
+import { ModulesAndDeckMapView } from './ModulesAndDeckMapView'
 import { useNotifyDeckConfigurationQuery } from '../../resources/deck_configuration'
 
 import type { CutoutId, CutoutFixtureId } from '@opentrons/shared-data'
@@ -68,7 +68,7 @@ export function ProtocolSetupModulesAndDeck({
     showSetupInstructionsModal,
     setShowSetupInstructionsModal,
   ] = React.useState<boolean>(false)
-  const [showDeckMapModal, setShowDeckMapModal] = React.useState<boolean>(false)
+  const [showMapView, setShowMapView] = React.useState<boolean>(false)
   const [
     clearModuleMismatchBanner,
     setClearModuleMismatchBanner,
@@ -113,14 +113,6 @@ export function ProtocolSetupModulesAndDeck({
               setShowSetupInstructionsModal={setShowSetupInstructionsModal}
             />
           ) : null}
-          {showDeckMapModal ? (
-            <ModulesAndDeckMapViewModal
-              setShowDeckMapModal={setShowDeckMapModal}
-              attachedProtocolModuleMatches={attachedProtocolModuleMatches}
-              runId={runId}
-              protocolAnalysis={mostRecentAnalysis}
-            />
-          ) : null}
         </>,
         getTopPortalEl()
       )}
@@ -143,53 +135,68 @@ export function ProtocolSetupModulesAndDeck({
         marginTop="5.75rem"
         marginBottom={SPACING.spacing80}
       >
-        {isModuleMismatch && !clearModuleMismatchBanner ? (
-          <InlineNotification
-            type="alert"
-            onCloseClick={e => {
-              e.stopPropagation()
-              setClearModuleMismatchBanner(true)
-            }}
-            heading={t('extra_module_attached')}
-            message={t('module_mismatch_body')}
+        {showMapView ? (
+          <ModulesAndDeckMapView
+            attachedProtocolModuleMatches={attachedProtocolModuleMatches}
+            runId={runId}
+            protocolAnalysis={mostRecentAnalysis}
           />
-        ) : null}
-        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-          <Flex
-            color={COLORS.grey60}
-            fontSize={TYPOGRAPHY.fontSize22}
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-            gridGap={SPACING.spacing24}
-            lineHeight={TYPOGRAPHY.lineHeight28}
-            paddingX={SPACING.spacing24}
-          >
-            <LegacyStyledText flex="3.5 0 0">
-              {i18n.format(t('deck_hardware'), 'titleCase')}
-            </LegacyStyledText>
-            <LegacyStyledText flex="2 0 0">{t('location')}</LegacyStyledText>
-            <LegacyStyledText flex="4 0 0"> {t('status')}</LegacyStyledText>
-          </Flex>
-          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-            {hasModules ? (
-              <ModuleTable
-                attachedProtocolModuleMatches={attachedProtocolModuleMatches}
-                deckDef={deckDef}
-                runId={runId}
+        ) : (
+          <>
+            {isModuleMismatch && !clearModuleMismatchBanner ? (
+              <InlineNotification
+                type="alert"
+                onCloseClick={e => {
+                  e.stopPropagation()
+                  setClearModuleMismatchBanner(true)
+                }}
+                heading={t('extra_module_attached')}
+                message={t('module_mismatch_body')}
               />
             ) : null}
-            <FixtureTable
-              robotType={FLEX_ROBOT_TYPE}
-              mostRecentAnalysis={mostRecentAnalysis}
-              setSetupScreen={setSetupScreen}
-              setCutoutId={setCutoutId}
-              setProvidedFixtureOptions={setProvidedFixtureOptions}
-            />
-          </Flex>
-        </Flex>
+            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+              <Flex
+                color={COLORS.grey60}
+                fontSize={TYPOGRAPHY.fontSize22}
+                fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                gridGap={SPACING.spacing24}
+                lineHeight={TYPOGRAPHY.lineHeight28}
+                paddingX={SPACING.spacing24}
+              >
+                <LegacyStyledText flex="3.5 0 0">
+                  {i18n.format(t('deck_hardware'), 'titleCase')}
+                </LegacyStyledText>
+                <LegacyStyledText flex="2 0 0">
+                  {t('location')}
+                </LegacyStyledText>
+                <LegacyStyledText flex="4 0 0"> {t('status')}</LegacyStyledText>
+              </Flex>
+              <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+                {hasModules ? (
+                  <ModuleTable
+                    attachedProtocolModuleMatches={
+                      attachedProtocolModuleMatches
+                    }
+                    deckDef={deckDef}
+                    runId={runId}
+                  />
+                ) : null}
+                <FixtureTable
+                  robotType={FLEX_ROBOT_TYPE}
+                  mostRecentAnalysis={mostRecentAnalysis}
+                  setSetupScreen={setSetupScreen}
+                  setCutoutId={setCutoutId}
+                  setProvidedFixtureOptions={setProvidedFixtureOptions}
+                />
+              </Flex>
+            </Flex>
+          </>
+        )}
       </Flex>
       <FloatingActionButton
+        buttonText={showMapView ? t('list_view') : t('map_view')}
         onClick={() => {
-          setShowDeckMapModal(true)
+          setShowMapView(mapView => !mapView)
         }}
       />
     </>


### PR DESCRIPTION
# Overview

changes the deck hardware and labware map views from modals to page content. alters the floating action button to remove the default icon.

closes PLAT-391, PLAT-392

<img width="1136" alt="Screen Shot 2024-08-06 at 10 29 48 AM" src="https://github.com/user-attachments/assets/91ee7862-6c28-42ad-8caf-c161d27b7ff5">
<img width="1136" alt="Screen Shot 2024-08-06 at 10 29 37 AM" src="https://github.com/user-attachments/assets/651d62e3-cd3b-4b34-bca7-a2c4b8d509f9">


## Test Plan and Hands on Testing

verified map view/list view toggle, updated unit tests

## Changelog

 - Changes map view action button behavior

## Review requests

check toggling between list/map view

## Risk assessment

low
