### PR TITLE
refactor(app): Refactor intervention modal render behavior

### DIFF
--- a/app/src/organisms/InterventionModal/index.tsx
+++ b/app/src/organisms/InterventionModal/index.tsx
@@ -70,29 +70,27 @@ export function useInterventionModal({
   /* Props that must be truthy for the modal to render. Prevents multiple null checks while guaranteeing prop type safety. */
   modalProps: Omit<InterventionModalProps, 'onResume'> | null
 } {
-  return React.useMemo(() => {
-    const isValidIntervention =
-      lastRunCommand != null &&
-      robotName != null &&
-      isInterventionCommand(lastRunCommand) &&
-      runData != null &&
-      runStatus != null &&
-      !TERMINAL_RUN_STATUSES.includes(runStatus)
+  const isValidIntervention =
+    lastRunCommand != null &&
+    robotName != null &&
+    isInterventionCommand(lastRunCommand) &&
+    runData != null &&
+    runStatus != null &&
+    !TERMINAL_RUN_STATUSES.includes(runStatus)
 
-    if (!isValidIntervention) {
-      return { showModal: false, modalProps: null }
-    } else {
-      return {
-        showModal: true,
-        modalProps: {
-          command: lastRunCommand,
-          run: runData,
-          robotName,
-          analysis,
-        },
-      }
+  if (!isValidIntervention) {
+    return { showModal: false, modalProps: null }
+  } else {
+    return {
+      showModal: true,
+      modalProps: {
+        command: lastRunCommand,
+        run: runData,
+        robotName,
+        analysis,
+      },
     }
-  }, [runData?.id, lastRunCommand?.key, runStatus])
+  }
 }
 
 export interface InterventionModalProps {

--- a/app/src/organisms/InterventionModal/index.tsx
+++ b/app/src/organisms/InterventionModal/index.tsx
@@ -58,6 +58,10 @@ export interface UseInterventionModalProps {
   analysis: CompletedProtocolAnalysis | null
 }
 
+export type UseInterventionModalResult =
+  | { showModal: false; modalProps: null }
+  | { showModal: true; modalProps: Omit<InterventionModalProps, 'onResume'> }
+
 // If showModal is true, modalProps are guaranteed not to be null.
 export function useInterventionModal({
   runData,
@@ -65,11 +69,7 @@ export function useInterventionModal({
   runStatus,
   robotName,
   analysis,
-}: UseInterventionModalProps): {
-  showModal: boolean
-  /* Props that must be truthy for the modal to render. Prevents multiple null checks while guaranteeing prop type safety. */
-  modalProps: Omit<InterventionModalProps, 'onResume'> | null
-} {
+}: UseInterventionModalProps): UseInterventionModalResult {
   const isValidIntervention =
     lastRunCommand != null &&
     robotName != null &&

--- a/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -13,7 +13,10 @@ import {
 } from '@opentrons/api-client'
 
 import { i18n } from '../../../i18n'
-import { InterventionModal } from '../../InterventionModal'
+import {
+  useInterventionModal,
+  InterventionModal,
+} from '../../InterventionModal'
 import { ProgressBar } from '../../../atoms/ProgressBar'
 import { useRunStatus } from '../../RunTimeControl/hooks'
 import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
@@ -27,11 +30,7 @@ import {
   mockUseCommandResultNonDeterministic,
   NON_DETERMINISTIC_COMMAND_KEY,
 } from '../__fixtures__'
-import {
-  mockMoveLabwareCommandFromSlot,
-  mockPauseCommandWithStartTime,
-  mockRunData,
-} from '../../InterventionModal/__fixtures__'
+
 import { RunProgressMeter } from '..'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { useLastRunCommand } from '../../Devices/hooks/useLastRunCommand'
@@ -70,7 +69,7 @@ describe('RunProgressMeter', () => {
   beforeEach(() => {
     vi.mocked(ProgressBar).mockReturnValue(<div>MOCK PROGRESS BAR</div>)
     vi.mocked(InterventionModal).mockReturnValue(
-      <div>MOCK INTERVENTION MODAL</div>
+      <div>MOCK_INTERVENTION_MODAL</div>
     )
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_RUNNING)
     when(useMostRecentCompletedAnalysis)
@@ -96,6 +95,10 @@ describe('RunProgressMeter', () => {
       currentStepNumber: null,
       hasRunDiverged: true,
     })
+    vi.mocked(useInterventionModal).mockReturnValue({
+      showModal: false,
+      modalProps: {} as any,
+    })
 
     props = {
       runId: NON_DETERMINISTIC_RUN_ID,
@@ -119,31 +122,18 @@ describe('RunProgressMeter', () => {
     screen.getByText('Not started yet')
     screen.getByText('Download run log')
   })
-  it('should render an intervention modal when lastRunCommand is a pause command', () => {
-    vi.mocked(useNotifyAllCommandsQuery).mockReturnValue({
-      data: { data: [mockPauseCommandWithStartTime], meta: { totalLength: 1 } },
-    } as any)
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: { data: { labware: [] } },
-    } as any)
-    vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
-    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue({} as any)
-    render(props)
-  })
 
-  it('should render an intervention modal when lastRunCommand is a move labware command', () => {
-    vi.mocked(useNotifyAllCommandsQuery).mockReturnValue({
-      data: {
-        data: [mockMoveLabwareCommandFromSlot],
-        meta: { totalLength: 1 },
-      },
-    } as any)
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: { data: mockRunData },
-    } as any)
+  it('should render an intervention modal when showInterventionModal is true', () => {
     vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
-    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue({} as any)
+    vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_IDLE)
+    vi.mocked(useInterventionModal).mockReturnValue({
+      showModal: true,
+      modalProps: {} as any,
+    })
+
     render(props)
+
+    screen.getByText('MOCK_INTERVENTION_MODAL')
   })
 
   it('should render the correct run status when run status is completed', () => {

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -120,7 +120,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
 
   return (
     <>
-      {showIntervention && interventionProps != null
+      {showIntervention
         ? createPortal(
             <InterventionModal
               {...interventionProps}

--- a/app/src/pages/RunningProtocol/__tests__/RunningProtocol.test.tsx
+++ b/app/src/pages/RunningProtocol/__tests__/RunningProtocol.test.tsx
@@ -44,6 +44,10 @@ import {
   useErrorRecoveryFlows,
 } from '../../../organisms/ErrorRecoveryFlows'
 import { useLastRunCommand } from '../../../organisms/Devices/hooks/useLastRunCommand'
+import {
+  useInterventionModal,
+  InterventionModal,
+} from '../../../organisms/InterventionModal'
 
 import type { UseQueryResult } from 'react-query'
 import type { ProtocolAnalyses, RunCommandSummary } from '@opentrons/api-client'
@@ -64,6 +68,7 @@ vi.mock('../../../resources/runs')
 vi.mock('../../../redux/config')
 vi.mock('../../../organisms/ErrorRecoveryFlows')
 vi.mock('../../../organisms/Devices/hooks/useLastRunCommand')
+vi.mock('../../../organisms/InterventionModal')
 
 const RUN_ID = 'run_id'
 const ROBOT_NAME = 'otie'
@@ -159,6 +164,13 @@ describe('RunningProtocol', () => {
       isERActive: false,
       failedCommand: {} as any,
     })
+    vi.mocked(useInterventionModal).mockReturnValue({
+      showModal: false,
+      modalProps: {} as any,
+    })
+    vi.mocked(InterventionModal).mockReturnValue(
+      <div>MOCK_INTERVENTION_MODAL</div>
+    )
   })
 
   afterEach(() => {
@@ -217,6 +229,16 @@ describe('RunningProtocol', () => {
     })
     render(`/runs/${RUN_ID}/run`)
     screen.getByText('MOCK ERROR RECOVERY')
+  })
+
+  it('should render an InterventionModal appropriately', () => {
+    vi.mocked(useInterventionModal).mockReturnValue({
+      showModal: true,
+      modalProps: {} as any,
+    })
+    render(`/runs/${RUN_ID}/run`)
+
+    screen.getByText('MOCK_INTERVENTION_MODAL')
   })
 
   // ToDo (kj:04/04/2023) need to figure out the way to simulate swipe

--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -192,7 +192,7 @@ export function RunningProtocol(): JSX.Element {
             isActiveRun={true}
           />
         ) : null}
-        {showIntervention && interventionProps != null ? (
+        {showIntervention ? (
           <InterventionModal {...interventionProps} onResume={playRun} />
         ) : null}
         <Flex

--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -24,14 +24,15 @@ import {
 import {
   RUN_STATUS_STOP_REQUESTED,
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
-  RUN_STATUS_FINISHING,
 } from '@opentrons/api-client'
 
 import { StepMeter } from '../../atoms/StepMeter'
 import { useMostRecentCompletedAnalysis } from '../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { useNotifyRunQuery } from '../../resources/runs'
-import { InterventionModal } from '../../organisms/InterventionModal'
-import { isInterventionCommand } from '../../organisms/InterventionModal/utils'
+import {
+  InterventionModal,
+  useInterventionModal,
+} from '../../organisms/InterventionModal'
 import {
   useRunStatus,
   useRunTimestamps,
@@ -89,10 +90,6 @@ export function RunningProtocol(): JSX.Element {
     showConfirmCancelRunModal,
     setShowConfirmCancelRunModal,
   ] = React.useState<boolean>(false)
-  const [
-    interventionModalCommandKey,
-    setInterventionModalCommandKey,
-  ] = React.useState<string | null>(null)
   const lastAnimatedCommand = React.useRef<string | null>(null)
   const { ref, style, swipeType, setSwipeType } = useSwipe()
   const robotSideAnalysis = useMostRecentCompletedAnalysis(runId)
@@ -124,6 +121,16 @@ export function RunningProtocol(): JSX.Element {
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
   const robotType = useRobotType(robotName)
   const { isERActive, failedCommand } = useErrorRecoveryFlows(runId, runStatus)
+  const {
+    showModal: showIntervention,
+    modalProps: interventionProps,
+  } = useInterventionModal({
+    runStatus,
+    lastRunCommand,
+    runData: runRecord?.data ?? null,
+    robotName,
+    analysis: robotSideAnalysis,
+  })
 
   React.useEffect(() => {
     if (
@@ -142,23 +149,6 @@ export function RunningProtocol(): JSX.Element {
       setSwipeType('')
     }
   }, [currentOption, swipeType, setSwipeType])
-
-  React.useEffect(() => {
-    if (
-      lastRunCommand != null &&
-      interventionModalCommandKey != null &&
-      lastRunCommand.key !== interventionModalCommandKey
-    ) {
-      // set intervention modal command key to null if different from current command key
-      setInterventionModalCommandKey(null)
-    } else if (
-      lastRunCommand?.key != null &&
-      isInterventionCommand(lastRunCommand) &&
-      interventionModalCommandKey === null
-    ) {
-      setInterventionModalCommandKey(lastRunCommand.key)
-    }
-  }, [lastRunCommand, interventionModalCommandKey])
 
   return (
     <>
@@ -202,18 +192,8 @@ export function RunningProtocol(): JSX.Element {
             isActiveRun={true}
           />
         ) : null}
-        {interventionModalCommandKey != null &&
-        runRecord?.data != null &&
-        lastRunCommand != null &&
-        isInterventionCommand(lastRunCommand) &&
-        runStatus !== RUN_STATUS_FINISHING ? (
-          <InterventionModal
-            robotName={robotName}
-            command={lastRunCommand}
-            onResume={playRun}
-            run={runRecord.data}
-            analysis={robotSideAnalysis}
-          />
+        {showIntervention && interventionProps != null ? (
+          <InterventionModal {...interventionProps} onResume={playRun} />
         ) : null}
         <Flex
           ref={ref}


### PR DESCRIPTION
(Hopefully) closes [RQA-2904](https://opentrons.atlassian.net/browse/RQA-2904)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The logic for rendering `InterventionModal` on the ODD/Desktop is a little bit different when looking at the exact conditions, and this (likely) causes the `InterventionModal` to render on the ODD sometimes but not on the desktop app, and vice versa. 

This is a good opportunity to refactor all of this logic into its own hook and use that hook where we render `InterventionModal`. After thinking through the render logic, there's room to simplify it a bit, too. We don't actually need stateful storage of an intervention command key. Also, I decided to separate `showModal` from `modalProps` (which lets us pass all the non-null props simply), even though we could technically just do a truthy check for `modalProps` for rendering `InterventionModal`, since this is maybe a bit more intuitive. Lastly, a few missing tests are added. 

To help with bug testing intervention modals, I added a couple `console.warns`.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Smoke tested intervention modals during protocol runs. I didn't see any disparity between the app and ODD while testing, but this bug was a bit tricky to repro to begin with.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Unified the InterventionModal render logic for the desktop app and ODD.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2904]: https://opentrons.atlassian.net/browse/RQA-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ