### PR TITLE
fix(api): Fix liquid probes always causing `opentrons_simulate` to raise `MustHomeError`

### DIFF
--- a/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
@@ -47,7 +47,11 @@ async def create_simulating_orchestrator(
         robot_type=robot_type
     )
 
-    # TODO(mc, 2021-08-25): move initial home to protocol engine
+    # TODO(mm, 2024-08-06): This home has theoretically been replaced by Protocol Engine
+    # `home` commands within the `RunOrchestrator` or `ProtocolRunner`. However, it turns
+    # out that this `HardwareControlAPI`-level home is accidentally load-bearing,
+    # working around Protocol Engine bugs where *both* layers need to be homed for
+    # certain commands to work. https://opentrons.atlassian.net/browse/EXEC-646
     await simulating_hardware_api.home()
 
     protocol_engine = await create_protocol_engine(

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -308,7 +308,7 @@ def test_liquid_probe_get_protocol_api() -> None:
         "opentrons_96_wellplate_200ul_pcr_full_skirt", "A2"
     )
     pipette.pick_up_tip(tip_rack["A1"])
-    pipette.require_liquid_presence(well_plate["A1"])
+    pipette.require_liquid_presence(well_plate["A1"])  # Should not raise MustHomeError.
 
 
 def test_liquid_probe_simulate_file() -> None:
@@ -330,7 +330,9 @@ def test_liquid_probe_simulate_file() -> None:
         """
     )
     protocol_contents_stream = io.StringIO(protocol_contents)
-    simulate.simulate(protocol_file=protocol_contents_stream)  # Should not raise.
+    simulate.simulate(
+        protocol_file=protocol_contents_stream
+    )  # Should not raise MustHomeError.
 
 
 class TestGetProtocolAPILabware:

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -296,6 +296,43 @@ def test_get_protocol_api_usable_without_homing(api_version: APIVersion) -> None
     pipette.pick_up_tip(tip_rack["A1"])  # Should not raise.
 
 
+def test_liquid_probe_get_protocol_api() -> None:
+    """Covers `simulate.get_protocol_api()`-specific issues with liquid probes.
+
+    See https://opentrons.atlassian.net/browse/EXEC-646.
+    """
+    protocol = simulate.get_protocol_api(version="2.20", robot_type="Flex")
+    pipette = protocol.load_instrument("flex_1channel_1000", mount="left")
+    tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "A1")
+    well_plate = protocol.load_labware(
+        "opentrons_96_wellplate_200ul_pcr_full_skirt", "A2"
+    )
+    pipette.pick_up_tip(tip_rack["A1"])
+    pipette.require_liquid_presence(well_plate["A1"])
+
+
+def test_liquid_probe_simulate_file() -> None:
+    """Covers `opentrons_simulate`-specific issues with liquid probes.
+
+    See https://opentrons.atlassian.net/browse/EXEC-646.
+    """
+    protocol_contents = textwrap.dedent(
+        """\
+        requirements = {"robotType": "Flex", "apiLevel": "2.20"}
+        def run(protocol):
+            pipette = protocol.load_instrument("flex_1channel_1000", mount="left")
+            tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "A1")
+            well_plate = protocol.load_labware(
+                "opentrons_96_wellplate_200ul_pcr_full_skirt", "A2"
+            )
+            pipette.pick_up_tip(tip_rack["A1"])
+            pipette.require_liquid_presence(well_plate["A1"])
+        """
+    )
+    protocol_contents_stream = io.StringIO(protocol_contents)
+    simulate.simulate(protocol_file=protocol_contents_stream)  # Should not raise.
+
+
 class TestGetProtocolAPILabware:
     """Tests for making sure get_protocol_api() handles extra labware correctly."""
 

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -109,6 +109,11 @@ def get_api_context(
             extra_labware=extra_labware,
             hardware_simulator=ThreadManager(_thread_manager_build_hw_api),
             robot_type="Flex",
+            # use_virtual_hardware=False makes this simulation work unlike
+            # opentrons_simulate, app-side analysis, and server-side analysis.
+            # We need to do this because some of our hardware testing scripts still
+            # interact directly with the OT3API and there is no way to tell Protocol
+            # Engine's hardware virtualization about those updates.
             use_virtual_hardware=False,
         )
     else:


### PR DESCRIPTION
## Overview

Fixes EXEC-646.

## Test Plan and Hands on Testing

Hands-on testing not applicable—this is just for simulation and analysis. Simulation and analysis are covered by automated tests.

## Changelog

See the technical investigation in EXEC-646 for background.

I'm "fixing" this by unifying all the simulation and analysis entry points to "redundantly" home both the `opentrons.protocol_engine` *and* `opentrons.hardware_control` layers.

This definitely feels like the wrong way to solve this. But I'm not sure if there's a better way without addressing the bigger problem of `opentrons.hardware_control`-level simulation and `opentrons.protocol_engine`-level hardware virtualization trying to do the same thing.

We could implement an `opentrons.protocol_engine`-virtualized version of this valid-position check. But that would further mirror `opentrons.hardware_control` behavior inside `opentrons.protocol_engine`, which we know is a losing battle.

We could have `opentrons.protocol_engine` virtualized homes propagate down to the `opentrons.hardware_control` layer. But that would be a weird special case—we don't do that for any other virtualized hardware interactions—and anyway, at that point, why have `opentrons.protocol_engine`-level virtualization at all?

We could just skip the valid-position check in simulation. But that would introduce an avoidable difference between simulation and execution. But this is maybe the least bad option.

## Review requests

Any better ideas?

## Risk assessment

Low.
