### PR TITLE
feat(api): Allow omitting `description` and `display_color` from `ProtocolContext.define_liquid()`

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -132,6 +132,11 @@ This table lists the correspondence between Protocol API versions and robot soft
 Changes in API Versions
 =======================
 
+Version 2.20
+------------
+
+- You can now call :py:obj:`.ProtocolContext.define_liquid()` without supplying a ``description`` or ``display_color``.
+
 Version 2.19
 ------------
 

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -208,7 +208,7 @@ def ensure_and_convert_deck_slot(
                 api_element=f"Specifying a deck slot like '{deck_slot}'",
                 until_version=f"{_COORDINATE_DECK_LABEL_VERSION_GATE}",
                 current_version=f"{api_version}",
-                message=f" Increase your protocol's apiLevel, or use slot '{alternative}' instead.",
+                message=f"Increase your protocol's apiLevel, or use slot '{alternative}' instead.",
             )
 
         return parsed_slot.to_equivalent_for_robot_type(robot_type)

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1153,7 +1153,7 @@ def test_home(
     decoy.verify(mock_core.home(), times=1)
 
 
-def test_add_liquid(
+def test_define_liquid(
     decoy: Decoy, mock_core: ProtocolCore, subject: ProtocolContext
 ) -> None:
     """It should add a liquid to the state."""
@@ -1175,6 +1175,43 @@ def test_add_liquid(
     )
 
     assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    ("api_version", "expect_success"),
+    [
+        (APIVersion(2, 19), False),
+        (APIVersion(2, 20), True),
+    ],
+)
+def test_define_liquid_arg_defaulting(
+    expect_success: bool,
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """Test API version dependent behavior for missing description and display_color."""
+    success_result = Liquid(
+        _id="water-id", name="water", description=None, display_color=None
+    )
+    decoy.when(
+        mock_core.define_liquid(name="water", description=None, display_color=None)
+    ).then_return(success_result)
+
+    if expect_success:
+        assert (
+            subject.define_liquid(
+                name="water"
+                # description and display_color omitted.
+            )
+            == success_result
+        )
+    else:
+        with pytest.raises(APIVersionError):
+            subject.define_liquid(
+                name="water"
+                # description and display_color omitted.
+            )
 
 
 def test_bundled_data(

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -964,7 +964,7 @@ class IncorrectAPIVersion(GeneralError):
                 f"{api_element} is not yet available in the API version in use."
             )
         if message:
-            checked_message = checked_message + message
+            checked_message = checked_message + " " + message
         checked_message = (
             checked_message
             or "This feature is not yet available in the API version in use."


### PR DESCRIPTION
## Overview

Closes AUTH-633. This is pretty simple and self-contained, so I figured we might as well try to squeeze it in v8.0.

## Test Plan and Hands on Testing

Play with different `apiLevel`s for this "protocol":

```python
requirements = {"apiLevel": "2.20"}

def run(protocol):
    protocol.define_liquid(name="Liquid name", description=None)  # display_color omitted.
```

## Changelog

* When `define_liquid()` is called without supplying any value for `description` or `display_color`, act as if `None` was supplied. This takes a little bit of trickery to retain the existing behavior for older `apiLevel`s, which is to require some explicit value, even if that value is just `None`. The new behavior is gated behind `apiLevel 2.20`.
* A little bit of Sphinx trickery to prevent the trickery above from making the method signature look really confusing in the reference documentation.

## Review requests

Do we want any of these docstring changes in a different branch?

## Risk assessment

Lo.