### PR TITLE
fix(robot-server): fetching of data files used in runs of a protocol

### DIFF
--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -205,6 +205,10 @@ class RunDataManager:
             created_at=created_at,
             protocol_id=protocol.protocol_id if protocol is not None else None,
         )
+        run_time_parameters = self._run_orchestrator_store.get_run_time_parameters()
+        self._run_store.insert_csv_rtp(
+            run_id=run_id, run_time_parameters=run_time_parameters
+        )
         await self._runs_publisher.start_publishing_for_run(
             get_current_command=self.get_current_command,
             get_recovery_target_command=self.get_recovery_target_command,
@@ -216,7 +220,7 @@ class RunDataManager:
             run_resource=run_resource,
             state_summary=state_summary,
             current=True,
-            run_time_parameters=self._run_orchestrator_store.get_run_time_parameters(),
+            run_time_parameters=run_time_parameters,
         )
 
     def get(self, run_id: str) -> Union[Run, BadRun]:

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -217,7 +217,7 @@ class RunStore:
         with self._sql_engine.begin() as transaction:
             csv_rtps = transaction.execute(select_all_csv_rtp).all()
 
-        return [_covert_row_to_csv_rtp(row) for row in csv_rtps]
+        return [_convert_row_to_csv_rtp(row) for row in csv_rtps]
 
     def insert_csv_rtp(
         self, run_id: str, run_time_parameters: List[RunTimeParameter]
@@ -543,9 +543,13 @@ class RunStore:
         delete_commands = sqlalchemy.delete(run_command_table).where(
             run_command_table.c.run_id == run_id
         )
+        delete_csv_rtps = sqlalchemy.delete(run_csv_rtp_table).where(
+            run_csv_rtp_table.c.run_id == run_id
+        )
         with self._sql_engine.begin() as transaction:
             transaction.execute(delete_actions)
             transaction.execute(delete_commands)
+            transaction.execute(delete_csv_rtps)
             result = transaction.execute(delete_run)
 
         if result.rowcount < 1:
@@ -574,7 +578,7 @@ class RunStore:
 _run_columns = [run_table.c.id, run_table.c.protocol_id, run_table.c.created_at]
 
 
-def _covert_row_to_csv_rtp(
+def _convert_row_to_csv_rtp(
     row: sqlalchemy.engine.Row,
 ) -> CSVParameterRunResource:
     run_id = row.run_id

--- a/robot-server/tests/integration/http_api/protocols/test_analyses_with_csv_file_parameters.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_analyses_with_csv_file_parameters.tavern.yaml
@@ -96,6 +96,7 @@ stages:
                 - displayName: Liquid handling CSV file
                   variableName: liq_handling_csv_file
                   description: A CSV file that contains wells to use for pipetting
+                  type: csv_file
                   file:
                     id: '{csv_file_id}'
                     name: 'sample_record.csv'

--- a/robot-server/tests/integration/http_api/protocols/test_get_csv_files_used_with_protocol.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_get_csv_files_used_with_protocol.tavern.yaml
@@ -5,6 +5,12 @@ marks:
       - ot2_server_base_url
 
 stages:
+  # The order of these data file uploads is important for this test,
+  # since the list of data files returned for the specified protocol is in upload order.
+  # The order in which the files are uploaded in this test is the same as the order in which
+  # these files are uploaded in the overall integration tests suite.
+  # Until we add data file cleanup after each test, maintaining this order within the suite
+  # will be important.
   - name: Upload data file 1
     request:
       url: '{ot2_server_base_url}/dataFiles'
@@ -31,6 +37,21 @@ stages:
         json:
           data_file_2_id: data.id
           data_file_2_name: data.name
+      status_code:
+        - 201
+        - 200
+
+  - name: Upload data file 3
+    request:
+      url: '{ot2_server_base_url}/dataFiles'
+      method: POST
+      files:
+        file: 'tests/integration/data_files/test.csv'
+    response:
+      save:
+        json:
+          data_file_3_id: data.id
+          data_file_3_name: data.name
       status_code:
         - 201
         - 200
@@ -88,7 +109,59 @@ stages:
           metadata: !anything
         links: !anything
 
-  - name: Create a run from the protocol and CSV file
+  - name: Start a new analysis with a different CSV file
+    request:
+      url: '{ot2_server_base_url}/protocols/{protocol_id}/analyses'
+      method: POST
+      json:
+        data:
+          forceReAnalyze: true
+          runTimeParameterFiles:
+            liq_handling_csv_file: '{data_file_3_id}'
+    response:
+      strict:
+        - json:off
+      status_code: 201
+      json:
+        data:
+          - id: '{analysis_id}'
+            status: completed
+          - id: !anystr
+            status: pending
+            runTimeParameters:
+              - displayName: Liquid handling CSV file
+                variableName: liq_handling_csv_file
+                description: A CSV file that contains wells to use for pipetting
+                type: csv_file
+                file:
+                  id: '{data_file_3_id}'
+                  name: 'test.csv'
+
+  - name: Wait until analysis is completed
+    max_retries: 5
+    delay_after: 1
+    request:
+      url: '{ot2_server_base_url}/protocols/{protocol_id}'
+    response:
+      status_code: 200
+      json:
+        data:
+          analyses: []
+          analysisSummaries:
+            - id: '{analysis_id}'
+              status: completed
+            - id: !anystr
+              status: completed
+          id: !anything
+          protocolType: !anything
+          files: !anything
+          createdAt: !anything
+          robotType: !anything
+          protocolKind: !anything
+          metadata: !anything
+        links: !anything
+
+  - name: Create a run from the protocol and a CSV file
     request:
       url: '{ot2_server_base_url}/runs'
       method: POST
@@ -152,16 +225,6 @@ stages:
                 id: '{data_file_2_id}'
                 name: 'sample_plates.csv'
 
-  - name: Mark the run as not-current
-    request:
-      url: '{ot2_server_base_url}/runs/{run_id2}'
-      method: PATCH
-      json:
-        data:
-          current: False
-    response:
-      status_code: 200
-
   - name: Fetch data files used with the protocol so far
     request:
       url: '{ot2_server_base_url}/protocols/{protocol_id}/dataFiles'
@@ -170,11 +233,14 @@ stages:
       json:
         meta:
           cursor: 0
-          totalLength: 2
+          totalLength: 3
         data:
           - id: '{data_file_1_id}'
             name: "sample_record.csv"
             createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
           - id: '{data_file_2_id}'
             name: "sample_plates.csv"
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+          - id: '{data_file_3_id}'
+            name: "test.csv"
             createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"

--- a/robot-server/tests/integration/http_api/protocols/test_get_csv_files_used_with_protocol.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_get_csv_files_used_with_protocol.tavern.yaml
@@ -11,12 +11,16 @@ stages:
   # these files are uploaded in the overall integration tests suite.
   # Until we add data file cleanup after each test, maintaining this order within the suite
   # will be important.
+
+  # sample_record -> test
+  # sample_plates -> sample_record
+  # test -> sample_plates
   - name: Upload data file 1
     request:
       url: '{ot2_server_base_url}/dataFiles'
       method: POST
       files:
-        file: 'tests/integration/data_files/sample_record.csv'
+        file: 'tests/integration/data_files/test.csv'
     response:
       save:
         json:
@@ -31,7 +35,7 @@ stages:
       url: '{ot2_server_base_url}/dataFiles'
       method: POST
       files:
-        file: 'tests/integration/data_files/sample_plates.csv'
+        file: 'tests/integration/data_files/sample_record.csv'
     response:
       save:
         json:
@@ -46,7 +50,7 @@ stages:
       url: '{ot2_server_base_url}/dataFiles'
       method: POST
       files:
-        file: 'tests/integration/data_files/test.csv'
+        file: 'tests/integration/data_files/sample_plates.csv'
     response:
       save:
         json:
@@ -85,7 +89,7 @@ stages:
                   type: csv_file
                   file:
                     id: '{data_file_1_id}'
-                    name: 'sample_record.csv'
+                    name: 'test.csv'
 
   - name: Wait until analysis is completed
     max_retries: 5
@@ -135,7 +139,7 @@ stages:
                 type: csv_file
                 file:
                   id: '{data_file_3_id}'
-                  name: 'test.csv'
+                  name: 'sample_plates.csv'
 
   - name: Wait until analysis is completed
     max_retries: 5
@@ -191,7 +195,7 @@ stages:
               type: csv_file
               file:
                 id: '{data_file_1_id}'
-                name: 'sample_record.csv'
+                name: 'test.csv'
 
   - name: Create another run from the protocol and a different CSV file
     request:
@@ -223,7 +227,7 @@ stages:
               type: csv_file
               file:
                 id: '{data_file_2_id}'
-                name: 'sample_plates.csv'
+                name: 'sample_record.csv'
 
   - name: Fetch data files used with the protocol so far
     request:
@@ -236,11 +240,11 @@ stages:
           totalLength: 3
         data:
           - id: '{data_file_1_id}'
-            name: "sample_record.csv"
+            name: "test.csv"
             createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
           - id: '{data_file_2_id}'
-            name: "sample_plates.csv"
+            name: "sample_record.csv"
             createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
           - id: '{data_file_3_id}'
-            name: "test.csv"
+            name: "sample_plates.csv"
             createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"

--- a/robot-server/tests/integration/http_api/protocols/test_get_csv_files_used_with_protocol.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_get_csv_files_used_with_protocol.tavern.yaml
@@ -1,0 +1,180 @@
+test_name: Test the /protocols/{protocolID}/dataFiles endpoint
+
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+
+stages:
+  - name: Upload data file 1
+    request:
+      url: '{ot2_server_base_url}/dataFiles'
+      method: POST
+      files:
+        file: 'tests/integration/data_files/sample_record.csv'
+    response:
+      save:
+        json:
+          data_file_1_id: data.id
+          data_file_1_name: data.name
+      status_code:
+        - 201
+        - 200
+
+  - name: Upload data file 2
+    request:
+      url: '{ot2_server_base_url}/dataFiles'
+      method: POST
+      files:
+        file: 'tests/integration/data_files/sample_plates.csv'
+    response:
+      save:
+        json:
+          data_file_2_id: data.id
+          data_file_2_name: data.name
+      status_code:
+        - 201
+        - 200
+
+  - name: Upload protocol with CSV file ID
+    request:
+      url: '{ot2_server_base_url}/protocols'
+      method: POST
+      data:
+        runTimeParameterFiles: '{{"liq_handling_csv_file": "{data_file_1_id}"}}'
+      files:
+        files: 'tests/integration/protocols/basic_transfer_with_run_time_parameters.py'
+    response:
+      save:
+        json:
+          protocol_id: data.id
+          analysis_id: data.analysisSummaries[0].id
+          run_time_parameters_data1: data.analysisSummaries[0].runTimeParameters
+      strict:
+        json:off
+      status_code: 201
+      json:
+        data:
+          analysisSummaries:
+            - id: !anystr
+              status: pending
+              runTimeParameters:
+                - displayName: Liquid handling CSV file
+                  variableName: liq_handling_csv_file
+                  description: A CSV file that contains wells to use for pipetting
+                  type: csv_file
+                  file:
+                    id: '{data_file_1_id}'
+                    name: 'sample_record.csv'
+
+  - name: Wait until analysis is completed
+    max_retries: 5
+    delay_after: 1
+    request:
+      url: '{ot2_server_base_url}/protocols/{protocol_id}'
+    response:
+      status_code: 200
+      json:
+        data:
+          analyses: []
+          analysisSummaries:
+            - id: '{analysis_id}'
+              status: completed
+          id: !anything
+          protocolType: !anything
+          files: !anything
+          createdAt: !anything
+          robotType: !anything
+          protocolKind: !anything
+          metadata: !anything
+        links: !anything
+
+  - name: Create a run from the protocol and CSV file
+    request:
+      url: '{ot2_server_base_url}/runs'
+      method: POST
+      json:
+        data:
+          protocolId: '{protocol_id}'
+          runTimeParameterFiles:
+            liq_handling_csv_file: '{data_file_1_id}'
+    response:
+      status_code: 201
+      save:
+        json:
+          run_id1: data.id
+          run_time_parameters_data2: data.runTimeParameters
+      strict:
+        json:off
+      json:
+        data:
+          id: !anystr
+          ok: True
+          createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+          status: idle
+          runTimeParameters:
+            - displayName: Liquid handling CSV file
+              variableName: liq_handling_csv_file
+              description: A CSV file that contains wells to use for pipetting
+              type: csv_file
+              file:
+                id: '{data_file_1_id}'
+                name: 'sample_record.csv'
+
+  - name: Create another run from the protocol and a different CSV file
+    request:
+      url: '{ot2_server_base_url}/runs'
+      method: POST
+      json:
+        data:
+          protocolId: '{protocol_id}'
+          runTimeParameterFiles:
+            liq_handling_csv_file: '{data_file_2_id}'
+    response:
+      status_code: 201
+      save:
+        json:
+          run_id2: data.id
+          run_time_parameters_data3: data.runTimeParameters
+      strict:
+        json:off
+      json:
+        data:
+          id: !anystr
+          ok: True
+          createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+          status: idle
+          runTimeParameters:
+            - displayName: Liquid handling CSV file
+              variableName: liq_handling_csv_file
+              description: A CSV file that contains wells to use for pipetting
+              type: csv_file
+              file:
+                id: '{data_file_2_id}'
+                name: 'sample_plates.csv'
+
+  - name: Mark the run as not-current
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id2}'
+      method: PATCH
+      json:
+        data:
+          current: False
+    response:
+      status_code: 200
+
+  - name: Fetch data files used with the protocol so far
+    request:
+      url: '{ot2_server_base_url}/protocols/{protocol_id}/dataFiles'
+    response:
+      status_code: 200
+      json:
+        meta:
+          cursor: 0
+          totalLength: 2
+        data:
+          - id: '{data_file_1_id}'
+            name: "sample_record.csv"
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+          - id: '{data_file_2_id}'
+            name: "sample_plates.csv"
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"

--- a/robot-server/tests/integration/http_api/runs/test_run_with_run_time_parameters.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_run_with_run_time_parameters.tavern.yaml
@@ -27,7 +27,9 @@ stages:
       save:
         json:
           data_file_id: data.id
-      status_code: 201
+      status_code:
+        - 201
+        - 200
       json:
         data:
           id: !anystr

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -585,7 +585,7 @@ async def test_get_referenced_data_files(
     subject.insert(protocol_resource_1)
     await data_files_store.insert(
         DataFileInfo(
-            id="data-file-id",
+            id="data-file-id-1",
             name="file-name",
             file_hash="abc123",
             created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
@@ -632,7 +632,7 @@ async def test_get_referenced_data_files(
             CSVParameterResource(
                 analysis_id="analysis-id-1",
                 parameter_variable_name="csv-var",
-                file_id="data-file-id",
+                file_id="data-file-id-1",
             ),
             CSVParameterResource(
                 analysis_id="analysis-id-1",
@@ -648,23 +648,20 @@ async def test_get_referenced_data_files(
     )
     result = await subject.get_referenced_data_files("protocol-id")
 
-    for data_file in result:
-        assert data_file in [
-            DataFile(
-                id="data-file-id",
-                name="file-name",
-                createdAt=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
-            ),
-            DataFile(
-                id="data-file-id-2",
-                name="file-name",
-                createdAt=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
-            ),
-            DataFile(
-                id="data-file-id-3",
-                name="file-name",
-                createdAt=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
-            ),
-        ]
-
-    assert len(result) == 3
+    assert result == [
+        DataFile(
+            id="data-file-id-1",
+            name="file-name",
+            createdAt=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        ),
+        DataFile(
+            id="data-file-id-2",
+            name="file-name",
+            createdAt=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        ),
+        DataFile(
+            id="data-file-id-3",
+            name="file-name",
+            createdAt=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        ),
+    ]

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -213,6 +213,7 @@ async def test_create(
         modules=engine_state_summary.modules,
         liquids=engine_state_summary.liquids,
     )
+    decoy.verify(mock_run_store.insert_csv_rtp(run_id=run_id, run_time_parameters=[]))
 
 
 async def test_create_with_options(
@@ -297,6 +298,11 @@ async def test_create_with_options(
         modules=engine_state_summary.modules,
         liquids=engine_state_summary.liquids,
         runTimeParameters=[bool_parameter, file_parameter],
+    )
+    decoy.verify(
+        mock_run_store.insert_csv_rtp(
+            run_id=run_id, run_time_parameters=[bool_parameter, file_parameter]
+        )
     )
 
 

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -484,7 +484,12 @@ def test_get_all_runs(
     assert result == expected_result
 
 
-def test_remove_run(subject: RunStore, mock_runs_publisher: mock.Mock) -> None:
+async def test_remove_run(
+    subject: RunStore,
+    mock_runs_publisher: mock.Mock,
+    data_files_store: DataFilesStore,
+    run_time_parameters: List[pe_types.RunTimeParameter],
+) -> None:
     """It can remove a previously stored run entry."""
     action = RunAction(
         actionType=RunActionType.PLAY,
@@ -498,6 +503,15 @@ def test_remove_run(subject: RunStore, mock_runs_publisher: mock.Mock) -> None:
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
     )
     subject.insert_action(run_id="run-id", action=action)
+    await data_files_store.insert(
+        DataFileInfo(
+            id="file-id",
+            name="my_csv_file.csv",
+            file_hash="file-hash",
+            created_at=datetime(year=2024, month=1, day=1, tzinfo=timezone.utc),
+        )
+    )
+    subject.insert_csv_rtp(run_id="run-id", run_time_parameters=run_time_parameters)
     subject.remove(run_id="run-id")
 
     assert subject.get_all(length=20) == []


### PR DESCRIPTION
Closes AUTH-638

# Overview

Fixes a bug where CSV files used in protocol runs were not being saved to the CSV RTP table for runs, and as a result, were not being included in response for the `/protocols/{protocolId}/dataFiles` endpoint.

## Test Plan and Hands on Testing

Testing with app & ODD:
- [x] Upload a protocol that uses a CSV parameter
- [x] Send the protocol to a robot, upload the csv file to use
- [x] Run the protocol
- [x] Run the protocol again with a different CSV file -> Do this 5 times (so total 6 runs with 6 different CSV files). By re-running the protocol 6 times, we are making the robot delete its oldest analysis (since max analyses per protocol is 5), essentially deleting the first CSV file from the *analysis* csv table, but not from runs table
- [x] Check that when you run the protocol again on the ODD, it shows you all the 6 different CSV files previously uploaded

Testing with Postman/ direct HTTP requests:
- [x] Upload a few data files
- [x] Upload a protocol that uses a CSV parameter and specify a data file (data_file_1) for the CSV param
- [x] Start a new analysis for the same protocol by specifying a second data file (data_file_2) for the CSV param
- [x] Create a run for the protocol by specifying data_file_1 for its CSV param
- [x] Create another run for the protocol by specifying a third data file (data_file_3) for its CSV param
- [x] Check that the response to `GET /protocols/{protocolId}/dataFiles` contains the 3 data files used with the runs & analyses. Check that they are listed in the order that the files were uploaded to the server (via `POST /dataFiles`)


## Changelog

- wired up CSV RTP table insertion during run creation
- updated the run deletion code to remove the CSV RTP entry from the `run_csv_rtp_table` before deleting the run.
- updated the `../{protocolId}/dataFiles` response so that it lists the files in the order they were uploaded.
- added tests

## Review requests

- Usual code review stuff
- Is there a better way to write the SQL query to get the ordered list of data files used in runs and analyses?

## Risk assessment

Low. Fixes bug
