### PR TITLE
fix(app): fix accessing file name on FileCard

### DIFF
--- a/app/src/organisms/ChooseRobotSlideout/FileCard.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/FileCard.tsx
@@ -51,7 +51,7 @@ export function FileCard(props: FileCardProps): JSX.Element {
             white-space: nowrap;
           `}
         >
-          {truncateString(fileRunTimeParameter?.file?.name ?? '', 35, 18)}
+          {truncateString(fileRunTimeParameter?.file?.file?.name ?? '', 35, 18)}
         </LegacyStyledText>
         <Flex alignItems={ALIGN_CENTER}>
           <Btn

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/FileCard.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/FileCard.test.tsx
@@ -30,7 +30,7 @@ const mockSetRunTimeParametersOverrides = vi.fn()
 
 const mockCsvRunTimeParameterSuccess: CsvFileParameter = {
   displayName: 'My sample file',
-  file: { id: 'my_file_id', name: 'my_file.csv' },
+  file: { id: 'my_file_id', file: { name: 'my_file.csv' } as File },
   variableName: 'my_sample_csv',
   description: 'This is a mock CSV runtime parameter',
   type: 'csv_file',


### PR DESCRIPTION
# Overview

Fixes accidental reversion resulting in populating file name on `FileCard` with empty string. We need to reach into `csvParam.file.file.name` rather than just `csvParam.file.name` on desktop.

## Test Plan and Hands on Testing

- begin protocol setup on Desktop for CSV RTP protocol
- on slideout, upload CSV file
- verify that name populates FileCard 
- repeat with invalid file (non-.csv extension)
- verify that name populates but error style shows

## Changelog

- correctly access file object name at `FileCard`
- update tests

## Review requests

view test plan

## Risk assessment

low