### PR TITLE
feat(app): extend `getModuleImage` util for high res images

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
@@ -67,7 +67,11 @@ export const LabwareStackModal = (
   )
   const moduleImg =
     moduleModel != null ? (
-      <img width="156px" height="130px" src={getModuleImage(moduleModel)} />
+      <img
+        width="156px"
+        height="130px"
+        src={getModuleImage(moduleModel, true)}
+      />
     ) : null
 
   return isOnDevice ? (

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/__tests__/utils.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/__tests__/utils.test.ts
@@ -9,6 +9,13 @@ describe('getModuleImage', () => {
     )
   })
 
+  it('should render the high res magnetic module image when the model is a magnetic module gen 1 high res', () => {
+    const result = getModuleImage('magneticModuleV1', true)
+    expect(result).toEqual(
+      '/app/src/assets/images/modules/magneticModuleV2@3x.png'
+    )
+  })
+
   it('should render the magnetic module image when the model is a magnetic module gen 2', () => {
     const result = getModuleImage('magneticModuleV2')
     expect(result).toEqual(
@@ -30,6 +37,13 @@ describe('getModuleImage', () => {
     )
   })
 
+  it('should render the high res temperature module image when the model is a temperature module high res', () => {
+    const result = getModuleImage('temperatureModuleV2', true)
+    expect(result).toEqual(
+      '/app/src/assets/images/modules/temperatureModuleV2@3x.png'
+    )
+  })
+
   it('should render the heater-shaker module image when the model is a heater-shaker module gen 1', () => {
     const result = getModuleImage('heaterShakerModuleV1')
     expect(result).toEqual(
@@ -37,9 +51,23 @@ describe('getModuleImage', () => {
     )
   })
 
+  it('should render the high res heater-shaker module image when the model is a heater-shaker module gen 1 high res', () => {
+    const result = getModuleImage('heaterShakerModuleV1', true)
+    expect(result).toEqual(
+      '/app/src/assets/images/modules/heaterShakerModuleV1@3x.png'
+    )
+  })
+
   it('should render the thermocycler module image when the model is a thermocycler module gen 1', () => {
     const result = getModuleImage('thermocyclerModuleV1')
     expect(result).toEqual('/app/src/assets/images/thermocycler_closed.png')
+  })
+
+  it('should render the high res thermocycler module image when the model is a thermocycler module gen 1 high res', () => {
+    const result = getModuleImage('thermocyclerModuleV1', true)
+    expect(result).toEqual(
+      '/app/src/assets/images/modules/thermocyclerModuleV1@3x.png'
+    )
   })
 
   it('should render the thermocycler module image when the model is a thermocycler module gen 2', () => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/utils.ts
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/utils.ts
@@ -15,6 +15,10 @@ import magneticModule from '../../../../assets/images/magnetic_module_gen_2_tran
 import temperatureModule from '../../../../assets/images/temp_deck_gen_2_transparent.png'
 import thermoModuleGen1 from '../../../../assets/images/thermocycler_closed.png'
 import heaterShakerModule from '../../../../assets/images/heater_shaker_module_transparent.png'
+import magneticModuleHighRes from '../../../../assets/images/modules/magneticModuleV2@3x.png'
+import temperatureModuleHighRes from '../../../../assets/images/modules/temperatureModuleV2@3x.png'
+import thermoModuleGen1HighRes from '../../../../assets/images/modules/thermocyclerModuleV1@3x.png'
+import heaterShakerModuleHighRes from '../../../../assets/images/modules/heaterShakerModuleV1@3x.png'
 import thermoModuleGen2 from '../../../../assets/images/thermocycler_gen_2_closed.png'
 import magneticBlockGen1 from '../../../../assets/images/magnetic_block_gen_1.png'
 import stagingAreaMagneticBlockGen1 from '../../../../assets/images/staging_area_magnetic_block_gen_1.png'
@@ -25,18 +29,21 @@ import wasteChuteStagingArea from '../../../../assets/images/waste_chute_with_st
 
 import type { CutoutFixtureId, ModuleModel } from '@opentrons/shared-data'
 
-export function getModuleImage(model: ModuleModel): string {
+export function getModuleImage(
+  model: ModuleModel,
+  highRes: boolean = false
+): string {
   switch (model) {
     case 'magneticModuleV1':
     case 'magneticModuleV2':
-      return magneticModule
+      return highRes ? magneticModuleHighRes : magneticModule
     case 'temperatureModuleV1':
     case 'temperatureModuleV2':
-      return temperatureModule
+      return highRes ? temperatureModuleHighRes : temperatureModule
     case 'heaterShakerModuleV1':
-      return heaterShakerModule
+      return highRes ? heaterShakerModuleHighRes : heaterShakerModule
     case 'thermocyclerModuleV1':
-      return thermoModuleGen1
+      return highRes ? thermoModuleGen1HighRes : thermoModuleGen1
     case 'thermocyclerModuleV2':
       return thermoModuleGen2
     case 'magneticBlockV1':


### PR DESCRIPTION
# Overview

Adds optional `highRes` argument to `getModuleImage` util to retrieve higher res module images where applicable for use in `LabwareStackModal`.

## Test Plan and Hands on Testing

- begin a protocol run on Desktop for a protocol with stacked entities
- open Labware setup -> map view
- select a stack to open `LabwareStackModal`
- verify that module image is high resolution
<img width="528" alt="Screenshot 2024-08-07 at 1 22 34 PM" src="https://github.com/user-attachments/assets/ed6239bc-4675-4291-8f9e-d7114363070e">

- repeat above steps on ODD
<img width="751" alt="Screenshot 2024-08-07 at 1 22 50 PM" src="https://github.com/user-attachments/assets/d5cb6ad4-3e39-4c04-ab06-20f0f927a44f">

## Changelog

- add optional `highRes` boolean arg to `getModuleImage` util
- add tests
- implement in `LabwareStackModal`

## Review requests

see test plan

## Risk assessment

low