### PR TITLE
refactor(app): fix title element props in LabwareStackModal

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
@@ -155,13 +155,9 @@ export const LabwareStackModal = (
     <LegacyModal
       onClose={closeModal}
       closeOnOutsideClick
-      title={
-        <Flex gridGap={SPACING.spacing8}>
-          <DeckInfoLabel deckLabel={slotName} />
-          <DeckInfoLabel iconName="stacked" />
-          <StyledText>{t('stacked_slot')}</StyledText>
-        </Flex>
-      }
+      title={t('stacked_slot')}
+      titleElement1={<DeckInfoLabel deckLabel={slotName} />}
+      titleElement2={<DeckInfoLabel iconName="stacked" />}
       childrenPadding={0}
       marginLeft="0"
     >


### PR DESCRIPTION
# Overview

Pass `LegacyModal` title text and icon elements as separate props in `LabwareStackModal`

## Test Plan and Hands on Testing

- begin a protocol run for a protocol containing stacked labware/adapeters/modules ([example](https://github.com/user-attachments/files/16531269/flex_MOAM_218.py.zip))
- select Labware setup step -> map view
- click a stack
- verify that modal title matches designs specified in linked ticket

## Changelog

- pass separate title props to `LegacyModal` in `LabwareStackModal`

## Review requests

Please see test plan and ensure code logic is correct.

## Risk assessment

low