### PR TITLE
feat(app, api-client, react-api-client): add api-client function for `getCsvFile`

### DIFF
--- a/api-client/src/dataFiles/getCsvFile.ts
+++ b/api-client/src/dataFiles/getCsvFile.ts
@@ -1,0 +1,12 @@
+import { GET, request } from '../request'
+
+import type { CsvFileDataResponse } from './types'
+import type { ResponsePromise } from '../request'
+import type { HostConfig } from '../types'
+
+export function getCsvFile(
+  config: HostConfig,
+  fileId: string
+): ResponsePromise<CsvFileDataResponse> {
+  return request<CsvFileDataResponse>(GET, `/dataFiles/${fileId}`, null, config)
+}

--- a/api-client/src/dataFiles/index.ts
+++ b/api-client/src/dataFiles/index.ts
@@ -1,3 +1,4 @@
+export { getCsvFile } from './getCsvFile'
 export { getCsvFileRaw } from './getCsvFileRaw'
 export { uploadCsvFile } from './uploadCsvFile'
 

--- a/api-client/src/dataFiles/types.ts
+++ b/api-client/src/dataFiles/types.ts
@@ -17,9 +17,7 @@ export interface CsvFileDataResponse {
   data: CsvFileData
 }
 
-export interface UploadedCsvFileResponse {
-  data: CsvFileData
-}
+export type UploadedCsvFileResponse = CsvFileDataResponse
 
 export interface UploadedCsvFilesResponse {
   data: CsvFileData[]

--- a/api-client/src/dataFiles/types.ts
+++ b/api-client/src/dataFiles/types.ts
@@ -13,6 +13,10 @@ export interface CsvFileData {
   name: string
 }
 
+export interface CsvFileDataResponse {
+  data: CsvFileData
+}
+
 export interface UploadedCsvFileResponse {
   data: CsvFileData
 }

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -13,7 +13,6 @@ import {
   SPACING,
   LegacyStyledText,
 } from '@opentrons/components'
-import { useAllCsvFilesQuery } from '@opentrons/react-api-client'
 import { formatInterval } from '../RunTimeControl/utils'
 import { formatTimestamp } from './utils'
 import { EMPTY_TIMESTAMP } from './constants'
@@ -41,9 +40,9 @@ export function HistoricalProtocolRun(
   const { t } = useTranslation('run_details')
   const { run, protocolName, robotIsBusy, robotName, protocolKey } = props
   const [drawerOpen, setDrawerOpen] = React.useState(false)
-  const { data: protocolFileData } = useAllCsvFilesQuery(run.protocolId ?? '')
-  const allProtocolDataFiles =
-    protocolFileData != null ? protocolFileData.data : []
+  const countRunDataFiles = run.runTimeParameters.filter(
+    parameter => parameter.type === 'csv_file'
+  ).length
   const runStatus = run.status
   const runDisplayName = formatTimestamp(run.createdAt)
   let duration = EMPTY_TIMESTAMP
@@ -92,7 +91,7 @@ export function HistoricalProtocolRun(
             width="5%"
             data-testid={`RecentProtocolRuns_Files_${protocolKey}`}
           >
-            {allProtocolDataFiles.length}
+            {countRunDataFiles}
           </LegacyStyledText>
           <LegacyStyledText
             as="p"

--- a/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
@@ -141,7 +141,7 @@ export function HistoricalProtocolRunDrawer(
         </Flex>
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
           {runDataFileIds.map((fileId, index) => {
-            return <CsvFileDataRow fileId={fileId} index={index} />
+            return <CsvFileDataRow key={`csv_file_${index}`} fileId={fileId} />
           })}
         </Flex>
       </Flex>
@@ -268,11 +268,10 @@ export function HistoricalProtocolRunDrawer(
 
 interface CsvFileDataRowProps {
   fileId: string
-  index: number
 }
 
 function CsvFileDataRow(props: CsvFileDataRowProps): JSX.Element | null {
-  const { fileId, index } = props
+  const { fileId } = props
 
   const { data: fileData, isSuccess } = useCsvFileQuery(fileId)
   if (!isSuccess) {
@@ -281,7 +280,6 @@ function CsvFileDataRow(props: CsvFileDataRowProps): JSX.Element | null {
   const { name, createdAt } = fileData.data
   return (
     <Flex
-      key={`csv_file_${index}`}
       justifyContent={JUSTIFY_FLEX_START}
       alignItems={ALIGN_CENTER}
       padding={SPACING.spacing12}

--- a/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
@@ -273,8 +273,8 @@ interface CsvFileDataRowProps {
 function CsvFileDataRow(props: CsvFileDataRowProps): JSX.Element | null {
   const { fileId } = props
 
-  const { data: fileData, isSuccess } = useCsvFileQuery(fileId)
-  if (!isSuccess) {
+  const { data: fileData } = useCsvFileQuery(fileId)
+  if (fileData == null) {
     return null
   }
   const { name, createdAt } = fileData.data

--- a/app/src/organisms/Devices/__tests__/HistoricalProtocolRun.test.tsx
+++ b/app/src/organisms/Devices/__tests__/HistoricalProtocolRun.test.tsx
@@ -9,7 +9,9 @@ import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/
 import { useRunStatus, useRunTimestamps } from '../../RunTimeControl/hooks'
 import { HistoricalProtocolRun } from '../HistoricalProtocolRun'
 import { HistoricalProtocolRunOverflowMenu } from '../HistoricalProtocolRunOverflowMenu'
+
 import type { RunStatus, RunData } from '@opentrons/api-client'
+import type { RunTimeParameter } from '@opentrons/shared-data'
 
 vi.mock('../../../redux/protocol-storage')
 vi.mock('../../RunTimeControl/hooks')
@@ -20,6 +22,7 @@ const run = {
   id: 'test_id',
   protocolId: 'test_protocol_id',
   status: 'succeeded' as RunStatus,
+  runTimeParameters: [] as RunTimeParameter[],
 } as RunData
 
 const render = (props: React.ComponentProps<typeof HistoricalProtocolRun>) => {

--- a/react-api-client/src/dataFiles/__tests__/useCsvFileQuery.test.tsx
+++ b/react-api-client/src/dataFiles/__tests__/useCsvFileQuery.test.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { getCsvFile } from '@opentrons/api-client'
+import { useHost } from '../../api'
+import { useCsvFileQuery } from '..'
+
+import type {
+  CsvFileData,
+  CsvFileDataResponse,
+  HostConfig,
+  Response,
+} from '@opentrons/api-client'
+
+vi.mock('@opentrons/api-client')
+vi.mock('../../api/useHost')
+
+const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
+const FILE_ID = 'file123'
+const FILE_NAME = 'my_file.csv'
+const FILE_CONTENT_RESPONSE = {
+  data: {
+    name: FILE_NAME,
+    id: FILE_ID,
+    createdAt: '2024-06-07T19:19:56.268029+00:00',
+  } as CsvFileData,
+} as CsvFileDataResponse
+
+describe('useCsvFileQuery hook', () => {
+  let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
+
+  beforeEach(() => {
+    const queryClient = new QueryClient()
+    const clientProvider: React.FunctionComponent<{
+      children: React.ReactNode
+    }> = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    wrapper = clientProvider
+  })
+
+  it('should return no data if no host', () => {
+    vi.mocked(useHost).mockReturnValue(null)
+
+    const { result } = renderHook(() => useCsvFileQuery(FILE_ID), {
+      wrapper,
+    })
+
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('should return no data if the get file request fails', () => {
+    vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
+    vi.mocked(getCsvFile).mockRejectedValue('oh no')
+
+    const { result } = renderHook(() => useCsvFileQuery(FILE_ID), {
+      wrapper,
+    })
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('should return file data if successful request', async () => {
+    vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
+    vi.mocked(getCsvFile).mockResolvedValue({
+      data: FILE_CONTENT_RESPONSE,
+    } as Response<CsvFileDataResponse>)
+
+    const { result } = renderHook(() => useCsvFileQuery(FILE_ID), {
+      wrapper,
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(FILE_CONTENT_RESPONSE)
+    })
+  })
+})

--- a/react-api-client/src/dataFiles/index.ts
+++ b/react-api-client/src/dataFiles/index.ts
@@ -1,2 +1,3 @@
+export { useCsvFileQuery } from './useCsvFileQuery'
 export { useCsvFileRawQuery } from './useCsvFileRawQuery'
 export { useUploadCsvFileMutation } from './useUploadCsvFileMutation'

--- a/react-api-client/src/dataFiles/useCsvFileQuery.ts
+++ b/react-api-client/src/dataFiles/useCsvFileQuery.ts
@@ -16,7 +16,7 @@ export function useCsvFileQuery(
   }
 
   const query = useQuery<CsvFileDataResponse>(
-    [host, `/dataFiles/${fileId}`],
+    [host, 'dataFiles', fileId],
     () =>
       getCsvFile(host as HostConfig, fileId).then(response => response.data),
     allOptions

--- a/react-api-client/src/dataFiles/useCsvFileQuery.ts
+++ b/react-api-client/src/dataFiles/useCsvFileQuery.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query'
+import { getCsvFile } from '@opentrons/api-client'
+import { useHost } from '../api'
+
+import type { UseQueryOptions, UseQueryResult } from 'react-query'
+import type { HostConfig, CsvFileDataResponse } from '@opentrons/api-client'
+
+export function useCsvFileQuery(
+  fileId: string,
+  options?: UseQueryOptions<CsvFileDataResponse>
+): UseQueryResult<CsvFileDataResponse> {
+  const host = useHost()
+  const allOptions: UseQueryOptions<CsvFileDataResponse> = {
+    ...options,
+    enabled: host !== null && fileId !== null,
+  }
+
+  const query = useQuery<CsvFileDataResponse>(
+    [host, `/dataFiles/${fileId}`],
+    () =>
+      getCsvFile(host as HostConfig, fileId).then(response => response.data),
+    allOptions
+  )
+  return query
+}

--- a/react-api-client/src/dataFiles/useCsvFileRawQuery.ts
+++ b/react-api-client/src/dataFiles/useCsvFileRawQuery.ts
@@ -19,7 +19,7 @@ export function useCsvFileRawQuery(
   }
 
   const query = useQuery<DownloadedCsvFileResponse>(
-    [host, `/dataFiles/${fileId}/download`],
+    [host, 'dataFiles', fileId, 'download'],
     () =>
       getCsvFileRaw(host as HostConfig, fileId).then(response => response.data),
     allOptions


### PR DESCRIPTION
# Overview

Add new api-client function for `getCsvFile`, which takes a fileId and returns `CsvFileData`:
```
{
  id: string
  createdAt: string
  name: string
}
```
Wrap in react query hook and implement in `HistoricalProtocolRunDrawer`.

## Test Plan and Hands on Testing

- Run a CSV RTP protocol on a bot. Finish or cancel the run
- Navigate to the used bot's device details page on Desktop
- Scroll down to historical protocol runs
- Verify that the number of files for your run is correct (should be 1)
- Expand the recent run, opening `HistoricalProtocolRunDrawer`
- Verify that data for only the file used in _this run_ populates in a table, and you can download the file.

## Changelog

- add api client function for `getCsvFile`
- add react query hook for `useCsvFileQuery`
- implement in `HistoricalProtocolRunDrawer`
- add tests and types

## Review requests

see test plan

## Risk assessment

low