### PR TITLE
fix(api): update the byonoy library to 2024.07.0 [DO NOT MERGE!!]

### DIFF
--- a/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
+++ b/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
@@ -72,13 +72,13 @@ class AsyncByonoy:
         loop = loop or asyncio.get_running_loop()
         executor = ThreadPoolExecutor(max_workers=1)
 
-        import pybyonoy_device_library as byonoy  # type: ignore[import-not-found]
+        import byonoy_devices as byonoy  # type: ignore[import-not-found]
 
         interface: AbsProtocol = byonoy
 
         device_sn = cls.serial_number_from_port(usb_port.name)
         found: List[AbsProtocol.Device] = await loop.run_in_executor(
-            executor=executor, func=byonoy.byonoy_available_devices
+            executor=executor, func=byonoy.available_devices
         )
         device = cls.match_device_with_sn(device_sn, found)
 
@@ -121,7 +121,7 @@ class AsyncByonoy:
 
         err, device_handle = await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(self._interface.byonoy_open_device, self._device),
+            func=partial(self._interface.open_device, self._device),
         )
         self._raise_if_error(err.name, f"Error opening device: {err}")
         self._device_handle = device_handle
@@ -132,7 +132,7 @@ class AsyncByonoy:
         handle = self._verify_device_handle()
         await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(self._interface.byonoy_free_device, handle),
+            func=partial(self._interface.free_device, handle),
         )
         self._device_handle = None
 
@@ -143,7 +143,7 @@ class AsyncByonoy:
         handle = self._verify_device_handle()
         return await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(self._interface.byonoy_device_open, handle),
+            func=partial(self._interface.device_open, handle),
         )
 
     async def get_device_information(self) -> Dict[str, str]:
@@ -151,7 +151,7 @@ class AsyncByonoy:
         handle = self._verify_device_handle()
         err, device_info = await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(self._interface.byonoy_get_device_information, handle),
+            func=partial(self._interface.get_device_information, handle),
         )
         self._raise_if_error(err.name, f"Error getting device information: {err}")
         serial_match = SERIAL_PARSER.match(device_info.sn)
@@ -170,7 +170,7 @@ class AsyncByonoy:
         handle = self._verify_device_handle()
         err, status = await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(self._interface.byonoy_get_device_status, handle),
+            func=partial(self._interface.get_device_status, handle),
         )
         self._raise_if_error(err.name, f"Error getting device status: {err}")
         return self.convert_device_state(status.name)
@@ -182,11 +182,9 @@ class AsyncByonoy:
             return False, f"Firmware file not found: {firmware_file_path}"
         err = await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(
-                self._interface.byonoy_update_device, handle, firmware_file_path
-            ),
+            func=partial(self._interface.update_device, handle, firmware_file_path),
         )
-        if err.name != "BYONOY_ERROR_NO_ERROR":
+        if err.name != "ERROR_NO_ERROR":
             return False, f"Byonoy update failed with error: {err}"
         return True, ""
 
@@ -195,7 +193,7 @@ class AsyncByonoy:
         handle = self._verify_device_handle()
         err, uptime = await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(self._interface.byonoy_get_device_uptime, handle),
+            func=partial(self._interface.get_device_uptime, handle),
         )
         self._raise_if_error(err.name, "Error getting device uptime: ")
         return uptime
@@ -205,7 +203,7 @@ class AsyncByonoy:
         handle = self._verify_device_handle()
         err, lid_info = await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(self._interface.byonoy_get_device_parts_aligned, handle),
+            func=partial(self._interface.get_device_parts_aligned, handle),
         )
         self._raise_if_error(err.name, f"Error getting lid status: {err}")
         return (
@@ -217,9 +215,7 @@ class AsyncByonoy:
         handle = self._verify_device_handle()
         err, wavelengths = await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(
-                self._interface.byonoy_abs96_get_available_wavelengths, handle
-            ),
+            func=partial(self._interface.abs96_get_available_wavelengths, handle),
         )
         self._raise_if_error(err.name, "Error getting available wavelengths: ")
         self._supported_wavelengths = wavelengths
@@ -235,7 +231,7 @@ class AsyncByonoy:
         err, measurements = await self._loop.run_in_executor(
             executor=self._executor,
             func=partial(
-                self._interface.byonoy_abs96_single_measure,
+                self._interface.abs96_single_measure,
                 handle,
                 self._current_config,
             ),
@@ -248,7 +244,7 @@ class AsyncByonoy:
         handle = self._verify_device_handle()
         err, presence = await self._loop.run_in_executor(
             executor=self._executor,
-            func=partial(self._interface.byonoy_get_device_slot_status, handle),
+            func=partial(self._interface.get_device_slot_status, handle),
         )
         self._raise_if_error(err.name, f"Error getting slot status: {err}")
         return self.convert_plate_presence(presence.name)
@@ -256,16 +252,14 @@ class AsyncByonoy:
     def _get_supported_wavelengths(self) -> List[int]:
         handle = self._verify_device_handle()
         wavelengths: List[int]
-        err, wavelengths = self._interface.byonoy_abs96_get_available_wavelengths(
-            handle
-        )
+        err, wavelengths = self._interface.abs96_get_available_wavelengths(handle)
         self._raise_if_error(err.name, f"Error getting available wavelengths: {err}")
         self._supported_wavelengths = wavelengths
         return wavelengths
 
     def _initialize_measurement(self, conf: AbsProtocol.MeasurementConfig) -> None:
         handle = self._verify_device_handle()
-        err = self._interface.byonoy_abs96_initialize_single_measurement(handle, conf)
+        err = self._interface.abs96_initialize_single_measurement(handle, conf)
         self._raise_if_error(err.name, f"Error initializing measurement: {err}")
         self._current_config = conf
 
@@ -304,12 +298,12 @@ class AsyncByonoy:
         msg: str = "Error occurred: ",
     ) -> None:
         if err_name in [
-            "BYONOY_ERROR_DEVICE_CLOSED",
-            "BYONOY_ERROR_DEVICE_COMMUNICATION_FAILURE",
-            "BYONOY_ERROR_UNSUPPORTED_OPERATION",
+            "ERROR_DEVICE_CLOSED",
+            "ERROR_DEVICE_COMMUNICATION_FAILURE",
+            "ERROR_UNSUPPORTED_OPERATION",
         ]:
             raise AbsorbanceReaderDisconnectedError(self._device.sn)
-        if err_name != "BYONOY_ERROR_NO_ERROR":
+        if err_name != "ERROR_NO_ERROR":
             raise RuntimeError(msg, err_name)
 
     @staticmethod

--- a/api/src/opentrons/drivers/absorbance_reader/hid_protocol.py
+++ b/api/src/opentrons/drivers/absorbance_reader/hid_protocol.py
@@ -11,28 +11,28 @@ from typing import (
 Response = TypeVar("Response")
 
 ErrorCodeNames = Literal[
-    "BYONOY_ERROR_NO_ERROR",
-    "BYONOY_ERROR_UNKNOWN_ERROR",
-    "BYONOY_ERROR_DEVICE_CLOSED",
-    "BYONOY_ERROR_INVALID_ARGUMENT",
-    "BYONOY_ERROR_NO_MEMORY",
-    "BYONOY_ERROR_UNSUPPORTED_OPERATION",
-    "BYONOY_ERROR_DEVICE_COMMUNICATION_FAILURE",
-    "BYONOY_ERROR_DEVICE_OPERATION_FAILED",
-    "BYONOY_ERROR_DEVICE_OPEN_PREFIX",
-    "BYONOY_ERROR_DEVICE_NOT_FOUND",
-    "BYONOY_ERROR_DEVICE_TOO_NEW",
-    "BYONOY_ERROR_DEVICE_ALREADY_OPEN",
-    "BYONOY_ERROR_FIRMWARE_UPDATE_ERROR_PREFIX",
-    "BYONOY_ERROR_FIRMWARE_UPDATE_FILE_NOT_FOUND",
-    "BYONOY_ERROR_FIRMWARE_UPDATE_FILE_NOT_VALID",
-    "BYONOY_ERROR_FIRMWARE_UPDATE_FAILED",
-    "BYONOY_ERROR_FILE_ERROR_PREFIX",
-    "BYONOY_ERROR_FILE_WRITE_ERROR",
-    "BYONOY_ERROR_MEASUTEMNT_ERROR_PREFIX",
-    "BYONOY_ERROR_MEASUTEMNT_SLOT_NOT_EMPTY",
-    "BYONOY_ERROR_NOT_INITIALIZED",
-    "BYONOY_ERROR_INTERNAL",
+    "ERROR_NO_ERROR",
+    "ERROR_UNKNOWN_ERROR",
+    "ERROR_DEVICE_CLOSED",
+    "ERROR_INVALID_ARGUMENT",
+    "ERROR_NO_MEMORY",
+    "ERROR_UNSUPPORTED_OPERATION",
+    "ERROR_DEVICE_COMMUNICATION_FAILURE",
+    "ERROR_DEVICE_OPERATION_FAILED",
+    "ERROR_DEVICE_OPEN_PREFIX",
+    "ERROR_DEVICE_NOT_FOUND",
+    "ERROR_DEVICE_TOO_NEW",
+    "ERROR_DEVICE_ALREADY_OPEN",
+    "ERROR_FIRMWARE_UPDATE_ERROR_PREFIX",
+    "ERROR_FIRMWARE_UPDATE_FILE_NOT_FOUND",
+    "ERROR_FIRMWARE_UPDATE_FILE_NOT_VALID",
+    "ERROR_FIRMWARE_UPDATE_FAILED",
+    "ERROR_FILE_ERROR_PREFIX",
+    "ERROR_FILE_WRITE_ERROR",
+    "ERROR_MEASUTEMNT_ERROR_PREFIX",
+    "ERROR_MEASUTEMNT_SLOT_NOT_EMPTY",
+    "ERROR_NOT_INITIALIZED",
+    "ERROR_INTERNAL",
 ]
 
 SlotStateNames = Literal[
@@ -87,57 +87,49 @@ class AbsorbanceHidInterface(Protocol):
     def ByonoyAbs96SingleMeasurementConfig(self) -> MeasurementConfig:
         ...
 
-    def byonoy_open_device(self, device: Device) -> Tuple[ErrorCode, int]:
+    def open_device(self, device: Device) -> Tuple[ErrorCode, int]:
         ...
 
-    def byonoy_free_device(self, device_handle: int) -> Tuple[ErrorCode, bool]:
+    def free_device(self, device_handle: int) -> Tuple[ErrorCode, bool]:
         ...
 
-    def byonoy_device_open(self, device_handle: int) -> bool:
+    def device_open(self, device_handle: int) -> bool:
         ...
 
-    def byonoy_get_device_information(
+    def get_device_information(
         self, device_handle: int
     ) -> Tuple[ErrorCode, DeviceInfo]:
         ...
 
-    def byonoy_update_device(
-        self, device_handle: int, firmware_file_path: str
-    ) -> ErrorCode:
+    def update_device(self, device_handle: int, firmware_file_path: str) -> ErrorCode:
         ...
 
-    def byonoy_get_device_status(
-        self, device_handle: int
-    ) -> Tuple[ErrorCode, DeviceState]:
+    def get_device_status(self, device_handle: int) -> Tuple[ErrorCode, DeviceState]:
         ...
 
-    def byonoy_get_device_uptime(self, device_handle: int) -> Tuple[ErrorCode, int]:
+    def get_device_uptime(self, device_handle: int) -> Tuple[ErrorCode, int]:
         ...
 
-    def byonoy_get_device_slot_status(
-        self, device_handle: int
-    ) -> Tuple[ErrorCode, SlotState]:
+    def get_device_slot_status(self, device_handle: int) -> Tuple[ErrorCode, SlotState]:
         ...
 
-    def byonoy_get_device_parts_aligned(
-        self, device_handle: int
-    ) -> Tuple[ErrorCode, bool]:
+    def get_device_parts_aligned(self, device_handle: int) -> Tuple[ErrorCode, bool]:
         ...
 
-    def byonoy_abs96_get_available_wavelengths(
+    def abs96_get_available_wavelengths(
         self, device_handle: int
     ) -> Tuple[ErrorCode, List[int]]:
         ...
 
-    def byonoy_abs96_initialize_single_measurement(
+    def abs96_initialize_single_measurement(
         self, device_handle: int, conf: MeasurementConfig
     ) -> ErrorCode:
         ...
 
-    def byonoy_abs96_single_measure(
+    def abs96_single_measure(
         self, device_handle: int, conf: MeasurementConfig
     ) -> Tuple[ErrorCode, List[float]]:
         ...
 
-    def byonoy_available_devices(self) -> List[Device]:
+    def available_devices(self) -> List[Device]:
         ...

--- a/api/tests/opentrons/drivers/absorbance_reader/test_driver.py
+++ b/api/tests/opentrons/drivers/absorbance_reader/test_driver.py
@@ -23,8 +23,8 @@ def mock_device() -> MagicMock:
 
 
 class MockErrorCode(Enum):
-    BYONOY_ERROR_NO_ERROR = "no_error"
-    BYONOY_ERROR = "error"
+    ERROR_NO_ERROR = "no_error"
+    ERROR = "error"
 
 
 @pytest.fixture
@@ -50,20 +50,20 @@ async def test_driver_connect_disconnect(
     mock_interface: MagicMock,
     driver: AbsorbanceReaderDriver,
 ) -> None:
-    mock_interface.byonoy_open_device.return_value = (
-        MockErrorCode.BYONOY_ERROR_NO_ERROR,
+    mock_interface.open_device.return_value = (
+        MockErrorCode.ERROR_NO_ERROR,
         1,
     )
 
     assert not await driver.is_connected()
     await driver.connect()
 
-    mock_interface.byonoy_open_device.assert_called_once()
+    mock_interface.open_device.assert_called_once()
     assert await driver.is_connected()
     assert driver._connection._verify_device_handle()
     assert driver._connection._device_handle == 1
 
-    mock_interface.byonoy_free_device.return_value = MockErrorCode.BYONOY_ERROR_NO_ERROR
+    mock_interface.free_device.return_value = MockErrorCode.ERROR_NO_ERROR
     await driver.disconnect()
 
     assert not await driver.is_connected()
@@ -80,14 +80,14 @@ async def test_driver_get_device_info(
     DEVICE_INFO.sn = "SN: BYOMAA00013 REF: DE MAA 001"
     DEVICE_INFO.version = "Absorbance V1.0.2 2024-04-18"
 
-    mock_interface.byonoy_get_device_information.return_value = (
-        MockErrorCode.BYONOY_ERROR_NO_ERROR,
+    mock_interface.get_device_information.return_value = (
+        MockErrorCode.ERROR_NO_ERROR,
         DEVICE_INFO,
     )
 
     info = await connected_driver.get_device_info()
 
-    mock_interface.byonoy_get_device_information.assert_called_once()
+    mock_interface.get_device_information.assert_called_once()
     assert info == {"serial": "BYOMAA00013", "model": "ABS96", "version": "v1.0.2"}
 
 
@@ -102,14 +102,14 @@ async def test_driver_get_lid_status(
     module_status: AbsorbanceReaderLidStatus,
 ) -> None:
 
-    mock_interface.byonoy_get_device_parts_aligned.return_value = (
-        MockErrorCode.BYONOY_ERROR_NO_ERROR,
+    mock_interface.get_device_parts_aligned.return_value = (
+        MockErrorCode.ERROR_NO_ERROR,
         parts_aligned,
     )
 
     status = await connected_driver.get_lid_status()
 
-    mock_interface.byonoy_get_device_parts_aligned.assert_called_once()
+    mock_interface.get_device_parts_aligned.assert_called_once()
     assert status == module_status
 
 
@@ -118,8 +118,8 @@ async def test_driver_get_supported_wavelengths(
     connected_driver: AbsorbanceReaderDriver,
 ) -> None:
     SUPPORTED_WAVELENGTHS = [450, 500]
-    mock_interface.byonoy_abs96_get_available_wavelengths.return_value = (
-        MockErrorCode.BYONOY_ERROR_NO_ERROR,
+    mock_interface.abs96_get_available_wavelengths.return_value = (
+        MockErrorCode.ERROR_NO_ERROR,
         SUPPORTED_WAVELENGTHS,
     )
 
@@ -127,7 +127,7 @@ async def test_driver_get_supported_wavelengths(
 
     wavelengths = await connected_driver.get_available_wavelengths()
 
-    mock_interface.byonoy_abs96_get_available_wavelengths.assert_called_once()
+    mock_interface.abs96_get_available_wavelengths.assert_called_once()
     assert connected_driver._connection._supported_wavelengths == SUPPORTED_WAVELENGTHS
     assert wavelengths == SUPPORTED_WAVELENGTHS
 
@@ -138,8 +138,8 @@ async def test_driver_initialize_and_read(
 ) -> None:
     # set up mock interface
     connected_driver._connection._supported_wavelengths = [450, 500]
-    mock_interface.byonoy_abs96_initialize_single_measurement.return_value = (
-        MockErrorCode.BYONOY_ERROR_NO_ERROR
+    mock_interface.abs96_initialize_single_measurement.return_value = (
+        MockErrorCode.ERROR_NO_ERROR
     )
     mock_interface.ByonoyAbs96SingleMeasurementConfig = MagicMock(
         spec=AbsorbanceHidInterface.MeasurementConfig
@@ -151,18 +151,18 @@ async def test_driver_initialize_and_read(
 
     conf = connected_driver._connection._current_config
     assert conf and conf.sample_wavelength == 450
-    mock_interface.byonoy_abs96_initialize_single_measurement.assert_called_once_with(
+    mock_interface.abs96_initialize_single_measurement.assert_called_once_with(
         1, conf
     )
 
     # setup up mock interface
     MEASURE_RESULT = [0.1] * 96
-    mock_interface.byonoy_abs96_single_measure.return_value = (
-        MockErrorCode.BYONOY_ERROR_NO_ERROR,
+    mock_interface.abs96_single_measure.return_value = (
+        MockErrorCode.ERROR_NO_ERROR,
         MEASURE_RESULT,
     )
 
     result = await connected_driver.get_single_measurement(450)
-    mock_interface.byonoy_abs96_single_measure.assert_called_once_with(1, conf)
+    mock_interface.abs96_single_measure.assert_called_once_with(1, conf)
 
     assert result == MEASURE_RESULT

--- a/api/tests/opentrons/drivers/absorbance_reader/test_driver.py
+++ b/api/tests/opentrons/drivers/absorbance_reader/test_driver.py
@@ -151,9 +151,7 @@ async def test_driver_initialize_and_read(
 
     conf = connected_driver._connection._current_config
     assert conf and conf.sample_wavelength == 450
-    mock_interface.abs96_initialize_single_measurement.assert_called_once_with(
-        1, conf
-    )
+    mock_interface.abs96_initialize_single_measurement.assert_called_once_with(1, conf)
 
     # setup up mock interface
     MEASURE_RESULT = [0.1] * 96


### PR DESCRIPTION
# Overview

We got a new 2024.07.0 library update from Byonoy, this pull request updates the function names and error codes to reflect the new library names. This pull request goes in conjunction with this oe-core pr [Opentrons/oe-core#159](https://github.com/Opentrons/oe-core/pull/159).

Library Introduces the following changes
`There are two major changes. 
* The name of the Python module has been changed to byonoy_devices
*  The Byonoy prefix has been removed from all datatypes, enumerations, and method names.

There are some bug fixes
* One bug that has been fixed is the vid/pid which was returning wrong values.
* Another fix is to remove an unintended busy wait when opening devices.
* A few other improvements

## Test Plan and Hands on Testing

- [x] Make sure we can still open/free the device
- [x] Make sure we can read the status of the device and info using the poller
- [ ] Make sure we can still update the device

## Changelog

- Change the name of the `AbsorbanceHidInterface` functions to match that of the new library
- Change the name of the `ErrorCodeNames` to match the new library

## Review requests
## Risk assessment

Low, unreleased