### PR TITLE
fix(shared-data): Partial tip 96ch single nozzle pickup press distance value adjustment

### DIFF
--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
@@ -147,7 +147,7 @@
         "SingleA1": {
           "default": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -172,7 +172,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -189,7 +189,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -206,7 +206,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -225,7 +225,7 @@
         "SingleH1": {
           "default": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -250,7 +250,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -267,7 +267,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -284,7 +284,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -303,7 +303,7 @@
         "SingleA12": {
           "default": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -328,7 +328,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -345,7 +345,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -362,7 +362,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -381,7 +381,7 @@
         "SingleH12": {
           "default": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -406,7 +406,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -423,7 +423,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -440,7 +440,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_6.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_6.json
@@ -147,7 +147,7 @@
         "SingleA1": {
           "default": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -172,7 +172,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -189,7 +189,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -206,7 +206,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -225,7 +225,7 @@
         "SingleH1": {
           "default": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -250,7 +250,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -267,7 +267,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -284,7 +284,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -303,7 +303,7 @@
         "SingleA12": {
           "default": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -328,7 +328,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -345,7 +345,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -362,7 +362,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -381,7 +381,7 @@
         "SingleH12": {
           "default": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -406,7 +406,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -423,7 +423,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -440,7 +440,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.5,
+            "distance": 12,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {


### PR DESCRIPTION


# Overview
Covers RQA-2920

The single tip pick up values for single-channel nozzle maps for the 96ch pipette resulted in failure to reliably pick up tips. Adjusting the press distance from 10.5mm to 12mm has passed a series of iterative tests, and can now move on to validation testing.

In parallel to this PR, internal hardware testing should revalidate existing values and identify ideal operating values for the single channel configuration, or sign off on the value adjustment present in this PR.

## Test Plan and Hands on Testing

- [x] Execute the QA series of partial tip single channel 96ch pipette tests for Northside and Southside configurations to ensure success.

## Changelog

Updated 96ch single channel press distance from 10.5mm to 12mm for all single channel configuration maps on v3.5 and v3.6 96ch Pipettes.


## Risk assessment
Given that these values were found through SW testing on Flex system and not HW testing, the values may not be the most appropriate to use. They do succeed in allowing single channel pickup on the 96ch, but should be signed off on by HW testing personnel. 