### PR TITLE
feat(app, components): add stacking to non-module stacks

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
@@ -210,14 +210,21 @@ export const LabwareStackModal = (
                 justifyContent={JUSTIFY_SPACE_BETWEEN}
               >
                 <LabwareStackLabel text={adapterName ?? ''} />
-                <LabwareStackRender
-                  definitionTop={topDefinition}
-                  definitionBottom={adapterDef}
-                  highlightBottom={true}
-                  highlightTop={false}
-                />
+                {adapterDef.parameters.loadName ===
+                'opentrons_flex_96_tiprack_adapter' ? (
+                  tiprackAdapterImg
+                ) : (
+                  <LabwareStackRender
+                    definitionTop={topDefinition}
+                    definitionBottom={adapterDef}
+                    highlightBottom={true}
+                    highlightTop={false}
+                  />
+                )}
               </Flex>
-              <Divider marginY={SPACING.spacing16} />
+              {moduleModel != null ? (
+                <Divider marginY={SPACING.spacing16} />
+              ) : null}
             </>
           ) : null}
           {moduleModel != null ? (

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
@@ -29,6 +29,7 @@ import {
   getModuleType,
   TC_MODULE_LOCATION_OT2,
   TC_MODULE_LOCATION_OT3,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import tiprackAdapter from '../../../../assets/images/labware/opentrons_flex_96_tiprack_adapter.png'
 
@@ -72,7 +73,7 @@ export const LabwareStackModal = (
   const isModuleThermocycler =
     moduleModel == null
       ? false
-      : getModuleType(moduleModel) === 'thermocyclerModuleType'
+      : getModuleType(moduleModel) === THERMOCYCLER_MODULE_TYPE
   const thermocyclerLocation =
     robotType === FLEX_ROBOT_TYPE
       ? TC_MODULE_LOCATION_OT3

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -25,7 +25,6 @@ import { OffDeckLabwareList } from './OffDeckLabwareList'
 
 import type {
   CompletedProtocolAnalysis,
-  LoadLabwareRunTimeCommand,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import { LabwareStackModal } from './LabwareStackModal'
@@ -143,23 +142,15 @@ export function SetupLabwareMap({
         topLabwareId != null &&
         labwareInAdapter != null
 
-      const loadLabwareCommand = commands.find(
-        command =>
-          command.commandType === 'loadLabware' &&
-          command.result?.labwareId === labwareId
-      ) as LoadLabwareRunTimeCommand
-      const labwareLocation = loadLabwareCommand?.params.location
       return {
-        labwareLocation,
+        labwareLocation: { slotName },
         definition: topLabwareDefinition,
         topLabwareId,
         topLabwareDisplayName,
-        // TODO (nd: 08/08/2024) fix passing of onLabwareClick to actually perform click handling.
-        // Here, I set to an empty function to produce pointer cursor style.
-        onLabwareClick: isLabwareInStack ? () => {} : undefined,
         highlight: isLabwareInStack && hoverLabwareId === topLabwareId,
         labwareChildren: (
           <g
+            cursor={isLabwareInStack ? 'pointer' : ''}
             onClick={() => {
               if (isLabwareInStack) {
                 setLabwareStackDetailsLabwareId(topLabwareId)

--- a/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLocationInfoNames.test.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/__tests__/getLocationInfoNames.test.ts
@@ -6,6 +6,7 @@ import type { ModuleModel } from '@opentrons/shared-data'
 const ADAPTER_DISPLAY_NAME = 'Opentrons 96 Flat Bottom Adapter'
 const LABWARE_DISPLAY_NAME = 'Corning 24 Well Plate 3.4 mL Flat'
 const SLOT = '5'
+const SLOT_EXTENSION = 'C4'
 const MOCK_MODEL = 'heaterShakerModuleV1' as ModuleModel
 const ADAPTER_ID =
   'd9a85adf-d272-4edd-9aae-426ef5756fef:opentrons/opentrons_96_flat_bottom_adapter/1'
@@ -119,6 +120,34 @@ const MOCK_ADAPTER_COMMANDS = [
     },
   },
 ]
+const MOCK_ADAPTER_EXTENSION_COMMANDS = [
+  {
+    commandType: 'loadLabware',
+    params: {
+      location: {
+        addressableAreaName: SLOT_EXTENSION,
+      },
+    },
+    result: {
+      labwareId: ADAPTER_ID,
+      definition: {
+        metadata: { displayName: ADAPTER_DISPLAY_NAME },
+      },
+    },
+  },
+  {
+    commandType: 'loadLabware',
+    params: {
+      location: {
+        labwareId: ADAPTER_ID,
+      },
+    },
+    result: {
+      labwareId: LABWARE_ID,
+      definition: {},
+    },
+  },
+]
 
 vi.mock('@opentrons/shared-data')
 
@@ -166,6 +195,17 @@ describe('getLocationInfoNames', () => {
     }
     expect(
       getLocationInfoNames(LABWARE_ID, MOCK_ADAPTER_COMMANDS as any)
+    ).toEqual(expected)
+  })
+  it('returns the adapter, slot number if the labware is on an adapter on the deck extension slot', () => {
+    const expected = {
+      slotName: SLOT_EXTENSION,
+      labwareName: LABWARE_DISPLAY_NAME,
+      adapterName: ADAPTER_DISPLAY_NAME,
+      adapterId: ADAPTER_ID,
+    }
+    expect(
+      getLocationInfoNames(LABWARE_ID, MOCK_ADAPTER_EXTENSION_COMMANDS as any)
     ).toEqual(expected)
   })
 })

--- a/app/src/organisms/Devices/ProtocolRun/utils/getLocationInfoNames.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLocationInfoNames.ts
@@ -89,6 +89,18 @@ export function getLocationInfoNames(
       }
     } else if (
       loadedAdapterCommand?.params.location !== 'offDeck' &&
+      'addressableAreaName' in loadedAdapterCommand?.params.location
+    ) {
+      return {
+        slotName: loadedAdapterCommand?.params.location.addressableAreaName,
+        labwareName,
+        labwareNickname,
+        adapterName:
+          loadedAdapterCommand?.result?.definition.metadata.displayName,
+        adapterId: loadedAdapterCommand?.result?.labwareId,
+      }
+    } else if (
+      loadedAdapterCommand?.params.location !== 'offDeck' &&
       'moduleId' in loadedAdapterCommand?.params.location
     ) {
       const moduleId = loadedAdapterCommand?.params.location.moduleId

--- a/app/src/organisms/ProtocolSetupLabware/LabwareMapView.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/LabwareMapView.tsx
@@ -85,6 +85,10 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
       const topLabwareDefinition =
         labwareInAdapter?.result?.definition ?? labwareDef
       const topLabwareId = labwareInAdapter?.result?.labwareId ?? labwareId
+      const isLabwareInStack =
+        topLabwareDefinition != null &&
+        topLabwareId != null &&
+        labwareInAdapter != null
 
       return {
         labwareLocation: { slotName },
@@ -95,6 +99,7 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
         },
         labwareChildren: null,
         highlight: true,
+        stacked: isLabwareInStack,
       }
     }
   )

--- a/components/src/hardware-sim/Labware/LabwareAdapter/index.tsx
+++ b/components/src/hardware-sim/Labware/LabwareAdapter/index.tsx
@@ -4,6 +4,9 @@ import { Opentrons96FlatBottomAdapter } from './Opentrons96FlatBottomAdapter'
 import { OpentronsUniversalFlatAdapter } from './OpentronsUniversalFlatAdapter'
 import { OpentronsAluminumFlatBottomPlate } from './OpentronsAluminumFlatBottomPlate'
 import { OpentronsFlex96TiprackAdapter } from './OpentronsFlex96TiprackAdapter'
+import { COLORS } from '../../../helix-design-system'
+import { LabwareOutline } from '../labwareInternals'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 const LABWARE_ADAPTER_LOADNAME_PATHS = {
   opentrons_96_deep_well_adapter: Opentrons96DeepWellAdapter,
@@ -20,13 +23,28 @@ export const labwareAdapterLoadNames = Object.keys(
 
 export interface LabwareAdapterProps {
   labwareLoadName: LabwareAdapterLoadName
+  definition?: LabwareDefinition2
+  highlight?: boolean
 }
 
 export const LabwareAdapter = (
   props: LabwareAdapterProps
 ): JSX.Element | null => {
-  const { labwareLoadName } = props
+  const { labwareLoadName, definition, highlight = false } = props
+  const highlightOutline =
+    highlight && definition != null ? (
+      <LabwareOutline
+        definition={definition}
+        highlight={highlight}
+        fill={COLORS.transparent}
+      />
+    ) : null
   const SVGElement = LABWARE_ADAPTER_LOADNAME_PATHS[labwareLoadName]
 
-  return <SVGElement />
+  return (
+    <g>
+      <SVGElement />
+      {highlightOutline}
+    </g>
+  )
 }

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -88,6 +88,8 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
         >
           <LabwareAdapter
             labwareLoadName={labwareLoadName as LabwareAdapterLoadName}
+            definition={definition}
+            highlight={props.highlight}
           />
         </g>
       </g>

--- a/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.tsx
@@ -65,6 +65,7 @@ export function LabwareOutline(props: LabwareOutlineProps): JSX.Element {
             rx="8"
             ry="8"
             showRadius={showRadius}
+            fill={backgroundFill}
           />
           <LabwareBorder
             borderThickness={2.2 * OUTLINE_THICKNESS_MM}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Add stack icon, highlight, and click handling to non-module stacks (example: slot + adapter + labware)


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

- Upload a protocol with a variety of labware + module + adapter combinations ([example](https://github.com/user-attachments/files/16552473/flex_demo.py.zip))
- Start a run and proceed to labware setup map view
- Confirm that stack icon appears on any valid stack
- Confirm that on desktop, stacks highlight when hovered, even when top labware is adapter. On ODD, all labware is highlighted, even when top labware is adapter
- Confirm that clicking a stack produces labware stack modal with correct stack elements, special casing 96 tiprack adapter to png

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

- Special case 96 tiprack adapter to png in `LabwareStackModal` for desktop
- Pass correct labware locations in `labwareOnDeck` to `BaseDeck` from `SetupLabwareMap` (desktop component). Pass correct `highlight` and `stacked` props
- Pass correct `stacked` prop to `BaseDeck` from `LabwareMapView` (ODD component)
- Accommodate highlight in `LabwareAdapter`

## Review requests

see test plan

## Risk assessment

medium