### PR TITLE
fix(app-shell-odd): do not retrigger system downloads if one is already in progress

### DIFF
--- a/app-shell-odd/src/system-update/index.ts
+++ b/app-shell-odd/src/system-update/index.ts
@@ -58,6 +58,11 @@ export function registerRobotSystemUpdate(dispatch: Dispatch): Dispatch {
     switch (action.type) {
       case UI_INITIALIZED:
       case 'shell:CHECK_UPDATE':
+        // short circuit early if we're already downloading the latest system files
+        if (isGettingLatestSystemFiles) {
+          log.info(`system update download already in progress`)
+          return
+        }
         updateLatestVersion()
           .then(() => {
             if (isUpdateAvailable() && !isGettingLatestSystemFiles) {


### PR DESCRIPTION
# Overview

Ugh... this is a pretty bad oopsy. If the ODD is downloading a robot system zip, it is possible (and in fact, common) that additional downloads of the same system zip would get started into new temp dirs. 

This has been an issue for the entirety of the Flex's existence, but we think this issue is made worse in China because of their harsh firewalls. 

This PR properly short circuits system downloads early if one is already in progress.

Props to @vegano1 for finding this!


## Changelog

- Do not initiate new system file downloads if one is already in progress


## Risk assessment

Medium