### PR TITLE
feat(shared-data) add labware definitions for inner well geometry

### DIFF
--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -105,6 +105,33 @@ class DisplayCategory(str, Enum):
     other = "other"
 
 
+class CircleArea(BaseModel):
+    radius: float
+
+
+class RectangleArea(BaseModel):
+    length: float
+    width: float
+
+
+class Hemisphere(BaseModel):
+    radius: float
+    depth: float
+
+
+CrossSectionShape = Union[CircleArea, RectangleArea]
+
+
+class CrossSection(BaseModel):
+    shape: CrossSectionShape
+    height: float
+
+
+class InnerLabwareGeometry(BaseModel):
+    cross_sections: List[CrossSection]
+    hemisphere: Optional[Hemisphere]
+
+
 class LabwareRole(str, Enum):
     labware = "labware"
     fixture = "fixture"


### PR DESCRIPTION
## Overview
This is a first pass at the shape of inner well geometry data in `labware.py`. This might need to change in the future,