### PR TITLE
fix(app): update SetupLiquids button text

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -51,6 +51,7 @@
   "confirm_heater_shaker_module_modal_title": "Confirm Heater-Shaker Module is attached",
   "confirm_offsets": "Confirm offsets",
   "confirm_liquids": "Confirm liquids",
+  "confirm_locations_and_volumes": "Confirm locations and volumes",
   "confirm_placements": "Confirm placements",
   "confirm_selection": "Confirm selection",
   "confirm_values": "Confirm values",

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquids.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquids.test.tsx
@@ -50,7 +50,7 @@ describe('SetupLiquids', () => {
     render(props)
     screen.getByRole('button', { name: 'List View' })
     screen.getByRole('button', { name: 'Map View' })
-    screen.getByRole('button', { name: 'Confirm placements' })
+    screen.getByRole('button', { name: 'Confirm locations and volumes' })
   })
   it('renders the map view when you press that toggle button', () => {
     render(props)

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/index.tsx
@@ -59,7 +59,7 @@ export function SetupLiquids({
           }}
           disabled={isLiquidSetupConfirmed}
         >
-          {t('confirm_placements')}
+          {t('confirm_locations_and_volumes')}
         </PrimaryButton>
       </Flex>
     </Flex>


### PR DESCRIPTION
# Overview

Update text for SetupLiquids confirmation button on desktop to reflect designs.

Closes RQA-2929

## Test Plan and Hands on Testing

- Begin protocol setup for protocol with liquids
- Verify that confirmation button text shows 'Confirm locations and volumes' 
<img width="715" alt="Screenshot 2024-08-08 at 4 33 21 PM" src="https://github.com/user-attachments/assets/5bcd3c51-586d-4f02-9944-4e4bc19d18cc">

## Changelog

- update button text
- add translation
- update test

## Review requests

js, see test plan

## Risk assessment

low