### PR TITLE
fix(robot-server): Publish to `maintenance_runs/current_run` on initial `PLAY` action

### DIFF
--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -115,7 +115,7 @@ class MaintenanceRunDataManager:
             state_summary=state_summary,
         )
 
-        await self._maintenance_runs_publisher.publish_current_maintenance_run()
+        await self._maintenance_runs_publisher.publish_current_maintenance_run_async()
 
         return maintenance_run_data
 
@@ -157,7 +157,7 @@ class MaintenanceRunDataManager:
         if run_id == self._run_orchestrator_store.current_run_id:
             await self._run_orchestrator_store.clear()
 
-            await self._maintenance_runs_publisher.publish_current_maintenance_run()
+            await self._maintenance_runs_publisher.publish_current_maintenance_run_async()
 
         else:
             raise MaintenanceRunNotFoundError(run_id=run_id)

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -30,7 +30,12 @@ from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
 from robot_server.maintenance_runs.dependencies import (
     get_maintenance_run_orchestrator_store,
 )
-from robot_server.service.notifications import get_runs_publisher, RunsPublisher
+from robot_server.service.notifications import (
+    get_runs_publisher,
+    get_maintenance_runs_publisher,
+    RunsPublisher,
+    MaintenanceRunsPublisher,
+)
 
 log = logging.getLogger(__name__)
 actions_router = APIRouter()
@@ -49,6 +54,9 @@ async def get_run_controller(
     run_orchestrator_store: RunOrchestratorStore = Depends(get_run_orchestrator_store),
     run_store: RunStore = Depends(get_run_store),
     runs_publisher: RunsPublisher = Depends(get_runs_publisher),
+    maintenance_runs_publisher: MaintenanceRunsPublisher = Depends(
+        get_maintenance_runs_publisher
+    ),
 ) -> RunController:
     """Get a RunController for the current run.
 
@@ -72,6 +80,7 @@ async def get_run_controller(
         run_orchestrator_store=run_orchestrator_store,
         run_store=run_store,
         runs_publisher=runs_publisher,
+        maintenance_runs_publisher=maintenance_runs_publisher,
     )
 
 

--- a/robot-server/robot_server/runs/run_controller.py
+++ b/robot-server/robot_server/runs/run_controller.py
@@ -13,7 +13,7 @@ from .action_models import RunAction, RunActionType
 
 from opentrons.protocol_engine.types import DeckConfigurationType
 
-from robot_server.service.notifications import RunsPublisher
+from robot_server.service.notifications import RunsPublisher, MaintenanceRunsPublisher
 
 log = logging.getLogger(__name__)
 
@@ -32,12 +32,14 @@ class RunController:
         run_orchestrator_store: RunOrchestratorStore,
         run_store: RunStore,
         runs_publisher: RunsPublisher,
+        maintenance_runs_publisher: MaintenanceRunsPublisher,
     ) -> None:
         self._run_id = run_id
         self._task_runner = task_runner
         self._run_orchestrator_store = run_orchestrator_store
         self._run_store = run_store
         self._runs_publisher = runs_publisher
+        self._maintenance_runs_publisher = maintenance_runs_publisher
 
     def create_action(
         self,
@@ -80,6 +82,8 @@ class RunController:
                         func=self._run_protocol_and_insert_result,
                         deck_configuration=action_payload,
                     )
+                    # Playing a protocol run terminates an existing maintenance run.
+                    self._maintenance_runs_publisher.publish_current_maintenance_run()
 
             elif action_type == RunActionType.PAUSE:
                 log.info(f'Pausing run "{self._run_id}".')

--- a/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
@@ -16,13 +16,19 @@ class MaintenanceRunsPublisher:
         """Returns a configured Maintenance Runs Publisher."""
         self._client = client
 
-    async def publish_current_maintenance_run(
+    async def publish_current_maintenance_run_async(
         self,
     ) -> None:
         """Publishes the equivalent of GET /maintenance_run/current_run"""
         await self._client.publish_advise_refetch_async(
             topic=topics.MAINTENANCE_RUNS_CURRENT_RUN
         )
+
+    def publish_current_maintenance_run(
+        self,
+    ) -> None:
+        """Publishes the equivalent of GET /maintenance_run/current_run"""
+        self._client.publish_advise_refetch(topic=topics.MAINTENANCE_RUNS_CURRENT_RUN)
 
 
 _maintenance_runs_publisher_accessor: AppStateAccessor[

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -14,7 +14,7 @@ from opentrons.protocol_engine import (
 from opentrons.protocol_engine.types import RunTimeParameter, BooleanParameter
 from opentrons.protocol_runner import RunResult
 
-from robot_server.service.notifications import RunsPublisher
+from robot_server.service.notifications import RunsPublisher, MaintenanceRunsPublisher
 from robot_server.service.task_runner import TaskRunner
 from robot_server.runs.action_models import RunAction, RunActionType
 from robot_server.runs.run_orchestrator_store import RunOrchestratorStore
@@ -46,6 +46,12 @@ def mock_task_runner(decoy: Decoy) -> TaskRunner:
 def mock_runs_publisher(decoy: Decoy) -> RunsPublisher:
     """Get a mock RunsPublisher."""
     return decoy.mock(cls=RunsPublisher)
+
+
+@pytest.fixture()
+def mock_maintenance_runs_publisher(decoy: Decoy) -> MaintenanceRunsPublisher:
+    """Get a mock RunsPublisher."""
+    return decoy.mock(cls=MaintenanceRunsPublisher)
 
 
 @pytest.fixture
@@ -99,6 +105,7 @@ def subject(
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     mock_runs_publisher: RunsPublisher,
+    mock_maintenance_runs_publisher: MaintenanceRunsPublisher,
 ) -> RunController:
     """Get a RunController test subject."""
     return RunController(
@@ -107,6 +114,7 @@ def subject(
         run_store=mock_run_store,
         task_runner=mock_task_runner,
         runs_publisher=mock_runs_publisher,
+        maintenance_runs_publisher=mock_maintenance_runs_publisher,
     )
 
 
@@ -144,6 +152,7 @@ async def test_create_play_action_to_start(
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     mock_runs_publisher: RunsPublisher,
+    mock_maintenance_runs_publisher: MaintenanceRunsPublisher,
     engine_state_summary: StateSummary,
     run_time_parameters: List[RunTimeParameter],
     protocol_commands: List[pe_commands.Command],
@@ -191,6 +200,12 @@ async def test_create_play_action_to_start(
             run_time_parameters=run_time_parameters,
         ),
         await mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
+        times=1,
+    )
+
+    # Verify maintenance run publication after background task execution
+    decoy.verify(
+        mock_maintenance_runs_publisher.publish_current_maintenance_run(),
         times=1,
     )
 

--- a/robot-server/tests/service/notifications/publishers/test_maintenance_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_maintenance_runs_publisher.py
@@ -24,7 +24,7 @@ async def test_publish_current_maintenance_run(
     notification_client: AsyncMock, maintenance_runs_publisher: MaintenanceRunsPublisher
 ) -> None:
     """It should publish a notify flag for maintenance runs."""
-    await maintenance_runs_publisher.publish_current_maintenance_run()
+    await maintenance_runs_publisher.publish_current_maintenance_run_async()
     notification_client.publish_advise_refetch_async.assert_awaited_once_with(
         topic=topics.MAINTENANCE_RUNS_CURRENT_RUN
     )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When a client posts a `PLAY` action that starts a protocol run, any existing maintenance run ID is cleared from the server. This means that MQTT should update subscribers interested in the current maintenance run. 

I've decided to follow the existing pattern for how we've handled async/sync publishing in the past, which is create a sync version if one doesn't exist instead of changing the method that uses the publish to async. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified via Postman that the `refetch` at `robot-server/maintenance_runs/current_run` occurs when playing a protocol run for the first time that run.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed starting protocol runs not properly alerting the desktop app and ODD that maintenance runs should be closed. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
