### PR TITLE
fix(app): thermocycler location display

### DIFF
--- a/app/src/pages/ProtocolDetails/Hardware.tsx
+++ b/app/src/pages/ProtocolDetails/Hardware.tsx
@@ -21,6 +21,8 @@ import {
   GRIPPER_V1_2,
   MAGNETIC_BLOCK_FIXTURES,
   MAGNETIC_BLOCK_TYPE,
+  TC_MODULE_LOCATION_OT3,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import {
@@ -113,7 +115,11 @@ function HardwareItem({
     </LegacyStyledText>
   )
   if (hardware.hardwareType === 'module') {
-    location = <DeckInfoLabel deckLabel={hardware.slot} />
+    const slot =
+      getModuleType(hardware.moduleModel) === THERMOCYCLER_MODULE_TYPE
+        ? TC_MODULE_LOCATION_OT3
+        : hardware.slot
+    location = <DeckInfoLabel deckLabel={slot} />
   } else if (hardware.hardwareType === 'fixture') {
     location = (
       <DeckInfoLabel

--- a/app/src/pages/ProtocolDetails/__tests__/Hardware.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/Hardware.test.tsx
@@ -60,6 +60,13 @@ describe('Hardware', () => {
             connected: false,
           },
           {
+            hardwareType: 'module',
+            moduleModel: 'thermocyclerModuleV2',
+            slot: 'B1',
+            hasSlotConflict: false,
+            connected: false,
+          },
+          {
             hardwareType: 'fixture',
             cutoutFixtureId: WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
             location: { cutout: WASTE_CHUTE_CUTOUT },
@@ -92,6 +99,7 @@ describe('Hardware', () => {
     })
     screen.getByRole('row', { name: '1 Heater-Shaker Module GEN1' })
     screen.getByRole('row', { name: '3 Temperature Module GEN2' })
+    screen.getByRole('row', { name: 'A1+B1 Thermocycler Module GEN2' })
     screen.getByRole('row', { name: 'D3 Waste chute only' })
     screen.getByRole('row', { name: 'B3 Staging area slot' })
   })


### PR DESCRIPTION
# Overview

Special case thermocycler location on ODD ProtocolDetails Hardware (A1+B1)

Closes RQA-2938

## Test Plan and Hands on Testing

- Upload a protocol that loads a thermocycler onto a flex
- Navigate to ProtocolDetails > Hardware on ODD
- Verify that Thermocycler display is A1+B1
<img width="962" alt="Screenshot 2024-08-09 at 10 50 47 AM" src="https://github.com/user-attachments/assets/2fc500d5-846f-49ac-9338-25dc39040a3f">


## Changelog

- special case TC module location on ProtocolDetails Hardware
- add test

## Review requests

see test plan

## Risk assessment

low