### PR TITLE
fix(app): fix liquid & modules confirm

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -74,6 +74,7 @@
   "deck_conflict_info": "<block>Update the deck configuration by removing the <strong>{{currentFixture}}</strong> in location <strong>{{cutout}}</strong>. Either remove the fixture from the deck configuration or update the protocol.</block>",
   "deck_conflict": "Deck location conflict",
   "deck_hardware": "Deck hardware",
+  "deck_hardware_ready": "Deck hardware ready",
   "deck_map": "Deck Map",
   "default_values": "Default values",
   "example": "Example",

--- a/app/src/organisms/Devices/ProtocolRun/EmptySetupStep.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/EmptySetupStep.tsx
@@ -6,24 +6,30 @@ import {
   SPACING,
   LegacyStyledText,
   TYPOGRAPHY,
+  DIRECTION_ROW,
+  JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
 
 interface EmptySetupStepProps {
   title: React.ReactNode
   description: string
+  rightElement?: React.ReactNode
 }
 
 export function EmptySetupStep(props: EmptySetupStepProps): JSX.Element {
-  const { title, description } = props
+  const { title, description, rightElement } = props
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} color={COLORS.grey40}>
-      <LegacyStyledText
-        css={TYPOGRAPHY.h3SemiBold}
-        marginBottom={SPACING.spacing4}
-      >
-        {title}
-      </LegacyStyledText>
-      <LegacyStyledText as="p">{description}</LegacyStyledText>
+    <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+      <Flex flexDirection={DIRECTION_COLUMN} color={COLORS.grey40}>
+        <LegacyStyledText
+          css={TYPOGRAPHY.h3SemiBold}
+          marginBottom={SPACING.spacing4}
+        >
+          {title}
+        </LegacyStyledText>
+        <LegacyStyledText as="p">{description}</LegacyStyledText>
+      </Flex>
+      {rightElement}
     </Flex>
   )
 }

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -513,6 +513,8 @@ function PrepareToRun({
     areModulesReady && areFixturesReady && !isLocationConflict
       ? 'ready'
       : 'not ready'
+  // Liquids information
+  const liquidsInProtocol = mostRecentAnalysis?.liquids ?? []
 
   const isReadyToRun =
     incompleteInstrumentCount === 0 && areModulesReady && areFixturesReady
@@ -525,7 +527,11 @@ function PrepareToRun({
           confirmAttachment()
         } else if (
           runStatus === RUN_STATUS_IDLE &&
-          !(labwareConfirmed && offsetsConfirmed && liquidsConfirmed)
+          !(
+            labwareConfirmed &&
+            offsetsConfirmed &&
+            (liquidsConfirmed || liquidsInProtocol.length === 0)
+          )
         ) {
           confirmStepsComplete()
         } else {
@@ -654,9 +660,6 @@ function PrepareToRun({
     runRecord?.data?.labwareOffsets ?? []
   )
 
-  // Liquids information
-  const liquidsInProtocol = mostRecentAnalysis?.liquids ?? []
-
   const { data: doorStatus } = useDoorQuery({
     refetchInterval: FETCH_DURATION_MS,
   })
@@ -757,7 +760,7 @@ function PrepareToRun({
               detail={modulesDetail}
               subDetail={modulesSubDetail}
               status={modulesStatus}
-              disabled={
+              interactionDisabled={
                 protocolModulesInfo.length === 0 && !protocolHasFixtures
               }
             />
@@ -799,7 +802,11 @@ function PrepareToRun({
                 setSetupScreen('liquids')
               }}
               title={i18n.format(t('liquids'), 'capitalize')}
-              status={liquidsConfirmed ? 'ready' : 'general'}
+              status={
+                liquidsConfirmed || liquidsInProtocol.length === 0
+                  ? 'ready'
+                  : 'general'
+              }
               detail={
                 liquidsInProtocol.length > 0
                   ? t('initial_liquids_num', {
@@ -807,7 +814,7 @@ function PrepareToRun({
                     })
                   : t('liquids_not_in_setup')
               }
-              disabled={liquidsInProtocol.length === 0}
+              interactionDisabled={liquidsInProtocol.length === 0}
             />
           </>
         ) : (


### PR DESCRIPTION
Fixes RQA-2925 for desktop: the liquids entry now will count as complete for the purposes of not popping or being listed in the modal if you have no liquids. It also gets complete decorations if there are no liquids. That required adding that rightElement thing to the empty version of the setup step, and that also is what we would need to do for modules, so also add decorations for modules and fix the completion logic to count the module actually being plugged in again (this was RQA-2928).

On the ODD, similar kind of logic but a lot easier to implement because the data is more local; we can default the state to !hasLiquids, and then use the same styling we already had implemented for runtime parameters for the setup step.

Also, remove some stylistically out of date text transforms on the setup cards.

## testing and review
- [x] Upload a protocol that has no liquids and no modules and no deck fixtures
   - [x] the liquids and modules tabs should should default to completed, meaning
      - [x] on desktop, they get complete badges and text (including on the OT-2)
      - [x] on the ODD, they get rendered green
      - [x] on desktop and ODD, they don't inhibit starting the run
          - [x] including that if you haven't confirmed some other step, the steps nag modal doesn't mention liquids
- [x] on a protocol that requires modules, if you don't have the modules plugged in you get an action needed badge


Closes RQA-2928
Closes RQA-2925
