### PR TITLE
feat(robot-server): add data file deletion endpoint

### DIFF
--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -8,15 +8,16 @@ from decoy import Decoy
 from fastapi import UploadFile
 from opentrons.protocol_reader import FileHasher, FileReaderWriter, BufferedFile
 
-from robot_server.service.json_api import MultiBodyMeta
+from robot_server.service.json_api import MultiBodyMeta, SimpleEmptyBody
 
 from robot_server.data_files.data_files_store import DataFilesStore, DataFileInfo
-from robot_server.data_files.models import DataFile, FileIdNotFoundError
+from robot_server.data_files.models import DataFile, FileIdNotFoundError, FileInUseError
 from robot_server.data_files.router import (
     upload_data_file,
     get_data_file_info_by_id,
     get_data_file,
     get_all_data_files,
+    delete_file_by_id,
 )
 from robot_server.data_files.file_auto_deleter import DataFileAutoDeleter
 from robot_server.errors.error_responses import ApiError
@@ -377,3 +378,48 @@ async def test_get_all_data_file_info(
         ),
     ]
     assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=2)
+
+
+async def test_delete_by_file_id(
+    decoy: Decoy,
+    data_files_store: DataFilesStore,
+) -> None:
+    """It should delete the data file."""
+    result = await delete_file_by_id(
+        dataFileId="file-id", data_files_store=data_files_store
+    )
+    decoy.verify(data_files_store.remove(file_id="file-id"))
+
+    assert result.content == SimpleEmptyBody()
+    assert result.status_code == 200
+
+
+async def test_delete_non_existent_file(
+    decoy: Decoy,
+    data_files_store: DataFilesStore,
+) -> None:
+    """It should raise an error if the file ID doesn't exist."""
+    decoy.when(data_files_store.remove("file-id")).then_raise(
+        FileIdNotFoundError(data_file_id="file-id")
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await delete_file_by_id(dataFileId="file-id", data_files_store=data_files_store)
+
+    assert exc_info.value.status_code == 404
+
+
+async def test_delete_file_in_use(
+    decoy: Decoy,
+    data_files_store: DataFilesStore,
+) -> None:
+    """It should raise an error if the file to be deleted is in use."""
+    decoy.when(data_files_store.remove("file-id")).then_raise(
+        FileInUseError(
+            data_file_id="file-id", ids_used_in_runs=set(), ids_used_in_analyses=set()
+        )
+    )
+    with pytest.raises(ApiError) as exc_info:
+        await delete_file_by_id(dataFileId="file-id", data_files_store=data_files_store)
+
+    assert exc_info.value.status_code == 409

--- a/robot-server/tests/integration/http_api/data_files/test_deletion.tavern.yaml
+++ b/robot-server/tests/integration/http_api/data_files/test_deletion.tavern.yaml
@@ -1,0 +1,37 @@
+test_name: Delete a data file from the server
+
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+
+stages:
+  - name: Upload a data file
+    request:
+      url: '{ot2_server_base_url}/dataFiles'
+      method: POST
+      files:
+        file: 'tests/integration/data_files/sample_record.csv'
+    response:
+      save:
+        json:
+          data_file_id: data.id
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          name: "sample_record.csv"
+          createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+
+  - name: Delete the data file
+    request:
+      url: '{ot2_server_base_url}/dataFiles/{data_file_id}'
+      method: DELETE
+    response:
+      status_code: 200
+
+  - name: Check that the file is removed
+    request:
+      url: '{ot2_server_base_url}/dataFiles/{data_file_id}'
+      method: GET
+    response:
+      status_code: 404

--- a/robot-server/tests/integration/http_api/data_files/test_upload_data_file.tavern.yaml
+++ b/robot-server/tests/integration/http_api/data_files/test_upload_data_file.tavern.yaml
@@ -49,6 +49,7 @@ stages:
           id: !anystr
           name: "sample_record.csv"
           createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+
   - name: Get color_codes.csv file info
     request:
       url: '{ot2_server_base_url}/dataFiles/{data_file_id}'

--- a/robot-server/tests/integration/http_api/protocols/test_analyses_with_csv_file_parameters.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_analyses_with_csv_file_parameters.tavern.yaml
@@ -18,11 +18,6 @@ stages:
           csv_file_name: data.name
           file_created_at: data.createdAt
       status_code:
-      # If the file exists on the test server then accept 200 else 201.
-      # We have to do this because the persistent storage is scoped to a test session and
-      # there are tests elsewhere in the suite that upload the same file.
-      # We currently do not allow deleting data files over http, so this situation is not easy to change.
-      - 200
       - 201
       json:
         data:

--- a/robot-server/tests/integration/http_api/protocols/test_get_csv_files_used_with_protocol.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_get_csv_files_used_with_protocol.tavern.yaml
@@ -5,16 +5,6 @@ marks:
       - ot2_server_base_url
 
 stages:
-  # The order of these data file uploads is important for this test,
-  # since the list of data files returned for the specified protocol is in upload order.
-  # The order in which the files are uploaded in this test is the same as the order in which
-  # these files are uploaded in the overall integration tests suite.
-  # Until we add data file cleanup after each test, maintaining this order within the suite
-  # will be important.
-
-  # sample_record -> test
-  # sample_plates -> sample_record
-  # test -> sample_plates
   - name: Upload data file 1
     request:
       url: '{ot2_server_base_url}/dataFiles'
@@ -28,7 +18,6 @@ stages:
           data_file_1_name: data.name
       status_code:
         - 201
-        - 200
 
   - name: Upload data file 2
     request:
@@ -43,7 +32,6 @@ stages:
           data_file_2_name: data.name
       status_code:
         - 201
-        - 200
 
   - name: Upload data file 3
     request:
@@ -58,7 +46,6 @@ stages:
           data_file_3_name: data.name
       status_code:
         - 201
-        - 200
 
   - name: Upload protocol with CSV file ID
     request:

--- a/robot-server/tests/integration/http_api/runs/test_run_with_run_time_parameters.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_run_with_run_time_parameters.tavern.yaml
@@ -29,7 +29,6 @@ stages:
           data_file_id: data.id
       status_code:
         - 201
-        - 200
       json:
         data:
           id: !anystr

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -341,6 +341,20 @@ class RobotClient:
         response.raise_for_status()
         return response
 
+    async def get_data_files(self) -> Response:
+        """GET /dataFiles."""
+        response = await self.httpx_client.get(url=f"{self.base_url}/dataFiles")
+        response.raise_for_status()
+        return response
+
+    async def delete_data_file(self, file_id: str) -> Response:
+        """DELETE /dataFiles/{file_id}."""
+        response = await self.httpx_client.delete(
+            f"{self.base_url}/dataFiles/{file_id}"
+        )
+        response.raise_for_status()
+        return response
+
     async def get_data_files_download(self, data_file_id: str) -> Response:
         """GET /dataFiles/{data_file_id}/download"""
         response = await self.httpx_client.get(


### PR DESCRIPTION
Closes AUTH-649

# Overview

Adds data file deletion endpoint and updates integration test teardown to clear all data files after each test.

## Test Plan and Hands on Testing

This endpoint is not used by the app or ODD. Also is primarily created for the integration tests so integration tests passing should be good enough.

## Changelog

- added `DEL /dataFiles/{dataFileId}` endpoint
- added data files deletion to `integration/conftest.py`
- updated data file upload tavern tests to expect only 201 response upon file upload
- added data file deletion tests

## Risk assessment

None. Affects tests only.

