### PR TITLE
fix(app): require offsets before confirming

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -265,6 +265,7 @@
   "run_disabled_modules_and_calibration_not_complete": "Make sure robot calibration is complete and all modules are connected before proceeding to run",
   "run_disabled_modules_not_connected": "Make sure all modules are connected before proceeding to run",
   "run_labware_position_check": "run labware position check",
+  "run_labware_position_check_to_get_offsets": "Run Labware Position Check to get your labware offset data.",
   "run_never_started": "Run was never started",
   "run": "Run",
   "secure_labware_instructions": "Secure labware instructions",

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
@@ -135,9 +135,10 @@ export function SetupLabwarePositionCheck(
         >
           {t('confirm_offsets')}
         </SecondaryButton>
-        {lpcDisabledReason !== null ? (
+        {lpcDisabledReason != null || nonIdentityOffsets.length === 0 ? (
           <Tooltip tooltipProps={confirmOffsetsTooltipProps}>
-            {lpcDisabledReason}
+            {lpcDisabledReason ??
+              t('run_labware_position_check_to_get_offsets')}
           </Tooltip>
         ) : null}
         <PrimaryButton

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
@@ -127,7 +127,11 @@ export function SetupLabwarePositionCheck(
           id="LPC_setOffsetsConfirmed"
           padding={`${SPACING.spacing8} ${SPACING.spacing16}`}
           {...confirmOffsetsTargetProps}
-          disabled={offsetsConfirmed || lpcDisabledReason !== null}
+          disabled={
+            offsetsConfirmed ||
+            lpcDisabledReason !== null ||
+            nonIdentityOffsets.length === 0
+          }
         >
           {t('confirm_offsets')}
         </SecondaryButton>

--- a/app/src/organisms/ProtocolSetupOffsets/index.tsx
+++ b/app/src/organisms/ProtocolSetupOffsets/index.tsx
@@ -93,6 +93,7 @@ export function ProtocolSetupOffsets({
             ) : (
               <SmallButton
                 buttonText={t('confirm_placements')}
+                disabled={nonIdentityOffsets.length === 0}
                 onClick={() => {
                   setIsConfirmed(true)
                   setSetupScreen('prepare to run')


### PR DESCRIPTION
This forces you to take a pass through LPC or just commit to skipping it all.

## reviewing and testing
- [x] you can't click the button on odd when there are no offsets
- [x] you can't click the button on desktop when there are no offsets
- [x] you can click the button on odd when there are offsets
- [x] you can click the button on desktop when there are offsets

Closes RQA-2930
