### PR TITLE
fix(app): Update tip detection logic

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -22,7 +22,6 @@ import {
   useModulesQuery,
   useDoorQuery,
   useHost,
-  useInstrumentsQuery,
   useRunCommandErrors,
 } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
@@ -166,7 +165,6 @@ export function ProtocolRunHeader({
   const isRobotViewable = useIsRobotViewable(robotName)
   const runStatus = useRunStatus(runId)
   const { analysisErrors } = useProtocolAnalysisErrors(runId)
-  const { data: attachedInstruments } = useInstrumentsQuery()
   const isRunCurrent = Boolean(useNotifyRunQuery(runId)?.data?.data?.current)
   const mostRecentRunId = useMostRecentRunId()
   const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
@@ -224,10 +222,8 @@ export function ProtocolRunHeader({
     aPipetteWithTip,
   } = useTipAttachmentStatus({
     runId,
-    runRecord,
-    attachedInstruments,
+    runRecord: runRecord ?? null,
     host,
-    isFlex,
   })
   const {
     showDTModal,

--- a/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardFlows.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardFlows.test.tsx
@@ -13,6 +13,7 @@ import {
 import { getPipettesWithTipAttached } from '../getPipettesWithTipAttached'
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import { DropTipWizard } from '../DropTipWizard'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
 
 import type { Mock } from 'vitest'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
@@ -28,6 +29,7 @@ vi.mock('@opentrons/shared-data', async importOriginal => {
 vi.mock('../DropTipWizard')
 vi.mock('../getPipettesWithTipAttached')
 vi.mock('../hooks')
+vi.mock('@opentrons/react-api-client')
 
 const MOCK_ACTUAL_PIPETTE = {
   ...mockPipetteInfo.pipetteSpecs,
@@ -60,6 +62,7 @@ describe('useTipAttachmentStatus', () => {
     vi.mocked(getPipetteModelSpecs).mockReturnValue(MOCK_ACTUAL_PIPETTE)
     vi.mocked(DropTipWizard).mockReturnValue(<div>MOCK DROP TIP WIZ</div>)
     mockGetPipettesWithTipAttached.mockResolvedValue(mockPipettesWithTip)
+    vi.mocked(useInstrumentsQuery).mockReturnValue({ data: {} } as any)
   })
 
   afterEach(() => {

--- a/app/src/organisms/DropTipWizardFlows/__tests__/getPipettesWithTipAttached.test.ts
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/getPipettesWithTipAttached.test.ts
@@ -46,7 +46,7 @@ const mockCommands = {
     createMockCommand(LOAD_PIPETTE, 'load-left', LEFT_PIPETTE_ID),
     createMockCommand(LOAD_PIPETTE, 'load-right', RIGHT_PIPETTE_ID),
     createMockCommand(PICK_UP_TIP, 'pickup-left', LEFT_PIPETTE_ID),
-    createMockCommand(DROP_TIP, 'drop-left', LEFT_PIPETTE_ID, 'failed'),
+    createMockCommand(DROP_TIP, 'drop-left', LEFT_PIPETTE_ID, 'succeeded'),
   ],
   meta: { cursor: 0, totalLength: 4 },
 }
@@ -89,6 +89,20 @@ describe('getPipettesWithTipAttached', () => {
   })
 
   it('returns an empty array when no tips are attached according to protocol', async () => {
+    const mockCommandsWithoutAttachedTips = {
+      ...mockCommands,
+      data: [
+        createMockCommand(LOAD_PIPETTE, 'load-left', LEFT_PIPETTE_ID),
+        createMockCommand(LOAD_PIPETTE, 'load-right', RIGHT_PIPETTE_ID),
+        createMockCommand(PICK_UP_TIP, 'pickup-left', LEFT_PIPETTE_ID),
+        createMockCommand(DROP_TIP, 'drop-left', LEFT_PIPETTE_ID, 'succeeded'),
+      ],
+    }
+
+    vi.mocked(getCommands).mockResolvedValue({
+      data: mockCommandsWithoutAttachedTips,
+    } as any)
+
     const result = await getPipettesWithTipAttached(DEFAULT_PARAMS)
     expect(result).toEqual([])
   })

--- a/app/src/organisms/DropTipWizardFlows/__tests__/getPipettesWithTipAttached.test.ts
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/getPipettesWithTipAttached.test.ts
@@ -8,135 +8,54 @@ import type { GetPipettesWithTipAttached } from '../getPipettesWithTipAttached'
 
 vi.mock('@opentrons/api-client')
 
+const HOST_NAME = 'localhost'
+const RUN_ID = 'testRunId'
+const LEFT_PIPETTE_ID = 'testId1'
+const RIGHT_PIPETTE_ID = 'testId2'
+const LEFT_PIPETTE_NAME = 'testLeftName'
+const RIGHT_PIPETTE_NAME = 'testRightName'
+const PICK_UP_TIP = 'pickUpTip'
+const DROP_TIP = 'dropTip'
+const DROP_TIP_IN_PLACE = 'dropTipInPlace'
+const LOAD_PIPETTE = 'loadPipette'
+const FIXIT_INTENT = 'fixit'
+
 const mockAttachedInstruments = {
   data: [
-    {
-      mount: 'left',
-      state: {
-        tipDetected: true,
-      },
-    },
-    {
-      mount: 'right',
-      state: {
-        tipDetected: true,
-      },
-    },
+    { mount: LEFT, state: { tipDetected: true } },
+    { mount: RIGHT, state: { tipDetected: true } },
   ],
-  meta: {
-    cursor: 0,
-    totalLength: 2,
-  },
+  meta: { cursor: 0, totalLength: 2 },
 }
+
+const createMockCommand = (
+  type: string,
+  id: string,
+  pipetteId: string,
+  status = 'succeeded'
+) => ({
+  id,
+  key: `${id}-key`,
+  commandType: type,
+  status,
+  params: { pipetteId },
+})
 
 const mockCommands = {
   data: [
-    {
-      id: '7bce590e-78bd-4e6c-9166-cbd3d39468bf',
-      key: 'b56a8e50-b08e-4792-ae97-70d175d2cf9a',
-      commandType: 'loadPipette',
-      createdAt: '2023-10-20T13:16:53.519743+00:00',
-      startedAt: '2023-10-20T13:18:06.494736+00:00',
-      completedAt: '2023-10-20T13:18:06.758755+00:00',
-      status: 'succeeded',
-      params: {
-        pipetteName: 'p1000_single_flex',
-        mount: 'left',
-        pipetteId: 'testId1',
-      },
-    },
-    {
-      id: 'e6ebdf69-f1f3-418c-9f25-2068180bfaa8',
-      key: 'b0a989d0-b651-4735-b3e8-e1f20ce5f53a',
-      commandType: 'loadLabware',
-      createdAt: '2023-10-20T13:16:53.536868+00:00',
-      startedAt: '2023-10-20T13:18:06.764154+00:00',
-      completedAt: '2023-10-20T13:18:06.765661+00:00',
-      status: 'succeeded',
-      params: {
-        location: {
-          slotName: 'A3',
-        },
-        loadName: 'opentrons_1_trash_3200ml_fixed',
-        namespace: 'opentrons',
-        version: 1,
-        labwareId:
-          'df371a43-1885-4590-8ca3-d38dc3096753:opentrons/opentrons_1_trash_3200ml_fixed/1',
-        displayName: 'Opentrons Fixed Trash',
-      },
-    },
-    {
-      id: '256f1bcf-ae9f-4190-be8a-5389f6b1a962',
-      key: '88c55e6a-4eb7-4863-a96e-de1de8ae27da',
-      commandType: 'pickUpTip',
-      createdAt: '2023-10-20T13:16:53.633713+00:00',
-      startedAt: '2023-10-20T13:18:06.830080+00:00',
-      completedAt: '2023-10-20T13:18:18.820189+00:00',
-      status: 'succeeded',
-      params: {
-        labwareId:
-          'c4b5c4b1-b4f7-4ec6-a4b7-6c8155d7288b:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
-        pipetteId: 'testId1',
-      },
-    },
-    {
-      id: '7f362b85-2005-4ea7-ab50-3aba27be79ca',
-      key: '1bd57042-2f0d-4c0c-afa6-b1a7dfbff769',
-      commandType: 'aspirate',
-      createdAt: '2023-10-20T13:16:53.635966+00:00',
-      startedAt: '2023-10-20T13:18:18.822130+00:00',
-      completedAt: '2023-10-20T13:18:23.424071+00:00',
-      status: 'succeeded',
-      params: {
-        labwareId:
-          'd56511f1-8d02-4891-adba-d2710ae02279:opentrons/armadillo_96_wellplate_200ul_pcr_full_skirt/2',
-        wellName: 'A1',
-        wellLocation: {
-          origin: 'bottom',
-          offset: {
-            x: 0,
-            y: 0,
-            z: 1.0,
-          },
-        },
-        flowRate: 137.35,
-        volume: 5.0,
-        pipetteId: 'testId1',
-      },
-    },
-    {
-      id: '0220242c-4fe4-4d0c-92d8-71fcc45e944e',
-      key: 'a3e946a0-9b93-45d4-8d22-d08815bab0ce',
-      commandType: 'dropTip',
-      status: 'failed',
-      params: {
-        pipetteId: 'testId1',
-      },
-    },
+    createMockCommand(LOAD_PIPETTE, 'load-left', LEFT_PIPETTE_ID),
+    createMockCommand(LOAD_PIPETTE, 'load-right', RIGHT_PIPETTE_ID),
+    createMockCommand(PICK_UP_TIP, 'pickup-left', LEFT_PIPETTE_ID),
+    createMockCommand(DROP_TIP, 'drop-left', LEFT_PIPETTE_ID, 'failed'),
   ],
-  links: {
-    current: {
-      href:
-        '/runs/0d61a8ce-e5b8-4e09-9bf9-a65523094663/commands/0220242c-4fe4-4d0c-92d8-71fcc45e944e',
-      meta: {
-        runId: '0d61a8ce-e5b8-4e09-9bf9-a65523094663',
-        commandId: '0220242c-4fe4-4d0c-92d8-71fcc45e944e',
-        index: 10,
-        key: 'a3e946a0-9b93-45d4-8d22-d08815bab0ce',
-        createdAt: '2023-10-20T13:16:53.671711+00:00',
-      },
-    },
-  },
-  meta: {
-    cursor: 0,
-    totalLength: 11,
-  },
+  meta: { cursor: 0, totalLength: 4 },
 }
+
 const mockRunRecord = {
   data: {
     pipettes: [
-      { id: 'testId1', pipetteName: 'testLeftName', mount: 'left' },
-      { id: 'testId2', pipetteName: 'testRightName', mount: 'right' },
+      { id: LEFT_PIPETTE_ID, pipetteName: LEFT_PIPETTE_NAME, mount: LEFT },
+      { id: RIGHT_PIPETTE_ID, pipetteName: RIGHT_PIPETTE_NAME, mount: RIGHT },
     ],
   },
 }
@@ -146,9 +65,8 @@ describe('getPipettesWithTipAttached', () => {
 
   beforeEach(() => {
     DEFAULT_PARAMS = {
-      host: { hostname: 'localhost' },
-      isFlex: true,
-      runId: 'testRunId',
+      host: { hostname: HOST_NAME },
+      runId: RUN_ID,
       attachedInstruments: mockAttachedInstruments as any,
       runRecord: mockRunRecord as any,
     }
@@ -158,88 +76,99 @@ describe('getPipettesWithTipAttached', () => {
     } as any)
   })
 
-  it('returns an empty array if attachedInstruments is undefined', () => {
-    const params = {
-      ...DEFAULT_PARAMS,
-      attachedInstruments: undefined,
-    } as GetPipettesWithTipAttached
-
-    const result = getPipettesWithTipAttached(params)
-    return expect(result).resolves.toEqual([])
+  it('returns an empty array if attachedInstruments is null', async () => {
+    const params = { ...DEFAULT_PARAMS, attachedInstruments: null }
+    const result = await getPipettesWithTipAttached(params)
+    expect(result).toEqual([])
   })
 
-  it('returns an empty array if runRecord is undefined', () => {
-    const params = {
-      ...DEFAULT_PARAMS,
-      runRecord: undefined,
-    } as GetPipettesWithTipAttached
-
-    const result = getPipettesWithTipAttached(params)
-    return expect(result).resolves.toEqual([])
+  it('returns an empty array if runRecord is null', async () => {
+    const params = { ...DEFAULT_PARAMS, runRecord: null }
+    const result = await getPipettesWithTipAttached(params)
+    expect(result).toEqual([])
   })
 
-  it('returns pipettes with sensor detected tip attachment if the robot is a Flex', () => {
-    const result = getPipettesWithTipAttached(DEFAULT_PARAMS)
-    return expect(result).resolves.toEqual(mockAttachedInstruments.data)
+  it('returns an empty array when no tips are attached according to protocol', async () => {
+    const result = await getPipettesWithTipAttached(DEFAULT_PARAMS)
+    expect(result).toEqual([])
   })
 
-  it('returns pipettes with protocol detected tip attachment if the sensor does not detect tip attachment', () => {
-    const noTipDetectedInstruments = {
-      ...mockAttachedInstruments,
-      data: mockAttachedInstruments.data.map(item => ({
-        ...item,
-        state: {
-          ...item.state,
-          tipDetected: false,
-        },
-      })),
+  it('returns pipettes with protocol detected tip attachment', async () => {
+    const mockCommandsWithPickUpTip = {
+      ...mockCommands,
+      data: [
+        ...mockCommands.data,
+        createMockCommand(PICK_UP_TIP, 'pickup-left-2', LEFT_PIPETTE_ID),
+        createMockCommand(PICK_UP_TIP, 'pickup-right', RIGHT_PIPETTE_ID),
+      ],
     }
 
-    const params = {
-      ...DEFAULT_PARAMS,
-      attachedInstruments: noTipDetectedInstruments,
-    } as GetPipettesWithTipAttached
+    vi.mocked(getCommands).mockResolvedValue({
+      data: mockCommandsWithPickUpTip,
+    } as any)
 
-    const result = getPipettesWithTipAttached(params)
-    return expect(result).resolves.toEqual([noTipDetectedInstruments.data[0]])
-  })
-
-  it('returns pipettes with protocol detected tip attachment if the robot is an OT-2', () => {
-    const params = {
-      ...DEFAULT_PARAMS,
-      isFlex: false,
-    } as GetPipettesWithTipAttached
-
-    const result = getPipettesWithTipAttached(params)
-    return expect(result).resolves.toEqual([mockAttachedInstruments.data[0]])
+    const result = await getPipettesWithTipAttached(DEFAULT_PARAMS)
+    expect(result).toEqual(mockAttachedInstruments.data)
   })
 
   it('always returns the left mount before the right mount if both pipettes have tips attached', async () => {
+    const mockCommandsWithPickUpTip = {
+      ...mockCommands,
+      data: [
+        ...mockCommands.data,
+        createMockCommand(PICK_UP_TIP, 'pickup-right', RIGHT_PIPETTE_ID),
+        createMockCommand(PICK_UP_TIP, 'pickup-left-2', LEFT_PIPETTE_ID),
+      ],
+    }
+
+    vi.mocked(getCommands).mockResolvedValue({
+      data: mockCommandsWithPickUpTip,
+    } as any)
+
     const result = await getPipettesWithTipAttached(DEFAULT_PARAMS)
+    expect(result.length).toBe(2)
     expect(result[0].mount).toEqual(LEFT)
     expect(result[1].mount).toEqual(RIGHT)
   })
 
   it('does not return otherwise legitimate failed tip exchange commands if fixit intent tip commands are present and successful', async () => {
-    const mockCommandsWithFixit = mockCommands.data.push({
-      id: '0220242c-4fe4-4d0c-92d8-71fcc45e944e',
-      key: 'a3e946a0-9b93-45d4-8d22-d08815bab0ce',
-      intent: 'fixit',
-      commandType: 'dropTipInPlace',
-      status: 'succeeded',
-      params: {
-        pipetteId: 'testId1',
-      },
-    } as any)
+    const mockCommandsWithFixit = {
+      ...mockCommands,
+      data: [
+        ...mockCommands.data,
+        {
+          ...createMockCommand(
+            DROP_TIP_IN_PLACE,
+            'fixit-drop',
+            LEFT_PIPETTE_ID
+          ),
+          intent: FIXIT_INTENT,
+        },
+      ],
+    }
 
     vi.mocked(getCommands).mockResolvedValue({
-      data: { data: mockCommandsWithFixit, meta: { totalLength: 11 } },
+      data: mockCommandsWithFixit,
     } as any)
 
-    const result = await getPipettesWithTipAttached({
-      ...DEFAULT_PARAMS,
-      isFlex: false,
-    })
+    const result = await getPipettesWithTipAttached(DEFAULT_PARAMS)
     expect(result).toEqual([])
+  })
+
+  it('considers a tip attached only if the last tip exchange command was pickUpTip', async () => {
+    const mockCommandsWithPickUpTip = {
+      ...mockCommands,
+      data: [
+        ...mockCommands.data,
+        createMockCommand(PICK_UP_TIP, 'pickup-left-2', LEFT_PIPETTE_ID),
+      ],
+    }
+
+    vi.mocked(getCommands).mockResolvedValue({
+      data: mockCommandsWithPickUpTip,
+    } as any)
+
+    const result = await getPipettesWithTipAttached(DEFAULT_PARAMS)
+    expect(result).toEqual([mockAttachedInstruments.data[0]])
   })
 })

--- a/app/src/organisms/DropTipWizardFlows/getPipettesWithTipAttached.ts
+++ b/app/src/organisms/DropTipWizardFlows/getPipettesWithTipAttached.ts
@@ -102,7 +102,8 @@ function checkPipettesForAttachedTips(
       isTipExchangeCommand &&
       pipetteUsedInCommandWithUnknownTipStatus != null
     ) {
-      const tipPossiblyAttached = commandType === 'pickUpTip'
+      const tipPossiblyAttached =
+        commands[i].status !== 'succeeded' || commandType === 'pickUpTip'
 
       if (tipPossiblyAttached) {
         mountsWithTipAttached.push(

--- a/app/src/organisms/DropTipWizardFlows/getPipettesWithTipAttached.ts
+++ b/app/src/organisms/DropTipWizardFlows/getPipettesWithTipAttached.ts
@@ -17,15 +17,13 @@ import type {
 export interface GetPipettesWithTipAttached {
   host: HostConfig | null
   runId: string
-  isFlex: boolean
-  attachedInstruments?: Instruments
-  runRecord?: Run
+  attachedInstruments: Instruments | null
+  runRecord: Run | null
 }
 
 export function getPipettesWithTipAttached({
   host,
   runId,
-  isFlex,
   attachedInstruments,
   runRecord,
 }: GetPipettesWithTipAttached): Promise<PipetteData[]> {
@@ -39,7 +37,6 @@ export function getPipettesWithTipAttached({
   ).then(executedCmdData =>
     checkPipettesForAttachedTips(
       executedCmdData.data,
-      isFlex,
       runRecord.data.pipettes,
       attachedInstruments.data as PipetteData[]
     )
@@ -62,34 +59,15 @@ function getCommandsExecutedDuringRun(
   })
 }
 
+const TIP_EXCHANGE_COMMAND_TYPES = ['dropTip', 'dropTipInPlace', 'pickUpTip']
+
 function checkPipettesForAttachedTips(
   commands: RunCommandSummary[],
-  isFlex: boolean,
   pipettesUsedInRun: LoadedPipette[],
   attachedPipettes: PipetteData[]
 ): PipetteData[] {
   let pipettesWithUnknownTipStatus = pipettesUsedInRun
-  let mountsWithTipAttached: Array<PipetteData['mount']> = []
-
-  // Check if the Flex detects a tip attached.
-  if (isFlex) {
-    mountsWithTipAttached = pipettesWithUnknownTipStatus
-      .filter(pipetteWithUnknownTipStatus =>
-        attachedPipettes.some(
-          attachedInstrument =>
-            attachedInstrument.mount === pipetteWithUnknownTipStatus.mount &&
-            attachedInstrument.state?.tipDetected
-        )
-      )
-      .map(pipetteWithTipDetected => pipetteWithTipDetected.mount)
-
-    pipettesWithUnknownTipStatus = pipettesWithUnknownTipStatus.filter(
-      pipetteWithUnkownStatus =>
-        !mountsWithTipAttached.includes(pipetteWithUnkownStatus.mount)
-    )
-  }
-
-  const TIP_EXCHANGE_COMMAND_TYPES = ['dropTip', 'dropTipInPlace', 'pickUpTip']
+  const mountsWithTipAttached: Array<PipetteData['mount']> = []
 
   // Iterate backwards through commands, finding first tip exchange command for each pipette.
   // If there's a chance the tip is still attached, flag the pipette.
@@ -124,8 +102,7 @@ function checkPipettesForAttachedTips(
       isTipExchangeCommand &&
       pipetteUsedInCommandWithUnknownTipStatus != null
     ) {
-      const tipPossiblyAttached =
-        commands[i].status !== 'succeeded' || commandType === 'pickUpTip'
+      const tipPossiblyAttached = commandType === 'pickUpTip'
 
       if (tipPossiblyAttached) {
         mountsWithTipAttached.push(

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -1,5 +1,4 @@
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
-import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { useRouteUpdateActions } from './useRouteUpdateActions'
 import { useRecoveryCommands } from './useRecoveryCommands'
@@ -106,7 +105,6 @@ export function useERUtils({
 
   const tipStatusUtils = useRecoveryTipStatus({
     runId,
-    isFlex: robotType === FLEX_ROBOT_TYPE,
     runRecord,
     attachedInstruments,
   })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryTipStatus.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryTipStatus.ts
@@ -12,7 +12,6 @@ import type {
 
 interface UseRecoveryTipStatusProps {
   runId: string
-  isFlex: boolean
   attachedInstruments?: Instruments
   runRecord?: Run
 }
@@ -33,6 +32,7 @@ export function useRecoveryTipStatus(
   const tipAttachmentStatusUtils = useTipAttachmentStatus({
     ...props,
     host,
+    runRecord: props.runRecord ?? null,
   })
 
   const determineTipStatusWithLoading = (): Promise<PipetteWithTip[]> => {

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -37,7 +37,6 @@ import {
 import {
   useHost,
   useProtocolQuery,
-  useInstrumentsQuery,
   useDeleteRunMutation,
   useRunCommandErrors,
 } from '@opentrons/react-api-client'
@@ -82,7 +81,6 @@ export function RunSummary(): JSX.Element {
   const { data: runRecord } = useNotifyRunQuery(runId, { staleTime: Infinity })
   const isRunCurrent = Boolean(runRecord?.data?.current)
   const mostRecentRunId = useMostRecentRunId()
-  const { data: attachedInstruments } = useInstrumentsQuery()
   const { deleteRun } = useDeleteRunMutation()
   const runStatus = runRecord?.data.status ?? null
   const didRunSucceed = runStatus === RUN_STATUS_SUCCEEDED
@@ -168,10 +166,8 @@ export function RunSummary(): JSX.Element {
     aPipetteWithTip,
   } = useTipAttachmentStatus({
     runId,
-    runRecord,
-    attachedInstruments,
+    runRecord: runRecord ?? null,
     host,
-    isFlex: true,
   })
 
   // Determine tip status on initial render only. Error Recovery always handles tip status, so don't show it twice.


### PR DESCRIPTION
Closes [RQA-2935](https://opentrons.atlassian.net/browse/RQA-2935)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Now, whenever a protocol run ends, show drop tip CTAs if the run command history shows the run ended with tips attached, even if this was intentionally done by the user (intentional in the sense of the protocol never explicitly specifying a drop tip before the run ends).

All the changes here really occur in `getPipettesWithTipAttached`, and there are two:
- The aforementioned change.
- Don't use the Flex sensors anymore, since in practice, it's difficult to ensure the data we get isn't stale without delaying action for a bit.

Note that the run failure behavior and error recovery behavior remains the same.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified the above behavior using the following protocols:

Case 1, the client doesn't explicitly drop tips in their protocol (show the CTAs): 
```
from opentrons import protocol_api

# metadata
metadata = {
    "protocolName": "Pick up tip with no return",
    "author": "Name <opentrons@example.com>",
    "description": "Simple protocol to get started using the Flex",
}

# requirements
requirements = {"robotType": "Flex", "apiLevel": "2.15"}


# protocol run function
def run(protocol: protocol_api.ProtocolContext):
    tiprack_left = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul", location="C2"
    )
    left_pipette = protocol.load_instrument(
        instrument_name="flex_8channel_1000", mount="left", tip_racks=[tiprack_left]
    )
    left_pipette.pick_up_tip()


```

Case 2, the client does explicitly drop tips in their protocol (don't show the CTAs): 
```
from opentrons import protocol_api

# metadata
metadata = {
    "protocolName": "Pick up tip",
    "author": "Name <opentrons@example.com>",
    "description": "Simple protocol to get started using the Flex",
}

# requirements
requirements = {"robotType": "Flex", "apiLevel": "2.15"}


# protocol run function
def run(protocol: protocol_api.ProtocolContext):
    tiprack_left = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_200ul", location="D1"
    )
    left_pipette = protocol.load_instrument(
        instrument_name="flex_1channel_1000", mount="left", tip_racks=[tiprack_left]
    )
    left_pipette.pick_up_tip()
    left_pipette.return_tip()
```
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Drop tip CTAs now properly display at the end of a run based on tip state.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
@SyntaxColoring points out that at the end of a run, the robot implictly drops the tip without an explicit drop tip at the end of a protocol:

- The E-stop was pressed
- The run loaded no obvious trash where we can drop them
- The run was stopped by the user, as opposed to erroring or completing naturally

Knowing this, are we still ok nagging the users with drop tip CTAs despite the tips not actually being there? 
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low with the caveat mentioned in review requests
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2935]: https://opentrons.atlassian.net/browse/RQA-2935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ