### PR TITLE
feat(robot-server): Pulse status bar yellow during error recovery

### DIFF
--- a/api/src/opentrons/hardware_control/backends/status_bar_state.py
+++ b/api/src/opentrons/hardware_control/backends/status_bar_state.py
@@ -48,6 +48,11 @@ class StatusBarStateController:
         if self._enabled:
             await self._controller.static_color(status_bar.YELLOW)
 
+    async def _status_bar_error_recovery(self) -> None:
+        self._status_bar_state = StatusBarState.ERROR_RECOVERY
+        if self._enabled:
+            await self._controller.pulse_color(status_bar.YELLOW)
+
     async def _status_bar_confirm(self) -> None:
         # Confirm should revert to IDLE
         self._status_bar_state = StatusBarState.IDLE
@@ -163,6 +168,7 @@ class StatusBarStateController:
             StatusBarState.PAUSED: self._status_bar_paused,
             StatusBarState.HARDWARE_ERROR: self._status_bar_hardware_error,
             StatusBarState.SOFTWARE_ERROR: self._status_bar_software_error,
+            StatusBarState.ERROR_RECOVERY: self._status_bar_error_recovery,
             StatusBarState.CONFIRMATION: self._status_bar_confirm,
             StatusBarState.RUN_COMPLETED: self._status_bar_run_complete,
             StatusBarState.UPDATING: self._status_bar_updating,

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -572,17 +572,23 @@ class PauseType(enum.Enum):
 
 
 class StatusBarState(enum.Enum):
-    IDLE = 0
-    RUNNING = 1
-    PAUSED = 2
-    HARDWARE_ERROR = 3
-    SOFTWARE_ERROR = 4
-    CONFIRMATION = 5
-    RUN_COMPLETED = 6
-    UPDATING = 7
-    ACTIVATION = 8
-    DISCO = 9
-    OFF = 10
+    """Semantic status bar states.
+
+    These mostly correspond to cases listed out in the Flex manual.
+    """
+
+    IDLE = enum.auto()
+    RUNNING = enum.auto()
+    PAUSED = enum.auto()
+    HARDWARE_ERROR = enum.auto()
+    SOFTWARE_ERROR = enum.auto()
+    ERROR_RECOVERY = enum.auto()
+    CONFIRMATION = enum.auto()
+    RUN_COMPLETED = enum.auto()
+    UPDATING = enum.auto()
+    ACTIVATION = enum.auto()
+    DISCO = enum.auto()
+    OFF = enum.auto()
 
     def transient(self) -> bool:
         return self.value in {

--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -37,14 +37,15 @@ def _engine_status_to_status_bar(
             return StatusBarState.IDLE if initialization_done else StatusBarState.OFF
         case EngineStatus.RUNNING:
             return StatusBarState.RUNNING
+        case EngineStatus.PAUSED:
+            return StatusBarState.PAUSED
         case (
-            EngineStatus.PAUSED
-            | EngineStatus.BLOCKED_BY_OPEN_DOOR
+            EngineStatus.BLOCKED_BY_OPEN_DOOR
             | EngineStatus.AWAITING_RECOVERY
             | EngineStatus.AWAITING_RECOVERY_PAUSED
             | EngineStatus.AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR
         ):
-            return StatusBarState.PAUSED
+            return StatusBarState.ERROR_RECOVERY
         case EngineStatus.STOP_REQUESTED | EngineStatus.FINISHING:
             return StatusBarState.UPDATING
         case EngineStatus.STOPPED:

--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -37,11 +37,10 @@ def _engine_status_to_status_bar(
             return StatusBarState.IDLE if initialization_done else StatusBarState.OFF
         case EngineStatus.RUNNING:
             return StatusBarState.RUNNING
-        case EngineStatus.PAUSED:
+        case EngineStatus.PAUSED | EngineStatus.BLOCKED_BY_OPEN_DOOR:
             return StatusBarState.PAUSED
         case (
-            EngineStatus.BLOCKED_BY_OPEN_DOOR
-            | EngineStatus.AWAITING_RECOVERY
+            EngineStatus.AWAITING_RECOVERY
             | EngineStatus.AWAITING_RECOVERY_PAUSED
             | EngineStatus.AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR
         ):


### PR DESCRIPTION
## Overview

During error recovery, make the Flex's status bar light pulse yellow instead of pulsing blue. Closes RQA-2945.

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/1c845d1b-248e-474a-a3d3-34fa0a87bf6a

It looks more yellow in person.

## Review requests

None in particular.

## Risk assessment

Low.