### PR TITLE
fix(app-shell): forward usb request errors and log

### DIFF
--- a/app-shell/src/system-info/usb-devices.ts
+++ b/app-shell/src/system-info/usb-devices.ts
@@ -133,10 +133,15 @@ function upstreamDeviceFromUsbDeviceWinAPI(
       const parsePoshJsonOutputToWmiObjectArray = (
         dump: string
       ): WmiObject[] => {
-        if (dump[0] === '[') {
-          return JSON.parse(dump) as WmiObject[]
-        } else {
-          return [JSON.parse(dump) as WmiObject]
+        try {
+          if (dump[0] === '[') {
+            return JSON.parse(dump) as WmiObject[]
+          } else {
+            return [JSON.parse(dump) as WmiObject]
+          }
+        } catch (e: any) {
+          log.error(`Failed to parse posh json output: ${dump}`)
+          throw e
         }
       }
       if (dump.stderr !== '') {

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -95,17 +95,17 @@ function reconstructFormData(ipcSafeFormData: IPCSafeFormData): FormData {
 }
 
 const cloneError = (e: any): Record<string, unknown> =>
-  Object.entries(axios.isAxiosError(e) ? e.toJSON() : e).reduce(
-    (acc, [k, v]) => {
-      try {
-        acc[k] = structuredClone(v)
-        return acc
-      } catch (e) {
-        return acc
-      }
-    },
-    {} as Record<string, unknown>
-  )
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  Object.entries(axios.isAxiosError(e) ? e.toJSON() : e).reduce<
+    Record<string, unknown>
+  >((acc, [k, v]) => {
+    try {
+      acc[k] = structuredClone(v)
+      return acc
+    } catch (e) {
+      return acc
+    }
+  }, {})
 
 async function usbListener(
   _event: IpcMainInvokeEvent,

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -98,6 +98,18 @@ function reconstructFormData(ipcSafeFormData: IPCSafeFormData): FormData {
     return result
 }
 
+const cloneError = (e: object): object =>
+    Object.entries(axios.isAxiosError(e) ? e.toJSON() : e).reduce(
+        (acc, [k, v]) => {
+            try {
+                return (acc[k] = structuredClone(v))
+            } catch (e) {
+                return acc
+            }
+        },
+        {}
+    )
+
 async function usbListener(
     _event: IpcMainInvokeEvent,
     config: AxiosRequestConfig
@@ -135,7 +147,7 @@ async function usbListener(
     } catch (e) {
         usbLog.info(`${config.method} ${config.url} failed: ${e}`)
         return {
-            error: axios.isAxiosError(e) ? e.toJSON() : e,
+            error: cloneError(e),
         }
     }
 }

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -122,6 +122,7 @@ async function usbListener(
       headers: { ...config.headers, ...formHeaders },
     })
     usbLog.silly(`${config.method} ${config.url} resolved ok`)
+    usbLog.info(`response is ${JSON.stringify(response.data)}`)
     return {
       error: false,
       data: response.data,

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -18,7 +18,7 @@ import {
 } from './constants'
 
 import type { IpcMainInvokeEvent } from 'electron'
-import type { AxiosRequestConfig, isAxiosError } from 'axios'
+import { AxiosRequestConfig, isAxiosError } from 'axios'
 import type { IPCSafeFormData } from '@opentrons/app/src/redux/shell/types'
 import type { UsbDevice } from '@opentrons/app/src/redux/system-info/types'
 import type { PortInfo } from '@opentrons/usb-bridge/node-client'

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -18,7 +18,7 @@ import {
 } from './constants'
 
 import type { IpcMainInvokeEvent } from 'electron'
-import { AxiosRequestConfig, isAxiosError } from 'axios'
+import type { AxiosRequestConfig } from 'axios'
 import type { IPCSafeFormData } from '@opentrons/app/src/redux/shell/types'
 import type { UsbDevice } from '@opentrons/app/src/redux/system-info/types'
 import type { PortInfo } from '@opentrons/usb-bridge/node-client'
@@ -131,7 +131,7 @@ async function usbListener(
   } catch (e) {
     usbLog.info(
       `${config.method} ${config.url} failed: ${
-        isAxiosError(e) ? e.toJSON() : JSON.stringify(e)
+        axios.isAxiosError(e) ? e.toJSON() : JSON.stringify(e)
       }`
     )
     throw e

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -130,9 +130,9 @@ async function usbListener(
     }
   } catch (e) {
     usbLog.info(
-      `${config.method} ${config.url} failed: ${
-        axios.isAxiosError(e) ? e.toJSON() : JSON.stringify(e)
-      }`
+      `${config.method} ${config.url} failed: ${JSON.stringify(
+        axios.isAxiosError(e) ? e.toJSON() : e
+      )}`
     )
     throw e
   }

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -3,18 +3,18 @@ import axios from 'axios'
 import FormData from 'form-data'
 
 import {
-    fetchSerialPortList,
-    SerialPortHttpAgent,
-    DEFAULT_PRODUCT_ID,
-    DEFAULT_VENDOR_ID,
+  fetchSerialPortList,
+  SerialPortHttpAgent,
+  DEFAULT_PRODUCT_ID,
+  DEFAULT_VENDOR_ID,
 } from '@opentrons/usb-bridge/node-client'
 
 import { createLogger } from './log'
 import { usbRequestsStart, usbRequestsStop } from './config/actions'
 import {
-    SYSTEM_INFO_INITIALIZED,
-    USB_DEVICE_ADDED,
-    USB_DEVICE_REMOVED,
+  SYSTEM_INFO_INITIALIZED,
+  USB_DEVICE_ADDED,
+  USB_DEVICE_REMOVED,
 } from './constants'
 
 import type { IpcMainInvokeEvent } from 'electron'
@@ -29,202 +29,194 @@ const usbLog = createLogger('usb')
 let usbFetchInterval: NodeJS.Timeout
 
 export function getSerialPortHttpAgent(): SerialPortHttpAgent | undefined {
-    return usbHttpAgent
+  return usbHttpAgent
 }
 export function createSerialPortHttpAgent(
-    path: string,
-    onComplete: (err: Error | null, agent?: SerialPortHttpAgent) => void
+  path: string,
+  onComplete: (err: Error | null, agent?: SerialPortHttpAgent) => void
 ): void {
-    if (usbHttpAgent != null) {
-        onComplete(
-            new Error('Tried to make a USB http agent when one already existed')
-        )
-    } else {
-        usbHttpAgent = new SerialPortHttpAgent(
-            {
-                maxFreeSockets: 1,
-                maxSockets: 1,
-                maxTotalSockets: 1,
-                keepAlive: true,
-                keepAliveMsecs: Infinity,
-                path,
-                logger: usbLog,
-                timeout: 100000,
-            },
-            (err, agent?) => {
-                if (err != null) {
-                    usbHttpAgent = undefined
-                }
-                onComplete(err, agent)
-            }
-        )
-    }
+  if (usbHttpAgent != null) {
+    onComplete(
+      new Error('Tried to make a USB http agent when one already existed')
+    )
+  } else {
+    usbHttpAgent = new SerialPortHttpAgent(
+      {
+        maxFreeSockets: 1,
+        maxSockets: 1,
+        maxTotalSockets: 1,
+        keepAlive: true,
+        keepAliveMsecs: Infinity,
+        path,
+        logger: usbLog,
+        timeout: 100000,
+      },
+      (err, agent?) => {
+        if (err != null) {
+          usbHttpAgent = undefined
+        }
+        onComplete(err, agent)
+      }
+    )
+  }
 }
 
 export function destroyAndStopUsbHttpRequests(dispatch: Dispatch): void {
-    if (usbHttpAgent != null) {
-        usbHttpAgent.destroy()
-    }
-    usbHttpAgent = undefined
-    ipcMain.removeHandler('usb:request')
-    dispatch(usbRequestsStop())
-    // handle any additional invocations of usb:request
-    ipcMain.handle('usb:request', () =>
-        Promise.resolve({
-            status: 400,
-            statusText: 'USB robot disconnected',
-        })
-    )
+  if (usbHttpAgent != null) {
+    usbHttpAgent.destroy()
+  }
+  usbHttpAgent = undefined
+  ipcMain.removeHandler('usb:request')
+  dispatch(usbRequestsStop())
+  // handle any additional invocations of usb:request
+  ipcMain.handle('usb:request', () =>
+    Promise.resolve({
+      status: 400,
+      statusText: 'USB robot disconnected',
+    })
+  )
 }
 
 function isUsbDeviceOt3(device: UsbDevice): boolean {
-    return (
-        device.productId === parseInt(DEFAULT_PRODUCT_ID, 16) &&
-        device.vendorId === parseInt(DEFAULT_VENDOR_ID, 16)
-    )
+  return (
+    device.productId === parseInt(DEFAULT_PRODUCT_ID, 16) &&
+    device.vendorId === parseInt(DEFAULT_VENDOR_ID, 16)
+  )
 }
 
 function reconstructFormData(ipcSafeFormData: IPCSafeFormData): FormData {
-    const result = new FormData()
-    ipcSafeFormData.forEach(entry => {
-        entry.type === 'file'
-            ? result.append(
-                  entry.name,
-                  Buffer.from(entry.value),
-                  entry.filename
-              )
-            : result.append(entry.name, entry.value)
-    })
-    return result
+  const result = new FormData()
+  ipcSafeFormData.forEach(entry => {
+    entry.type === 'file'
+      ? result.append(entry.name, Buffer.from(entry.value), entry.filename)
+      : result.append(entry.name, entry.value)
+  })
+  return result
 }
 
-const cloneError = (e: object): object =>
-    Object.entries(axios.isAxiosError(e) ? e.toJSON() : e).reduce(
-        (acc, [k, v]) => {
-            try {
-                return (acc[k] = structuredClone(v))
-            } catch (e) {
-                return acc
-            }
-        },
-        {}
-    )
+const cloneError = (e: any): Record<string, unknown> =>
+  Object.entries(axios.isAxiosError(e) ? e.toJSON() : e).reduce(
+    (acc, [k, v]) => {
+      try {
+        acc[k] = structuredClone(v)
+        return acc
+      } catch (e) {
+        return acc
+      }
+    },
+    {} as Record<string, unknown>
+  )
 
 async function usbListener(
-    _event: IpcMainInvokeEvent,
-    config: AxiosRequestConfig
+  _event: IpcMainInvokeEvent,
+  config: AxiosRequestConfig
 ): Promise<unknown> {
-    // TODO(bh, 2023-05-03): remove mutation
-    let { data } = config
-    let formHeaders = {}
+  // TODO(bh, 2023-05-03): remove mutation
+  let { data } = config
+  let formHeaders = {}
 
-    // check for formDataProxy
-    if (data?.proxiedFormData != null) {
-        // reconstruct FormData
-        const formData = reconstructFormData(
-            data.proxiedFormData as IPCSafeFormData
-        )
-        formHeaders = formData.getHeaders()
-        data = formData
-    }
+  // check for formDataProxy
+  if (data?.proxiedFormData != null) {
+    // reconstruct FormData
+    const formData = reconstructFormData(
+      data.proxiedFormData as IPCSafeFormData
+    )
+    formHeaders = formData.getHeaders()
+    data = formData
+  }
 
-    const usbHttpAgent = getSerialPortHttpAgent()
-    try {
-        usbLog.silly(`${config.method} ${config.url} timeout=${config.timeout}`)
-        const response = await axios.request({
-            httpAgent: usbHttpAgent,
-            ...config,
-            data,
-            headers: { ...config.headers, ...formHeaders },
-        })
-        usbLog.silly(`${config.method} ${config.url} resolved ok`)
-        return {
-            error: null,
-            data: response.data,
-            status: response.status,
-            statusText: response.statusText,
-        }
-    } catch (e) {
-        usbLog.info(`${config.method} ${config.url} failed: ${e}`)
-        return {
-            error: cloneError(e),
-        }
+  const usbHttpAgent = getSerialPortHttpAgent()
+  try {
+    usbLog.silly(`${config.method} ${config.url} timeout=${config.timeout}`)
+    const response = await axios.request({
+      httpAgent: usbHttpAgent,
+      ...config,
+      data,
+      headers: { ...config.headers, ...formHeaders },
+    })
+    usbLog.silly(`${config.method} ${config.url} resolved ok`)
+    return {
+      error: null,
+      data: response.data,
+      status: response.status,
+      statusText: response.statusText,
     }
+  } catch (e: any) {
+    usbLog.info(`${config.method} ${config.url} failed: ${e}`)
+    return {
+      error: cloneError(e),
+    }
+  }
 }
 
 function pollSerialPortAndCreateAgent(dispatch: Dispatch): void {
-    // usb poll already initialized
-    if (usbFetchInterval != null) {
-        return
-    }
-    usbFetchInterval = setInterval(() => {
-        // already connected to an Opentrons robot via USB
-        tryCreateAndStartUsbHttpRequests(dispatch)
-    }, 10000)
+  // usb poll already initialized
+  if (usbFetchInterval != null) {
+    return
+  }
+  usbFetchInterval = setInterval(() => {
+    // already connected to an Opentrons robot via USB
+    tryCreateAndStartUsbHttpRequests(dispatch)
+  }, 10000)
 }
 
 function tryCreateAndStartUsbHttpRequests(dispatch: Dispatch): void {
-    fetchSerialPortList()
-        .then((list: PortInfo[]) => {
-            const ot3UsbSerialPort = list.find(
-                port =>
-                    port.productId?.localeCompare(DEFAULT_PRODUCT_ID, 'en-US', {
-                        sensitivity: 'base',
-                    }) === 0 &&
-                    port.vendorId?.localeCompare(DEFAULT_VENDOR_ID, 'en-US', {
-                        sensitivity: 'base',
-                    }) === 0
-            )
+  fetchSerialPortList()
+    .then((list: PortInfo[]) => {
+      const ot3UsbSerialPort = list.find(
+        port =>
+          port.productId?.localeCompare(DEFAULT_PRODUCT_ID, 'en-US', {
+            sensitivity: 'base',
+          }) === 0 &&
+          port.vendorId?.localeCompare(DEFAULT_VENDOR_ID, 'en-US', {
+            sensitivity: 'base',
+          }) === 0
+      )
 
-            // retry if no Flex serial port found - usb-detection and serialport packages have race condition
-            if (ot3UsbSerialPort == null) {
-                usbLog.debug('No Flex serial port found.')
-                return
-            }
-            if (usbHttpAgent == null) {
-                createSerialPortHttpAgent(
-                    ot3UsbSerialPort.path,
-                    (err, agent?) => {
-                        if (err != null) {
-                            const message = err?.message ?? err
-                            usbLog.error(
-                                `Failed to create serial port: ${message}`
-                            )
-                        }
-                        if (agent != null) {
-                            ipcMain.removeHandler('usb:request')
-                            ipcMain.handle('usb:request', usbListener)
-                            dispatch(usbRequestsStart())
-                        }
-                    }
-                )
-            }
+      // retry if no Flex serial port found - usb-detection and serialport packages have race condition
+      if (ot3UsbSerialPort == null) {
+        usbLog.debug('No Flex serial port found.')
+        return
+      }
+      if (usbHttpAgent == null) {
+        createSerialPortHttpAgent(ot3UsbSerialPort.path, (err, agent?) => {
+          if (err != null) {
+            const message = err?.message ?? err
+            usbLog.error(`Failed to create serial port: ${message}`)
+          }
+          if (agent != null) {
+            ipcMain.removeHandler('usb:request')
+            ipcMain.handle('usb:request', usbListener)
+            dispatch(usbRequestsStart())
+          }
         })
-        .catch(e =>
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            usbLog.debug(`fetchSerialPortList error ${e?.message ?? 'unknown'}`)
-        )
+      }
+    })
+    .catch(e =>
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      usbLog.debug(`fetchSerialPortList error ${e?.message ?? 'unknown'}`)
+    )
 }
 
 export function registerUsb(dispatch: Dispatch): (action: Action) => unknown {
-    return function handleIncomingAction(action: Action): void {
-        switch (action.type) {
-            case SYSTEM_INFO_INITIALIZED:
-                if (action.payload.usbDevices.find(isUsbDeviceOt3) != null) {
-                    tryCreateAndStartUsbHttpRequests(dispatch)
-                }
-                pollSerialPortAndCreateAgent(dispatch)
-                break
-            case USB_DEVICE_ADDED:
-                if (isUsbDeviceOt3(action.payload.usbDevice)) {
-                    tryCreateAndStartUsbHttpRequests(dispatch)
-                }
-                break
-            case USB_DEVICE_REMOVED:
-                if (isUsbDeviceOt3(action.payload.usbDevice)) {
-                    destroyAndStopUsbHttpRequests(dispatch)
-                }
-                break
+  return function handleIncomingAction(action: Action): void {
+    switch (action.type) {
+      case SYSTEM_INFO_INITIALIZED:
+        if (action.payload.usbDevices.find(isUsbDeviceOt3) != null) {
+          tryCreateAndStartUsbHttpRequests(dispatch)
         }
+        pollSerialPortAndCreateAgent(dispatch)
+        break
+      case USB_DEVICE_ADDED:
+        if (isUsbDeviceOt3(action.payload.usbDevice)) {
+          tryCreateAndStartUsbHttpRequests(dispatch)
+        }
+        break
+      case USB_DEVICE_REMOVED:
+        if (isUsbDeviceOt3(action.payload.usbDevice)) {
+          destroyAndStopUsbHttpRequests(dispatch)
+        }
+        break
     }
+  }
 }

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -57,7 +57,11 @@ export async function appShellRequestor<Data>(
       : data
   const configProxy = { ...config, data: formDataProxy }
 
-  return await remote.ipcRenderer.invoke('usb:request', configProxy)
+  const result = await remote.ipcRenderer.invoke('usb:request', configProxy)
+  if (result?.error != null) {
+    throw result.error
+  }
+  return result
 }
 
 interface CallbackStore {


### PR DESCRIPTION
We were swallowing all errors from usb requests, which doesn't seem like a great idea - it definitely led to lots of errors in browser logs.

Fixing this by propagating the errors back across the IPC allows the browser-side tanstack query stuff to actually notice that there were errors. Previously, those queries would just come back with `undefined`, and stuff higher up the stack would see that its maintenance run data was `undefined`, which is not something we test for or care about.

This seems to be a magic bullet that fixes various USB stability issues; I'm a bit suspicious of it solving _everything_, but in my testing it solves some things and it certainly can't hurt.

Closes RQA-2931 RQA-2933
