### PR TITLE
fix(api): Lld end z retract position bug

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2651,7 +2651,7 @@ class OT3API(
             top_types.Point(*self._config.gripper_mount_offset),
         )
         cp = self.critical_point_for(mount, None)
-        return deck_end_z + offset[2] + cp.z
+        return deck_end_z + offset.z + cp.z
 
     async def liquid_probe(
         self,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2629,7 +2629,7 @@ class OT3API(
         force_both_sensors: bool = False,
     ) -> float:
         plunger_direction = -1 if probe_settings.aspirate_while_sensing else 1
-        await self._backend.liquid_probe(
+        end_z = await self._backend.liquid_probe(
             mount,
             p_travel,
             probe_settings.mount_speed,
@@ -2641,8 +2641,17 @@ class OT3API(
             probe=probe,
             force_both_sensors=force_both_sensors,
         )
-        end_pos = await self.gantry_position(mount, refresh=True)
-        return end_pos.z
+        machine_pos = await self._backend.update_position()
+        machine_pos[Axis.by_mount(mount)] = end_z
+        deck_end_z = self._deck_from_machine(machine_pos)[Axis.by_mount(mount)]
+        offset = offset_for_mount(
+            mount,
+            top_types.Point(*self._config.left_mount_offset),
+            top_types.Point(*self._config.right_mount_offset),
+            top_types.Point(*self._config.gripper_mount_offset),
+        )
+        cp = self.critical_point_for(mount, None)
+        return deck_end_z + offset[2] + cp.z
 
     async def liquid_probe(
         self,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -815,15 +815,9 @@ async def test_liquid_probe(
     with patch.object(
         hardware_backend, "liquid_probe", AsyncMock(spec=hardware_backend.liquid_probe)
     ) as mock_liquid_probe:
-        return_dict = {
-            head_node: 140,
-            NodeId.gantry_x: 0,
-            NodeId.gantry_y: 0,
-            pipette_node: 0,
-        }
 
         # make sure aspirate while sensing reverses direction
-        mock_liquid_probe.return_value = return_dict
+        mock_liquid_probe.return_value = 140
         fake_settings_aspirate = LiquidProbeSettings(
             mount_speed=5,
             plunger_speed=20,
@@ -849,8 +843,6 @@ async def test_liquid_probe(
             force_both_sensors=False,
         )
 
-        return_dict[head_node], return_dict[pipette_node] = 142, 142
-        mock_liquid_probe.return_value = return_dict
         await ot3_hardware.liquid_probe(
             mount, fake_max_z_dist, fake_liquid_settings
         )  # should raise no exceptions
@@ -903,7 +895,7 @@ async def test_liquid_probe_plunger_moves(
             PipetteLiquidNotFoundError,
             PipetteLiquidNotFoundError,
             PipetteLiquidNotFoundError,
-            None,
+            140,
         ]
 
         fake_max_z_dist = 75.0
@@ -1056,16 +1048,10 @@ async def test_multi_liquid_probe(
     with patch.object(
         hardware_backend, "liquid_probe", AsyncMock(spec=hardware_backend.liquid_probe)
     ) as mock_liquid_probe:
-        return_dict = {
-            NodeId.head_l: 140,
-            NodeId.gantry_x: 0,
-            NodeId.gantry_y: 0,
-            NodeId.pipette_left: 0,
-        }
         side_effects = [
             PipetteLiquidNotFoundError(),
             PipetteLiquidNotFoundError(),
-            return_dict,
+            140,
         ]
 
         # make sure aspirate while sensing reverses direction
@@ -1102,9 +1088,6 @@ async def test_multi_liquid_probe(
             force_both_sensors=False,
         )
         assert mock_liquid_probe.call_count == 3
-
-        return_dict[NodeId.head_l], return_dict[NodeId.pipette_left] = 142, 142
-        mock_liquid_probe.return_value = return_dict
 
 
 async def test_liquid_not_found(

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -201,7 +201,7 @@ async def run_sync_buffer_to_csv(
             ),
             expected_nodes=[tool],
         )
-    if raise_z is not None and False:
+    if raise_z is not None:
         #  if probing is finished, move the head node back up before requesting the data buffer
         if positions[head_node].move_ack == MoveCompleteAck.stopped_by_condition:
             await raise_z.run(can_messenger=messenger)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The Z is supposed to retract out to the liquid before sending over the buffered data, however a line from testing got merged in there and this wasn't happening. Also had to fixup the api side since it was calculating the liquid height based off where the machine position was after hardware control took over, now it actually uses the return value to that it returns, converts it to deck coordinates and applies the corresponding offsets.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
