### PR TITLE
fix(api): Error handling for unsupported pipette configuration behavior with partial column and row

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2096,7 +2096,7 @@ class InstrumentContext(publisher.CommandPublisher):
             if style == NozzleLayout.PARTIAL_COLUMN:
                 if self.channels == 1 or self.channels == 96:
                     raise ValueError(
-                        "Partial Column configuraiton is only supported on 8-Channel Pipettes."
+                        "Partial column configuration is only supported on 8-Channel pipettes."
                     )
 
                 if end is None:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2111,7 +2111,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 if start == "H1" or start == "H12":
                     if "A" in end:
                         raise ValueError(
-                            f"When configuring in Partial Column with 'start'={start} the 'end' parameter cannot be in row A."
+                            f"A partial column configuration with 'start'={start} cannot have its 'end' parameter be in row A."
                         )
                     back_left_resolved = end
                 elif start == "A1" or start == "A12":

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2093,6 +2093,11 @@ class InstrumentContext(publisher.CommandPublisher):
                     raise ValueError(
                         "Row configuration is only supported on 96-Channel pipettes."
                     )
+            if style == NozzleLayout.COLUMN:
+                if self.channels != 96:
+                    raise ValueError(
+                        "Column configuration is only supported on 96-Channel pipettes."
+                    )
             if style == NozzleLayout.PARTIAL_COLUMN:
                 if self.channels == 1 or self.channels == 96:
                     raise ValueError(
@@ -2111,13 +2116,13 @@ class InstrumentContext(publisher.CommandPublisher):
                 if start == "H1" or start == "H12":
                     if "A" in end:
                         raise ValueError(
-                            f"A partial column configuration with 'start'={start} cannot have its 'end' parameter be in row A."
+                            f"A partial column configuration with 'start'={start} cannot have its 'end' parameter be in row A. Use `ALL` configuration to utilize all nozzles."
                         )
                     back_left_resolved = end
                 elif start == "A1" or start == "A12":
                     if "H" in end:
                         raise ValueError(
-                            f"A partial column configuration with 'start'={start} cannot have its 'end' parameter be in row H."
+                            f"A partial column configuration with 'start'={start} cannot have its 'end' parameter be in row H. Use `ALL` configuration to utilize all nozzles."
                         )
                     front_right_resolved = end
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2128,7 +2128,7 @@ class InstrumentContext(publisher.CommandPublisher):
                     )
             elif not (front_right is None and back_left is None):
                 raise ValueError(
-                    f"Parameters 'front_right' and 'back_left' cannot be used with {style.value} Nozzle Configuration Layout."
+                    f"Parameters 'front_right' and 'back_left' cannot be used with a {style.value} nozzle configuration."
                 )
 
         self._core.configure_nozzle_layout(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2091,7 +2091,7 @@ class InstrumentContext(publisher.CommandPublisher):
             if style == NozzleLayout.ROW:
                 if self.channels != 96:
                     raise ValueError(
-                        "Row configuraiton is only supported on 96-Channel Pipettes."
+                        "Row configuration is only supported on 96-Channel pipettes."
                     )
             if style == NozzleLayout.PARTIAL_COLUMN:
                 if self.channels == 1 or self.channels == 96:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2077,6 +2077,8 @@ class InstrumentContext(publisher.CommandPublisher):
                 f"Nozzle layout configuration of style {style.value} is unsupported in API Versions lower than {_PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN}."
             )
 
+        front_right_resolved = front_right
+        back_left_resolved = back_left
         if style != NozzleLayout.ALL:
             if start is None:
                 raise ValueError(
@@ -2086,29 +2088,48 @@ class InstrumentContext(publisher.CommandPublisher):
                 raise ValueError(
                     f"Starting nozzle specified is not one of {types.ALLOWED_PRIMARY_NOZZLES}"
                 )
-        if style == NozzleLayout.QUADRANT:
-            if front_right is None and back_left is None:
-                raise ValueError(
-                    "Cannot configure a QUADRANT layout without a front right or back left nozzle."
-                )
-        elif not (front_right is None and back_left is None):
-            raise ValueError(
-                f"Parameters 'front_right' and 'back_left' cannot be used with {style.value} Nozzle Configuration Layout."
-            )
+            if style == NozzleLayout.ROW:
+                if self.channels != 96:
+                    raise ValueError(
+                        "Row configuraiton is only supported on 96-Channel Pipettes."
+                    )
+            if style == NozzleLayout.PARTIAL_COLUMN:
+                if self.channels == 1 or self.channels == 96:
+                    raise ValueError(
+                        "Partial Column configuraiton is only supported on 8-Channel Pipettes."
+                    )
 
-        front_right_resolved = front_right
-        back_left_resolved = back_left
-        if style == NozzleLayout.PARTIAL_COLUMN:
-            if end is None:
-                raise ValueError(
-                    "Parameter 'end' is required for Partial Column Nozzle Configuration Layout."
-                )
+                if end is None:
+                    raise ValueError(
+                        "Parameter 'end' is required for Partial Column Nozzle Configuration Layout."
+                    )
+                if start[0] in end:
+                    raise ValueError(
+                        "When configuring in Partial Column the 'start' and 'end' parameters cannot be in the same row."
+                    )
+                # Determine if 'end' will be configured as front_right or back_left
+                if start == "H1" or start == "H12":
+                    if "A" in end:
+                        raise ValueError(
+                            f"When configuring in Partial Column with 'start'={start} the 'end' parameter cannot be in row A."
+                        )
+                    back_left_resolved = end
+                elif start == "A1" or start == "A12":
+                    if "H" in end:
+                        raise ValueError(
+                            f"When configuring in Partial Column with 'start'={start} the 'end' parameter cannot be in row H."
+                        )
+                    front_right_resolved = end
 
-            # Determine if 'end' will be configured as front_right or back_left
-            if start == "H1" or start == "H12":
-                back_left_resolved = end
-            elif start == "A1" or start == "A12":
-                front_right_resolved = end
+            if style == NozzleLayout.QUADRANT:
+                if front_right is None and back_left is None:
+                    raise ValueError(
+                        "Cannot configure a QUADRANT layout without a front right or back left nozzle."
+                    )
+            elif not (front_right is None and back_left is None):
+                raise ValueError(
+                    f"Parameters 'front_right' and 'back_left' cannot be used with {style.value} Nozzle Configuration Layout."
+                )
 
         self._core.configure_nozzle_layout(
             style,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2105,7 +2105,7 @@ class InstrumentContext(publisher.CommandPublisher):
                     )
                 if start[0] in end:
                     raise ValueError(
-                        "When configuring in Partial Column the 'start' and 'end' parameters cannot be in the same row."
+                        "The 'start' and 'end' parameters of a partial column configuration cannot be in the same row."
                     )
                 # Determine if 'end' will be configured as front_right or back_left
                 if start == "H1" or start == "H12":

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2101,7 +2101,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
                 if end is None:
                     raise ValueError(
-                        "Parameter 'end' is required for Partial Column Nozzle Configuration Layout."
+                        "Partial column configurations require the 'end' parameter."
                     )
                 if start[0] in end:
                     raise ValueError(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2117,7 +2117,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 elif start == "A1" or start == "A12":
                     if "H" in end:
                         raise ValueError(
-                            f"When configuring in Partial Column with 'start'={start} the 'end' parameter cannot be in row H."
+                            f"A partial column configuration with 'start'={start} cannot have its 'end' parameter be in row H."
                         )
                     front_right_resolved = end
 

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1128,18 +1128,28 @@ def test_prepare_to_aspirate_checks_volume(
 
 
 @pytest.mark.parametrize(
-    argnames=["style", "primary_nozzle", "front_right_nozzle", "end", "exception"],
+    argnames=[
+        "pipette_channels",
+        "style",
+        "primary_nozzle",
+        "front_right_nozzle",
+        "end",
+        "exception",
+    ],
     argvalues=[
-        [NozzleLayout.COLUMN, "A1", None, None, does_not_raise()],
-        [NozzleLayout.SINGLE, None, None, None, pytest.raises(ValueError)],
-        [NozzleLayout.ROW, "E1", None, None, pytest.raises(ValueError)],
-        [NozzleLayout.PARTIAL_COLUMN, "H1", None, "G1", does_not_raise()],
-        [NozzleLayout.PARTIAL_COLUMN, "H1", "H1", "G1", pytest.raises(ValueError)],
-        [NozzleLayout.PARTIAL_COLUMN, "H1", None, "A1", pytest.raises(ValueError)],
+        [96, NozzleLayout.COLUMN, "A1", None, None, does_not_raise()],
+        [96, NozzleLayout.SINGLE, None, None, None, pytest.raises(ValueError)],
+        [96, NozzleLayout.ROW, "E1", None, None, pytest.raises(ValueError)],
+        [8, NozzleLayout.PARTIAL_COLUMN, "H1", None, "G1", does_not_raise()],
+        [8, NozzleLayout.PARTIAL_COLUMN, "H1", "H1", "G1", pytest.raises(ValueError)],
+        [8, NozzleLayout.PARTIAL_COLUMN, "H1", None, "A1", pytest.raises(ValueError)],
     ],
 )
 def test_configure_nozzle_layout(
     subject: InstrumentContext,
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    pipette_channels: int,
     style: NozzleLayout,
     primary_nozzle: Optional[str],
     front_right_nozzle: Optional[str],
@@ -1147,6 +1157,7 @@ def test_configure_nozzle_layout(
     exception: ContextManager[None],
 ) -> None:
     """The correct model is passed to the engine client."""
+    decoy.when(mock_instrument_core.get_channels()).then_return(pipette_channels)
     with exception:
         subject.configure_nozzle_layout(
             style=style, start=primary_nozzle, end=end, front_right=front_right_nozzle

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1135,6 +1135,7 @@ def test_prepare_to_aspirate_checks_volume(
         [NozzleLayout.ROW, "E1", None, None, pytest.raises(ValueError)],
         [NozzleLayout.PARTIAL_COLUMN, "H1", None, "G1", does_not_raise()],
         [NozzleLayout.PARTIAL_COLUMN, "H1", "H1", "G1", pytest.raises(ValueError)],
+        [NozzleLayout.PARTIAL_COLUMN, "H1", None, "A1", pytest.raises(ValueError)],
     ],
 )
 def test_configure_nozzle_layout(
@@ -1146,6 +1147,41 @@ def test_configure_nozzle_layout(
     exception: ContextManager[None],
 ) -> None:
     """The correct model is passed to the engine client."""
+    with exception:
+        subject.configure_nozzle_layout(
+            style=style, start=primary_nozzle, end=end, front_right=front_right_nozzle
+        )
+
+
+@pytest.mark.parametrize(
+    argnames=[
+        "pipette_channels",
+        "style",
+        "primary_nozzle",
+        "front_right_nozzle",
+        "end",
+        "exception",
+    ],
+    argvalues=[
+        [8, NozzleLayout.PARTIAL_COLUMN, "A1", None, "G1", does_not_raise()],
+        [96, NozzleLayout.PARTIAL_COLUMN, "H1", None, "G1", pytest.raises(ValueError)],
+        [8, NozzleLayout.ROW, "H1", None, None, pytest.raises(ValueError)],
+        [96, NozzleLayout.ROW, "H1", None, None, does_not_raise()],
+    ],
+)
+def test_pipette_supports_nozzle_layout(
+    subject: InstrumentContext,
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    pipette_channels: int,
+    style: NozzleLayout,
+    primary_nozzle: Optional[str],
+    front_right_nozzle: Optional[str],
+    end: Optional[str],
+    exception: ContextManager[None],
+) -> None:
+    """Test that error is raised when a pipette attempts to use an unsupported layout."""
+    decoy.when(mock_instrument_core.get_channels()).then_return(pipette_channels)
     with exception:
         subject.configure_nozzle_layout(
             style=style, start=primary_nozzle, end=end, front_right=front_right_nozzle


### PR DESCRIPTION
# Overview
Covers PLAT-457
The 96ch does not currently have any approved nozzle maps supporting partial column configuration, so we want to raise a more helpful error when attempting it. Also, if the user provided a configuration that spanned A1 through H1 or H1 through H12 the partial column would accept it (maps existed for these). We want to block off this improper use of the API. The 8ch pipette similarly will now raise an error when attempting a ROW configuration, which is only meant for the 96ch.

## Test Plan and Hands on Testing

- [x] Ensure all expected configurations are supported for partial tip layout for a given pipette
- [x] Ensure an error is raised if a protocol attempts to configure a pipette with an invalid layout

## Changelog
`configure_nozzle_layout` API has new error cases and test cases to prevent improper use of API 2.20 layouts. 

## Review requests


## Risk assessment
Low, this simply enforces proper use of new behavior for 8.0.0. Eventually, if we want to enable partial column on the 96ch we will need to remove it's error case, but for now this makes use cases clearer with better feedback from analysis.