### PR TITLE
fix(app): update legacy run type

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -54,11 +54,11 @@ export interface LegacyGoodRunData {
   modules: LoadedModule[]
   protocolId?: string
   labwareOffsets?: LabwareOffset[]
-  runTimeParameters: RunTimeParameter[]
 }
 
 export interface KnownGoodRunData extends LegacyGoodRunData {
   ok: true
+  runTimeParameters: RunTimeParameter[]
 }
 
 export interface KnownInvalidRunData extends LegacyGoodRunData {

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -40,9 +40,12 @@ export function HistoricalProtocolRun(
   const { t } = useTranslation('run_details')
   const { run, protocolName, robotIsBusy, robotName, protocolKey } = props
   const [drawerOpen, setDrawerOpen] = React.useState(false)
-  const countRunDataFiles = run.runTimeParameters.filter(
-    parameter => parameter.type === 'csv_file'
-  ).length
+  const countRunDataFiles =
+    'runTimeParameters' in run
+      ? run?.runTimeParameters.filter(
+          parameter => parameter.type === 'csv_file'
+        ).length
+      : 0
   const runStatus = run.status
   const runDisplayName = formatTimestamp(run.createdAt)
   let duration = EMPTY_TIMESTAMP

--- a/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
@@ -46,15 +46,17 @@ export function HistoricalProtocolRunDrawer(
   const allLabwareOffsets = run.labwareOffsets?.sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
-  const runDataFileIds = run.runTimeParameters.reduce<string[]>(
-    (acc, parameter) => {
-      if (parameter.type === 'csv_file') {
-        return parameter.file?.id != null ? [...acc, parameter.file?.id] : acc
-      }
-      return acc
-    },
-    []
-  )
+  const runDataFileIds =
+    'runTimeParameters' in run
+      ? run.runTimeParameters.reduce<string[]>((acc, parameter) => {
+          if (parameter.type === 'csv_file') {
+            return parameter.file?.id != null
+              ? [...acc, parameter.file?.id]
+              : acc
+          }
+          return acc
+        }, [])
+      : []
   const uniqueLabwareOffsets = allLabwareOffsets?.filter(
     (offset, index, array) => {
       return (

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
@@ -56,15 +56,15 @@ export function ProtocolRunRuntimeParameters({
   // because the most recent analysis may not reflect the selected run (e.g. cloning a run
   // from a historical protocol run from the device details page)
   const run = useNotifyRunQuery(runId).data
-  let runTimeParameters
-  if (isRunTerminal) {
-    runTimeParameters =
-      run?.data != null && 'runTimeParameters' in run?.data
-        ? run?.data?.runTimeParameters
-        : []
-  } else {
-    runTimeParameters = mostRecentAnalysis?.runTimeParameters ?? []
-  }
+  const runTimeParametersFromRun =
+    run?.data != null && 'runTimeParameters' in run?.data
+      ? run?.data?.runTimeParameters
+      : []
+  const runTimeParametersFromAnalysis =
+    mostRecentAnalysis?.runTimeParameters ?? []
+  const runTimeParameters = isRunTerminal
+    ? runTimeParametersFromRun
+    : runTimeParametersFromAnalysis
   const hasRunTimeParameters = runTimeParameters.length > 0
   const hasCustomRunTimeParameterValues = runTimeParameters.some(parameter =>
     parameter.type !== 'csv_file' ? parameter.value !== parameter.default : true

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
@@ -56,10 +56,15 @@ export function ProtocolRunRuntimeParameters({
   // because the most recent analysis may not reflect the selected run (e.g. cloning a run
   // from a historical protocol run from the device details page)
   const run = useNotifyRunQuery(runId).data
-  const runTimeParameters =
-    (isRunTerminal
-      ? run?.data?.runTimeParameters
-      : mostRecentAnalysis?.runTimeParameters) ?? []
+  let runTimeParameters
+  if (isRunTerminal) {
+    runTimeParameters =
+      run?.data != null && 'runTimeParameters' in run?.data
+        ? run?.data?.runTimeParameters
+        : []
+  } else {
+    runTimeParameters = mostRecentAnalysis?.runTimeParameters ?? []
+  }
   const hasRunTimeParameters = runTimeParameters.length > 0
   const hasCustomRunTimeParameterValues = runTimeParameters.some(parameter =>
     parameter.type !== 'csv_file' ? parameter.value !== parameter.default : true

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -48,7 +48,11 @@ export function useCloneRun(
   )
   const cloneRun = (): void => {
     if (runRecord != null) {
-      const { protocolId, labwareOffsets, runTimeParameters } = runRecord.data
+      const { protocolId, labwareOffsets } = runRecord.data
+      const runTimeParameters =
+        'runTimeParameters' in runRecord.data
+          ? runRecord.data.runTimeParameters
+          : []
       const runTimeParameterValues = getRunTimeParameterValuesForRun(
         runTimeParameters
       )


### PR DESCRIPTION
# Overview

This PR fixes an error where a whitescreen occurs when opening device details for a robot with robot server <7.3. Move `runTimeParameters` property from `LegacyGoodRunData` to `KnownGoodRunData` since robot server does not return RTP for server versions <7.3. Check for `runTimeParameters` property explicitly when needed. 

Closes RQA-2962

## Test Plan and Hands on Testing

- Select device details for a robot running <7.3.
- Verify that details render and no white screen occurs, and that historical protocol run drawers are expandable.

## Changelog

- update api-client run types
- fix TS errors by explicitly checking for RTP property on run

## Review requests

see test plan

## Risk assessment

low