### PR TITLE
feat(components): listButton and accordion children creation

### DIFF
--- a/components/src/atoms/ListButton/ListButton.stories.tsx
+++ b/components/src/atoms/ListButton/ListButton.stories.tsx
@@ -25,8 +25,9 @@ const meta: Meta<typeof ListButtonComponent> = {
 export default meta
 
 type Story = StoryObj<typeof ListButtonComponent>
+type ListButtonComponentProps = React.ComponentProps<typeof ListButtonComponent>
 
-const Template = (args: any): JSX.Element => {
+const Template = (args: ListButtonComponentProps): JSX.Element => {
   const [containerExpand, setContainerExpand] = React.useState<boolean>(false)
   const [buttonValue, setButtonValue] = React.useState<string | null>(null)
   const [nestedButtonValue, setNestedButtonValue] = React.useState<
@@ -42,7 +43,7 @@ const Template = (args: any): JSX.Element => {
     >
       <ListButtonAccordion
         key="main"
-        mainHeadline="Main heading"
+        mainHeadline="Main heading, click to expand accordion"
         headline="accordion heading"
         isExpanded={containerExpand}
       >
@@ -52,7 +53,7 @@ const Template = (args: any): JSX.Element => {
               key="buttonNested"
               isSelected={buttonValue === 'radio button nested'}
               buttonValue="radio button nested"
-              buttonText="Radio button with nested"
+              buttonText="Radio button, click to expand nested accordion"
               onChange={e => {
                 e.stopPropagation()
                 setButtonValue('radio button nested')

--- a/components/src/atoms/ListButton/ListButton.stories.tsx
+++ b/components/src/atoms/ListButton/ListButton.stories.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react'
+
+import { ListButton as ListButtonComponent } from './index'
+import {
+  ListButtonAccordion,
+  ListButtonAccordionContainer,
+  ListButtonRadioButton,
+} from './ListButtonChildren/index'
+import { StyledText } from '../..'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta<typeof ListButtonComponent> = {
+  title: 'Library/Atoms/ListButton',
+  component: ListButtonComponent,
+  argTypes: {
+    type: {
+      control: {
+        type: 'select',
+        options: ['noActive', 'success', 'warning'],
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ListButtonComponent>
+
+const Template = (args: any): JSX.Element => {
+  const [containerExpand, setContainerExpand] = React.useState<boolean>(false)
+  const [buttonValue, setButtonValue] = React.useState<string | null>(null)
+  const [nestedButtonValue, setNestedButtonValue] = React.useState<
+    string | null
+  >(null)
+
+  return (
+    <ListButtonComponent
+      {...args}
+      onClick={() => {
+        setContainerExpand(!containerExpand)
+      }}
+    >
+      <ListButtonAccordion
+        key="main"
+        mainHeadline="Main heading"
+        headline="accordion heading"
+        isExpanded={containerExpand}
+      >
+        <ListButtonAccordionContainer id="mainAccordionContainer">
+          <>
+            <ListButtonRadioButton
+              key="buttonNested"
+              isSelected={buttonValue === 'radio button nested'}
+              buttonValue="radio button nested"
+              buttonText="Radio button with nested"
+              onChange={e => {
+                e.stopPropagation()
+                setButtonValue('radio button nested')
+              }}
+            />
+
+            {buttonValue === 'radio button nested' ? (
+              <ListButtonAccordionContainer id="nestedAccordionContainer">
+                <ListButtonAccordion
+                  key="child"
+                  isNested
+                  headline="nested accordion heading"
+                  isExpanded={buttonValue === 'radio button nested'}
+                >
+                  <>
+                    <ListButtonRadioButton
+                      isSelected={nestedButtonValue === 'radio button1'}
+                      buttonValue="radio button1"
+                      buttonText="nested button"
+                      onChange={() => {
+                        setNestedButtonValue('radio button1')
+                      }}
+                    />
+                    {nestedButtonValue === 'radio button1' ? (
+                      <StyledText desktop="bodyDefaultRegular">
+                        Nested button option
+                      </StyledText>
+                    ) : null}
+                  </>
+                  <ListButtonRadioButton
+                    isSelected={nestedButtonValue === 'radio button2'}
+                    buttonValue="radio button2"
+                    buttonText="nested button 2"
+                    onChange={() => {
+                      setNestedButtonValue('radio button2')
+                    }}
+                  />
+                  <ListButtonRadioButton
+                    isSelected={nestedButtonValue === 'radio button3'}
+                    buttonValue="radio button3"
+                    buttonText="nested button 3"
+                    onChange={() => {
+                      setNestedButtonValue('radio button3')
+                    }}
+                  />
+                </ListButtonAccordion>
+              </ListButtonAccordionContainer>
+            ) : null}
+          </>
+          <>
+            <ListButtonRadioButton
+              key="buttonNonNested"
+              isSelected={buttonValue === 'radio button non nest'}
+              buttonValue="radio button non nest"
+              buttonText="Radio button without nested"
+              onChange={() => {
+                setButtonValue('radio button non nest')
+              }}
+            />
+
+            {buttonValue === 'radio button non nest' ? (
+              <StyledText desktop="bodyDefaultRegular">
+                Non nested button option
+              </StyledText>
+            ) : null}
+          </>
+        </ListButtonAccordionContainer>
+      </ListButtonAccordion>
+    </ListButtonComponent>
+  )
+}
+export const ListButton: Story = {
+  render: Template,
+  args: {
+    type: 'noActive',
+  },
+}

--- a/components/src/atoms/ListButton/ListButtonChildren/ListButtonAccordion.tsx
+++ b/components/src/atoms/ListButton/ListButtonChildren/ListButtonAccordion.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { Flex } from '../../../primitives'
+import { DIRECTION_COLUMN } from '../../../styles'
+import { SPACING } from '../../../ui-style-constants'
+import { StyledText } from '../../StyledText'
+
+interface ListButtonAccordionProps {
+  headline: string
+  children: React.ReactNode
+  //    determines if the accordion is expanded or not
+  isExpanded?: boolean
+  //    is it nested into another accordion?
+  isNested?: boolean
+  //    optional main headline for the top level accordion
+  mainHeadline?: string
+}
+
+/*
+    To be used with ListButton, ListButtonAccordion and ListButtonRadioButton
+    This is the accordion component to use both as just an accordion or nested accordion
+**/
+export function ListButtonAccordion(
+  props: ListButtonAccordionProps
+): JSX.Element {
+  const {
+    headline,
+    children,
+    mainHeadline,
+    isExpanded = false,
+    isNested = false,
+  } = props
+
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN} width="100%">
+      {mainHeadline != null ? (
+        <Flex marginBottom={isExpanded ? SPACING.spacing40 : '0'}>
+          <StyledText desktopStyle="bodyDefaultSemiBold">
+            {mainHeadline}
+          </StyledText>
+        </Flex>
+      ) : null}
+      {isExpanded ? (
+        <Flex
+          marginTop={isNested ? SPACING.spacing4 : '0'}
+          flexDirection={DIRECTION_COLUMN}
+          gridGap={SPACING.spacing4}
+          marginLeft={isNested ? SPACING.spacing40 : '0'}
+        >
+          <Flex marginBottom={SPACING.spacing4}>
+            <StyledText desktopStyle="bodyDefaultSemiBold">
+              {headline}
+            </StyledText>
+          </Flex>
+          <Flex flexDirection={DIRECTION_COLUMN}>{children}</Flex>
+        </Flex>
+      ) : null}
+    </Flex>
+  )
+}

--- a/components/src/atoms/ListButton/ListButtonChildren/ListButtonAccordion.tsx
+++ b/components/src/atoms/ListButton/ListButtonChildren/ListButtonAccordion.tsx
@@ -7,11 +7,11 @@ import { StyledText } from '../../StyledText'
 interface ListButtonAccordionProps {
   headline: string
   children: React.ReactNode
-  //    determines if the accordion is expanded or not
+  // determines if the accordion is expanded or not
   isExpanded?: boolean
-  //    is it nested into another accordion?
+  // is it nested into another accordion?
   isNested?: boolean
-  //    optional main headline for the top level accordion
+  // optional main headline for the top level accordion
   mainHeadline?: string
 }
 

--- a/components/src/atoms/ListButton/ListButtonChildren/ListButtonAccordionContainer.tsx
+++ b/components/src/atoms/ListButton/ListButtonChildren/ListButtonAccordionContainer.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { Flex } from '../../../primitives'
+import { DIRECTION_COLUMN } from '../../../styles'
+
+interface ListButtonAccordionContainerProps {
+  children: React.ReactNode
+  id: string
+}
+/*
+    To be used with ListButtonAccordion to stop propagation since multiple
+    layers have a CTA
+**/
+export function ListButtonAccordionContainer(
+  props: ListButtonAccordionContainerProps
+): JSX.Element {
+  const { id, children } = props
+
+  return (
+    <Flex
+      key={id}
+      flexDirection={DIRECTION_COLUMN}
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation()
+      }}
+    >
+      {children}
+    </Flex>
+  )
+}

--- a/components/src/atoms/ListButton/ListButtonChildren/ListButtonRadioButton.tsx
+++ b/components/src/atoms/ListButton/ListButtonChildren/ListButtonRadioButton.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+import { SPACING } from '../../../ui-style-constants'
+import { BORDERS, COLORS } from '../../../helix-design-system'
+import { Flex } from '../../../primitives'
+import { StyledText } from '../../StyledText'
+
+import type { StyleProps } from '../../../primitives'
+
+interface ListButtonRadioButtonProps extends StyleProps {
+  buttonText: string
+  buttonValue: string | number
+  onChange: React.ChangeEventHandler<HTMLInputElement>
+  disabled?: boolean
+  isSelected?: boolean
+  id?: string
+}
+
+//  used for helix and as a child button to ListButtonAccordion
+export function ListButtonRadioButton(
+  props: ListButtonRadioButtonProps
+): JSX.Element {
+  const {
+    buttonText,
+    buttonValue,
+    isSelected = false,
+    onChange,
+    disabled = false,
+    id = buttonText,
+  } = props
+
+  const SettingButton = styled.input`
+    display: none;
+  `
+
+  const AVAILABLE_BUTTON_STYLE = css`
+    background: ${COLORS.white};
+    color: ${COLORS.black90};
+
+    &:hover {
+      background-color: ${COLORS.grey10};
+    }
+  `
+
+  const SELECTED_BUTTON_STYLE = css`
+    background: ${COLORS.blue50};
+    color: ${COLORS.white};
+
+    &:active {
+      background-color: ${COLORS.blue60};
+    }
+  `
+
+  const DISABLED_STYLE = css`
+    color: ${COLORS.grey40};
+    background-color: ${COLORS.grey10};
+  `
+
+  const SettingButtonLabel = styled.label`
+    border-radius: ${BORDERS.borderRadius8};
+    cursor: pointer;
+    padding: 14px ${SPACING.spacing12};
+    width: 100%;
+
+    ${isSelected ? SELECTED_BUTTON_STYLE : AVAILABLE_BUTTON_STYLE}
+    ${disabled && DISABLED_STYLE}
+  `
+
+  return (
+    <Flex width="100%" margin={SPACING.spacing4}>
+      <SettingButton
+        checked={isSelected}
+        id={id}
+        disabled={disabled}
+        onChange={onChange}
+        type="radio"
+        value={buttonValue}
+      />
+      <SettingButtonLabel role="label" htmlFor={id}>
+        <StyledText desktopStyle="bodyDefaultRegular">{buttonText}</StyledText>
+      </SettingButtonLabel>
+    </Flex>
+  )
+}

--- a/components/src/atoms/ListButton/ListButtonChildren/index.ts
+++ b/components/src/atoms/ListButton/ListButtonChildren/index.ts
@@ -1,0 +1,3 @@
+export * from './ListButtonAccordion'
+export * from './ListButtonAccordionContainer'
+export * from './ListButtonRadioButton'

--- a/components/src/atoms/ListButton/__tests__/ListButton.test.tsx
+++ b/components/src/atoms/ListButton/__tests__/ListButton.test.tsx
@@ -24,19 +24,19 @@ describe('ListButton', () => {
   it('should render correct style - noActive', () => {
     render(props)
     const listButton = screen.getByTestId('ListButton_noActive')
-    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.grey35}`)
+    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.grey30}`)
   })
   it('should render correct style - connected', () => {
     props.type = 'connected'
     render(props)
     const listButton = screen.getByTestId('ListButton_connected')
-    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.green35}`)
+    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.green30}`)
   })
   it('should render correct style - notConnected', () => {
     props.type = 'notConnected'
     render(props)
     const listButton = screen.getByTestId('ListButton_notConnected')
-    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.yellow35}`)
+    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.yellow30}`)
   })
   it('should call on click when pressed', () => {
     render(props)

--- a/components/src/atoms/ListButton/__tests__/ListButton.test.tsx
+++ b/components/src/atoms/ListButton/__tests__/ListButton.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../testing/utils'
+import { COLORS } from '../../../helix-design-system'
+
+import { ListButton } from '..'
+
+const render = (props: React.ComponentProps<typeof ListButton>) =>
+  renderWithProviders(<ListButton {...props} />)
+
+describe('ListButton', () => {
+  let props: React.ComponentProps<typeof ListButton>
+
+  beforeEach(() => {
+    props = {
+      type: 'noActive',
+      children: <div>mock ListButton content</div>,
+      onClick: vi.fn(),
+    }
+  })
+
+  it('should render correct style - noActive', () => {
+    render(props)
+    const listButton = screen.getByTestId('ListButton_noActive')
+    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.grey35}`)
+  })
+  it('should render correct style - connected', () => {
+    props.type = 'connected'
+    render(props)
+    const listButton = screen.getByTestId('ListButton_connected')
+    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.green35}`)
+  })
+  it('should render correct style - notConnected', () => {
+    props.type = 'notConnected'
+    render(props)
+    const listButton = screen.getByTestId('ListButton_notConnected')
+    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.yellow35}`)
+  })
+  it('should call on click when pressed', () => {
+    render(props)
+    fireEvent.click(screen.getByText('mock ListButton content'))
+    expect(props.onClick).toHaveBeenCalled()
+  })
+})

--- a/components/src/atoms/ListButton/__tests__/ListButtonAccordion.test.tsx
+++ b/components/src/atoms/ListButton/__tests__/ListButtonAccordion.test.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { describe, it, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../testing/utils'
+
+import { ListButtonAccordion } from '..'
+
+const render = (props: React.ComponentProps<typeof ListButtonAccordion>) =>
+  renderWithProviders(<ListButtonAccordion {...props} />)
+
+describe('ListButtonAccordion', () => {
+  let props: React.ComponentProps<typeof ListButtonAccordion>
+
+  beforeEach(() => {
+    props = {
+      children: <div>mock ListButtonAccordion content</div>,
+      headline: 'mock headline',
+      isExpanded: true,
+    }
+  })
+
+  it('should render non nested accordion', () => {
+    render(props)
+    screen.getByText('mock headline')
+    screen.getByText('mock ListButtonAccordion content')
+  })
+  it('should render non nested accordion with main headline', () => {
+    props.isNested = true
+    props.mainHeadline = 'mock main headline'
+    render(props)
+    screen.getByText('mock main headline')
+    screen.getByText('mock headline')
+    screen.getByText('mock ListButtonAccordion content')
+  })
+})

--- a/components/src/atoms/ListButton/__tests__/ListButtonRadioButton.test.tsx
+++ b/components/src/atoms/ListButton/__tests__/ListButtonRadioButton.test.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import { describe, it, beforeEach, vi, expect } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../testing/utils'
+
+import { ListButtonRadioButton } from '..'
+
+const render = (props: React.ComponentProps<typeof ListButtonRadioButton>) =>
+  renderWithProviders(<ListButtonRadioButton {...props} />)
+
+describe('ListButtonRadioButton', () => {
+  let props: React.ComponentProps<typeof ListButtonRadioButton>
+
+  beforeEach(() => {
+    props = {
+      buttonText: 'mock text',
+      buttonValue: 'mockValue',
+      onChange: vi.fn(),
+    }
+  })
+
+  it('should render non nested accordion', () => {
+    render(props)
+    fireEvent.click(screen.getByText('mock text'))
+    expect(props.onChange).toHaveBeenCalled()
+  })
+})

--- a/components/src/atoms/ListButton/index.tsx
+++ b/components/src/atoms/ListButton/index.tsx
@@ -21,16 +21,16 @@ const LISTBUTTON_PROPS_BY_TYPE: Record<
   { backgroundColor: string; hoverBackgroundColor: string }
 > = {
   noActive: {
-    backgroundColor: COLORS.grey35,
-    hoverBackgroundColor: COLORS.grey40,
+    backgroundColor: COLORS.grey30,
+    hoverBackgroundColor: COLORS.grey35,
   },
   connected: {
-    backgroundColor: COLORS.green35,
+    backgroundColor: COLORS.green30,
     hoverBackgroundColor: COLORS.green35,
   },
   notConnected: {
-    backgroundColor: COLORS.yellow35,
-    hoverBackgroundColor: COLORS.yellow40,
+    backgroundColor: COLORS.yellow30,
+    hoverBackgroundColor: COLORS.yellow35,
   },
 }
 

--- a/components/src/atoms/ListButton/index.tsx
+++ b/components/src/atoms/ListButton/index.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import { css } from 'styled-components'
+import { Flex } from '../../primitives'
+import { SPACING } from '../../ui-style-constants'
+import { BORDERS, COLORS } from '../../helix-design-system'
+import type { StyleProps } from '../../primitives'
+
+export * from './ListButtonChildren/index'
+
+export type ListButtonType = 'noActive' | 'connected' | 'notConnected'
+
+interface ListButtonProps extends StyleProps {
+  type: ListButtonType
+  children: React.ReactNode
+  disabled?: boolean
+  onClick?: () => void
+}
+
+const LISTBUTTON_PROPS_BY_TYPE: Record<
+  ListButtonType,
+  { backgroundColor: string; hoverBackgroundColor: string }
+> = {
+  noActive: {
+    backgroundColor: COLORS.grey35,
+    hoverBackgroundColor: COLORS.grey40,
+  },
+  connected: {
+    backgroundColor: COLORS.green35,
+    hoverBackgroundColor: COLORS.green35,
+  },
+  notConnected: {
+    backgroundColor: COLORS.yellow35,
+    hoverBackgroundColor: COLORS.yellow40,
+  },
+}
+
+/*
+  ListButton is used in helix 
+  TODO(ja, 8/12/24): shuld be used in ODD as well and need to add
+  odd stylings
+**/
+export function ListButton(props: ListButtonProps): JSX.Element {
+  const { type, children, disabled, onClick, ...styleProps } = props
+  const listButtonProps = LISTBUTTON_PROPS_BY_TYPE[type]
+
+  const LIST_BUTTON_STYLE = css`
+    cursor: pointer;
+    background-color: ${disabled
+      ? COLORS.grey35
+      : listButtonProps.backgroundColor};
+    max-width: 26.875rem;
+    padding: ${SPACING.spacing20} ${SPACING.spacing24};
+    border-radius: ${BORDERS.borderRadius16};
+
+    &:hover {
+      background-color: ${listButtonProps.hoverBackgroundColor};
+    }
+  `
+
+  return (
+    <Flex
+      data-testid={`ListButton_${type}`}
+      onClick={onClick}
+      css={LIST_BUTTON_STYLE}
+      {...styleProps}
+    >
+      {children}
+    </Flex>
+  )
+}


### PR DESCRIPTION
closes AUTH-657

# Overview

Create `ListButton`, `ListButtonAccordion`, `ListButtonRadioButton` and `ListButtonAccordionContainer` to be used in PD redesign

## Test Plan and Hands on Testing

it is not used yet so check the storybook. should be able to expand the accordion and pressing on the buttons should also expand an accordion if it is nested

## Changelog

create all the above components mentioned above and add a story. also add tests for each

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

low