### PR TITLE
fix(app): Debounce jog controls during DTWiz

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -21,6 +21,7 @@ import type { RunCommandByCommandTypeParams } from './useDropTipCreateCommands'
 
 const JOG_COMMAND_TIMEOUT_MS = 10000
 const MAXIMUM_BLOWOUT_FLOW_RATE_UL_PER_S = 50
+const MAX_QUEUED_JOGS = 3
 
 type UseDropTipSetupCommandsParams = UseDTWithTypeParams & {
   activeMaintenanceRunId: string | null
@@ -35,10 +36,9 @@ type UseDropTipSetupCommandsParams = UseDTWithTypeParams & {
 }
 
 export interface UseDropTipCommandsResult {
-  /*  */
   handleCleanUpAndClose: (homeOnExit?: boolean) => Promise<void>
   moveToAddressableArea: (addressableArea: AddressableAreaName) => Promise<void>
-  handleJog: (axis: Axis, dir: Sign, step: StepSize) => Promise<void>
+  handleJog: (axis: Axis, dir: Sign, step: StepSize) => void
   blowoutOrDropTip: (
     currentStep: DropTipFlowsStep,
     proceed: () => void
@@ -46,7 +46,6 @@ export interface UseDropTipCommandsResult {
   handleMustHome: () => Promise<void>
 }
 
-// Returns setup commands used in Drop Tip Wizard.
 export function useDropTipCommands({
   issuedCommandsType,
   toggleIsExiting,
@@ -61,6 +60,8 @@ export function useDropTipCommands({
 }: UseDropTipSetupCommandsParams): UseDropTipCommandsResult {
   const isFlex = robotType === FLEX_ROBOT_TYPE
   const [hasSeenClose, setHasSeenClose] = React.useState(false)
+  const [jogQueue, setJogQueue] = React.useState<Array<() => Promise<void>>>([])
+  const [isJogging, setIsJogging] = React.useState(false)
 
   const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({
     onSuccess: () => {
@@ -149,7 +150,7 @@ export function useDropTipCommands({
     })
   }
 
-  const handleJog = (axis: Axis, dir: Sign, step: StepSize): Promise<void> => {
+  const executeJog = (axis: Axis, dir: Sign, step: StepSize): Promise<void> => {
     return new Promise((resolve, reject) => {
       return runCommand({
         command: {
@@ -172,6 +173,30 @@ export function useDropTipCommands({
           })
           resolve()
         })
+    })
+  }
+
+  const processJogQueue = (): void => {
+    if (jogQueue.length > 0 && !isJogging) {
+      setIsJogging(true)
+      const nextJog = jogQueue[0]
+      setJogQueue(prevQueue => prevQueue.slice(1))
+      nextJog().finally(() => {
+        setIsJogging(false)
+      })
+    }
+  }
+
+  React.useEffect(() => {
+    processJogQueue()
+  }, [jogQueue.length, isJogging])
+
+  const handleJog = (axis: Axis, dir: Sign, step: StepSize): void => {
+    setJogQueue(prevQueue => {
+      if (prevQueue.length < MAX_QUEUED_JOGS) {
+        return [...prevQueue, () => executeJog(axis, dir, step)]
+      }
+      return prevQueue
     })
   }
 


### PR DESCRIPTION
Closes [RQA-2951](https://opentrons.atlassian.net/browse/RQA-2951)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In Error Recovery (and DTWiz in general), the pipette is z-homed before users move to a location to drop tips. Because this location is quite far from the deck, users will likely want to press their arrow keys to jog the pipette quickly, and this will in turn cause the robot to execute potentially 50+ `moveRelative` commands with no way of stopping it.

While not debouncing other flows with jog controls (ex, LPC) has historical context and is less prone to users over-clicking the jog buttons, we should debounce the jog controls within dt wiz. 

The solution here is to allow a queue of `MAX_QUEUED_JOGS`. Three is reasonable after testing. 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that commands are actually debounced. Note that given the way command debouncing works in practice, you may have to click more three times in quick succession before you notice you are actually getting debounced. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Users can no longer "over-jog" during Drop Tip wizard and Error Recovery. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2951]: https://opentrons.atlassian.net/browse/RQA-2951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ