### PR TITLE
fix(app): fix stale failedCommand during Error Recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -62,7 +62,7 @@ export function useFailedLabwareUtils({
         failedCommandByRunRecord,
         runCommands,
       }),
-    [failedCommandByRunRecord?.error?.errorType, runCommands]
+    [failedCommandByRunRecord?.key, runCommands?.meta.totalLength]
   )
 
   const tipSelectionUtils = useTipSelectionUtils(recentRelevantFailedLabwareCmd)
@@ -74,12 +74,12 @@ export function useFailedLabwareUtils({
         recentRelevantFailedLabwareCmd,
         runRecord
       ),
-    [protocolAnalysis, recentRelevantFailedLabwareCmd, runRecord]
+    [protocolAnalysis?.id, recentRelevantFailedLabwareCmd?.key]
   )
 
   const failedLabware = React.useMemo(
     () => getFailedLabware(recentRelevantFailedLabwareCmd, runRecord),
-    [recentRelevantFailedLabwareCmd, runRecord]
+    [recentRelevantFailedLabwareCmd?.key]
   )
 
   const relevantWellName = getRelevantWellName(

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRetainedFailedCommandBySource.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRetainedFailedCommandBySource.ts
@@ -41,7 +41,11 @@ export function useRetainedFailedCommandBySource(
         })
       }
     }
-  }, [failedCommandByRunRecord?.key, protocolAnalysis?.id])
+  }, [
+    failedCommandByRunRecord?.key,
+    failedCommandByRunRecord?.error?.errorType,
+    protocolAnalysis?.id,
+  ])
 
   return retainedFailedCommand
 }


### PR DESCRIPTION
Closes [RQA-2936](https://opentrons.atlassian.net/browse/RQA-2936)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Recently, we added functionality to "retain" the failed command, so the app has the ability to show certain things even after the server no longer currently recovers from a failed command. 

The exact dependency array used to update the retained failed command didn't properly account for the exact command, so sometimes you'd enter error recovery with a stale command the second time you entered error recovery. This fixes that and cleans up some of the memoized labware calculation utilities, which weren't completely correct either. 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified correct behavior according to the protocol/steps in the linked ticket.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the Error Recovery tip selector not always showing the correct well from which to pick up tips.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2936]: https://opentrons.atlassian.net/browse/RQA-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ