### PR TITLE
fix(app): shrink Setup Robot Modal links to fit content

### DIFF
--- a/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
+++ b/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
@@ -5,6 +5,7 @@ import {
   ALIGN_FLEX_END,
   DIRECTION_COLUMN,
   Flex,
+  FLEX_MAX_CONTENT,
   Link,
   PrimaryButton,
   SPACING,
@@ -50,10 +51,16 @@ export function NewRobotSetupHelp(): JSX.Element {
                 <LegacyStyledText as="p" marginBottom={SPACING.spacing16}>
                   {t('new_robot_instructions')}
                 </LegacyStyledText>
-                <ExternalLink href={NEW_FLEX_SETUP_SUPPORT_ARTICLE_HREF}>
+                <ExternalLink
+                  href={NEW_FLEX_SETUP_SUPPORT_ARTICLE_HREF}
+                  width={FLEX_MAX_CONTENT}
+                >
                   {t('opentrons_flex_quickstart_guide')}
                 </ExternalLink>
-                <ExternalLink href={NEW_OT2_SETUP_SUPPORT_ARTICLE_HREF}>
+                <ExternalLink
+                  href={NEW_OT2_SETUP_SUPPORT_ARTICLE_HREF}
+                  width={FLEX_MAX_CONTENT}
+                >
                   {t('ot2_quickstart_guide')}
                 </ExternalLink>
                 <PrimaryButton


### PR DESCRIPTION
# Overview

On modal produced by desktop app `DeviceLanding` "See how to setup a new robot" link, shrink link clickable area to fit content.

Closes RQA-2961

## Test Plan and Hands on Testing

- On Desktop, navigate to Devices tab and click "See how to setup a new robot" at top of page
- On modal, move cursor over whitespace to the right of links and verify that the space is not clickable

https://github.com/user-attachments/assets/cc5eca15-49c7-433c-b1b2-ca1b4b580c0c


## Changelog

- fit link to content

## Review requests

see test plan

## Risk assessment

low