### PR TITLE
feat(api): add innner well geometry to labware definitions

### DIFF
--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -14,7 +14,7 @@ from opentrons_shared_data.labware.labware_definition import (
     Metadata1,
     WellDefinition,
     BoundedSection,
-    InnerGeometrySection,
+    TopCrossSection,
 )
 from opentrons_shared_data.protocol.models import (
     protocol_schema_v6,
@@ -689,14 +689,14 @@ def _load_labware_definition_data() -> LabwareDefinition:
         cornerOffsetFromSlot=CornerOffsetFromSlot(x=0, y=0, z=0),
         innerWellGeometry=[
             BoundedSection(
-                geometry=InnerGeometrySection(
+                geometry=TopCrossSection(
                     shape="hemisphere",
                     diameter=25,
                 ),
                 top_height=10,
             ),
             BoundedSection(
-                geometry=InnerGeometrySection(
+                geometry=TopCrossSection(
                     shape="rectangular",
                     xDimension=5.6,
                     yDimension=6.5,

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -15,6 +15,8 @@ from opentrons_shared_data.labware.labware_definition import (
     WellDefinition,
     BoundedSection,
     TopCrossSection,
+    InnerLabwareGeometry,
+    Hemisphere,
 )
 from opentrons_shared_data.protocol.models import (
     protocol_schema_v6,
@@ -687,23 +689,30 @@ def _load_labware_definition_data() -> LabwareDefinition:
         },
         dimensions=Dimensions(yDimension=85.5, zDimension=100, xDimension=127.75),
         cornerOffsetFromSlot=CornerOffsetFromSlot(x=0, y=0, z=0),
-        innerWellGeometry=[
-            BoundedSection(
-                geometry=TopCrossSection(
-                    shape="hemisphere",
-                    diameter=25,
+        innerWellGeometry=InnerLabwareGeometry(
+            frusta=[
+                BoundedSection(
+                    geometry=TopCrossSection(
+                        shape="rectangular",
+                        xDimension=7.6,
+                        yDimension=8.5,
+                    ),
+                    top_height=45,
                 ),
-                top_height=10,
-            ),
-            BoundedSection(
-                geometry=TopCrossSection(
-                    shape="rectangular",
-                    xDimension=5.6,
-                    yDimension=6.5,
+                BoundedSection(
+                    geometry=TopCrossSection(
+                        shape="rectangular",
+                        xDimension=5.6,
+                        yDimension=6.5,
+                    ),
+                    top_height=20,
                 ),
-                top_height=45,
+            ],
+            bottom_shape=Hemisphere(
+                diameter=6,
+                depth=10,
             ),
-        ],
+        ),
         brand=BrandData(brand="foo"),
         metadata=Metadata(
             displayName="Foo 8 Well Plate 33uL",

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -14,7 +14,7 @@ from opentrons_shared_data.labware.labware_definition import (
     Metadata1,
     WellDefinition,
     BoundedSection,
-    TopCrossSection,
+    RectangularCrossSection,
     InnerLabwareGeometry,
     Hemisphere,
 )
@@ -692,23 +692,24 @@ def _load_labware_definition_data() -> LabwareDefinition:
         innerWellGeometry=InnerLabwareGeometry(
             frusta=[
                 BoundedSection(
-                    geometry=TopCrossSection(
+                    geometry=RectangularCrossSection(
                         shape="rectangular",
                         xDimension=7.6,
                         yDimension=8.5,
                     ),
-                    top_height=45,
+                    topHeight=45,
                 ),
                 BoundedSection(
-                    geometry=TopCrossSection(
+                    geometry=RectangularCrossSection(
                         shape="rectangular",
                         xDimension=5.6,
                         yDimension=6.5,
                     ),
-                    top_height=20,
+                    topHeight=20,
                 ),
             ],
-            bottom_shape=Hemisphere(
+            bottomShape=Hemisphere(
+                shape="hemispherical",
                 diameter=6,
                 depth=10,
             ),

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -13,6 +13,8 @@ from opentrons_shared_data.labware.labware_definition import (
     Group,
     Metadata1,
     WellDefinition,
+    BoundedSection,
+    InnerGeometrySection,
 )
 from opentrons_shared_data.protocol.models import (
     protocol_schema_v6,
@@ -685,6 +687,23 @@ def _load_labware_definition_data() -> LabwareDefinition:
         },
         dimensions=Dimensions(yDimension=85.5, zDimension=100, xDimension=127.75),
         cornerOffsetFromSlot=CornerOffsetFromSlot(x=0, y=0, z=0),
+        innerWellGeometry=[
+            BoundedSection(
+                geometry=InnerGeometrySection(
+                    shape="hemisphere",
+                    diameter=25,
+                ),
+                top_height=10,
+            ),
+            BoundedSection(
+                geometry=InnerGeometrySection(
+                    shape="rectangular",
+                    xDimension=5.6,
+                    yDimension=6.5,
+                ),
+                top_height=45,
+            ),
+        ],
         brand=BrandData(brand="foo"),
         metadata=Metadata(
             displayName="Foo 8 Well Plate 33uL",

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -16,7 +16,7 @@ from opentrons_shared_data.labware.labware_definition import (
     BoundedSection,
     RectangularCrossSection,
     InnerLabwareGeometry,
-    Hemisphere,
+    SphericalSegment,
 )
 from opentrons_shared_data.protocol.models import (
     protocol_schema_v6,
@@ -708,9 +708,9 @@ def _load_labware_definition_data() -> LabwareDefinition:
                     topHeight=20,
                 ),
             ],
-            bottomShape=Hemisphere(
-                shape="hemispherical",
-                diameter=6,
+            bottomShape=SphericalSegment(
+                shape="spherical",
+                radius_of_curvature=6,
                 depth=10,
             ),
         ),

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -224,21 +224,16 @@ class WellDefinition(BaseModel):
     )
 
 
-class Hemisphere(BaseModel):
+class CircularCrossSection(BaseModel):
+    shape: Literal["circular"] = Field(..., description="Denote shape as circular")
     diameter: _NonNegativeNumber = Field(
-        ...,
-        description="diameter of bottom subsection of wells",
-    )
-    depth: _NonNegativeNumber = Field(
-        ..., description="The depth of a hemispherical bottom of a well"
+        ..., description="The diameter of a circular cross section of a well"
     )
 
 
-class TopCrossSection(BaseModel):
-    shape: Literal["rectangular", "circular"] = Field(
-        ...,
-        description="Shape of a cross-section of a well used to determine how "
-        "to calculate area",
+class RectangularCrossSection(BaseModel):
+    shape: Literal["rectangular"] = Field(
+        ..., description="Denote shape as rectangular"
     )
     xDimension: Optional[_NonNegativeNumber] = Field(
         None,
@@ -248,18 +243,32 @@ class TopCrossSection(BaseModel):
         None,
         description="y dimension of a subsection of wells",
     )
-    diameter: Optional[_NonNegativeNumber] = Field(
-        None,
-        description="diameter of a subsection of wells",
+
+
+class Hemisphere(BaseModel):
+    shape: Literal["hemispherical"] = Field(
+        ..., description="Denote shape as hemispherical"
     )
+    diameter: _NonNegativeNumber = Field(
+        ...,
+        description="diameter of bottom subsection of wells",
+    )
+    depth: _NonNegativeNumber = Field(
+        ..., description="The depth of a hemispherical bottom of a well"
+    )
+
+
+TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
+BottomShape = Union[CircularCrossSection, RectangularCrossSection, Hemisphere]
 
 
 class BoundedSection(BaseModel):
     geometry: TopCrossSection = Field(
         ...,
         description="Geometrical information needed to calculate the volume of a subsection of a well",
+        discriminator="shape",
     )
-    top_height: _NonNegativeNumber = Field(
+    topHeight: _NonNegativeNumber = Field(
         ...,
         description="The height at the top of a bounded subsection of a well, relative to the bottom"
         "of the well",
@@ -299,8 +308,10 @@ class InnerLabwareGeometry(BaseModel):
         ...,
         description="A list of all of the sections of the well that have a contiguous shape",
     )
-    bottom_shape: Optional[Hemisphere] = Field(
-        None, description="An optional non-frustum shape at the bottom of a well"
+    bottomShape: BottomShape = Field(
+        ...,
+        description="An optional non-frustum shape at the bottom of a well",
+        discriminator="shape",
     )
 
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -105,6 +105,33 @@ class DisplayCategory(str, Enum):
     other = "other"
 
 
+class CircleArea(BaseModel):
+    radius: float
+
+
+class RectangleArea(BaseModel):
+    length: float
+    width: float
+
+
+class Hemisphere(BaseModel):
+    radius: float
+    depth: float
+
+
+CrossSectionShape = Union[CircleArea, RectangleArea]
+
+
+class CrossSection(BaseModel):
+    shape: CrossSectionShape
+    height: float
+
+
+class InnerLabwareGeometry(BaseModel):
+    cross_sections: List[CrossSection]
+    hemisphere: Optional[Hemisphere]
+
+
 class LabwareRole(str, Enum):
     labware = "labware"
     fixture = "fixture"

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -245,21 +245,19 @@ class RectangularCrossSection(BaseModel):
     )
 
 
-class Hemisphere(BaseModel):
-    shape: Literal["hemispherical"] = Field(
-        ..., description="Denote shape as hemispherical"
-    )
-    diameter: _NonNegativeNumber = Field(
+class SphericalSegment(BaseModel):
+    shape: Literal["spherical"] = Field(..., description="Denote shape as spherical")
+    radius_of_curvature: _NonNegativeNumber = Field(
         ...,
-        description="diameter of bottom subsection of wells",
+        description="radius of curvature of bottom subsection of wells",
     )
     depth: _NonNegativeNumber = Field(
-        ..., description="The depth of a hemispherical bottom of a well"
+        ..., description="The depth of a spherical bottom of a well"
     )
 
 
 TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
-BottomShape = Union[CircularCrossSection, RectangularCrossSection, Hemisphere]
+BottomShape = Union[CircularCrossSection, RectangularCrossSection, SphericalSegment]
 
 
 class BoundedSection(BaseModel):
@@ -310,7 +308,7 @@ class InnerLabwareGeometry(BaseModel):
     )
     bottomShape: BottomShape = Field(
         ...,
-        description="The shape at the bottom of the well: either a hemisphere or a cross-section",
+        description="The shape at the bottom of the well: either a spherical segment or a cross-section",
         discriminator="shape",
     )
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -310,7 +310,7 @@ class InnerLabwareGeometry(BaseModel):
     )
     bottomShape: BottomShape = Field(
         ...,
-        description="An optional non-frustum shape at the bottom of a well",
+        description="The shape at the bottom of the well: either a hemisphere or a cross-section",
         discriminator="shape",
     )
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -245,18 +245,14 @@ class InnerGeometrySection(BaseModel):
 
 
 class BoundedSection(BaseModel):
-    shape: InnerGeometrySection = Field(
+    geometry: InnerGeometrySection = Field(
         ...,
-        description="Geometrical layout of the geometry of a section of the inside of a well",
+        description="Geometrical information needed to calculate the volume of a subsection of a well",
     )
     top_height: _NonNegativeNumber = Field(
         ...,
         description="The height at the top of a bounded subsection of a well"
     )
-
-
-class InnerLabwareGeometry(BaseModel):
-    boundedSections: List[BoundedSection]
 
 
 class Metadata1(BaseModel):
@@ -361,9 +357,9 @@ class LabwareDefinition(BaseModel):
         default_factory=None,
         description="Force, in Newtons, with which the gripper should grip the labware.",
     )
-    innerWellGeometry: Optional[InnerLabwareGeometry] = Field(
-        ...,
-        description="A layout describing the geometry of the inside of the wells.",
+    innerWellGeometry: Optional[List[BoundedSection]] = Field(
+        None,
+        description="A list of bounded sections describing the geometry of the inside of the wells.",
     )
 
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -224,11 +224,11 @@ class WellDefinition(BaseModel):
     )
 
 
-class InnerGeometrySection(BaseModel):
+class TopCrossSection(BaseModel):
     shape: Literal["rectangular", "circular", "hemisphere"] = Field(
         ...,
         description="Shape of a cross-section of a well used to determine how "
-                    "to calculate area",
+        "to calculate area",
     )
     xDimension: Optional[_NonNegativeNumber] = Field(
         None,
@@ -245,13 +245,12 @@ class InnerGeometrySection(BaseModel):
 
 
 class BoundedSection(BaseModel):
-    geometry: InnerGeometrySection = Field(
+    geometry: TopCrossSection = Field(
         ...,
         description="Geometrical information needed to calculate the volume of a subsection of a well",
     )
     top_height: _NonNegativeNumber = Field(
-        ...,
-        description="The height at the top of a bounded subsection of a well"
+        ..., description="The height at the top of a bounded subsection of a well"
     )
 
 
@@ -361,6 +360,3 @@ class LabwareDefinition(BaseModel):
         None,
         description="A list of bounded sections describing the geometry of the inside of the wells.",
     )
-
-
-

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -224,23 +224,33 @@ class WellDefinition(BaseModel):
     )
 
 
+class Hemisphere(BaseModel):
+    diameter: _NonNegativeNumber = Field(
+        ...,
+        description="diameter of bottom subsection of wells",
+    )
+    depth: _NonNegativeNumber = Field(
+        ..., description="The depth of a hemispherical bottom of a well"
+    )
+
+
 class TopCrossSection(BaseModel):
-    shape: Literal["rectangular", "circular", "hemisphere"] = Field(
+    shape: Literal["rectangular", "circular"] = Field(
         ...,
         description="Shape of a cross-section of a well used to determine how "
         "to calculate area",
     )
     xDimension: Optional[_NonNegativeNumber] = Field(
         None,
-        description="x dimension of rectangular wells",
+        description="x dimension of a subsection of wells",
     )
     yDimension: Optional[_NonNegativeNumber] = Field(
         None,
-        description="y dimension of rectangular wells",
+        description="y dimension of a subsection of wells",
     )
     diameter: Optional[_NonNegativeNumber] = Field(
         None,
-        description="diameter of circular wells",
+        description="diameter of a subsection of wells",
     )
 
 
@@ -279,6 +289,16 @@ class Group(BaseModel):
     )
     brand: Optional[BrandData] = Field(
         None, description="Brand data for the well group (e.g. for tubes)"
+    )
+
+
+class InnerLabwareGeometry(BaseModel):
+    frusta: List[BoundedSection] = Field(
+        ...,
+        description="A list of all of the sections of the well that have a contiguous shape",
+    )
+    bottom_shape: Optional[Hemisphere] = Field(
+        None, description="An optional non-frustum shape at the bottom of a well"
     )
 
 
@@ -356,7 +376,7 @@ class LabwareDefinition(BaseModel):
         default_factory=None,
         description="Force, in Newtons, with which the gripper should grip the labware.",
     )
-    innerWellGeometry: Optional[List[BoundedSection]] = Field(
+    innerWellGeometry: Optional[InnerLabwareGeometry] = Field(
         None,
         description="A list of bounded sections describing the geometry of the inside of the wells.",
     )

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -105,33 +105,6 @@ class DisplayCategory(str, Enum):
     other = "other"
 
 
-class CircleArea(BaseModel):
-    radius: float
-
-
-class RectangleArea(BaseModel):
-    length: float
-    width: float
-
-
-class Hemisphere(BaseModel):
-    radius: float
-    depth: float
-
-
-CrossSectionShape = Union[CircleArea, RectangleArea]
-
-
-class CrossSection(BaseModel):
-    shape: CrossSectionShape
-    height: float
-
-
-class InnerLabwareGeometry(BaseModel):
-    cross_sections: List[CrossSection]
-    hemisphere: Optional[Hemisphere]
-
-
 class LabwareRole(str, Enum):
     labware = "labware"
     fixture = "fixture"
@@ -251,6 +224,41 @@ class WellDefinition(BaseModel):
     )
 
 
+class InnerGeometrySection(BaseModel):
+    shape: Literal["rectangular", "circular", "hemisphere"] = Field(
+        ...,
+        description="Shape of a cross-section of a well used to determine how "
+                    "to calculate area",
+    )
+    xDimension: Optional[_NonNegativeNumber] = Field(
+        None,
+        description="x dimension of rectangular wells",
+    )
+    yDimension: Optional[_NonNegativeNumber] = Field(
+        None,
+        description="y dimension of rectangular wells",
+    )
+    diameter: Optional[_NonNegativeNumber] = Field(
+        None,
+        description="diameter of circular wells",
+    )
+
+
+class BoundedSection(BaseModel):
+    shape: InnerGeometrySection = Field(
+        ...,
+        description="Geometrical layout of the geometry of a section of the inside of a well",
+    )
+    top_height: _NonNegativeNumber = Field(
+        ...,
+        description="The height at the top of a bounded subsection of a well"
+    )
+
+
+class InnerLabwareGeometry(BaseModel):
+    boundedSections: List[BoundedSection]
+
+
 class Metadata1(BaseModel):
     """
     Metadata specific to a grid of wells in a labware
@@ -353,3 +361,10 @@ class LabwareDefinition(BaseModel):
         default_factory=None,
         description="Force, in Newtons, with which the gripper should grip the labware.",
     )
+    innerWellGeometry: Optional[InnerLabwareGeometry] = Field(
+        ...,
+        description="A layout describing the geometry of the inside of the wells.",
+    )
+
+
+

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -260,7 +260,9 @@ class BoundedSection(BaseModel):
         description="Geometrical information needed to calculate the volume of a subsection of a well",
     )
     top_height: _NonNegativeNumber = Field(
-        ..., description="The height at the top of a bounded subsection of a well"
+        ...,
+        description="The height at the top of a bounded subsection of a well, relative to the bottom"
+        "of the well",
     )
 
 

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -37,6 +37,7 @@ LabwareRoles = Union[
 
 Circular = Literal["circular"]
 Rectangular = Literal["rectangular"]
+Hemispherical = Literal["hemispherical"]
 WellShape = Union[Circular, Rectangular]
 
 
@@ -117,33 +118,34 @@ class WellGroup(TypedDict, total=False):
     brand: LabwareBrandData
 
 
-class CircularArea(TypedDict):
+class CircularCrossSection(TypedDict):
     shape: Circular
     diameter: float
 
 
-class RectangularArea(TypedDict):
+class RectangularCrossSection(TypedDict):
     shape: Rectangular
     xDimension: float
     yDimension: float
 
 
-TopCrossSection = Union[CircularArea, RectangularArea]
-
-
 class Hemisphere(TypedDict):
+    shape: Hemispherical
     diameter: float
-    depth: float
+
+
+TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
+BottomShape = Union[CircularCrossSection, RectangularCrossSection, Hemisphere]
 
 
 class BoundedSection(TypedDict):
     geometry: TopCrossSection
-    top_height: float
+    topHeight: float
 
 
 class InnerLabwareGeometry(TypedDict):
     frusta: List[BoundedSection]
-    bottom_shape: Optional[Hemisphere]
+    bottomShape: BottomShape
 
 
 class _RequiredLabwareDefinition(TypedDict):

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -157,13 +157,10 @@ class HemisphereDimensions(TypedDict):
     diameter: float
 
 
+# This will either be a 2-Dimensional cross-section or a hemisphere
 InnerGeometrySection = Union[CircularArea, RectangularArea, HemisphereDimensions]
 
 
 class BoundedSection(TypedDict):
-    shape: InnerGeometrySection
+    geometry: InnerGeometrySection
     top_height: float
-
-
-class InnerLabwareGeometry(TypedDict):
-    bounded_sections: List[BoundedSection]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -37,6 +37,7 @@ LabwareRoles = Union[
 
 Circular = Literal["circular"]
 Rectangular = Literal["rectangular"]
+Hemisphere = Literal["hemisphere"]
 WellShape = Union[Circular, Rectangular]
 
 
@@ -138,3 +139,31 @@ class LabwareDefinition(_RequiredLabwareDefinition, total=False):
     gripperOffsets: Dict[str, GripperOffsets]
     gripForce: float
     gripHeightFromLabwareBottom: float
+
+
+class CircularArea(TypedDict):
+    shape: Circular
+    diameter: float
+
+
+class RectangularArea(TypedDict):
+    shape: Rectangular
+    xDimension: float
+    yDimension: float
+
+
+class HemisphereDimensions(TypedDict):
+    shape: Hemisphere
+    diameter: float
+
+
+InnerGeometrySection = Union[CircularArea, RectangularArea, HemisphereDimensions]
+
+
+class BoundedSection(TypedDict):
+    shape: InnerGeometrySection
+    top_height: float
+
+
+class InnerLabwareGeometry(TypedDict):
+    bounded_sections: List[BoundedSection]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -135,7 +135,7 @@ class Hemisphere(TypedDict):
 
 
 TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
-BottomShape = Union[CircularCrossSection, RectangularCrossSection, Hemisphere]
+BottomShape = Union[CircularCrossSection, RectangularCrossSection, Hemispherical]
 
 
 class BoundedSection(TypedDict):

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -136,7 +136,7 @@ class SphericalSegment(TypedDict):
 
 
 TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
-BottomShape = Union[CircularCrossSection, RectangularCrossSection, Spherical]
+BottomShape = Union[CircularCrossSection, RectangularCrossSection, SphericalSegment]
 
 
 class BoundedSection(TypedDict):

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -158,9 +158,9 @@ class HemisphereDimensions(TypedDict):
 
 
 # This will either be a 2-Dimensional cross-section or a hemisphere
-InnerGeometrySection = Union[CircularArea, RectangularArea, HemisphereDimensions]
+TopCrossSection = Union[CircularArea, RectangularArea, HemisphereDimensions]
 
 
 class BoundedSection(TypedDict):
-    geometry: InnerGeometrySection
+    geometry: TopCrossSection
     top_height: float

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -37,7 +37,7 @@ LabwareRoles = Union[
 
 Circular = Literal["circular"]
 Rectangular = Literal["rectangular"]
-Hemispherical = Literal["hemispherical"]
+Spherical = Literal["spherical"]
 WellShape = Union[Circular, Rectangular]
 
 
@@ -129,13 +129,14 @@ class RectangularCrossSection(TypedDict):
     yDimension: float
 
 
-class Hemisphere(TypedDict):
-    shape: Hemispherical
-    diameter: float
+class SphericalSegment(TypedDict):
+    shape: Spherical
+    radius_of_curvature: float
+    depth: float
 
 
 TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
-BottomShape = Union[CircularCrossSection, RectangularCrossSection, Hemispherical]
+BottomShape = Union[CircularCrossSection, RectangularCrossSection, Spherical]
 
 
 class BoundedSection(TypedDict):

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -3,7 +3,7 @@
 types in this file by and large require the use of typing_extensions.
 this module shouldn't be imported unless typing.TYPE_CHECKING is true.
 """
-from typing import Dict, List, NewType, Union
+from typing import Dict, List, NewType, Union, Optional
 from typing_extensions import Literal, TypedDict
 
 
@@ -37,7 +37,6 @@ LabwareRoles = Union[
 
 Circular = Literal["circular"]
 Rectangular = Literal["rectangular"]
-Hemisphere = Literal["hemisphere"]
 WellShape = Union[Circular, Rectangular]
 
 
@@ -118,6 +117,35 @@ class WellGroup(TypedDict, total=False):
     brand: LabwareBrandData
 
 
+class CircularArea(TypedDict):
+    shape: Circular
+    diameter: float
+
+
+class RectangularArea(TypedDict):
+    shape: Rectangular
+    xDimension: float
+    yDimension: float
+
+
+TopCrossSection = Union[CircularArea, RectangularArea]
+
+
+class Hemisphere(TypedDict):
+    diameter: float
+    depth: float
+
+
+class BoundedSection(TypedDict):
+    geometry: TopCrossSection
+    top_height: float
+
+
+class InnerLabwareGeometry(TypedDict):
+    frusta: List[BoundedSection]
+    bottom_shape: Optional[Hemisphere]
+
+
 class _RequiredLabwareDefinition(TypedDict):
     schemaVersion: Literal[2]
     version: int
@@ -139,28 +167,4 @@ class LabwareDefinition(_RequiredLabwareDefinition, total=False):
     gripperOffsets: Dict[str, GripperOffsets]
     gripForce: float
     gripHeightFromLabwareBottom: float
-
-
-class CircularArea(TypedDict):
-    shape: Circular
-    diameter: float
-
-
-class RectangularArea(TypedDict):
-    shape: Rectangular
-    xDimension: float
-    yDimension: float
-
-
-class HemisphereDimensions(TypedDict):
-    shape: Hemisphere
-    diameter: float
-
-
-# This will either be a 2-Dimensional cross-section or a hemisphere
-TopCrossSection = Union[CircularArea, RectangularArea, HemisphereDimensions]
-
-
-class BoundedSection(TypedDict):
-    geometry: TopCrossSection
-    top_height: float
+    innerWellGeometry: Optional[InnerLabwareGeometry]


### PR DESCRIPTION
## Overview
Add the Labware Definition types for static liquid tracking to shared-data.

Each labware defintion will now have an optional `innerWellGeometry` entry. This will be a list of `BoundedSection`s, as well as a `bottomShape.`

A `Bounded Section` will represent either a 'frustum' or a hemisphere- a subsection of a well with a uniform shape. It will hold a `TopCrossSection`, and will carry the `height` of the top cross-section of the shape it represents.

`bottomShape` will denote whether the bottom of a well is a `SphericalSection`, or a flat plane. It will also hold all of the necessary data to compute either the surface area or volume of the bottom section of the well

`TopCrossSection` will hold all the data necessary to calculate the area of the top cross-section of its `BoundedSection`.