### PR TITLE
fix(app): fix adapter/module location on move labware modal

### DIFF
--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -23,12 +23,12 @@ import {
 } from '@opentrons/components'
 import {
   OT2_ROBOT_TYPE,
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
+  THERMOCYCLER_MODULE_TYPE,
   getDeckDefFromRobotType,
-  getLabwareDisplayName,
   getLoadedLabwareDefinitionsByUri,
-  getModuleDisplayName,
   getModuleType,
-  getOccludedSlotCountForModule,
 } from '@opentrons/shared-data'
 
 import {
@@ -36,7 +36,6 @@ import {
   getRunModuleRenderInfo,
   getLabwareNameFromRunData,
   getModuleModelFromRunData,
-  getModuleDisplayLocationFromRunData,
 } from './utils'
 import { Divider } from '../../atoms/structure'
 import {
@@ -252,15 +251,15 @@ function LabwareDisplayLocation(
   props: LabwareDisplayLocationProps
 ): JSX.Element {
   const { t } = useTranslation('protocol_command_text')
-  const { protocolData, location, robotType, labwareDefsByUri } = props
-  let displayLocation: React.ReactNode = ''
+  const { protocolData, location, robotType } = props
+  let displayLocation: string = ''
   if (location === 'offDeck') {
     // TODO(BC, 08/28/23): remove this string cast after update i18next to >23 (see https://www.i18next.com/overview/typescript#argument-of-type-defaulttfuncreturn-is-not-assignable-to-parameter-of-type-xyz)
-    displayLocation = <DeckInfoLabel deckLabel={String(t('offdeck'))} />
+    displayLocation = String(t('offdeck'))
   } else if ('slotName' in location) {
-    displayLocation = <DeckInfoLabel deckLabel={location.slotName} />
+    displayLocation = location.slotName
   } else if ('addressableAreaName' in location) {
-    displayLocation = <DeckInfoLabel deckLabel={location.addressableAreaName} />
+    displayLocation = location.addressableAreaName
   } else if ('moduleId' in location) {
     const moduleModel = getModuleModelFromRunData(
       protocolData,
@@ -269,41 +268,32 @@ function LabwareDisplayLocation(
     if (moduleModel == null) {
       console.warn('labware is located on an unknown module model')
     } else {
-      displayLocation = t('module_in_slot', {
-        count: getOccludedSlotCountForModule(
-          getModuleType(moduleModel),
-          robotType
-        ),
-        module: getModuleDisplayName(moduleModel),
-        slot_name: getModuleDisplayLocationFromRunData(
-          protocolData,
-          location.moduleId
-        ),
-      })
+      const slotName =
+        getLoadedModule(protocolData, location.moduleId)?.location?.slotName ??
+        ''
+      const isModuleUnderAdapterThermocycler =
+        getModuleType(moduleModel) === THERMOCYCLER_MODULE_TYPE
+      if (isModuleUnderAdapterThermocycler) {
+        displayLocation =
+          robotType === OT2_ROBOT_TYPE
+            ? TC_MODULE_LOCATION_OT2
+            : TC_MODULE_LOCATION_OT3
+      } else {
+        displayLocation = slotName
+      }
     }
   } else if ('labwareId' in location) {
     const adapter = protocolData.labware.find(
       lw => lw.id === location.labwareId
     )
-    const adapterDef =
-      adapter != null ? labwareDefsByUri[adapter.definitionUri] : null
-    const adapterDisplayName =
-      adapterDef != null ? getLabwareDisplayName(adapterDef) : ''
-
     if (adapter == null) {
       console.warn('labware is located on an unknown adapter')
     } else if (adapter.location === 'offDeck') {
       displayLocation = t('off_deck')
     } else if ('slotName' in adapter.location) {
-      displayLocation = t('adapter_in_slot', {
-        adapter: adapterDisplayName,
-        slot_name: adapter.location.slotName,
-      })
+      displayLocation = adapter.location.slotName
     } else if ('addressableAreaName' in adapter.location) {
-      return t('adapter_in_slot', {
-        adapter: adapterDisplayName,
-        slot: adapter.location.addressableAreaName,
-      })
+      displayLocation = adapter.location.addressableAreaName
     } else if ('moduleId' in adapter.location) {
       const moduleIdUnderAdapter = adapter.location.moduleId
       const moduleModel = protocolData.modules.find(
@@ -315,19 +305,20 @@ function LabwareDisplayLocation(
         const slotName =
           getLoadedModule(protocolData, adapter.location.moduleId)?.location
             ?.slotName ?? ''
-        displayLocation = t('adapter_in_module_in_slot', {
-          count: getOccludedSlotCountForModule(
-            getModuleType(moduleModel),
-            robotType ?? OT2_ROBOT_TYPE
-          ),
-          module: getModuleDisplayName(moduleModel),
-          adapter: adapterDisplayName,
-          slot_name: slotName,
-        })
+        const isModuleUnderAdapterThermocycler =
+          getModuleType(moduleModel) === THERMOCYCLER_MODULE_TYPE
+        if (isModuleUnderAdapterThermocycler) {
+          displayLocation =
+            robotType === OT2_ROBOT_TYPE
+              ? TC_MODULE_LOCATION_OT2
+              : TC_MODULE_LOCATION_OT3
+        } else {
+          displayLocation = slotName
+        }
       }
     } else {
       console.warn('display location could not be established: ', location)
     }
   }
-  return <>{displayLocation}</>
+  return <DeckInfoLabel deckLabel={displayLocation} />
 }


### PR DESCRIPTION
# Overview

Set `LabwareDisplayLocation` in `MoveLabwareInterventionContent` to slot name or addressable area name even if move target is an adapter or if the initial/final location is not directly on a slot, but rather on top of a labware/adapter or module.

Closes RQA-2783

## Test Plan and Hands on Testing

- Run a protocol with labware movements to/from modules or adapters
- Verify that modal shows the base location (slot name) rather than text describing the adapter/module
<img width="759" alt="Screenshot 2024-08-12 at 5 36 09 PM" src="https://github.com/user-attachments/assets/7bae4cfb-0f73-48b0-99bc-2a4ff8655a36">
<img width="756" alt="Screenshot 2024-08-12 at 5 36 01 PM" src="https://github.com/user-attachments/assets/b406f2e2-1cc4-4bab-9c76-06ed116d6e51">

## Changelog

- return proper `DeckInfoLabel` for initial/final labware location
- special case Thermocycler location as 'A1+B1' for Flex or '7, 8, 10,11' for OT-2
 
## Review requests

see test plan

## Risk assessment

low