### PR TITLE
fix(app): clear number wells selected error when deselecting

### DIFF
--- a/app/src/organisms/QuickTransferFlow/SelectDestWells.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectDestWells.tsx
@@ -167,6 +167,7 @@ export function SelectDestWells(props: SelectDestWellsProps): JSX.Element {
             <WellSelection
               definition={labwareDefinition}
               deselectWells={(wells: string[]) => {
+                setIsNumberWellsSelectedError(false)
                 setSelectedWells(prevWells =>
                   without(Object.keys(prevWells), ...wells).reduce(
                     (acc, well) => {


### PR DESCRIPTION
# Overview

clears the quick transfer well selection number of wells selected error for destination labware when deselecting wells, same as when selecting wells

closes RQA-2914

## Test Plan and Hands on Testing

verified the error clears when deselecting wells in 384 well destination labware

## Changelog

 - Clears number wells selected error when deselecting quick transfer destination labware wells

## Review requests

confirm the fix

## Risk assessment

low
