### PR TITLE
fix(app): support drop tip CTAs when two pipettes have tips attached

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolDropTipModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolDropTipModal.tsx
@@ -66,7 +66,6 @@ export function useProtocolDropTipModal({
   // Close the modal if a different app closes the run context.
   React.useEffect(() => {
     if (isRunCurrent && !isHomingPipettes) {
-      console.log('HITTING SET SHOW MODAL')
       setShowDTModal(areTipsAttached)
     } else if (!isRunCurrent) {
       setShowDTModal(false)

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolDropTipModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolDropTipModal.tsx
@@ -32,7 +32,7 @@ type UseProtocolDropTipModalProps = Pick<
   areTipsAttached: TipAttachmentStatusResult['areTipsAttached']
   toggleDTWiz: () => void
   currentRunId: string
-  onClose: () => void
+  onSkipAndHome: () => void
   /* True if the most recent run is the current run */
   isRunCurrent: boolean
 }
@@ -49,15 +49,16 @@ export function useProtocolDropTipModal({
   areTipsAttached,
   toggleDTWiz,
   isRunCurrent,
-  onClose,
+  onSkipAndHome,
   ...homePipetteProps
 }: UseProtocolDropTipModalProps): UseProtocolDropTipModalResult {
   const [showDTModal, setShowDTModal] = React.useState(areTipsAttached)
 
   const { homePipettes, isHomingPipettes } = useHomePipettes({
     ...homePipetteProps,
-    onComplete: () => {
-      onClose()
+    isRunCurrent,
+    onHome: () => {
+      onSkipAndHome()
       setShowDTModal(false)
     },
   })
@@ -65,6 +66,7 @@ export function useProtocolDropTipModal({
   // Close the modal if a different app closes the run context.
   React.useEffect(() => {
     if (isRunCurrent && !isHomingPipettes) {
+      console.log('HITTING SET SHOW MODAL')
       setShowDTModal(areTipsAttached)
     } else if (!isRunCurrent) {
       setShowDTModal(false)

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -227,6 +227,7 @@ export function ProtocolRunHeader({
     runRecord: runRecord ?? null,
     host,
   })
+
   const {
     showDTModal,
     onDTModalSkip,
@@ -240,7 +241,7 @@ export function ProtocolRunHeader({
     instrumentModelSpecs: aPipetteWithTip?.specs,
     mount: aPipetteWithTip?.mount,
     robotType,
-    onClose: () => {
+    onSkipAndHome: () => {
       closeCurrentRun()
     },
   })
@@ -515,13 +516,16 @@ export function ProtocolRunHeader({
             robotType={isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE}
             mount={aPipetteWithTip.mount}
             instrumentModelSpecs={aPipetteWithTip.specs}
-            closeFlow={() =>
-              setTipStatusResolved()
-                .then(toggleDTWiz)
-                .then(() => {
+            closeFlow={isTakeover => {
+              if (isTakeover) {
+                toggleDTWiz()
+              } else {
+                void setTipStatusResolved(() => {
+                  toggleDTWiz()
                   closeCurrentRun()
-                })
-            }
+                }, toggleDTWiz)
+              }
+            }}
           />
         ) : null}
       </Flex>

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -227,7 +227,6 @@ export function ProtocolRunHeader({
     runRecord: runRecord ?? null,
     host,
   })
-
   const {
     showDTModal,
     onDTModalSkip,

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolDropTipModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolDropTipModal.test.tsx
@@ -26,7 +26,7 @@ describe('useProtocolDropTipModal', () => {
       areTipsAttached: true,
       toggleDTWiz: vi.fn(),
       isRunCurrent: true,
-      onClose: vi.fn(),
+      onSkipAndHome: vi.fn(),
       currentRunId: 'MOCK_ID',
       mount: 'left',
       instrumentModelSpecs: mockLeftSpecs,

--- a/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
+++ b/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
@@ -25,12 +25,12 @@ import type { UseHomePipettesProps } from './hooks'
 
 type TipsAttachedModalProps = Pick<
   UseHomePipettesProps,
-  'robotType' | 'instrumentModelSpecs' | 'mount'
+  'robotType' | 'instrumentModelSpecs' | 'mount' | 'isRunCurrent'
 > & {
   aPipetteWithTip: PipetteWithTip
   host: HostConfig | null
   setTipStatusResolved: (onEmpty?: () => void) => Promise<void>
-  onClose: () => void
+  onSkipAndHome: () => void
 }
 
 export const handleTipsAttachedModal = (
@@ -56,8 +56,9 @@ const TipsAttachedModal = NiceModal.create(
     const { showDTWiz, toggleDTWiz } = useDropTipWizardFlows()
     const { homePipettes, isHomingPipettes } = useHomePipettes({
       ...homePipetteProps,
-      onComplete: () => {
-        cleanUpAndClose()
+      onHome: () => {
+        modal.remove()
+        void setTipStatusResolved()
       },
     })
 
@@ -71,9 +72,13 @@ const TipsAttachedModal = NiceModal.create(
       homePipettes()
     }
 
-    const cleanUpAndClose = (): void => {
-      modal.remove()
-      props.onClose()
+    const cleanUpAndClose = (isTakeover?: boolean): void => {
+      toggleDTWiz()
+
+      if (!isTakeover) {
+        modal.remove()
+        void setTipStatusResolved()
+      }
     }
 
     const is96Channel = specs.channels === 96
@@ -119,8 +124,8 @@ const TipsAttachedModal = NiceModal.create(
             instrumentModelSpecs={specs}
             mount={mount}
             robotType={FLEX_ROBOT_TYPE}
-            closeFlow={() => {
-              cleanUpAndClose()
+            closeFlow={isTakeover => {
+              cleanUpAndClose(isTakeover)
             }}
           />
         ) : null}

--- a/app/src/organisms/DropTipWizardFlows/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/TipsAttachedModal.test.tsx
@@ -55,7 +55,8 @@ const render = (aPipetteWithTip: PipetteWithTip) => {
             robotType: FLEX_ROBOT_TYPE,
             mount: 'left',
             instrumentModelSpecs: mockPipetteInfo.pipetteSpecs as any,
-            onClose: vi.fn(),
+            onSkipAndHome: vi.fn(),
+            isRunCurrent: true,
           })
         }
         data-testid="testButton"

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -33,6 +33,7 @@ type UseDropTipSetupCommandsParams = UseDTWithTypeParams & {
   setErrorDetails: (errorDetails: SetRobotErrorDetailsParams) => void
   toggleIsExiting: () => void
   fixitCommandTypeUtils?: FixitCommandTypeUtils
+  toggleClientEndRun: () => void
 }
 
 export interface UseDropTipCommandsResult {
@@ -57,20 +58,14 @@ export function useDropTipCommands({
   instrumentModelSpecs,
   robotType,
   fixitCommandTypeUtils,
+  toggleClientEndRun,
 }: UseDropTipSetupCommandsParams): UseDropTipCommandsResult {
   const isFlex = robotType === FLEX_ROBOT_TYPE
   const [hasSeenClose, setHasSeenClose] = React.useState(false)
   const [jogQueue, setJogQueue] = React.useState<Array<() => Promise<void>>>([])
   const [isJogging, setIsJogging] = React.useState(false)
 
-  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({
-    onSuccess: () => {
-      closeFlow()
-    },
-    onError: () => {
-      closeFlow()
-    },
-  })
+  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation()
   const deckConfig = useNotifyDeckConfigurationQuery().data ?? []
 
   const handleCleanUpAndClose = (homeOnExit: boolean = true): Promise<void> => {
@@ -93,6 +88,8 @@ export function useDropTipCommands({
                 console.error(error.message)
               })
               .finally(() => {
+                toggleClientEndRun()
+                closeFlow()
                 deleteMaintenanceRun(activeMaintenanceRunId)
               })
           }

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
@@ -41,10 +41,14 @@ export function useDropTipWithType(
   const { isExiting, toggleIsExiting } = useIsExitingDT(issuedCommandsType)
   const { errorDetails, setErrorDetails } = useErrorDetails()
 
-  const activeMaintenanceRunId = useDropTipMaintenanceRun({
+  const {
+    activeMaintenanceRunId,
+    toggleClientEndRun,
+  } = useDropTipMaintenanceRun({
     ...params,
     setErrorDetails,
   })
+
   const dtCreateCommandUtils = useDropTipCreateCommands({
     ...params,
     setErrorDetails,
@@ -59,6 +63,7 @@ export function useDropTipWithType(
     setErrorDetails,
     toggleIsExiting,
     fixitCommandTypeUtils,
+    toggleClientEndRun,
   })
 
   useRegisterPipetteFixitType({ ...params, ...dtCreateCommandUtils })

--- a/app/src/organisms/DropTipWizardFlows/index.tsx
+++ b/app/src/organisms/DropTipWizardFlows/index.tsx
@@ -35,7 +35,8 @@ export interface DropTipWizardFlowsProps {
   robotType: RobotType
   mount: PipetteData['mount']
   instrumentModelSpecs: PipetteModelSpecs
-  closeFlow: () => void
+  /* isTakeover allows for optionally specifying a different callback if a different client cancels the "setup" type flow. */
+  closeFlow: (isTakeover?: boolean) => void
   /* Optional. If provided, DT will issue "fixit" commands and render alternate Error Recovery compatible views. */
   fixitCommandTypeUtils?: FixitCommandTypeUtils
 }

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -187,7 +187,6 @@ export function RunSummary(): JSX.Element {
   // TODO(jh, 08-02-24): Revisit useCurrentRunRoute and top level redirects.
   const queryClient = useQueryClient()
   const returnToDash = (): void => {
-    closeCurrentRun()
     // Eagerly clear the query caches to prevent top level redirecting back to this page.
     queryClient.setQueryData([host, 'runs', 'details'], () => undefined)
     queryClient.setQueryData([host, 'runs', runId, 'details'], () => undefined)
@@ -237,7 +236,8 @@ export function RunSummary(): JSX.Element {
         instrumentModelSpecs: aPipetteWithTip.specs,
         mount: aPipetteWithTip.mount,
         robotType: FLEX_ROBOT_TYPE,
-        onClose: () => {
+        isRunCurrent,
+        onSkipAndHome: () => {
           closeCurrentRun()
           returnToDash()
         },
@@ -259,7 +259,8 @@ export function RunSummary(): JSX.Element {
         instrumentModelSpecs: aPipetteWithTip.specs,
         mount: aPipetteWithTip.mount,
         robotType: FLEX_ROBOT_TYPE,
-        onClose: () => {
+        isRunCurrent,
+        onSkipAndHome: () => {
           runAgain()
         },
       })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In 8.0, drop tip wiz now shows CTAs when a run is successful, and we determine tip attachment status solely from the history of tip attachment commands. Because of this, it's likely users will have protocols similar to the following:

```
left_pipette.pick_up_tip()   
[do something without dropping the tip explicitly in the protocol]
right_pipette.pick_up_tip()
[do something without dropping the tip explicitly in the protocol]
[end protocol]
```

In these situations, we want to prompt users to check tips on both pipettes.

This is simple in theory, but in practice, there are a lot of side-effects we have to consider: run status, whether the run is current, which app is controlling the robot, how to properly load the correct pipette...there's a lot of variables. Unfortunately, drop tip wizard in its current iteration is already overloaded and in need of a refactor. Following the control flow is difficult to say the least. If you're brave, #15947 offers some context behind the most recent systems created.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Smoke tested all drop tip flows and interactions, ensuring correct behavior. I used this protocol. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- New drop tip CTAs support dropping tips from two pipettes, if applicable.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
There is a lot we can do to clean this up, but this entire flow is getting a facelift for 8.1, so I think it's safe to focus on functionality for now. 
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- lowish-med. I smoke tested this thoroughly. 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
