### PR TITLE
fix(app): Fix "run again" button after cancelling a run

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -236,6 +236,7 @@
   "protocol_run_complete": "Protocol run complete.",
   "protocol_run_failed": "Protocol run failed.",
   "protocol_run_started": "Protocol run started.",
+  "protocol_run_stopped": "Protocol run stopped.",
   "protocol_specifies": "Protocol specifies",
   "protocol_upload_revamp_feedback": "Have feedback about this experience?",
   "quantity": "Quantity",

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -732,13 +732,21 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
       return module.moduleType === 'heaterShakerModuleType'
     })
     .some(module => module?.data != null && module.data.speedStatus !== 'idle')
+  const isValidRunAgain =
+    runStatus != null && RUN_AGAIN_STATUSES.includes(runStatus)
+  const validRunAgainButRequiresSetup = isValidRunAgain && !isSetupComplete
+  const runAgainWithSpinner = validRunAgainButRequiresSetup && isResetRunLoading
 
   let buttonText: string = ''
   let handleButtonClick = (): void => {}
   let buttonIconName: IconName | null = null
   let disableReason = null
 
-  if (currentRunId === runId && (!isSetupComplete || isFixtureMismatch)) {
+  if (
+    currentRunId === runId &&
+    (!isSetupComplete || isFixtureMismatch) &&
+    !isValidRunAgain
+  ) {
     disableReason = t('setup_incomplete')
   } else if (isOtherRunCurrent) {
     disableReason = t('shared:robot_is_busy')
@@ -803,7 +811,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
       }
     }
   } else if (runStatus != null && RUN_AGAIN_STATUSES.includes(runStatus)) {
-    buttonIconName = 'play'
+    buttonIconName = runAgainWithSpinner ? 'ot-spinner' : 'play'
     buttonText = t('run_again')
     handleButtonClick = () => {
       reset()
@@ -825,7 +833,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
         boxShadow="none"
         display={DISPLAY_FLEX}
         padding={`${SPACING.spacing12} ${SPACING.spacing16}`}
-        disabled={isRunControlButtonDisabled}
+        disabled={isRunControlButtonDisabled && !validRunAgainButRequiresSetup}
         onClick={handleButtonClick}
         id="ProtocolRunHeader_runControlButton"
         {...targetProps}
@@ -836,7 +844,9 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
             size={SIZE_1}
             marginRight={SPACING.spacing8}
             spin={
-              isProtocolAnalyzing || runStatus === RUN_STATUS_STOP_REQUESTED
+              isProtocolAnalyzing ||
+              runStatus === RUN_STATUS_STOP_REQUESTED ||
+              runAgainWithSpinner
             }
           />
         ) : null}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -287,6 +287,7 @@ export function ProtocolRunHeader({
       })
 
       // Close the run if no tips are attached after running tip check at least once.
+      // This marks the robot as "not busy" as soon as a run is cancelled if drop tip CTAs are unnecessary.
       if (initialPipettesWithTipsCount === 0) {
         closeCurrentRun()
       }

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -170,6 +170,7 @@ export function ProtocolRunHeader({
       ?.data?.current
   )
   const mostRecentRunId = useMostRecentRunId()
+  const isMostRecentRun = mostRecentRunId === runId
   const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
   const { startedAt, stoppedAt, completedAt } = useRunTimestamps(runId)
   const [showRunFailedModal, setShowRunFailedModal] = React.useState(false)
@@ -178,7 +179,7 @@ export function ProtocolRunHeader({
       runStatus != null &&
       // @ts-expect-error runStatus expected to possibly not be terminal
       RUN_STATUSES_TERMINAL.includes(runStatus) &&
-      isRunCurrent,
+      isMostRecentRun,
   })
   const isResetRunLoadingRef = React.useRef(false)
   const { data: runRecord } = useNotifyRunQuery(runId, { staleTime: Infinity })
@@ -222,6 +223,7 @@ export function ProtocolRunHeader({
     resetTipStatus,
     setTipStatusResolved,
     aPipetteWithTip,
+    initialPipettesWithTipsCount,
   } = useTipAttachmentStatus({
     runId,
     runRecord: runRecord ?? null,
@@ -283,6 +285,11 @@ export function ProtocolRunHeader({
           ...robotAnalyticsData,
         },
       })
+
+      // Close the run if no tips are attached after running tip check at least once.
+      if (initialPipettesWithTipsCount === 0) {
+        closeCurrentRun()
+      }
     }
   }, [runStatus, isRunCurrent, runId])
 
@@ -415,7 +422,7 @@ export function ProtocolRunHeader({
             {t('shared:close_robot_door')}
           </Banner>
         ) : null}
-        {mostRecentRunId === runId ? (
+        {isMostRecentRun ? (
           <TerminalRunBanner
             {...{
               runStatus,

--- a/app/src/organisms/Devices/ProtocolRun/SetupRobotCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupRobotCalibration.tsx
@@ -20,6 +20,8 @@ import { useIsFlex, useRunHasStarted } from '../hooks'
 import { SetupDeckCalibration } from './SetupDeckCalibration'
 import { SetupInstrumentCalibration } from './SetupInstrumentCalibration'
 import { SetupTipLengthCalibration } from './SetupTipLengthCalibration'
+import { useRunStatus } from '../../RunTimeControl/hooks'
+import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 
 import type { ProtocolCalibrationStatus } from '../../../redux/calibration/types'
 import type { StepKey } from './ProtocolRunSetup'
@@ -48,10 +50,13 @@ export function SetupRobotCalibration({
   const trackEvent = useTrackEvent()
 
   const runHasStarted = useRunHasStarted(runId)
+  const runStatus = useRunStatus(runId)
   const isFlex = useIsFlex(robotName)
 
   let tooltipText: string | null = null
-  if (runHasStarted) {
+  if (runStatus === RUN_STATUS_STOPPED) {
+    tooltipText = t('protocol_run_stopped')
+  } else if (runHasStarted) {
     tooltipText = t('protocol_run_started')
   } else if (calibrationStatus.reason != null) {
     tooltipText = t(calibrationStatus.reason)

--- a/app/src/organisms/DropTipWizardFlows/index.tsx
+++ b/app/src/organisms/DropTipWizardFlows/index.tsx
@@ -92,6 +92,8 @@ export interface TipAttachmentStatusResult {
   ) => Promise<PipetteWithTip>
   /* Relevant pipette information for a pipette with a tip attached. If both pipettes have tips attached, return the left pipette. */
   aPipetteWithTip: PipetteWithTip | null
+  /* The initial number of pipettes with tips. Null if there has been no tip check yet. */
+  initialPipettesWithTipsCount: number | null
 }
 
 // Returns various utilities for interacting with the cache of pipettes with tips attached.
@@ -101,6 +103,9 @@ export function useTipAttachmentStatus(
   const [pipettesWithTip, setPipettesWithTip] = React.useState<
     PipetteWithTip[]
   >([])
+  const [initialPipettesCount, setInitialPipettesCount] = React.useState<
+    number | null
+  >(null)
   const { data: attachedInstruments } = useInstrumentsQuery({
     refetchInterval: INSTRUMENTS_POLL_MS,
   })
@@ -129,6 +134,10 @@ export function useTipAttachmentStatus(
       ) as PipetteWithTip[]
 
       setPipettesWithTip(pipettesWithTipAndSpecs)
+      // Set only once.
+      if (initialPipettesCount === null) {
+        setInitialPipettesCount(pipettesWithTipAndSpecs.length)
+      }
 
       return Promise.resolve(pipettesWithTipAndSpecs)
     })
@@ -163,5 +172,6 @@ export function useTipAttachmentStatus(
     resetTipStatus,
     aPipetteWithTip,
     setTipStatusResolved,
+    initialPipettesWithTipsCount: initialPipettesCount,
   }
 }


### PR DESCRIPTION
Closes [RQA-2982](https://opentrons.atlassian.net/browse/RQA-2982)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

After error recovery and drop tip changes, run context is required after the run is cancelled. Before, if the run was cancelled, the app would implicitly close the run context. We can't do that any longer, but in order for some setup buttons to work properly, we need to close the run context somehow. 

Currently, after a run is cancelled, the "run again" button is greyed out if a user hasn't calibrated their instruments, although they were just running the protocol prior to cancelling it (note that users can't actually play a run without calibration, but they can create a run). Let's allow users to "run again" (create a run), and then be in the proper run state to perform setup. I don't know if this ever was the intended behavior of protocol runs in the past, but a lot of the existing copy points to this behavior being desired, anyway. 

EDIT: After giving this more thought, while I do think we should make the "run again" button selectable to remain consistent with copy and behavioral expectations, it's possible to retain the old behavior as well and close the current run when run status is stopped. It requires more special casing within `ProtocolRunHeader`, but `isRunCurrent` is really something only utilized by drop tip CTAs at the end of the day, so it's not *too* difficult to reason about. Given the overall complexity of these interactions, I think it's best not to push our luck in assuming what does/doesn't work until we formally refactor all of this. 

TLDR: From an end user perspective, nothing changes between 7.X and 8.0. Functionally, we special-case the drop tip logic to play nicely with run currenting/uncurrenting, tie the new recovery error rendering logic to `isMostRecentRun` (effectively what we were doing in 7.X), and now give the client an escape hatch if the run is cancelled but doesn't close the current run context. 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified users can now calibrate instruments given the behavior described in the ticket. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The run again button is no longer disabled after a run is cancelled. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2982]: https://opentrons.atlassian.net/browse/RQA-2982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ