### PR TITLE
fix(app): Fix "retry new tips" during Error Recovery overpressure flow

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -157,10 +157,6 @@ function DropTipFlowsContainer(
   const { cancelRun } = recoveryCommands
 
   const { mount, specs } = tipStatusUtils.aPipetteWithTip as PipetteWithTip // Safe as we have to have tips to get to this point in the flow.
-  console.log(
-    '=>(ManageTips.tsx:160) tipStatusUtils.aPipetteWithTip',
-    tipStatusUtils.aPipetteWithTip
-  )
 
   const onCloseFlow = (): void => {
     if (selectedRecoveryOption === RETRY_NEW_TIPS.ROUTE) {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -32,6 +32,8 @@ import type { FixitCommandTypeUtils } from '../../DropTipWizardFlows/types'
 export function ManageTips(props: RecoveryContentProps): JSX.Element {
   const { recoveryMap } = props
 
+  routeAlternativelyIfNoPipette(props)
+
   const buildContent = (): JSX.Element => {
     const { DROP_TIP_FLOWS } = RECOVERY_MAP
     const { step, route } = recoveryMap
@@ -155,6 +157,10 @@ function DropTipFlowsContainer(
   const { cancelRun } = recoveryCommands
 
   const { mount, specs } = tipStatusUtils.aPipetteWithTip as PipetteWithTip // Safe as we have to have tips to get to this point in the flow.
+  console.log(
+    '=>(ManageTips.tsx:160) tipStatusUtils.aPipetteWithTip',
+    tipStatusUtils.aPipetteWithTip
+  )
 
   const onCloseFlow = (): void => {
     if (selectedRecoveryOption === RETRY_NEW_TIPS.ROUTE) {
@@ -319,4 +325,42 @@ export function useDropTipFlowUtils({
     routeOverride: buildRouteOverride(),
     reportMap: updateSubMap,
   }
+}
+
+// Handle cases in which there is no pipette that could be used for drop tip wizard by routing
+// to the next step or to option selection, if no special routing is provided.
+function routeAlternativelyIfNoPipette(props: RecoveryContentProps): void {
+  const {
+    routeUpdateActions,
+    currentRecoveryOptionUtils,
+    tipStatusUtils,
+  } = props
+  const { proceedToRouteAndStep } = routeUpdateActions
+  const { selectedRecoveryOption } = currentRecoveryOptionUtils
+  const {
+    RETRY_NEW_TIPS,
+    SKIP_STEP_WITH_NEW_TIPS,
+    OPTION_SELECTION,
+  } = RECOVERY_MAP
+
+  if (tipStatusUtils.aPipetteWithTip == null)
+    switch (selectedRecoveryOption) {
+      case RETRY_NEW_TIPS.ROUTE: {
+        proceedToRouteAndStep(
+          selectedRecoveryOption,
+          RETRY_NEW_TIPS.STEPS.REPLACE_TIPS
+        )
+        break
+      }
+      case SKIP_STEP_WITH_NEW_TIPS.ROUTE: {
+        proceedToRouteAndStep(
+          selectedRecoveryOption,
+          SKIP_STEP_WITH_NEW_TIPS.STEPS.REPLACE_TIPS
+        )
+        break
+      }
+      default: {
+        proceedToRouteAndStep(OPTION_SELECTION.ROUTE)
+      }
+    }
 }

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/ManageTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/ManageTips.test.tsx
@@ -171,6 +171,59 @@ describe('ManageTips', () => {
 
     screen.getByText('MOCK DROP TIP FLOWS')
   })
+
+  describe('routeAlternativelyIfNoPipette', () => {
+    it('should route to RETRY_NEW_TIPS.STEPS.REPLACE_TIPS when selectedRecoveryOption is RETRY_NEW_TIPS.ROUTE and no pipette with tip', () => {
+      props.tipStatusUtils.aPipetteWithTip = null
+      props.currentRecoveryOptionUtils.selectedRecoveryOption =
+        RETRY_NEW_TIPS.ROUTE
+
+      render(props)
+
+      expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
+        RETRY_NEW_TIPS.ROUTE,
+        RETRY_NEW_TIPS.STEPS.REPLACE_TIPS
+      )
+    })
+
+    it('should route to SKIP_STEP_WITH_NEW_TIPS.STEPS.REPLACE_TIPS when selectedRecoveryOption is SKIP_STEP_WITH_NEW_TIPS.ROUTE and no pipette with tip', () => {
+      props.tipStatusUtils.aPipetteWithTip = null
+      props.currentRecoveryOptionUtils.selectedRecoveryOption =
+        RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE
+
+      render(props)
+
+      expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
+        RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE,
+        RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.STEPS.REPLACE_TIPS
+      )
+    })
+
+    it('should route to OPTION_SELECTION.ROUTE when selectedRecoveryOption is not RETRY_NEW_TIPS or SKIP_STEP_WITH_NEW_TIPS and no pipette with tip', () => {
+      props.tipStatusUtils.aPipetteWithTip = null
+      props.currentRecoveryOptionUtils.selectedRecoveryOption =
+        RECOVERY_MAP.CANCEL_RUN.ROUTE
+
+      render(props)
+
+      expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
+        RECOVERY_MAP.OPTION_SELECTION.ROUTE
+      )
+    })
+
+    it('should not route alternatively when there is a pipette with tip', () => {
+      props.tipStatusUtils.aPipetteWithTip = {
+        mount: 'left',
+        specs: MOCK_ACTUAL_PIPETTE,
+      }
+      props.currentRecoveryOptionUtils.selectedRecoveryOption =
+        RETRY_NEW_TIPS.ROUTE
+
+      render(props)
+
+      expect(mockProceedToRouteAndStep).not.toHaveBeenCalled()
+    })
+  })
 })
 
 describe('useDropTipFlowUtils', () => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -103,10 +103,17 @@ export function useERUtils({
     robotType,
   })
 
+  const failedPipetteInfo = getFailedCommandPipetteInfo({
+    failedCommandByRunRecord,
+    runRecord,
+    attachedInstruments,
+  })
+
   const tipStatusUtils = useRecoveryTipStatus({
     runId,
     runRecord,
     attachedInstruments,
+    failedPipetteInfo,
   })
 
   const routeUpdateActions = useRouteUpdateActions({
@@ -114,12 +121,6 @@ export function useERUtils({
     recoveryMap,
     toggleERWizAsActiveUser,
     setRecoveryMap: setRM,
-  })
-
-  const failedPipetteInfo = getFailedCommandPipetteInfo({
-    failedCommandByRunRecord,
-    runRecord,
-    attachedInstruments,
   })
 
   const failedLabwareUtils = useFailedLabwareUtils({

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryTipStatus.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryTipStatus.ts
@@ -1,10 +1,12 @@
 import * as React from 'react'
+import head from 'lodash/head'
 
 import { useHost } from '@opentrons/react-api-client'
+import { getPipetteModelSpecs } from '@opentrons/shared-data'
 
 import { useTipAttachmentStatus } from '../../DropTipWizardFlows'
 
-import type { Run, Instruments } from '@opentrons/api-client'
+import type { Run, Instruments, PipetteData } from '@opentrons/api-client'
 import type {
   TipAttachmentStatusResult,
   PipetteWithTip,
@@ -12,6 +14,7 @@ import type {
 
 interface UseRecoveryTipStatusProps {
   runId: string
+  failedPipetteInfo: PipetteData | null
   attachedInstruments?: Instruments
   runRecord?: Run
 }
@@ -27,6 +30,10 @@ export function useRecoveryTipStatus(
   props: UseRecoveryTipStatusProps
 ): RecoveryTipStatusUtils {
   const [isLoadingTipStatus, setIsLoadingTipStatus] = React.useState(false)
+  const [
+    failedCommandPipette,
+    setFailedCommandPipette,
+  ] = React.useState<PipetteWithTip | null>(null)
   const host = useHost()
 
   const tipAttachmentStatusUtils = useTipAttachmentStatus({
@@ -37,17 +44,47 @@ export function useRecoveryTipStatus(
 
   const determineTipStatusWithLoading = (): Promise<PipetteWithTip[]> => {
     const { determineTipStatus } = tipAttachmentStatusUtils
+    const { failedPipetteInfo } = props
     setIsLoadingTipStatus(true)
 
-    return determineTipStatus().then(pipettesWithTips => {
-      setIsLoadingTipStatus(false)
+    return determineTipStatus().then(pipettesWithTip => {
+      // In cases in which determineTipStatus doesn't think a tip could be attached to any pipette, supply the pipette
+      // involved in the failed command, if any.
+      let failedCommandPipettes: PipetteWithTip[]
+      const specs =
+        failedPipetteInfo != null
+          ? getPipetteModelSpecs(failedPipetteInfo.instrumentModel)
+          : null
 
-      return Promise.resolve(pipettesWithTips)
+      if (
+        pipettesWithTip.length === 0 &&
+        failedPipetteInfo != null &&
+        specs != null
+      ) {
+        const currentPipette: PipetteWithTip = {
+          mount: failedPipetteInfo.mount,
+          specs,
+        }
+
+        failedCommandPipettes = [currentPipette]
+      } else {
+        failedCommandPipettes = pipettesWithTip
+      }
+
+      setIsLoadingTipStatus(false)
+      setFailedCommandPipette(head(failedCommandPipettes) ?? null)
+      console.log(
+        '=>(useRecoveryTipStatus.ts:76) failedCommandPipettes',
+        failedCommandPipettes
+      )
+
+      return Promise.resolve(pipettesWithTip)
     })
   }
 
   return {
     ...tipAttachmentStatusUtils,
+    aPipetteWithTip: failedCommandPipette,
     determineTipStatus: determineTipStatusWithLoading,
     isLoadingTipStatus,
     runId: props.runId,

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryContentWrapper.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryContentWrapper.tsx
@@ -106,6 +106,6 @@ const STYLE = css`
   width: 100%;
   height: 100%;
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    gap: none;
+    gap: 0;
   }
 `


### PR DESCRIPTION
Closes [RQA-2989](https://opentrons.atlassian.net/browse/RQA-2989)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Drop tip wizard's tip detection logic comprised of checking the sensors and checking the protocol analysis. Recently, we dropped the sensor detection and now rely purely on protocol analysis. Doing so exposed a bug: based on the way command fetching works out of post-run drop tip wizard, we can't always tell during a run in progress if tips are attached without writing extensive special-case logic for error recovery or performing questionably large network requests for command data, so when error recovery tries to do recovery flows involving drop tip wizard, it doesn't know which pipette we care about.

A reasonable alternative is something we should have anyway as it creates error boundaries around error recovery:

- If we can't reasonably get the pipette of interest from the protocol analysis, we can almost certainly get it from the failed command (and we get this info via `failedPipetteInfo`, so we can just use it here). 
- If for whatever reason we can't get it from the failed command, we can provide a fallback and just route users around drop tip wizard to select another recovery option or to a later step in the flow (this is really just to prevent whitescreening - realistically, we can always get the pipette of interest from the `failedPipetteInfo`). 

f1bdba25fc490cd95b2e6596f63f56f1dc92b9a1 - After solving the white screen issue, I realized I never pushed the commit in a previous PR that actually made use the pipette's natural id to #15970. Woops. This is necessary for any of the commands to work within error recovery, and I'm including it here, because both these commits are required to make it useable!

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified fixes work as expected when tested against the ticket linked above.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Users can now drop tips again in error recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2989]: https://opentrons.atlassian.net/browse/RQA-2989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ