### PR TITLE
fix(app): restore scroll to top when changing desktop routes

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -121,7 +121,7 @@ export const DesktopApp = (): JSX.Element => {
                         <Route
                           key={path}
                           element={
-                            <>
+                            <React.Fragment key={Component.name}>
                               <Breadcrumbs />
                               <Box
                                 position={POSITION_RELATIVE}
@@ -138,7 +138,7 @@ export const DesktopApp = (): JSX.Element => {
                                   <Component />
                                 </Box>
                               </Box>
-                            </>
+                            </React.Fragment>
                           }
                           path={path}
                         />


### PR DESCRIPTION
# Overview

Seemingly after React Router migration from v5->v6, the window retains its scroll position even after changing routes. We would expect scroll position to renew to the top of the window when changing routes, as the `Route` component is updated. To force this, I pass a key to the `React.Fragment` supplied as the `element` prop within each mapped `Route`, following the API.

This seems to be related to a [separate top-level routing issue](https://github.com/Opentrons/opentrons/pull/15875) on the ODD and should be investigated further after release. Interestingly, React Router provides an explicit [`ScrollRestoration`](https://reactrouter.com/en/main/components/scroll-restoration`) component that is meant to be used to achieve the behavior that we are seeing now, maintaining scroll position between routes, so I would think that excluding this component would result in scroll returning to the top by default.

Closes RQA-2953

## Test Plan and Hands on Testing

- On desktop, scroll down on a scrollable component. A good example is the Devices Landing page
- Select a device low on the scrolled page
- Verify that you are routed to the device's details page, and your scroll renews at the top of the window

https://github.com/user-attachments/assets/c22f6ff7-a257-42a1-b7df-3e3ae8a8950f


## Changelog

- add key to top of `element` prop in mapped `Routes`

## Review requests

see test plan

## Risk assessment

Low, but requires further investigation as I would think React Router would handle this implicitly.