### PR TITLE
fix(api): filter get_run_commands

### DIFF
--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -101,7 +101,20 @@ class CommandHistory:
         """Get all command IDs."""
         return self._all_command_ids
 
-    def get_slice(self, start: int, stop: int, command_ids: list[str]) -> List[Command]:
+    def get_filtered_slice(
+        self, start: int, stop: int, all_commands: bool
+    ) -> List[Command]:
+        queued_ids = self.get_filtered_queue_ids(
+            [CommandIntent.PROTOCOL, CommandIntent.SETUP, CommandIntent.FIXIT]
+            if all_commands
+            else [CommandIntent.PROTOCOL, CommandIntent.SETUP]
+        )
+        commands = list(queued_ids)[start:stop]
+        return [self._commands_by_id[command].command for command in commands]
+
+    def get_slice(
+        self, start: int, stop: int, command_ids: Optional[list[str]] = None
+    ) -> List[Command]:
         """Get a list of commands between start and stop."""
         selected_command_ids = command_ids or self._all_command_ids
         commands = selected_command_ids[start:stop]

--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -105,7 +105,7 @@ class CommandHistory:
         self, start: int, stop: int, command_ids: Optional[list[str]] = None
     ) -> List[Command]:
         """Get a list of commands between start and stop."""
-        selected_command_ids = command_ids or self._all_command_ids
+        selected_command_ids = command_ids if command_ids is not None else self._all_command_ids
         commands = selected_command_ids[start:stop]
         return [self._commands_by_id[command].command for command in commands]
 

--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -105,7 +105,9 @@ class CommandHistory:
         self, start: int, stop: int, command_ids: Optional[list[str]] = None
     ) -> List[Command]:
         """Get a list of commands between start and stop."""
-        selected_command_ids = command_ids if command_ids is not None else self._all_command_ids
+        selected_command_ids = (
+            command_ids if command_ids is not None else self._all_command_ids
+        )
         commands = selected_command_ids[start:stop]
         return [self._commands_by_id[command].command for command in commands]
 

--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -97,6 +97,14 @@ class CommandHistory:
             for command_id in self._all_command_ids
         ]
 
+    def get_filtered_queue_ids(self, all_commands: bool) -> list[str]:
+        print(list(self.get_fixit_queue_ids()))
+        return [
+            i
+            for i in self._all_command_ids
+            if i not in list(self.get_fixit_queue_ids())
+        ]
+
     def get_all_ids(self) -> List[str]:
         """Get all command IDs."""
         return self._all_command_ids

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -583,6 +583,7 @@ class CommandView(HasState[CommandState]):
         self,
         cursor: Optional[int],
         length: int,
+        all_commands: bool
     ) -> CommandSlice:
         """Get a subset of commands around a given cursor.
 
@@ -591,6 +592,7 @@ class CommandView(HasState[CommandState]):
         """
         running_command = self._state.command_history.get_running_command()
         queued_command_ids = self._state.command_history.get_queue_ids()
+        filtered_command_ids = self._state.command_history.get_filtered_queue_ids(all_commands=all_commands)
         total_length = self._state.command_history.length()
 
         # TODO(mm, 2024-05-17): This looks like it's attempting to do the same thing

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -599,17 +599,16 @@ class CommandView(HasState[CommandState]):
         running_command = self._state.command_history.get_running_command()
         queued_command_ids = self._state.command_history.get_queue_ids()
         total_length = len(command_ids)
-        cursor_index = cursor
 
         # TODO(mm, 2024-05-17): This looks like it's attempting to do the same thing
         # as self.get_current(), but in a different way. Can we unify them?
-        if cursor_index is None:
+        if cursor is None:
             if running_command is not None:
-                cursor_index = running_command.index
+                cursor = running_command.index
             elif len(queued_command_ids) > 0:
                 # Get the most recently executed command,
                 # which we can find just before the first queued command.
-                cursor_index = (
+                cursor = (
                     self._state.command_history.get(queued_command_ids.head()).index - 1
                 )
             elif (
@@ -621,12 +620,12 @@ class CommandView(HasState[CommandState]):
                 # reach as failed. This makes command status alone insufficient to
                 # find the most recent command that actually executed, so we need to
                 # store that separately.
-                cursor_index = self._state.failed_command.index
+                cursor = self._state.failed_command.index
             else:
-                cursor_index = total_length - length
+                cursor = total_length - length
 
         # start is inclusive, stop is exclusive
-        actual_cursor = max(0, min(cursor_index, total_length - 1))
+        actual_cursor = max(0, min(cursor, total_length - 1))
         stop = min(total_length, actual_cursor + length)
 
         commands = self._state.command_history.get_slice(

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -579,11 +579,22 @@ class CommandView(HasState[CommandState]):
         """
         return self._state.command_history.get_all_commands()
 
+    def get_filtered_queue_ids(self, all_commands: bool) -> List[str]:
+        """Get a list of all filtered commands in state.
+
+        Entries are returned in the order of first-added command to last-added command.
+        Replacing a command (to change its status, for example) keeps its place in the
+        ordering.
+
+        If all_commands is True, retunred list will contain all command intents.
+        If False, return list will contain only safe commands.
+        """
+        return self._state.command_history.get_filtered_queue_ids(
+            all_commands=all_commands
+        )
+
     def get_slice(
-        self,
-        cursor: Optional[int],
-        length: int,
-        all_commands: bool
+        self, cursor: Optional[int], length: int, all_commands: bool
     ) -> CommandSlice:
         """Get a subset of commands around a given cursor.
 
@@ -592,7 +603,9 @@ class CommandView(HasState[CommandState]):
         """
         running_command = self._state.command_history.get_running_command()
         queued_command_ids = self._state.command_history.get_queue_ids()
-        filtered_command_ids = self._state.command_history.get_filtered_queue_ids(all_commands=all_commands)
+        filtered_command_ids = self._state.command_history.get_filtered_queue_ids(
+            all_commands=all_commands
+        )
         total_length = self._state.command_history.length()
 
         # TODO(mm, 2024-05-17): This looks like it's attempting to do the same thing

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -597,6 +597,7 @@ class CommandView(HasState[CommandState]):
             else [CommandIntent.PROTOCOL, CommandIntent.SETUP]
         )
         total_length = len(command_ids)
+        cursor_index = cursor
 
         if cursor is None:
             current_cursor = self.get_current()

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -580,7 +580,7 @@ class CommandView(HasState[CommandState]):
         return self._state.command_history.get_all_commands()
 
     def get_slice(
-        self, cursor: Optional[int], length: int, all_commands: bool
+        self, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:
         """Get a subset of commands around a given cursor.
 
@@ -593,7 +593,7 @@ class CommandView(HasState[CommandState]):
                 CommandIntent.SETUP,
                 CommandIntent.FIXIT,
             ]
-            if all_commands
+            if include_fixit_commands
             else [CommandIntent.PROTOCOL, CommandIntent.SETUP]
         )
         running_command = self._state.command_history.get_running_command()

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -257,7 +257,7 @@ class RunOrchestrator:
         return self._protocol_engine.state_view.commands.get_current()
 
     def get_command_slice(
-        self, cursor: Optional[int], length: int, all_commands: bool
+        self, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
 
@@ -267,7 +267,7 @@ class RunOrchestrator:
             all_commands: Get all command intents.
         """
         return self._protocol_engine.state_view.commands.get_slice(
-            cursor=cursor, length=length, all_commands=all_commands
+            cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
         )
 
     def get_command_error_slice(

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -257,10 +257,7 @@ class RunOrchestrator:
         return self._protocol_engine.state_view.commands.get_current()
 
     def get_command_slice(
-        self,
-        cursor: Optional[int],
-        length: int,
-        all_commands: bool
+        self, cursor: Optional[int], length: int, all_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
 

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -260,15 +260,17 @@ class RunOrchestrator:
         self,
         cursor: Optional[int],
         length: int,
+        all_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
 
         Args:
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
+            all_commands: Get all command intents.
         """
         return self._protocol_engine.state_view.commands.get_slice(
-            cursor=cursor, length=length
+            cursor=cursor, length=length, all_commands=all_commands
         )
 
     def get_command_error_slice(

--- a/api/tests/opentrons/protocol_engine/state/test_command_history.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_history.py
@@ -96,7 +96,7 @@ def test_get_all_commands(command_history: CommandHistory) -> None:
 
 def test_get_all_filtered_commands(command_history: CommandHistory) -> None:
     """It should return a list of all commands without fixit commands."""
-    assert list(command_history.get_filtered_queue_ids()) == []
+    assert list(command_history.get_filtered_command_ids()) == []
     command_entry_1 = create_queued_command_entry()
     command_entry_2 = create_queued_command_entry(index=1)
     command_history._add("0", command_entry_1)
@@ -104,7 +104,7 @@ def test_get_all_filtered_commands(command_history: CommandHistory) -> None:
     command_history._add_to_queue("0")
     command_history._add_to_queue("1")
     command_history._add_to_fixit_queue("1")
-    assert list(command_history.get_filtered_queue_ids()) == ["0"]
+    assert list(command_history.get_filtered_command_ids()) == ["0"]
 
 
 def test_get_all_ids(command_history: CommandHistory) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_history.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_history.py
@@ -101,12 +101,14 @@ def test_get_all_commands(command_history: CommandHistory) -> None:
 def test_get_filtered_commands(command_history: CommandHistory) -> None:
     """It should return a list of all commands without fixit commands."""
     assert list(command_history.get_filtered_command_ids()) == []
-    command_entry_1 = create_queued_command_entry()
-    command_entry_2 = create_queued_command_entry(index=1)
-    fixit_command_entry_1 = create_queued_command_entry(intent=CommandIntent.FIXIT)
-    command_history._add("0", command_entry_1)
-    command_history._add("1", command_entry_2)
-    command_history._add("fixit-1", fixit_command_entry_1)
+    command_entry_1 = create_queued_command(command_id="0")
+    command_entry_2 = create_queued_command(command_id="1")
+    fixit_command_entry_1 = create_queued_command(
+        intent=CommandIntent.FIXIT, command_id="fixit-1"
+    )
+    command_history.append_queued_command(command_entry_1)
+    command_history.append_queued_command(command_entry_2)
+    command_history.append_queued_command(fixit_command_entry_1)
     assert list(command_history.get_filtered_command_ids()) == ["0", "1"]
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_history.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_history.py
@@ -94,6 +94,17 @@ def test_get_all_commands(command_history: CommandHistory) -> None:
     ]
 
 
+def test_get_all_filtered_commands(command_history: CommandHistory) -> None:
+    """It should return a list of all commapnds."""
+    assert command_history.get_filtered_queue_ids(all_commands=False) == []
+    command_entry_1 = create_queued_command_entry()
+    command_entry_2 = create_queued_command_entry(index=1)
+    command_history._add("0", command_entry_1)
+    command_history._add("1", command_entry_2)
+    command_history._add_to_fixit_queue("1")
+    assert command_history.get_filtered_queue_ids(all_commands=False) == ["0"]
+
+
 def test_get_all_ids(command_history: CommandHistory) -> None:
     """It should return a list of all command IDs."""
     assert command_history.get_all_ids() == []

--- a/api/tests/opentrons/protocol_engine/state/test_command_history.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_history.py
@@ -95,14 +95,16 @@ def test_get_all_commands(command_history: CommandHistory) -> None:
 
 
 def test_get_all_filtered_commands(command_history: CommandHistory) -> None:
-    """It should return a list of all commapnds."""
-    assert command_history.get_filtered_queue_ids(all_commands=False) == []
+    """It should return a list of all commands without fixit commands."""
+    assert list(command_history.get_filtered_queue_ids()) == []
     command_entry_1 = create_queued_command_entry()
     command_entry_2 = create_queued_command_entry(index=1)
     command_history._add("0", command_entry_1)
     command_history._add("1", command_entry_2)
+    command_history._add_to_queue("0")
+    command_history._add_to_queue("1")
     command_history._add_to_fixit_queue("1")
-    assert command_history.get_filtered_queue_ids(all_commands=False) == ["0"]
+    assert list(command_history.get_filtered_queue_ids()) == ["0"]
 
 
 def test_get_all_ids(command_history: CommandHistory) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -904,7 +904,7 @@ def test_get_current() -> None:
 def test_get_slice_empty() -> None:
     """It should return a slice from the tail if no current command."""
     subject = get_command_view(commands=[])
-    result = subject.get_slice(cursor=0, length=2)
+    result = subject.get_slice(cursor=0, length=2, all_commands=True)
 
     assert result == CommandSlice(commands=[], cursor=0, total_length=0)
 
@@ -918,7 +918,7 @@ def test_get_slice() -> None:
 
     subject = get_command_view(commands=[command_1, command_2, command_3, command_4])
 
-    result = subject.get_slice(cursor=1, length=3)
+    result = subject.get_slice(cursor=1, length=3, all_commands=True)
 
     assert result == CommandSlice(
         commands=[command_2, command_3, command_4],
@@ -926,7 +926,7 @@ def test_get_slice() -> None:
         total_length=4,
     )
 
-    result = subject.get_slice(cursor=-3, length=10)
+    result = subject.get_slice(cursor=-3, length=10, all_commands=True)
 
     assert result == CommandSlice(
         commands=[command_1, command_2, command_3, command_4],
@@ -944,7 +944,7 @@ def test_get_slice_default_cursor_no_current() -> None:
 
     subject = get_command_view(commands=[command_1, command_2, command_3, command_4])
 
-    result = subject.get_slice(cursor=None, length=3)
+    result = subject.get_slice(cursor=None, length=3, all_commands=True)
 
     assert result == CommandSlice(
         commands=[command_2, command_3, command_4],
@@ -975,7 +975,7 @@ def test_get_slice_default_cursor_failed_command() -> None:
         failed_command=CommandEntry(index=2, command=command_3),
     )
 
-    result = subject.get_slice(cursor=None, length=3)
+    result = subject.get_slice(cursor=None, length=3, all_commands=True)
 
     assert result == CommandSlice(
         commands=[command_3, command_4],
@@ -997,7 +997,7 @@ def test_get_slice_default_cursor_running() -> None:
         running_command_id="command-id-3",
     )
 
-    result = subject.get_slice(cursor=None, length=2)
+    result = subject.get_slice(cursor=None, length=2, all_commands=True)
 
     assert result == CommandSlice(
         commands=[command_3, command_4],

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -1006,6 +1006,51 @@ def test_get_slice_default_cursor_running() -> None:
     )
 
 
+def test_get_slice_without_fixit() -> None:
+    """It should select a cursor based on the running command, if present."""
+    command_1 = create_succeeded_command(command_id="command-id-1")
+    command_2 = create_succeeded_command(command_id="command-id-2")
+    command_3 = create_running_command(command_id="command-id-3")
+    command_4 = create_queued_command(command_id="command-id-4")
+    command_5 = create_queued_command(command_id="command-id-5")
+    command_6 = create_queued_command(
+        command_id="fixit-id-1", intent=cmd.CommandIntent.FIXIT
+    )
+    command_7 = create_queued_command(
+        command_id="fixit-id-2", intent=cmd.CommandIntent.FIXIT
+    )
+
+    subject = get_command_view(
+        commands=[
+            command_1,
+            command_2,
+            command_3,
+            command_4,
+            command_5,
+            command_6,
+            command_7,
+        ],
+        queued_command_ids=[
+            "command-id-1",
+            "command-id-2",
+            "command-id-3",
+            "command-id-4",
+            "command-id-5",
+            "fixit-id-1",
+            "fixit-id-2",
+        ],
+        queued_fixit_command_ids=["fixit-id-1", "fixit-id-2"],
+    )
+
+    result = subject.get_slice(cursor=None, length=7, all_commands=False)
+
+    assert result == CommandSlice(
+        commands=[command_1, command_2, command_3, command_4, command_5],
+        cursor=0,
+        total_length=5,
+    )
+
+
 def test_get_errors_slice_empty() -> None:
     """It should return a slice from the tail if no current command."""
     subject = get_command_view(failed_command_errors=[])

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -904,7 +904,7 @@ def test_get_current() -> None:
 def test_get_slice_empty() -> None:
     """It should return a slice from the tail if no current command."""
     subject = get_command_view(commands=[])
-    result = subject.get_slice(cursor=0, length=2, all_commands=True)
+    result = subject.get_slice(cursor=0, length=2, include_fixit_commands=True)
 
     assert result == CommandSlice(commands=[], cursor=0, total_length=0)
 
@@ -918,7 +918,7 @@ def test_get_slice() -> None:
 
     subject = get_command_view(commands=[command_1, command_2, command_3, command_4])
 
-    result = subject.get_slice(cursor=1, length=3, all_commands=True)
+    result = subject.get_slice(cursor=1, length=3, include_fixit_commands=True)
 
     assert result == CommandSlice(
         commands=[command_2, command_3, command_4],
@@ -926,7 +926,7 @@ def test_get_slice() -> None:
         total_length=4,
     )
 
-    result = subject.get_slice(cursor=-3, length=10, all_commands=True)
+    result = subject.get_slice(cursor=-3, length=10, include_fixit_commands=True)
 
     assert result == CommandSlice(
         commands=[command_1, command_2, command_3, command_4],
@@ -944,7 +944,7 @@ def test_get_slice_default_cursor_no_current() -> None:
 
     subject = get_command_view(commands=[command_1, command_2, command_3, command_4])
 
-    result = subject.get_slice(cursor=None, length=3, all_commands=True)
+    result = subject.get_slice(cursor=None, length=3, include_fixit_commands=True)
 
     assert result == CommandSlice(
         commands=[command_2, command_3, command_4],
@@ -975,7 +975,7 @@ def test_get_slice_default_cursor_failed_command() -> None:
         failed_command=CommandEntry(index=2, command=command_3),
     )
 
-    result = subject.get_slice(cursor=None, length=3, all_commands=True)
+    result = subject.get_slice(cursor=None, length=3, include_fixit_commands=True)
 
     assert result == CommandSlice(
         commands=[command_3, command_4],
@@ -997,7 +997,7 @@ def test_get_slice_default_cursor_running() -> None:
         running_command_id="command-id-3",
     )
 
-    result = subject.get_slice(cursor=None, length=2, all_commands=True)
+    result = subject.get_slice(cursor=None, length=2, include_fixit_commands=True)
 
     assert result == CommandSlice(
         commands=[command_3, command_4],
@@ -1042,7 +1042,7 @@ def test_get_slice_without_fixit() -> None:
         queued_fixit_command_ids=["fixit-id-1", "fixit-id-2"],
     )
 
-    result = subject.get_slice(cursor=None, length=7, all_commands=False)
+    result = subject.get_slice(cursor=None, length=7, include_fixit_commands=False)
 
     assert result == CommandSlice(
         commands=[command_1, command_2, command_3, command_4, command_5],

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -155,7 +155,7 @@ async def get_commands_list(
         pageLength: Maximum number of items to return.
     """
     cmd_slice = orchestrator.get_command_slice(
-        cursor=cursor, length=pageLength, all_commands=True
+        cursor=cursor, length=pageLength, include_fixit_commands=True
     )
     commands = cast(List[StatelessCommand], cmd_slice.commands)
     meta = MultiBodyMeta(cursor=cmd_slice.cursor, totalLength=cmd_slice.total_length)

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -154,7 +154,9 @@ async def get_commands_list(
         cursor: Cursor index for the collection response.
         pageLength: Maximum number of items to return.
     """
-    cmd_slice = orchestrator.get_command_slice(cursor=cursor, length=pageLength)
+    cmd_slice = orchestrator.get_command_slice(
+        cursor=cursor, length=pageLength, all_commands=True
+    )
     commands = cast(List[StatelessCommand], cmd_slice.commands)
     meta = MultiBodyMeta(cursor=cmd_slice.cursor, totalLength=cmd_slice.total_length)
 

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -229,7 +229,7 @@ class MaintenanceRunOrchestratorStore:
         return self.run_orchestrator.get_command_slice(
             cursor=cursor,
             length=length,
-            include_fixit_commands=False,  # TODO(tz, 8-12-24) change to arg in router.
+            include_fixit_commands=False,
         )
 
     def get_current_command(self) -> Optional[CommandPointer]:

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -226,7 +226,11 @@ class MaintenanceRunOrchestratorStore:
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
         """
-        return self.run_orchestrator.get_command_slice(cursor=cursor, length=length)
+        return self.run_orchestrator.get_command_slice(
+            cursor=cursor,
+            length=length,
+            all_commands=False,  # TODO(tz, 8-12-24) change to arg in router.
+        )
 
     def get_current_command(self) -> Optional[CommandPointer]:
         """Get the "current" command, if any."""

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -229,7 +229,7 @@ class MaintenanceRunOrchestratorStore:
         return self.run_orchestrator.get_command_slice(
             cursor=cursor,
             length=length,
-            all_commands=False,  # TODO(tz, 8-12-24) change to arg in router.
+            include_fixit_commands=False,  # TODO(tz, 8-12-24) change to arg in router.
         )
 
     def get_current_command(self) -> Optional[CommandPointer]:

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -271,7 +271,7 @@ async def get_run_commands(
         _DEFAULT_COMMAND_LIST_LENGTH,
         description="The maximum number of commands in the list to return.",
     ),
-    allCommands: bool = Query(
+    includeFixitCommands: bool = Query(
         True,
         description="If `true`, return all commands (protocol, setup, fixit)."
         " If `false`, only return safe commands (protocol, setup).",
@@ -293,7 +293,7 @@ async def get_run_commands(
             run_id=runId,
             cursor=cursor,
             length=pageLength,
-            all_commands=allCommands,
+            include_fixit_commands=includeFixitCommands,
         )
     except RunNotFoundError as e:
         raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -271,6 +271,11 @@ async def get_run_commands(
         _DEFAULT_COMMAND_LIST_LENGTH,
         description="The maximum number of commands in the list to return.",
     ),
+    allCommands: Optional[bool] = Query(
+        True,
+        description="If `true`, return all commands (protocol, setup, fixit)."
+        " If `false`, only return safe commands (protocol, setup).",
+    ),
     run_data_manager: RunDataManager = Depends(get_run_data_manager),
 ) -> PydanticResponse[MultiBody[RunCommandSummary, CommandCollectionLinks]]:
     """Get a summary of a set of commands in a run.
@@ -279,6 +284,8 @@ async def get_run_commands(
         runId: Requested run ID, from the URL
         cursor: Cursor index for the collection response.
         pageLength: Maximum number of items to return.
+        allCommands: If `true`, return all commands."
+            " If `false`, only return safe commands.
         run_data_manager: Run data retrieval interface.
     """
     try:
@@ -286,6 +293,7 @@ async def get_run_commands(
             run_id=runId,
             cursor=cursor,
             length=pageLength,
+            all_commands=allCommands,
         )
     except RunNotFoundError as e:
         raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -284,7 +284,7 @@ async def get_run_commands(
         runId: Requested run ID, from the URL
         cursor: Cursor index for the collection response.
         pageLength: Maximum number of items to return.
-        allCommands: If `true`, return all commands."
+        includeFixitCommands: If `true`, return all commands."
             " If `false`, only return safe commands.
         run_data_manager: Run data retrieval interface.
     """

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -271,7 +271,7 @@ async def get_run_commands(
         _DEFAULT_COMMAND_LIST_LENGTH,
         description="The maximum number of commands in the list to return.",
     ),
-    allCommands: Optional[bool] = Query(
+    allCommands: bool = Query(
         True,
         description="If `true`, return all commands (protocol, setup, fixit)."
         " If `false`, only return safe commands (protocol, setup).",

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -367,7 +367,7 @@ class RunDataManager:
         )
 
     def get_commands_slice(
-        self, run_id: str, cursor: Optional[int], length: int, all_commands: bool
+        self, run_id: str, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
 
@@ -375,14 +375,14 @@ class RunDataManager:
             run_id: ID of the run.
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
-            all_commands: Weather we should return all command intents.
+            include_fixit_commands: Weather we should include fixit commands.
 
         Raises:
             RunNotFoundError: The given run identifier was not found in the database.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
             return self._run_orchestrator_store.get_command_slice(
-                cursor=cursor, length=length, all_commands=all_commands
+                cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
             )
 
         # Let exception propagate

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -367,7 +367,11 @@ class RunDataManager:
         )
 
     def get_commands_slice(
-        self, run_id: str, cursor: Optional[int], length: int, include_fixit_commands: bool
+        self,
+        run_id: str,
+        cursor: Optional[int],
+        length: int,
+        include_fixit_commands: bool,
     ) -> CommandSlice:
         """Get a slice of run commands.
 
@@ -382,7 +386,9 @@ class RunDataManager:
         """
         if run_id == self._run_orchestrator_store.current_run_id:
             return self._run_orchestrator_store.get_command_slice(
-                cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
+                cursor=cursor,
+                length=length,
+                include_fixit_commands=include_fixit_commands,
             )
 
         # Let exception propagate

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -367,10 +367,7 @@ class RunDataManager:
         )
 
     def get_commands_slice(
-        self,
-        run_id: str,
-        cursor: Optional[int],
-        length: int,
+        self, run_id: str, cursor: Optional[int], length: int, all_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
 
@@ -378,13 +375,14 @@ class RunDataManager:
             run_id: ID of the run.
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
+            all_commands: Weather we should return all command intents.
 
         Raises:
             RunNotFoundError: The given run identifier was not found in the database.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
             return self._run_orchestrator_store.get_command_slice(
-                cursor=cursor, length=length
+                cursor=cursor, length=length, all_commands=all_commands
             )
 
         # Let exception propagate

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -330,17 +330,18 @@ class RunOrchestratorStore:
         return self.run_orchestrator.get_current_command()
 
     def get_command_slice(
-        self,
-        cursor: Optional[int],
-        length: int,
+        self, cursor: Optional[int], length: int, all_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
 
         Args:
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
+            all_commands: Get all command intents.
         """
-        return self.run_orchestrator.get_command_slice(cursor=cursor, length=length)
+        return self.run_orchestrator.get_command_slice(
+            cursor=cursor, length=length, all_commands=all_commands
+        )
 
     def get_command_error_slice(
         self,

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -330,17 +330,17 @@ class RunOrchestratorStore:
         return self.run_orchestrator.get_current_command()
 
     def get_command_slice(
-        self, cursor: Optional[int], length: int, all_commands: bool
+        self, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:
         """Get a slice of run commands.
 
         Args:
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
-            all_commands: Get all command intents.
+            include_fixit_commands: Get all command intents.
         """
         return self.run_orchestrator.get_command_slice(
-            cursor=cursor, length=length, all_commands=all_commands
+            cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
         )
 
     def get_command_error_slice(

--- a/robot-server/tests/commands/test_router.py
+++ b/robot-server/tests/commands/test_router.py
@@ -138,7 +138,9 @@ async def test_get_commands_list(
         )
     )
     decoy.when(
-        run_orchestrator.get_command_slice(cursor=1337, length=42, all_commands=True)
+        run_orchestrator.get_command_slice(
+            cursor=1337, length=42, include_fixit_commands=True
+        )
     ).then_return(
         CommandSlice(commands=[command_1, command_2], cursor=0, total_length=2)
     )

--- a/robot-server/tests/commands/test_router.py
+++ b/robot-server/tests/commands/test_router.py
@@ -137,7 +137,9 @@ async def test_get_commands_list(
             index=0,
         )
     )
-    decoy.when(run_orchestrator.get_command_slice(cursor=1337, length=42)).then_return(
+    decoy.when(
+        run_orchestrator.get_command_slice(cursor=1337, length=42, all_commands=True)
+    ).then_return(
         CommandSlice(commands=[command_1, command_2], cursor=0, total_length=2)
     )
 

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -332,7 +332,7 @@ async def test_get_run_commands(
     )
     decoy.when(
         mock_run_data_manager.get_commands_slice(
-            run_id="run-id", cursor=None, length=42, all_commands=True
+            run_id="run-id", cursor=None, length=42, include_fixit_commands=True
         )
     ).then_return(CommandSlice(commands=[command], cursor=1, total_length=3))
 
@@ -398,7 +398,7 @@ async def test_get_run_commands_empty(
     decoy.when(mock_run_data_manager.get_current_command("run-id")).then_return(None)
     decoy.when(
         mock_run_data_manager.get_commands_slice(
-            run_id="run-id", cursor=21, length=42, all_commands=True
+            run_id="run-id", cursor=21, length=42, include_fixit_commands=True
         )
     ).then_return(CommandSlice(commands=[], cursor=0, total_length=0))
 
@@ -424,7 +424,7 @@ async def test_get_run_commands_not_found(
 
     decoy.when(
         mock_run_data_manager.get_commands_slice(
-            run_id="run-id", cursor=21, length=42, all_commands=True
+            run_id="run-id", cursor=21, length=42, include_fixit_commands=True
         )
     ).then_raise(not_found_error)
     decoy.when(mock_run_data_manager.get_current_command(run_id="run-id")).then_raise(

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -332,9 +332,7 @@ async def test_get_run_commands(
     )
     decoy.when(
         mock_run_data_manager.get_commands_slice(
-            run_id="run-id",
-            cursor=None,
-            length=42,
+            run_id="run-id", cursor=None, length=42, all_commands=True
         )
     ).then_return(CommandSlice(commands=[command], cursor=1, total_length=3))
 
@@ -399,7 +397,9 @@ async def test_get_run_commands_empty(
     """It should return an empty commands list if no commands."""
     decoy.when(mock_run_data_manager.get_current_command("run-id")).then_return(None)
     decoy.when(
-        mock_run_data_manager.get_commands_slice(run_id="run-id", cursor=21, length=42)
+        mock_run_data_manager.get_commands_slice(
+            run_id="run-id", cursor=21, length=42, all_commands=True
+        )
     ).then_return(CommandSlice(commands=[], cursor=0, total_length=0))
 
     result = await get_run_commands(
@@ -423,7 +423,9 @@ async def test_get_run_commands_not_found(
     not_found_error = RunNotFoundError("oh no")
 
     decoy.when(
-        mock_run_data_manager.get_commands_slice(run_id="run-id", cursor=21, length=42)
+        mock_run_data_manager.get_commands_slice(
+            run_id="run-id", cursor=21, length=42, all_commands=True
+        )
     ).then_raise(not_found_error)
     decoy.when(mock_run_data_manager.get_current_command(run_id="run-id")).then_raise(
         not_found_error

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -845,7 +845,7 @@ def test_get_commands_slice_from_db(
         mock_run_store.get_commands_slice(run_id="run_id", cursor=1, length=2)
     ).then_return(expected_command_slice)
     result = subject.get_commands_slice(
-        run_id="run_id", cursor=1, length=2, all_commands=True
+        run_id="run_id", cursor=1, length=2, include_fixit_commands=True
     )
 
     assert expected_command_slice == result
@@ -877,7 +877,7 @@ def test_get_commands_slice_current_run(
         expected_command_slice
     )
 
-    result = subject.get_commands_slice("run-id", 1, 2, all_commands=True)
+    result = subject.get_commands_slice("run-id", 1, 2, include_fixit_commands=True)
 
     assert expected_command_slice == result
 
@@ -928,7 +928,7 @@ def test_get_commands_slice_from_db_run_not_found(
     ).then_raise(RunNotFoundError(run_id="run-id"))
     with pytest.raises(RunNotFoundError):
         subject.get_commands_slice(
-            run_id="run-id", cursor=1, length=2, all_commands=True
+            run_id="run-id", cursor=1, length=2, include_fixit_commands=True
         )
 
 

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -844,7 +844,9 @@ def test_get_commands_slice_from_db(
     decoy.when(
         mock_run_store.get_commands_slice(run_id="run_id", cursor=1, length=2)
     ).then_return(expected_command_slice)
-    result = subject.get_commands_slice(run_id="run_id", cursor=1, length=2)
+    result = subject.get_commands_slice(
+        run_id="run_id", cursor=1, length=2, all_commands=True
+    )
 
     assert expected_command_slice == result
 
@@ -871,11 +873,11 @@ def test_get_commands_slice_current_run(
         commands=expected_commands_result, cursor=1, total_length=3
     )
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
-    decoy.when(mock_run_orchestrator_store.get_command_slice(1, 2)).then_return(
+    decoy.when(mock_run_orchestrator_store.get_command_slice(1, 2, True)).then_return(
         expected_command_slice
     )
 
-    result = subject.get_commands_slice("run-id", 1, 2)
+    result = subject.get_commands_slice("run-id", 1, 2, all_commands=True)
 
     assert expected_command_slice == result
 
@@ -925,7 +927,9 @@ def test_get_commands_slice_from_db_run_not_found(
         mock_run_store.get_commands_slice(run_id="run-id", cursor=1, length=2)
     ).then_raise(RunNotFoundError(run_id="run-id"))
     with pytest.raises(RunNotFoundError):
-        subject.get_commands_slice(run_id="run-id", cursor=1, length=2)
+        subject.get_commands_slice(
+            run_id="run-id", cursor=1, length=2, all_commands=True
+        )
 
 
 def test_get_current_command(


### PR DESCRIPTION
# Overview

closes [EXEC-654](https://opentrons.atlassian.net/browse/EXEC-654).
get filtered command list

## Test Plan and Hands on Testing

- upload a protocol that will enter ER.
- add some fixit commands.
- make sure you dont see the fixit commands in the run log. 

## Changelog

- added an arg `allCommands` to `get_run_commands`.
- add logic to `CommandState` and `CommandHistory` to filter based on the protocol intent. 

## Review requests

changes make sense? how ugly is this? 

## Risk assessment

Medium. need to make sure nothing that uses run commands changed the default behavior. 

[EXEC-654]: https://opentrons.atlassian.net/browse/EXEC-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ