### PR TITLE
fix(api): add default values to optional fields of QUADRANT configuration

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -815,6 +815,12 @@ class InstrumentCore(AbstractInstrument[WellCore]):
                 primaryNozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle)
             )
         elif style == NozzleLayout.QUADRANT or style == NozzleLayout.PARTIAL_COLUMN:
+            assert (
+                # We make sure to set these nozzles in the calling function
+                # if using QUADRANT or PARTIAL_COLUMN. Asserting only for type verification here.
+                front_right_nozzle is not None
+                and back_left_nozzle is not None
+            ), f"Both front right and back left nozzles are required for {style} configuration."
             configuration_model = QuadrantNozzleLayoutConfiguration(
                 primaryNozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle),
                 frontRightNozzle=front_right_nozzle,

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -888,12 +888,12 @@ class QuadrantNozzleLayoutConfiguration(BaseModel):
         description="The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
     )
     frontRightNozzle: Optional[str] = Field(
-        ...,
+        None,
         regex=NOZZLE_NAME_REGEX,
         description="The front right nozzle in your configuration.",
     )
     backLeftNozzle: Optional[str] = Field(
-        ...,
+        None,
         regex=NOZZLE_NAME_REGEX,
         description="The back left nozzle in your configuration.",
     )

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -887,13 +887,13 @@ class QuadrantNozzleLayoutConfiguration(BaseModel):
         ...,
         description="The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
     )
-    frontRightNozzle: Optional[str] = Field(
-        None,
+    frontRightNozzle: str = Field(
+        ...,
         regex=NOZZLE_NAME_REGEX,
         description="The front right nozzle in your configuration.",
     )
-    backLeftNozzle: Optional[str] = Field(
-        None,
+    backLeftNozzle: str = Field(
+        ...,
         regex=NOZZLE_NAME_REGEX,
         description="The back left nozzle in your configuration.",
     )

--- a/api/tests/opentrons/protocol_api/partial_tip_configurations.py
+++ b/api/tests/opentrons/protocol_api/partial_tip_configurations.py
@@ -1,0 +1,492 @@
+"""Partial tip configurations for tests."""
+import pytest
+from contextlib import nullcontext as does_not_raise
+from typing import NamedTuple, Optional, ContextManager, Any
+
+from opentrons.protocol_api._nozzle_layout import NozzleLayout
+
+
+class NozzleLayoutArgs(NamedTuple):
+    """Arguments to use in `configure_nozzle_layout`."""
+
+    style: NozzleLayout
+    start: Optional[str]
+    end: Optional[str]
+    front_right: Optional[str]
+    back_left: Optional[str]
+
+
+class PipetteIndependentNozzleConfigSpec(NamedTuple):
+    """Parametrization data for pipette-independent nozzle configs test."""
+
+    nozzle_layout_args: NozzleLayoutArgs
+    expected_raise: ContextManager[Any]
+
+
+PIPETTE_INDEPENDENT_TEST_SPECS = [
+    PipetteIndependentNozzleConfigSpec(
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.SINGLE,
+            start=None,
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Cannot configure a nozzle layout of style SINGLE without a starting nozzle.",
+        ),
+    ),
+    PipetteIndependentNozzleConfigSpec(
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.SINGLE,
+            start="H1",
+            end="B1",
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with the SINGLE nozzle configuration.",
+        ),
+    ),
+    PipetteIndependentNozzleConfigSpec(
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.SINGLE,
+            start="H1",
+            end=None,
+            front_right="C1",
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with the SINGLE nozzle configuration.",
+        ),
+    ),
+    PipetteIndependentNozzleConfigSpec(
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.SINGLE,
+            start="H1",
+            end=None,
+            front_right=None,
+            back_left="C1",
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with the SINGLE nozzle configuration.",
+        ),
+    ),
+    PipetteIndependentNozzleConfigSpec(
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.SINGLE,
+            start="A1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=does_not_raise(),
+    ),
+    PipetteIndependentNozzleConfigSpec(
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ALL,
+            start="H1",
+            end="G1",
+            front_right="X1",
+            back_left="Z1",
+        ),
+        expected_raise=does_not_raise(),
+    ),  # Arguments are ignored
+    PipetteIndependentNozzleConfigSpec(
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ALL,
+            start=None,
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=does_not_raise(),
+    ),
+]
+
+
+class PipetteReliantNozzleConfigSpec(NamedTuple):
+    """Test parametrization data."""
+
+    pipette_channels: int
+    nozzle_layout_args: NozzleLayoutArgs
+    expected_raise: ContextManager[Any]
+
+
+PIPETTE_RELIANT_TEST_SPECS = [
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.COLUMN,
+            start="A1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="COLUMN configuration is only supported on 96-Channel pipettes.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.COLUMN,
+            start="E1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Starting nozzle specified is not one of \\['A1', 'H1', 'A12', 'H12'\\].",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.COLUMN,
+            start="A1",
+            end="B1",
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with"
+            " the COLUMN nozzle configuration.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.COLUMN,
+            start="A1",
+            end=None,
+            front_right="A1",
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with"
+            " the COLUMN nozzle configuration.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.COLUMN,
+            start="A1",
+            end=None,
+            front_right=None,
+            back_left="B1",
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with"
+            " the COLUMN nozzle configuration.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.COLUMN,
+            start="A1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=does_not_raise(),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ROW,
+            start="H1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="ROW configuration is only supported on 96-Channel pipettes.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ROW,
+            start="B1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Starting nozzle specified is not one of \\['A1', 'H1', 'A12', 'H12'\\].",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ROW,
+            start="A1",
+            end="B1",
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with"
+            " the ROW nozzle configuration.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ROW,
+            start="A1",
+            end=None,
+            front_right="A1",
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with"
+            " the ROW nozzle configuration.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ROW,
+            start="A1",
+            end=None,
+            front_right=None,
+            back_left="B1",
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'end', 'front_right' and 'back_left' cannot be used with"
+            " the ROW nozzle configuration.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ROW,
+            start="H1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=does_not_raise(),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="H1",
+            end="G1",
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Partial column configuration is only supported on 8-Channel pipettes",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="H1",
+            end=None,
+            front_right="H1",
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Partial column configurations require the 'end' parameter.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="H1",
+            end="G1",
+            front_right="H1",
+            back_left=None,
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'front_right' and 'back_left' cannot be used with the PARTIAL_COLUMN configuration.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="H1",
+            end="G1",
+            front_right=None,
+            back_left="H1",
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="Parameters 'front_right' and 'back_left' cannot be used with the PARTIAL_COLUMN configuration.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="H1",
+            end="A1",
+            front_right=None,
+            back_left="H1",
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="A partial column configuration with 'start'=H1 cannot have its 'end' parameter be in row A."
+            " Use `ALL` configuration to utilize all nozzles.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="A1",
+            end="H1",
+            front_right=None,
+            back_left="H1",
+        ),
+        expected_raise=pytest.raises(
+            ValueError,
+            match="A partial column configuration with 'start'=A1 cannot have its 'end' parameter be in row H."
+            " Use `ALL` configuration to utilize all nozzles.",
+        ),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="A1",
+            end="G1",
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=does_not_raise(),
+    ),
+    PipetteReliantNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="H1",
+            end="G1",
+            front_right=None,
+            back_left=None,
+        ),
+        expected_raise=does_not_raise(),
+    ),
+]
+
+
+class ExpectedCoreArgs(NamedTuple):
+    """The converted arguments expected to be passed to instrument core."""
+
+    primary_nozzle: Optional[str]
+    front_right_nozzle: Optional[str]
+    back_left_nozzle: Optional[str]
+
+
+class InstrumentCoreNozzleConfigSpec(NamedTuple):
+    """Test parametrization data."""
+
+    pipette_channels: int
+    nozzle_layout_args: NozzleLayoutArgs
+    expected_core_args: ExpectedCoreArgs
+
+
+INSTRUMENT_CORE_NOZZLE_LAYOUT_TEST_SPECS = [
+    InstrumentCoreNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.SINGLE,
+            start="A1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_core_args=ExpectedCoreArgs(
+            primary_nozzle="A1",
+            front_right_nozzle=None,
+            back_left_nozzle=None,
+        ),
+    ),
+    InstrumentCoreNozzleConfigSpec(
+        pipette_channels=8,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.PARTIAL_COLUMN,
+            start="A1",
+            end="D1",
+            front_right=None,
+            back_left=None,
+        ),
+        expected_core_args=ExpectedCoreArgs(
+            primary_nozzle="A1",
+            front_right_nozzle="D1",
+            back_left_nozzle="A1",
+        ),
+    ),
+    InstrumentCoreNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.COLUMN,
+            start="H1",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_core_args=ExpectedCoreArgs(
+            primary_nozzle="H1",
+            front_right_nozzle=None,
+            back_left_nozzle=None,
+        ),
+    ),
+    InstrumentCoreNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ROW,
+            start="A12",
+            end=None,
+            front_right=None,
+            back_left=None,
+        ),
+        expected_core_args=ExpectedCoreArgs(
+            primary_nozzle="A12",
+            front_right_nozzle=None,
+            back_left_nozzle=None,
+        ),
+    ),
+    InstrumentCoreNozzleConfigSpec(
+        pipette_channels=96,
+        nozzle_layout_args=NozzleLayoutArgs(
+            style=NozzleLayout.ALL,
+            start="A12",
+            end=None,
+            front_right="D3",
+            back_left=None,
+        ),
+        expected_core_args=ExpectedCoreArgs(  # These args are eventually ignored
+            primary_nozzle="A12",
+            front_right_nozzle="D3",
+            back_left_nozzle=None,
+        ),
+    ),
+]

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2,9 +2,8 @@
 import inspect
 import pytest
 from collections import OrderedDict
-from contextlib import nullcontext as does_not_raise
 from datetime import datetime
-from typing import ContextManager, Optional
+from typing import ContextManager, Optional, Any
 from unittest.mock import sentinel
 
 from decoy import Decoy
@@ -18,6 +17,16 @@ from opentrons.protocol_engine.errors.error_occurrence import (
 from opentrons.legacy_broker import LegacyBroker
 
 from opentrons.protocol_engine.errors.exceptions import TipNotAttachedError
+from tests.opentrons.protocol_api.partial_tip_configurations import (
+    PipetteReliantNozzleConfigSpec,
+    PIPETTE_RELIANT_TEST_SPECS,
+    NozzleLayoutArgs,
+    PipetteIndependentNozzleConfigSpec,
+    PIPETTE_INDEPENDENT_TEST_SPECS,
+    InstrumentCoreNozzleConfigSpec,
+    INSTRUMENT_CORE_NOZZLE_LAYOUT_TEST_SPECS,
+    ExpectedCoreArgs,
+)
 from tests.opentrons.protocol_engine.pipette_fixtures import (
     NINETY_SIX_COLS,
     NINETY_SIX_MAP,
@@ -47,7 +56,6 @@ from opentrons.protocol_api.core.legacy.legacy_instrument_core import (
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
-from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons_shared_data.pipette.pipette_definition import ValidNozzleMaps
 from opentrons.types import Location, Mount, Point
 
@@ -1128,75 +1136,86 @@ def test_prepare_to_aspirate_checks_volume(
 
 
 @pytest.mark.parametrize(
-    argnames=[
-        "pipette_channels",
-        "style",
-        "primary_nozzle",
-        "front_right_nozzle",
-        "end",
-        "exception",
-    ],
-    argvalues=[
-        [96, NozzleLayout.COLUMN, "A1", None, None, does_not_raise()],
-        [96, NozzleLayout.SINGLE, None, None, None, pytest.raises(ValueError)],
-        [96, NozzleLayout.ROW, "E1", None, None, pytest.raises(ValueError)],
-        [8, NozzleLayout.PARTIAL_COLUMN, "H1", None, "G1", does_not_raise()],
-        [8, NozzleLayout.PARTIAL_COLUMN, "H1", "H1", "G1", pytest.raises(ValueError)],
-        [8, NozzleLayout.PARTIAL_COLUMN, "H1", None, "A1", pytest.raises(ValueError)],
-    ],
+    argnames=PipetteReliantNozzleConfigSpec._fields,
+    argvalues=PIPETTE_RELIANT_TEST_SPECS,
+)
+def test_configure_pip_reliant_nozzle_layout_checks_for_config_validity(
+    subject: InstrumentContext,
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    pipette_channels: int,
+    nozzle_layout_args: NozzleLayoutArgs,
+    expected_raise: ContextManager[Any],
+) -> None:
+    """It should raise an error if you specify the wrong arguments for the nozzle configuration."""
+    decoy.when(mock_instrument_core.get_channels()).then_return(pipette_channels)
+    with expected_raise:
+        subject.configure_nozzle_layout(
+            style=nozzle_layout_args.style,
+            start=nozzle_layout_args.start,
+            end=nozzle_layout_args.end,
+            front_right=nozzle_layout_args.front_right,
+            back_left=nozzle_layout_args.back_left,
+        )
+
+
+@pytest.mark.parametrize(
+    "pipette_channels",
+    [1, 8, 96],
+)
+@pytest.mark.parametrize(
+    argnames=PipetteIndependentNozzleConfigSpec._fields,
+    argvalues=PIPETTE_INDEPENDENT_TEST_SPECS,
+)
+def test_configure_pip_independent_nozzle_layout_checks_for_config_validity(
+    subject: InstrumentContext,
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    pipette_channels: int,
+    nozzle_layout_args: NozzleLayoutArgs,
+    expected_raise: ContextManager[Any],
+) -> None:
+    """It should raise an error if you specify the wrong arguments for the nozzle configuration."""
+    decoy.when(mock_instrument_core.get_channels()).then_return(pipette_channels)
+    with expected_raise:
+        subject.configure_nozzle_layout(
+            style=nozzle_layout_args.style,
+            start=nozzle_layout_args.start,
+            end=nozzle_layout_args.end,
+            front_right=nozzle_layout_args.front_right,
+            back_left=nozzle_layout_args.back_left,
+        )
+
+
+@pytest.mark.parametrize(
+    argnames=InstrumentCoreNozzleConfigSpec._fields,
+    argvalues=INSTRUMENT_CORE_NOZZLE_LAYOUT_TEST_SPECS,
 )
 def test_configure_nozzle_layout(
     subject: InstrumentContext,
     decoy: Decoy,
     mock_instrument_core: InstrumentCore,
     pipette_channels: int,
-    style: NozzleLayout,
-    primary_nozzle: Optional[str],
-    front_right_nozzle: Optional[str],
-    end: Optional[str],
-    exception: ContextManager[None],
+    nozzle_layout_args: NozzleLayoutArgs,
+    expected_core_args: ExpectedCoreArgs,
 ) -> None:
-    """The correct model is passed to the engine client."""
+    """It should pass the correct configuration model to the engine client."""
     decoy.when(mock_instrument_core.get_channels()).then_return(pipette_channels)
-    with exception:
-        subject.configure_nozzle_layout(
-            style=style, start=primary_nozzle, end=end, front_right=front_right_nozzle
+    subject.configure_nozzle_layout(
+        style=nozzle_layout_args.style,
+        start=nozzle_layout_args.start,
+        end=nozzle_layout_args.end,
+        front_right=nozzle_layout_args.front_right,
+        back_left=nozzle_layout_args.back_left,
+    )
+    decoy.verify(
+        mock_instrument_core.configure_nozzle_layout(
+            style=nozzle_layout_args.style,
+            primary_nozzle=expected_core_args.primary_nozzle,
+            front_right_nozzle=expected_core_args.front_right_nozzle,
+            back_left_nozzle=expected_core_args.back_left_nozzle,
         )
-
-
-@pytest.mark.parametrize(
-    argnames=[
-        "pipette_channels",
-        "style",
-        "primary_nozzle",
-        "front_right_nozzle",
-        "end",
-        "exception",
-    ],
-    argvalues=[
-        [8, NozzleLayout.PARTIAL_COLUMN, "A1", None, "G1", does_not_raise()],
-        [96, NozzleLayout.PARTIAL_COLUMN, "H1", None, "G1", pytest.raises(ValueError)],
-        [8, NozzleLayout.ROW, "H1", None, None, pytest.raises(ValueError)],
-        [96, NozzleLayout.ROW, "H1", None, None, does_not_raise()],
-    ],
-)
-def test_pipette_supports_nozzle_layout(
-    subject: InstrumentContext,
-    decoy: Decoy,
-    mock_instrument_core: InstrumentCore,
-    pipette_channels: int,
-    style: NozzleLayout,
-    primary_nozzle: Optional[str],
-    front_right_nozzle: Optional[str],
-    end: Optional[str],
-    exception: ContextManager[None],
-) -> None:
-    """Test that error is raised when a pipette attempts to use an unsupported layout."""
-    decoy.when(mock_instrument_core.get_channels()).then_return(pipette_channels)
-    with exception:
-        subject.configure_nozzle_layout(
-            style=style, start=primary_nozzle, end=end, front_right=front_right_nozzle
-        )
+    )
 
 
 @pytest.mark.parametrize("api_version", [APIVersion(2, 15)])


### PR DESCRIPTION
Closes RQA-2992

# Overview

The `QuadrantNozzleLayoutConfiguration` has two optional fields- `frontRightNozzle` and `backLeftNozzle`, but they didn't have a default value assigned. So when the app tries to fetch the run's data, if the RunStore reads the following valid command from the database-

```
{
  "id": "44c2ebda-4e81-42f4-bbd7-91710ca30242",
  "createdAt": "2024-08-13T20:00:19.662654+00:00",
  "commandType": "configureNozzleLayout",
  "key": "2a57aa0e5f1e286b479c11d95e2cce35",
  "status": "succeeded",
  "params": {
    "pipetteId": "984f1433-acfd-48e7-b213-3c6fdfd85321",
    "configurationParams": {
      "style": "QUADRANT",
      "primaryNozzle": "H1",
      "backLeftNozzle": "B1"
    }
  },
  "result": {},
  "startedAt": "2024-08-13T20:00:19.664360+00:00",
  "completedAt": "2024-08-13T20:00:19.676488+00:00",
  "notes": []
}
```

..then pydantic runs into a validation error since it doesn't know how to parse `configurationParams` with a missing `frontRightNozzle`.

This was resulting in the 'Download Run Log' option to give a 500 error.

Once default values are set for the fields, pydantic is able to parse the params correctly and run log downloads without any issues.

## Test Plan and Hands on Testing

- [ ] Run the below protocol on a robot
- [ ] Close the run (this is important)
- [ ] Download run log from app. This should succeed

Protocol for testing:

```
from opentrons.protocol_api import PARTIAL_COLUMN

metadata = {
    "protocolName": "8 Channel SINGLE Happy Path A1 or H1",
    "description": "Tip Rack South Clearance for the 8 Channel pipette and a SINGLE partial tip configuration.",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.20",
}

def run(protocol):
    trash = protocol.load_trash_bin("A3")  # must load trash bin
    thermocycler = protocol.load_module("thermocycler module gen2")
    partial_tip_rack = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_50ul",
        label="Partial Tip Rack",
        location="B3",
    )
    pipette = protocol.load_instrument(instrument_name="flex_8channel_50", mount="right")
    # mount on the right and you will get an error.
    pipette.configure_nozzle_layout(
        style=PARTIAL_COLUMN,
        start="H1",
        end="B1",  # 2 Tips
        tip_racks=[partial_tip_rack],
    )
    source_labware_B2 = protocol.load_labware(
        load_name="nest_96_wellplate_100ul_pcr_full_skirt",
        label="B2 Source Labware",
        location="B2",
    )
    destination_labware_C2 = protocol.load_labware(
        load_name="nest_96_wellplate_100ul_pcr_full_skirt",
        label="C2 Destination Labware",
        location="C2",
    )
    volume = 10  # Default volume for actions that require it
    pipette.transfer(volume, source_labware_B2["A6"], destination_labware_C2["A6"])
```

## Review requests

It's been a while since I looked at the partial tip code so want to make sure that parts of the code that consume quadrant configuration know to verify the presence of at least one of `frontRightNozzle` or `backLeftNozzle` and to handle the case where neither is specified.

The alternative to this approach would be to make the two fields non-optional and make the python API extract the info of the missing field before calling the engine command.

## Risk assessment

None. Bug fix.
