### PR TITLE
fix(app): Fix cancelling a run showing the error banner (desktop)/button (ODD)

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -247,7 +247,9 @@ export function ProtocolRunHeader({
     },
   })
 
-  const enteredER = runRecord?.data.hasEverEnteredErrorRecovery
+  const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
+  const cancelledWithoutRecovery =
+    !enteredER && runStatus === RUN_STATUS_STOPPED
 
   React.useEffect(() => {
     if (isFlex) {
@@ -432,6 +434,7 @@ export function ProtocolRunHeader({
               setShowRunFailedModal,
               commandErrorList,
               highestPriorityError,
+              cancelledWithoutRecovery,
             }}
             isResetRunLoading={isResetRunLoadingRef.current}
             isRunCurrent={isRunCurrent}
@@ -914,6 +917,7 @@ interface TerminalRunProps {
   commandErrorList?: RunCommandErrors
   isResetRunLoading: boolean
   isRunCurrent: boolean
+  cancelledWithoutRecovery: boolean
   highestPriorityError?: RunError | null
 }
 function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
@@ -926,6 +930,7 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
     highestPriorityError,
     isResetRunLoading,
     isRunCurrent,
+    cancelledWithoutRecovery,
   } = props
   const { t } = useTranslation('run_details')
   const completedWithErrors =
@@ -992,9 +997,12 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
     !completedWithErrors
   ) {
     return buildSuccessBanner()
-  } else if (
-    highestPriorityError != null ||
-    (completedWithErrors && !isResetRunLoading)
+  }
+  // TODO(jh, 08-14-24): The backend never returns the "user cancelled a run" error and cancelledWithoutRecovery becomes unnecessary.
+  else if (
+    !cancelledWithoutRecovery &&
+    (highestPriorityError != null ||
+      (completedWithErrors && !isResetRunLoading))
   ) {
     return buildErrorBanner()
   } else {

--- a/app/src/organisms/DropTipWizardFlows/index.tsx
+++ b/app/src/organisms/DropTipWizardFlows/index.tsx
@@ -112,9 +112,8 @@ export function useTipAttachmentStatus(
   })
 
   const aPipetteWithTip = head(pipettesWithTip) ?? null
-
   const areTipsAttached =
-    pipettesWithTip.length != null && head(pipettesWithTip)?.specs != null
+    pipettesWithTip.length > 0 && head(pipettesWithTip)?.specs != null
 
   const determineTipStatus = React.useCallback((): Promise<
     PipetteWithTip[]
@@ -146,6 +145,7 @@ export function useTipAttachmentStatus(
 
   const resetTipStatus = (): void => {
     setPipettesWithTip([])
+    setInitialPipettesCount(null)
   }
 
   const setTipStatusResolved = (

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -128,7 +128,7 @@ export function RunSummary(): JSX.Element {
   const robotAnalyticsData = useRobotAnalyticsData(robotName as string)
   const { reportRecoveredRunResult } = useRecoveryAnalytics()
 
-  const enteredER = runRecord?.data.hasEverEnteredErrorRecovery
+  const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
   React.useEffect(() => {
     if (isRunCurrent && typeof enteredER === 'boolean') {
       reportRecoveredRunResult(runStatus, enteredER)
@@ -156,6 +156,13 @@ export function RunSummary(): JSX.Element {
       RUN_STATUSES_TERMINAL.includes(runStatus) &&
       isRunCurrent,
   })
+  // TODO(jh, 08-14-24): The backend never returns the "user cancelled a run" error and cancelledWithoutRecovery becomes unnecessary.
+  const cancelledWithoutRecovery =
+    !enteredER && runStatus === RUN_STATUS_STOPPED
+  const showErrorDetailsBtn =
+    !cancelledWithoutRecovery &&
+    ((runRecord?.data.errors != null && runRecord?.data.errors.length > 0) ||
+      (commandErrorList != null && commandErrorList?.data.length > 0))
 
   let headerText =
     commandErrorList != null && commandErrorList.data.length > 0
@@ -419,8 +426,7 @@ export function RunSummary(): JSX.Element {
               height="17rem"
               css={showRunAgainSpinner ? RUN_AGAIN_CLICKED_STYLE : undefined}
             />
-            {(commandErrorList != null && commandErrorList?.data.length > 0) ||
-            !didRunSucceed ? (
+            {showErrorDetailsBtn ? (
               <LargeButton
                 flex="1"
                 iconName="info"
@@ -428,12 +434,6 @@ export function RunSummary(): JSX.Element {
                 onClick={handleViewErrorDetails}
                 buttonText={t('view_error_details')}
                 height="17rem"
-                disabled={
-                  (runRecord?.data.errors == null ||
-                    runRecord?.data.errors.length === 0) &&
-                  (commandErrorList == null ||
-                    commandErrorList?.data.length === 0)
-                }
               />
             ) : null}
           </Flex>


### PR DESCRIPTION
Closes [RQA-3037](https://opentrons.atlassian.net/browse/RQA-3037)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

See the ticket for the full explanation of the problem statement and the current solution.

Also, I've taken the opportunity here to clear a regression that's not reported, but has been present in the code for quite some time: on the ODD, if there's no actual error message to display, the post-run "view error details" button no longer renders. This was done alongside the new conditional button display logic.

Also, I'm ashamedly pushing in one drop tip here that is evident when reproing this bug - on the desktop, we need to reset the initial tip count between runs, otherwise the drop tip CTAs quickly render/unrender. 

### Current Behavior

https://github.com/user-attachments/assets/59ce3259-d23e-4ace-a641-6d2757559ab1

### Fixed Behavior

https://github.com/user-attachments/assets/0ea960b9-6f65-4004-9ec4-fa29cad46fc7

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Cancelling a run no longer shows the error banner/button with a cancel error, unless the user cancelled in Error Recovery.
- On the ODD, the error button no longer appears unless it has reason to appear.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3037]: https://opentrons.atlassian.net/browse/RQA-3037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ