### PR TITLE
fix(app, react-api-client): invalidate queries for protocol on run creation

### DIFF
--- a/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
@@ -70,13 +70,7 @@ export function useCreateProtocolAnalysisMutation(
       )
         .then(response => {
           queryClient
-            .invalidateQueries([host, 'protocols', protocolId, 'analyses'])
-            .then(() =>
-              queryClient.setQueryData(
-                [host, 'protocols', protocolId, 'analyses'],
-                response.data
-              )
-            )
+            .invalidateQueries([host, 'protocols'])
             .catch((e: Error) => {
               throw e
             })


### PR DESCRIPTION
# Overview

On ODD, confirming runtime parameters uses the `useCreateProtocolAnalysis` hook, which exposes the `createProtocolAnalysis` function. Firstly, we need to only create a run on success of analysis creation rather than synchronously. Secondly, we need to invalidate all queries for the protocol, rather than for the protocol's analyses. This resolves an issue where stale error data from `useProtocolAnalysisErrors` from a previous failed analysis was being flashed after being pushed to a new run, even though the analysis was new.

Closes RQA-3001

## Test Plan and Hands on Testing

- On ODD, start protocol setup with a protocol that will fail analysis with a given RTP configuration
- Confirm values and verify that analysis failed modal shows
- Exit modal and cancel run
- Start protocol setup _for the same protocol_ but select RTPs that will pass analysis
- verify that run loads without flash

https://github.com/user-attachments/assets/07c8d97f-1400-4c38-953e-4b28236001d3

ing analysis failed modal

## Changelog

- In `useCreateProtocolAnalysis` hook, invalidate queries through `protocolId` rather than analyses
- In `ProtocolSetupParameters`, move `createRun` to the `onSuccess` callback of `createProtocolAnalysis`

## Review requests

See test plan

## Risk assessment

low