### PR TITLE
refactor(shared-data): allow for multiple inner well geometry definitions

### DIFF
--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -689,8 +689,8 @@ def _load_labware_definition_data() -> LabwareDefinition:
         },
         dimensions=Dimensions(yDimension=85.5, zDimension=100, xDimension=127.75),
         cornerOffsetFromSlot=CornerOffsetFromSlot(x=0, y=0, z=0),
-        innerLabwareGeometry=[
-            InnerWellGeometry(
+        innerLabwareGeometry={
+            "welldefinition1111": InnerWellGeometry(
                 frusta=[
                     BoundedSection(
                         geometry=RectangularCrossSection(
@@ -715,7 +715,7 @@ def _load_labware_definition_data() -> LabwareDefinition:
                     depth=10,
                 ),
             )
-        ],
+        },
         brand=BrandData(brand="foo"),
         metadata=Metadata(
             displayName="Foo 8 Well Plate 33uL",

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -15,7 +15,7 @@ from opentrons_shared_data.labware.labware_definition import (
     WellDefinition,
     BoundedSection,
     RectangularCrossSection,
-    InnerLabwareGeometry,
+    InnerWellGeometry,
     SphericalSegment,
 )
 from opentrons_shared_data.protocol.models import (
@@ -689,8 +689,8 @@ def _load_labware_definition_data() -> LabwareDefinition:
         },
         dimensions=Dimensions(yDimension=85.5, zDimension=100, xDimension=127.75),
         cornerOffsetFromSlot=CornerOffsetFromSlot(x=0, y=0, z=0),
-        innerWellGeometry=[
-            InnerLabwareGeometry(
+        innerLabwareGeometry=[
+            InnerWellGeometry(
                 frusta=[
                     BoundedSection(
                         geometry=RectangularCrossSection(

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -689,31 +689,33 @@ def _load_labware_definition_data() -> LabwareDefinition:
         },
         dimensions=Dimensions(yDimension=85.5, zDimension=100, xDimension=127.75),
         cornerOffsetFromSlot=CornerOffsetFromSlot(x=0, y=0, z=0),
-        innerWellGeometry=InnerLabwareGeometry(
-            frusta=[
-                BoundedSection(
-                    geometry=RectangularCrossSection(
-                        shape="rectangular",
-                        xDimension=7.6,
-                        yDimension=8.5,
+        innerWellGeometry=[
+            InnerLabwareGeometry(
+                frusta=[
+                    BoundedSection(
+                        geometry=RectangularCrossSection(
+                            shape="rectangular",
+                            xDimension=7.6,
+                            yDimension=8.5,
+                        ),
+                        topHeight=45,
                     ),
-                    topHeight=45,
-                ),
-                BoundedSection(
-                    geometry=RectangularCrossSection(
-                        shape="rectangular",
-                        xDimension=5.6,
-                        yDimension=6.5,
+                    BoundedSection(
+                        geometry=RectangularCrossSection(
+                            shape="rectangular",
+                            xDimension=5.6,
+                            yDimension=6.5,
+                        ),
+                        topHeight=20,
                     ),
-                    topHeight=20,
+                ],
+                bottomShape=SphericalSegment(
+                    shape="spherical",
+                    radius_of_curvature=6,
+                    depth=10,
                 ),
-            ],
-            bottomShape=SphericalSegment(
-                shape="spherical",
-                radius_of_curvature=6,
-                depth=10,
-            ),
-        ),
+            )
+        ],
         brand=BrandData(brand="foo"),
         metadata=Metadata(
             displayName="Foo 8 Well Plate 33uL",

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -222,7 +222,7 @@ class WellDefinition(BaseModel):
         description="If 'rectangular', use xDimension and "
         "yDimension; if 'circular' use diameter",
     )
-    innerGeometryDefinition: Optional[_NonNegativeNumber] = Field(
+    geometryDefinitionIndex: Optional[_NonNegativeNumber] = Field(
         None, description="Index number of the well's corresponding" "innerWellGeometry"
     )
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -223,7 +223,7 @@ class WellDefinition(BaseModel):
         "yDimension; if 'circular' use diameter",
     )
     geometryDefinitionId: Optional[str] = Field(
-        None, description="Index number of the well's corresponding" "innerWellGeometry"
+        None, description="str id of the well's corresponding" "innerWellGeometry"
     )
 
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -390,7 +390,7 @@ class LabwareDefinition(BaseModel):
         default_factory=None,
         description="Force, in Newtons, with which the gripper should grip the labware.",
     )
-    innerLabwareGeometry: Optional[List[InnerWellGeometry]] = Field(
+    innerLabwareGeometry: Optional[Dict[str, InnerWellGeometry]] = Field(
         None,
-        description="A list of bounded sections describing the geometry of the inside of the wells.",
+        description="A dictionary holding all unique inner well geometries in a labware.",
     )

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -222,7 +222,7 @@ class WellDefinition(BaseModel):
         description="If 'rectangular', use xDimension and "
         "yDimension; if 'circular' use diameter",
     )
-    geometryDefinitionIndex: Optional[_NonNegativeNumber] = Field(
+    geometryDefinitionId: Optional[str] = Field(
         None, description="Index number of the well's corresponding" "innerWellGeometry"
     )
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -222,6 +222,9 @@ class WellDefinition(BaseModel):
         description="If 'rectangular', use xDimension and "
         "yDimension; if 'circular' use diameter",
     )
+    innerGeometryDefinition: Optional[_NonNegativeNumber] = Field(
+        None, description="Index number of the well's corresponding" "innerWellGeometry"
+    )
 
 
 class CircularCrossSection(BaseModel):
@@ -387,7 +390,7 @@ class LabwareDefinition(BaseModel):
         default_factory=None,
         description="Force, in Newtons, with which the gripper should grip the labware.",
     )
-    innerWellGeometry: Optional[InnerLabwareGeometry] = Field(
+    innerWellGeometry: Optional[List[InnerLabwareGeometry]] = Field(
         None,
         description="A list of bounded sections describing the geometry of the inside of the wells.",
     )

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -304,7 +304,7 @@ class Group(BaseModel):
     )
 
 
-class InnerLabwareGeometry(BaseModel):
+class InnerWellGeometry(BaseModel):
     frusta: List[BoundedSection] = Field(
         ...,
         description="A list of all of the sections of the well that have a contiguous shape",
@@ -390,7 +390,7 @@ class LabwareDefinition(BaseModel):
         default_factory=None,
         description="Force, in Newtons, with which the gripper should grip the labware.",
     )
-    innerWellGeometry: Optional[List[InnerLabwareGeometry]] = Field(
+    innerLabwareGeometry: Optional[List[InnerWellGeometry]] = Field(
         None,
         description="A list of bounded sections describing the geometry of the inside of the wells.",
     )

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -172,4 +172,4 @@ class LabwareDefinition(_RequiredLabwareDefinition, total=False):
     gripperOffsets: Dict[str, GripperOffsets]
     gripForce: float
     gripHeightFromLabwareBottom: float
-    innerLabwareGeometry: NotRequired[List[InnerWellGeometry]]
+    innerLabwareGeometry: NotRequired[Dict[str, InnerWellGeometry]]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -146,7 +146,7 @@ class BoundedSection(TypedDict):
     topHeight: float
 
 
-class InnerLabwareGeometry(TypedDict):
+class InnerWellGeometry(TypedDict):
     frusta: List[BoundedSection]
     bottomShape: BottomShape
 
@@ -172,4 +172,4 @@ class LabwareDefinition(_RequiredLabwareDefinition, total=False):
     gripperOffsets: Dict[str, GripperOffsets]
     gripForce: float
     gripHeightFromLabwareBottom: float
-    innerWellGeometry: NotRequired[List[InnerLabwareGeometry]]
+    innerLabwareGeometry: NotRequired[List[InnerWellGeometry]]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -3,8 +3,8 @@
 types in this file by and large require the use of typing_extensions.
 this module shouldn't be imported unless typing.TYPE_CHECKING is true.
 """
-from typing import Dict, List, NewType, Union, Optional
-from typing_extensions import Literal, TypedDict
+from typing import Dict, List, NewType, Union
+from typing_extensions import Literal, TypedDict, NotRequired
 
 
 LabwareUri = NewType("LabwareUri", str)
@@ -90,6 +90,7 @@ class CircularWellDefinition(TypedDict):
     y: float
     z: float
     diameter: float
+    innerGeometryDefinition: NotRequired[float]
 
 
 class RectangularWellDefinition(TypedDict):
@@ -101,6 +102,7 @@ class RectangularWellDefinition(TypedDict):
     z: float
     xDimension: float
     yDimension: float
+    innerGeometryDefinition: NotRequired[float]
 
 
 WellDefinition = Union[CircularWellDefinition, RectangularWellDefinition]
@@ -170,4 +172,4 @@ class LabwareDefinition(_RequiredLabwareDefinition, total=False):
     gripperOffsets: Dict[str, GripperOffsets]
     gripForce: float
     gripHeightFromLabwareBottom: float
-    innerWellGeometry: Optional[InnerLabwareGeometry]
+    innerWellGeometry: NotRequired[List[InnerLabwareGeometry]]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -90,7 +90,7 @@ class CircularWellDefinition(TypedDict):
     y: float
     z: float
     diameter: float
-    geometryDefinitionIndex: NotRequired[int]
+    geometryDefinitionId: NotRequired[str]
 
 
 class RectangularWellDefinition(TypedDict):
@@ -102,7 +102,7 @@ class RectangularWellDefinition(TypedDict):
     z: float
     xDimension: float
     yDimension: float
-    geometryDefinitionIndex: NotRequired[int]
+    geometryDefinitionId: NotRequired[str]
 
 
 WellDefinition = Union[CircularWellDefinition, RectangularWellDefinition]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -90,7 +90,7 @@ class CircularWellDefinition(TypedDict):
     y: float
     z: float
     diameter: float
-    innerGeometryDefinition: NotRequired[float]
+    geometryDefinitionIndex: NotRequired[int]
 
 
 class RectangularWellDefinition(TypedDict):
@@ -102,7 +102,7 @@ class RectangularWellDefinition(TypedDict):
     z: float
     xDimension: float
     yDimension: float
-    innerGeometryDefinition: NotRequired[float]
+    geometryDefinitionIndex: NotRequired[int]
 
 
 WellDefinition = Union[CircularWellDefinition, RectangularWellDefinition]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -151,7 +151,7 @@ class InnerWellGeometry(TypedDict):
     bottomShape: BottomShape
 
 
-class _RequiredLabwareDefinition(TypedDict):
+class LabwareDefinition(TypedDict):
     schemaVersion: Literal[2]
     version: int
     namespace: str
@@ -163,13 +163,10 @@ class _RequiredLabwareDefinition(TypedDict):
     dimensions: LabwareDimensions
     wells: Dict[str, WellDefinition]
     groups: List[WellGroup]
-
-
-class LabwareDefinition(_RequiredLabwareDefinition, total=False):
-    stackingOffsetWithLabware: Dict[str, NamedOffset]
-    stackingOffsetWithModule: Dict[str, NamedOffset]
-    allowedRoles: List[LabwareRoles]
-    gripperOffsets: Dict[str, GripperOffsets]
-    gripForce: float
-    gripHeightFromLabwareBottom: float
+    stackingOffsetWithLabware: NotRequired[Dict[str, NamedOffset]]
+    stackingOffsetWithModule: NotRequired[Dict[str, NamedOffset]]
+    allowedRoles: NotRequired[List[LabwareRoles]]
+    gripperOffsets: NotRequired[Dict[str, GripperOffsets]]
+    gripForce: NotRequired[float]
+    gripHeightFromLabwareBottom: NotRequired[float]
     innerLabwareGeometry: NotRequired[Dict[str, InnerWellGeometry]]


### PR DESCRIPTION
## Overview
The addition of `innerWellGeometry` to labware definitions only allows for one inner well definition, which would exclude labware with wells of different shapes and sizes. This pr changes `innerLabwareGeometry` and `WellDefinition` to allow multiple kinds of wells. 

The idea is that `innerLabwareGeometry` will become a dictionary containing all of the unique `InnerWellGeometry` objects, and each object will be assigned a uuid by the protocol engine. `WellDefinition` will get a new parameter, `geometryDefinitionId`, which will hold the corresponding uuid of the well's inner geometry definition. 

## Changelog

- change `LabwareDefinition`'s `innerWellGeometry` to `Optional[Dict[str, InnerLabwareGeometry]]` from `Optional[InnerLabwareGeometry]`
- add `geometryDefinitionIndex` entry to `WellDefinition`
- switch the names of `innerWellGeometry` and `InnerLabwareGeometry`- `innerLabwareGeometry` should hold all of the `InnerWellGeometry` objects
- combine `RequiredLabwareDefinition` and `LabwareDefinition` and replace `total=False` with `NotRequired`