### PR TITLE
fix(robot-server, app): Fix ODD routing back to previous screen

### DIFF
--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -143,6 +143,10 @@ export function RunSummary(): JSX.Element {
   const [showRunAgainSpinner, setShowRunAgainSpinner] = React.useState<boolean>(
     false
   )
+  const [showReturnToSpinner, setShowReturnToSpinner] = React.useState<boolean>(
+    false
+  )
+
   const robotSerialNumber =
     localRobot?.health?.robot_serial ??
     localRobot?.serverHealth?.serialNumber ??
@@ -229,6 +233,7 @@ export function RunSummary(): JSX.Element {
   }
 
   const handleReturnToDash = (aPipetteWithTip: PipetteWithTip | null): void => {
+    setShowReturnToSpinner(true)
     if (isRunCurrent && aPipetteWithTip != null) {
       void handleTipsAttachedModal({
         setTipStatusResolved: setTipStatusResolvedAndRoute(handleReturnToDash),
@@ -290,7 +295,22 @@ export function RunSummary(): JSX.Element {
     setShowSplash(false)
   }
 
-  const RUN_AGAIN_SPINNER_TEXT = (
+  const buildReturnToCopy = (): string =>
+    isQuickTransfer ? t('return_to_quick_transfer') : t('return_to_dashboard')
+
+  const buildReturnToWithSpinnerText = (): JSX.Element => (
+    <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="16rem">
+      {buildReturnToCopy()}
+      <Icon
+        name="ot-spinner"
+        aria-label="icon_ot-spinner"
+        spin={true}
+        size="3.5rem"
+        color={COLORS.white}
+      />
+    </Flex>
+  )
+  const buildRunAgainWithSpinnerText = (): JSX.Element => (
     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="16rem">
       {t('run_again')}
       <Icon
@@ -407,10 +427,11 @@ export function RunSummary(): JSX.Element {
                 handleReturnToDash(aPipetteWithTip)
               }}
               buttonText={
-                isQuickTransfer
-                  ? t('return_to_quick_transfer')
-                  : t('return_to_dashboard')
+                showReturnToSpinner
+                  ? buildReturnToWithSpinnerText()
+                  : buildReturnToCopy()
               }
+              css={showReturnToSpinner ? RETURN_TO_CLICKED_STYLE : undefined}
             />
             <EqualWidthButton
               iconName="play-round-corners"
@@ -418,7 +439,9 @@ export function RunSummary(): JSX.Element {
                 handleRunAgain(aPipetteWithTip)
               }}
               buttonText={
-                showRunAgainSpinner ? RUN_AGAIN_SPINNER_TEXT : t('run_again')
+                showRunAgainSpinner
+                  ? buildRunAgainWithSpinnerText()
+                  : t('run_again')
               }
               css={showRunAgainSpinner ? RUN_AGAIN_CLICKED_STYLE : undefined}
             />
@@ -508,6 +531,22 @@ const DURATION_TEXT_STYLE = css`
   font-size: ${TYPOGRAPHY.fontSize22};
   line-height: ${TYPOGRAPHY.lineHeight28};
   font-weight: ${TYPOGRAPHY.fontWeightRegular};
+`
+
+const RETURN_TO_CLICKED_STYLE = css`
+  background-color: ${COLORS.blue40};
+  &:focus {
+    background-color: ${COLORS.blue40};
+  }
+  &:hover {
+    background-color: ${COLORS.blue40};
+  }
+  &:focus-visible {
+    background-color: ${COLORS.blue40};
+  }
+  &:active {
+    background-color: ${COLORS.blue40};
+  }
 `
 
 const RUN_AGAIN_CLICKED_STYLE = css`

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
-import { useQueryClient } from 'react-query'
 
 import {
   ALIGN_CENTER,
@@ -195,15 +194,6 @@ export function RunSummary(): JSX.Element {
     }
   }, [isRunCurrent, enteredER])
 
-  // TODO(jh, 08-02-24): Revisit useCurrentRunRoute and top level redirects.
-  const queryClient = useQueryClient()
-  const returnToDash = (): void => {
-    // Eagerly clear the query caches to prevent top level redirecting back to this page.
-    queryClient.setQueryData([host, 'runs', 'details'], () => undefined)
-    queryClient.setQueryData([host, 'runs', runId, 'details'], () => undefined)
-    navigate('/')
-  }
-
   const returnToQuickTransfer = (): void => {
     if (!isRunCurrent) {
       deleteRun(runId)
@@ -249,15 +239,21 @@ export function RunSummary(): JSX.Element {
         robotType: FLEX_ROBOT_TYPE,
         isRunCurrent,
         onSkipAndHome: () => {
-          closeCurrentRun()
-          returnToDash()
+          closeCurrentRun({
+            onSuccess: () => {
+              navigate('/')
+            },
+          })
         },
       })
     } else if (isQuickTransfer) {
       returnToQuickTransfer()
     } else {
-      closeCurrentRun()
-      returnToDash()
+      closeCurrentRun({
+        onSuccess: () => {
+          navigate('/')
+        },
+      })
     }
   }
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -359,6 +359,8 @@ class RunDataManager:
             parameters = self._run_orchestrator_store.get_run_time_parameters()
             run_resource = self._run_store.get(run_id=run_id)
 
+        await self._runs_publisher.publish_runs_advise_refetch_async(run_id)
+
         return _build_run(
             run_resource=run_resource,
             state_summary=state_summary,

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -664,6 +664,10 @@ async def test_update_current(
         await mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
         times=1,
     )
+    decoy.verify(
+        await mock_runs_publisher.publish_runs_advise_refetch_async(run_id),
+        times=1,
+    )
     assert result == Run(
         current=False,
         id=run_resource.run_id,


### PR DESCRIPTION
Closes [RQA-3036](https://opentrons.atlassian.net/browse/RQA-3036) and [RQA-3038](https://opentrons.atlassian.net/browse/RQA-3038)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The recent react-router update exposed an existing bug: MQTT did not properly publish a refetch to `runs/:runId` after a client sends a `PATCH` to `runs/:runId`. Although the exact reasoning concerning why the migration from `history.push` to `navigate` exposes this problem is unknown, this PR provides the necessary publish event to the app's top level redirection logic and prevents redirection back to the previous route. Note that this does mean we have to account for noticible client latency now, so this PR also adds loading state when "return to dashboard" is clicked.

https://github.com/user-attachments/assets/5ac10b55-a409-45c4-b333-efcd0c19e518

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified clicking "Run again" on the ODD routes the user to the correct location with no unexpected redirection elsewhere.
- Verified MQTT now sends a publish update after the app `PATCH`es `run/:runId`. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the ODD routing  back to the previous screen after clicking buttons.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3036]: https://opentrons.atlassian.net/browse/RQA-3036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-3038]: https://opentrons.atlassian.net/browse/RQA-3038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ