### PR TITLE
fix(api,robot-server): Use the host deck config in the `opentrons.execute` entry points

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -689,8 +689,6 @@ def _get_protocol_engine_config() -> Config:
         # We deliberately omit ignore_pause=True because, in the current implementation of
         # opentrons.protocol_api.core.engine, that would incorrectly make
         # ProtocolContext.is_simulating() return True.
-        use_simulated_deck_config=True,
-        # TODO the above is not correct for this and it should use the robot's actual config
     )
 
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -545,6 +545,7 @@ def _create_live_context_pe(
         create_protocol_engine_in_thread(
             hardware_api=hardware_api_wrapped,
             config=_get_protocol_engine_config(),
+            deck_configuration=entrypoint_util.get_deck_configuration(),
             error_recovery_policy=error_recovery_policy.never_recover,
             drop_tips_after_run=False,
             post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,

--- a/api/src/opentrons/protocol_engine/create_protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/create_protocol_engine.py
@@ -69,6 +69,7 @@ async def create_protocol_engine(
 def create_protocol_engine_in_thread(
     hardware_api: HardwareControlAPI,
     config: Config,
+    deck_configuration: typing.Optional[DeckConfigurationType],
     error_recovery_policy: ErrorRecoveryPolicy,
     drop_tips_after_run: bool,
     post_run_hardware_state: PostRunHardwareState,
@@ -97,6 +98,7 @@ def create_protocol_engine_in_thread(
         _protocol_engine(
             hardware_api,
             config,
+            deck_configuration,
             error_recovery_policy,
             drop_tips_after_run,
             post_run_hardware_state,
@@ -113,6 +115,7 @@ def create_protocol_engine_in_thread(
 async def _protocol_engine(
     hardware_api: HardwareControlAPI,
     config: Config,
+    deck_configuration: typing.Optional[DeckConfigurationType],
     error_recovery_policy: ErrorRecoveryPolicy,
     drop_tips_after_run: bool,
     post_run_hardware_state: PostRunHardwareState,
@@ -131,10 +134,7 @@ async def _protocol_engine(
         protocol_engine=protocol_engine,
     )
     try:
-        # TODO(mm, 2023-11-21): Callers like opentrons.execute need to be able to pass in
-        # the deck_configuration argument to ProtocolEngine.play().
-        # https://opentrons.atlassian.net/browse/RSS-400
-        orchestrator.play()
+        orchestrator.play(deck_configuration)
         yield protocol_engine
     finally:
         await orchestrator.finish(

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -814,6 +814,7 @@ def _create_live_context_pe(
             config=_get_protocol_engine_config(
                 robot_type, use_pe_virtual_hardware=use_pe_virtual_hardware
             ),
+            deck_configuration=None,
             error_recovery_policy=error_recovery_policy.never_recover,
             drop_tips_after_run=False,
             post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,

--- a/api/src/opentrons/util/entrypoint_util.py
+++ b/api/src/opentrons/util/entrypoint_util.py
@@ -8,6 +8,8 @@ import json
 import logging
 from json import JSONDecodeError
 import pathlib
+import subprocess
+import sys
 import tempfile
 from typing import (
     Dict,
@@ -21,7 +23,15 @@ from typing import (
 
 from jsonschema import ValidationError  # type: ignore
 
-from opentrons.config import IS_ROBOT, JUPYTER_NOTEBOOK_LABWARE_DIR
+from opentrons.calibration_storage.deck_configuration import (
+    deserialize_deck_configuration,
+)
+from opentrons.config import (
+    ARCHITECTURE,
+    IS_ROBOT,
+    JUPYTER_NOTEBOOK_LABWARE_DIR,
+    SystemArchitecture,
+)
 from opentrons.protocol_api import labware
 from opentrons.calibration_storage import helpers
 from opentrons.protocol_engine.errors.error_occurrence import (
@@ -125,12 +135,52 @@ def datafiles_from_paths(paths: Sequence[Union[str, pathlib.Path]]) -> Dict[str,
 
 
 def get_deck_configuration() -> DeckConfigurationType:
-    """Return the host robot's current deck configuration."""
-    # TODO: Search for the file where robot-server stores it.
-    # Flex: /var/lib/opentrons-robot-server/deck_configuration.json
-    # OT-2: /data/opentrons_robot_server/deck_configuration.json
-    # https://opentrons.atlassian.net/browse/RSS-400
-    return []
+    """Return the host robot's current deck configuration.
+
+    This is a hacky implementation because the deck configuration is owned by
+    robot-server. See `robot_server.deck_configuration.cli`.
+    """
+    match ARCHITECTURE:
+        # These hard-coded paths need to be kept in sync with robot-server's
+        # systemd configuration:
+        case SystemArchitecture.BUILDROOT:
+            robot_server_persistence_dir = "/data/opentrons_robot_server"
+        case SystemArchitecture.YOCTO:
+            robot_server_persistence_dir = "/var/lib/opentrons-robot-server"
+        case SystemArchitecture.HOST:
+            # todo(mm, 2024-08-13):
+            # It's unclear what should happen if you run an `opentrons.execute` entry
+            # point on a non-robot device that doesn't have robot-server. I can't
+            # imagine we'd let actual users do this, but it might happen in internal
+            # testing. This empty list return value is totally arbitrary and will
+            # probably not do the right thing.
+            return []
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "robot_server.deck_configuration.cli",
+            "--persistence-directory",
+            robot_server_persistence_dir,
+        ],
+        check=True,
+        capture_output=True,
+    )
+    deserialized_deck_configuration = deserialize_deck_configuration(proc.stdout)
+    if deserialized_deck_configuration is None:
+        raise RuntimeError("Error getting the host robot's deck configuration.")
+
+    cutout_fixture_placements, _ = deserialized_deck_configuration
+
+    return [
+        (
+            cutout_fixture_placement.cutout_id,
+            cutout_fixture_placement.cutout_fixture_id,
+            cutout_fixture_placement.opentrons_module_serial_number,
+        )
+        for cutout_fixture_placement in cutout_fixture_placements
+    ]
 
 
 @contextlib.contextmanager

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -316,6 +316,7 @@ def _make_ot3_pe_ctx(
             use_simulated_deck_config=True,
             block_on_door_open=False,
         ),
+        deck_configuration=None,
         error_recovery_policy=error_recovery_policy.never_recover,
         drop_tips_after_run=False,
         post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -21,6 +21,7 @@ from opentrons_shared_data.pipette import (
 from opentrons import execute, types
 from opentrons.hardware_control import Controller, api
 from opentrons.protocol_api.core.engine import ENGINE_CORE_API_VERSION
+from opentrons.protocol_engine.types import DeckConfigurationType
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.util import entrypoint_util
 
@@ -58,6 +59,33 @@ def mock_get_attached_instr(  # noqa: D103
         types.Mount.LEFT: {"model": None, "id": None},
     }
     return gai_mock
+
+
+@pytest.fixture(autouse=True)
+def mock_deck_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Override the "host device deck config" to be an OT-2's normal deck config."""
+
+    def mock_get_deck_configuration() -> DeckConfigurationType:
+        return [
+            ("cutout1", "singleStandardSlot", None),
+            ("cutout2", "singleStandardSlot", None),
+            ("cutout3", "singleStandardSlot", None),
+            ("cutout4", "singleStandardSlot", None),
+            ("cutout5", "singleStandardSlot", None),
+            ("cutout6", "singleStandardSlot", None),
+            ("cutout7", "singleStandardSlot", None),
+            ("cutout8", "singleStandardSlot", None),
+            ("cutout9", "singleStandardSlot", None),
+            ("cutout10", "singleStandardSlot", None),
+            ("cutout11", "singleStandardSlot", None),
+            ("cutout12", "fixedTrashSlot", None),
+        ]
+
+    monkeypatch.setattr(
+        entrypoint_util, "get_deck_configuration", mock_get_deck_configuration
+    )
 
 
 @pytest.mark.parametrize(

--- a/robot-server/robot_server/deck_configuration/cli.py
+++ b/robot-server/robot_server/deck_configuration/cli.py
@@ -1,0 +1,77 @@
+"""A command line interface to return the server's current deck configuration.
+
+This is a hack to let entry points like `opentrons_execute` automatically use the
+robot's current deck configuration. Those entry points live outside of this package,
+in the `opentrons` library, so they can't read the underlying storage themselves;
+and this server can't run at the same time as them, so they can't get the deck config
+by querying this server over localhost HTTP.
+
+The right solution is probably either:
+
+* Get the entry points to coexist with the server so they can do a localhost HTTP query.
+* Or move storage of deck configuration from the server to the `opentrons` library
+  so the entry points can read it directly.
+"""
+
+import argparse
+import asyncio
+import pathlib
+import sys
+import textwrap
+
+from opentrons.protocol_engine.types import DeckType
+from opentrons.protocols.api_support import deck_type
+
+
+from robot_server.persistence.file_and_directory_names import (
+    DECK_CONFIGURATION_FILE,
+    LATEST_VERSION_DIRECTORY,
+)
+from . import store
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(
+        description=textwrap.dedent(
+            """\
+            Output, on stdout, this device's deck configuration, serialized in a form
+            that the `opentrons` package knows how to deserialize.
+
+            This is an internal CLI, for use by Opentrons only.
+            """
+        )
+    )
+    parser.add_argument(
+        "--persistence-directory",
+        type=pathlib.Path,
+        required=True,
+        help=textwrap.dedent(
+            """\
+            The path to robot-server's root persistence directory.
+            This must match the persistence directory launch option that's normally
+            provided to robot-server on this machine.
+            """
+        ),
+    )
+
+    persistence_directory = parser.parse_args().persistence_directory
+    assert isinstance(persistence_directory, pathlib.Path)
+
+    # This will not be correct if the server needs to run a migration to
+    # LATEST_VERSION_DIRECTORY and this CLI runs before the server has had a chance to
+    # complete that. We could theoretically do the migration ourselves right here, but
+    # that would be dangerous if the server process is still running.
+    probable_current_file = (
+        persistence_directory / LATEST_VERSION_DIRECTORY / DECK_CONFIGURATION_FILE
+    )
+
+    host_deck_type = DeckType(deck_type.guess_from_global_config())
+
+    serialized_bytes = asyncio.run(
+        store.get_for_cli(host_deck_type, probable_current_file)
+    )
+    sys.stdout.buffer.write(serialized_bytes)
+
+
+if __name__ == "__main__":
+    _main()

--- a/robot-server/robot_server/deck_configuration/store.py
+++ b/robot-server/robot_server/deck_configuration/store.py
@@ -148,11 +148,11 @@ def _http_types_to_storage_types(
 ) -> _StorableDeckConfiguration:
     storage_cutout_fixture_placements = [
         calibration_storage_types.CutoutFixturePlacement(
-            cutout_fixture_id=e.cutoutFixtureId,
-            cutout_id=e.cutoutId,
-            opentrons_module_serial_number=e.opentronsModuleSerialNumber,
+            cutout_fixture_id=http_element.cutoutFixtureId,
+            cutout_id=http_element.cutoutId,
+            opentrons_module_serial_number=http_element.opentronsModuleSerialNumber,
         )
-        for e in http_val.cutoutFixtures
+        for http_element in http_val.cutoutFixtures
     ]
     return storage_cutout_fixture_placements, last_modified_at
 
@@ -163,11 +163,11 @@ def _storage_types_to_http_types(
     storage_cutout_fixtures, last_modified_at = storage_val
     http_cutout_fixtures = [
         models.CutoutFixture.construct(
-            cutoutFixtureId=e.cutout_fixture_id,
-            cutoutId=e.cutout_id,
-            opentronsModuleSerialNumber=e.opentrons_module_serial_number,
+            cutoutFixtureId=storage_element.cutout_fixture_id,
+            cutoutId=storage_element.cutout_id,
+            opentronsModuleSerialNumber=storage_element.opentrons_module_serial_number,
         )
-        for e in storage_cutout_fixtures
+        for storage_element in storage_cutout_fixtures
     ]
     return models.DeckConfigurationResponse.construct(
         cutoutFixtures=http_cutout_fixtures,

--- a/robot-server/robot_server/deck_configuration/store.py
+++ b/robot-server/robot_server/deck_configuration/store.py
@@ -109,6 +109,40 @@ class DeckConfigurationStore:  # noqa: D101
             return _storage_types_to_http_types(from_storage)
 
 
+async def get_for_cli(deck_type: DeckType, path: Path) -> bytes:
+    """Get the robot's current deck configuration.
+
+    This is a hack to support `opentrons.deck_configuration.cli`. This is supposed to
+    act like `DeckConfigurationStore.get()`, but with two differences:
+
+    1. You can call this without dealing with the notification system
+       (`DeckConfigurationPublisher`).
+    2. The return type is different. Whereas `DeckConfigurationStore.get()` returns
+       a JSON document to expose over HTTP, this returns the data in the on-disk format
+       defined by `opentrons.calibration_storage`.
+
+    This is unsafe to call while there is an active `DeckConfigurationStore`, and
+    should only be called by `opentrons.deck_configuration.cli`.
+    """
+    # This read bypasses the store's normal locking and is therefore unsafe in the face
+    # of concurrent access. That's "okay" because the CLI should't run at the same
+    # time as the server anyway.
+    from_storage = await _read(anyio.Path(path))
+    if from_storage is not None:
+        return serialize_deck_configuration(from_storage[0], from_storage[1])
+    else:
+        default_as_http_response = _get_default(deck_type)
+        default_as_http_request = models.DeckConfigurationRequest.construct(
+            cutoutFixtures=default_as_http_response.cutoutFixtures
+        )
+        storable_default = _http_types_to_storage_types(
+            default_as_http_request,
+            # This timestamp is arbitrary. The CLI's caller does not care about it.
+            datetime.fromtimestamp(0),
+        )
+        return serialize_deck_configuration(storable_default[0], storable_default[1])
+
+
 def _http_types_to_storage_types(
     http_val: models.DeckConfigurationRequest, last_modified_at: datetime
 ) -> _StorableDeckConfiguration:

--- a/robot-server/robot_server/deck_configuration/store.py
+++ b/robot-server/robot_server/deck_configuration/store.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Optional, TypeAlias
 
 import anyio
 
@@ -20,6 +20,12 @@ from robot_server.service.notifications import DeckConfigurationPublisher
 from . import defaults
 from . import models
 from opentrons.protocol_engine.types import DeckConfigurationType
+
+
+# The type used by the lower-level opentrons.calibration_storage API.
+_StorableDeckConfiguration: TypeAlias = tuple[
+    list[calibration_storage_types.CutoutFixturePlacement], datetime
+]
 
 
 # TODO(mm, 2023-11-17): Add unit tests for DeckConfigurationStore.
@@ -57,18 +63,12 @@ class DeckConfigurationStore:  # noqa: D101
         You are responsible for validating it against this robot's deck type before passing it in
         to this method.
         """
+        storable_deck_configuration = _http_types_to_storage_types(
+            request, last_modified_at
+        )
         async with self._lock:
             await _write(
-                path=self._path,
-                cutout_fixture_placements=[
-                    calibration_storage_types.CutoutFixturePlacement(
-                        cutout_fixture_id=e.cutoutFixtureId,
-                        cutout_id=e.cutoutId,
-                        opentrons_module_serial_number=e.opentronsModuleSerialNumber,
-                    )
-                    for e in request.cutoutFixtures
-                ],
-                last_modified_at=last_modified_at,
+                path=self._path, storable_deck_configuration=storable_deck_configuration
             )
             await self._deck_configuration_publisher.publish_deck_configuration()
 
@@ -104,31 +104,53 @@ class DeckConfigurationStore:  # noqa: D101
             # 5XX errors. We think falling back to an arbitrary default is safe because users
             # of the Opentrons App will always have an opportunity to view and confirm their robot's
             # deck configuration before running a protocol.
-            return models.DeckConfigurationResponse.construct(
-                cutoutFixtures=defaults.for_deck_definition(
-                    self._deck_type.value
-                ).cutoutFixtures,
-                lastModifiedAt=None,
-            )
+            return _get_default(self._deck_type)
         else:
-            cutout_fixtures_from_storage, last_modified_at = from_storage
-            cutout_fixtures = [
-                models.CutoutFixture.construct(
-                    cutoutFixtureId=e.cutout_fixture_id,
-                    cutoutId=e.cutout_id,
-                    opentronsModuleSerialNumber=e.opentrons_module_serial_number,
-                )
-                for e in cutout_fixtures_from_storage
-            ]
-        return models.DeckConfigurationResponse.construct(
-            cutoutFixtures=cutout_fixtures,
-            lastModifiedAt=last_modified_at,
+            return _storage_types_to_http_types(from_storage)
+
+
+def _http_types_to_storage_types(
+    http_val: models.DeckConfigurationRequest, last_modified_at: datetime
+) -> _StorableDeckConfiguration:
+    storage_cutout_fixture_placements = [
+        calibration_storage_types.CutoutFixturePlacement(
+            cutout_fixture_id=e.cutoutFixtureId,
+            cutout_id=e.cutoutId,
+            opentrons_module_serial_number=e.opentronsModuleSerialNumber,
         )
+        for e in http_val.cutoutFixtures
+    ]
+    return storage_cutout_fixture_placements, last_modified_at
+
+
+def _storage_types_to_http_types(
+    storage_val: _StorableDeckConfiguration,
+) -> models.DeckConfigurationResponse:
+    storage_cutout_fixtures, last_modified_at = storage_val
+    http_cutout_fixtures = [
+        models.CutoutFixture.construct(
+            cutoutFixtureId=e.cutout_fixture_id,
+            cutoutId=e.cutout_id,
+            opentronsModuleSerialNumber=e.opentrons_module_serial_number,
+        )
+        for e in storage_cutout_fixtures
+    ]
+    return models.DeckConfigurationResponse.construct(
+        cutoutFixtures=http_cutout_fixtures,
+        lastModifiedAt=last_modified_at,
+    )
+
+
+def _get_default(deck_type: DeckType) -> models.DeckConfigurationResponse:
+    return models.DeckConfigurationResponse.construct(
+        cutoutFixtures=defaults.for_deck_definition(deck_type.value).cutoutFixtures,
+        lastModifiedAt=None,
+    )
 
 
 async def _read(
     path: anyio.Path,
-) -> Optional[Tuple[List[calibration_storage_types.CutoutFixturePlacement], datetime]]:
+) -> Optional[_StorableDeckConfiguration]:
     """Read the deck configuration from the filesystem.
 
     Return `None` if the file is missing or corrupt.
@@ -144,9 +166,9 @@ async def _read(
 
 async def _write(
     path: anyio.Path,
-    cutout_fixture_placements: List[calibration_storage_types.CutoutFixturePlacement],
-    last_modified_at: datetime,
+    storable_deck_configuration: _StorableDeckConfiguration,
 ) -> None:
+    cutout_fixture_placements, last_modified_at = storable_deck_configuration
     await path.write_bytes(
         serialize_deck_configuration(cutout_fixture_placements, last_modified_at)
     )

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -100,5 +100,6 @@ class DevServer:
 
     def stop(self) -> None:
         """Stop the robot server."""
+        # todo(mm, 2024-08-15): self.proc does not necessarily exist if startup fails.
         self.proc.send_signal(signal.SIGTERM)
         self.proc.wait()

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -320,6 +320,14 @@ class RobotClient:
         response.raise_for_status()
         return response
 
+    async def get_deck_configuration(self) -> Response:
+        """PUT /deck_configuration."""
+        response = await self.httpx_client.get(
+            url=f"{self.base_url}/deck_configuration",
+        )
+        response.raise_for_status()
+        return response
+
     async def put_deck_configuration(
         self,
         req_body: Dict[str, object],

--- a/robot-server/tests/integration/test_deck_configuration_cli.py
+++ b/robot-server/tests/integration/test_deck_configuration_cli.py
@@ -1,0 +1,84 @@
+"""Integration tests for `robot_server.deck_configuration.cli`."""
+
+import asyncio
+import copy
+import pathlib
+import sys
+
+from .dev_server import DevServer
+from .robot_client import RobotClient
+
+from opentrons.calibration_storage import deserialize_deck_configuration
+from opentrons.calibration_storage.types import CutoutFixturePlacement
+
+
+# Our Tavern tests have servers that stay up for the duration of the test session.
+# We need to pick a different port for our servers to avoid colliding with those.
+# Beware that if there is a collision, these tests' manual DevServer() constructions will currently
+# *not* raise an error--the tests will try to use the preexisting session-scoped servers. :(
+_PORT = "15555"
+
+
+async def run_cli(persistence_directory: pathlib.Path) -> bytes:
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "robot_server.deck_configuration.cli",
+        "--persistence-directory",
+        str(persistence_directory),
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    assert (
+        proc.returncode == 0
+    ), f"Subprocess exited with failure.\nstdout:\n{stdout!r}\nstderr:\n{stderr.decode()}"
+    return stdout
+
+
+async def test_deck_configuration_cli(tmp_path: pathlib.Path) -> None:
+    """Test that the deck config CLI's output reflects changes made over HTTP."""
+    persistence_directory = tmp_path / "persistence_directory"
+
+    async with RobotClient.make(
+        base_url=f"http://localhost:{_PORT}", version="*"
+    ) as robot_client:
+        with DevServer(
+            is_ot3=True, persistence_directory=persistence_directory, port=_PORT
+        ) as server:
+            # The CLI should return some default deck configuration even when the
+            # persistence directory is empty.
+            initial_cli_output = await run_cli(persistence_directory)
+            assert deserialize_deck_configuration(initial_cli_output) is not None
+
+            server.start()
+            await robot_client.wait_until_ready()
+
+            # Use the HTTP API to make a single modification to the deck config.
+            initial_http_deck_config = (
+                await robot_client.get_deck_configuration()
+            ).json()["data"]
+            modified_http_deck_config = copy.deepcopy(initial_http_deck_config)
+            for cutout_fixture in modified_http_deck_config["cutoutFixtures"]:
+                if cutout_fixture["cutoutId"] == "cutoutD3":
+                    cutout_fixture["cutoutFixtureId"] = "stagingAreaRightSlot"
+            assert modified_http_deck_config != initial_http_deck_config
+            await robot_client.put_deck_configuration(
+                {"data": modified_http_deck_config}
+            )
+
+            server.stop()
+
+            # The CLI should see the modification that we made over HTTP.
+            new_cli_output = await run_cli(persistence_directory)
+            deserialized_new_cli_output = deserialize_deck_configuration(new_cli_output)
+            assert deserialized_new_cli_output is not None
+            assert (
+                CutoutFixturePlacement(
+                    cutout_id="cutoutD3",
+                    cutout_fixture_id="stagingAreaRightSlot",
+                    opentrons_module_serial_number=None,
+                )
+                in deserialized_new_cli_output[0]
+            )


### PR DESCRIPTION
## Overview

Closes EXEC-216 and RESC-311.

When we added deck configuration, we [decided](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3825041467/Deck+configuration+database+architecture) to store it in `robot-server`. We knew `api` would also need some way to read it, in order to support the `opentrons.execute` entry points (EXEC-216). We imagined that we would do that with some kind of hack where `api` reaches into `robot-server`'s persistence directory. For time constraints, we never actually implemented that hack, which causes problems like RESC-311. This PR implements it.

## Test plan and hands on testing

Here is a test protocol:

```python
from opentrons import protocol_api, execute

requirements = {"robotType": "Flex", "apiLevel": "2.20"}

def run(protocol: protocol_api.ProtocolContext) -> None:
    pipette = protocol.load_instrument("flex_8channel_1000", mount="right")
    pipette.home()
    lw1 = protocol.load_labware("nest_12_reservoir_15ml", "D2")
    lw2 = protocol.load_labware("nest_12_reservoir_15ml", "C3")
    for _ in range(5):
        pipette.move_to(lw1["A12"].top(z=10))
        protocol.delay(1)
        pipette.move_to(lw2["A12"].top(z=10))
        protocol.delay(1)
```

* [x] Flex: It should dodge over the waste chute if, and only if, the robot has been configured to have one.
    * [x] `opentrons_execute`
    * [x] `opentrons.execute.execute()`
    * [x] `opentrons.execute.get_protocol_api()` (with appropriate syntactic modifications)
* [x] OT-2 (with appropriate protocol modifications): The OT-2 does not have a modifiable deck configuration, so we just need to test that the protocol doesn't error.
    * [x] `opentrons_execute`
    * [x] `opentrons.execute.execute()`
    * [x] `opentrons.execute.get_protocol_api()` (with appropriate syntactic modifications)

## Changelog

This implementation basically follows the original plan of hard-coding `robot-server`'s persistence directory inside `api`.

There is one level of indirection: locating and reading the file *within* the persistence directory is delegated to `robot-server`, via a one-off CLI, `python -m robot_server.deck_configuration.cli --persistence-directory=...`. This keeps the *exact* details of the file private to `robot-server`. In particular, it relieves `api` of having to keep up with which versioned subdirectory is currently active—`opentrons_robot_server/5` vs. `opentrons_robot_server/6`, etc.

## Review requests

Does the code explain itself reasonably well? Will this be easy enough to understand in 6 months?

I think there are probably a lot of variations that we could do. Like pass the file path instead of the file contents, or pass a different serialized form. But, it seems like it's fundamentally going to be messy as long as this combination of things is true:

* The `opentrons.execute` entry points live in `api`
* The deck configuration is owned by `robot-server`
* The `opentrons.execute` entry points cannot run at the same time as `robot-server`

## Risk assessment

Medium. This affects the programmatic entry points:

|                          |                                          |                                                  |
|--------------------------|------------------------------------------|--------------------------------------------------|
| `opentrons_simulate` CLI | `opentrons.simulate.simulate()` function | `opentrons.simulate.get_protocol_api()` function |
| `opentrons_execute` CLI  | `opentrons.execute.execute()` function   | `opentrons.execute.get_protocol_api()` function  |
