### PR TITLE
feat(api): Plate Reader live data hookup for read behavior

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -1,7 +1,7 @@
 """Protocol API module implementation logic."""
 from __future__ import annotations
 
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from opentrons.hardware_control import SynchronousAdapter, modules as hw_modules
 from opentrons.hardware_control.modules.types import (
@@ -23,6 +23,7 @@ from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 from opentrons.protocol_engine.errors.exceptions import (
     LabwareNotLoadedOnModuleError,
     NoMagnetEngageHeightError,
+    CannotPerformModuleAction,
 )
 
 from opentrons.protocols.api_support.types import APIVersion
@@ -536,14 +537,24 @@ class AbsorbanceReaderCore(ModuleCore, AbstractAbsorbanceReaderCore):
         )
         self._initialized_value = wavelength
 
-    def read(self) -> None:
-        """Initiate read on the Absorbance Reader."""
+    def read(self) -> Optional[Dict[str, float]]:
+        """Initiate a read on the Absorbance Reader, and return the results. During Analysis, this will return None."""
         if self._initialized_value:
             self._engine_client.execute_command(
                 cmd.absorbance_reader.ReadAbsorbanceParams(
                     moduleId=self.module_id, sampleWavelength=self._initialized_value
                 )
             )
+        read_result = self._engine_client.state.modules.get_absorbance_reader_substate(
+            self.module_id
+        ).data
+        if not self._engine_client.state.config.use_virtual_modules:
+            if read_result is not None:
+                return read_result
+            raise CannotPerformModuleAction(
+                "Absorbance Reader failed to return expected read result."
+            )
+        return None
 
     def close_lid(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -545,10 +545,12 @@ class AbsorbanceReaderCore(ModuleCore, AbstractAbsorbanceReaderCore):
                     moduleId=self.module_id, sampleWavelength=self._initialized_value
                 )
             )
-        read_result = self._engine_client.state.modules.get_absorbance_reader_substate(
-            self.module_id
-        ).data
         if not self._engine_client.state.config.use_virtual_modules:
+            read_result = (
+                self._engine_client.state.modules.get_absorbance_reader_substate(
+                    self.module_id
+                ).data
+            )
             if read_result is not None:
                 return read_result
             raise CannotPerformModuleAction(

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, TypeVar, ClassVar
+from typing import List, Dict, Optional, TypeVar, ClassVar
 
 from opentrons.drivers.types import (
     HeaterShakerLabwareLatchStatus,
@@ -359,7 +359,7 @@ class AbstractAbsorbanceReaderCore(AbstractModuleCore):
         """Initialize the Absorbance Reader by taking zero reading."""
 
     @abstractmethod
-    def read(self) -> None:
+    def read(self) -> Optional[Dict[str, float]]:
         """Get an absorbance reading from the Absorbance Reader."""
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Optional, Union, cast
+from typing import List, Dict, Optional, Union, cast
 
 from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons_shared_data.module.types import ModuleModel, ModuleType
@@ -1008,6 +1008,6 @@ class AbsorbanceReaderContext(ModuleContext):
         self._core.initialize(wavelength)
 
     @requires_version(2, 21)
-    def read(self) -> None:
-        """Initiate read on the Absorbance Reader."""
-        self._core.read()
+    def read(self) -> Optional[Dict[str, float]]:
+        """Initiate read on the Absorbance Reader. Returns a dictionary of values ordered by well name."""
+        return self._core.read()

--- a/api/src/opentrons/protocol_engine/state/module_substates/absorbance_reader_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/absorbance_reader_substate.py
@@ -1,6 +1,6 @@
 """Heater-Shaker Module sub-state."""
 from dataclasses import dataclass
-from typing import NewType, Optional, List
+from typing import NewType, Optional, Dict
 
 from opentrons.protocol_engine.errors import CannotPerformModuleAction
 
@@ -16,7 +16,7 @@ class AbsorbanceReaderSubState:
     configured: bool
     measured: bool
     is_lid_on: bool
-    data: Optional[List[float]]
+    data: Optional[Dict[str, float]]
     configured_wavelength: Optional[int]
     lid_id: Optional[str]
 

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 20)
+MAX_SUPPORTED_VERSION = APIVersion(2, 21)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 21)
+MAX_SUPPORTED_VERSION = APIVersion(2, 20)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)


### PR DESCRIPTION
# Overview

Covers PLAT-204, PLAT-467

Ensure the Plate reader `.read()` method utilizes live data, initiates a read and returns the data from the plate reader module. Include validations for expected reader state and read action success.

## Test Plan and Hands on Testing
The following protocol should return the plate reader values in a comment at the end (Note: must enable AP 2.21):
```
from opentrons import protocol_api

# metadata
metadata = {
    'protocolName': 'Absorbance Reader Lid Test',
    'author': 'Platform Expansion',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.21",
}

# protocol run function
def run(protocol: protocol_api.ProtocolContext):
    mod = protocol.load_module('absorbanceReaderV1', 'D3')
    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "A2")
    mod.initialize(450)
    mod.open_lid()
    protocol.move_labware(plate, mod, use_gripper=True)
    mod.close_lid()
    result = mod.read()
    protocol.comment(msg=f"result: {result}")
```
## Changelog


## Review requests

Currently during analysis the `.read()` command returns None, what should we do here? Should we return an empty dictionary, or a dictionary of 96 samples equal to 0? Let me know your thoughts.

## Risk assessment

