### PR TITLE
refactor(app): z-home pipette after a failed recovery action

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryError.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryError.tsx
@@ -54,16 +54,21 @@ export function ErrorRecoveryFlowError({
   getRecoveryOptionCopy,
   currentRecoveryOptionUtils,
   routeUpdateActions,
+  recoveryCommands,
 }: RecoveryContentProps): JSX.Element {
   const { OPTION_SELECTION } = RECOVERY_MAP
   const { t } = useTranslation('error_recovery')
   const { selectedRecoveryOption } = currentRecoveryOptionUtils
-  const { proceedToRouteAndStep } = routeUpdateActions
+  const { proceedToRouteAndStep, setRobotInMotion } = routeUpdateActions
+  const { homePipetteZAxes } = recoveryCommands
 
   const userRecoveryOptionCopy = getRecoveryOptionCopy(selectedRecoveryOption)
 
   const onPrimaryClick = (): void => {
-    void proceedToRouteAndStep(OPTION_SELECTION.ROUTE)
+    void setRobotInMotion(true)
+      .then(() => homePipetteZAxes())
+      .finally(() => setRobotInMotion(false))
+      .then(() => proceedToRouteAndStep(OPTION_SELECTION.ROUTE))
   }
 
   return (


### PR DESCRIPTION
Closes [RQA-2999](https://opentrons.atlassian.net/browse/RQA-2999)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If a recovery action fails, we don't z-home the pipettes. This can get annoying, especially if the user wants to move labware on the deck. Let's z-home the pipette after a recovery action fails.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that clicking "Back to menu" after a failed recovery action now z-homes the pipette.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The pipette now z-homes when clicking "back to menu" after a recovery action fails. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low code wise. This doesn't seem problematic to users after bouncing this question around, either. 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2999]: https://opentrons.atlassian.net/browse/RQA-2999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ