### PR TITLE
fix(app): address DQA for labware stacking work 

### DIFF
--- a/app/src/molecules/ToggleGroup/useToggleGroup.tsx
+++ b/app/src/molecules/ToggleGroup/useToggleGroup.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   SPACING,
   PrimaryButton,
+  StyledText,
 } from '@opentrons/components'
 import { useTrackEvent } from '../../redux/analytics'
 
@@ -15,14 +16,12 @@ const BUTTON_GROUP_STYLES = css`
   width: fit-content;
 
   button {
-    height: 28px;
+    height: auto;
     width: auto;
     font-weight: 400;
     font-size: 11px;
     line-height: 14px;
     box-shadow: none;
-    padding-top: 6px;
-    padding-bottom: 8px;
     &:focus {
       box-shadow: none;
       color: ${COLORS.white};
@@ -58,16 +57,14 @@ const BUTTON_GROUP_STYLES = css`
 `
 
 const ACTIVE_STYLE = css`
-  padding-left: ${SPACING.spacing8};
-  padding-right: ${SPACING.spacing8};
+  padding: ${SPACING.spacing8};
   background-color: ${COLORS.blue50};
   color: ${COLORS.white};
   pointer-events: none;
 `
 
 const DEFAULT_STYLE = css`
-  padding-left: ${SPACING.spacing8};
-  padding-right: ${SPACING.spacing8};
+  padding: ${SPACING.spacing8};
   background-color: ${COLORS.white};
   color: ${COLORS.black90};
   border: 1px ${COLORS.grey30} solid;
@@ -108,7 +105,7 @@ export const useToggleGroup = (
         onClick={handleLeftClick}
         data-testid="useToggleGroup_leftButton"
       >
-        {left}
+        <StyledText desktopStyle="bodyDefaultRegular">{left}</StyledText>
       </PrimaryButton>
       <PrimaryButton
         css={selectedValue === right ? ACTIVE_STYLE : DEFAULT_STYLE}
@@ -116,7 +113,7 @@ export const useToggleGroup = (
         onClick={handleRightClick}
         data-testid="useToggleGroup_rightButton"
       >
-        {right}
+        <StyledText desktopStyle="bodyDefaultRegular">{right}</StyledText>
       </PrimaryButton>
     </Flex>,
   ]

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -268,7 +268,7 @@ export function LabwareListItem(
 
   return (
     <LabwareRow>
-      <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing2}>
+      <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing2} width="5rem">
         {slotInfo != null && isFlex ? (
           <DeckInfoLabel deckLabel={slotInfo} />
         ) : (
@@ -283,7 +283,7 @@ export function LabwareListItem(
           <DeckInfoLabel iconName="stacked" />
         ) : null}
       </Flex>
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
         {nestedLabwareInfo != null &&
         nestedLabwareInfo?.sharedSlotId === slotInfo ? (
           <>
@@ -305,7 +305,7 @@ export function LabwareListItem(
                 </StyledText>
               </Flex>
             </Flex>
-            <Divider />
+            <Divider marginY="0" />
           </>
         ) : null}
         <Flex>
@@ -328,7 +328,7 @@ export function LabwareListItem(
         </Flex>
         {moduleDisplayName != null ? (
           <>
-            <Divider />
+            <Divider marginY="0" />
             <Flex
               justifyContent={JUSTIFY_SPACE_BETWEEN}
               flexDirection={DIRECTION_ROW}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareStackModal.tsx
@@ -113,7 +113,7 @@ export const LabwareStackModal = (
       onOutsideClick={closeModal}
       header={{
         title: (
-          <Flex gridGap={SPACING.spacing4}>
+          <Flex gridGap={SPACING.spacing8}>
             <DeckInfoLabel
               deckLabel={isModuleThermocycler ? thermocyclerLocation : slotName}
             />

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareList.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 import {
   DIRECTION_COLUMN,
   Flex,
@@ -17,13 +16,6 @@ import type { ModuleRenderInfoForProtocol } from '../../hooks'
 import type { ModuleTypesThatRequireExtraAttention } from '../utils/getModuleTypesThatRequireExtraAttention'
 import type { LabwareSetupItem } from '../../../../pages/Protocols/utils'
 
-const HeaderRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 5.2fr 5.3fr;
-  grid-gap: ${SPACING.spacing16};
-  padding-left: ${SPACING.spacing24};
-  padding-top: ${SPACING.spacing20};
-`
 interface SetupLabwareListProps {
   attachedModuleInfo: { [moduleId: string]: ModuleRenderInfoForProtocol }
   commands: RunTimeCommand[]
@@ -46,14 +38,22 @@ export function SetupLabwareList(
       gridGap={SPACING.spacing4}
       marginBottom={SPACING.spacing16}
     >
-      <HeaderRow>
-        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+      <Flex
+        gridGap={SPACING.spacing16}
+        paddingLeft={SPACING.spacing24}
+        paddingTop={SPACING.spacing20}
+      >
+        <StyledText
+          width="5rem"
+          desktopStyle="bodyDefaultRegular"
+          color={COLORS.grey60}
+        >
           {t('location')}
         </StyledText>
         <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
           {t('labware_name')}
         </StyledText>
-      </HeaderRow>
+      </Flex>
       {allItems.map((labwareItem, index) => {
         const labwareOnAdapter = allItems.find(
           item =>

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -29,7 +29,6 @@ import {
   getLabwareDefURI,
   getLabwareDisplayName,
   getModuleDisplayName,
-  getModuleType,
   HEATERSHAKER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { parseInitialLoadedLabwareByAdapter } from '@opentrons/api-client'

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -29,6 +29,7 @@ import {
   getLabwareDefURI,
   getLabwareDisplayName,
   getModuleDisplayName,
+  getModuleType,
   HEATERSHAKER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { parseInitialLoadedLabwareByAdapter } from '@opentrons/api-client'
@@ -541,8 +542,6 @@ function RowLabware({
       ? matchedModule.attachedModuleMatch
       : null
 
-  const matchedModuleType = matchedModule?.attachedModuleMatch?.moduleType
-
   let slotName: string = ''
   let location: JSX.Element | string | null = null
   if (initialLocation === 'offDeck') {
@@ -555,11 +554,10 @@ function RowLabware({
   } else if ('addressableAreaName' in initialLocation) {
     slotName = initialLocation.addressableAreaName
     location = <DeckInfoLabel deckLabel={initialLocation.addressableAreaName} />
-  } else if (matchedModuleType != null && matchedModule?.slotName != null) {
-    slotName = matchedModule.slotName
+  } else if (labware.moduleLocation != null) {
     location = (
       <>
-        <DeckInfoLabel deckLabel={matchedModule?.slotName} />
+        <DeckInfoLabel deckLabel={labware.moduleLocation.slotName} />
       </>
     )
   } else if ('labwareId' in initialLocation) {


### PR DESCRIPTION
# Overview

Provide various design fixes following DQA for labware stacking.

Closes RQA-3017, RQA-3023

## Test Plan and Hands on Testing

#### Desktop
- Start run for protocol with stacked entities
- Expand labware setup step
- Verify that `ToggleGroup` for list/map view is updated to match designs as specified in tickets
- Verify that list items are updated to match designs as specified in tickets
![image](https://github.com/user-attachments/assets/96af201d-efa4-43a5-bae3-5ea2a70c5a22)
![image](https://github.com/user-attachments/assets/a6ae3c1e-cc14-42c1-8136-205c85973d65)

#### ODD
- Start run for protocol with stacked entities
- Click labware setup step > map view
- Select stack to open `LabwareStackModal` and verify that spacing between header icons is 8px
![image](https://github.com/user-attachments/assets/ee4230c3-906f-4f80-af07-a8dd7040e067)

## Changelog

- update `ToggleGroup` style
- fix `SetupLabwareList` left side width (fixed: 80px) and vertical spacing for right hand elements
- update gridGap for ODD `LabwareStackModal` header `DeckInfoLabel`s (stacked + slot)

## Review requests

- see test plan

## Risk assessment

low