### PR TITLE
fix(components): change desktop DeckInfoLabel border width to 1px

### DIFF
--- a/components/src/molecules/DeckInfoLabel/__tests__/DeckInfoLabel.test.tsx
+++ b/components/src/molecules/DeckInfoLabel/__tests__/DeckInfoLabel.test.tsx
@@ -28,7 +28,7 @@ describe('DeckInfoLabel', () => {
     )
     expect(deckInfoLabel).toHaveStyle(`height: ${SPACING.spacing20}`)
     expect(deckInfoLabel).toHaveStyle('width: max-content')
-    expect(deckInfoLabel).toHaveStyle(`border: 2px solid ${COLORS.black90}`)
+    expect(deckInfoLabel).toHaveStyle(`border: 1px solid ${COLORS.black90}`)
     expect(deckInfoLabel).toHaveStyle(`border-radius: ${BORDERS.borderRadius8}`)
   })
 

--- a/components/src/molecules/DeckInfoLabel/index.tsx
+++ b/components/src/molecules/DeckInfoLabel/index.tsx
@@ -33,7 +33,7 @@ export const DeckInfoLabel = styled(DeckInfoLabelComponent)`
   align-items: ${ALIGN_CENTER};
   background-color: ${props =>
     props.highlight ?? false ? COLORS.blue50 : 'inherit'};
-  border: 2px solid
+  border: 1px solid
     ${props => (props.highlight ?? false ? 'transparent' : COLORS.black90)};
   width: ${props => props.width ?? 'max-content'};
   padding: ${SPACING.spacing2} ${SPACING.spacing4};
@@ -48,6 +48,7 @@ export const DeckInfoLabel = styled(DeckInfoLabelComponent)`
   }
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    border-width: 2px;
     border-radius: ${BORDERS.borderRadius12};
     height: ${props => props.height ?? SPACING.spacing32};
     padding: ${SPACING.spacing4}


### PR DESCRIPTION
# Overview

changes the desktop DeckInfoLabel border width to 1px

closes RQA-3032

![Screen Shot 2024-08-15 at 5 01 43 PM](https://github.com/user-attachments/assets/8b84da8a-ce42-47c3-8947-b60ea43fa3b4)

## Test Plan and Hands on Testing

verified the border is 1px on desktop and remains 2px on touchscreen 

## Changelog

 - Changes desktop DeckInfoLabel border width to 1px

## Review requests

## Risk assessment

low
