### PR TITLE
fix(app): do not show fixit commands in run log

### DIFF
--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -161,45 +161,49 @@ export const RunPreviewComponent = (
             const isCurrent = index === currentRunCommandIndex
             const backgroundColor = isCurrent ? COLORS.blue30 : COLORS.grey20
             const iconColor = isCurrent ? COLORS.blue60 : COLORS.grey50
-            return (
-              <Flex
-                key={command.id}
-                alignItems={ALIGN_CENTER}
-                gridGap={SPACING.spacing8}
-              >
-                <LegacyStyledText
-                  minWidth={SPACING.spacing16}
-                  fontSize={TYPOGRAPHY.fontSizeCaption}
-                >
-                  {index + 1}
-                </LegacyStyledText>
+            if (command && command.intent != 'fixit') {
+              return (
                 <Flex
-                  flexDirection={DIRECTION_COLUMN}
-                  gridGap={SPACING.spacing4}
-                  width="100%"
-                  backgroundColor={
-                    index === jumpedIndex ? '#F5E3FF' : backgroundColor
-                  }
-                  color={COLORS.black90}
-                  borderRadius={BORDERS.borderRadius4}
-                  padding={SPACING.spacing8}
-                  css={css`
-                    transition: background-color ${COLOR_FADE_MS}ms ease-out,
-                      border-color ${COLOR_FADE_MS}ms ease-out;
-                  `}
+                  key={command.id}
+                  alignItems={ALIGN_CENTER}
+                  gridGap={SPACING.spacing8}
                 >
-                  <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
-                    <CommandIcon command={command} color={iconColor} />
-                    <CommandText
-                      command={command}
-                      commandTextData={protocolDataFromAnalysisOrRun}
-                      robotType={robotType}
-                      color={COLORS.black90}
-                    />
+                  <LegacyStyledText
+                    minWidth={SPACING.spacing16}
+                    fontSize={TYPOGRAPHY.fontSizeCaption}
+                  >
+                    {index + 1}
+                  </LegacyStyledText>
+                  <Flex
+                    flexDirection={DIRECTION_COLUMN}
+                    gridGap={SPACING.spacing4}
+                    width="100%"
+                    backgroundColor={
+                      index === jumpedIndex ? '#F5E3FF' : backgroundColor
+                    }
+                    color={COLORS.black90}
+                    borderRadius={BORDERS.borderRadius4}
+                    padding={SPACING.spacing8}
+                    css={css`
+                      transition: background-color ${COLOR_FADE_MS}ms ease-out,
+                        border-color ${COLOR_FADE_MS}ms ease-out;
+                    `}
+                  >
+                    <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
+                      <CommandIcon command={command} color={iconColor} />
+                      <CommandText
+                        command={command}
+                        commandTextData={protocolDataFromAnalysisOrRun}
+                        robotType={robotType}
+                        color={COLORS.black90}
+                      />
+                    </Flex>
                   </Flex>
                 </Flex>
-              </Flex>
-            )
+              )
+            } else {
+              return null
+            }
           }}
         </ViewportList>
         {currentRunCommandIndex >= 0 ? (

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -84,8 +84,7 @@ export const RunPreviewComponent = (
     () =>
       commandsFromQuery?.filter(
         command =>
-          !('intent' in command && command.intent === 'fixit') ||
-          !('intent' in command)
+!('intent' in command) || command.intent !== 'fixit'
       ),
     [commandsFromQuery == null]
   )

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -160,9 +160,11 @@ export const RunPreviewComponent = (
             const isCurrent = index === currentRunCommandIndex
             const backgroundColor = isCurrent ? COLORS.blue30 : COLORS.grey20
             const iconColor = isCurrent ? COLORS.blue60 : COLORS.grey50
-            
 
-            if (command != null && !('intent' in command && command.intent === 'fixit')) {
+            if (
+              command != null &&
+              !('intent' in command && command.intent === 'fixit')
+            ) {
               return (
                 <Flex
                   key={command.id}

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -81,7 +81,7 @@ export const RunPreviewComponent = (
     setIsCurrentCommandVisible,
   ] = React.useState<boolean>(true)
   const filteredCommandsFromQuery = React.useMemo(
-    () => 
+    () =>
       commandsFromQuery?.filter(
         command =>
           !('intent' in command && command.intent === 'fixit') ||
@@ -90,7 +90,9 @@ export const RunPreviewComponent = (
     [commandsFromQuery == null]
   )
 
-  if (robotSideAnalysis == null) {return null}
+  if (robotSideAnalysis == null) {
+    return null
+  }
 
   const commands = isRunTerminal
     ? filteredCommandsFromQuery

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -83,8 +83,7 @@ export const RunPreviewComponent = (
   const filteredCommandsFromQuery = React.useMemo(
     () =>
       commandsFromQuery?.filter(
-        command =>
-!('intent' in command) || command.intent !== 'fixit'
+        command => !('intent' in command) || command.intent !== 'fixit'
       ),
     [commandsFromQuery == null]
   )
@@ -115,7 +114,6 @@ export const RunPreviewComponent = (
     commands != null
       ? commands.findIndex(c => c.key === currentRunCommandKey)
       : 0
-  console.log('currentRunCommandIndex ', currentRunCommandIndex)
   if (isRunCommandDataLoading || commands == null) {
     return (
       <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
@@ -125,7 +123,6 @@ export const RunPreviewComponent = (
       </Flex>
     )
   }
-  console.log('commands before ', commands)
   return commands.length === 0 ? (
     <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
       <InfoScreen contentType="runNotStarted" />
@@ -161,8 +158,6 @@ export const RunPreviewComponent = (
             lowestVisibleIndex,
             highestVisibleIndex,
           ]) => {
-            console.log('lowestVisibleIndex ', lowestVisibleIndex)
-            console.log('highestVisibleIndex ', highestVisibleIndex)
             if (currentRunCommandIndex >= 0) {
               setIsCurrentCommandVisible(
                 currentRunCommandIndex >= lowestVisibleIndex &&

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -35,7 +35,6 @@ import { useLastRunCommand } from '../Devices/hooks/useLastRunCommand'
 import type { RunStatus } from '@opentrons/api-client'
 import type { RobotType } from '@opentrons/shared-data'
 import type { ViewportListRef } from 'react-viewport-list'
-
 const COLOR_FADE_MS = 500
 const LIVE_RUN_COMMANDS_POLL_MS = 3000
 // arbitrary large number of commands
@@ -161,7 +160,8 @@ export const RunPreviewComponent = (
             const isCurrent = index === currentRunCommandIndex
             const backgroundColor = isCurrent ? COLORS.blue30 : COLORS.grey20
             const iconColor = isCurrent ? COLORS.blue60 : COLORS.grey50
-            if (command && command.intent != 'fixit') {
+
+            if (command != null && !('intent' in command)) {
               return (
                 <Flex
                   key={command.id}

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -160,8 +160,9 @@ export const RunPreviewComponent = (
             const isCurrent = index === currentRunCommandIndex
             const backgroundColor = isCurrent ? COLORS.blue30 : COLORS.grey20
             const iconColor = isCurrent ? COLORS.blue60 : COLORS.grey50
+            
 
-            if (command != null && !('intent' in command)) {
+            if (command != null && !('intent' in command && command.intent === 'fixit')) {
               return (
                 <Flex
                   key={command.id}

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -80,10 +80,22 @@ export const RunPreviewComponent = (
     isCurrentCommandVisible,
     setIsCurrentCommandVisible,
   ] = React.useState<boolean>(true)
-  if (robotSideAnalysis == null) return null
+  const filteredCommandsFromQuery = React.useMemo(
+    () => 
+      commandsFromQuery?.filter(
+        command =>
+          !('intent' in command && command.intent === 'fixit') ||
+          !('intent' in command)
+      ),
+    [commandsFromQuery == null]
+  )
+
+  if (robotSideAnalysis == null) {return null}
+
   const commands = isRunTerminal
-    ? commandsFromQuery
+    ? filteredCommandsFromQuery
     : robotSideAnalysis.commands
+
   // pass relevant data from run rather than analysis so that CommandText utilities can properly hash the entities' IDs
   // TODO (nd:05/02/2024, AUTH-380): update name and types for CommandText (and children/utilities) use of analysis.
   // We should ideally pass only subset of analysis/run data required by these children and utilities
@@ -102,7 +114,7 @@ export const RunPreviewComponent = (
     commands != null
       ? commands.findIndex(c => c.key === currentRunCommandKey)
       : 0
-
+  console.log('currentRunCommandIndex ', currentRunCommandIndex)
   if (isRunCommandDataLoading || commands == null) {
     return (
       <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
@@ -112,6 +124,7 @@ export const RunPreviewComponent = (
       </Flex>
     )
   }
+  console.log('commands before ', commands)
   return commands.length === 0 ? (
     <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
       <InfoScreen contentType="runNotStarted" />
@@ -147,6 +160,8 @@ export const RunPreviewComponent = (
             lowestVisibleIndex,
             highestVisibleIndex,
           ]) => {
+            console.log('lowestVisibleIndex ', lowestVisibleIndex)
+            console.log('highestVisibleIndex ', highestVisibleIndex)
             if (currentRunCommandIndex >= 0) {
               setIsCurrentCommandVisible(
                 currentRunCommandIndex >= lowestVisibleIndex &&
@@ -160,53 +175,45 @@ export const RunPreviewComponent = (
             const isCurrent = index === currentRunCommandIndex
             const backgroundColor = isCurrent ? COLORS.blue30 : COLORS.grey20
             const iconColor = isCurrent ? COLORS.blue60 : COLORS.grey50
-
-            if (
-              command != null &&
-              !('intent' in command && command.intent === 'fixit')
-            ) {
-              return (
-                <Flex
-                  key={command.id}
-                  alignItems={ALIGN_CENTER}
-                  gridGap={SPACING.spacing8}
+            return (
+              <Flex
+                key={command.id}
+                alignItems={ALIGN_CENTER}
+                gridGap={SPACING.spacing8}
+              >
+                <LegacyStyledText
+                  minWidth={SPACING.spacing16}
+                  fontSize={TYPOGRAPHY.fontSizeCaption}
                 >
-                  <LegacyStyledText
-                    minWidth={SPACING.spacing16}
-                    fontSize={TYPOGRAPHY.fontSizeCaption}
-                  >
-                    {index + 1}
-                  </LegacyStyledText>
-                  <Flex
-                    flexDirection={DIRECTION_COLUMN}
-                    gridGap={SPACING.spacing4}
-                    width="100%"
-                    backgroundColor={
-                      index === jumpedIndex ? '#F5E3FF' : backgroundColor
-                    }
-                    color={COLORS.black90}
-                    borderRadius={BORDERS.borderRadius4}
-                    padding={SPACING.spacing8}
-                    css={css`
-                      transition: background-color ${COLOR_FADE_MS}ms ease-out,
-                        border-color ${COLOR_FADE_MS}ms ease-out;
-                    `}
-                  >
-                    <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
-                      <CommandIcon command={command} color={iconColor} />
-                      <CommandText
-                        command={command}
-                        commandTextData={protocolDataFromAnalysisOrRun}
-                        robotType={robotType}
-                        color={COLORS.black90}
-                      />
-                    </Flex>
+                  {index + 1}
+                </LegacyStyledText>
+                <Flex
+                  flexDirection={DIRECTION_COLUMN}
+                  gridGap={SPACING.spacing4}
+                  width="100%"
+                  backgroundColor={
+                    index === jumpedIndex ? '#F5E3FF' : backgroundColor
+                  }
+                  color={COLORS.black90}
+                  borderRadius={BORDERS.borderRadius4}
+                  padding={SPACING.spacing8}
+                  css={css`
+                    transition: background-color ${COLOR_FADE_MS}ms ease-out,
+                      border-color ${COLOR_FADE_MS}ms ease-out;
+                  `}
+                >
+                  <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
+                    <CommandIcon command={command} color={iconColor} />
+                    <CommandText
+                      command={command}
+                      commandTextData={protocolDataFromAnalysisOrRun}
+                      robotType={robotType}
+                      color={COLORS.black90}
+                    />
                   </Flex>
                 </Flex>
-              )
-            } else {
-              return null
-            }
+              </Flex>
+            )
           }}
         </ViewportList>
         {currentRunCommandIndex >= 0 ? (


### PR DESCRIPTION

# Overview

closes https://opentrons.atlassian.net/browse/RQA-2889.
filter out fixit commands from run log.

## Test Plan and Hands on Testing

run a protocol with ER flow.
make sure after the run is terminal fixit commands do not show.

## Changelog

filter out fixit commands when fetching commands from DB
