### PR TITLE
docs(api): add deep well adapter for temperature module

### DIFF
--- a/api/docs/v2/modules/temperature_module.rst
+++ b/api/docs/v2/modules/temperature_module.rst
@@ -39,6 +39,8 @@ You can use these standalone adapter definitions to load Opentrons verified or c
      - ``opentrons_aluminum_flat_bottom_plate``
    * - Opentrons 96 Well Aluminum Block
      - ``opentrons_96_well_aluminum_block``
+   * - Opentrons 96 Deep Well Temperature Module Adapter
+     - ``opentrons_96_deep_well_temp_mod_adapter``
      
 For example, these commands load a PCR plate on top of the 96-well block::
 


### PR DESCRIPTION

# Overview

List the new Opentrons 96 Deep Well Temperature Module Adapter in the Python docs.

There are no `versionadded` statements or additions to the Versioning page because adding labware _is not_ gated by API level.

Addresses RTC-471.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-temp-mod-deep-well-adapter/v2/modules/temperature_module.html#standalone-adapters)

## Changelog

- add one row to table

## Review requests

- Anywhere else we would want to mention this?
- Do we need to say what labware is compatible with the adapter, and how to make your own with stacking offsets? We don't do that for other adapters but it seems to be a common source of confusion. Maybe better addressed in a separate PR.

## Risk assessment

nada