### PR TITLE
fix(app): remove protocol name link when protocol not stored

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -65,6 +65,7 @@ import {
   ANALYTICS_PROTOCOL_RUN_ACTION,
 } from '../../../redux/analytics'
 import { getIsHeaterShakerAttached } from '../../../redux/config'
+import { getStoredProtocol } from '../../../redux/protocol-storage'
 import { Tooltip } from '../../../atoms/Tooltip'
 import { useCloseCurrentRun } from '../../ProtocolUpload/hooks'
 import { ConfirmCancelModal } from '../../RunDetails/ConfirmCancelModal'
@@ -158,6 +159,9 @@ export function ProtocolRunHeader({
     protocolKey,
     isProtocolAnalyzing,
   } = useProtocolDetailsForRun(runId)
+  const storedProtocol = useSelector((state: State) =>
+    getStoredProtocol(state, protocolKey)
+  )
   const { reportRecoveredRunResult } = useRecoveryAnalytics()
 
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
@@ -390,7 +394,7 @@ export function ProtocolRunHeader({
             />
           )}
         <Flex>
-          {protocolKey != null ? (
+          {storedProtocol != null ? (
             <Link to={`/protocols/${protocolKey}`}>
               <LegacyStyledText
                 as="h2"

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -60,6 +60,8 @@ import { mockConnectableRobot } from '../../../../redux/discovery/__fixtures__'
 import { getRobotUpdateDisplayInfo } from '../../../../redux/robot-update'
 import { getIsHeaterShakerAttached } from '../../../../redux/config'
 import { getRobotSettings } from '../../../../redux/robot-settings'
+import { getStoredProtocol } from '../../../../redux/protocol-storage'
+import { storedProtocolData as storedProtocolDataFixture } from '../../../../redux/protocol-storage/__fixtures__'
 import {
   useProtocolDetailsForRun,
   useProtocolAnalysisErrors,
@@ -107,6 +109,7 @@ import type { Mock } from 'vitest'
 import type * as OpentronsSharedData from '@opentrons/shared-data'
 import type * as OpentronsComponents from '@opentrons/components'
 import type * as OpentronsApiClient from '@opentrons/api-client'
+import type { State } from '../../../../redux/types'
 
 const mockNavigate = vi.fn()
 
@@ -145,6 +148,7 @@ vi.mock('../../../ModuleCard/hooks')
 vi.mock('../../../RunProgressMeter')
 vi.mock('../../../../redux/analytics')
 vi.mock('../../../../redux/config')
+vi.mock('../../../../redux/protocol-storage')
 vi.mock('../RunFailedModal')
 vi.mock('../../../../redux/robot-update/selectors')
 vi.mock('../../../../redux/robot-settings/selectors')
@@ -164,6 +168,7 @@ const CREATED_AT = '03/03/2022 19:08:49'
 const STARTED_AT = '2022-03-03T19:09:40.620530+00:00'
 const COMPLETED_AT = '2022-03-03T19:39:53.620530+00:00'
 const PROTOCOL_NAME = 'A Protocol for Otie'
+const PROTOCOL_KEY = 'fakeProtocolKey'
 const mockSettings = {
   id: 'enableDoorSafetySwitch',
   title: 'Enable Door Safety Switch',
@@ -179,7 +184,7 @@ const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as OpentronsShar
 const PROTOCOL_DETAILS = {
   displayName: PROTOCOL_NAME,
   protocolData: simpleV6Protocol,
-  protocolKey: 'fakeProtocolKey',
+  protocolKey: PROTOCOL_KEY,
   isProtocolAnalyzing: false,
   robotType: 'OT-2 Standard' as const,
 }
@@ -414,6 +419,9 @@ describe('ProtocolRunHeader', () => {
     vi.mocked(DropTipWizardFlows).mockReturnValue(
       <div>MOCK_DROP_TIP_WIZARD_FLOWS</div>
     )
+    when(getStoredProtocol)
+      .calledWith({} as State, PROTOCOL_KEY)
+      .thenReturn(storedProtocolDataFixture)
   })
 
   afterEach(() => {
@@ -446,6 +454,15 @@ describe('ProtocolRunHeader', () => {
     when(vi.mocked(useProtocolDetailsForRun))
       .calledWith(RUN_ID)
       .thenReturn({ ...PROTOCOL_DETAILS, protocolKey: null })
+    render()
+
+    expect(
+      screen.queryByRole('link', { name: 'A Protocol for Otie' })
+    ).toBeNull()
+  })
+
+  it('does not render link to protocol detail page if stored protocol is absent', () => {
+    vi.mocked(getStoredProtocol).mockReturnValue(null)
     render()
 
     expect(

--- a/app/src/redux/protocol-storage/selectors.ts
+++ b/app/src/redux/protocol-storage/selectors.ts
@@ -16,7 +16,7 @@ export const getStoredProtocols: (
 
 export const getStoredProtocol: (
   state: State,
-  protocolKey?: string
+  protocolKey?: string | null
 ) => StoredProtocolData | null = (state, protocolKey) =>
   protocolKey != null
     ? state.protocolStorage.filesByProtocolKey[protocolKey] ?? null


### PR DESCRIPTION
# Overview

removes the desktop protocol run setup link to protocol details when the protocol is not stored locally. this changes the previous behavior that redirected the link to the protocol list page.

closes RQA-2955

<img width="1344" alt="Screen Shot 2024-08-16 at 5 10 28 PM" src="https://github.com/user-attachments/assets/1e425aa3-9b31-4dba-81f5-5956c724e4a0">


## Test Plan and Hands on Testing

verified removed link, added unit test

## Changelog

 - Removes protocol name link when protocol not stored

## Review requests

start a protocol, delete the source protocol locally, observe the non-linked protocol name

## Risk assessment

low
