### PR TITLE
fix(app): Update isRunning runs statuses

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useRunStatuses.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunStatuses.test.tsx
@@ -5,8 +5,14 @@ import {
   RUN_STATUS_RUNNING,
   RUN_STATUS_STOPPED,
   RUN_STATUS_SUCCEEDED,
+  RUN_STATUS_AWAITING_RECOVERY,
+  RUN_STATUS_AWAITING_RECOVERY_PAUSED,
+  RUN_STATUS_STOP_REQUESTED,
+  RUN_STATUS_FINISHING,
+  RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
+  RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR,
 } from '@opentrons/api-client'
-import { vi, it, expect, describe, beforeEach, afterEach } from 'vitest'
+import { vi, it, expect, describe, beforeEach } from 'vitest'
 
 import { useCurrentRunId } from '../../../../resources/runs'
 import { useRunStatus } from '../../../RunTimeControl/hooks'
@@ -15,13 +21,10 @@ import { useRunStatuses } from '..'
 vi.mock('../../../../resources/runs')
 vi.mock('../../../RunTimeControl/hooks')
 
-describe(' useRunStatuses ', () => {
+describe('useRunStatuses', () => {
   beforeEach(() => {
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_RUNNING)
     vi.mocked(useCurrentRunId).mockReturnValue('123')
-  })
-  afterEach(() => {
-    vi.resetAllMocks()
   })
 
   it('returns everything as false when run status is null', () => {
@@ -35,7 +38,7 @@ describe(' useRunStatuses ', () => {
     })
   })
 
-  it('returns true isRunStill and Terminal when run status is suceeded', () => {
+  it(`returns true isRunStill and Terminal when run status is ${RUN_STATUS_SUCCEEDED}`, () => {
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_SUCCEEDED)
     const result = useRunStatuses()
     expect(result).toStrictEqual({
@@ -46,7 +49,7 @@ describe(' useRunStatuses ', () => {
     })
   })
 
-  it('returns true isRunStill and Terminal when run status is stopped', () => {
+  it(`returns true isRunStill and Terminal when run status is ${RUN_STATUS_STOPPED}`, () => {
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_STOPPED)
     const result = useRunStatuses()
     expect(result).toStrictEqual({
@@ -57,7 +60,7 @@ describe(' useRunStatuses ', () => {
     })
   })
 
-  it('returns true isRunStill and Terminal when run status is failed', () => {
+  it(`returns true isRunStill and Terminal when run status is ${RUN_STATUS_FAILED}`, () => {
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_FAILED)
     const result = useRunStatuses()
     expect(result).toStrictEqual({
@@ -68,7 +71,7 @@ describe(' useRunStatuses ', () => {
     })
   })
 
-  it('returns true isRunStill and isRunIdle when run status is idle', () => {
+  it(`returns true isRunStill and isRunIdle when run status is ${RUN_STATUS_IDLE}`, () => {
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_IDLE)
     const result = useRunStatuses()
     expect(result).toStrictEqual({
@@ -79,7 +82,7 @@ describe(' useRunStatuses ', () => {
     })
   })
 
-  it('returns true isRunRunning when status is running', () => {
+  it(`returns true isRunRunning when status is ${RUN_STATUS_RUNNING}`, () => {
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_RUNNING)
     const result = useRunStatuses()
     expect(result).toStrictEqual({
@@ -90,8 +93,76 @@ describe(' useRunStatuses ', () => {
     })
   })
 
-  it('returns true isRunRunning when status is paused', () => {
+  it(`returns true isRunRunning when status is ${RUN_STATUS_PAUSED}`, () => {
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_PAUSED)
+    const result = useRunStatuses()
+    expect(result).toStrictEqual({
+      isRunRunning: true,
+      isRunStill: false,
+      isRunTerminal: false,
+      isRunIdle: false,
+    })
+  })
+
+  it(`returns true isRunRunning when status is ${RUN_STATUS_AWAITING_RECOVERY}`, () => {
+    vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_AWAITING_RECOVERY)
+    const result = useRunStatuses()
+    expect(result).toStrictEqual({
+      isRunRunning: true,
+      isRunStill: false,
+      isRunTerminal: false,
+      isRunIdle: false,
+    })
+  })
+
+  it(`returns true isRunRunning when status is ${RUN_STATUS_AWAITING_RECOVERY_PAUSED}`, () => {
+    vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_AWAITING_RECOVERY_PAUSED)
+    const result = useRunStatuses()
+    expect(result).toStrictEqual({
+      isRunRunning: true,
+      isRunStill: false,
+      isRunTerminal: false,
+      isRunIdle: false,
+    })
+  })
+
+  it(`returns true isRunRunning when status is ${RUN_STATUS_STOP_REQUESTED}`, () => {
+    vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_STOP_REQUESTED)
+    const result = useRunStatuses()
+    expect(result).toStrictEqual({
+      isRunRunning: true,
+      isRunStill: false,
+      isRunTerminal: false,
+      isRunIdle: false,
+    })
+  })
+
+  it(`returns true isRunRunning when status is ${RUN_STATUS_FINISHING}`, () => {
+    vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_FINISHING)
+    const result = useRunStatuses()
+    expect(result).toStrictEqual({
+      isRunRunning: true,
+      isRunStill: false,
+      isRunTerminal: false,
+      isRunIdle: false,
+    })
+  })
+
+  it(`returns true isRunRunning when status is ${RUN_STATUS_BLOCKED_BY_OPEN_DOOR}`, () => {
+    vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_BLOCKED_BY_OPEN_DOOR)
+    const result = useRunStatuses()
+    expect(result).toStrictEqual({
+      isRunRunning: true,
+      isRunStill: false,
+      isRunTerminal: false,
+      isRunIdle: false,
+    })
+  })
+
+  it(`returns true isRunRunning when status is ${RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR}`, () => {
+    vi.mocked(useRunStatus).mockReturnValue(
+      RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR
+    )
     const result = useRunStatuses()
     expect(result).toStrictEqual({
       isRunRunning: true,

--- a/app/src/organisms/Devices/hooks/useRunStatuses.ts
+++ b/app/src/organisms/Devices/hooks/useRunStatuses.ts
@@ -5,6 +5,10 @@ import {
   RUN_STATUS_IDLE,
   RUN_STATUS_PAUSED,
   RUN_STATUS_RUNNING,
+  RUN_STATUS_STOP_REQUESTED,
+  RUN_STATUS_FINISHING,
+  RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
+  RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR,
 } from '@opentrons/api-client'
 import { useCurrentRunId } from '../../../resources/runs'
 import { useRunStatus } from '../../RunTimeControl/hooks'
@@ -23,16 +27,14 @@ export function useRunStatuses(): RunStatusesInfo {
   const runStatus = useRunStatus(currentRunId)
   const isRunIdle = runStatus === RUN_STATUS_IDLE
   const isRunRunning =
-    // todo(mm, 2024-03-13): This excludes statuses like:
-    // * RUN_STATUS_FINISHING
-    // * RUN_STATUS_STOP_REQUESTED
-    // * RUN_STATUS_BLOCKED_BY_OPEN_DOOR
-    // * RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR
-    // And it's not clear whether that's intentional.
     runStatus === RUN_STATUS_PAUSED ||
     runStatus === RUN_STATUS_RUNNING ||
     runStatus === RUN_STATUS_AWAITING_RECOVERY ||
-    runStatus === RUN_STATUS_AWAITING_RECOVERY_PAUSED
+    runStatus === RUN_STATUS_AWAITING_RECOVERY_PAUSED ||
+    runStatus === RUN_STATUS_STOP_REQUESTED ||
+    runStatus === RUN_STATUS_FINISHING ||
+    runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR ||
+    runStatus === RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR
   const isRunTerminal =
     runStatus != null
       ? (RUN_STATUSES_TERMINAL as RunStatus[]).includes(runStatus)

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/OverflowMenu.tsx
@@ -214,6 +214,8 @@ export function OverflowMenu({
               css={css`
                 border-radius: ${BORDERS.borderRadius8};
               `}
+              disabled={isRunning}
+              aria-label={`CalibrationOverflowMenu_button_calibrate`}
             >
               {t(
                 ot3PipCal == null


### PR DESCRIPTION
Closes [RQA-2892](https://opentrons.atlassian.net/browse/RQA-2892)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The fix for this ticket is twofold:

1. Add a disabled state to the calibration overflow menu button dependent on the `isRunning` run status.

But more importantly...

2. `useRunStatuses` needs updating. It's missing the new error recovery statuses, and some older statuses that qualify as a protocol still running, such as "finishing" and "stop requested". 

I've checked the usages of `isRunRunning`, and from what I can tell, we use this for overflow menu disabled states. I'm somewhat confident in saying that we aren't breaking anything extensively by adding these new run statuses to `isRunRunning`, but it's difficult to verify every last usage given how extensively we use `useRunStatuses` in the app. 

Interestingly enough, this is yet another way the app tries to categorize run statuses into more semantic groups that it cares about. This is definitely grounds for refactoring as the app:
- Often locally defines run statuses into groups it cares about.
- Imports groups of run statuses it cares about from `api-client`.
- Uses this hook to define run statuses it cares about.

<img width="1019" alt="Screenshot 2024-08-19 at 10 01 00 AM" src="https://github.com/user-attachments/assets/cd1d750c-969f-4e8a-a597-d1650a19d81d">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that the calibration button is now disabled when a run is running.
- Smoke tested the app, verifying everything looks disabled/enabled as it should be when a run is running or not.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Calibration via a robot settings overflow menu button is no longer enabled while a run is running. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish. Looking at the code and smoke testing, I can't see any significant problems with updating `useRunStatuses`, but it's hard to confirm this given how extensively we use this hook for overflow menues.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2892]: https://opentrons.atlassian.net/browse/RQA-2892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ