### PR TITLE
fix(app): blur quick transfer well selection reset button on click

### DIFF
--- a/app/src/organisms/QuickTransferFlow/SelectDestWells.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectDestWells.tsx
@@ -107,9 +107,10 @@ export function SelectDestWells(props: SelectDestWellsProps): JSX.Element {
   const resetButtonProps: React.ComponentProps<typeof SmallButton> = {
     buttonType: 'tertiaryLowLight',
     buttonText: t('shared:reset'),
-    onClick: () => {
+    onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
       setIsNumberWellsSelectedError(false)
       setSelectedWells({})
+      e.currentTarget.blur?.()
     },
   }
   let labwareDefinition =

--- a/app/src/organisms/QuickTransferFlow/SelectSourceWells.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectSourceWells.tsx
@@ -52,8 +52,9 @@ export function SelectSourceWells(props: SelectSourceWellsProps): JSX.Element {
   const resetButtonProps: React.ComponentProps<typeof SmallButton> = {
     buttonType: 'tertiaryLowLight',
     buttonText: t('shared:reset'),
-    onClick: () => {
+    onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
       setSelectedWells({})
+      e.currentTarget.blur?.()
     },
   }
   let displayLabwareDefinition = state.source


### PR DESCRIPTION
# Overview

blurs the quick transfer source and destination well selection reset buttons on click to remove the button focus styling

closes RQA-2863

## Test Plan and Hands on Testing

verified that reset button focus styling does not persist after click

## Changelog

 - Blurs quick transfer well selection reset button on click

## Review requests

go to the quick transfer select source wells/select destination wells pages, confirm that the reset button focus styling does not persist after click

## Risk assessment

low
