### PR TITLE
fix(app): fix module orientation in intervention modal deck map

### DIFF
--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -22,13 +22,14 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
+  getDeckDefFromRobotType,
+  getLoadedLabwareDefinitionsByUri,
+  getModuleType,
+  inferModuleOrientationFromXCoordinate,
   OT2_ROBOT_TYPE,
   TC_MODULE_LOCATION_OT2,
   TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
-  getDeckDefFromRobotType,
-  getLoadedLabwareDefinitionsByUri,
-  getModuleType,
 } from '@opentrons/shared-data'
 
 import {
@@ -213,7 +214,13 @@ export function MoveLabwareInterventionContent({
                       nestedLabwareDef,
                       nestedLabwareId,
                     }) => (
-                      <Module key={moduleId} def={moduleDef} x={x} y={y}>
+                      <Module
+                        key={moduleId}
+                        def={moduleDef}
+                        x={x}
+                        y={y}
+                        orientation={inferModuleOrientationFromXCoordinate(x)}
+                      >
                         {nestedLabwareDef != null &&
                         nestedLabwareId !== command.params.labwareId ? (
                           <LabwareRender definition={nestedLabwareDef} />


### PR DESCRIPTION
# Overview

On intervention modal deck map, we need to pass an orientation to any `Module` components on `BaseDeck`. This reflects the actual orientation of the module on the physical deck.

Closes RQA-3006

## Test Plan and Hands on Testing

- Run a protocol with a module loaded on the right column of slots, with a manual labware move (an OT-2 protocol like [this](https://github.com/user-attachments/files/16662402/ot2_demo.py.zip) pronounces the issue more explicitly, as module renders are fully above-deck)
- On intervention modal, confirm that the right-loaded module is oriented properly. The default orientation is 'left' and should be overwritten.

<img width="768" alt="Screenshot 2024-08-19 at 11 23 00 AM" src="https://github.com/user-attachments/assets/b39ab082-ca2f-4142-a99a-d3d5c66ad735">
<img width="770" alt="Screenshot 2024-08-19 at 11 24 10 AM" src="https://github.com/user-attachments/assets/4a45b256-a96a-48e5-9e8b-7a4d4bbaefb9">


## Changelog

- Infer module orientation from X coordinate and pass to `Module` SVG component

## Review requests

- See test plan and check code logic

## Risk assessment

low
