### PR TITLE
fix(app): Correct "it's" to "its" in OT-2 calibration copy

### DIFF
--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -91,7 +91,7 @@
   "pipette_offset_recalibrate_both_mounts": "Pipette offsets for both mounts will have to be recalibrated.",
   "pipette_offset_requires_tip_length": "You don’t have a tip length saved with this pipette yet. You will need to calibrate tip length before calibrating your pipette offset.",
   "pipette_offset_title": "pipette offset calibration",
-  "place_cal_block": "Place the Calibration Block into it's designated slot",
+  "place_cal_block": "Place the Calibration Block into its designated slot",
   "place_full_tip_rack": "Place a full {{tip_rack}} into slot 8",
   "position_pipette_over_tip": "Position pipette over A1",
   "prepare_the_space": "Prepare the space",

--- a/app/src/organisms/CalibrationPanels/__tests__/DeckSetup.test.tsx
+++ b/app/src/organisms/CalibrationPanels/__tests__/DeckSetup.test.tsx
@@ -74,7 +74,7 @@ describe('DeckSetup', () => {
 
     screen.getByRole('heading', { name: 'Prepare the space' })
     screen.getByText('Place a full 300ul Tiprack FIXTURE into slot 8')
-    screen.getByText("Place the Calibration Block into it's designated slot")
+    screen.getByText('Place the Calibration Block into its designated slot')
     expect(screen.queryByText('To check the left pipette:')).toBeNull()
     expect(screen.queryByText('Clear all other deck slots')).toBeNull()
   })
@@ -88,9 +88,7 @@ describe('DeckSetup', () => {
     screen.getByRole('heading', { name: 'Prepare the space' })
     screen.getByText('Place a full 300ul Tiprack FIXTURE into slot 8')
     expect(
-      screen.queryByText(
-        "Place the Calibration Block into it's designated slot"
-      )
+      screen.queryByText('Place the Calibration Block into its designated slot')
     ).toBeNull()
     expect(screen.queryByText('To check the left pipette:')).toBeNull()
     expect(screen.queryByText('Clear all other deck slots')).toBeNull()
@@ -105,7 +103,7 @@ describe('DeckSetup', () => {
 
     screen.getByRole('heading', { name: 'Prepare the space' })
     screen.getByText('Place a full fake tiprack display name into slot 8')
-    screen.getByText("Place the Calibration Block into it's designated slot")
+    screen.getByText('Place the Calibration Block into its designated slot')
     screen.getByText('To check the left pipette:')
     screen.getByText('Clear all other deck slots')
   })
@@ -122,9 +120,7 @@ describe('DeckSetup', () => {
     screen.getByText('To check the left pipette:')
     screen.getByText('Clear all other deck slots')
     expect(
-      screen.queryByText(
-        "Place the Calibration Block into it's designated slot"
-      )
+      screen.queryByText('Place the Calibration Block into its designated slot')
     ).toBeNull()
   })
 })


### PR DESCRIPTION
# Overview

This fixes a grammar error in OT-2 calibration.

## Test Plan and Hands on Testing

None needed.

## Changelog

`it's` -> `its`.

## Review requests

None.

## Risk assessment

None.