### PR TITLE
fix(app): App delete quick transfer desktop

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -255,7 +255,7 @@ export function ProtocolRunHeader({
     robotType,
     onSkipAndHome: () => {
       closeCurrentRun({
-        onSuccess: () => {
+        onSettled: () => {
           if (isQuickTransfer) {
             deleteRun(runId)
             navigate(`/devices/${robotName}`)
@@ -313,7 +313,7 @@ export function ProtocolRunHeader({
       // This marks the robot as "not busy" as soon as a run is cancelled if drop tip CTAs are unnecessary.
       if (initialPipettesWithTipsCount === 0 && !enteredER) {
         closeCurrentRun({
-          onSuccess: () => {
+          onSettled: () => {
             if (isQuickTransfer) {
               deleteRun(runId)
               navigate(`/devices/${robotName}`)
@@ -369,7 +369,7 @@ export function ProtocolRunHeader({
       properties: robotAnalyticsData ?? undefined,
     })
     closeCurrentRun({
-      onSuccess: () => {
+      onSettled: () => {
         if (isQuickTransfer) {
           deleteRun(runId)
           navigate(`/devices/${robotName}`)
@@ -568,7 +568,7 @@ export function ProtocolRunHeader({
                 void setTipStatusResolved(() => {
                   toggleDTWiz()
                   closeCurrentRun({
-                    onSuccess: () => {
+                    onSettled: () => {
                       if (isQuickTransfer) {
                         deleteRun(runId)
                         navigate(`/devices/${robotName}`)

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -21,6 +21,7 @@ import {
 import {
   useModulesQuery,
   useDoorQuery,
+  useDeleteRunMutation,
   useHost,
   useRunCommandErrors,
 } from '@opentrons/react-api-client'
@@ -169,6 +170,7 @@ export function ProtocolRunHeader({
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
   const isRobotViewable = useIsRobotViewable(robotName)
   const runStatus = useRunStatus(runId)
+  const { deleteRun } = useDeleteRunMutation()
   const { analysisErrors } = useProtocolAnalysisErrors(runId)
   const isRunCurrent = Boolean(
     useNotifyRunQuery(runId, { refetchInterval: CURRENT_RUN_POLL_MS })?.data
@@ -306,6 +308,7 @@ export function ProtocolRunHeader({
         closeCurrentRun({
           onSuccess: () => {
             if (isQuickTransfer) {
+              deleteRun(runId)
               navigate(`/devices/${robotName}`)
             }
           },
@@ -361,6 +364,7 @@ export function ProtocolRunHeader({
     closeCurrentRun({
       onSuccess: () => {
         if (isQuickTransfer) {
+          deleteRun(runId)
           navigate(`/devices/${robotName}`)
         }
       },
@@ -473,6 +477,7 @@ export function ProtocolRunHeader({
               closeCurrentRun({
                 onSuccess: () => {
                   if (isQuickTransfer) {
+                    deleteRun(runId)
                     navigate(`/devices/${robotName}`)
                   }
                 },

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -158,6 +158,7 @@ export function ProtocolRunHeader({
     displayName,
     protocolKey,
     isProtocolAnalyzing,
+    isQuickTransfer,
   } = useProtocolDetailsForRun(runId)
   const storedProtocol = useSelector((state: State) =>
     getStoredProtocol(state, protocolKey)
@@ -302,7 +303,13 @@ export function ProtocolRunHeader({
       // Close the run if no tips are attached after running tip check at least once.
       // This marks the robot as "not busy" as soon as a run is cancelled if drop tip CTAs are unnecessary.
       if (initialPipettesWithTipsCount === 0 && !enteredER) {
-        closeCurrentRun()
+        closeCurrentRun({
+          onSuccess: () => {
+            if (isQuickTransfer) {
+              navigate(`/devices/${robotName}`)
+            }
+          },
+        })
       }
     }
   }, [runStatus, isRunCurrent, runId, enteredER])
@@ -351,7 +358,13 @@ export function ProtocolRunHeader({
       name: ANALYTICS_PROTOCOL_RUN_ACTION.FINISH,
       properties: robotAnalyticsData ?? undefined,
     })
-    closeCurrentRun()
+    closeCurrentRun({
+      onSuccess: () => {
+        if (isQuickTransfer) {
+          navigate(`/devices/${robotName}`)
+        }
+      },
+    })
   }
 
   return (
@@ -449,6 +462,22 @@ export function ProtocolRunHeader({
             }}
             isResetRunLoading={isResetRunLoadingRef.current}
             isRunCurrent={isRunCurrent}
+          />
+        ) : null}
+        {mostRecentRunId === runId && showDropTipBanner && areTipsAttached ? (
+          <ProtocolDropTipBanner
+            onLaunchWizardClick={toggleDTWiz}
+            onCloseClick={() => {
+              resetTipStatus()
+              setShowDropTipBanner(false)
+              closeCurrentRun({
+                onSuccess: () => {
+                  if (isQuickTransfer) {
+                    navigate(`/devices/${robotName}`)
+                  }
+                },
+              })
+            }}
           />
         ) : null}
         {showDTModal ? (

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -254,7 +254,14 @@ export function ProtocolRunHeader({
     mount: aPipetteWithTip?.mount,
     robotType,
     onSkipAndHome: () => {
-      closeCurrentRun()
+      closeCurrentRun({
+        onSuccess: () => {
+          if (isQuickTransfer) {
+            deleteRun(runId)
+            navigate(`/devices/${robotName}`)
+          }
+        },
+      })
     },
   })
 
@@ -468,23 +475,6 @@ export function ProtocolRunHeader({
             isRunCurrent={isRunCurrent}
           />
         ) : null}
-        {mostRecentRunId === runId && showDropTipBanner && areTipsAttached ? (
-          <ProtocolDropTipBanner
-            onLaunchWizardClick={toggleDTWiz}
-            onCloseClick={() => {
-              resetTipStatus()
-              setShowDropTipBanner(false)
-              closeCurrentRun({
-                onSuccess: () => {
-                  if (isQuickTransfer) {
-                    deleteRun(runId)
-                    navigate(`/devices/${robotName}`)
-                  }
-                },
-              })
-            }}
-          />
-        ) : null}
         {showDTModal ? (
           <ProtocolDropTipModal
             onSkip={onDTModalSkip}
@@ -577,7 +567,14 @@ export function ProtocolRunHeader({
               } else {
                 void setTipStatusResolved(() => {
                   toggleDTWiz()
-                  closeCurrentRun()
+                  closeCurrentRun({
+                    onSuccess: () => {
+                      if (isQuickTransfer) {
+                        deleteRun(runId)
+                        navigate(`/devices/${robotName}`)
+                      }
+                    },
+                  })
                 }, toggleDTWiz)
               }
             }}

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -20,6 +20,7 @@ import {
   useModulesQuery,
   usePipettesQuery,
   useDismissCurrentRunMutation,
+  useDeleteRunMutation,
   useEstopQuery,
   useDoorQuery,
   useInstrumentsQuery,
@@ -284,6 +285,9 @@ describe('ProtocolRunHeader', () => {
     )
     vi.mocked(useModulesQuery).mockReturnValue({
       data: { data: [] },
+    } as any)
+    vi.mocked(useDeleteRunMutation).mockReturnValue({
+      deleteRun: vi.fn(),
     } as any)
     vi.mocked(usePipettesQuery).mockReturnValue({
       data: {

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -187,6 +187,7 @@ const PROTOCOL_DETAILS = {
   protocolKey: PROTOCOL_KEY,
   isProtocolAnalyzing: false,
   robotType: 'OT-2 Standard' as const,
+  isQuickTransfer: false,
 }
 
 const RUN_COMMAND_ERRORS = {
@@ -477,6 +478,7 @@ describe('ProtocolRunHeader', () => {
       protocolKey: null,
       isProtocolAnalyzing: true,
       robotType: 'OT-2 Standard',
+      isQuickTransfer: false,
     })
 
     render()

--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolDetailsForRun.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolDetailsForRun.test.tsx
@@ -58,6 +58,7 @@ describe('useProtocolDetailsForRun hook', () => {
       protocolKey: null,
       isProtocolAnalyzing: false,
       robotType: 'OT-3 Standard',
+      isQuickTransfer: false,
     })
   })
 
@@ -95,6 +96,7 @@ describe('useProtocolDetailsForRun hook', () => {
       protocolKey: 'fakeProtocolKey',
       isProtocolAnalyzing: false,
       robotType: 'OT-2 Standard',
+      isQuickTransfer: false,
     })
   })
 })

--- a/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolDetailsForRun.ts
@@ -21,6 +21,7 @@ export interface ProtocolDetails {
   protocolKey: string | null
   isProtocolAnalyzing?: boolean
   robotType: RobotType
+  isQuickTransfer: boolean
 }
 
 export function useProtocolDetailsForRun(
@@ -67,5 +68,6 @@ export function useProtocolDetailsForRun(
       (mostRecentAnalysis?.status === 'completed'
         ? mostRecentAnalysis?.robotType ?? FLEX_ROBOT_TYPE
         : FLEX_ROBOT_TYPE),
+    isQuickTransfer: protocolRecord?.data.protocolKind === 'quick-transfer',
   }
 }

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -236,14 +236,15 @@ export function RunSummary(): JSX.Element {
   const returnToQuickTransfer = (): void => {
     if (!isRunCurrent) {
       deleteRun(runId)
+      navigate('/quick-transfer')
     } else {
       closeCurrentRun({
         onSuccess: () => {
           deleteRun(runId)
+          navigate('/quick-transfer')
         },
       })
     }
-    navigate('/quick-transfer')
   }
 
   // TODO(jh, 05-30-24): EXEC-487. Refactor reset() so we can redirect to the setup page, showing the shimmer skeleton instead.

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -134,6 +134,11 @@ export function RunSummary(): JSX.Element {
       reportRecoveredRunResult(runStatus, enteredER)
     }
   }, [isRunCurrent, enteredER])
+  React.useEffect(() => {
+    if (runRecord == null) {
+      navigate('/')
+    }
+  })
 
   const { reset, isResetRunLoading } = useRunControls(runId, onCloneRunSuccess)
   const trackEvent = useTrackEvent()

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -80,7 +80,13 @@ export function RunSummary(): JSX.Element {
   const { t } = useTranslation('run_details')
   const navigate = useNavigate()
   const host = useHost()
-  const { data: runRecord } = useNotifyRunQuery(runId, { staleTime: Infinity })
+  const { data: runRecord } = useNotifyRunQuery(runId, {
+    staleTime: Infinity,
+    onError: () => {
+      // in case the run is remotely deleted by a desktop app, navigate to the dash
+      navigate('/')
+    },
+  })
   const isRunCurrent = Boolean(
     useNotifyRunQuery(runId, { refetchInterval: CURRENT_RUN_POLL_MS })?.data
       ?.data?.current
@@ -134,15 +140,6 @@ export function RunSummary(): JSX.Element {
       reportRecoveredRunResult(runStatus, enteredER)
     }
   }, [isRunCurrent, enteredER])
-
-  React.useEffect(() => {
-    // in case the run is remotely deleted by a desktop app, navigate to the dash
-    console.log('run record == null: ', runRecord == null)
-    console.log('is quick transfer: ', isQuickTransfer)
-    if (runRecord == null && isQuickTransfer) {
-      navigate('/')
-    }
-  }, [runRecord, isQuickTransfer])
 
   const { reset, isResetRunLoading } = useRunControls(runId, onCloneRunSuccess)
   const trackEvent = useTrackEvent()

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -140,7 +140,7 @@ export function RunSummary(): JSX.Element {
     if (runRecord == null) {
       navigate('/')
     }
-  })
+  }, [runRecord])
 
   const { reset, isResetRunLoading } = useRunControls(runId, onCloneRunSuccess)
   const trackEvent = useTrackEvent()

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -134,7 +134,9 @@ export function RunSummary(): JSX.Element {
       reportRecoveredRunResult(runStatus, enteredER)
     }
   }, [isRunCurrent, enteredER])
+
   React.useEffect(() => {
+    // in case the run is remotely deleted by a desktop app, navigate to the dash
     if (runRecord == null) {
       navigate('/')
     }

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -137,10 +137,12 @@ export function RunSummary(): JSX.Element {
 
   React.useEffect(() => {
     // in case the run is remotely deleted by a desktop app, navigate to the dash
-    if (runRecord == null) {
+    console.log('run record == null: ', runRecord == null)
+    console.log('is quick transfer: ', isQuickTransfer)
+    if (runRecord == null && isQuickTransfer) {
       navigate('/')
     }
-  }, [runRecord])
+  }, [runRecord, isQuickTransfer])
 
   const { reset, isResetRunLoading } = useRunControls(runId, onCloneRunSuccess)
   const trackEvent = useTrackEvent()


### PR DESCRIPTION
Fix RQA-3048
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Since we don't want to hang onto Quick Transfer run records, we need to handle run deletion in case an ODD initiated quick transfer run is cancelled from a desktop. In the event that a quick transfer run is deleted by a desktop app, we also need to redirect the ODD screen back to the dashboard.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Initiate a quick transfer run from an ODD. On a desktop app, view that run and cancel it. Once the cancellation has occurred, see that the desktop app redirects to the robot dashboard while deleting the run in the background. Once the deletion has occurred, see that the ODD redirects to the dashboard.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Add `isQuickTransfer` field to `ProtocolRunDetails`
2. In `ProtocolRunHeader` whenever a run is dismissed, add check in an `onSettled` to handle deletion and redirection if the run is a quick transfer
3. In `RunSummary` on ODD add `useEffect` that will monitor for remote run deletion and redirect to the dashboard if the run disappears

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over code, I've tested this out but more testing is welcome!
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
