### PR TITLE
fix(app): Add command text for reloadLabware

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -57,6 +57,7 @@
   "pause_on": "Pause on {{robot_name}}",
   "pickup_tip": "Picking up tip(s) from {{well_range}} of {{labware}} in {{labware_location}}",
   "prepare_to_aspirate": "Preparing {{pipette}} to aspirate",
+  "reloading_labware": "Reloading {{labware}}",
   "return_tip": "Returning tip to {{well_name}} of {{labware}} in {{labware_location}}",
   "right": "Right",
   "save_position": "Saving position",

--- a/app/src/molecules/Command/__fixtures__/mockRobotSideAnalysis.json
+++ b/app/src/molecules/Command/__fixtures__/mockRobotSideAnalysis.json
@@ -6431,6 +6431,20 @@
         },
         "pipetteId": "f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb"
       }
+    },
+    {
+      "id": "84f7af1d-c097-4d4b-9819-ad56479bbbb8",
+      "createdAt": "2023-01-31T21:53:04.965216+00:00",
+      "commandType": "reloadLabware",
+      "key": "1248111104",
+      "status": "succeeded",
+      "params": {
+        "labwareId": "c8f42311-f83f-4722-9821-9d2225e4b0b5"
+      },
+      "result": {
+        "labwareId": "c8f42311-f83f-4722-9821-9d2225e4b0b5",
+        "offsetId": "offsetId-abc123"
+      }
     }
   ],
   "errors": [],

--- a/app/src/molecules/Command/__tests__/CommandText.test.tsx
+++ b/app/src/molecules/Command/__tests__/CommandText.test.tsx
@@ -588,6 +588,23 @@ describe('CommandText', () => {
     )
     screen.getByText('Load NEST 96 Well Plate 100 µL PCR Full Skirt off deck')
   })
+  it('renders correct text for reloadLabware', () => {
+    const reloadLabwareCommand = mockCommandTextData.commands.find(
+      c => c.commandType === 'reloadLabware'
+    )
+    expect(reloadLabwareCommand).not.toBeUndefined()
+    if (reloadLabwareCommand != null) {
+      renderWithProviders(
+        <CommandText
+          commandTextData={mockCommandTextData}
+          robotType={FLEX_ROBOT_TYPE}
+          command={reloadLabwareCommand}
+        />,
+        { i18nInstance: i18n }
+      )
+    }
+    screen.getByText('Reloading NEST 96 Well Plate 100 µL PCR Full Skirt (1)')
+  })
   it('renders correct text for loadLiquid', () => {
     const loadLabwareCommands = mockCommandTextData.commands.filter(
       c => c.commandType === 'loadLabware'

--- a/app/src/molecules/Command/hooks/useCommandTextString/index.tsx
+++ b/app/src/molecules/Command/hooks/useCommandTextString/index.tsx
@@ -71,6 +71,7 @@ export function useCommandTextString(
       }
 
     case 'loadLabware':
+    case 'reloadLabware':
     case 'loadPipette':
     case 'loadModule':
     case 'loadLiquid':

--- a/app/src/molecules/Command/hooks/useCommandTextString/utils/getLoadCommandText.ts
+++ b/app/src/molecules/Command/hooks/useCommandTextString/utils/getLoadCommandText.ts
@@ -140,6 +140,14 @@ export const getLoadCommandText = ({
             })
       }
     }
+    case 'reloadLabware': {
+      const { labwareId } = command.params
+      const labware =
+        commandTextData != null
+          ? getLabwareName(commandTextData, labwareId)
+          : null
+      return t('reloading_labware', { labware })
+    }
     case 'loadLiquid': {
       const { liquidId, labwareId } = command.params
       return t('load_liquids_info_protocol_setup', {

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -29,6 +29,15 @@ export interface LoadLabwareRunTimeCommand
     LoadLabwareCreateCommand {
   result?: LoadLabwareResult
 }
+export interface ReloadLabwareCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'reloadLabware'
+  params: { labwareId: string }
+}
+export interface ReloadLabwareRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    ReloadLabwareCreateCommand {
+  result?: ReloadLabwareResult
+}
 export interface MoveLabwareCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveLabware'
   params: MoveLabwareParams
@@ -76,6 +85,7 @@ export type SetupRunTimeCommand =
   | ConfigureNozzleLayoutRunTimeCommand
   | LoadPipetteRunTimeCommand
   | LoadLabwareRunTimeCommand
+  | ReloadLabwareRunTimeCommand
   | LoadModuleRunTimeCommand
   | LoadLiquidRunTimeCommand
   | MoveLabwareRunTimeCommand
@@ -84,6 +94,7 @@ export type SetupCreateCommand =
   | ConfigureNozzleLayoutCreateCommand
   | LoadPipetteCreateCommand
   | LoadLabwareCreateCommand
+  | ReloadLabwareCreateCommand
   | LoadModuleCreateCommand
   | LoadLiquidCreateCommand
   | MoveLabwareCreateCommand
@@ -123,7 +134,13 @@ interface LoadLabwareParams {
 interface LoadLabwareResult {
   labwareId: string
   definition: LabwareDefinition2
+  // todo(mm, 2024-08-19): This does not match the server-returned offsetId field.
+  // Confirm nothing client-side is trying to use this, then replace it with offsetId.
   offset: LabwareOffset
+}
+interface ReloadLabwareResult {
+  labwareId: string
+  offsetId?: string | null
 }
 
 export type LabwareMovementStrategy =


### PR DESCRIPTION
# Overview

Closes EXEC-681.

## Test Plan and Hands on Testing

<img width="886" alt="Screenshot 2024-08-19 at 3 20 33 PM" src="https://github.com/user-attachments/assets/ade344cd-7b4f-4be0-95e0-413665d5a161">

## Changelog

Render `reloadLabware` commands, which happen when you call the PAPI [`set_offset()`](https://docs.opentrons.com/v2/new_protocol_api.html?highlight=set_offset#opentrons.protocol_api.Labware.set_offset) method, as "Reloading [labware name]".
 
## Review requests

I'm mostly just blind-following the existing patterns. Are there any nuances I missed?

## Risk assessment

Low.