### PR TITLE
feat(protocol-designer): default robot type to Flex on protocol onboarding

### DIFF
--- a/protocol-designer/src/load-file/types.ts
+++ b/protocol-designer/src/load-file/types.ts
@@ -18,7 +18,7 @@ export interface NewProtocolFields {
   name: string | null | undefined
   description: string | null | undefined
   organizationOrAuthor: string | null | undefined
-  robotType: RobotType | undefined
+  robotType: RobotType
 }
 export interface LoadFileAction {
   type: 'LOAD_FILE'

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectRobot.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectRobot.tsx
@@ -16,7 +16,7 @@ export function SelectRobot(props: WizardTileProps): JSX.Element {
       stepNumber={1}
       header={t('basics')}
       subHeader={t('questions')}
-      disabled={robotType === undefined}
+      disabled={false}
       proceed={() => {
         proceed(1)
       }}

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/index.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/index.tsx
@@ -99,7 +99,7 @@ const initialFormState: WizardFormState = {
     name: undefined,
     description: undefined,
     organizationOrAuthor: undefined,
-    robotType: undefined,
+    robotType: FLEX_ROBOT_TYPE,
   },
   pipettesByMount: {
     left: { pipetteName: undefined, tiprackDefURI: undefined },


### PR DESCRIPTION
# Overview

When creating a new protocol on PD, the wizard's first screen for robot selection should default to Flex.

closes AUTH-715

## Test Plan and Hands on Testing

- turn on PD redesign FF
- create a new protocol
- verify that on select robot page, the Flex option is preselected

https://github.com/user-attachments/assets/2951ad0e-29dd-403d-80d2-187da370ae64


## Changelog

- update initial form state

## Review requests

- see test plan

## Risk assessment

low