### PR TITLE
fix(app): Fix green check flows post DQA

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -18,7 +18,6 @@ import {
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
   parseAllRequiredModuleModels,
-  parseLiquidsInLoadOrder,
 } from '@opentrons/shared-data'
 
 import { Line } from '../../../atoms/structure'
@@ -165,11 +164,7 @@ export function ProtocolRunSetup({
   })
 
   const liquids = protocolAnalysis?.liquids ?? []
-  const liquidsInLoadOrder =
-    protocolAnalysis != null
-      ? parseLiquidsInLoadOrder(liquids, protocolAnalysis.commands)
-      : []
-  const hasLiquids = liquidsInLoadOrder.length > 0
+  const hasLiquids = liquids.length > 0
   const hasModules = protocolAnalysis != null && modules.length > 0
   // need config compatibility (including check for single slot conflicts)
   const requiredDeckConfigCompatibility = getRequiredDeckConfig(
@@ -191,7 +186,11 @@ export function ProtocolRunSetup({
   const [liquidSetupComplete, setLiquidSetupComplete] = React.useState<boolean>(
     !hasLiquids
   )
-  if (!hasLiquids && missingSteps.includes('liquids')) {
+  if (
+    !hasLiquids &&
+    protocolAnalysis != null &&
+    missingSteps.includes('liquids')
+  ) {
     setMissingSteps(missingSteps.filter(step => step !== 'liquids'))
   }
   const [lpcComplete, setLpcComplete] = React.useState<boolean>(false)

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -515,6 +515,7 @@ function PrepareToRun({
       : 'not ready'
   // Liquids information
   const liquidsInProtocol = mostRecentAnalysis?.liquids ?? []
+  const areLiquidsInProtocol = liquidsInProtocol.length > 0
 
   const isReadyToRun =
     incompleteInstrumentCount === 0 && areModulesReady && areFixturesReady
@@ -528,7 +529,7 @@ function PrepareToRun({
           !(
             labwareConfirmed &&
             offsetsConfirmed &&
-            (liquidsConfirmed || liquidsInProtocol.length === 0)
+            (liquidsConfirmed || !areLiquidsInProtocol)
           )
         ) {
           confirmStepsComplete()
@@ -803,18 +804,16 @@ function PrepareToRun({
               }}
               title={i18n.format(t('liquids'), 'capitalize')}
               status={
-                liquidsConfirmed || liquidsInProtocol.length === 0
-                  ? 'ready'
-                  : 'general'
+                liquidsConfirmed || !areLiquidsInProtocol ? 'ready' : 'general'
               }
               detail={
-                liquidsInProtocol.length > 0
+                areLiquidsInProtocol
                   ? t('initial_liquids_num', {
                       count: liquidsInProtocol.length,
                     })
                   : t('liquids_not_in_setup')
               }
-              interactionDisabled={liquidsInProtocol.length === 0}
+              interactionDisabled={!areLiquidsInProtocol}
             />
           </>
         ) : (
@@ -889,6 +888,8 @@ export function ProtocolSetup(): JSX.Element {
     }
   )
 
+  const areLiquidsInProtocol = (mostRecentAnalysis?.liquids?.length ?? 0) > 0
+
   React.useEffect(() => {
     if (mostRecentAnalysis?.status === 'completed') {
       setIsPollingForCompletedAnalysis(false)
@@ -954,7 +955,7 @@ export function ProtocolSetup(): JSX.Element {
   const missingSteps = [
     !offsetsConfirmed ? t('applied_labware_offsets') : null,
     !labwareConfirmed ? t('labware_placement') : null,
-    !liquidsConfirmed ? t('liquids') : null,
+    !liquidsConfirmed && areLiquidsInProtocol ? t('liquids') : null,
   ].filter(s => s != null)
   const {
     confirm: confirmMissingSteps,


### PR DESCRIPTION
Closes [RQA-3040](https://opentrons.atlassian.net/browse/RQA-3040), and [RQA-3035](https://opentrons.atlassian.net/browse/RQA-3035)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

These fixes are very minor and straightforward. See tickets for proof of fixes. 

d500b472410f6cd76433e5173b913cdca97c0174 - `L958` is the actual change. We just needed a new conditional here.
08e097130864ab22367819461baf97493d3fa1aa - `protocolAnalysis` is always null for the first render cycle, so we were preemptively filtering out `liquids`. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See tickets for screenshots.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed copy within the setup confirmation modal not always reflecting what needed to be confirmed after clicking "start run".
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3040]: https://opentrons.atlassian.net/browse/RQA-3040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-3035]: https://opentrons.atlassian.net/browse/RQA-3035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ