### PR TITLE
fix(app): increase size of robot version mismatch tooltip

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -189,7 +189,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
         {t('rerun_now')}
       </MenuItem>
       {isRobotOnWrongVersionOfSoftware && (
-        <Tooltip tooltipProps={tooltipProps}>
+        <Tooltip tooltipProps={tooltipProps} maxWidth={'max-content'}>
           {t('shared:a_software_update_is_available')}
         </Tooltip>
       )}

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -17,6 +17,7 @@ import {
   SPACING,
   SIZE_1,
   ALIGN_CENTER,
+  FLEX_MAX_CONTENT,
 } from '@opentrons/components'
 import { useDeleteRunMutation } from '@opentrons/react-api-client'
 
@@ -165,7 +166,6 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
 
   return (
     <Flex
-      whiteSpace="nowrap"
       zIndex={10}
       borderRadius="4px 4px 0px 0px"
       boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
@@ -174,6 +174,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
       top="2.3rem"
       right={0}
       flexDirection={DIRECTION_COLUMN}
+      width={FLEX_MAX_CONTENT}
     >
       <NavLink to={`/devices/${robotName}/protocol-runs/${runId}/run-preview`}>
         <MenuItem data-testid="RecentProtocolRun_OverflowMenu_viewRunRecord">
@@ -189,7 +190,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
         {t('rerun_now')}
       </MenuItem>
       {isRobotOnWrongVersionOfSoftware && (
-        <Tooltip tooltipProps={tooltipProps} maxWidth={'max-content'}>
+        <Tooltip tooltipProps={tooltipProps}>
           {t('shared:a_software_update_is_available')}
         </Tooltip>
       )}


### PR DESCRIPTION
# Overview

closes RQA-2857


## Changelog

-  increase size of robot version mismatch tooltip

## Review requests

- Go to "Recent Protocol Runs" table in robot details page
- Make sure robot and app are on mismatched versions of software OR trick the app by going to line 191 in `app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx` and replace `isRobotOnWrongVersionOfSoftware` with `true`
- Verify the tooltip text does not get cut off when hovering on "rerun protocol"

## Risk assessment

Low
