### PR TITLE
fix(api): Fix malformed PAPI error message

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2066,6 +2066,8 @@ class InstrumentContext(publisher.CommandPublisher):
             NozzleLayout.QUADRANT,
         ]
         if style in disabled_layouts:
+            # todo(mm, 2024-08-20): UnsupportedAPIError boils down to an API_REMOVED
+            # error code, which is not correct here.
             raise UnsupportedAPIError(
                 message=f"Nozzle layout configuration of style {style.value} is currently unsupported."
             )
@@ -2076,7 +2078,11 @@ class InstrumentContext(publisher.CommandPublisher):
             < _PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN
         ) and (style not in original_enabled_layouts):
             raise APIVersionError(
-                f"Nozzle layout configuration of style {style.value} is unsupported in API Versions lower than {_PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN}."
+                api_element=f"Nozzle layout configuration of style {style.value}",
+                until_version=str(
+                    _PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN
+                ),
+                current_version=str(self._api_version),
             )
 
         front_right_resolved = front_right

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -581,7 +581,7 @@ class Labware:
                 api_element="Labware.set_calibration()",
                 since_version=f"{ENGINE_CORE_API_VERSION}",
                 current_version=f"{self._api_version}",
-                message=" Try using the Opentrons App's Labware Position Check.",
+                extra_message="Try using the Opentrons App's Labware Position Check.",
             )
         self._core.set_calibration(delta)
 
@@ -632,7 +632,7 @@ class Labware:
                 api_element="Labware.set_offset()",
                 until_version=f"{SET_OFFSET_RESTORED_API_VERSION}",
                 current_version=f"{self._api_version}",
-                message=" This feature not available in versions 2.14 thorugh 2.17. You can also use the Opentrons App's Labware Position Check.",
+                extra_message="This feature not available in versions 2.14 thorugh 2.17. You can also use the Opentrons App's Labware Position Check.",
             )
         else:
             self._core.set_calibration(Point(x=x, y=y, z=z))
@@ -974,7 +974,7 @@ class Labware:
                 api_element="Labware.use_tips",
                 since_version=f"{ENGINE_CORE_API_VERSION}",
                 current_version=f"{self._api_version}",
-                message=" To modify tip state, use Labware.reset.",
+                extra_message="To modify tip state, use Labware.reset.",
             )
 
         assert num_channels > 0, "Bad call to use_tips: num_channels<=0"
@@ -1064,7 +1064,7 @@ class Labware:
                 api_element="Labware.return_tips()",
                 since_version=f"{ENGINE_CORE_API_VERSION}",
                 current_version=f"{self._api_version}",
-                message=" Use Labware.reset() instead.",
+                extra_message="Use Labware.reset() instead.",
             )
 
         # This logic is the inverse of :py:meth:`use_tips`

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -103,7 +103,7 @@ class ModuleContext(CommandPublisher):
             raise UnsupportedAPIError(
                 api_element="`ModuleContext.load_labware_object`",
                 since_version="2.14",
-                message=" Use `ModuleContext.load_labware` or `load_labware_by_definition` instead.",
+                extra_message="Use `ModuleContext.load_labware` or `load_labware_by_definition` instead.",
             )
 
         _log.warning(
@@ -305,7 +305,7 @@ class ModuleContext(CommandPublisher):
         raise UnsupportedAPIError(
             api_element="`ModuleContext.geometry`",
             since_version="2.14",
-            message=" Use properties of the `ModuleContext` itself.",
+            extra_message="Use properties of the `ModuleContext` itself.",
         )
 
     def __repr__(self) -> str:
@@ -482,7 +482,7 @@ class MagneticModuleContext(ModuleContext):
                     api_element="The height parameter of MagneticModuleContext.engage()",
                     since_version=f"{_MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN}",
                     current_version=f"{self._api_version}",
-                    message=" Use offset or height_from_base.",
+                    extra_message="Use offset or height_from_base.",
                 )
             self._core.engage(height_from_home=height)
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -279,7 +279,7 @@ class ProtocolContext(CommandPublisher):
                 api_element="ProtocolContext.max_speeds",
                 since_version=f"{ENGINE_CORE_API_VERSION}",
                 current_version=f"{self._api_version}",
-                message=" Set speeds using InstrumentContext.default_speed or the per-method 'speed' argument.",
+                extra_message="Set speeds using InstrumentContext.default_speed or the per-method 'speed' argument.",
             )
 
         return self._core.get_max_speeds()
@@ -1046,7 +1046,7 @@ class ProtocolContext(CommandPublisher):
                 api_element="A Python Protocol safely resuming itself after a pause",
                 since_version=f"{ENGINE_CORE_API_VERSION}",
                 current_version=f"{self._api_version}",
-                message=" To wait automatically for a period of time, use ProtocolContext.delay().",
+                extra_message="To wait automatically for a period of time, use ProtocolContext.delay().",
             )
 
         # TODO(mc, 2023-02-13): this assert should be enough for mypy
@@ -1167,7 +1167,7 @@ class ProtocolContext(CommandPublisher):
                     api_element="Fixed Trash",
                     since_version="2.16",
                     current_version=f"{self._api_version}",
-                    message=" Fixed trash is no longer supported on Flex protocols.",
+                    extra_message="Fixed trash is no longer supported on Flex protocols.",
                 )
             disposal_locations = self._core.get_disposal_locations()
             if len(disposal_locations) == 0:
@@ -1240,7 +1240,7 @@ class ProtocolContext(CommandPublisher):
                     api_element="Calling `define_liquid()` without a `description`",
                     current_version=str(self._api_version),
                     until_version=str(desc_and_display_color_omittable_since),
-                    message="Use a newer API version or explicitly supply `description=None`.",
+                    extra_message="Use a newer API version or explicitly supply `description=None`.",
                 )
             else:
                 description = None
@@ -1250,7 +1250,7 @@ class ProtocolContext(CommandPublisher):
                     api_element="Calling `define_liquid()` without a `display_color`",
                     current_version=str(self._api_version),
                     until_version=str(desc_and_display_color_omittable_since),
-                    message="Use a newer API version or explicitly supply `display_color=None`.",
+                    extra_message="Use a newer API version or explicitly supply `display_color=None`.",
                 )
             else:
                 display_color = None

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -208,7 +208,7 @@ def ensure_and_convert_deck_slot(
                 api_element=f"Specifying a deck slot like '{deck_slot}'",
                 until_version=f"{_COORDINATE_DECK_LABEL_VERSION_GATE}",
                 current_version=f"{api_version}",
-                message=f"Increase your protocol's apiLevel, or use slot '{alternative}' instead.",
+                extra_message=f"Increase your protocol's apiLevel, or use slot '{alternative}' instead.",
             )
 
         return parsed_slot.to_equivalent_for_robot_type(robot_type)

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -86,9 +86,9 @@ async def post_serial_command(
     if requested_version >= 3:
         raise LegacyErrorResponse.from_exc(
             APIRemoved(
-                "/modules/{serial}",
-                "3",
-                "This endpoint has been removed. Use POST /commands instead.",
+                api_element="/modules/{serial}",
+                since_version="3",
+                extra_message="This endpoint has been removed. Use POST /commands instead.",
             ),
         ).as_error(status.HTTP_410_GONE)
 


### PR DESCRIPTION
## Overview

This fixes a malformed error message caught by the snapshot tests in #16062:

```
Nozzle layout configuration of style SINGLE is unsupported in API Versions lower than 2.20. is not yet available in the API version in use.
```

## Test Plan and Hands on Testing

I'm relying on automated tests.

## Changelog

* Rework the underlying exceptions so that if you construct them with just a single unnamed string argument, it's used directly as the `message`, without any surprise concatenation. I think this is least surprising to the caller, given our codebase's existing exception conventions.

Also, for niceness:

* `typing.overload`s, for clarity.
* In the mode where we generate the exception message automatically from `api_element`+`since_version`+`current_version`, handle some additional cases of partially missing information.

## Review requests

None.

## Risk assessment

Low.
