### PR TITLE
fix(app): fix desktop showing trash bin requires action

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -251,7 +251,6 @@ export function ProtocolRunSetup({
       rightElProps: {
         stepKey: MODULE_SETUP_KEY,
         complete:
-          calibrationStatusRobot.complete &&
           calibrationStatusModules.complete &&
           !isMissingModule &&
           !isFixtureMismatch,


### PR DESCRIPTION
Closes [RQA-2954](https://opentrons.atlassian.net/browse/RQA-2954) for real

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In #16005, it was noted that reproing the initial ticket was difficult. The trick to reproing the ticket is _not_ to have pipettes attached & calibrated and then have prepared deck hardware. Doing so exposes the bug. 

The fix is simple: the modules logic was checking to see if pipettes are attached/calibrated and conditionally rendering copy based on that. We shouldn't do that here.  

### Current Behavior
![Screenshot 2024-08-12 at 9 58 25 AM](https://github.com/user-attachments/assets/5d6f68f3-e1d7-4c1e-b87e-da02b02f3656)


### Fixed Behavior

![Screenshot 2024-08-20 at 2 35 29 PM](https://github.com/user-attachments/assets/426f6298-3c18-432d-9f52-e10caf2c5bdd)

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See screenshot above.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed modules and deck showing "action needed" when no action is needed.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-2954]: https://opentrons.atlassian.net/browse/RQA-2954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ