### PR TITLE
fix(app): fix never clicking setup tab after the run has started

### DIFF
--- a/app/src/pages/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Devices/ProtocolRunDetails/index.tsx
@@ -322,11 +322,12 @@ const SetupTab = (props: SetupTabProps): JSX.Element | null => {
     'not_available_for_a_completed_run'
   )}`
 
+  // On the initial render only, navigate to "run preview" if the run has started.
   React.useEffect(() => {
     if (runHasStarted && protocolRunDetailsTab === 'setup') {
       navigate(`/devices/${robotName}/protocol-runs/${runId}/run-preview`)
     }
-  }, [runHasStarted, navigate, protocolRunDetailsTab, robotName, runId])
+  }, [])
 
   return (
     <RoundTab


### PR DESCRIPTION
Closes [RQA-3065](https://opentrons.atlassian.net/browse/RQA-3065) and [RQA-3059](https://opentrons.atlassian.net/browse/RQA-3059)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We recently updated the routing logic to the setup tab, but the `useEffect` dependency array is a bit overzealous. Let's only do the redirect on the first click only. 

### Current Behavior

https://github.com/user-attachments/assets/98b8337e-e535-4759-b84a-411a101b19eb

### Fixed Behavior

https://github.com/user-attachments/assets/20548912-a861-46a6-b2df-548adca10307

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed never being able to click on Setup after the run has started. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowwww
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3065]: https://opentrons.atlassian.net/browse/RQA-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-3059]: https://opentrons.atlassian.net/browse/RQA-3059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ