### PR TITLE
fix(shared-data, api): Fix the robot deck extents limitations

### DIFF
--- a/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
+++ b/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
@@ -61,13 +61,6 @@ def test_deck_conflicts_for_96_ch_a12_column_configuration() -> None:
     ):
         instrument.pick_up_tip(badly_placed_tiprack.wells_by_name()["A1"])
 
-    with pytest.raises(
-        PartialTipMovementNotAllowedError, match="outside of robot bounds"
-    ):
-        # Picking up from A1 in an east-most slot using a configuration with column 12 would
-        # result in a collision with the side of the robot.
-        instrument.pick_up_tip(well_placed_tiprack.wells_by_name()["A1"])
-
     instrument.pick_up_tip(well_placed_tiprack.wells_by_name()["A12"])
     instrument.aspirate(50, well_placed_labware.wells_by_name()["A4"])
 

--- a/shared-data/robot/definitions/1/ot3.json
+++ b/shared-data/robot/definitions/1/ot3.json
@@ -2,9 +2,9 @@
   "displayName": "OT-3",
   "robotType": "OT-3 Standard",
   "models": ["OT-3 Standard"],
-  "extents": [477.2, 493.8, 0.0],
+  "extents": [519.1, 493.8, 0.0],
   "mountOffsets": {
-    "left": [-13.5, -60.5, 255.675],
+    "left": [-59.7, -60.5, 255.675],
     "right": [40.5, -60.5, 255.675],
     "gripper": [84.55, -12.75, 93.85]
   }


### PR DESCRIPTION
# Overview
Covers RQA-3067
The new deck extents logic accidentally removed the ability to access wells in Column A1 of a labware in Column 1 of the deck. These new deck extents ensure the following truths about the deck:

- A 96ch in column A12 configuration can pick up tips from Column A1 of a tiprack in Column 1 of the deck
- A 96ch in column A12 configuration can reach column A2 of a labware inside of a thermocycler
- A 96ch in column A1 configuration can reach column A10 of a labware in Column 3 of the deck

## Test Plan and Hands on Testing

- [x] The deck extents limits above are enforceable and will pass/throw analysis respectively
- [x] The following protocol testing the extreme deck extent limitations of single tip pickup in all four corners of the deck passes analysis and execution:
```
from opentrons import protocol_api
from opentrons.protocol_api import COLUMN, ALL, SINGLE, ROW, OFF_DECK

requirements = {
	"robotType": "Flex",
	"apiLevel": "2.20"
}

def run(protocol: protocol_api.ProtocolContext):
    pipette = protocol.load_instrument(instrument_name="flex_96channel_1000")
    trash = protocol.load_trash_bin("B3")
    t1 = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul",
        label="A1 Corner Tiprack 1",
        location="B1",
    )
    t2 = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul",
        label="D1 Corner Tiprack",
        location="C1",
    )
    t3 = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul",
        label="A3 Corner Tiprack 1",
        location="B2",
    )
    t4 = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul",
        label="D3 Corner Tiprack",
        location="C2",
    )
    t5 = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul",
        label="A3 Corner Tiprack 2",
        location="A2",
    )
    t6 = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul",
        label="A1 Corner Tiprack 2",
        location="D4",
    )

    ### SETUP TIPRACK FUNCTIONS
    # These functions serve the purpose of removing tips from a tiprack before it is moved to a corner slot
    # This is done to ensure the tiprack is in such a state that it will trigger zero deck extent conflicts

    # Setup T2
    def t2_setup() -> None:
        pipette.configure_nozzle_layout(
            style=ROW,
            start="A1",
            tip_racks=[t2],
        )
        for i in range(3):
            pipette.pick_up_tip()
            pipette.drop_tip()

    # Setup T3
    def t3_setup() -> None:
        pipette.configure_nozzle_layout(
            style=COLUMN,
            start="A1",
            tip_racks=[t3]
        )
        for i in range(2):
            pipette.pick_up_tip()
            pipette.drop_tip()

    #Setup T4
    def t4_setup() -> None:
        pipette.configure_nozzle_layout(
            style=ROW,
            start="A1",
            tip_racks=[t4],
        )
        for i in range(3):
            pipette.pick_up_tip()
            pipette.drop_tip()

        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A1",
            tip_racks=[t4],
        )
        for i in range(10):
            pipette.pick_up_tip()
            pipette.drop_tip()

    # Setup T5
    def t5_setup() -> None:
        pipette.configure_nozzle_layout(
            style=ROW,
            start="H1",
            tip_racks=[t5],
        )
        for i in range(7):
            pipette.pick_up_tip()
            pipette.drop_tip()

        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A1",
            tip_racks=[t5],
        )
        for i in range(2):
            pipette.pick_up_tip()
            pipette.drop_tip()

    # Setup T6
    def t6_setup() -> None:
        pipette.configure_nozzle_layout(
            style=ROW,
            start="H1",
            tip_racks=[t6],
        )
        for i in range(7):
            pipette.pick_up_tip()
            pipette.drop_tip()
    
    ### PICKUP TIP FUNCTIONS
    # These functions perform pickup tip behavior for a given tiprack
    
    # Pickup T2
    def t1_pickup() -> None:
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A1",
            tip_racks=[t1],
        )
        for i in range(48):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A12",
            tip_racks=[t1],
        )
        for i in range(48):
            pipette.pick_up_tip()
            pipette.drop_tip()

    # Pickup T2
    def t2_pickup() -> None:
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A1",
            tip_racks=[t2],
        )
        for i in range(15):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A12",
            tip_racks=[t2],
        )
        for i in range(15):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="H1",
            tip_racks=[t2],
        )
        for i in range(15):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="H12",
            tip_racks=[t2],
        )
        for i in range(15):
            pipette.pick_up_tip()
            pipette.drop_tip()

    # Pickup T3
    def t3_pickup() -> None:
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A1",
            tip_racks=[t3],
        )
        for i in range(30):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A12",
            tip_racks=[t3],
        )
        for i in range(30):
            pipette.pick_up_tip()
            pipette.drop_tip()
            
    # Pickup T4
    def t4_pickup() -> None:
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A1",
            tip_racks=[t4],
        )
        for i in range(10):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="A12",
            tip_racks=[t4],
        )
        for i in range(10):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="H1",
            tip_racks=[t4],
        )
        for i in range(10):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="H12",
            tip_racks=[t4],
        )
        for i in range(15):
            pipette.pick_up_tip()
            pipette.drop_tip()

    # Pickup T5
    def t5_pickup() -> None:
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="H1",
            tip_racks=[t5],
        )
        for i in range(5):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="H12",
            tip_racks=[t5],
        )
        for i in range(4):
            pipette.pick_up_tip()
            pipette.drop_tip()
    
    # Pickup T6
    def t6_pickup() -> None:
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="H1",
            tip_racks=[t6],
        )
        for i in range(6):
            pipette.pick_up_tip()
            pipette.drop_tip()
        pipette.configure_nozzle_layout(
            style=SINGLE,
            start="H12",
            tip_racks=[t6],
        )
        for i in range(6):
            pipette.pick_up_tip()
            pipette.drop_tip()

    ### Protocol Actions
    # Perform Setup of first set of tipracks
    protocol.move_labware(t1, "A1", True)
    t2_setup()
    protocol.move_labware(t2, "D1", True)
    t3_setup()
    protocol.move_labware(t3, "A3", True)
    t4_setup()
    protocol.move_labware(t4, "D3", True)

    # Clear out T2 first to make room for T5
    t2_pickup()
    protocol.move_labware(t5, "B2", True)
    t5_setup()
    protocol.move_labware(t5, "C1", True)

    # Clear out T1, T3, and T4
    t1_pickup()
    t3_pickup()
    protocol.move_labware(t6, "A4", True)
    t4_pickup()
    protocol.move_labware(t6, "D4", True)


    # Move T3, then move and handle T5
    protocol.move_labware(t3, "D2", True)
    protocol.move_labware(t5, "A3", True)
    t5_pickup()

    # Move T6 to On-Deck in B2 and setup, then move to A1 and handle
    protocol.move_labware(t6, "B2", True)
    t6_setup()
    protocol.move_labware(t1, "C3", True)
    protocol.move_labware(t6, "A1", True)
    t6_pickup()
```

## Changelog
Update the deck extents to allow desired movement. Removed test case that assumed Column A1 of a labware in Column 1 were unreachable. 

## Review requests
Take a look at the extents values being used and also the logical positions being reached on the deck in the test protocol. Does this extents limitation set make sense?
The numbers in the definition do not come from a hardware control document directly, but are the artificial limitations we introduce in deck space between the physical deck slot limits and the physical gantry limits. This "sweet spot" are our safe operational deck extents.

## Risk assessment
Medium - we should be sure that this passes the checks for our "do it all" protocols that access odd positions on the deck.