### PR TITLE
fix(app): disallow non .py or .json protocol upload

### DIFF
--- a/app/src/assets/localization/en/protocol_info.json
+++ b/app/src/assets/localization/en/protocol_info.json
@@ -25,6 +25,7 @@
   "import_a_file": "Import a protocol to get started",
   "import_new_protocol": "Import a Protocol",
   "import": "Import",
+  "incompatible_file_type": "Incompatible file type",
   "instrument_cal_data_title": "Calibration data",
   "instrument_not_attached": "Not attached",
   "instruments_title": "Required Pipettes",

--- a/app/src/organisms/ProtocolsLanding/ProtocolUploadInput.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolUploadInput.tsx
@@ -10,6 +10,7 @@ import {
   SPACING,
   LegacyStyledText,
 } from '@opentrons/components'
+import { ERROR_TOAST } from '../../atoms/Toast'
 import { UploadInput } from '../../molecules/UploadInput'
 import { addProtocol } from '../../redux/protocol-storage'
 import {
@@ -17,11 +18,16 @@ import {
   ANALYTICS_IMPORT_PROTOCOL_TO_APP,
 } from '../../redux/analytics'
 import { useLogger } from '../../logger'
+import { useToaster } from '../ToasterOven'
 
 import type { Dispatch } from '../../redux/types'
 
 export interface UploadInputProps {
   onUpload?: () => void
+}
+
+const isValidProtocolFileName = (protocolFileName: string): boolean => {
+  return protocolFileName.endsWith('.py') || protocolFileName.endsWith('.json')
 }
 
 export function ProtocolUploadInput(
@@ -31,17 +37,24 @@ export function ProtocolUploadInput(
   const dispatch = useDispatch<Dispatch>()
   const logger = useLogger(new URL('', import.meta.url).pathname)
   const trackEvent = useTrackEvent()
+  const { makeToast } = useToaster()
 
   const handleUpload = (file: File): void => {
     if (file.path === null) {
       logger.warn('Failed to upload file, path not found')
     }
-    dispatch(addProtocol(file.path))
+    if (isValidProtocolFileName(file.name)) {
+      dispatch(addProtocol(file.path))
+    } else {
+      makeToast(t('incompatible_file_type') as string, ERROR_TOAST, {
+        closeButton: true,
+      })
+    }
+    props.onUpload?.()
     trackEvent({
       name: ANALYTICS_IMPORT_PROTOCOL_TO_APP,
       properties: { protocolFileName: file.name },
     })
-    props.onUpload?.()
   }
 
   return (


### PR DESCRIPTION
# Overview

Analagous to our handling of non-.json custom labware upload, we want to disallow upload of .py or .json files on Desktop. Expected behavior is to check the filename extension of the prospective uploaded file (erring on the side of lenient acceptance), and close the slideout and make error toast if the extension is not .py or .json.

Closes RQA-2959

## Test Plan and Hands on Testing

- On Desktop, navigate to Protocols landing and select 'Import'
- On slideout, import a non-.json or .py file through file explorer or drag-and-drop
- Verify that slideout closes and "Incompatible file type" error toast renders
- Repeat with a .json or .py file and verify that slideout closes and protocol is added and analysis begins

With other protocols:

https://github.com/user-attachments/assets/62abbaf5-be48-4d9b-a5a7-5f2b43ddf4cb

With no other protocols:

https://github.com/user-attachments/assets/52b9025e-246b-4cb4-a859-65dad3d99b35

## Changelog

- Check attempted uploaded protocol file extension before adding protocol
- Make toast and close slideout if invalid file

## Review requests

- See code and test plan. If there is a different pattern for file type checking as specified in `isValidProtocolFileName`, I can update.

## Risk assessment

Low-medium. We want to allow any attempted upload within reasonable file type matching