### PR TITLE
refactor(robot-server): Interact with Paho from a single thread

### DIFF
--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -106,7 +106,7 @@ async def on_startup() -> None:
             fbl_mark_persistence_init_complete
         ],
     )
-    await initialize_notifications(
+    initialize_notifications(
         app_state=app.state,
     )
 

--- a/robot-server/robot_server/client_data/router.py
+++ b/robot-server/robot_server/client_data/router.py
@@ -72,7 +72,7 @@ async def put_client_data(  # noqa: D103
     ],
 ) -> SimpleBody[ClientData]:
     store.put(key, request_body.data)
-    await client_data_publisher.publish_client_data(key)
+    client_data_publisher.publish_client_data(key)
     return SimpleBody.construct(data=store.get(key))
 
 
@@ -124,7 +124,7 @@ async def delete_client_data(  # noqa: D103
             fastapi.status.HTTP_404_NOT_FOUND
         ) from e
     else:
-        await client_data_publisher.publish_client_data(key)
+        client_data_publisher.publish_client_data(key)
         return SimpleEmptyBody.construct()
 
 
@@ -142,5 +142,5 @@ async def delete_all_client_data(  # noqa: D103
     keys_that_will_be_deleted = store.get_keys()
     store.delete_all()
     for deleted_key in keys_that_will_be_deleted:
-        await client_data_publisher.publish_client_data(deleted_key)
+        client_data_publisher.publish_client_data(deleted_key)
     return SimpleEmptyBody.construct()

--- a/robot-server/robot_server/deck_configuration/store.py
+++ b/robot-server/robot_server/deck_configuration/store.py
@@ -70,7 +70,7 @@ class DeckConfigurationStore:  # noqa: D101
             await _write(
                 path=self._path, storable_deck_configuration=storable_deck_configuration
             )
-            await self._deck_configuration_publisher.publish_deck_configuration()
+            self._deck_configuration_publisher.publish_deck_configuration()
 
             return await self._get_assuming_locked()
 
@@ -92,7 +92,7 @@ class DeckConfigurationStore:  # noqa: D101
         """Delete the robot's current deck configuration, resetting it to the default."""
         async with self._lock:
             await self._path.unlink(missing_ok=True)
-            await self._deck_configuration_publisher.publish_deck_configuration()
+            self._deck_configuration_publisher.publish_deck_configuration()
 
     async def _get_assuming_locked(self) -> models.DeckConfigurationResponse:
         from_storage = await _read(self._path)

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -115,7 +115,7 @@ class MaintenanceRunDataManager:
             state_summary=state_summary,
         )
 
-        await self._maintenance_runs_publisher.publish_current_maintenance_run_async()
+        self._maintenance_runs_publisher.publish_current_maintenance_run()
 
         return maintenance_run_data
 
@@ -157,7 +157,7 @@ class MaintenanceRunDataManager:
         if run_id == self._run_orchestrator_store.current_run_id:
             await self._run_orchestrator_store.clear()
 
-            await self._maintenance_runs_publisher.publish_current_maintenance_run_async()
+            self._maintenance_runs_publisher.publish_current_maintenance_run()
 
         else:
             raise MaintenanceRunNotFoundError(run_id=run_id)

--- a/robot-server/robot_server/runs/run_controller.py
+++ b/robot-server/robot_server/runs/run_controller.py
@@ -116,6 +116,4 @@ class RunController:
             commands=result.commands,
             run_time_parameters=result.parameters,
         )
-        await self._runs_publisher.publish_pre_serialized_commands_notification(
-            self._run_id
-        )
+        self._runs_publisher.publish_pre_serialized_commands_notification(self._run_id)

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -211,7 +211,7 @@ class RunDataManager:
         self._run_store.insert_csv_rtp(
             run_id=run_id, run_time_parameters=run_time_parameters
         )
-        await self._runs_publisher.start_publishing_for_run(
+        self._runs_publisher.start_publishing_for_run(
             get_current_command=self.get_current_command,
             get_recovery_target_command=self.get_recovery_target_command,
             get_state_summary=self._get_good_state_summary,
@@ -306,7 +306,7 @@ class RunDataManager:
         if run_id == self._run_orchestrator_store.current_run_id:
             await self._run_orchestrator_store.clear()
 
-        await self._runs_publisher.clean_up_run(run_id=run_id)
+        self._runs_publisher.clean_up_run(run_id=run_id)
 
         self._run_store.remove(run_id=run_id)
 
@@ -351,15 +351,13 @@ class RunDataManager:
                 commands=commands,
                 run_time_parameters=parameters,
             )
-            await self._runs_publisher.publish_pre_serialized_commands_notification(
-                run_id
-            )
+            self._runs_publisher.publish_pre_serialized_commands_notification(run_id)
         else:
             state_summary = self._run_orchestrator_store.get_state_summary()
             parameters = self._run_orchestrator_store.get_run_time_parameters()
             run_resource = self._run_store.get(run_id=run_id)
 
-        await self._runs_publisher.publish_runs_advise_refetch_async(run_id)
+        self._runs_publisher.publish_runs_advise_refetch(run_id)
 
         return _build_run(
             run_resource=run_resource,

--- a/robot-server/robot_server/service/notifications/initialize_notifications.py
+++ b/robot-server/robot_server/service/notifications/initialize_notifications.py
@@ -5,7 +5,7 @@ from .notification_client import initialize_notification_client
 from .publisher_notifier import initialize_pe_publisher_notifier
 
 
-async def initialize_notifications(app_state: AppState) -> None:
+def initialize_notifications(app_state: AppState) -> None:
     """Initialize the notification system for the given app state."""
     initialize_notification_client(app_state)
-    await initialize_pe_publisher_notifier(app_state)
+    initialize_pe_publisher_notifier(app_state)

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -214,7 +214,10 @@ async def clean_up_notification_client(app_state: AppState) -> None:
 
 def get_notification_client(
     app_state: Annotated[AppState, Depends(get_app_state)],
-) -> Optional[NotificationClient]:
+) -> NotificationClient:
     """Intended to be used by endpoint functions as a FastAPI dependency."""
     notification_client = _notification_client_accessor.get_from(app_state)
+    assert (
+        notification_client is not None
+    ), "Forgot to initialize notification client as part of server startup?"
     return notification_client

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -82,25 +82,9 @@ class NotificationClient:
         self._client.loop_stop()
         await to_thread.run_sync(self._client.disconnect)
 
-    async def publish_advise_refetch_async(self, topic: TopicName) -> None:
-        """Asynchronously publish a refetch message on a specific topic to the MQTT broker.
-
-        Args:
-            topic: The topic to publish the message on.
-        """
-        await to_thread.run_sync(self.publish_advise_refetch, topic)
-
-    async def publish_advise_unsubscribe_async(self, topic: TopicName) -> None:
-        """Asynchronously publish an unsubscribe message on a specific topic to the MQTT broker.
-
-        Args:
-            topic: The topic to publish the message on.
-        """
-        await to_thread.run_sync(self.publish_advise_unsubscribe, topic)
-
     def publish_advise_refetch(
         self,
-        topic: str,
+        topic: TopicName,
     ) -> None:
         """Publish a refetch message on a specific topic to the MQTT broker.
 
@@ -118,7 +102,7 @@ class NotificationClient:
 
     def publish_advise_unsubscribe(
         self,
-        topic: str,
+        topic: TopicName,
     ) -> None:
         """Publish an unsubscribe message on a specific topic to the MQTT broker.
 

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -154,7 +154,7 @@ class NotificationClient:
         if rc == 0:
             log.info("Successfully connected to MQTT broker.")
         else:
-            log.info(f"Failed to connect to MQTT broker with reason code: {rc}")
+            log.error(f"Failed to connect to MQTT broker with reason code: {rc}")
 
     def _on_disconnect(
         self,
@@ -174,7 +174,7 @@ class NotificationClient:
         if rc == 0:
             log.info("Successfully disconnected from MQTT broker.")
         else:
-            log.info(f"Failed to disconnect from MQTT broker with reason code: {rc}")
+            log.error(f"Failed to disconnect from MQTT broker with reason code: {rc}")
 
 
 _notification_client_accessor: AppStateAccessor[NotificationClient] = AppStateAccessor[
@@ -192,8 +192,11 @@ def initialize_notification_client(app_state: AppState) -> None:
 
     try:
         notification_client.connect()
-    except Exception as error:
-        log.info(f"Could not successfully connect to notification server: {error}")
+    except Exception:
+        log.warning(
+            "Could not successfully connect to MQTT broker. Is this a dev server?",
+            exc_info=True,
+        )
 
 
 async def clean_up_notification_client(app_state: AppState) -> None:

--- a/robot-server/robot_server/service/notifications/publisher_notifier.py
+++ b/robot-server/robot_server/service/notifications/publisher_notifier.py
@@ -26,8 +26,11 @@ class PublisherNotifier:
         """Extend the list of callbacks with a given list of callbacks."""
         self._callbacks.extend(callbacks)
 
-    async def _initialize(self) -> None:
+    def _initialize(self) -> None:
         """Initializes an instance of PublisherNotifier. This method should only be called once."""
+        # fixme(mm, 2024-08-20): This task currently leaks; this class needs a close()
+        # method or something. This gets easier when app_setup.py switches to using a
+        # context manager for ASGI app setup and teardown.
         self._notifier = asyncio.create_task(self._wait_for_event())
 
     def _notify_publishers(self) -> None:
@@ -67,7 +70,7 @@ def get_pe_notify_publishers(
     return publisher_notifier._notify_publishers
 
 
-async def initialize_pe_publisher_notifier(app_state: AppState) -> None:
+def initialize_pe_publisher_notifier(app_state: AppState) -> None:
     """Create a new `NotificationClient` and store it on `app_state`.
 
     Intended to be called just once, when the server starts up.
@@ -77,4 +80,4 @@ async def initialize_pe_publisher_notifier(app_state: AppState) -> None:
     )
     _pe_publisher_notifier_accessor.set_on(app_state, publisher_notifier)
 
-    await publisher_notifier._initialize()
+    publisher_notifier._initialize()

--- a/robot-server/robot_server/service/notifications/publishers/client_data_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/client_data_publisher.py
@@ -13,11 +13,9 @@ class ClientDataPublisher:
     def __init__(self, client: NotificationClient) -> None:
         self._client = client
 
-    async def publish_client_data(self, client_data_key: str) -> None:
+    def publish_client_data(self, client_data_key: str) -> None:
         """Publish the equivalent of `GET /clientData/{key}`."""
-        await self._client.publish_advise_refetch_async(
-            topics.client_data(client_data_key)
-        )
+        self._client.publish_advise_refetch(topics.client_data(client_data_key))
 
 
 async def get_client_data_publisher(

--- a/robot-server/robot_server/service/notifications/publishers/deck_configuration_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/deck_configuration_publisher.py
@@ -18,11 +18,11 @@ class DeckConfigurationPublisher:
         """Returns a configured Deck Configuration Publisher."""
         self._client = client
 
-    async def publish_deck_configuration(
+    def publish_deck_configuration(
         self,
     ) -> None:
         """Publishes the equivalent of GET /deck_configuration"""
-        await self._client.publish_advise_refetch_async(topic=topics.DECK_CONFIGURATION)
+        self._client.publish_advise_refetch(topic=topics.DECK_CONFIGURATION)
 
 
 _deck_configuration_publisher_accessor: AppStateAccessor[

--- a/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
@@ -18,14 +18,6 @@ class MaintenanceRunsPublisher:
         """Returns a configured Maintenance Runs Publisher."""
         self._client = client
 
-    async def publish_current_maintenance_run_async(
-        self,
-    ) -> None:
-        """Publishes the equivalent of GET /maintenance_run/current_run"""
-        await self._client.publish_advise_refetch_async(
-            topic=topics.MAINTENANCE_RUNS_CURRENT_RUN
-        )
-
     def publish_current_maintenance_run(
         self,
     ) -> None:

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -199,7 +199,7 @@ async def test_create_play_action_to_start(
             commands=protocol_commands,
             run_time_parameters=run_time_parameters,
         ),
-        await mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
+        mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
         times=1,
     )
 

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -661,11 +661,11 @@ async def test_update_current(
     result = await subject.update(run_id=run_id, current=False)
 
     decoy.verify(
-        await mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
+        mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
         times=1,
     )
     decoy.verify(
-        await mock_runs_publisher.publish_runs_advise_refetch_async(run_id),
+        mock_runs_publisher.publish_runs_advise_refetch(run_id),
         times=1,
     )
     assert result == Run(
@@ -720,7 +720,7 @@ async def test_update_current_noop(
             commands=matchers.Anything(),
             run_time_parameters=matchers.Anything(),
         ),
-        await mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
+        mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
         times=0,
     )
 

--- a/robot-server/tests/service/notifications/publishers/test_deck_configuration_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_deck_configuration_publisher.py
@@ -1,31 +1,30 @@
 """Tests for the deck configuration publisher."""
 import pytest
-from unittest.mock import AsyncMock
+from decoy import Decoy
 
 from robot_server.service.notifications import DeckConfigurationPublisher, topics
+from robot_server.service.notifications.notification_client import NotificationClient
 
 
 @pytest.fixture
-def notification_client() -> AsyncMock:
+def notification_client(decoy: Decoy) -> NotificationClient:
     """Mocked notification client."""
-    return AsyncMock()
+    return decoy.mock(cls=NotificationClient)
 
 
 @pytest.fixture
 def deck_configuration_publisher(
-    notification_client: AsyncMock,
+    notification_client: NotificationClient,
 ) -> DeckConfigurationPublisher:
     """Instantiate DeckConfigurationPublisher."""
     return DeckConfigurationPublisher(notification_client)
 
 
-@pytest.mark.asyncio
-async def test_publish_current_maintenance_run(
-    notification_client: AsyncMock,
+def test_publish_current_maintenance_run(
+    notification_client: NotificationClient,
     deck_configuration_publisher: DeckConfigurationPublisher,
+    decoy: Decoy,
 ) -> None:
     """It should publish a notify flag for deck configuration updates."""
-    await deck_configuration_publisher.publish_deck_configuration()
-    notification_client.publish_advise_refetch_async.assert_awaited_once_with(
-        topic=topics.DECK_CONFIGURATION
-    )
+    deck_configuration_publisher.publish_deck_configuration()
+    decoy.verify(notification_client.publish_advise_refetch(topics.DECK_CONFIGURATION))

--- a/robot-server/tests/service/notifications/publishers/test_maintenance_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_maintenance_runs_publisher.py
@@ -1,30 +1,32 @@
 """Tests for the maintenance runs publisher."""
 import pytest
-from unittest.mock import AsyncMock
+from decoy import Decoy
 
 from robot_server.service.notifications import MaintenanceRunsPublisher, topics
+from robot_server.service.notifications.notification_client import NotificationClient
 
 
 @pytest.fixture
-def notification_client() -> AsyncMock:
+def notification_client(decoy: Decoy) -> NotificationClient:
     """Mocked notification client."""
-    return AsyncMock()
+    return decoy.mock(cls=NotificationClient)
 
 
 @pytest.fixture
 def maintenance_runs_publisher(
-    notification_client: AsyncMock,
+    notification_client: NotificationClient,
 ) -> MaintenanceRunsPublisher:
     """Instantiate MaintenanceRunsPublisher."""
     return MaintenanceRunsPublisher(notification_client)
 
 
-@pytest.mark.asyncio
-async def test_publish_current_maintenance_run(
-    notification_client: AsyncMock, maintenance_runs_publisher: MaintenanceRunsPublisher
+def test_publish_current_maintenance_run(
+    notification_client: NotificationClient,
+    maintenance_runs_publisher: MaintenanceRunsPublisher,
+    decoy: Decoy,
 ) -> None:
     """It should publish a notify flag for maintenance runs."""
-    await maintenance_runs_publisher.publish_current_maintenance_run_async()
-    notification_client.publish_advise_refetch_async.assert_awaited_once_with(
-        topic=topics.MAINTENANCE_RUNS_CURRENT_RUN
+    maintenance_runs_publisher.publish_current_maintenance_run()
+    decoy.verify(
+        notification_client.publish_advise_refetch(topics.MAINTENANCE_RUNS_CURRENT_RUN)
     )

--- a/robot-server/tests/service/notifications/test_publisher_notifier.py
+++ b/robot-server/tests/service/notifications/test_publisher_notifier.py
@@ -8,15 +8,6 @@ from robot_server.service.notifications import (
 )
 
 
-async def test_initialize() -> None:
-    """It should create a new task."""
-    publisher_notifier = PublisherNotifier(ChangeNotifier())
-
-    await publisher_notifier._initialize()
-
-    assert asyncio.get_running_loop()
-
-
 def test_notify_publishers() -> None:
     """Invoke the change notifier's notify method."""
     change_notifier = MagicMock()
@@ -65,11 +56,9 @@ async def test_wait_for_event() -> None:
         await asyncio.sleep(0.1)
         change_notifier.notify()
 
-    task = asyncio.create_task(publisher_notifier._initialize())
+    publisher_notifier._initialize()
 
-    await asyncio.gather(trigger_callbacks(), task)
+    await asyncio.gather(trigger_callbacks())
 
     assert callback_called
     assert callback_2_called
-
-    task.cancel()


### PR DESCRIPTION
## Overview

Closes EXEC-685. See that ticket for explanation.

## Test Plan and Hands on Testing

* [x] Push this to a real robot, click around, and make sure notifications are still basically working.

## Changelog

* Remove all multithreaded access to Paho. We should now exclusively interact with it through robot-server's main FastAPI thread.
* A few other minor refactors. See the commit messages for details.

## Review requests

Double-check my understanding of how Paho works. If I'm wrong about its [`publish()`](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.publish) method being non-blocking, this risks stalling all of robot-server. For example, if some Paho buffer fills up, robot-server will stop responding to `GET /health` requests until it's drained.

## Risk assessment

Low-ish, but see review requests.