### PR TITLE
fix(app): fix robotType condition for overflow menu in protocol card

### DIFF
--- a/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
@@ -74,9 +74,7 @@ export function ProtocolOverflowMenu(
   }, true)
 
   const robotType =
-    mostRecentAnalysis != null && mostRecentAnalysis.errors.length === 0
-      ? mostRecentAnalysis?.robotType ?? null
-      : null
+    mostRecentAnalysis != null ? mostRecentAnalysis?.robotType ?? null : null
 
   const handleClickShowInFolder: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
@@ -117,6 +115,7 @@ export function ProtocolOverflowMenu(
     navigate(`/protocols/${protocolKey}/timeline`)
     setShowOverflowMenu(prevShowOverflowMenu => !prevShowOverflowMenu)
   }
+
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix robotType condition for overflow menu in protocol card since robotType is not null even when a protocol gets failed.
the issue was checking Array error size and robotType was `null` when an OT-2 protocol was failed.
then overflow menu displays `send to robot`.

https://github.com/user-attachments/assets/d2d2a156-ddeb-4844-bd8d-7c26188fae01

protocol that is attached to the ticket
![Screenshot 2024-08-21 at 6 57 45 PM](https://github.com/user-attachments/assets/ef78bdfd-c22e-434d-87d4-fc4e16bb5720)


close RQA-3066

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
check the following cases
- valid OT-2 protocol -> not display send to flex
- invalid OT-2 protocol -> not display send to flex
- valid Flex protocol -> display send to flex
- invalid Flex protocol -> display send to flex 
- test the protocol Josh attached
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
