### PR TITLE
fix(app): Fix React Router navigation in React Query callbacks

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -126,14 +126,20 @@ export function useProtocolReceiptToast(): void {
 
 export function useCurrentRunRoute(): string | null {
   const currentRunId = useCurrentRunId({ refetchInterval: CURRENT_RUN_POLL })
-  const { data: runRecord } = useNotifyRunQuery(currentRunId, {
-    staleTime: Infinity,
-    enabled: currentRunId != null,
+  const { data: runRecord, isFetching } = useNotifyRunQuery(currentRunId, {
+    refetchInterval: CURRENT_RUN_POLL,
   })
 
   const runStatus = runRecord?.data.status
   const runActions = runRecord?.data.actions
-  if (runRecord == null || runStatus == null || runActions == null) return null
+  if (
+    runRecord == null ||
+    runStatus == null ||
+    runActions == null ||
+    isFetching
+  ) {
+    return null
+  }
   // grabbing run id off of the run query to have all routing info come from one source of truth
   const runId = runRecord.data.id
   const hasRunStarted = runActions?.some(

--- a/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloseCurrentRun.ts
@@ -23,10 +23,10 @@ export function useCloseCurrentRun(): {
   ): void => {
     if (currentRunId != null) {
       dismissCurrentRun(currentRunId, {
-        ...options,
         onError: () => {
           console.warn('failed to dismiss current')
         },
+        ...options,
       })
     }
   }

--- a/app/src/resources/runs/useNotifyAllRunsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllRunsQuery.ts
@@ -8,26 +8,36 @@ import type { HostConfig, GetRunsParams, Runs } from '@opentrons/api-client'
 import type { UseAllRunsQueryOptions } from '@opentrons/react-api-client/src/runs/useAllRunsQuery'
 import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
 
+// TODO(jh, 08-21-24): Abstract harder.
 export function useNotifyAllRunsQuery(
   params: GetRunsParams = {},
   options: QueryOptionsWithPolling<UseAllRunsQueryOptions, AxiosError> = {},
   hostOverride?: HostConfig | null
 ): UseQueryResult<Runs, AxiosError> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const {
+    notifyOnSettled,
+    shouldRefetch,
+    isNotifyEnabled,
+  } = useNotifyDataReady({
     topic: 'robot-server/runs',
     options,
     hostOverride,
   })
 
+  const queryOptions = {
+    ...options,
+    onSettled: isNotifyEnabled ? notifyOnSettled : options.onSettled,
+    refetchInterval: isNotifyEnabled ? false : options.refetchInterval,
+  }
   const httpResponse = useAllRunsQuery(
     params,
-    {
-      ...(options as UseAllRunsQueryOptions),
-      enabled: options?.enabled !== false && shouldRefetch,
-      onSettled: notifyOnSettled,
-    },
+    queryOptions as UseAllRunsQueryOptions,
     hostOverride
   )
+
+  if (isNotifyEnabled && shouldRefetch) {
+    httpResponse.refetch()
+  }
 
   return httpResponse
 }

--- a/app/src/resources/useNotifyDataReady.ts
+++ b/app/src/resources/useNotifyDataReady.ts
@@ -16,7 +16,7 @@ import type { UseQueryOptions } from 'react-query'
 import type { HostConfig } from '@opentrons/api-client'
 import type { NotifyTopic, NotifyResponseData } from '../redux/shell/types'
 
-export type HTTPRefetchFrequency = 'once' | 'always' | null
+export type HTTPRefetchFrequency = 'once' | null
 
 export interface QueryOptionsWithPolling<TData, TError = Error>
   extends UseQueryOptions<TData, TError> {
@@ -30,10 +30,20 @@ interface useNotifyDataReadyProps<TData, TError = Error> {
 }
 
 interface useNotifyDataReadyResults {
+  /* Reset notification refetch state. */
   notifyOnSettled: () => void
+  /* Whether notifications indicate the server has new data ready. */
   shouldRefetch: boolean
+  /* Whether notifications are enabled as determined by client options and notification health. */
+  isNotifyEnabled: boolean
 }
 
+// React query hooks perform refetches when instructed by the shell via a refetch mechanism, which useNotifyDataReady manages.
+// The notification refetch states may be:
+// 'once' - The shell has received an MQTT update. Execute the HTTP refetch once.
+// null - The shell has not received an MQTT update. Don't execute an HTTP refetch.
+//
+// Eagerly assume notifications are enabled unless specified by the client via React Query options or by the shell via errors.
 export function useNotifyDataReady<TData, TError = Error>({
   topic,
   options,
@@ -47,6 +57,7 @@ export function useNotifyDataReady<TData, TError = Error>({
   const forcePollingFF = useFeatureFlag('forceHttpPolling')
   const seenHostname = React.useRef<string | null>(null)
   const [refetch, setRefetch] = React.useState<HTTPRefetchFrequency>(null)
+  const [isNotifyEnabled, setIsNotifyEnabled] = React.useState(true)
 
   const { enabled, staleTime, forceHttpPolling } = options
 
@@ -69,7 +80,7 @@ export function useNotifyDataReady<TData, TError = Error>({
       dispatch(notifySubscribeAction(hostname, topic))
       seenHostname.current = hostname
     } else {
-      setRefetch('always')
+      setIsNotifyEnabled(false)
     }
 
     return () => {
@@ -86,7 +97,7 @@ export function useNotifyDataReady<TData, TError = Error>({
 
   const onDataEvent = React.useCallback((data: NotifyResponseData): void => {
     if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
-      setRefetch('always')
+      setIsNotifyEnabled(false)
       if (data === 'ECONNREFUSED') {
         doTrackEvent({
           name: ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
@@ -104,5 +115,9 @@ export function useNotifyDataReady<TData, TError = Error>({
     }
   }, [refetch])
 
-  return { notifyOnSettled, shouldRefetch: refetch != null }
+  return {
+    notifyOnSettled,
+    shouldRefetch: refetch != null,
+    isNotifyEnabled,
+  }
 }


### PR DESCRIPTION
Closes [RQA-3063](https://opentrons.atlassian.net/browse/RQA-3063) and partially closes [RQA-3038](https://opentrons.atlassian.net/browse/RQA-3038)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR addresses a few issues that have sprung up after the recent React Router migration.

### Why after the React Router Migration?

The working hypothesis is there is some lower-level difference between how `history.push` and `navigate` function. More specifically, `history.push` _seems_ to cause additional render cycles to occur, which while bad in terms of performance, bailed us out of a few of our own React Query bugs. Upgrades to React Router, which replace `history.push` with `navigate` seem to have reduced these non-performant extra render cycles but exposed some of the pre-existing bugs within our own code.

### The User-Presenting Problem

When performing a `navigate` within a post-Query callback (onSettled, onSuccess, etc) on the ODD, `useCurrentRunRoute` is the major consideration: with data provided by `useCurrentRunId` and `useNotifyRunQuery`, it makes decisions on whether the ODD should be on a particular route. In order to manually navigate somewhere while `useCurrentRunRoute` thinks we should be somewhere else, we first have to clear `useCurrentRunId`, then we can navigate. Our hooks, specifically the `closeCurrentRun` hook in this case, sends out a `PATCH` request, then clears the query caches on response, then returns the fresh data. 

In practice, what happens is the following:

1. We click the "return to dashboard" button. This sends out our `PATCH` request.
2. We do not navigate the user until this request completes. Using one of the post-Query callbacks, we navigate the user.
3. The user hits the dashboard. Fresh data says there is no current run.
4. We are often (but not always) routed back to the Run Summary page unexpectedly. 
5. Clicking the "return to dashboard" button again seemingly always redirects us to the dashboard.

### The Solutions

A few fixes are required to get the intended behavior, as each fix exposes a lower-level problem each time.

### Fix 1: `closeCurrentRun` swallows post-Query callbacks

The hook only executes if there is a current run. If there is no current run, nothing happens. If something else closes the run (say the desktop), no `onSuccess` callback will ever execute. The fix here is the new `closeCurrentRunIfValid` wrapper in `RunSummary/index.tsx`. Although we really should change the behavior of the hook itself, it was decided that since we have to migrate away from all these query callbacks soon anyway, we might as well keep the blast radius smaller (especially since this is a `chore_release` fix). 

Oh yeah, also, we were overriding any `onError` callback with a custom `console.log`, which doesn't seem right, so I changed the order of operations here.

### Fix 2: `useNotifyDataReady` and `useNotify` hooks.

It's not very intuitive, but the[ React Query docs](https://tanstack.com/query/v4/docs/framework/react/guides/disabling-queries) make it pretty clear that if a query is disabled, then "The query will ignore query client `invalidateQueries` and `refetchQueries` calls that would normally result in the query refetching." The `notify` hooks explicitly keep the HTTP hook disabled UNTIL the server tells us to refetch. This was done to prevent passed-in `refetchInterval`s from causing polling, but this is clearly the wrong approach.

The above was causing the following behavior:

1. We click the "return to dashboard" button. This sends out our `PATCH` request.
2. We do not navigate the user until this request completes. Using one of the post-Query callbacks, we navigate the user.
3. The user hits the dashboard. Fresh data has NOT yet returned because MQTT controls whether or not the hook is enabled, and we are always disabled immediately after the `closeCurrentRun` hook returns, because MQTT takes some milliseconds to tell the app that the hook needs to be enabled. Yes, the cache data is correctly cleared on the query key, but for that specific hook, which is disabled, the cache is preserved. 

So that's the bug - the hook is `disabled`, which means we use the stale cache data. This redirects us back to `RunSummary`. The network request completes usually a few MS later, and that's what always allows the second click to work.

This isn't too bad to fix, actually. Instead of conditionally enabling the hook, we always keep it enabled, and instead we just conditionally use a `refetchInterval` is one is present and otherwise only refetch when the shell tells us to refetch.

### Fix 3: `useCurrentRunRoute`

Yeah...so it turns out we also had logic in the app for keeping `useNotifyRunQuery` disabled if `currentRunId` is `null`. So guess what? This still results in stale data even after fixing the MQTT issue. This isn't a recent thing: this `enabled` condition has existed for the entirety of `useCurrentRunRoute`. The reason it's only entirely blocking now is that we fixed the other bugs, and MQTT is very fast, so it's very apparent that we're using stale cached, non-invalidated data. Prior to MQTT, polling was slow, so you'd get a 5 second window for fetching the `runRecord` before the `currentRun` went to null and disabled the hook. In other words, this has always been a bug, but it likely occurred only on the occasion in practice. 

The solution here is just to remove the enabled condition. This DOES mean we ask the server for a run record with a `null` runId once in a while, but I don't think there's any way around it. React Router doesn't seem to provide us a way to update the cache on invalidations but not actually perform a refetch if runId is null. It seems we get `enabled` and nothing else to work with. 

### Fix 3.5: Some Cleanup

- We use `navigate('/')` instead of `navigate('/dashboard/)`, and this does seem to make navigation a bit slower (granted, this is entirely anecdotal, since I didn't actually test this claim). More importantly, we don't actually have a root route, so I think it's probably better not to assume how React Router works/doens't work.
- I added `isFetching` as a condition to `useCurrentRunRoute`. I really do think we want this, since this acts as insurance in case we have improperly set up query key invalidation, which has several points of failure. This doesn't add any user-noticeable latency, and I think it might actually solve some weird blippiness that occurs occasionally. 


### TODO but (not in `chore_release`)

Yeah, we need a new layer of abstraction for the notification logic, as it's clearly leaking into the notification hooks themselves. Because this is `chore_release`, I've decided to keep fixes as localized as possible instead of risking larger issues with app-side networking.

I do plan on following up on this for 8.1, sooner rather than later.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- I ran probably 20 protocol runs and couldn't repro this with the PR's changes. It was something like 1/2-1/3 times before these changes. 
- Smoke tested the app to ensure nothing is totally broken.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed clicking "return to dashboard" sometimes not navigating users to the dashboard.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish-medium. This touches some pretty fundamental app networking code, but it's nothing as scary as it sounds.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3038]: https://opentrons.atlassian.net/browse/RQA-3038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-3063]: https://opentrons.atlassian.net/browse/RQA-3063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ