### PR TITLE
fix(shared-data): add filter tipracks to newest version of the 96 channel def

### DIFF
--- a/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/default/3_6.json
+++ b/shared-data/pipette/definitions/2/liquid/ninety_six_channel/p1000/default/3_6.json
@@ -180,6 +180,9 @@
   "defaultTipracks": [
     "opentrons/opentrons_flex_96_tiprack_1000ul/1",
     "opentrons/opentrons_flex_96_tiprack_200ul/1",
-    "opentrons/opentrons_flex_96_tiprack_50ul/1"
+    "opentrons/opentrons_flex_96_tiprack_50ul/1",
+    "opentrons/opentrons_flex_96_filtertiprack_1000ul/1",
+    "opentrons/opentrons_flex_96_filtertiprack_200ul/1",
+    "opentrons/opentrons_flex_96_filtertiprack_50ul/1"
   ]
 }


### PR DESCRIPTION
fix RQA-3053

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Filter tipracks were missing from the `defaultTipracks` list on the 3.6 version of the 96 channel liquid specs
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
On the select tiprack screen of Quick Transfer when selecting a 96 channel, filter tipracks should now be visible 
<img width="1035" alt="Screen Shot 2024-08-21 at 3 14 34 PM" src="https://github.com/user-attachments/assets/86e6bbbf-f567-4001-9503-6f2358254ed3">

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Matched 3.6 `defaultTipracks` list with the list for every other 96 channel version
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Is there any reason we wouldn't want to add these?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
