### PR TITLE
fix(app): quick transfer uses C2 for aspirate and dispense if labware is the same

### DIFF
--- a/app/src/assets/localization/en/quick_transfer.json
+++ b/app/src/assets/localization/en/quick_transfer.json
@@ -117,7 +117,7 @@
   "set_transfer_volume": "Set transfer volume",
   "source": "Source",
   "source_labware": "Source labware",
-  "source_labware_d2": "Source labware in D2",
+  "source_labware_c2": "Source labware in C2",
   "starting_well": "starting well",
   "storage_limit_reached": "Storage limit reached",
   "tip_drop_location": "Tip drop location",

--- a/app/src/organisms/QuickTransferFlow/SelectDestLabware.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectDestLabware.tsx
@@ -118,8 +118,8 @@ export function SelectDestLabware(
               onChange={() => {
                 setSelectedLabware('source')
               }}
-              buttonLabel={t('source_labware_d2')}
-              buttonValue="source-labware-d2"
+              buttonLabel={t('source_labware_c2')}
+              buttonValue="source-labware-c2"
               subButtonLabel={state.source.metadata.displayName}
             />
           ) : null}

--- a/app/src/organisms/QuickTransferFlow/__tests__/SelectDestLabware.test.tsx
+++ b/app/src/organisms/QuickTransferFlow/__tests__/SelectDestLabware.test.tsx
@@ -96,7 +96,7 @@ describe('SelectDestLabware', () => {
       },
     })
     render(props)
-    screen.getByText('Source labware in D2')
+    screen.getByText('Source labware in C2')
     screen.getByText('source labware name')
   })
   it('enables continue button if you select a labware', () => {
@@ -109,7 +109,7 @@ describe('SelectDestLabware', () => {
     })
     const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
     expect(continueBtn).toBeDisabled()
-    const sourceLabware = screen.getByText('Source labware in D2')
+    const sourceLabware = screen.getByText('Source labware in C2')
     fireEvent.click(sourceLabware)
     expect(continueBtn).toBeEnabled()
   })

--- a/app/src/organisms/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -299,7 +299,6 @@ export function generateQuickTransferArgs(
   const flowRatesForSupportedTip =
     quickTransferState.pipette.liquids.default.supportedTips[tipType]
   const pipetteEntity = Object.values(invariantContext.pipetteEntities)[0]
-  const labwareEntityValues = Object.values(invariantContext.labwareEntities)
 
   const sourceLabwareId = Object.keys(robotState.labware).find(
     key => robotState.labware[key].slot === 'C2'

--- a/app/src/organisms/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -300,17 +300,32 @@ export function generateQuickTransferArgs(
     quickTransferState.pipette.liquids.default.supportedTips[tipType]
   const pipetteEntity = Object.values(invariantContext.pipetteEntities)[0]
   const labwareEntityValues = Object.values(invariantContext.labwareEntities)
-  const sourceLabwareEntity = labwareEntityValues.find(
-    entity =>
-      entity.labwareDefURI === getLabwareDefURI(quickTransferState.source)
+
+  const sourceLabwareId = Object.keys(robotState.labware).find(
+    key => robotState.labware[key].slot === 'C2'
   )
+  const sourceLabwareEntity =
+    sourceLabwareId != null
+      ? invariantContext.labwareEntities[sourceLabwareId]
+      : labwareEntityValues.find(
+          entity =>
+            entity.labwareDefURI === getLabwareDefURI(quickTransferState.source)
+        )
   let destLabwareEntity = sourceLabwareEntity
   if (quickTransferState.destination !== 'source') {
-    destLabwareEntity = labwareEntityValues.find(
-      entity =>
-        entity.labwareDefURI ===
-        getLabwareDefURI(quickTransferState.destination as LabwareDefinition2)
+    const destinationLabwareId = Object.keys(robotState.labware).find(
+      key => robotState.labware[key].slot === 'D2'
     )
+    destLabwareEntity =
+      destinationLabwareId != null
+        ? invariantContext.labwareEntities[destinationLabwareId]
+        : labwareEntityValues.find(
+            entity =>
+              entity.labwareDefURI ===
+              getLabwareDefURI(
+                quickTransferState.destination as LabwareDefinition2
+              )
+          )
   }
 
   let nozzles = null

--- a/app/src/organisms/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -301,7 +301,7 @@ export function generateQuickTransferArgs(
   const pipetteEntity = Object.values(invariantContext.pipetteEntities)[0]
 
   const sourceLabwareId = Object.keys(robotState.labware).find(
-    key => robotState.labware[key].slot === 'C2'
+    labwareId => robotState.labware[labwareId].slot === 'C2'
   )
   const sourceLabwareEntity =
     sourceLabwareId != null
@@ -310,7 +310,7 @@ export function generateQuickTransferArgs(
   let destLabwareEntity = sourceLabwareEntity
   if (quickTransferState.destination !== 'source') {
     const destinationLabwareId = Object.keys(robotState.labware).find(
-      key => robotState.labware[key].slot === 'D2'
+      labwareId => robotState.labware[labwareId].slot === 'D2'
     )
     destLabwareEntity =
       destinationLabwareId != null

--- a/app/src/organisms/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -307,10 +307,7 @@ export function generateQuickTransferArgs(
   const sourceLabwareEntity =
     sourceLabwareId != null
       ? invariantContext.labwareEntities[sourceLabwareId]
-      : labwareEntityValues.find(
-          entity =>
-            entity.labwareDefURI === getLabwareDefURI(quickTransferState.source)
-        )
+      : undefined
   let destLabwareEntity = sourceLabwareEntity
   if (quickTransferState.destination !== 'source') {
     const destinationLabwareId = Object.keys(robotState.labware).find(
@@ -319,13 +316,7 @@ export function generateQuickTransferArgs(
     destLabwareEntity =
       destinationLabwareId != null
         ? invariantContext.labwareEntities[destinationLabwareId]
-        : labwareEntityValues.find(
-            entity =>
-              entity.labwareDefURI ===
-              getLabwareDefURI(
-                quickTransferState.destination as LabwareDefinition2
-              )
-          )
+        : undefined
   }
 
   let nozzles = null


### PR DESCRIPTION
fix RQA-3073

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
If you choose to load two of the same labware in C2 and D2 for quick transfer, both labware were getting loaded in the protocol but the labware in C2 was being used for both aspiration and dispense. This is because of the way I was grabbing the labware entities in `generateQuickTransferArgs`. This PR fixes that discrepancy by grabbing the entity by labware location as opposed to labwareUri which will match for identical labware 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Go through QT and select two of the same labware for source and destination (do not choose the "source labware" option for destination)
Create a transfer, and examine the file logged in dev tools. The ID used for the `loadLabware` command for slot D2 will now match the ID used for the `dispense` command
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Corrected copy for "source labware" option on the destination labware selection screen
2. Changed the way we get the `sourceLabwareEntity` and `destLabwareEntity` in `generateQuickTransferArgs` to first grab the labware id that corresponds to the correct location from the robot state

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over code, I've tested this out
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
