### PR TITLE
fix(app): Location conflicts in ODD run setup

### DIFF
--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -36,7 +36,6 @@ import {
   getDeckDefFromRobotType,
   getModuleDisplayName,
   getFixtureDisplayName,
-  SINGLE_SLOT_FIXTURES,
 } from '@opentrons/shared-data'
 
 import {

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -449,11 +449,7 @@ function PrepareToRun({
       const isCurrentFixtureCompatible =
         cutoutFixtureId != null &&
         compatibleCutoutFixtureIds.includes(cutoutFixtureId)
-      return (
-        !isCurrentFixtureCompatible &&
-        cutoutFixtureId != null &&
-        !SINGLE_SLOT_FIXTURES.includes(cutoutFixtureId)
-      )
+      return !isCurrentFixtureCompatible && cutoutFixtureId != null
     }
   )
   const isLocationConflict = locationConflictSlots.some(


### PR DESCRIPTION
For some reason, the logic in the location conflict checking in
specifically the ODD run setup top level is different from everywhere
else and was not counting location conflicts where the thing that was
currently loaded was a slot plate. This caused any situation where a
module was requested by the protocol but not loaded in the deck config
to not display the right warning:

- connecting a connectable module but not loading it in
deck config would cause the warning to be "calibration required" (which
isn't right)
- requesting something like a magblock in the protocol but having a slot
would cause there to be no warning at all

Removing the thing where we only count conflicts if the thing that's
loaded isn't a slot fixes both of these. I have no idea why this was
here.

## Testing
- [x] Load a protocol that wants a thermocycler, connect the thermocycler, don't load it in deck config. should say location conflict
- [x] load a protocol that wants a magblock, don't configure it; should say location conflict

Closes RQA-2985, RQA-3068
