### PR TITLE
fix(app): fix Recent Run Protocol Card onClick routing behavior

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -38,7 +38,7 @@ import { useMissingProtocolHardware } from '../../../pages/Protocols/hooks'
 import { useCloneRun } from '../../ProtocolUpload/hooks'
 import { useRerunnableStatusText } from './hooks'
 
-import type { Run, RunData, RunStatus } from '@opentrons/api-client'
+import type { RunData, RunStatus } from '@opentrons/api-client'
 import type { ProtocolResource } from '@opentrons/shared-data'
 
 interface RecentRunProtocolCardProps {
@@ -142,7 +142,7 @@ export function ProtocolWithLastRun({
       cloneRun()
       // Navigate to a dummy setup skeleton until TopLevelRedirects routes to the proper setup page. Doing so prevents
       // needing to manage complex UI state updates for protocol cards, overzealous dashboard rendering, and potential navigation pitfalls.
-      navigate(`/runs/1234/setup`)
+      navigate('/runs/1234/setup')
       trackEvent({
         name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
         properties: { sourceLocation: 'RecentRunProtocolCard' },

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -88,10 +88,7 @@ export function ProtocolWithLastRun({
   const trackEvent = useTrackEvent()
   // TODO(BC, 08/29/23): reintroduce this analytics event when we refactor the hook to fetch data lazily (performance concern)
   // const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runData.id)
-  const onResetSuccess = (createRunResponse: Run): void => {
-    navigate(`runs/${createRunResponse.data.id}/setup`)
-  }
-  const { cloneRun } = useCloneRun(runData.id, onResetSuccess)
+  const { cloneRun } = useCloneRun(runData.id)
   const [showSpinner, setShowSpinner] = React.useState<boolean>(false)
 
   const protocolName =
@@ -143,6 +140,9 @@ export function ProtocolWithLastRun({
       navigate(`/protocols/${protocolId}`)
     } else {
       cloneRun()
+      // Navigate to a dummy setup skeleton until TopLevelRedirects routes to the proper setup page. Doing so prevents
+      // needing to manage complex UI state updates for protocol cards, overzealous dashboard rendering, and potential navigation pitfalls.
+      navigate(`/runs/1234/setup`)
       trackEvent({
         name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
         properties: { sourceLocation: 'RecentRunProtocolCard' },

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -158,9 +158,10 @@ describe('RecentRunProtocolCard', () => {
     when(useTrackProtocolRunEvent).calledWith(RUN_ID, ROBOT_NAME).thenReturn({
       trackProtocolRunEvent: mockTrackProtocolRunEvent,
     })
-    when(useCloneRun)
-      .calledWith(RUN_ID, expect.anything())
-      .thenReturn({ cloneRun: mockCloneRun, isLoading: false })
+    vi.mocked(useCloneRun).mockReturnValue({
+      cloneRun: mockCloneRun,
+      isLoading: false,
+    })
   })
 
   afterEach(() => {

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -36,10 +36,13 @@ export function useCloneRun(
         'protocols',
         protocolKey,
       ])
-      Promise.all([invalidateRuns, invalidateProtocols]).catch((e: Error) => {
-        console.error(`error invalidating runs query: ${e.message}`)
-      })
-      if (onSuccessCallback != null) onSuccessCallback(response)
+      Promise.all([invalidateRuns, invalidateProtocols])
+        .then(() => {
+          onSuccessCallback?.(response)
+        })
+        .catch((e: Error) => {
+          console.error(`error invalidating runs query: ${e.message}`)
+        })
     },
   })
   const { createProtocolAnalysis } = useCreateProtocolAnalysisMutation(


### PR DESCRIPTION
Closes [RQA-3038](https://opentrons.atlassian.net/browse/RQA-3038)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a longstanding issue (although the severity and presentation of the underlying issue has varied over time) in which clicking on a `RecentRunProtocolCard` often leads to unexpected UI updates, full screen re-renders, and routing problems.

See #16084 for more explanation on why routing issues are more prevalent this release (and why QA is probably now filing these existing issues more aggressively). 

The `RecentRunProtocolCard` actively navigates to a page managed by `TopLevelRedirects`, and the code that caused the active navigation existed before MQTT effectively made these redirects instantaneous (and deprecating the need for active redirects to pages managed by `TopLevelRedirects`). In other words, we really don't have to do any navigation here at all, but that leads to two questions:

- What's actually causing this bug?
- What happens if we just let `TopLevelRedirects` do the navigation?

First, it's difficult to pinpoint exactly what's causing the unexpected routing behavior, however, it very much appears that:

- It's almost certainly not `TopLevelRedirects` itself. I verified this with extensive console.logging. Note that this logic doesn't do anything when the app thinks we should still be on the dashboard.
- It's almost certainly some extra render cycles occurring somewhere in the app as a result of the `cloneRun` function, which does a good bit of query invalidation. It's quite difficult to pinpoint exactly what's causing the full on dashboard re-rendering to occur (see the current behavior video), because we don't actually have React Devtools on the physical ODD (yeah, I should probably look into this). 

So what does a good fix look like? If we just let `TopLevelRedirects` passively navigate us, we unfortunately get some wonky, but expected UI. The protocol cards are sorted based on timestamps, so the cards shuffle around when you click a card, the timestamps change a few times, and THEN we see the navigation occur cleanly.

A much simpler and effective solution is to actively navigate to a fake `RunSetup` page. This solves the above problem (users don't see crazy shuffling cards), and it plays well with `TopLevelRedirects` (this component doesn't do anything until the real setup route is valid, and then it redirects us to that route cleanly).


### Current Behavior 

Some variation of the following:

https://github.com/user-attachments/assets/a0cc66d1-9871-403d-9108-1a66d1523cb5


https://github.com/user-attachments/assets/4a066e9b-4ff7-489e-ad5f-cab250a0d463

### Fixed Behavior

https://github.com/user-attachments/assets/ca73c043-9dfe-48d2-a064-5a1ccb24bb70


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed odd routing behavior when clicking on protocol cards.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3038]: https://opentrons.atlassian.net/browse/RQA-3038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ