### PR TITLE
fix(robot-server): allow partial network info

### DIFF
--- a/robot-server/robot_server/service/legacy/routers/networking.py
+++ b/robot-server/robot_server/service/legacy/routers/networking.py
@@ -1,10 +1,10 @@
 import logging
 import os
 import subprocess
+from typing import Optional
 
 from starlette import status
 from starlette.responses import JSONResponse
-from typing import Optional
 from fastapi import APIRouter, HTTPException, File, Path, UploadFile, Query
 
 from opentrons_shared_data.errors import ErrorCodes
@@ -45,8 +45,20 @@ router = APIRouter()
 async def get_networking_status() -> NetworkingStatus:
     try:
         connectivity = await nmcli.is_connected()
-        # TODO(mc, 2020-09-17): interfaces should be typed
-        interfaces = {i.value: await nmcli.iface_info(i) for i in nmcli.NETWORK_IFACES}
+
+        async def _permissive_get_iface(
+            i: nmcli.NETWORK_IFACES,
+        ) -> dict[str, dict[str, str | None]]:
+            try:
+                return {i.value: await nmcli.iface_info(i)}
+            except ValueError:
+                log.warning(f"Could not get state of iface {i.value}")
+                return {}
+
+        interfaces: dict[str, dict[str, str | None]] = {}
+        for interface in nmcli.NETWORK_IFACES:
+            this_iface = await _permissive_get_iface(interface)
+            interfaces.update(this_iface)
         log.debug(f"Connectivity: {connectivity}")
         log.debug(f"Interfaces: {interfaces}")
         return NetworkingStatus(


### PR DESCRIPTION
We have a single route that gets all the network info for the machine. If the system command to get info for one of the interfaces failed, the route as a whole would fail. We don't want that, because we want to get the rest of the information. Instead, let's catch teh error in the general overview endpoint, and return whatever information we have.

Closes RQA-3000
