### PR TITLE
docs(api): fix syntax error in cherrypicking use case

### DIFF
--- a/api/docs/v2/parameters/use_case_cherrypicking.rst
+++ b/api/docs/v2/parameters/use_case_cherrypicking.rst
@@ -123,9 +123,9 @@ The entire start of the ``run()`` function, including a pipette and fixed labwar
             instrument_name="flex_1channel_1000",
             mount="left",
             tip_racks=[tiprack]
+        )
         # load trash bin
         trash = protocol.load_trash_bin("A3")
-        )
         # load destination plate in deck slot C2
         dest_plate = protocol.load_labware(
             load_name="opentrons_96_wellplate_200ul_pcr_full_skirt",


### PR DESCRIPTION

# Overview

Thanks to @alexjoel42 for [noticing this syntax error](https://github.com/Opentrons/opentrons/pull/15910#issuecomment-2304798466) in the cherrypicking use case. I think I tried to shift loading the trash bin lower in the protocol and left it one line short of where it needed to go.

## Test Plan and Hands on Testing

I simulated the whole code block, no modifications except indentation, promise.

## Changelog

🆙 

## Risk assessment

none