### PR TITLE
refactor(protocol-designer): fix nav bar from rerouting unnecessarily

### DIFF
--- a/protocol-designer/src/NavigationBar.tsx
+++ b/protocol-designer/src/NavigationBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { NavLink, useLocation, useNavigate } from 'react-router-dom'
+import { NavLink, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -13,27 +13,18 @@ import {
   SPACING,
   StyledText,
 } from '@opentrons/components'
-import { getFileMetadata } from './file-data/selectors'
 import { actions as loadFileActions } from './load-file'
 import type { ThunkDispatch } from './types'
 
 export function NavigationBar(): JSX.Element {
   const { t } = useTranslation('shared')
-  const metadata = useSelector(getFileMetadata)
   const location = useLocation()
   const dispatch: ThunkDispatch<any> = useDispatch()
-  const navigate = useNavigate()
   const loadFile = (
     fileChangeEvent: React.ChangeEvent<HTMLInputElement>
   ): void => {
     dispatch(loadFileActions.loadProtocolFile(fileChangeEvent))
   }
-
-  React.useEffect(() => {
-    if (metadata?.created != null) {
-      navigate('/overview')
-    }
-  }, [metadata, navigate])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>


### PR DESCRIPTION
# Overview

Oops i'm pretty sure the use effect is not needed? but it was breaking the ability to go to deck setup. It seems to work as expected without it.

## Test Plan and Hands on Testing

Import a protocol from the nav bar and see that it redirects to the overview page and works as expected

## Changelog

remove use effect

## Risk assessment

low
