### PR TITLE
feat(protocol-designer): display toast for auto-loaded hardware

### DIFF
--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -19,6 +19,6 @@
   "starting_deck_state": "Starting deck state",
   "tipRack": "Tip rack",
   "tubeRack": "Tube rack",
-  "we_added_hardware": "We've added your deck hardware!",
+  "we_added_hardware": "We've added your deck hardware and tip racks!",
   "wellPlate": "Well plate"
 }

--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -4,6 +4,7 @@
   "add_fixture": "Add a fixture",
   "add_labware": "Add labware",
   "add_module": "Add a module",
+  "add_rest": "Add labware and liquids to complete deck setup",
   "aluminumBlock": "Aluminum block",
   "clear": "Clear",
   "custom_labware": "Add custom labware",
@@ -18,5 +19,6 @@
   "starting_deck_state": "Starting deck state",
   "tipRack": "Tip rack",
   "tubeRack": "Tube rack",
+  "we_added_hardware": "We've added your deck hardware!",
   "wellPlate": "Well plate"
 }

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -1,15 +1,27 @@
 import * as React from 'react'
-
-import { Tabs } from '@opentrons/components'
-
+import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
+import { INFO_TOAST, Tabs } from '@opentrons/components'
+
+import { useKitchen } from '../../organisms/Kitchen/hooks'
+import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
+import { getFileMetadata } from '../../file-data/selectors'
 import { DeckSetupContainer } from './DeckSetup'
 
 export function Designer(): JSX.Element {
   const { t } = useTranslation(['starting_deck_state', 'protocol_steps'])
+  const { bakeToast } = useKitchen()
+  const deckSetup = useSelector(getDeckSetupForActiveItem)
+  const metadata = useSelector(getFileMetadata)
   const [tab, setTab] = React.useState<'startingDeck' | 'protocolSteps'>(
     'startingDeck'
   )
+  const { modules, additionalEquipmentOnDeck } = deckSetup
+  const hasHardware =
+    (modules != null && Object.values(modules).length > 0) ||
+    // greater than 1 to account for the default loaded trashBin
+    Object.values(additionalEquipmentOnDeck).length > 1
+
   const startingDeckTab = {
     text: t('protocol_starting_deck'),
     isActive: tab === 'startingDeck',
@@ -24,6 +36,16 @@ export function Designer(): JSX.Element {
       setTab('protocolSteps')
     },
   }
+
+  // only display toast if its a newly made protocol
+  React.useEffect(() => {
+    if (hasHardware && metadata?.lastModified == null) {
+      bakeToast(t('add_rest') as string, INFO_TOAST, {
+        heading: t('we_added_hardware'),
+        closeButton: true,
+      })
+    }
+  }, [hasHardware])
 
   return (
     <>

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -45,7 +45,7 @@ export function Designer(): JSX.Element {
         closeButton: true,
       })
     }
-  }, [hasHardware])
+  }, [hasHardware, metadata])
 
   return (
     <>


### PR DESCRIPTION
closes AUTH-683

# Overview

Adds the toast indicating what has been auto-generated on the deck setup for new protocols.

## Test Plan and Hands on Testing

Go through the onboarding wizard and add a module or an additional fixture (besides the trash bin), should see a toast render when you open deck setup. If you import a protocol, it should not render and if you haven't added additional hardware it should not render

## Changelog

- add toast logic

## Risk assessment

low
