### PR TITLE
fix(app): Fix continuing with no tips selected during Error Recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -174,6 +174,7 @@ interface UseTipSelectionUtilsResult {
   tipSelectorDef: LabwareDefinition2
   selectTips: (tipGroup: WellGroup) => void
   deselectTips: (locations: string[]) => void
+  areTipsSelected: boolean
 }
 
 // TODO(jh, 06-18-24): Enforce failure/warning when accessing tipSelectionUtils
@@ -215,11 +216,15 @@ function useTipSelectionUtils(
     []
   )
 
+  const areTipsSelected =
+    selectedLocs != null && Object.keys(selectedLocs).length > 0
+
   return {
     selectedTipLocations: selectedLocs,
     tipSelectorDef,
     selectTips,
     deselectTips,
+    areTipsSelected,
   }
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
@@ -76,7 +76,7 @@ export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
         </TwoColumn>
         <RecoveryFooterButtons
           primaryBtnOnClick={primaryBtnOnClick}
-          primaryBtnDisabled={failedLabwareUtils.selectedTipLocations == null}
+          primaryBtnDisabled={!failedLabwareUtils.areTipsSelected}
           secondaryBtnOnClick={goBackPrevStep}
           primaryBtnTextOverride={t('pick_up_tips')}
           {...buildTertiaryBtnProps()}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
@@ -17,6 +17,7 @@ export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
     routeUpdateActions,
     recoveryCommands,
     isOnDevice,
+    failedLabwareUtils,
   } = props
   const { ROBOT_PICKING_UP_TIPS } = RECOVERY_MAP
   const { pickUpTips } = recoveryCommands
@@ -75,6 +76,7 @@ export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
         </TwoColumn>
         <RecoveryFooterButtons
           primaryBtnOnClick={primaryBtnOnClick}
+          primaryBtnDisabled={failedLabwareUtils.selectedTipLocations == null}
           secondaryBtnOnClick={goBackPrevStep}
           primaryBtnTextOverride={t('pick_up_tips')}
           {...buildTertiaryBtnProps()}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TipSelectionModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TipSelectionModal.tsx
@@ -17,12 +17,10 @@ export function TipSelectionModal(
   props: TipSelectionModalProps
 ): JSX.Element | null {
   const { isOnDevice, toggleModal, failedLabwareUtils } = props
-  const { selectedTipLocations } = failedLabwareUtils
+  const { areTipsSelected } = failedLabwareUtils
   const { t } = useTranslation('error_recovery')
 
   // If users end up in a state in which they deselect all wells, don't let them escape this modal.
-  const areTipsSelected = selectedTipLocations != null
-
   const modalHeader: ModalHeaderBaseProps = {
     title: t('change_tip_pickup_location'),
     hasExitIcon: areTipsSelected,

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TipSelectionModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TipSelectionModal.tsx
@@ -16,17 +16,25 @@ type TipSelectionModalProps = TipSelectionProps & {
 export function TipSelectionModal(
   props: TipSelectionModalProps
 ): JSX.Element | null {
-  const { toggleModal } = props
+  const { isOnDevice, toggleModal, failedLabwareUtils } = props
+  const { selectedTipLocations } = failedLabwareUtils
   const { t } = useTranslation('error_recovery')
+
+  // If users end up in a state in which they deselect all wells, don't let them escape this modal.
+  const areTipsSelected = selectedTipLocations != null
 
   const modalHeader: ModalHeaderBaseProps = {
     title: t('change_tip_pickup_location'),
-    hasExitIcon: true,
+    hasExitIcon: areTipsSelected,
   }
 
-  if (props.isOnDevice) {
+  if (isOnDevice) {
     return createPortal(
-      <Modal header={modalHeader} onOutsideClick={toggleModal} zIndex={15}>
+      <Modal
+        header={modalHeader}
+        onOutsideClick={areTipsSelected ? toggleModal : undefined}
+        zIndex={15}
+      >
         <TipSelection {...props} />
       </Modal>,
       getTopPortalEl()

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SelectTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SelectTips.test.tsx
@@ -49,7 +49,10 @@ describe('SelectTips', () => {
           channels: 8,
         },
       } as any,
-      failedLabwareUtils: { selectedTipLocations: { A1: null } } as any,
+      failedLabwareUtils: {
+        selectedTipLocations: { A1: null },
+        areTipsSelected: true,
+      } as any,
     }
 
     vi.mocked(TipSelectionModal).mockReturnValue(
@@ -143,7 +146,10 @@ describe('SelectTips', () => {
   it('disables the primary button if tips are not selected', () => {
     props = {
       ...props,
-      failedLabwareUtils: { selectedTipLocations: null } as any,
+      failedLabwareUtils: {
+        selectedTipLocations: null,
+        areTipsSelected: false,
+      } as any,
     }
 
     render(props)

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SelectTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SelectTips.test.tsx
@@ -49,6 +49,7 @@ describe('SelectTips', () => {
           channels: 8,
         },
       } as any,
+      failedLabwareUtils: { selectedTipLocations: { A1: null } } as any,
     }
 
     vi.mocked(TipSelectionModal).mockReturnValue(
@@ -137,5 +138,20 @@ describe('SelectTips', () => {
       name: 'Change location',
     })
     expect(tertiaryBtn[0]).toBeDisabled()
+  })
+
+  it('disables the primary button if tips are not selected', () => {
+    props = {
+      ...props,
+      failedLabwareUtils: { selectedTipLocations: null } as any,
+    }
+
+    render(props)
+
+    const primaryBtn = screen.getAllByRole('button', {
+      name: 'Pick up tips',
+    })
+
+    expect(primaryBtn[0]).toBeDisabled()
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TipSelectionModal.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TipSelectionModal.test.tsx
@@ -24,7 +24,10 @@ describe('TipSelectionModal', () => {
       ...mockRecoveryContentProps,
       allowTipSelection: true,
       toggleModal: vi.fn(),
-      failedLabwareUtils: { selectedTipLocations: { A1: null } } as any,
+      failedLabwareUtils: {
+        selectedTipLocations: { A1: null },
+        areTipsSelected: true,
+      } as any,
     }
 
     vi.mocked(TipSelection).mockReturnValue(<div>MOCK TIP SELECTION</div>)
@@ -46,7 +49,7 @@ describe('TipSelectionModal', () => {
   it('prevents from users from exiting the modal if no well(s) are selected', () => {
     props = {
       ...props,
-      failedLabwareUtils: { selectedTipLocations: null } as any,
+      failedLabwareUtils: { areTipsSelected: false } as any,
     }
 
     render(props)

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TipSelectionModal.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TipSelectionModal.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { describe, it, vi, beforeEach } from 'vitest'
+import { describe, it, vi, beforeEach, expect } from 'vitest'
 import { screen } from '@testing-library/react'
 
 import { mockRecoveryContentProps } from '../../__fixtures__'
@@ -24,6 +24,7 @@ describe('TipSelectionModal', () => {
       ...mockRecoveryContentProps,
       allowTipSelection: true,
       toggleModal: vi.fn(),
+      failedLabwareUtils: { selectedTipLocations: { A1: null } } as any,
     }
 
     vi.mocked(TipSelection).mockReturnValue(<div>MOCK TIP SELECTION</div>)
@@ -39,5 +40,17 @@ describe('TipSelectionModal', () => {
     render(props)
 
     screen.getByText('MOCK TIP SELECTION')
+    screen.getByLabelText('closeIcon')
+  })
+
+  it('prevents from users from exiting the modal if no well(s) are selected', () => {
+    props = {
+      ...props,
+      failedLabwareUtils: { selectedTipLocations: null } as any,
+    }
+
+    render(props)
+
+    expect(screen.queryByLabelText('closeIcon')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes [RQA-3083](https://opentrons.atlassian.net/browse/RQA-3083)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

During tip selection in Error Recovery, if a user clicks around enough, it's sometimes possible to get into a state in which no tips are selected. The user then may proceed with recovery, failing recovery since no tips are selected. 

This PR just adds some safeguards, so if a user does try to proceed with no active tips selected, the proceed CTAs are disabled. On the ODD, the user can't close the modal until they select tips. On the desktop (and also on the ODD technically, although this is unreachable due to the modal disabled state), the "Pick up tips" button is disabled.

Although a more direct solution would be to debug the state update handler, this bug is pretty difficult to repro in practice, and it seems to be somewhat difficult to solve for without delving into `WellLocation`, which is a pretty high risk component to be messing with right before a release. This fix is low risk, and adding these kind of disabled states if users get into weird spots is probably good UI practice, anyway.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

- [x] Verified that the X button on the ODD during tip selection disappears when no tips are selected (mash tip selection like 100x to repro this).
- [x] Verified that the "Pick up tips" button the desktop during tip selection disappears when no tips are selected (see above). 

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a bug in which users may proceed through error recovery with no tips selected.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Unless someone wants to test this themselves, I will test this on Tuesday in office (and merge it then if approval comes before Tuesday). 
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3083]: https://opentrons.atlassian.net/browse/RQA-3083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ