### PR TITLE
docs(api): fix version added statement syntax for LPD param of `load_instrument()`

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -915,6 +915,7 @@ class ProtocolContext(CommandPublisher):
                              from the Opentrons App or touchscreen.
         :param bool liquid_presence_detection: If ``True``, enable automatic
             :ref:`liquid presence detection <lpd>` for Flex 1-, 8-, or 96-channel pipettes.
+
             .. versionadded:: 2.20
         """
         instrument_name = validation.ensure_lowercase_name(instrument_name)


### PR DESCRIPTION
# Overview

As if Python having semantic indenting wasn't bad enough, Sphinx also has semantic newlines.

## Test Plan and Hands on Testing

before
<img width="491" alt="image" src="https://github.com/user-attachments/assets/7ad2d179-6861-4918-bbd8-434ca2495df1">

after
<img width="476" alt="image" src="https://github.com/user-attachments/assets/3f7b3c5c-741f-4405-8ce4-b57149c52a69">


## Changelog

one (1) byte

## Risk assessment

0️⃣ 