### PR TITLE
fix(components): fix SecondaryButton disabled cursor

### DIFF
--- a/components/src/atoms/buttons/SecondaryButton.tsx
+++ b/components/src/atoms/buttons/SecondaryButton.tsx
@@ -55,6 +55,7 @@ export const SecondaryButton = styled.button.withConfig<SecondaryButtonProps>({
     box-shadow: none;
     border-color: ${COLORS.grey30};
     color: ${COLORS.grey40};
+    cursor: default;
   }
 
   ${styleProps}


### PR DESCRIPTION
# Overview

add pointer cursor style to disabled pseudo class for SecondaryButton

RQA-3069

## Test Plan and Hands on Testing

- begin a run that will produce a blocked state for LPC (incorrect instruments/modules attached, for example)
- on run setup, expand LPC step
- hover over "confirm offsets" button and verify that cursor is default rather than pointer

## Changelog

- update `SecondaryButton` disabled cursor

## Review requests

see test plan

## Risk assessment

low