### PR TITLE
fix(app): fix run context not closing on the OT-2 after cancelled run

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -309,9 +309,9 @@ export function ProtocolRunHeader({
       // TODO(jh, 08-15-24): The enteredER condition is a hack, because errorCommands are only returned when a run is current.
       // Ideally the run should not need to be current to view errorCommands.
 
-      // Close the run if no tips are attached after running tip check at least once.
+      // Close the run if no tips are attached after running tip check at least once. Post-run tip checks only occur on the Flex.
       // This marks the robot as "not busy" as soon as a run is cancelled if drop tip CTAs are unnecessary.
-      if (initialPipettesWithTipsCount === 0 && !enteredER) {
+      if ((initialPipettesWithTipsCount === 0 || !isFlex) && !enteredER) {
         closeCurrentRun({
           onSettled: () => {
             if (isQuickTransfer) {


### PR DESCRIPTION
Closes [RQA-3090](https://opentrons.atlassian.net/browse/RQA-3090) and [RQA-3062](https://opentrons.atlassian.net/browse/RQA-3062)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In #16069, we properly close the run context...for Flexes only. Because we don't do tip status checks on the OT-2 post-run, the `initialPipettesWithTipsCount` is never populated, so the run never closes. This leads to unexpected behavior, like not being able to calibrate your OT-2 anymore, do normal post-run things, etc. 

### Current Behavior

https://github.com/user-attachments/assets/1dd3ba12-4247-4346-8b63-1c878e90d8d1

### Fixed Behavior

https://github.com/user-attachments/assets/d5fe39ec-cf5e-410f-981d-7de0384b1d2c


 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed not being able to do post-run calibration, setup, etc. on the OT-2.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3090]: https://opentrons.atlassian.net/browse/RQA-3090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-3062]: https://opentrons.atlassian.net/browse/RQA-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ