### PR TITLE
fix(app): analysis banner show scroll bar only when needed

### DIFF
--- a/app/src/organisms/ProtocolAnalysisFailure/index.tsx
+++ b/app/src/organisms/ProtocolAnalysisFailure/index.tsx
@@ -121,7 +121,7 @@ export function ProtocolAnalysisFailure(
 }
 
 const SCROLL_LONG = css`
-  overflow: scroll;
+  overflow: auto;
   width: inherit;
   max-height: 11.75rem;
 `


### PR DESCRIPTION
# Overview

closes [RQA-3091](https://opentrons.atlassian.net/browse/RQA-3091).
add overflow scroll when needed. 

## Test Plan and Hands on Testing

make sure long text analysis messages have a scroll bar and short messages do not.

## Changelog

`overflow: auto`


[RQA-3091]: https://opentrons.atlassian.net/browse/RQA-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ