### PR TITLE
fix(app): fix users not directed to "run preview" when starting a run

### DIFF
--- a/app/src/pages/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Devices/ProtocolRunDetails/index.tsx
@@ -322,12 +322,13 @@ const SetupTab = (props: SetupTabProps): JSX.Element | null => {
     'not_available_for_a_completed_run'
   )}`
 
-  // On the initial render only, navigate to "run preview" if the run has started.
+  // On the initial render or when a run first begins, navigate to "run preview" if the run has started.
+  // If "run again" is clicked, the user should NOT be directed back to the "setup" tab.
   React.useEffect(() => {
-    if (runHasStarted && protocolRunDetailsTab === 'setup') {
+    if (runHasStarted && protocolRunDetailsTab !== 'run-preview') {
       navigate(`/devices/${robotName}/protocol-runs/${runId}/run-preview`)
     }
-  }, [])
+  }, [runHasStarted])
 
   return (
     <RoundTab


### PR DESCRIPTION
Closes [RQA-3092](https://opentrons.atlassian.net/browse/RQA-3092)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We want users to be directed to the run preview panel (from any tab, not just the setup tab) when a run has started. We still want to ensure that users can still navigate to all tabs (which is why the dependency array is the way it is). See the code comment above the `useEffect` for the intended behavior. 


### Current Behavior

https://github.com/user-attachments/assets/1022142d-2043-48f5-8abe-1207a0e0dad1

### Fixed Behavior


https://github.com/user-attachments/assets/fb619b88-0286-419e-a7fc-cdf58be060d0

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Starting a run now properly navigates users to the "run preview" tab.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3092]: https://opentrons.atlassian.net/browse/RQA-3092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ