### PR TITLE
fix(app): disable view error details button if run is cancelled without ER

### DIFF
--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -182,12 +182,14 @@ export function RunSummary(): JSX.Element {
         RUN_STATUSES_TERMINAL.includes(runStatus) &&
         isRunCurrent,
     }
-  )
+    
   // TODO(jh, 08-14-24): The backend never returns the "user cancelled a run" error and cancelledWithoutRecovery becomes unnecessary.
+  const cancelledWithoutRecovery =
+    !enteredER && runStatus === RUN_STATUS_STOPPED
   const hasCommandErrors =
     commandErrorList != null && commandErrorList.data.length > 0
   const disableErrorDetailsBtn = !(
-    hasCommandErrors ||
+    (hasCommandErrors && !cancelledWithoutRecovery) ||
     (runRecord?.data.errors != null && runRecord?.data.errors.length > 0)
   )
 

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -182,7 +182,8 @@ export function RunSummary(): JSX.Element {
         RUN_STATUSES_TERMINAL.includes(runStatus) &&
         isRunCurrent,
     }
-    
+  )
+
   // TODO(jh, 08-14-24): The backend never returns the "user cancelled a run" error and cancelledWithoutRecovery becomes unnecessary.
   const cancelledWithoutRecovery =
     !enteredER && runStatus === RUN_STATUS_STOPPED


### PR DESCRIPTION
closes [RQA-3088](https://opentrons.atlassian.net/browse/RQA-3088)
when a run is cancelled without ER we need to disable the button.
currently working on desktop app but not on odd.

# Overview

enable button if the command errors are not as a result of a cancel run.

## Test Plan and Hands on Testing

- [x] explanation in ticket

## Risk assessment

low.


[RQA-3088]: https://opentrons.atlassian.net/browse/RQA-3088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ