### PR TITLE
 feat(protocol-designer): make dev ffs accessible in the redesign

### DIFF
--- a/protocol-designer/src/Bouncing.tsx
+++ b/protocol-designer/src/Bouncing.tsx
@@ -1,28 +1,7 @@
 import * as React from 'react'
 import { css } from 'styled-components'
-import { useDispatch, useSelector } from 'react-redux'
-import { createPortal } from 'react-dom'
-import { useTranslation } from 'react-i18next'
-import {
-  Box,
-  Btn,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  Icon,
-  JUSTIFY_END,
-  JUSTIFY_SPACE_BETWEEN,
-  Modal,
-  POSITION_ABSOLUTE,
-  PrimaryButton,
-  SPACING,
-  SecondaryButton,
-  StyledText,
-} from '@opentrons/components'
-import { getTopPortalEl } from './components/portals/TopPortal'
-import { getFeatureFlagData } from './feature-flags/selectors'
-import { userFacingFlags, actions as featureFlagActions } from './feature-flags'
-import type { FlagTypes } from './feature-flags'
+import { Box, COLORS, POSITION_ABSOLUTE } from '@opentrons/components'
+import { FeatureFlagsModal } from './organisms'
 
 interface Location {
   x: number
@@ -30,68 +9,12 @@ interface Location {
 }
 
 export const Bouncing = (): JSX.Element => {
-  const { t } = useTranslation(['feature_flags', 'shared'])
-  const flags = useSelector(getFeatureFlagData)
-  const dispatch = useDispatch()
   const [isDragging, setIsDragging] = React.useState<boolean>(false)
   const [position, setPosition] = React.useState<Location>({ x: 100, y: 100 })
   const [velocity, setVelocity] = React.useState<Location>({ x: 2, y: 2 })
   const [isPaused, setIsPaused] = React.useState<boolean>(false)
   const [isStopped, setIsStopped] = React.useState<boolean>(false)
   const [showFeatureFlags, setShowFeatureFlags] = React.useState<boolean>(false)
-  const allFlags = Object.keys(flags) as FlagTypes[]
-
-  const prereleaseFlagNames = allFlags.filter(
-    flagName => !userFacingFlags.includes(flagName)
-  )
-
-  const getDescription = (flag: FlagTypes): string => {
-    return t(`feature_flags:${flag}.description`)
-  }
-
-  const setFeatureFlags = (
-    flags: Partial<Record<FlagTypes, boolean | null | undefined>>
-  ): void => {
-    dispatch(featureFlagActions.setFeatureFlags(flags))
-  }
-
-  const toFlagRow = (flagName: FlagTypes): JSX.Element => {
-    const iconName = Boolean(flags[flagName])
-      ? 'ot-toggle-input-on'
-      : 'ot-toggle-input-off'
-
-    return (
-      <Flex key={flagName} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-        <Flex flexDirection={DIRECTION_COLUMN}>
-          <StyledText desktopStyle="bodyDefaultSemiBold">
-            {t(`feature_flags:${flagName}.title`)}
-          </StyledText>
-          <StyledText desktopStyle="bodyDefaultRegular">
-            {getDescription(flagName)}
-          </StyledText>
-        </Flex>
-        <Btn
-          role="switch"
-          aria-checked={Boolean(flags[flagName])}
-          size="2rem"
-          css={
-            Boolean(flags[flagName])
-              ? TOGGLE_ENABLED_STYLES
-              : TOGGLE_DISABLED_STYLES
-          }
-          onClick={() => {
-            setFeatureFlags({
-              [flagName as string]: !flags[flagName],
-            })
-          }}
-        >
-          <Icon name={iconName} height="1rem" />
-        </Btn>
-      </Flex>
-    )
-  }
-
-  const prereleaseFlagRows = prereleaseFlagNames.map(toFlagRow)
 
   const divSize = 50
 
@@ -164,55 +87,14 @@ export const Bouncing = (): JSX.Element => {
 
   return (
     <>
-      {showFeatureFlags
-        ? createPortal(
-            <Modal
-              width="40rem"
-              type="warning"
-              title="Developer Feature Flags"
-              onClose={() => {
-                setShowFeatureFlags(false)
-                setIsPaused(false)
-              }}
-              footer={
-                <Flex
-                  padding={SPACING.spacing16}
-                  justifyContent={JUSTIFY_END}
-                  gridGap={SPACING.spacing8}
-                >
-                  <SecondaryButton
-                    onClick={() => {
-                      setIsStopped(prev => !prev)
-                      setIsPaused(false)
-                    }}
-                  >
-                    {isStopped ? 'Resume bounce' : 'Stop ball from bouncing'}
-                  </SecondaryButton>
-                  <PrimaryButton
-                    onClick={() => {
-                      setShowFeatureFlags(false)
-                    }}
-                  >
-                    {t('shared:close')}
-                  </PrimaryButton>
-                </Flex>
-              }
-              closeOnOutsideClick
-            >
-              <StyledText desktopStyle="bodyDefaultRegular">
-                For internal use only.
-              </StyledText>
-              <Flex
-                flexDirection="column"
-                marginTop={SPACING.spacing16}
-                gridGap={SPACING.spacing16}
-              >
-                {prereleaseFlagRows}
-              </Flex>
-            </Modal>,
-            getTopPortalEl()
-          )
-        : null}
+      {showFeatureFlags ? (
+        <FeatureFlagsModal
+          isStopped={isStopped}
+          setIsStopped={setIsStopped}
+          setIsPaused={setIsPaused}
+          setShowFeatureFlags={setShowFeatureFlags}
+        />
+      ) : null}
 
       <Box
         onClick={() => {
@@ -241,35 +123,3 @@ export const Bouncing = (): JSX.Element => {
     </>
   )
 }
-
-const TOGGLE_DISABLED_STYLES = css`
-  color: ${COLORS.grey50};
-
-  &:hover {
-    color: ${COLORS.grey55};
-  }
-
-  &:focus-visible {
-    box-shadow: 0 0 0 3px ${COLORS.yellow50};
-  }
-
-  &:disabled {
-    color: ${COLORS.grey30};
-  }
-`
-
-const TOGGLE_ENABLED_STYLES = css`
-  color: ${COLORS.blue50};
-
-  &:hover {
-    color: ${COLORS.blue55};
-  }
-
-  &:focus-visible {
-    box-shadow: 0 0 0 3px ${COLORS.yellow50};
-  }
-
-  &:disabled {
-    color: ${COLORS.grey30};
-  }
-`

--- a/protocol-designer/src/Bouncing.tsx
+++ b/protocol-designer/src/Bouncing.tsx
@@ -1,0 +1,276 @@
+import * as React from 'react'
+import { css } from 'styled-components'
+import { useDispatch, useSelector } from 'react-redux'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  Btn,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  JUSTIFY_END,
+  JUSTIFY_SPACE_BETWEEN,
+  Modal,
+  POSITION_ABSOLUTE,
+  PrimaryButton,
+  SPACING,
+  SecondaryButton,
+  StyledText,
+} from '@opentrons/components'
+import { getTopPortalEl } from './components/portals/TopPortal'
+import { getFeatureFlagData } from './feature-flags/selectors'
+import {
+  FlagTypes,
+  userFacingFlags,
+  actions as featureFlagActions,
+} from './feature-flags'
+
+interface Location {
+  x: number
+  y: number
+}
+
+export const Bouncing = (): JSX.Element => {
+  const { t } = useTranslation(['feature_flags', 'shared'])
+  const flags = useSelector(getFeatureFlagData)
+  const dispatch = useDispatch()
+  const [isDragging, setIsDragging] = React.useState<boolean>(false)
+  const [position, setPosition] = React.useState<Location>({ x: 100, y: 100 })
+  const [velocity, setVelocity] = React.useState<Location>({ x: 2, y: 2 })
+  const [isPaused, setIsPaused] = React.useState<boolean>(false)
+  const [isStopped, setIsStopped] = React.useState<boolean>(false)
+  const [showFeatureFlags, setShowFeatureFlags] = React.useState<boolean>(false)
+  const allFlags = Object.keys(flags) as FlagTypes[]
+
+  const prereleaseFlagNames = allFlags.filter(
+    flagName => !userFacingFlags.includes(flagName)
+  )
+
+  const getDescription = (flag: FlagTypes): string => {
+    return t(`feature_flags:${flag}.description`)
+  }
+
+  const setFeatureFlags = (
+    flags: Partial<Record<FlagTypes, boolean | null | undefined>>
+  ): void => {
+    dispatch(featureFlagActions.setFeatureFlags(flags))
+  }
+
+  const toFlagRow = (flagName: FlagTypes): JSX.Element => {
+    const iconName = Boolean(flags[flagName])
+      ? 'ot-toggle-input-on'
+      : 'ot-toggle-input-off'
+
+    return (
+      <Flex key={flagName} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <StyledText desktopStyle="bodyDefaultSemiBold">
+            {t(`feature_flags:${flagName}.title`)}
+          </StyledText>
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {getDescription(flagName)}
+          </StyledText>
+        </Flex>
+        <Btn
+          role="switch"
+          aria-checked={Boolean(flags[flagName])}
+          size="2rem"
+          css={
+            Boolean(flags[flagName])
+              ? TOGGLE_ENABLED_STYLES
+              : TOGGLE_DISABLED_STYLES
+          }
+          onClick={() => {
+            setFeatureFlags({
+              [flagName as string]: !flags[flagName],
+            })
+          }}
+        >
+          <Icon name={iconName} height="1rem" />
+        </Btn>
+      </Flex>
+    )
+  }
+
+  const prereleaseFlagRows = prereleaseFlagNames.map(toFlagRow)
+
+  const divSize = 50
+
+  React.useEffect(() => {
+    if (!isPaused && !isStopped) {
+      const moveDiv = () => {
+        const screenWidth = window.innerWidth
+        const screenHeight = window.innerHeight
+
+        setPosition(prevPosition => {
+          let newX = prevPosition.x + velocity.x
+          let newY = prevPosition.y + velocity.y
+
+          if (newX <= 0 || newX + divSize >= screenWidth) {
+            setVelocity(prevVelocity => ({
+              ...prevVelocity,
+              x: prevVelocity.x * -1,
+            }))
+          }
+          if (newY <= 0 || newY + divSize >= screenHeight) {
+            setVelocity(prevVelocity => ({
+              ...prevVelocity,
+              y: prevVelocity.y * -1,
+            }))
+          }
+
+          return { x: newX, y: newY }
+        })
+      }
+
+      const intervalId = setInterval(moveDiv, 10)
+
+      return () => clearInterval(intervalId)
+    }
+  }, [velocity, isPaused, isStopped])
+
+  const handleMouseEnter = (): void => {
+    if (!isStopped) {
+      setIsPaused(true)
+    }
+  }
+
+  const handleMouseLeave = (): void => {
+    if (!isStopped) {
+      setIsPaused(false)
+    }
+  }
+
+  const handleMouseDown = (): void => {
+    if (isStopped) {
+      setIsDragging(true)
+    }
+  }
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>): void => {
+    if (isDragging) {
+      const newX = e.clientX - divSize / 2
+      const newY = e.clientY - divSize / 2
+      setPosition({ x: newX, y: newY })
+    }
+  }
+
+  const handleMouseUp = (): void => {
+    if (isDragging) {
+      setIsDragging(false)
+    }
+  }
+
+  return (
+    <>
+      {showFeatureFlags
+        ? createPortal(
+            <Modal
+              width="40rem"
+              type="warning"
+              title="Developer Feature Flags"
+              onClose={() => {
+                setShowFeatureFlags(false)
+                setIsPaused(false)
+              }}
+              footer={
+                <Flex
+                  padding={SPACING.spacing16}
+                  justifyContent={JUSTIFY_END}
+                  gridGap={SPACING.spacing8}
+                >
+                  <SecondaryButton
+                    onClick={() => {
+                      setIsStopped(prev => !prev)
+                      setIsPaused(false)
+                    }}
+                  >
+                    {isStopped ? 'Resume bounce' : 'Stop ball from bouncing'}
+                  </SecondaryButton>
+                  <PrimaryButton
+                    onClick={() => {
+                      setShowFeatureFlags(false)
+                    }}
+                  >
+                    {t('shared:close')}
+                  </PrimaryButton>
+                </Flex>
+              }
+              closeOnOutsideClick
+            >
+              <StyledText desktopStyle="bodyDefaultRegular">
+                For internal use only.
+              </StyledText>
+              <Flex
+                flexDirection="column"
+                marginTop={SPACING.spacing16}
+                gridGap={SPACING.spacing16}
+              >
+                {prereleaseFlagRows}
+              </Flex>
+            </Modal>,
+            getTopPortalEl()
+          )
+        : null}
+
+      <Box
+        onClick={() => {
+          setShowFeatureFlags(true)
+        }}
+        zIndex={4}
+        position={POSITION_ABSOLUTE}
+        width="3.125rem"
+        height="3.125rem"
+        backgroundColor={COLORS.blue50}
+        borderRadius="50%"
+        left={`${position.x}px`}
+        top={`${position.y}px`}
+        cursor="pointer"
+        css={css`
+          &:hover {
+            background-color: ${COLORS.blue60};
+          }
+        `}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+      />
+    </>
+  )
+}
+
+const TOGGLE_DISABLED_STYLES = css`
+  color: ${COLORS.grey50};
+
+  &:hover {
+    color: ${COLORS.grey55};
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px ${COLORS.yellow50};
+  }
+
+  &:disabled {
+    color: ${COLORS.grey30};
+  }
+`
+
+const TOGGLE_ENABLED_STYLES = css`
+  color: ${COLORS.blue50};
+
+  &:hover {
+    color: ${COLORS.blue55};
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px ${COLORS.yellow50};
+  }
+
+  &:disabled {
+    color: ${COLORS.grey30};
+  }
+`

--- a/protocol-designer/src/Bouncing.tsx
+++ b/protocol-designer/src/Bouncing.tsx
@@ -21,11 +21,8 @@ import {
 } from '@opentrons/components'
 import { getTopPortalEl } from './components/portals/TopPortal'
 import { getFeatureFlagData } from './feature-flags/selectors'
-import {
-  FlagTypes,
-  userFacingFlags,
-  actions as featureFlagActions,
-} from './feature-flags'
+import { userFacingFlags, actions as featureFlagActions } from './feature-flags'
+import type { FlagTypes } from './feature-flags'
 
 interface Location {
   x: number
@@ -100,13 +97,13 @@ export const Bouncing = (): JSX.Element => {
 
   React.useEffect(() => {
     if (!isPaused && !isStopped) {
-      const moveDiv = () => {
+      const moveDiv = (): void => {
         const screenWidth = window.innerWidth
         const screenHeight = window.innerHeight
 
         setPosition(prevPosition => {
-          let newX = prevPosition.x + velocity.x
-          let newY = prevPosition.y + velocity.y
+          const newX = prevPosition.x + velocity.x
+          const newY = prevPosition.y + velocity.y
 
           if (newX <= 0 || newX + divSize >= screenWidth) {
             setVelocity(prevVelocity => ({
@@ -127,7 +124,9 @@ export const Bouncing = (): JSX.Element => {
 
       const intervalId = setInterval(moveDiv, 10)
 
-      return () => clearInterval(intervalId)
+      return () => {
+        clearInterval(intervalId)
+      }
     }
   }, [velocity, isPaused, isStopped])
 

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -2,17 +2,13 @@ import * as React from 'react'
 import cx from 'classnames'
 import { DndProvider } from 'react-dnd'
 import { BrowserRouter } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { HTML5Backend } from 'react-dnd-html5-backend'
+import { DIRECTION_COLUMN, Flex } from '@opentrons/components'
 import {
-  DIRECTION_COLUMN,
-  DIRECTION_ROW,
-  Flex,
-  PrimaryButton,
-  SPACING,
-} from '@opentrons/components'
-import { getEnableRedesign } from './feature-flags/selectors'
-import { setFeatureFlags } from './feature-flags/actions'
+  getEnableRedesign,
+  getFeatureFlagData,
+} from './feature-flags/selectors'
 import { ComputingSpinner } from './components/ComputingSpinner'
 import { ConnectedNav } from './containers/ConnectedNav'
 import { Sidebar } from './containers/ConnectedSidebar'
@@ -28,6 +24,7 @@ import { GateModal } from './components/modals/GateModal'
 import { CreateFileWizard } from './components/modals/CreateFileWizard'
 import { AnnouncementModal } from './components/modals/AnnouncementModal'
 import { ProtocolRoutes } from './ProtocolRoutes'
+import { Bouncing } from './Bouncing'
 
 import styles from './components/ProtocolEditor.module.css'
 import './css/reset.module.css'
@@ -36,23 +33,17 @@ const showGateModal =
   process.env.NODE_ENV === 'production' || process.env.OT_PD_SHOW_GATE
 
 function ProtocolEditorComponent(): JSX.Element {
+  const flags = useSelector(getFeatureFlagData)
   const enableRedesign = useSelector(getEnableRedesign)
-  const dispatch = useDispatch()
+
+  const prereleaseModeEnabled = flags.PRERELEASE_MODE === true
 
   return (
     <div id="protocol-editor">
       <TopPortalRoot />
       {enableRedesign ? (
         <Flex flexDirection={DIRECTION_COLUMN}>
-          <Flex padding={SPACING.spacing12} flexDirection={DIRECTION_ROW}>
-            <PrimaryButton
-              onClick={() => {
-                dispatch(setFeatureFlags({ OT_PD_ENABLE_REDESIGN: false }))
-              }}
-            >
-              turn off redesign
-            </PrimaryButton>
-          </Flex>
+          {prereleaseModeEnabled ? <Bouncing /> : null}
           <BrowserRouter>
             <ProtocolRoutes />
           </BrowserRouter>

--- a/protocol-designer/src/organisms/FeatureFlagsModal/index.tsx
+++ b/protocol-designer/src/organisms/FeatureFlagsModal/index.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
+import { css } from 'styled-components'
+import {
+  Btn,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  JUSTIFY_END,
+  JUSTIFY_SPACE_BETWEEN,
+  Modal,
+  PrimaryButton,
+  SPACING,
+  SecondaryButton,
+  StyledText,
+} from '@opentrons/components'
+import { getFeatureFlagData } from '../../feature-flags/selectors'
+import { getTopPortalEl } from '../../components/portals/TopPortal'
+import {
+  userFacingFlags,
+  actions as featureFlagActions,
+} from '../../feature-flags'
+
+import type { FlagTypes } from '../../feature-flags'
+
+interface FeatureFlagsModalProps {
+  setShowFeatureFlags: React.Dispatch<React.SetStateAction<boolean>>
+  setIsPaused: React.Dispatch<React.SetStateAction<boolean>>
+  setIsStopped: React.Dispatch<React.SetStateAction<boolean>>
+  isStopped: boolean
+}
+export function FeatureFlagsModal(props: FeatureFlagsModalProps): JSX.Element {
+  const { setShowFeatureFlags, setIsPaused, setIsStopped, isStopped } = props
+  const { t } = useTranslation(['feature_flags', 'shared'])
+  const flags = useSelector(getFeatureFlagData)
+  const dispatch = useDispatch()
+  const allFlags = Object.keys(flags) as FlagTypes[]
+
+  const prereleaseFlagNames = allFlags.filter(
+    flagName => !userFacingFlags.includes(flagName)
+  )
+
+  const getDescription = (flag: FlagTypes): string => {
+    return t(`feature_flags:${flag}.description`)
+  }
+
+  const setFeatureFlags = (
+    flags: Partial<Record<FlagTypes, boolean | null | undefined>>
+  ): void => {
+    dispatch(featureFlagActions.setFeatureFlags(flags))
+  }
+
+  const toFlagRow = (flagName: FlagTypes): JSX.Element => {
+    const iconName = Boolean(flags[flagName])
+      ? 'ot-toggle-input-on'
+      : 'ot-toggle-input-off'
+
+    return (
+      <Flex key={flagName} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <StyledText desktopStyle="bodyDefaultSemiBold">
+            {t(`feature_flags:${flagName}.title`)}
+          </StyledText>
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {getDescription(flagName)}
+          </StyledText>
+        </Flex>
+        <Btn
+          role="switch"
+          aria-checked={Boolean(flags[flagName])}
+          size="2rem"
+          css={
+            Boolean(flags[flagName])
+              ? TOGGLE_ENABLED_STYLES
+              : TOGGLE_DISABLED_STYLES
+          }
+          onClick={() => {
+            setFeatureFlags({
+              [flagName as string]: !flags[flagName],
+            })
+          }}
+        >
+          <Icon name={iconName} height="1rem" />
+        </Btn>
+      </Flex>
+    )
+  }
+
+  const prereleaseFlagRows = prereleaseFlagNames.map(toFlagRow)
+
+  return createPortal(
+    <Modal
+      width="40rem"
+      type="warning"
+      title="Developer Feature Flags"
+      onClose={() => {
+        setShowFeatureFlags(false)
+        setIsPaused(false)
+      }}
+      footer={
+        <Flex
+          padding={SPACING.spacing16}
+          justifyContent={JUSTIFY_END}
+          gridGap={SPACING.spacing8}
+        >
+          <SecondaryButton
+            onClick={() => {
+              setIsStopped(prev => !prev)
+              setIsPaused(false)
+            }}
+          >
+            {isStopped ? 'Resume bounce' : 'Stop ball from bouncing'}
+          </SecondaryButton>
+          <PrimaryButton
+            onClick={() => {
+              setShowFeatureFlags(false)
+            }}
+          >
+            {t('shared:close')}
+          </PrimaryButton>
+        </Flex>
+      }
+      closeOnOutsideClick
+    >
+      <StyledText desktopStyle="bodyDefaultRegular">
+        For internal use only.
+      </StyledText>
+      <Flex
+        flexDirection="column"
+        marginTop={SPACING.spacing16}
+        gridGap={SPACING.spacing16}
+      >
+        {prereleaseFlagRows}
+      </Flex>
+    </Modal>,
+    getTopPortalEl()
+  )
+}
+
+const TOGGLE_DISABLED_STYLES = css`
+  color: ${COLORS.grey50};
+
+  &:hover {
+    color: ${COLORS.grey55};
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px ${COLORS.yellow50};
+  }
+
+  &:disabled {
+    color: ${COLORS.grey30};
+  }
+`
+
+const TOGGLE_ENABLED_STYLES = css`
+  color: ${COLORS.blue50};
+
+  &:hover {
+    color: ${COLORS.blue55};
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px ${COLORS.yellow50};
+  }
+
+  &:disabled {
+    color: ${COLORS.grey30};
+  }
+`

--- a/protocol-designer/src/organisms/index.ts
+++ b/protocol-designer/src/organisms/index.ts
@@ -1,3 +1,4 @@
+export * from './FeatureFlagsModal'
 export * from './FileUploadMessagesModal/'
 export * from './IncompatibleTipsModal'
 export * from './Kitchen'

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
@@ -64,7 +64,6 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
     robotType === FLEX_ROBOT_TYPE
       ? FLEX_SUPPORTED_MODULE_MODELS
       : OT2_SUPPORTED_MODULE_MODELS
-
   const filteredSupportedModules = supportedModules.filter(
     moduleModel =>
       !(
@@ -102,7 +101,6 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
       }
     })
   }
-
   return (
     <WizardBody
       stepNumber={robotType === FLEX_ROBOT_TYPE ? 4 : 3}
@@ -131,28 +129,32 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
                   ? module
                   : module !== ABSORBANCE_READER_V1
               )
-              .map(moduleModel => (
-                <EmptySelectorButton
-                  key={moduleModel}
-                  textAlignment={TYPOGRAPHY.textAlignLeft}
-                  size="small"
-                  iconName="plus"
-                  text={getModuleDisplayName(moduleModel)}
-                  onClick={() => {
-                    setValue('modules', {
-                      ...modules,
-                      [uuid()]: {
-                        model: moduleModel,
-                        type: getModuleType(moduleModel),
-                        slot:
-                          robotType === FLEX_ROBOT_TYPE
-                            ? DEFAULT_SLOT_MAP_FLEX[moduleModel]
-                            : DEFAULT_SLOT_MAP_OT2[getModuleType(moduleModel)],
-                      },
-                    })
-                  }}
-                />
-              ))}
+              .map(moduleModel => {
+                return (
+                  <EmptySelectorButton
+                    key={moduleModel}
+                    textAlignment={TYPOGRAPHY.textAlignLeft}
+                    size="small"
+                    iconName="plus"
+                    text={getModuleDisplayName(moduleModel)}
+                    onClick={() => {
+                      setValue('modules', {
+                        ...modules,
+                        [uuid()]: {
+                          model: moduleModel,
+                          type: getModuleType(moduleModel),
+                          slot:
+                            robotType === FLEX_ROBOT_TYPE
+                              ? DEFAULT_SLOT_MAP_FLEX[moduleModel]
+                              : DEFAULT_SLOT_MAP_OT2[
+                                  getModuleType(moduleModel)
+                                ],
+                        },
+                      })
+                    }}
+                  />
+                )
+              })}
           </Flex>
           {modules != null &&
           Object.keys(modules).length > 0 &&

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
@@ -64,6 +64,7 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
     robotType === FLEX_ROBOT_TYPE
       ? FLEX_SUPPORTED_MODULE_MODELS
       : OT2_SUPPORTED_MODULE_MODELS
+
   const filteredSupportedModules = supportedModules.filter(
     moduleModel =>
       !(
@@ -101,6 +102,7 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
       }
     })
   }
+
   return (
     <WizardBody
       stepNumber={robotType === FLEX_ROBOT_TYPE ? 4 : 3}
@@ -129,32 +131,28 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
                   ? module
                   : module !== ABSORBANCE_READER_V1
               )
-              .map(moduleModel => {
-                return (
-                  <EmptySelectorButton
-                    key={moduleModel}
-                    textAlignment={TYPOGRAPHY.textAlignLeft}
-                    size="small"
-                    iconName="plus"
-                    text={getModuleDisplayName(moduleModel)}
-                    onClick={() => {
-                      setValue('modules', {
-                        ...modules,
-                        [uuid()]: {
-                          model: moduleModel,
-                          type: getModuleType(moduleModel),
-                          slot:
-                            robotType === FLEX_ROBOT_TYPE
-                              ? DEFAULT_SLOT_MAP_FLEX[moduleModel]
-                              : DEFAULT_SLOT_MAP_OT2[
-                                  getModuleType(moduleModel)
-                                ],
-                        },
-                      })
-                    }}
-                  />
-                )
-              })}
+              .map(moduleModel => (
+                <EmptySelectorButton
+                  key={moduleModel}
+                  textAlignment={TYPOGRAPHY.textAlignLeft}
+                  size="small"
+                  iconName="plus"
+                  text={getModuleDisplayName(moduleModel)}
+                  onClick={() => {
+                    setValue('modules', {
+                      ...modules,
+                      [uuid()]: {
+                        model: moduleModel,
+                        type: getModuleType(moduleModel),
+                        slot:
+                          robotType === FLEX_ROBOT_TYPE
+                            ? DEFAULT_SLOT_MAP_FLEX[moduleModel]
+                            : DEFAULT_SLOT_MAP_OT2[getModuleType(moduleModel)],
+                      },
+                    })
+                  }}
+                />
+              ))}
           </Flex>
           {modules != null &&
           Object.keys(modules).length > 0 &&

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/WizardBody.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/WizardBody.tsx
@@ -40,7 +40,11 @@ export function WizardBody(props: WizardBodyProps): JSX.Element {
   const { t } = useTranslation('shared')
 
   return (
-    <Flex padding={SPACING.spacing16} gridGap={SPACING.spacing16}>
+    <Flex
+      padding={SPACING.spacing16}
+      gridGap={SPACING.spacing16}
+      height="calc(100vh - 48px)"
+    >
       <Flex
         width="60%"
         padding={SPACING.spacing80}

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/index.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/index.tsx
@@ -367,7 +367,7 @@ export function CreateNewProtocolWizard(): JSX.Element | null {
   }
 
   return (
-    <Box backgroundColor={COLORS.grey20}>
+    <Box backgroundColor={COLORS.grey20} height="calc(100vh - 48px)">
       <CreateFileForm
         currentWizardStep={currentWizardStep}
         createProtocolFile={createProtocolFile}

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -44,7 +44,7 @@ export function Landing(): JSX.Element {
       flexDirection={DIRECTION_COLUMN}
       alignItems={ALIGN_CENTER}
       paddingTop="14.875rem"
-      height="100vh"
+      height="calc(100vh - 48px)"
       width="100%"
     >
       <img


### PR DESCRIPTION
# Overview

Just some terrible(-ly fun) ui to access dev ffs while the redesign ff is turned on. (Got approval from Skye and Felix to add this in for now until we find the dev FFs a real home)

## Test Plan and Hands on Testing

Test that the ball opens the modal and you can turn on/off the feature flags & on/off the bouncing.

## Changelog

- make bouncing component
- make ff modal

## Risk assessment

low