### PR TITLE
fix(app): fix inaccurate loading state on terminal run preview

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -309,9 +309,9 @@ export function ProtocolRunHeader({
       // TODO(jh, 08-15-24): The enteredER condition is a hack, because errorCommands are only returned when a run is current.
       // Ideally the run should not need to be current to view errorCommands.
 
-      // Close the run if no tips are attached after running tip check at least once.
+      // Close the run if no tips are attached after running tip check at least once. Post-run tip checks only occur on the Flex.
       // This marks the robot as "not busy" as soon as a run is cancelled if drop tip CTAs are unnecessary.
-      if (initialPipettesWithTipsCount === 0 && !enteredER) {
+      if ((initialPipettesWithTipsCount === 0 || !isFlex) && !enteredER) {
         closeCurrentRun({
           onSettled: () => {
             if (isQuickTransfer) {

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -66,8 +66,6 @@ export const RunPreviewComponent = (
     runId,
     { cursor: 0, pageLength: MAX_COMMANDS },
     {
-      staleTime: Infinity,
-      cacheTime: Infinity,
       enabled: isRunTerminal,
     }
   )


### PR DESCRIPTION
# Overview

Remove `staleTime` and `cacheTime` from `useNotifyAllCommandsAsPreSerializedList` options to ensure we refetch from `/runs/${runId}/commandsAsPreSerializedList` as new commands data are published (once a run becomes terminal).

Closes RQA-3089

## Test Plan and Hands on Testing

- Start a protocol run on Flex or OT-2 from desktop
- Cancel the run or let it finish to produce a terminal state
- Verify that the accurate run log shows on the "Run Preview" tab. For canceled runs, you should see "Run was never started" info screen if canceled before running, or the list of completed commands if the run was started. For succeeded runs, you should see the full list of commands for the run.
<img width="708" alt="Screenshot 2024-08-26 at 10 55 13 AM" src="https://github.com/user-attachments/assets/db861fc1-4c23-4781-92b6-c9f50317d10b">

<img width="701" alt="Screenshot 2024-08-26 at 10 54 00 AM" src="https://github.com/user-attachments/assets/37b86669-126a-4e3a-af0f-419757363238">


## Changelog

- remove `staleTime` and `cacheTime` options from `useNotifyAllCommandsAsPreSerializedList`

## Review requests

- see test plan

## Risk assessment

low