### PR TITLE
fix(app): Various fixes and improvements for Quick Transfer protocols.

### DIFF
--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
@@ -162,11 +162,12 @@ export function AirGap(props: AirGapProps): JSX.Element {
         >
           {enableAirGapDisplayItems.map(displayItem => (
             <RadioButton
-              isSelected={ airGapEnabled === displayItem.option}
+              key={displayItem.description}
+              isSelected={airGapEnabled === displayItem.option}
               onChange={displayItem.onClick}
               buttonValue={displayItem.description}
               buttonLabel={displayItem.description}
-              radioButtonType='large'
+              radioButtonType="large"
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
@@ -10,7 +10,7 @@ import {
   ALIGN_CENTER,
 } from '@opentrons/components'
 import { getTopPortalEl } from '../../../App/portal'
-import { LargeButton } from '../../../atoms/buttons'
+import { RadioButton } from '../../../atoms/buttons'
 import { ChildNavigation } from '../../ChildNavigation'
 import { InputField } from '../../../atoms/InputField'
 import { ACTIONS } from '../constants'
@@ -161,13 +161,12 @@ export function AirGap(props: AirGapProps): JSX.Element {
           width="100%"
         >
           {enableAirGapDisplayItems.map(displayItem => (
-            <LargeButton
-              key={displayItem.description}
-              buttonType={
-                airGapEnabled === displayItem.option ? 'primary' : 'secondary'
-              }
-              onClick={displayItem.onClick}
-              buttonText={displayItem.description}
+            <RadioButton
+              isSelected={ airGapEnabled === displayItem.option}
+              onChange={displayItem.onClick}
+              buttonValue={displayItem.description}
+              buttonLabel={displayItem.description}
+              radioButtonType='large'
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -14,7 +14,7 @@ import {
   TRASH_BIN_ADAPTER_FIXTURE,
 } from '@opentrons/shared-data'
 import { getTopPortalEl } from '../../../App/portal'
-import { LargeButton } from '../../../atoms/buttons'
+import { RadioButton } from '../../../atoms/buttons'
 import { useNotifyDeckConfigurationQuery } from '../../../resources/deck_configuration'
 import { ChildNavigation } from '../../ChildNavigation'
 import { ACTIONS } from '../constants'
@@ -102,14 +102,14 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
 
   const enableBlowOutDisplayItems = [
     {
-      value: true,
+      option: true,
       description: t('option_enabled'),
       onClick: () => {
         setisBlowOutEnabled(true)
       },
     },
     {
-      value: false,
+      option: false,
       description: t('option_disabled'),
       onClick: () => {
         setisBlowOutEnabled(false)
@@ -175,15 +175,12 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
           width="100%"
         >
           {enableBlowOutDisplayItems.map(displayItem => (
-            <LargeButton
-              key={displayItem.description}
-              buttonType={
-                displayItem.value === isBlowOutEnabled ? 'primary' : 'secondary'
-              }
-              onClick={() => {
-                setisBlowOutEnabled(displayItem.value)
-              }}
-              buttonText={displayItem.description}
+            <RadioButton
+              isSelected={ isBlowOutEnabled === displayItem.option}
+              onChange={displayItem.onClick}
+              buttonValue={displayItem.description}
+              buttonLabel={displayItem.description}
+              radioButtonType='large'
             />
           ))}
         </Flex>
@@ -197,19 +194,16 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
           width="100%"
         >
           {blowOutLocationItems.map(blowOutLocationItem => (
-            <LargeButton
-              key={blowOutLocationItem.description}
-              buttonType={
-                blowOutLocation === blowOutLocationItem.location
-                  ? 'primary'
-                  : 'secondary'
-              }
-              onClick={() => {
+            <RadioButton
+              isSelected={ blowOutLocation === blowOutLocationItem.location}
+              onChange={() => {
                 setBlowOutLocation(
                   blowOutLocationItem.location as BlowOutLocation
                 )
               }}
-              buttonText={blowOutLocationItem.description}
+              buttonValue={blowOutLocationItem.description}
+              buttonLabel={blowOutLocationItem.description}
+              radioButtonType='large'
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -196,6 +196,7 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
         >
           {blowOutLocationItems.map(blowOutLocationItem => (
             <RadioButton
+              key={blowOutLocationItem.description}
               isSelected={blowOutLocation === blowOutLocationItem.location}
               onChange={() => {
                 setBlowOutLocation(

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -176,11 +176,12 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
         >
           {enableBlowOutDisplayItems.map(displayItem => (
             <RadioButton
-              isSelected={ isBlowOutEnabled === displayItem.option}
+              key={displayItem.description}
+              isSelected={isBlowOutEnabled === displayItem.option}
               onChange={displayItem.onClick}
               buttonValue={displayItem.description}
               buttonLabel={displayItem.description}
-              radioButtonType='large'
+              radioButtonType="large"
             />
           ))}
         </Flex>
@@ -195,7 +196,7 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
         >
           {blowOutLocationItems.map(blowOutLocationItem => (
             <RadioButton
-              isSelected={ blowOutLocation === blowOutLocationItem.location}
+              isSelected={blowOutLocation === blowOutLocationItem.location}
               onChange={() => {
                 setBlowOutLocation(
                   blowOutLocationItem.location as BlowOutLocation
@@ -203,7 +204,7 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
               }}
               buttonValue={blowOutLocationItem.description}
               buttonLabel={blowOutLocationItem.description}
-              radioButtonType='large'
+              radioButtonType="large"
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
@@ -178,13 +178,14 @@ export function Delay(props: DelayProps): JSX.Element {
           width="100%"
         >
           {delayEnabledDisplayItems.map(displayItem => (
-          <RadioButton
-            isSelected={ delayIsEnabled === displayItem.option}
-            onChange={displayItem.onClick}
-            buttonValue={displayItem.description}
-            buttonLabel={displayItem.description}
-            radioButtonType='large'
-          />
+            <RadioButton
+              key={displayItem.description}
+              isSelected={delayIsEnabled === displayItem.option}
+              onChange={displayItem.onClick}
+              buttonValue={displayItem.description}
+              buttonLabel={displayItem.description}
+              radioButtonType="large"
+            />
           ))}
         </Flex>
       ) : null}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
@@ -10,7 +10,7 @@ import {
   ALIGN_CENTER,
 } from '@opentrons/components'
 import { getTopPortalEl } from '../../../App/portal'
-import { LargeButton } from '../../../atoms/buttons'
+import { RadioButton } from '../../../atoms/buttons'
 import { ChildNavigation } from '../../ChildNavigation'
 import { InputField } from '../../../atoms/InputField'
 import { ACTIONS } from '../constants'
@@ -178,14 +178,13 @@ export function Delay(props: DelayProps): JSX.Element {
           width="100%"
         >
           {delayEnabledDisplayItems.map(displayItem => (
-            <LargeButton
-              key={displayItem.description}
-              buttonType={
-                delayIsEnabled === displayItem.option ? 'primary' : 'secondary'
-              }
-              onClick={displayItem.onClick}
-              buttonText={displayItem.description}
-            />
+          <RadioButton
+            isSelected={ delayIsEnabled === displayItem.option}
+            onChange={displayItem.onClick}
+            buttonValue={displayItem.description}
+            buttonLabel={displayItem.description}
+            radioButtonType='large'
+          />
           ))}
         </Flex>
       ) : null}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
@@ -159,11 +159,12 @@ export function Mix(props: MixProps): JSX.Element {
         >
           {enableMixDisplayItems.map(displayItem => (
             <RadioButton
-              isSelected={ mixIsEnabled === displayItem.option}
+              key={displayItem.description}
+              isSelected={mixIsEnabled === displayItem.option}
               onChange={displayItem.onClick}
               buttonValue={displayItem.description}
               buttonLabel={displayItem.description}
-              radioButtonType='large'
+              radioButtonType="large"
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
@@ -10,7 +10,7 @@ import {
   ALIGN_CENTER,
 } from '@opentrons/components'
 import { getTopPortalEl } from '../../../App/portal'
-import { LargeButton } from '../../../atoms/buttons'
+import { RadioButton } from '../../../atoms/buttons'
 import { ChildNavigation } from '../../ChildNavigation'
 import { InputField } from '../../../atoms/InputField'
 import { ACTIONS } from '../constants'
@@ -158,13 +158,12 @@ export function Mix(props: MixProps): JSX.Element {
           width="100%"
         >
           {enableMixDisplayItems.map(displayItem => (
-            <LargeButton
-              key={displayItem.description}
-              buttonType={
-                mixIsEnabled === displayItem.option ? 'primary' : 'secondary'
-              }
-              onClick={displayItem.onClick}
-              buttonText={displayItem.description}
+            <RadioButton
+              isSelected={ mixIsEnabled === displayItem.option}
+              onChange={displayItem.onClick}
+              buttonValue={displayItem.description}
+              buttonLabel={displayItem.description}
+              radioButtonType='large'
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -11,7 +11,7 @@ import {
 } from '@opentrons/components'
 import { useNotifyDeckConfigurationQuery } from '../../../resources/deck_configuration'
 import { getTopPortalEl } from '../../../App/portal'
-import { LargeButton } from '../../../atoms/buttons'
+import { RadioButton } from '../../../atoms/buttons'
 import { ChildNavigation } from '../../ChildNavigation'
 import { useBlowOutLocationOptions } from './BlowOut'
 
@@ -153,15 +153,14 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
           width="100%"
         >
           {allowedPipettePathOptions.map(option => (
-            <LargeButton
-              key={option.pathOption}
-              buttonType={
-                selectedPath === option.pathOption ? 'primary' : 'secondary'
-              }
-              onClick={() => {
+            <RadioButton
+              isSelected={ selectedPath === option.pathOption}
+              onChange={() => {
                 setSelectedPath(option.pathOption)
               }}
-              buttonText={option.description}
+              buttonValue={option.description}
+              buttonLabel={option.description}
+              radioButtonType='large'
             />
           ))}
         </Flex>
@@ -215,15 +214,14 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
           width="100%"
         >
           {blowOutLocationItems.map(option => (
-            <LargeButton
-              key={option.description}
-              buttonType={
-                blowOutLocation === option.location ? 'primary' : 'secondary'
-              }
-              onClick={() => {
+            <RadioButton
+              isSelected={ blowOutLocation === option.location}
+              onChange={() => {
                 setBlowOutLocation(option.location)
               }}
-              buttonText={option.description}
+              buttonValue={option.description}
+              buttonLabel={option.description}
+              radioButtonType='large'
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -154,13 +154,14 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
         >
           {allowedPipettePathOptions.map(option => (
             <RadioButton
-              isSelected={ selectedPath === option.pathOption}
+              key={option.description}
+              isSelected={selectedPath === option.pathOption}
               onChange={() => {
                 setSelectedPath(option.pathOption)
               }}
               buttonValue={option.description}
               buttonLabel={option.description}
-              radioButtonType='large'
+              radioButtonType="large"
             />
           ))}
         </Flex>
@@ -215,13 +216,14 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
         >
           {blowOutLocationItems.map(option => (
             <RadioButton
-              isSelected={ blowOutLocation === option.location}
+              key={option.description}
+              isSelected={blowOutLocation === option.location}
               onChange={() => {
                 setBlowOutLocation(option.location)
               }}
               buttonValue={option.description}
               buttonLabel={option.description}
-              radioButtonType='large'
+              radioButtonType="large"
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
@@ -10,7 +10,7 @@ import {
   ALIGN_CENTER,
 } from '@opentrons/components'
 import { getTopPortalEl } from '../../../App/portal'
-import { LargeButton } from '../../../atoms/buttons'
+import { RadioButton } from '../../../atoms/buttons'
 import { ChildNavigation } from '../../ChildNavigation'
 import { InputField } from '../../../atoms/InputField'
 import { ACTIONS } from '../constants'
@@ -150,15 +150,12 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
           width="100%"
         >
           {enableTouchTipDisplayItems.map(displayItem => (
-            <LargeButton
-              key={displayItem.description}
-              buttonType={
-                touchTipIsEnabled === displayItem.option
-                  ? 'primary'
-                  : 'secondary'
-              }
-              onClick={displayItem.onClick}
-              buttonText={displayItem.description}
+            <RadioButton
+              isSelected={ touchTipIsEnabled === displayItem.option}
+              onChange={displayItem.onClick}
+              buttonValue={displayItem.description}
+              buttonLabel={displayItem.description}
+              radioButtonType='large'
             />
           ))}
         </Flex>

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
@@ -151,11 +151,12 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
         >
           {enableTouchTipDisplayItems.map(displayItem => (
             <RadioButton
-              isSelected={ touchTipIsEnabled === displayItem.option}
+              key={displayItem.description}
+              isSelected={touchTipIsEnabled === displayItem.option}
               onChange={displayItem.onClick}
               buttonValue={displayItem.description}
               buttonLabel={displayItem.description}
-              radioButtonType='large'
+              radioButtonType="large"
             />
           ))}
         </Flex>

--- a/app/src/pages/ProtocolDetails/index.tsx
+++ b/app/src/pages/ProtocolDetails/index.tsx
@@ -521,7 +521,7 @@ export function ProtocolDetails(): JSX.Element | null {
           isScrolled={isScrolled}
           isProtocolFetching={isProtocolFetching}
         />
-        <Flex flexDirection={DIRECTION_COLUMN}>
+        <Flex flexDirection={DIRECTION_COLUMN} paddingTop={SPACING.spacing6}>
           <ProtocolSectionTabs
             currentOption={currentOption}
             setCurrentOption={setCurrentOption}

--- a/app/src/pages/QuickTransferDetails/index.tsx
+++ b/app/src/pages/QuickTransferDetails/index.tsx
@@ -403,7 +403,7 @@ export function QuickTransferDetails(): JSX.Element | null {
           isScrolled={isScrolled}
           isTransferFetching={isTransferFetching}
         />
-        <Flex flexDirection={DIRECTION_COLUMN}>
+        <Flex flexDirection={DIRECTION_COLUMN} paddingTop={SPACING.spacing6}>
           <TransferSectionTabs
             currentOption={currentOption}
             setCurrentOption={setCurrentOption}

--- a/app/src/pages/QuickTransferDetails/index.tsx
+++ b/app/src/pages/QuickTransferDetails/index.tsx
@@ -354,7 +354,7 @@ export function QuickTransferDetails(): JSX.Element | null {
       makeSnackbar(t('unpinned_transfer') as string)
     }
     dispatch(
-      updateConfigValue('protocols.pinnedTransferIds', pinnedTransferIds)
+      updateConfigValue('protocols.pinnedQuickTransferIds', pinnedTransferIds)
     )
   }
   const handleRunTransfer = (): void => {


### PR DESCRIPTION
# Overview

A few fixes for Quick Transfer protocol creation flow and behavior

Closes: [RQA-2850](https://opentrons.atlassian.net/browse/RQA-2850) [RQA-2851](https://opentrons.atlassian.net/browse/RQA-2851) [RQA-2868](https://opentrons.atlassian.net/browse/RQA-2868)

## Test Plan and Hands on Testing

- [x] Make sure that you can pin/unpin Quick Transfer protocols from the Quick Transfer dashboard and from the Quick Transfer Details card.
- [x] Make sure there is no border added or size change when selecting the Quick Transfer Advanced Settings options.
- [x] Make sure there is no cut-off when navigating through both Normal protocol and QuickTransfer protocol tab options. 

## Changelog

- Use the correct `protocols.pinnedQuickTransferIds` config instead of `protocols.pinnedTransferIds` for pinning/unpinning QT protocols from the protocol details page.
- Change the Quick Transfer advanced settings components from using `LargeButton` to the `RadioButton` component to fix the size change when interacting with the component.
- Add `SPACING.spacing_6` between the protocol details header and contents for both regular protocols and quick transfer protocols to account for the `focus-visible` blue selection box shown when clicking through the header.

## Review requests

## Risk assessment
low, unreleased

[RQA-2850]: https://opentrons.atlassian.net/browse/RQA-2850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2851]: https://opentrons.atlassian.net/browse/RQA-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2868]: https://opentrons.atlassian.net/browse/RQA-2868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ