### PR TITLE
fix(app): dont ignore errors in redux robotapi

### DIFF
--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -5,6 +5,7 @@ import mapValues from 'lodash/mapValues'
 import toString from 'lodash/toString'
 import omitBy from 'lodash/omitBy'
 import inRange from 'lodash/inRange'
+import type { AxiosError, AxiosResponse } from 'axios'
 
 import { OPENTRONS_USB } from '../../redux/discovery'
 import { appShellRequestor } from '../../redux/shell/remote'
@@ -62,15 +63,25 @@ export function fetchRobotApi(
           url,
           data: options.body,
         })
+          .then(response => ({
+            isError: false as const,
+            response,
+          }))
+          .catch(err => ({
+            isError: true as const,
+            ...(err as AxiosError<unknown>),
+          }))
       ).pipe(
-        map(response => ({
+        map(result => ({
           host,
           path,
           method,
-          body: response?.data,
-          status: response?.status,
+          body: result?.response?.data,
+          // FIXME(sf) this doesn't seem right, but also the type interface isn't written to allow for request
+          // failures that don't come from valid connections
+          status: result?.response?.status ?? -1,
           // appShellRequestor eventually calls axios.request, which doesn't provide an ok boolean in the response
-          ok: inRange(response?.status, 200, 300),
+          ok: result.isError || inRange(result?.response?.status, 200, 300),
         }))
       )
     : from(fetch(url, options)).pipe(

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -81,7 +81,9 @@ export function fetchRobotApi(
           // failures that don't come from valid connections
           status: result?.response?.status ?? -1,
           // appShellRequestor eventually calls axios.request, which doesn't provide an ok boolean in the response
-          ok: result.isError || inRange(result?.response?.status, 200, 300),
+          ok: result.isError
+            ? false
+            : inRange(result?.response?.status, 200, 300),
         }))
       )
     : from(fetch(url, options)).pipe(

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -79,7 +79,7 @@ export function fetchRobotApi(
           body: result?.response?.data,
           // FIXME(sf) this doesn't seem right, but also the type interface isn't written to allow for request
           // failures that don't come from valid connections
-          status: result?.response?.status ?? -1,
+          status: result?.response?.status ?? 444,
           // appShellRequestor eventually calls axios.request, which doesn't provide an ok boolean in the response
           ok: result.isError
             ? false

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -5,7 +5,7 @@ import mapValues from 'lodash/mapValues'
 import toString from 'lodash/toString'
 import omitBy from 'lodash/omitBy'
 import inRange from 'lodash/inRange'
-import type { AxiosError, AxiosResponse } from 'axios'
+import type { AxiosError } from 'axios'
 
 import { OPENTRONS_USB } from '../../redux/discovery'
 import { appShellRequestor } from '../../redux/shell/remote'


### PR DESCRIPTION
we added the ability for the USB interface to actually pass on communication errors to the browser side, but only some of the things that create those requests on the browser handled it properly. The old redux robot api client didn't. Now it does, at least on USB.

This sort of fixes RQA-3087 in that it will no longer be in the spinner forever and correctly expose the error that happened on the robot, but it doesn't fix it in that you'll now get an error and then a moment later the robot will say it's connected anyway.

Closes RQA-3087 (under the above constraint)