### PR TITLE
fix(app): filter out quick transfer runs from log on odd and desktop

### DIFF
--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -120,14 +120,15 @@ export function RecentProtocolRuns({
                 const protocol = protocols?.data?.data.find(
                   protocol => protocol.id === run.protocolId
                 )
-
+                const isQuickTransfer =
+                  protocol?.protocolKind === 'quick-transfer'
                 const protocolName =
                   protocol?.metadata.protocolName ??
                   protocol?.files[0].name ??
                   t('shared:loading') ??
                   ''
 
-                return (
+                return !isQuickTransfer ? (
                   <HistoricalProtocolRun
                     run={run}
                     protocolName={protocolName}
@@ -136,7 +137,7 @@ export function RecentProtocolRuns({
                     robotIsBusy={robotIsBusy}
                     key={index}
                   />
-                )
+                ) : null
               })}
           </>
         )}

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -51,7 +51,8 @@ export function RecentRunProtocolCard({
   const { data, isLoading } = useProtocolQuery(runData.protocolId ?? null)
   const protocolData = data?.data ?? null
   const isProtocolFetching = isLoading
-  return protocolData == null ? null : (
+  return protocolData == null ||
+    protocolData.protocolKind === 'quick-transfer' ? null : (
     <ProtocolWithLastRun
       protocolData={protocolData}
       runData={runData}


### PR DESCRIPTION
fix RQA-3105

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR filters out historical runs that are from quick transfer protocols on both ODD and desktop. This makes sure that these runs aren't visible in the few minutes before they are deleted and in case one gets left behind due to robot failure or something going wrong with the deletion
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Run a quick transfer protocol and have the robot run log open on a desktop app. Make sure that even if you linger on the ODD run summary for a few minutes before returning to dashboard or re-running (both of which trigger run deletion) the run never appears in the historical run list for desktop. 
The odd filtration is more of a fail-safe and we can't test it easily as you should never be able to reach the dashboard before the run gets deleted.

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
If the protocol associated with a historical run has `protocolKind === 'quick-transfer'`, return null in both `RecentProtocolRuns` on desktop and `RecentRunProtocolCard` on ODD
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over code changes
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
