### PR TITLE
fix(app): remove module card navigate on settled run query

### DIFF
--- a/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -237,9 +237,7 @@ describe('ModuleCard', () => {
       eatToast: mockEatToast,
     })
     vi.mocked(getRequestById).mockReturnValue(null)
-    when(useCurrentRunStatus)
-      .calledWith(expect.any(Object))
-      .thenReturn(RUN_STATUS_IDLE)
+    when(useCurrentRunStatus).calledWith().thenReturn(RUN_STATUS_IDLE)
     when(useIsFlex).calledWith(props.robotName).thenReturn(true)
     when(useIsEstopNotDisengaged).calledWith(props.robotName).thenReturn(false)
   })
@@ -311,9 +309,7 @@ describe('ModuleCard', () => {
   })
 
   it('renders kebab icon and it is disabled when run is in progress', () => {
-    when(useCurrentRunStatus)
-      .calledWith(expect.any(Object))
-      .thenReturn(RUN_STATUS_RUNNING)
+    when(useCurrentRunStatus).calledWith().thenReturn(RUN_STATUS_RUNNING)
     render({
       ...props,
       module: mockMagneticModule,

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { useNavigate } from 'react-router-dom'
 
 import {
   ALIGN_START,
@@ -126,14 +125,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const [showCalModal, setShowCalModal] = React.useState(false)
 
   const [targetProps, tooltipProps] = useHoverTooltip()
-  const navigate = useNavigate()
-  const runStatus = useCurrentRunStatus({
-    onSettled: data => {
-      if (data == null) {
-        navigate('/upload')
-      }
-    },
-  })
+
+  const runStatus = useCurrentRunStatus()
   const isFlex = useIsFlex(robotName)
   const requireModuleCalibration =
     isFlex &&


### PR DESCRIPTION
# Overview

removes a navigate route change on a settled run query with no data. it's unclear what the [original purpose](https://github.com/Opentrons/opentrons/pull/9778/commits/98d6c9e23c5d36f6bf0e4e4ebe267f6612869c54#diff-5c2b4f5be57a5d8e10d68bea57be8b919bdcf3278256bf10bcdb3ab3f49fed95) of the route change was, but the `/upload` route no longer exists and falls through to the `/protocols` page. the `onSettled` callback is triggered inconsistently on some robots when a query error propagates, likely due to recent [notification changes](https://github.com/Opentrons/opentrons/pull/16084). resolving the cause of that error should be considered in future notification work. @mjhuff 

closes RQA-3099

## Test Plan and Hands on Testing

verified the fix, updated unit test

## Changelog

 - Removes module card navigate on settled run query

## Review requests

is this sufficient for the release?

## Risk assessment

low, given no notification logic changes
