### PR TITLE
fix(app): update new confirmation buttons on protocol setup

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -10,6 +10,7 @@
   "additional_off_deck_labware": "Additional Off-Deck Labware",
   "all_files_associated": "All files associated with the protocol run are available on the robot detail screen.",
   "applied_labware_offsets": "applied labware offsets",
+  "applied_labware_offset_data": "Applied labware offset data",
   "are_you_sure_you_want_to_proceed": "Are you sure you want to proceed to run?",
   "attach_gripper_failure_reason": "Attach the required gripper to continue",
   "attach_gripper": "attach gripper",

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -187,6 +187,7 @@ export function ProtocolSetupLabware({
               setIsConfirmed(true)
               setSetupScreen('prepare to run')
             }}
+            buttonCategory="rounded"
           />
         )}
       </Flex>

--- a/app/src/organisms/ProtocolSetupLiquids/index.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/index.tsx
@@ -74,6 +74,7 @@ export function ProtocolSetupLiquids({
               setIsConfirmed(true)
               setSetupScreen('prepare to run')
             }}
+            buttonCategory="rounded"
           />
         )}
       </Flex>

--- a/app/src/organisms/ProtocolSetupOffsets/index.tsx
+++ b/app/src/organisms/ProtocolSetupOffsets/index.tsx
@@ -92,12 +92,13 @@ export function ProtocolSetupOffsets({
               />
             ) : (
               <SmallButton
-                buttonText={t('confirm_placements')}
+                buttonText={t('confirm_offsets')}
                 disabled={nonIdentityOffsets.length === 0}
                 onClick={() => {
                   setIsConfirmed(true)
                   setSetupScreen('prepare to run')
                 }}
+                buttonCategory="rounded"
               />
             )}
           </Flex>

--- a/app/src/organisms/ProtocolSetupOffsets/index.tsx
+++ b/app/src/organisms/ProtocolSetupOffsets/index.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Flex,
-  DIRECTION_ROW,
-  JUSTIFY_SPACE_BETWEEN,
   Chip,
+  DIRECTION_COLUMN,
+  DIRECTION_ROW,
+  Flex,
+  InfoScreen,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+  StyledText,
 } from '@opentrons/components'
 
 import type { LabwareOffset } from '@opentrons/api-client'
@@ -102,10 +106,24 @@ export function ProtocolSetupOffsets({
               />
             )}
           </Flex>
-          <TerseOffsetTable
-            offsets={nonIdentityOffsets}
-            labwareDefinitions={labwareDefinitions}
-          />
+          <Flex marginTop={SPACING.spacing32} flexDirection={DIRECTION_COLUMN}>
+            {nonIdentityOffsets.length > 0 ? (
+              <>
+                <StyledText
+                  oddStyle="level4HeaderSemiBold"
+                  marginBottom={SPACING.spacing8}
+                >
+                  {t('applied_labware_offset_data')}
+                </StyledText>
+                <TerseOffsetTable
+                  offsets={nonIdentityOffsets}
+                  labwareDefinitions={labwareDefinitions}
+                />
+              </>
+            ) : (
+              <InfoScreen contentType="noLabwareOffsetDataYet" />
+            )}
+          </Flex>
           <FloatingActionButton
             buttonText={t('update_offsets')}
             iconName="reticle"

--- a/components/src/molecules/ParametersTable/InfoScreen.tsx
+++ b/components/src/molecules/ParametersTable/InfoScreen.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 
 import { BORDERS, COLORS } from '../../helix-design-system'
-import { SPACING, TYPOGRAPHY } from '../../ui-style-constants/index'
-import { LegacyStyledText } from '../../atoms/StyledText'
+import { RESPONSIVENESS, SPACING } from '../../ui-style-constants/index'
+import { StyledText } from '../../atoms/StyledText'
 import { Icon } from '../../icons'
 import { Flex } from '../../primitives'
-import { ALIGN_CENTER, DIRECTION_COLUMN } from '../../styles'
+import { ALIGN_CENTER, DIRECTION_COLUMN, JUSTIFY_CENTER } from '../../styles'
+import { css } from 'styled-components'
 
 interface InfoScreenProps {
   contentType:
@@ -15,15 +16,14 @@ interface InfoScreenProps {
     | 'labware'
     | 'noFiles'
     | 'noLabwareOffsetData'
+    | 'noLabwareOffsetDataYet'
   t?: any
   backgroundColor?: string
+  height?: string
 }
 
-export function InfoScreen({
-  contentType,
-  t,
-  backgroundColor,
-}: InfoScreenProps): JSX.Element {
+export function InfoScreen(props: InfoScreenProps): JSX.Element {
+  const { contentType, t, backgroundColor } = props
   let bodyText: string = ''
   switch (contentType) {
     case 'parameters':
@@ -54,20 +54,42 @@ export function InfoScreen({
           ? t('no_offsets_available')
           : 'No Labware Offset data available'
       break
+    case 'noLabwareOffsetDataYet':
+      bodyText =
+        t != null ? t('no_labware_offset_data') : 'No labware offset data yet'
+      break
     default:
       bodyText = contentType
   }
 
   return (
     <Flex
-      alignItems={ALIGN_CENTER}
-      width="100%"
-      flexDirection={DIRECTION_COLUMN}
-      gridGap={SPACING.spacing12}
-      backgroundColor={backgroundColor ?? COLORS.grey30}
-      borderRadius={BORDERS.borderRadius8}
-      padding={`${SPACING.spacing40} ${SPACING.spacing16}`}
       data-testid={`InfoScreen_${contentType}`}
+      css={css`
+        width: 100%;
+        padding: ${SPACING.spacing40} ${SPACING.spacing16};
+        grid-gap: ${SPACING.spacing12};
+        flex-direction: ${DIRECTION_COLUMN};
+        background-color: ${backgroundColor ?? COLORS.grey30};
+        border-radius: ${BORDERS.borderRadius8};
+        align-items: ${ALIGN_CENTER};
+        justify-content: ${JUSTIFY_CENTER};
+        > svg {
+          height: 1.25rem;
+          width: 1.25rem;
+        }
+        @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          height: 27.25rem;
+          padding: 0;
+          grid-gap: ${SPACING.spacing32};
+          background-color: ${backgroundColor ?? COLORS.grey35};
+          border-radius: ${BORDERS.borderRadius12};
+          > svg {
+            height: 3rem;
+            width: 3rem;
+          }
+        }
+      `}
     >
       <Icon
         name="ot-alert"
@@ -75,9 +97,12 @@ export function InfoScreen({
         color={COLORS.grey60}
         aria-label="alert"
       />
-      <LegacyStyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+      <StyledText
+        desktopStyle="bodyDefaultSemiBold"
+        oddStyle="level3HeaderSemiBold"
+      >
         {bodyText}
-      </LegacyStyledText>
+      </StyledText>
     </Flex>
   )
 }


### PR DESCRIPTION
# Overview

Designs now specify explicit confirmation "green checks" for LPC, labware, and liquid setup. Here, I update the copy for LPC confirmation from 'Confirm placements' to 'Confirm offsets', along with adding new copy above the offset table I also update the button styles from 'default' to 'rounded' to reflect designs.

In addition, I add an `InfoScreen` showing no offset data if no non-identity vector offsets exit.

Closes RQA-3104

## Test Plan and Hands on Testing

- Begin protocol setup and select LPC setup step
- Verify that confirmation button copy and style match designs
- Repeat with labware and liquids setup steps
- Smoke test Desktop app to make sure other instances of InfoScreen are not affected

<img width="959" alt="Screenshot 2024-08-26 at 4 53 15 PM" src="https://github.com/user-attachments/assets/edb4980d-2dfd-46e3-919a-80fdad3535f2">

<img width="859" alt="Screenshot 2024-08-26 at 3 27 22 PM" src="https://github.com/user-attachments/assets/27e9973b-5a37-40ed-96fe-d069e0511c83">

<img width="1015" alt="Screenshot 2024-08-26 at 4 34 57 PM" src="https://github.com/user-attachments/assets/8775aaa2-3f5a-4a14-a003-d150796a7305">


## Changelog

- change copy for LPC confirmation button
- update button protocol setup screen confirmation buttons' styles to rounded
- add InfoScreen rather than table if no non-identity offsets applied
- add new copy above offset table

## Review requests

- see test plan

## Risk assessment

low