### PR TITLE
fix(app): display dtwiz in cancel on odd

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/hooks/useHomePipettes.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useHomePipettes.ts
@@ -37,14 +37,14 @@ export function useHomePipettes(
 
   // Home the pipette after user click once a maintenance run has been created.
   React.useEffect(() => {
-    if (isMaintenanceRunActive && isHomingPipettes && props.isRunCurrent) {
+    if (isMaintenanceRunActive && isHomingPipettes) {
       console.log('HITTING HERE!!!')
       void homePipettesCmd().finally(() => {
         props.onHome()
         deleteMaintenanceRun(activeMaintenanceRunId)
       })
     }
-  }, [isMaintenanceRunActive, isHomingPipettes, props.isRunCurrent])
+  }, [isMaintenanceRunActive, isHomingPipettes])
 
   const { createMaintenanceCommand } = useCreateMaintenanceCommandMutation()
 

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -55,7 +55,7 @@ export function ConfirmCancelRunModal({
     dismissCurrentRun,
     isLoading: isDismissing,
   } = useDismissCurrentRunMutation({
-    onSuccess: () => {
+    onSettled: () => {
       if (isQuickTransfer && !isActiveRun) {
         deleteRun(runId)
       }

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -242,10 +242,10 @@ export function RunSummary(): JSX.Element {
 
   // Determine tip status on initial render only. Error Recovery always handles tip status, so don't show it twice.
   React.useEffect(() => {
-    if (isRunCurrent && enteredER === false) {
+    if (enteredER === false) {
       void determineTipStatus()
     }
-  }, [isRunCurrent, enteredER])
+  }, [enteredER])
 
   const returnToQuickTransfer = (): void => {
     if (!isRunCurrent) {
@@ -282,7 +282,7 @@ export function RunSummary(): JSX.Element {
 
   const handleReturnToDash = (aPipetteWithTip: PipetteWithTip | null): void => {
     setShowReturnToSpinner(true)
-    if (isRunCurrent && aPipetteWithTip != null) {
+    if (aPipetteWithTip != null) {
       void handleTipsAttachedModal({
         setTipStatusResolved: setTipStatusResolvedAndRoute(handleReturnToDash),
         host,
@@ -307,7 +307,7 @@ export function RunSummary(): JSX.Element {
   }
 
   const handleRunAgain = (aPipetteWithTip: PipetteWithTip | null): void => {
-    if (isRunCurrent && aPipetteWithTip != null) {
+    if (aPipetteWithTip != null) {
       void handleTipsAttachedModal({
         setTipStatusResolved: setTipStatusResolvedAndRoute(handleRunAgain),
         host,


### PR DESCRIPTION
We were not handling the case of cancel - in which a run is not current in the postrun screens - correctly on ODD specifically and thus would never display the drop tip wizard.

Closes RQA-3107, RQA-3098
