### PR TITLE
fix(components): add 4th slot column label for magblock + staging area

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -110,6 +110,10 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
   const absorbanceReaderFixtures = deckConfig.filter(
     ({ cutoutFixtureId }) => cutoutFixtureId === ABSORBANCE_READER_V1_FIXTURE
   )
+  const magneticBlockStagingAreaFixtures = deckConfig.filter(
+    ({ cutoutFixtureId }) =>
+      cutoutFixtureId === STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE
+  )
 
   return (
     <RobotCoordinateSpace
@@ -261,7 +265,8 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
         color={darkFill}
         show4thColumn={
           stagingAreaFixtures.length > 0 ||
-          wasteChuteStagingAreaFixtures.length > 0
+          wasteChuteStagingAreaFixtures.length > 0 ||
+          magneticBlockStagingAreaFixtures.length > 0
         }
       />
       {children}


### PR DESCRIPTION
# Overview

Add condition for showing 4th slot column label for magnetic block with staging area fixture

Closes RQA-2838

## Test Plan and Hands on Testing

- Start with a fresh deck configuration
- Add magnetic block with staging area area fixture to right column of deck configuration
- Verify that 4th slot column label shows
- Remove above fixture and add only magnetic block to right column (without staging area)
- Verify that 4th slot column does not show

<img width="610" alt="Screenshot 2024-08-27 at 11 49 18 AM" src="https://github.com/user-attachments/assets/2cb706c0-949a-4fa9-8ae8-767f23154e5c">

<img width="592" alt="Screenshot 2024-08-27 at 11 49 58 AM" src="https://github.com/user-attachments/assets/613ce190-4da7-4039-95dd-d46cb7459477">

## Changelog

- add check for magblock with staging area to `SlotLabels` `show4thColumn` prop condition

## Review requests

see test plan

## Risk assessment

low