### PR TITLE
fix(robot-server): tolerate exceptions in mqtt notifier

### DIFF
--- a/robot-server/robot_server/service/notifications/publisher_notifier.py
+++ b/robot-server/robot_server/service/notifications/publisher_notifier.py
@@ -14,6 +14,7 @@ from opentrons.util.change_notifier import ChangeNotifier, ChangeNotifier_ts
 
 LOG = getLogger(__name__)
 
+
 class PublisherNotifier:
     """An interface that invokes notification callbacks whenever a generic notify event occurs."""
 
@@ -30,7 +31,9 @@ class PublisherNotifier:
 
     async def _initialize(self) -> None:
         """Initializes an instance of PublisherNotifier. This method should only be called once."""
-        self._notifier = asyncio.create_task(self._wait_for_event(), name='Run publisher notifier')
+        self._notifier = asyncio.create_task(
+            self._wait_for_event(), name="Run publisher notifier"
+        )
 
     def _notify_publishers(self) -> None:
         """A generic notifier, alerting all `waiters` of a change."""
@@ -45,9 +48,12 @@ class PublisherNotifier:
                     try:
                         await callback()
                     except BaseException:
-                        LOG.exception(f'PublisherNotifier: exception in callback {getattr(callback, "__name__", "<unknown>")}')
+                        LOG.exception(
+                            f'PublisherNotifier: exception in callback {getattr(callback, "__name__", "<unknown>")}'
+                        )
         except BaseException:
-            LOG.exception(f'PublisherNotifer notify task failed')
+            LOG.exception(f"PublisherNotifer notify task failed")
+
 
 _pe_publisher_notifier_accessor: AppStateAccessor[PublisherNotifier] = AppStateAccessor[
     PublisherNotifier

--- a/robot-server/robot_server/service/notifications/publisher_notifier.py
+++ b/robot-server/robot_server/service/notifications/publisher_notifier.py
@@ -52,7 +52,7 @@ class PublisherNotifier:
                             f'PublisherNotifier: exception in callback {getattr(callback, "__name__", "<unknown>")}'
                         )
         except BaseException:
-            LOG.exception(f"PublisherNotifer notify task failed")
+            LOG.exception("PublisherNotifer notify task failed")
 
 
 _pe_publisher_notifier_accessor: AppStateAccessor[PublisherNotifier] = AppStateAccessor[


### PR DESCRIPTION
Do you know what happens to an asyncio task when it calls a function that raises an exception and doesn't catch that exception? The same thing that happens to everything else.

Note: this _may_ fix the desyncing thing but it's a bit hard to test.

Closes RQA-3109, RQA-3108