### PR TITLE
fix(app): No longer dismiss run if canceled while running on ODD

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -55,9 +55,17 @@ export function ConfirmCancelRunModal({
     dismissCurrentRun,
     isLoading: isDismissing,
   } = useDismissCurrentRunMutation({
-    onSuccess: () => {
-      if (isQuickTransfer && !isActiveRun) {
+    onSettled: () => {
+      if (isQuickTransfer && protocolId != null) {
         deleteRun(runId)
+        navigate(`/quick-transfer/${protocolId}`)
+      } else if (isQuickTransfer) {
+        deleteRun(runId)
+        navigate('/quick-transfer')
+      } else if (protocolId != null) {
+        navigate(`/protocols/${protocolId}`)
+      } else {
+        navigate('/protocols')
       }
     },
   })
@@ -87,17 +95,8 @@ export function ConfirmCancelRunModal({
   React.useEffect(() => {
     if (runStatus === RUN_STATUS_STOPPED) {
       trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
-      dismissCurrentRun(runId)
       if (!isActiveRun) {
-        if (isQuickTransfer && protocolId != null) {
-          navigate(`/quick-transfer/${protocolId}`)
-        } else if (isQuickTransfer) {
-          navigate('/quick-transfer')
-        } else if (protocolId != null) {
-          navigate(`/protocols/${protocolId}`)
-        } else {
-          navigate('/protocols')
-        }
+        dismissCurrentRun(runId)
       }
     }
   }, [runStatus])

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
@@ -138,15 +138,7 @@ describe('ConfirmCancelRunModal', () => {
     expect(mockStopRun).toHaveBeenCalled()
   })
 
-  it('when run is stopped, the run is dismissed and the modal closes', () => {
-    when(useRunStatus).calledWith(RUN_ID).thenReturn(RUN_STATUS_STOPPED)
-    render(props)
-
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
-    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
-  })
-
-  it('when run is stopped, the run is dismissed and the modal closes - in prepare to run', () => {
+  it('when run is stopped, the run is dismissed and the modal closes if the run is not yet active', () => {
     props = {
       ...props,
       isActiveRun: false,
@@ -156,18 +148,13 @@ describe('ConfirmCancelRunModal', () => {
 
     expect(mockDismissCurrentRun).toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
-    expect(mockNavigate).toHaveBeenCalledWith('/protocols')
   })
-  it('when quick transfer run is stopped, the run is dismissed and you return to quick transfer', () => {
-    props = {
-      ...props,
-      isActiveRun: false,
-      isQuickTransfer: true,
-    }
+
+  it('when run is stopped, the run is not dismissed if the run is active', () => {
     when(useRunStatus).calledWith(RUN_ID).thenReturn(RUN_STATUS_STOPPED)
     render(props)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
-    expect(mockNavigate).toHaveBeenCalledWith('/quick-transfer')
+    expect(mockDismissCurrentRun).not.toHaveBeenCalled()
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
   })
 })

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -251,15 +251,10 @@ export function RunSummary(): JSX.Element {
   }, [isRunCurrent, enteredER])
 
   const returnToQuickTransfer = (): void => {
-    if (!isRunCurrent) {
+    closeCurrentRunIfValid(() => {
       deleteRun(runId)
       navigate('/quick-transfer')
-    } else {
-      closeCurrentRunIfValid(() => {
-        deleteRun(runId)
-        navigate('/quick-transfer')
-      })
-    }
+    })
   }
 
   // TODO(jh, 05-30-24): EXEC-487. Refactor reset() so we can redirect to the setup page, showing the shimmer skeleton instead.


### PR DESCRIPTION
fix RQA-3100, RQA-3098
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR changes the behavior of a run cancellation initiated on ODD. Previous behavior stopped the run, dismissed (or un-currented) the run, and then if the run was not yet started we'd manually redirect back to the protocols or quick transfer page. Now, we'll only dismiss the run if it has not yet started. This will fix the drop tip wizard not opening as expected after run cancellation.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
1. From ODD, cancel a run from the run setup screen. Ensure behavior has not changed and you are still redirected back to the protocol or quick transfer details page.
2. From ODD, cancel a run that is in progress and has a tip attached. See that the drop tip wizard opens if you press "return to dashboard". When viewing the same run from the desktop app, verify that the drop tip wizard does not close after a few seconds without any user intervention

While testing this, you may run into https://opentrons.atlassian.net/browse/RQA-3109 which is not fixed in this PR. If this is too difficult to test because of the hanging cancellation modal, we can wait to test and merge until that ticket is resolved.

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Moved `dismissCurrentRun` call in `ConfirmCancelRunModal` so that it is only called if a run is not active
2. Moved the post dismissal navigation logic to the `onSettled` callback of `useDismissCurrentRunMutation` 
4. Removed some unnecessary duplicate logic in the `returnToQuickTransfer` function - `closeCurrentRunIfValid` handles the current run functionality for us

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over code changes
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Medium - we do not think this will have any side effects but it is possible that there are places in the app where we expect a run to be dismissed after ODD cancellation
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
