### PR TITLE
fix(app): fall back to stored protocol analysis for pipette data

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupFlexPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupFlexPipetteCalibrationItem.tsx
@@ -16,6 +16,7 @@ import {
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { TertiaryButton } from '../../../atoms/buttons'
 import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { useStoredProtocolAnalysis } from '../hooks'
 import { PipetteWizardFlows } from '../../PipetteWizardFlows'
 import { FLOWS } from '../../PipetteWizardFlows/constants'
 import { SetupCalibrationItem } from './SetupCalibrationItem'
@@ -40,11 +41,13 @@ export function SetupFlexPipetteCalibrationItem({
   )
   const { data: attachedInstruments } = useInstrumentsQuery()
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
-  const loadPipetteCommand = mostRecentAnalysis?.commands.find(
+  const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)
+  const completedAnalysis = mostRecentAnalysis ?? storedProtocolAnalysis
+  const loadPipetteCommand = completedAnalysis?.commands.find(
     (command): command is LoadPipetteRunTimeCommand =>
       command.commandType === 'loadPipette' && command.params.mount === mount
   )
-  const requestedPipette = mostRecentAnalysis?.pipettes?.find(
+  const requestedPipette = completedAnalysis?.pipettes?.find(
     pipette => pipette.id === loadPipetteCommand?.result?.pipetteId
   )
 
@@ -120,7 +123,7 @@ export function SetupFlexPipetteCalibrationItem({
               ? NINETY_SIX_CHANNEL
               : SINGLE_MOUNT_PIPETTES
           }
-          pipetteInfo={mostRecentAnalysis?.pipettes}
+          pipetteInfo={completedAnalysis?.pipettes}
           onComplete={instrumentsRefetch}
         />
       )}


### PR DESCRIPTION
fix RQA-3111

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
In the run setup instrument section on a Flex we are falling back on the `storedProtocolAnalysis` if the robot analysis is pending for the gripper info but not for pipette info. This is confusing for the user since they see the gripper immediately when viewing run setup but the pipettes don't populate until the robot analysis is completed
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Start setup on a protocol with both pipettes and a gripper, see that the pipettes and gripper populate at the same time in the instrument section
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Fall back on `storedProtocolAnalysis` if `mostRecentCompletedAnalysis` does not exist
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over changes
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
