### PR TITLE
fix(app): filter robots for CSV protocols that raise analysis errors

### DIFF
--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -203,9 +203,9 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     first(srcFileNames) ??
     protocolKey
 
-  // intentionally show both robot types if analysis has any error
+  // intentionally show both robot types if analysis fails
   const robotType =
-    mostRecentAnalysis != null && mostRecentAnalysis.errors.length === 0
+    mostRecentAnalysis != null && mostRecentAnalysis.result !== 'not-ok'
       ? mostRecentAnalysis?.robotType ?? null
       : null
 


### PR DESCRIPTION
# Overview

We are intentionally permissive of robots on which to start protocol setup if analysis fails app-side. However, we previously checked whether the analysis contained errors to make this determination. Given that CSV parameter protocols raise analysis errors intentionally, but contain useful information regarding the robot type, we should filter robots if the analysis result is `parameter-value-required`.

Closes RQA-3114

## Test Plan and Hands on Testing

- Import a valid CSV protocol for OT-2 (like this)
- From protocol page, click start setup
- Verify that only OT-2 protocols show as options

https://github.com/user-attachments/assets/30cc3488-b98f-4498-9cfd-d19a2e05db4b


## Changelog

- check analysis result rather than errors when filtering robots

## Review requests

- see test plan

## Risk assessment

low