### PR TITLE
chore: known issue for partial pickup in error recovery

### DIFF
--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -28,6 +28,7 @@ Welcome to the v8.0.0 release of the Opentrons App!
 ### Known Issues
 
 - Labware offsets can't be applied to protocols that require selecting a CSV file as a runtime parameter value. Write the protocol in such a way that it passes analysis with or without the CSV file, or run Labware Position Check after confirming parameter values.
+- Error recovery can't perform partial tip pickup, because it doesn't account for the pipette nozzle configuration of 8- and 96-channel pipettes. If a recovery step requires partial tip pickup, cancel the protocol instead.
 
 ---
 


### PR DESCRIPTION

# Overview

Known issue that error recovery always uses a full configuration for tip pickup, regardless of what's specified in the protocol.

## Test Plan and Hands on Testing

Check in next alpha.

## Changelog

 +1 bullet

## Review requests

Does this capture what we decided in our conversations about this issue? Is there a way for users to know _for certain_ when this is the case? I think the answer is regrettably "no", because it's so protocol-specific and the run log step is not displayed at the moment they need to make this decision.

Have we tested if someone ignores this advice and proceeds with full 96 pickup on a rack with no adapter, will the robot move and attempt the pickup before erroring again? Or will it be caught as invalid prior to movement?

## Risk assessment

none