### PR TITLE
fix(app): use Keyboard.onInit hook to set the initial value of the keyboard.

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
@@ -13,6 +13,7 @@ interface NumericalKeyboardProps {
   isDecimal?: boolean
   hasHyphen?: boolean
   debug?: boolean
+  initialValue?: string
 }
 
 // the default keyboard layout intKeyboard that doesn't have decimal point and hyphen.
@@ -22,6 +23,7 @@ export function NumericalKeyboard({
   isDecimal = false,
   hasHyphen = false,
   debug = false,
+  initialValue = '',
 }: NumericalKeyboardProps): JSX.Element {
   const layoutName = `${isDecimal ? 'float' : 'int'}${
     hasHyphen ? 'NegKeyboard' : 'Keyboard'
@@ -35,6 +37,7 @@ export function NumericalKeyboard({
     <Keyboard
       keyboardRef={r => (keyboardRef.current = r)}
       theme={'hg-theme-default oddTheme1 numerical-keyboard'}
+      onInit={keyboard => {keyboard.setInput(initialValue)}}
       onChange={onChange}
       display={numericalCustom}
       useButtonTag={true}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
@@ -205,6 +205,7 @@ export function AirGap(props: AirGapProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
+              initialValue={String(volume)}
               onChange={e => {
                 setVolume(Number(e))
               }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
@@ -262,6 +262,7 @@ export function Delay(props: DelayProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
+              initialValue={String(position)}
               onChange={e => {
                 setPosition(Number(e))
               }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
@@ -141,6 +141,7 @@ export function FlowRateEntry(props: FlowRateEntryProps): JSX.Element {
         >
           <NumericalKeyboard
             keyboardRef={keyboardRef}
+            initialValue={String(flowRate)}
             onChange={e => {
               setFlowRate(Number(e))
             }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
@@ -202,6 +202,7 @@ export function Mix(props: MixProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
+              initialValue={String(mixVolume)}
               onChange={e => {
                 setMixVolume(Number(e))
               }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -199,6 +199,7 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
+              initialValue={String(disposalVolume)}
               onChange={e => {
                 setDisposalVolume(Number(e))
               }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
@@ -132,6 +132,7 @@ export function TipPositionEntry(props: TipPositionEntryProps): JSX.Element {
         >
           <NumericalKeyboard
             keyboardRef={keyboardRef}
+            initialValue={String(tipPosition)}
             onChange={e => {
               setTipPosition(Number(e))
             }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
@@ -194,6 +194,7 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
+              initialValue={String(position)}
               onChange={e => {
                 setPosition(Number(e))
               }}


### PR DESCRIPTION
# Overview

The keyboard component does not know about the value in any given Input component since they are separate components, which means when the keyboard first renders the keyboard object does not have a value so you can't delete the input in the given Input component. So let's add an `initialValue` property to the Keyboard component which uses the `Keyboard.onInit` hook to set the initial value of the keyboard.

Closes: [RQA-2916](https://opentrons.atlassian.net/browse/RQA-2916)


## Test Plan and Hands on Testing

- [x] Make sure that we can delete the initial value without first inputting a value for all Quick Transfer properties.

## Changelog

- Add an `initialValue` property to the `NumericalKeyboard` component which uses the `Keyboard.onInit` hook to set the initial value of the keyboard.
- Use the `NumericalKeyboard` component's new `initialValue` property for all Quick Transfer properties that require keyboard input.

## Review requests

makes sense?

## Risk assessment

low, although the Keyboard component is used by RTP, the new `initialValue` property is optional and won't affect anything unless used.

[RQA-2916]: https://opentrons.atlassian.net/browse/RQA-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ