### PR TITLE
feat(api): provide labware schema 3 definitions if possible

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -30,7 +30,6 @@ from opentrons.hardware_control.nozzle_manager import NozzleMap
 # remove when their usage is no longer needed
 from opentrons.protocols.labware import (  # noqa: F401
     get_labware_definition as get_labware_definition,
-    get_all_labware_definitions as get_all_labware_definitions,
     verify_definition as verify_definition,
     save_definition as save_definition,
 )

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -109,6 +109,7 @@ class LabwareState:
 
     definitions_by_uri: Dict[str, LabwareDefinition]
     deck_definition: DeckDefinitionV5
+    # here
 
 
 class LabwareStore(HasState[LabwareState], HandlesActions):

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -109,7 +109,6 @@ class LabwareState:
 
     definitions_by_uri: Dict[str, LabwareDefinition]
     deck_definition: DeckDefinitionV5
-    # here
 
 
 class LabwareStore(HasState[LabwareState], HandlesActions):

--- a/api/src/opentrons/protocols/api_support/constants.py
+++ b/api/src/opentrons/protocols/api_support/constants.py
@@ -4,6 +4,5 @@ from opentrons.config import get_opentrons_path
 
 OPENTRONS_NAMESPACE = "opentrons"
 CUSTOM_NAMESPACE = "custom_beta"
-# STANDARD_DEFS_PATH = Path("labware/definitions/2")
 STANDARD_DEFS_PATH = Path("labware/definitions")
 USER_DEFS_PATH = get_opentrons_path("labware_user_definitions_dir_v2")

--- a/api/src/opentrons/protocols/api_support/constants.py
+++ b/api/src/opentrons/protocols/api_support/constants.py
@@ -4,5 +4,6 @@ from opentrons.config import get_opentrons_path
 
 OPENTRONS_NAMESPACE = "opentrons"
 CUSTOM_NAMESPACE = "custom_beta"
-STANDARD_DEFS_PATH = Path("labware/definitions/2")
+# STANDARD_DEFS_PATH = Path("labware/definitions/2")
+STANDARD_DEFS_PATH = Path("labware/definitions")
 USER_DEFS_PATH = get_opentrons_path("labware_user_definitions_dir_v2")

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -391,13 +391,3 @@ def requires_version(major: int, minor: int) -> Callable[[FuncT], FuncT]:
         return cast(FuncT, _check_version_wrapper)
 
     return _set_version
-
-
-class ModifiedList(list[str]):
-    def __contains__(self, item: object) -> bool:
-        if not isinstance(item, str):
-            return False
-        for name in self:
-            if name == item.replace("-", "_").lower():
-                return True
-        return False

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -77,7 +77,7 @@ def get_all_labware_definitions() -> List[str]:
                     labware_list.append(sub_dir.name)
 
     # check for standard labware
-    _check_for_subdirectories(get_shared_data_root() / (STANDARD_DEFS_PATH + "/2"))
+    _check_for_subdirectories(get_shared_data_root() / (STANDARD_DEFS_PATH / "2"))
 
     # check for custom labware
     for namespace in os.scandir(USER_DEFS_PATH):
@@ -114,7 +114,6 @@ def save_definition(
             f'Saving definitions to the "{OPENTRONS_NAMESPACE}" namespace '
             + "is not permitted"
         )
-
     def_path = _get_path_to_labware(load_name, namespace, version, location)
 
     if not force and def_path.is_file():
@@ -219,7 +218,6 @@ def _get_standard_labware_definition(
         Definitions Folder from the Opentrons App before
         uploading your protocol.
         """
-
     if namespace is None:
         for fallback_namespace in [OPENTRONS_NAMESPACE, CUSTOM_NAMESPACE]:
             try:
@@ -252,15 +250,28 @@ def _get_path_to_labware(
 ) -> Path:
     if namespace == OPENTRONS_NAMESPACE:
         # all labware in OPENTRONS_NAMESPACE is stored in shared data
-        if load_name in os.listdir(
-            get_shared_data_root() / STANDARD_DEFS_PATH / "3"
-        ):
+        if load_name in os.listdir(get_shared_data_root() / STANDARD_DEFS_PATH / "3"):
             return (
-                get_shared_data_root() / STANDARD_DEFS_PATH / "3" / load_name / f"{version}.json"
+                get_shared_data_root()
+                / STANDARD_DEFS_PATH
+                / "3"
+                / load_name
+                / f"{version}.json"
             )
         else:
+            res = (
+                    get_shared_data_root()
+                    / STANDARD_DEFS_PATH
+                    / "2"
+                    / load_name
+                    / f"{version}.json"
+            )
             return (
-                    get_shared_data_root() / STANDARD_DEFS_PATH / "2" / load_name / f"{version}.json"
+                get_shared_data_root()
+                / STANDARD_DEFS_PATH
+                / "2"
+                / load_name
+                / f"{version}.json"
             )
     if not base_path:
         base_path = USER_DEFS_PATH

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -260,11 +260,11 @@ def _get_path_to_labware(
             )
         else:
             res = (
-                    get_shared_data_root()
-                    / STANDARD_DEFS_PATH
-                    / "2"
-                    / load_name
-                    / f"{version}.json"
+                get_shared_data_root()
+                / STANDARD_DEFS_PATH
+                / "2"
+                / load_name
+                / f"{version}.json"
             )
             return (
                 get_shared_data_root()

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -77,7 +77,7 @@ def get_all_labware_definitions() -> List[str]:
                     labware_list.append(sub_dir.name)
 
     # check for standard labware
-    _check_for_subdirectories(get_shared_data_root() / STANDARD_DEFS_PATH)
+    _check_for_subdirectories(get_shared_data_root() / (STANDARD_DEFS_PATH + "/2"))
 
     # check for custom labware
     for namespace in os.scandir(USER_DEFS_PATH):
@@ -252,9 +252,16 @@ def _get_path_to_labware(
 ) -> Path:
     if namespace == OPENTRONS_NAMESPACE:
         # all labware in OPENTRONS_NAMESPACE is stored in shared data
-        return (
-            get_shared_data_root() / STANDARD_DEFS_PATH / load_name / f"{version}.json"
-        )
+        if load_name in os.listdir(
+            get_shared_data_root() / STANDARD_DEFS_PATH / "3"
+        ):
+            return (
+                get_shared_data_root() / STANDARD_DEFS_PATH / "3" / load_name / f"{version}.json"
+            )
+        else:
+            return (
+                    get_shared_data_root() / STANDARD_DEFS_PATH / "2" / load_name / f"{version}.json"
+            )
     if not base_path:
         base_path = USER_DEFS_PATH
     def_path = base_path / namespace / load_name / f"{version}.json"

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import json
-import os
 
 from pathlib import Path
 from typing import Any, AnyStr, Dict, Optional, Union
@@ -226,29 +225,21 @@ def _get_path_to_labware(
 ) -> Path:
     if namespace == OPENTRONS_NAMESPACE:
         # all labware in OPENTRONS_NAMESPACE is stored in shared data
-
-        schema_3_load_name_present = load_name in os.listdir(
-            get_shared_data_root() / STANDARD_DEFS_PATH / "3"
+        schema_3_path = (
+            get_shared_data_root()
+            / STANDARD_DEFS_PATH
+            / "3"
+            / load_name
+            / f"{version}.json"
         )
-        if schema_3_load_name_present:
-            schema_3_version_present = f"{version}.json" in os.listdir(
-                get_shared_data_root() / STANDARD_DEFS_PATH / "3" / load_name
-            )
-            if schema_3_version_present:
-                return (
-                    get_shared_data_root()
-                    / STANDARD_DEFS_PATH
-                    / "3"
-                    / load_name
-                    / f"{version}.json"
-                )
-        return (
+        schema_2_path = (
             get_shared_data_root()
             / STANDARD_DEFS_PATH
             / "2"
             / load_name
             / f"{version}.json"
         )
+        return schema_3_path if schema_3_path.exists() else schema_2_path
     if not base_path:
         base_path = USER_DEFS_PATH
     def_path = base_path / namespace / load_name / f"{version}.json"


### PR DESCRIPTION
## Overview
Now that we have labware schema 3 merged, let's provide labware schema 3 definitions when they're available, and otherwise default to schema 2 like before.

## Changelog

- In `_get_path_to_labware`, see if a folder matching the labware's name exists, and if not return the definition in the schema 2 folder
- adjust `get_all_labware_definitions` to stay pointed at the schema 2 folder because I'm unsure where that gets used

## Review Requests
Let me know if this might break anything unexpected