### PR TITLE
feat(protocol-designer): wire up defining liquids

### DIFF
--- a/protocol-designer/src/assets/localization/en/liquids.json
+++ b/protocol-designer/src/assets/localization/en/liquids.json
@@ -1,3 +1,8 @@
 {
-  "liquids": "Liquids"
+  "define_liquid": "Define a liquid",
+  "delete_liquid": "Delete liquid",
+  "description": "Description",
+  "display_color": "Color",
+  "liquids": "Liquids",
+  "name": "Name"
 }

--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -88,6 +88,7 @@
   "re_export": "To use this definition, use Labware Creator to give it a unique load name and display name.",
   "remove": "remove",
   "right": "Right",
+  "save": "Save",
   "shared_display_name": "Shared display name: ",
   "shared_load_name": "Shared load name: ",
   "shares_name": "This labware has the same load name or display name as {{customOrStandard}}, which is already in this protocol.",

--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -14,6 +14,7 @@
   "custom": "Custom labware definitions",
   "customize_slot": "Customize slot {{slotName}}",
   "deck_hardware": "Deck hardware",
+  "define_liquid": "Define a liquid",
   "done": "Done",
   "duplicate": "Duplicate",
   "edit_labware": "Edit labware",

--- a/protocol-designer/src/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/organisms/DefineLiquidsModal/index.tsx
@@ -1,0 +1,315 @@
+import * as React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+import { SketchPicker } from 'react-color'
+import { yupResolver } from '@hookform/resolvers/yup'
+import styled from 'styled-components'
+import * as Yup from 'yup'
+import { Controller, useForm } from 'react-hook-form'
+import {
+  DEFAULT_LIQUID_COLORS,
+  DEPRECATED_WHALE_GREY,
+} from '@opentrons/shared-data'
+import {
+  BORDERS,
+  Btn,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  InputField,
+  JUSTIFY_END,
+  JUSTIFY_SPACE_BETWEEN,
+  LiquidIcon,
+  Modal,
+  POSITION_ABSOLUTE,
+  PrimaryButton,
+  SecondaryButton,
+  SPACING,
+  StyledText,
+  TYPOGRAPHY,
+  useOnClickOutside,
+} from '@opentrons/components'
+import * as labwareIngredActions from '../../labware-ingred/actions'
+import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
+import { swatchColors } from '../../components/swatchColors'
+import { checkColor } from './utils'
+
+import type { ColorResult } from 'react-color'
+import type { ThunkDispatch } from 'redux-thunk'
+import type { BaseState } from '../../types'
+import type { LiquidGroup } from '../../labware-ingred/types'
+
+interface LiquidEditFormValues {
+  name: string
+  displayColor: string
+  description?: string | null
+  serialize?: boolean
+  [key: string]: unknown
+}
+
+const INVALID_DISPLAY_COLORS = ['#000000', '#ffffff', DEPRECATED_WHALE_GREY]
+
+const liquidEditFormSchema: any = Yup.object().shape({
+  name: Yup.string().required('liquid name is required'),
+  displayColor: Yup.string().test(
+    'disallowed-color',
+    'Invalid display color',
+    value => {
+      if (value == null) {
+        return true
+      }
+      return !INVALID_DISPLAY_COLORS.includes(value)
+        ? !checkColor(value)
+        : false
+    }
+  ),
+  description: Yup.string(),
+  serialize: Yup.boolean(),
+})
+
+interface DefineLiquidsModalProps {
+  onClose: () => void
+}
+export function DefineLiquidsModal(
+  props: DefineLiquidsModalProps
+): JSX.Element {
+  const { onClose } = props
+  const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
+  const { t } = useTranslation(['liquids', 'shared'])
+  const selectedLiquid = useSelector(
+    labwareIngredSelectors.getSelectedLiquidGroupState
+  )
+  const nextGroupId = useSelector(labwareIngredSelectors.getNextLiquidGroupId)
+  const selectedLiquidGroupState = useSelector(
+    labwareIngredSelectors.getSelectedLiquidGroupState
+  )
+  const [showColorPicker, setShowColorPicker] = React.useState<boolean>(false)
+  const chooseColorWrapperRef = useOnClickOutside<HTMLDivElement>({
+    onClickOutside: () => {
+      setShowColorPicker(false)
+    },
+  })
+  const allIngredientGroupFields = useSelector(
+    labwareIngredSelectors.allIngredientGroupFields
+  )
+  const liquidGroupId =
+    selectedLiquidGroupState && selectedLiquidGroupState.liquidGroupId
+  const deleteLiquidGroup = (): void => {
+    if (liquidGroupId != null) {
+      dispatch(labwareIngredActions.deleteLiquidGroup(liquidGroupId))
+    }
+    onClose()
+  }
+
+  const cancelForm = (): void => {
+    dispatch(labwareIngredActions.deselectLiquidGroup())
+    onClose()
+  }
+
+  const saveForm = (formData: LiquidGroup): void => {
+    dispatch(
+      labwareIngredActions.editLiquidGroup({
+        ...formData,
+        liquidGroupId: liquidGroupId,
+      })
+    )
+    onClose()
+  }
+
+  const selectedIngredFields =
+    liquidGroupId != null ? allIngredientGroupFields[liquidGroupId] : null
+  const liquidId = selectedLiquid.liquidGroupId ?? nextGroupId
+
+  const initialValues: LiquidEditFormValues = {
+    name: selectedIngredFields?.name ?? '',
+    displayColor: selectedIngredFields?.displayColor ?? swatchColors(liquidId),
+    description: selectedIngredFields?.description ?? '',
+    serialize: selectedIngredFields?.serialize ?? false,
+  }
+
+  const {
+    handleSubmit,
+    formState: { errors, touchedFields },
+    control,
+    watch,
+    setValue,
+    register,
+  } = useForm<LiquidEditFormValues>({
+    defaultValues: initialValues,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    resolver: yupResolver(liquidEditFormSchema),
+  })
+  const name = watch('name')
+  const color = watch('displayColor')
+
+  const handleLiquidEdits = (values: LiquidEditFormValues): void => {
+    saveForm({
+      name: values.name,
+      displayColor: values.displayColor,
+      description: values.description ?? null,
+      serialize: values.serialize ?? false,
+    })
+  }
+
+  return (
+    <Modal
+      width="673px"
+      title={
+        selectedIngredFields != null ? (
+          <Flex gridGap={SPACING.spacing8}>
+            <LiquidIcon color={initialValues.displayColor} />
+            <StyledText desktopStyle="bodyLargeSemiBold">
+              {initialValues.name}
+            </StyledText>
+          </Flex>
+        ) : (
+          t('define_liquid')
+        )
+      }
+      type="info"
+      onClose={onClose}
+    >
+      <form onSubmit={handleSubmit(handleLiquidEdits)}>
+        <>
+          {showColorPicker ? (
+            <Flex
+              position={POSITION_ABSOLUTE}
+              left="4.375rem"
+              top="4.6875rem"
+              ref={chooseColorWrapperRef}
+            >
+              <Controller
+                name="displayColor"
+                control={control}
+                render={({ field }) => (
+                  <SketchPicker
+                    presetColors={DEFAULT_LIQUID_COLORS}
+                    color={color}
+                    onChange={(color: ColorResult) => {
+                      setValue('displayColor', color.hex)
+
+                      field.onChange(color.hex)
+                    }}
+                  />
+                )}
+              />
+            </Flex>
+          ) : null}
+
+          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
+            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                color={COLORS.grey60}
+                gridGap={SPACING.spacing4}
+              >
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {t('name')}
+                </StyledText>
+                <Controller
+                  control={control}
+                  name="name"
+                  render={({ field }) => (
+                    <InputField
+                      name="name"
+                      error={
+                        touchedFields.name != null ? errors.name?.message : null
+                      }
+                      value={name}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                  )}
+                />
+              </Flex>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                color={COLORS.grey60}
+                gridGap={SPACING.spacing4}
+              >
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {t('description')}
+                </StyledText>
+                <DescriptionField {...register('description')} />
+              </Flex>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                color={COLORS.grey60}
+                gridGap={SPACING.spacing4}
+              >
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {t('display_color')}
+                </StyledText>
+                <Btn
+                  onClick={() => {
+                    setShowColorPicker(prev => !prev)
+                  }}
+                >
+                  <LiquidIcon color={color} size="medium" />
+                </Btn>
+              </Flex>
+              {/* NOTE: this is for serialization if we decide to add it back */}
+              {/* <Controller
+            control={control}
+            name="serialize"
+            render={({ field }) => (
+              <DeprecatedCheckboxField
+                name="serialize"
+                label={t('liquid_edit.serialize')}
+                value={field.value}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  field.onChange(e)
+                }}
+              />
+            )}
+          /> */}
+            </Flex>
+            <Flex
+              justifyContent={
+                selectedIngredFields != null
+                  ? JUSTIFY_SPACE_BETWEEN
+                  : JUSTIFY_END
+              }
+              gridGap={SPACING.spacing8}
+            >
+              {selectedIngredFields != null ? (
+                <Btn
+                  onClick={deleteLiquidGroup}
+                  textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                >
+                  <StyledText desktopStyle="bodyDefaultRegular">
+                    {t('delete_liquid')}
+                  </StyledText>
+                </Btn>
+              ) : (
+                <SecondaryButton onClick={cancelForm}>
+                  {t('shared:close')}
+                </SecondaryButton>
+              )}
+              <PrimaryButton
+                type="submit"
+                disabled={
+                  errors.name != null ||
+                  name === '' ||
+                  errors.displayColor != null
+                }
+              >
+                {t('shared:save')}
+              </PrimaryButton>
+            </Flex>
+          </Flex>
+        </>
+      </form>
+    </Modal>
+  )
+}
+
+const DescriptionField = styled.textarea`
+  height: 6.875rem;
+  width: 100%;
+  border: 1px solid ${COLORS.grey50};
+  border-radius: ${BORDERS.borderRadius4};
+  padding: ${SPACING.spacing8};
+  font-size: ${TYPOGRAPHY.fontSizeP};
+  resize: none;
+`

--- a/protocol-designer/src/organisms/DefineLiquidsModal/utils.ts
+++ b/protocol-designer/src/organisms/DefineLiquidsModal/utils.ts
@@ -1,0 +1,8 @@
+export function checkColor(hex: string): boolean {
+  const cleanHex = hex.replace('#', '')
+  const red = parseInt(cleanHex.slice(0, 2), 16)
+  const green = parseInt(cleanHex.slice(2, 4), 16)
+  const blue = parseInt(cleanHex.slice(4, 6), 16)
+  const luminance = (0.299 * red + 0.587 * green + 0.114 * blue) / 255
+  return luminance < 0.1 || luminance > 0.9
+}

--- a/protocol-designer/src/organisms/index.ts
+++ b/protocol-designer/src/organisms/index.ts
@@ -1,3 +1,4 @@
+export * from './DefineLiquidsModal'
 export * from './FeatureFlagsModal'
 export * from './FileUploadMessagesModal/'
 export * from './IncompatibleTipsModal'

--- a/protocol-designer/src/pages/Designer/LiquidsOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/LiquidsOverflowMenu.tsx
@@ -15,7 +15,6 @@ import {
   POSITION_ABSOLUTE,
   SPACING,
   StyledText,
-  useOnClickOutside,
 } from '@opentrons/components'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import * as labwareIngredActions from '../../labware-ingred/actions'
@@ -25,29 +24,22 @@ const NAV_HEIGHT = '64px'
 
 interface LiquidsOverflowMenuProps {
   onClose: () => void
+  showLiquidsModal: () => void
+  overflowWrapperRef: React.RefObject<HTMLDivElement>
 }
 
 export function LiquidsOverflowMenu(
   props: LiquidsOverflowMenuProps
 ): JSX.Element {
-  const { onClose } = props
+  const { onClose, showLiquidsModal, overflowWrapperRef } = props
   const { t } = useTranslation(['starting_deck_state'])
   const liquids = useSelector(labwareIngredSelectors.allIngredientNamesIds)
   const dispatch: ThunkDispatch<any> = useDispatch()
-  const [showDefineLiquidModal, setDefineLiquidModal] = React.useState<boolean>(
-    false
-  )
-  const overflowWrapperRef = useOnClickOutside<HTMLDivElement>({
-    onClickOutside: () => {
-      if (!showDefineLiquidModal) {
-        onClose()
-      }
-    },
-  })
 
   return (
     <Flex
       position={POSITION_ABSOLUTE}
+      zIndex={5}
       right="50px"
       top={`calc(${NAV_HEIGHT} - 6px)`}
       whiteSpace={NO_WRAP}
@@ -66,8 +58,8 @@ export function LiquidsOverflowMenu(
           <MenuButton
             data-testid={`${name}_${ingredientId}`}
             onClick={() => {
-              setDefineLiquidModal(true)
               onClose()
+              showLiquidsModal()
               dispatch(labwareIngredActions.selectLiquidGroup(ingredientId))
             }}
             key={ingredientId}
@@ -83,8 +75,8 @@ export function LiquidsOverflowMenu(
       <MenuButton
         data-testid="defineLiquid"
         onClick={() => {
-          setDefineLiquidModal(true)
           onClose()
+          showLiquidsModal()
           dispatch(labwareIngredActions.createNewLiquidGroup())
         }}
         key="defineLiquid"

--- a/protocol-designer/src/pages/Designer/LiquidsOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/LiquidsOverflowMenu.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import { useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
+import {
+  ALIGN_CENTER,
+  BORDERS,
+  Box,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  LiquidIcon,
+  NO_WRAP,
+  POSITION_ABSOLUTE,
+  SPACING,
+  StyledText,
+  useOnClickOutside,
+} from '@opentrons/components'
+import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
+import * as labwareIngredActions from '../../labware-ingred/actions'
+import type { ThunkDispatch } from '../../types'
+
+const NAV_HEIGHT = '64px'
+
+interface LiquidsOverflowMenuProps {
+  onClose: () => void
+}
+
+export function LiquidsOverflowMenu(
+  props: LiquidsOverflowMenuProps
+): JSX.Element {
+  const { onClose } = props
+  const { t } = useTranslation(['starting_deck_state'])
+  const liquids = useSelector(labwareIngredSelectors.allIngredientNamesIds)
+  const dispatch: ThunkDispatch<any> = useDispatch()
+  const [showDefineLiquidModal, setDefineLiquidModal] = React.useState<boolean>(
+    false
+  )
+  const overflowWrapperRef = useOnClickOutside<HTMLDivElement>({
+    onClickOutside: () => {
+      if (!showDefineLiquidModal) {
+        onClose()
+      }
+    },
+  })
+
+  return (
+    <Flex
+      position={POSITION_ABSOLUTE}
+      right="50px"
+      top={`calc(${NAV_HEIGHT} - 6px)`}
+      whiteSpace={NO_WRAP}
+      ref={overflowWrapperRef}
+      borderRadius={BORDERS.borderRadius8}
+      boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
+      backgroundColor={COLORS.white}
+      flexDirection={DIRECTION_COLUMN}
+      onClick={(e: React.MouseEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }}
+    >
+      {liquids.map(({ name, displayColor, ingredientId }) => {
+        return (
+          <MenuButton
+            data-testid={`${name}_${ingredientId}`}
+            onClick={() => {
+              setDefineLiquidModal(true)
+              onClose()
+              dispatch(labwareIngredActions.selectLiquidGroup(ingredientId))
+            }}
+            key={ingredientId}
+          >
+            <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
+              <LiquidIcon color={displayColor ?? ''} />
+              <StyledText desktopStyle="bodyDefaultRegular">{name}</StyledText>
+            </Flex>
+          </MenuButton>
+        )
+      })}
+      <Box width="100%" border={`1px solid ${COLORS.grey20}`} />
+      <MenuButton
+        data-testid="defineLiquid"
+        onClick={() => {
+          setDefineLiquidModal(true)
+          onClose()
+          dispatch(labwareIngredActions.createNewLiquidGroup())
+        }}
+        key="defineLiquid"
+      >
+        <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing4}>
+          <Icon name="plus" size="1rem" />
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {t('define_liquid')}
+          </StyledText>
+        </Flex>
+      </MenuButton>
+    </Flex>
+  )
+}
+const MenuButton = styled.button`
+  background-color: ${COLORS.transparent};
+  cursor: pointer;
+  padding: ${SPACING.spacing8} ${SPACING.spacing12};
+  border: none;
+  &:hover {
+    background-color: ${COLORS.blue10};
+  }
+  &:disabled {
+    color: ${COLORS.grey40};
+    cursor: auto;
+  }
+`

--- a/protocol-designer/src/pages/Designer/__tests__/Designer.test.tsx
+++ b/protocol-designer/src/pages/Designer/__tests__/Designer.test.tsx
@@ -9,11 +9,13 @@ import { getFileMetadata } from '../../../file-data/selectors'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import { DeckSetupContainer } from '../DeckSetup'
 import { Designer } from '../index'
+import { LiquidsOverflowMenu } from '../LiquidsOverflowMenu'
 
 import type { NavigateFunction } from 'react-router-dom'
 
 const mockNavigate = vi.fn()
 
+vi.mock('../LiquidsOverflowMenu')
 vi.mock('../DeckSetup')
 vi.mock('../../../file-data/selectors')
 vi.mock('../../../top-selectors/labware-locations')
@@ -50,7 +52,11 @@ describe('Designer', () => {
     vi.mocked(DeckSetupContainer).mockReturnValue(
       <div>mock DeckSetupContainer</div>
     )
+    vi.mocked(LiquidsOverflowMenu).mockReturnValue(
+      <div>mock LiquidsOverflowMenu</div>
+    )
   })
+
   it('renders deck setup container and nav buttons', () => {
     render()
     screen.getByText('mock DeckSetupContainer')
@@ -62,6 +68,12 @@ describe('Designer', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Done' }))
     expect(mockNavigate).toHaveBeenCalledWith('/overview')
   })
-  it.todo('renders the liquids button overflow menu')
+
+  it('renders the liquids button overflow menu', () => {
+    render()
+    fireEvent.click(screen.getByText('Liquids'))
+    screen.getByText('mock LiquidsOverflowMenu')
+  })
+
   it.todo('renders the protocol steps page')
 })

--- a/protocol-designer/src/pages/Designer/__tests__/LiquidsOverflowMenu.test.tsx
+++ b/protocol-designer/src/pages/Designer/__tests__/LiquidsOverflowMenu.test.tsx
@@ -22,6 +22,8 @@ describe('SlotOverflowMenu', () => {
   beforeEach(() => {
     props = {
       onClose: vi.fn(),
+      showLiquidsModal: vi.fn(),
+      overflowWrapperRef: React.createRef(),
     }
     vi.mocked(labwareIngredSelectors.allIngredientNamesIds).mockReturnValue([
       {
@@ -36,6 +38,7 @@ describe('SlotOverflowMenu', () => {
     screen.getByText('mockname')
     fireEvent.click(screen.getByTestId('mockname_0'))
     expect(props.onClose).toHaveBeenCalled()
+    expect(props.showLiquidsModal).toHaveBeenCalled()
     expect(vi.mocked(labwareIngredActions.selectLiquidGroup)).toHaveBeenCalled()
     screen.getByText('Define a liquid')
     fireEvent.click(screen.getByTestId('defineLiquid'))
@@ -43,5 +46,6 @@ describe('SlotOverflowMenu', () => {
     expect(
       vi.mocked(labwareIngredActions.createNewLiquidGroup)
     ).toHaveBeenCalled()
+    expect(props.showLiquidsModal).toHaveBeenCalled()
   })
 })

--- a/protocol-designer/src/pages/Designer/__tests__/LiquidsOverflowMenu.test.tsx
+++ b/protocol-designer/src/pages/Designer/__tests__/LiquidsOverflowMenu.test.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+import { i18n } from '../../../assets/localization'
+import { selectors as labwareIngredSelectors } from '../../../labware-ingred/selectors'
+import * as labwareIngredActions from '../../../labware-ingred/actions'
+import { renderWithProviders } from '../../../__testing-utils__'
+import { LiquidsOverflowMenu } from '../LiquidsOverflowMenu'
+
+vi.mock('../../../labware-ingred/selectors')
+vi.mock('../../../labware-ingred/actions')
+
+const render = (props: React.ComponentProps<typeof LiquidsOverflowMenu>) => {
+  return renderWithProviders(<LiquidsOverflowMenu {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('SlotOverflowMenu', () => {
+  let props: React.ComponentProps<typeof LiquidsOverflowMenu>
+
+  beforeEach(() => {
+    props = {
+      onClose: vi.fn(),
+    }
+    vi.mocked(labwareIngredSelectors.allIngredientNamesIds).mockReturnValue([
+      {
+        displayColor: 'mockColor',
+        name: 'mockname',
+        ingredientId: '0',
+      },
+    ])
+  })
+  it('renders the overflow buttons with 1 liquid defined', () => {
+    render(props)
+    screen.getByText('mockname')
+    fireEvent.click(screen.getByTestId('mockname_0'))
+    expect(props.onClose).toHaveBeenCalled()
+    expect(vi.mocked(labwareIngredActions.selectLiquidGroup)).toHaveBeenCalled()
+    screen.getByText('Define a liquid')
+    fireEvent.click(screen.getByTestId('defineLiquid'))
+    expect(props.onClose).toHaveBeenCalled()
+    expect(
+      vi.mocked(labwareIngredActions.createNewLiquidGroup)
+    ).toHaveBeenCalled()
+  })
+})

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -19,12 +19,13 @@ import {
   Tabs,
   ToggleGroup,
 } from '@opentrons/components'
-
 import { useKitchen } from '../../organisms/Kitchen/hooks'
 import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
 import { getFileMetadata } from '../../file-data/selectors'
+import { DefineLiquidsModal } from '../../organisms'
 import { DeckSetupContainer } from './DeckSetup'
 import { OffDeck } from './Offdeck'
+import { LiquidsOverflowMenu } from './LiquidsOverflowMenu'
 
 import type { CutoutId } from '@opentrons/shared-data'
 import type { DeckSlot } from '@opentrons/step-generation'
@@ -44,6 +45,12 @@ export function Designer(): JSX.Element {
   const navigate = useNavigate()
   const deckSetup = useSelector(getDeckSetupForActiveItem)
   const metadata = useSelector(getFileMetadata)
+  const [liquidOverflowMenu, showLiquidOverflowMenu] = React.useState<boolean>(
+    false
+  )
+  const [showDefineLiquidModal, setDefineLiquidModal] = React.useState<boolean>(
+    false
+  )
   const [zoomInOnSlot, setZoomInOnSlot] = React.useState<OpenSlot | null>(null)
   const [tab, setTab] = React.useState<'startingDeck' | 'protocolSteps'>(
     'startingDeck'
@@ -87,80 +94,100 @@ export function Designer(): JSX.Element {
   }, [])
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN}>
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} padding={SPACING.spacing12}>
-        {zoomInOnSlot != null ? null : (
-          <Tabs tabs={[startingDeckTab, protocolStepTab]} />
-        )}
-        <Flex flexDirection={DIRECTION_COLUMN}>
-          <StyledText desktopStyle="bodyDefaultSemiBold">
-            {metadata?.protocolName != null && metadata?.protocolName !== ''
-              ? metadata?.protocolName
-              : t('untitled_protocol')}
-          </StyledText>
-          <Flex color={COLORS.grey60} justifyContent={JUSTIFY_CENTER}>
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('edit_protocol')}
+    <>
+      {showDefineLiquidModal ? (
+        <DefineLiquidsModal
+          onClose={() => {
+            setDefineLiquidModal(false)
+          }}
+        />
+      ) : null}
+      {liquidOverflowMenu ? (
+        <LiquidsOverflowMenu
+          onClose={() => {
+            showLiquidOverflowMenu(false)
+            setDefineLiquidModal(true)
+          }}
+        />
+      ) : null}
+      <Flex flexDirection={DIRECTION_COLUMN}>
+        <Flex
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          padding={SPACING.spacing12}
+        >
+          {zoomInOnSlot != null ? null : (
+            <Tabs tabs={[startingDeckTab, protocolStepTab]} />
+          )}
+          <Flex flexDirection={DIRECTION_COLUMN}>
+            <StyledText desktopStyle="bodyDefaultSemiBold">
+              {metadata?.protocolName != null && metadata?.protocolName !== ''
+                ? metadata?.protocolName
+                : t('untitled_protocol')}
             </StyledText>
-          </Flex>
-        </Flex>
-        <Flex gridGap={SPACING.spacing8}>
-          <PrimaryButton
-            onClick={() => {
-              //  TODO: wire up liquids overflow menu
-              console.log('wire up liquids')
-            }}
-          >
-            <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
-              <Icon size="1rem" name="liquid" />
+            <Flex color={COLORS.grey60} justifyContent={JUSTIFY_CENTER}>
               <StyledText desktopStyle="bodyDefaultRegular">
-                {t('liquids')}
+                {t('edit_protocol')}
               </StyledText>
             </Flex>
-          </PrimaryButton>
-          <SecondaryButton
-            onClick={() => {
-              navigate('/overview')
-            }}
-          >
-            {t('shared:done')}
-          </SecondaryButton>
+          </Flex>
+          <Flex gridGap={SPACING.spacing8}>
+            <PrimaryButton
+              onClick={() => {
+                showLiquidOverflowMenu(true)
+              }}
+            >
+              <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
+                <Icon size="1rem" name="liquid" />
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {t('liquids')}
+                </StyledText>
+              </Flex>
+            </PrimaryButton>
+
+            <SecondaryButton
+              onClick={() => {
+                navigate('/overview')
+              }}
+            >
+              {t('shared:done')}
+            </SecondaryButton>
+          </Flex>
+        </Flex>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          backgroundColor={COLORS.grey10}
+          padding={SPACING.spacing80}
+          height="calc(100vh - 64px)"
+        >
+          {tab === 'startingDeck' ? (
+            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
+              <Flex alignSelf={ALIGN_END}>
+                <ToggleGroup
+                  selectedValue={deckView}
+                  leftText={leftString}
+                  rightText={rightString}
+                  leftClick={() => {
+                    setDeckView(leftString)
+                  }}
+                  rightClick={() => {
+                    setDeckView(rightString)
+                  }}
+                />
+              </Flex>
+              {deckView === leftString ? (
+                <DeckSetupContainer
+                  setZoomInOnSlot={setZoomInOnSlot}
+                  zoomIn={zoomInOnSlot}
+                />
+              ) : (
+                <OffDeck />
+              )}
+            </Flex>
+          ) : (
+            <div>TODO wire this up</div>
+          )}
         </Flex>
       </Flex>
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        backgroundColor={COLORS.grey10}
-        padding={SPACING.spacing80}
-        height="calc(100vh - 64px)"
-      >
-        {tab === 'startingDeck' ? (
-          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
-            <Flex alignSelf={ALIGN_END}>
-              <ToggleGroup
-                selectedValue={deckView}
-                leftText={leftString}
-                rightText={rightString}
-                leftClick={() => {
-                  setDeckView(leftString)
-                }}
-                rightClick={() => {
-                  setDeckView(rightString)
-                }}
-              />
-            </Flex>
-            {deckView === leftString ? (
-              <DeckSetupContainer
-                setZoomInOnSlot={setZoomInOnSlot}
-                zoomIn={zoomInOnSlot}
-              />
-            ) : (
-              <OffDeck />
-            )}
-          </Flex>
-        ) : (
-          <div>TODO wire this up</div>
-        )}
-      </Flex>
-    </Flex>
+    </>
   )
 }

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -18,6 +18,7 @@ import {
   StyledText,
   Tabs,
   ToggleGroup,
+  useOnClickOutside,
 } from '@opentrons/components'
 import { useKitchen } from '../../organisms/Kitchen/hooks'
 import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
@@ -93,6 +94,14 @@ export function Designer(): JSX.Element {
     }
   }, [])
 
+  const overflowWrapperRef = useOnClickOutside<HTMLDivElement>({
+    onClickOutside: () => {
+      if (!showDefineLiquidModal) {
+        showLiquidOverflowMenu(false)
+      }
+    },
+  })
+
   return (
     <>
       {showDefineLiquidModal ? (
@@ -104,7 +113,11 @@ export function Designer(): JSX.Element {
       ) : null}
       {liquidOverflowMenu ? (
         <LiquidsOverflowMenu
+          overflowWrapperRef={overflowWrapperRef}
           onClose={() => {
+            showLiquidOverflowMenu(false)
+          }}
+          showLiquidsModal={() => {
             showLiquidOverflowMenu(false)
             setDefineLiquidModal(true)
           }}


### PR DESCRIPTION
closes AUTH-747

# Overview

You can define liquids now in the redesign

<img width="715" alt="Screenshot 2024-08-28 at 14 57 48" src="https://github.com/user-attachments/assets/21c00469-49ff-4cab-8f2a-3214be41a7d0">

<img width="704" alt="Screenshot 2024-08-28 at 14 57 24" src="https://github.com/user-attachments/assets/6e57923e-3c1f-4960-a38e-1a98c9b1c932">

## Test Plan and Hands on Testing

Go to deck setup and click on the liquids button in the top nav bar. It should open an overflow menu. Define a liquid and examine the modal. Should work as expected. Save the liquid and it should appear in the overflow menu. Try editing it and deleting it and make sure it works as expected

## Changelog

- create overflow menu and test
- modify the parent component test (`Designer`)
- create the liquid definition modal
- use `sketchColor` from `react-color`

## Risk assessment

low