### PR TITLE
fix(app): disable rerun until data is available

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -138,6 +138,7 @@
   "recalibrate_pipette": "Recalibrate pipette",
   "recent_protocol_runs": "Recent Protocol Runs",
   "rerun_now": "Rerun protocol now",
+  "rerun_loading": "Protocol re-run is disabled until data connection fully loads",
   "reset_all": "Reset all",
   "reset_estop": "Reset E-stop",
   "resume_operation": "Resume operation",

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -134,7 +134,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   }
   const trackEvent = useTrackEvent()
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
-  const { reset } = useRunControls(runId, onResetSuccess)
+  const { reset, isRunControlLoading } = useRunControls(runId, onResetSuccess)
   const { deleteRun } = useDeleteRunMutation()
   const robot = useRobot(robotName)
   const robotSerialNumber =
@@ -184,7 +184,9 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
       <MenuItem
         {...targetProps}
         onClick={handleResetClick}
-        disabled={robotIsBusy || isRobotOnWrongVersionOfSoftware}
+        disabled={
+          robotIsBusy || isRobotOnWrongVersionOfSoftware || isRunControlLoading
+        }
         data-testid="RecentProtocolRun_OverflowMenu_rerunNow"
       >
         {t('rerun_now')}
@@ -193,6 +195,9 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
         <Tooltip tooltipProps={tooltipProps}>
           {t('shared:a_software_update_is_available')}
         </Tooltip>
+      )}
+      {isRunControlLoading && (
+        <Tooltip tooltipProps={tooltipProps}>{t('rerun_loading')}</Tooltip>
       )}
       <MenuItem
         data-testid="RecentProtocolRun_OverflowMenu_downloadRunLog"

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -197,7 +197,9 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
         </Tooltip>
       )}
       {isRunControlLoading && (
-        <Tooltip tooltipProps={tooltipProps}>{t('rerun_loading')}</Tooltip>
+        <Tooltip whiteSpace="normal" tooltipProps={tooltipProps}>
+          {t('rerun_loading')}
+        </Tooltip>
       )}
       <MenuItem
         data-testid="RecentProtocolRun_OverflowMenu_downloadRunLog"

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -332,6 +332,7 @@ describe('ProtocolRunHeader', () => {
         isStopRunActionLoading: false,
         isResetRunLoading: false,
         isResumeRunFromRecoveryActionLoading: false,
+        isRunControlLoading: false,
       })
     when(vi.mocked(useRunStatus)).calledWith(RUN_ID).thenReturn(RUN_STATUS_IDLE)
     when(vi.mocked(useRunTimestamps)).calledWith(RUN_ID).thenReturn({
@@ -848,6 +849,7 @@ describe('ProtocolRunHeader', () => {
         isStopRunActionLoading: false,
         isResetRunLoading: true,
         isResumeRunFromRecoveryActionLoading: false,
+        isRunControlLoading: false,
       })
     render()
 

--- a/app/src/organisms/Devices/__tests__/HistoricalProtocolRunOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/HistoricalProtocolRunOverflowMenu.test.tsx
@@ -87,6 +87,7 @@ describe('HistoricalProtocolRunOverflowMenu', () => {
         isStopRunActionLoading: false,
         isResetRunLoading: false,
         isResumeRunFromRecoveryActionLoading: false,
+        isRunControlLoading: false,
       })
     when(useNotifyAllCommandsQuery)
       .calledWith(
@@ -144,6 +145,32 @@ describe('HistoricalProtocolRunOverflowMenu', () => {
       autoUpdateDisabledReason: null,
       updateFromFileDisabledReason: null,
     })
+    render(props)
+    const btn = screen.getByRole('button')
+    fireEvent.click(btn)
+    screen.getByRole('button', {
+      name: 'View protocol run record',
+    })
+    const rerunBtn = screen.getByRole('button', { name: 'Rerun protocol now' })
+    expect(rerunBtn).toBeDisabled()
+  })
+
+  it('disables the rerun protocol menu item if run data is loading', () => {
+    when(useRunControls)
+      .calledWith(RUN_ID, expect.anything())
+      .thenReturn({
+        play: () => {},
+        pause: () => {},
+        stop: () => {},
+        reset: () => {},
+        resumeFromRecovery: () => {},
+        isPlayRunActionLoading: false,
+        isPauseRunActionLoading: false,
+        isStopRunActionLoading: false,
+        isResetRunLoading: false,
+        isResumeRunFromRecoveryActionLoading: false,
+        isRunControlLoading: true,
+      })
     render(props)
     const btn = screen.getByRole('button')
     fireEvent.click(btn)

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -160,7 +160,8 @@ describe('RecentRunProtocolCard', () => {
     })
     vi.mocked(useCloneRun).mockReturnValue({
       cloneRun: mockCloneRun,
-      isLoading: false,
+      isLoadingRun: false,
+      isCloning: false,
     })
   })
 

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -26,9 +26,9 @@ export function useCloneRun(
 ): UseCloneRunResult {
   const host = useHost()
   const queryClient = useQueryClient()
-  const { data: runRecord, isStale: isLoadingRun } = useNotifyRunQuery(runId)
+  const { data: runRecord, isFetching, isRefetching } = useNotifyRunQuery(runId)
+  const isLoadingRun = isFetching || isRefetching
   const protocolKey = runRecord?.data.protocolId ?? null
-  console.log(`UCR: run data for ${runId}: stale: ${isLoadingRun}`)
   const { createRun, isLoading: isCloning } = useCreateRunMutation({
     onSuccess: response => {
       const invalidateRuns = queryClient.invalidateQueries([host, 'runs'])

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -15,7 +15,8 @@ import type { Run } from '@opentrons/api-client'
 
 interface UseCloneRunResult {
   cloneRun: () => void
-  isLoading: boolean
+  isLoadingRun: boolean
+  isCloning: boolean
 }
 
 export function useCloneRun(
@@ -25,10 +26,10 @@ export function useCloneRun(
 ): UseCloneRunResult {
   const host = useHost()
   const queryClient = useQueryClient()
-  const { data: runRecord } = useNotifyRunQuery(runId)
+  const { data: runRecord, isStale: isLoadingRun } = useNotifyRunQuery(runId)
   const protocolKey = runRecord?.data.protocolId ?? null
 
-  const { createRun, isLoading } = useCreateRunMutation({
+  const { createRun, isLoading: isCloning } = useCreateRunMutation({
     onSuccess: response => {
       const invalidateRuns = queryClient.invalidateQueries([host, 'runs'])
       const invalidateProtocols = queryClient.invalidateQueries([
@@ -80,5 +81,5 @@ export function useCloneRun(
     }
   }
 
-  return { cloneRun, isLoading }
+  return { cloneRun, isLoadingRun, isCloning }
 }

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -26,8 +26,7 @@ export function useCloneRun(
 ): UseCloneRunResult {
   const host = useHost()
   const queryClient = useQueryClient()
-  const { data: runRecord, isFetching, isRefetching } = useNotifyRunQuery(runId)
-  const isLoadingRun = isFetching || isRefetching
+  const { data: runRecord, isLoading: isLoadingRun } = useNotifyRunQuery(runId)
   const protocolKey = runRecord?.data.protocolId ?? null
   const { createRun, isLoading: isCloning } = useCreateRunMutation({
     onSuccess: response => {

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -28,7 +28,7 @@ export function useCloneRun(
   const queryClient = useQueryClient()
   const { data: runRecord, isStale: isLoadingRun } = useNotifyRunQuery(runId)
   const protocolKey = runRecord?.data.protocolId ?? null
-
+  console.log(`UCR: run data for ${runId}: stale: ${isLoadingRun}`)
   const { createRun, isLoading: isCloning } = useCreateRunMutation({
     onSuccess: response => {
       const invalidateRuns = queryClient.invalidateQueries([host, 'runs'])

--- a/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
@@ -59,9 +59,11 @@ describe('useRunControls hook', () => {
       isStopRunActionLoading: false,
       isResumeRunFromRecoveryActionLoading: false,
     })
-    when(useCloneRun)
-      .calledWith(mockPausedRun.id, undefined, true)
-      .thenReturn({ cloneRun: mockCloneRun, isLoading: false })
+    when(useCloneRun).calledWith(mockPausedRun.id, undefined, true).thenReturn({
+      cloneRun: mockCloneRun,
+      isCloning: false,
+      isLoadingRun: false,
+    })
 
     const { result } = renderHook(() => useRunControls(mockPausedRun.id))
 

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -34,6 +34,7 @@ export interface RunControls {
   isStopRunActionLoading: boolean
   isResumeRunFromRecoveryActionLoading: boolean
   isResetRunLoading: boolean
+  isRunControlLoading: boolean
 }
 
 export function useRunControls(
@@ -51,11 +52,11 @@ export function useRunControls(
     isResumeRunFromRecoveryActionLoading,
   } = useRunActionMutations(runId as string)
 
-  const { cloneRun, isLoading: isResetRunLoading } = useCloneRun(
-    runId ?? null,
-    onCloneRunSuccess,
-    true
-  )
+  const {
+    cloneRun,
+    isLoadingRun: isRunControlLoading,
+    isCloning: isResetRunLoading,
+  } = useCloneRun(runId ?? null, onCloneRunSuccess, true)
 
   return {
     play: playRun,
@@ -67,6 +68,7 @@ export function useRunControls(
     isPauseRunActionLoading,
     isStopRunActionLoading,
     isResumeRunFromRecoveryActionLoading,
+    isRunControlLoading,
     isResetRunLoading,
   }
 }

--- a/app/src/pages/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -257,6 +257,7 @@ describe('ProtocolSetup', () => {
         isStopRunActionLoading: false,
         isResetRunLoading: false,
         isResumeRunFromRecoveryActionLoading: false,
+        isRunControlLoading: false,
       })
     when(vi.mocked(useRunStatus)).calledWith(RUN_ID).thenReturn(RUN_STATUS_IDLE)
     vi.mocked(useProtocolAnalysisAsDocumentQuery).mockReturnValue({


### PR DESCRIPTION
We need the full run data to rerun a run, but that can be pretty significantly delayed on USB. Add a loading state for that button (disabled with a new tooltip) in that case.

Close RQA-3117

## testing
- [x] does this fix the issue
- [x] why is the tooltip like that