### PR TITLE
fix(shared-date): Update 96ch press distance for single channel pickup to correct pickup

### DIFF
--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
@@ -189,7 +189,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -206,7 +206,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.85,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -267,7 +267,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -284,7 +284,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.85,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -345,7 +345,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -362,7 +362,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.85,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -423,7 +423,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -440,7 +440,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.85,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_6.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_6.json
@@ -206,7 +206,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.85,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -284,7 +284,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.85,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -362,7 +362,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.85,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -440,7 +440,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.85,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_6.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_6.json
@@ -189,7 +189,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -206,7 +206,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -267,7 +267,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -284,7 +284,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -345,7 +345,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -362,7 +362,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -423,7 +423,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -440,7 +440,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 11,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {


### PR DESCRIPTION
# Overview
Covers RQA-3121

Ensure that we do not crush tips or pick up tiprack during press fit for 50ul and 200ul tips.

## Test Plan and Hands on Testing

The following Protocol passes for all of these cases without failing to pick up any tips and without crushing the plastic support ridges on the tips themselves:

- [x] 50uL Tiprack
- [x] 200uL Tiprack
- [x] 1000uL Tiprack
```
from opentrons import protocol_api
from opentrons.protocol_api import SINGLE

metadata = {
    'protocolName': "Partial Tip Press Fit Test",
    'description': "Flex protocol with 96ch pipette in single tip pickup configuration using all four single tip layouts and selectable tip rack."
}

requirements = {
	"robotType": "Flex",
	"apiLevel": "2.20"
}

def add_parameters(parameters):
    parameters.add_str(
        variable_name="tiprack_type",
        display_name="Tip-Rack Type",
        description="The Tiprack Type to run this protocol utilizing.",
        default="opentrons_flex_96_tiprack_50ul",
        choices=[
            {"display_name": "1000uL", "value": "opentrons_flex_96_tiprack_1000ul"},
            {"display_name": "200uL", "value": "opentrons_flex_96_tiprack_200ul"},
            {"display_name": "50uL", "value": "opentrons_flex_96_tiprack_50ul"},
        ]
    )

def run(protocol: protocol_api.ProtocolContext):
    pipette = protocol.load_instrument(instrument_name="flex_96channel_1000")
    trash = protocol.load_trash_bin("B3")
    tips = protocol.load_labware(
        load_name=protocol.params.tiprack_type,
        label="A1 Corner Tiprack 1",
        location="B2",
    )
    single_confs = ["H1", "H12", "A1", "A12"]
    pipette.configure_nozzle_layout(style=SINGLE, start="A1", tip_racks=[tips])
    for i in range(4):
        pipette.pick_up_tip()
        pipette.drop_tip()
    pipette.configure_nozzle_layout(style=SINGLE, start="A12", tip_racks=[tips])
    for i in range(4):
        pipette.pick_up_tip()
        pipette.drop_tip()
    pipette.configure_nozzle_layout(style=SINGLE, start="H1", tip_racks=[tips])
    for i in range(4):
        pipette.pick_up_tip()
        pipette.drop_tip()
    pipette.configure_nozzle_layout(style=SINGLE, start="H12", tip_racks=[tips])
    for i in range(4):
        pipette.pick_up_tip()
        pipette.drop_tip()

    counter = 0
    for i in range(80):
        pipette.configure_nozzle_layout(style=SINGLE, start=single_confs[counter], tip_racks=[tips])
        counter+=1
        if counter > 3:
            counter = 0
        pipette.pick_up_tip()
        pipette.drop_tip()
```

## Changelog

The press distance values for the 200uL and 50uL tip types were changed for the single nozzle layout configurations for the 96ch pipette to ensure positive tip attachment.

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low - only shared data values, improves pick up tip performance.