### PR TITLE
fix(app): fix csv filename wrapping

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
@@ -37,7 +37,9 @@ export function NumericalKeyboard({
     <Keyboard
       keyboardRef={r => (keyboardRef.current = r)}
       theme={'hg-theme-default oddTheme1 numerical-keyboard'}
-      onInit={keyboard => {keyboard.setInput(initialValue)}}
+      onInit={keyboard => {
+        keyboard.setInput(initialValue)
+      }}
       onChange={onChange}
       display={numericalCustom}
       useButtonTag={true}

--- a/app/src/atoms/buttons/RadioButton.tsx
+++ b/app/src/atoms/buttons/RadioButton.tsx
@@ -82,6 +82,7 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
         display: ${maxLines != null ? '-webkit-box' : undefined};
         -webkit-line-clamp: ${maxLines ?? undefined};
         -webkit-box-orient: ${maxLines != null ? 'vertical' : undefined};
+        word-wrap: break-word;
       }
     }
   `

--- a/app/src/organisms/ProtocolSetupParameters/ChooseCsvFile.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/ChooseCsvFile.tsx
@@ -29,7 +29,7 @@ import type {
 import type { CsvFileData } from '@opentrons/api-client'
 
 const MAX_CHARS = 52
-const CSV_FILENAME_BREAK_POINT = 46
+const CSV_FILENAME_BREAK_POINT = 42
 interface ChooseCsvFileProps {
   protocolId: string
   handleGoBack: () => void

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -17,10 +17,11 @@ import {
   Icon,
   JUSTIFY_END,
   JUSTIFY_SPACE_BETWEEN,
+  LegacyStyledText,
+  NO_WRAP,
   OVERFLOW_WRAP_ANYWHERE,
   POSITION_STICKY,
   SPACING,
-  LegacyStyledText,
   TEXT_ALIGN_RIGHT,
   truncateString,
   TYPOGRAPHY,
@@ -1081,7 +1082,7 @@ export function ProtocolSetup(): JSX.Element {
 }
 
 const CLIPPED_TEXT_STYLE = css`
-  white-space: nowrap;
+  white-space: ${NO_WRAP};
   overflow: hidden;
   text-overflow: ellipsis;
 `

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -115,6 +115,8 @@ interface ProtocolSetupStepProps {
   title: string
   // first line of detail text
   detail?: string | null
+  // clip detail text overflow with ellipsis
+  clipDetail?: boolean
   // second line of detail text
   subDetail?: string | null
   // disallow click handler, disabled styling
@@ -140,6 +142,7 @@ export function ProtocolSetupStep({
   detail,
   subDetail,
   disabled = false,
+  clipDetail = false,
   interactionDisabled = false,
   disabledReason,
   description,
@@ -250,6 +253,7 @@ export function ProtocolSetupStep({
             textAlign={TEXT_ALIGN_RIGHT}
             color={interactionDisabled ? COLORS.grey50 : COLORS.black90}
             maxWidth="20rem"
+            css={clipDetail ? CLIPPED_TEXT_STYLE : undefined}
           >
             {detail}
             {subDetail != null && detail != null ? <br /> : null}
@@ -1075,3 +1079,9 @@ export function ProtocolSetup(): JSX.Element {
     </>
   )
 }
+
+const CLIPPED_TEXT_STYLE = css`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`


### PR DESCRIPTION
# Overview

Wrap long CSV file names in `ChooseCsvFile` component to maintain style of selection screen

Closes RQA-3003

## Test Plan and Hands on Testing

- start CSV protocol setup on ODD
- on CSV file selection screen, plug in a USB with a CSV file with a long file name
- verify text is wrapped properly
<img width="861" alt="Screenshot 2024-08-28 at 2 17 25 PM" src="https://github.com/user-attachments/assets/72c6e3be-f54a-4bfc-8ced-8d743917c9a7">

## Changelog

- add word wrapping to `RadioButton` css
- modify breakpoint of filename

## Review requests

see test plan

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
