### PR TITLE
fix(app): update both thermocycler cutouts when removing for location conflict

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
@@ -37,7 +37,9 @@ export function NumericalKeyboard({
     <Keyboard
       keyboardRef={r => (keyboardRef.current = r)}
       theme={'hg-theme-default oddTheme1 numerical-keyboard'}
-      onInit={keyboard => {keyboard.setInput(initialValue)}}
+      onInit={keyboard => {
+        keyboard.setInput(initialValue)
+      }}
       onChange={onChange}
       display={numericalCustom}
       useButtonTag={true}

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
@@ -27,6 +27,8 @@ import {
   getCutoutFixturesForModuleModel,
   getFixtureIdByCutoutIdFromModuleSlotName,
   SINGLE_LEFT_SLOT_FIXTURE,
+  THERMOCYCLER_V2_FRONT_FIXTURE,
+  THERMOCYCLER_V2_REAR_FIXTURE,
 } from '@opentrons/shared-data'
 
 import { getTopPortalEl } from '../../../../App/portal'
@@ -83,8 +85,8 @@ export const LocationConflictModal = (
 
   // check if current fixture in cutoutId is thermocycler
   const isThermocyclerCurrentFixture =
-    deckConfigurationAtLocationFixtureId === 'thermocyclerModuleV2Rear' ||
-    deckConfigurationAtLocationFixtureId === 'thermocyclerModuleV2Front'
+    deckConfigurationAtLocationFixtureId === THERMOCYCLER_V2_REAR_FIXTURE ||
+    deckConfigurationAtLocationFixtureId === THERMOCYCLER_V2_FRONT_FIXTURE
 
   const currentFixtureDisplayName =
     deckConfigurationAtLocationFixtureId != null
@@ -126,6 +128,7 @@ export const LocationConflictModal = (
           /**
            * special-case for removing current thermocycler:
            * set paired cutout (B1 for A1, A1 for B1) to single slot left fixture
+           * TODO(bh, 2024-08-29): generalize to remove all entities from FixtureGroup
            */
           return {
             ...existingCutoutConfig,
@@ -160,6 +163,7 @@ export const LocationConflictModal = (
           /**
            * special-case for removing current thermocycler:
            * set paired cutout (B1 for A1, A1 for B1) to single slot left fixture
+           * TODO(bh, 2024-08-29): generalize to remove all entities from FixtureGroup
            */
           return {
             ...fixture,

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
@@ -26,6 +26,7 @@ import {
   THERMOCYCLER_MODULE_V2,
   getCutoutFixturesForModuleModel,
   getFixtureIdByCutoutIdFromModuleSlotName,
+  SINGLE_LEFT_SLOT_FIXTURE,
 } from '@opentrons/shared-data'
 
 import { getTopPortalEl } from '../../../../App/portal'
@@ -76,24 +77,19 @@ export const LocationConflictModal = (
     (deckFixture: CutoutConfig) => deckFixture.cutoutId === cutoutId
   )?.cutoutFixtureId
 
-  const isThermocycler =
+  const isThermocyclerRequired =
     requiredModule === THERMOCYCLER_MODULE_V1 ||
     requiredModule === THERMOCYCLER_MODULE_V2
+
+  // check if current fixture in cutoutId is thermocycler
+  const isThermocyclerCurrentFixture =
+    deckConfigurationAtLocationFixtureId === 'thermocyclerModuleV2Rear' ||
+    deckConfigurationAtLocationFixtureId === 'thermocyclerModuleV2Front'
 
   const currentFixtureDisplayName =
     deckConfigurationAtLocationFixtureId != null
       ? getFixtureDisplayName(deckConfigurationAtLocationFixtureId)
       : ''
-
-  // get fixture display name at A1 for themocycler if B1 is slot
-  const deckConfigurationAtA1 = deckConfig.find(
-    (deckFixture: CutoutConfig) => deckFixture.cutoutId === 'cutoutA1'
-  )?.cutoutFixtureId
-
-  const currentThermocyclerFixtureDisplayName =
-    currentFixtureDisplayName === 'Slot' && deckConfigurationAtA1 != null
-      ? getFixtureDisplayName(deckConfigurationAtA1)
-      : currentFixtureDisplayName
 
   const handleConfigureModule = (moduleSerialNumber?: string): void => {
     if (requiredModule != null) {
@@ -111,14 +107,34 @@ export const LocationConflictModal = (
       const newDeckConfig = deckConfig.map(existingCutoutConfig => {
         const replacementCutoutFixtureId =
           moduleFixtureIdByCutoutId[existingCutoutConfig.cutoutId]
-        return existingCutoutConfig.cutoutId in moduleFixtureIdByCutoutId &&
+        if (
+          existingCutoutConfig.cutoutId in moduleFixtureIdByCutoutId &&
           replacementCutoutFixtureId != null
-          ? {
-              ...existingCutoutConfig,
-              cutoutFixtureId: replacementCutoutFixtureId,
-              opentronsModuleSerialNumber: moduleSerialNumber,
-            }
-          : existingCutoutConfig
+        ) {
+          return {
+            ...existingCutoutConfig,
+            cutoutFixtureId: replacementCutoutFixtureId,
+            opentronsModuleSerialNumber: moduleSerialNumber,
+          }
+        } else if (
+          isThermocyclerCurrentFixture &&
+          ((cutoutId === 'cutoutA1' &&
+            existingCutoutConfig.cutoutId === 'cutoutB1') ||
+            (cutoutId === 'cutoutB1' &&
+              existingCutoutConfig.cutoutId === 'cutoutA1'))
+        ) {
+          /**
+           * special-case for removing current thermocycler:
+           * set paired cutout (B1 for A1, A1 for B1) to single slot left fixture
+           */
+          return {
+            ...existingCutoutConfig,
+            cutoutFixtureId: SINGLE_LEFT_SLOT_FIXTURE,
+            opentronsModuleSerialNumber: undefined,
+          }
+        } else {
+          return existingCutoutConfig
+        }
       })
       updateDeckConfiguration(newDeckConfig)
     }
@@ -129,15 +145,32 @@ export const LocationConflictModal = (
     if (requiredModule != null) {
       setShowModuleSelect(true)
     } else if (requiredFixtureId != null) {
-      const newRequiredFixtureDeckConfig = deckConfig.map(fixture =>
-        fixture.cutoutId === cutoutId
-          ? {
-              ...fixture,
-              cutoutFixtureId: requiredFixtureId,
-              opentronsModuleSerialNumber: undefined,
-            }
-          : fixture
-      )
+      const newRequiredFixtureDeckConfig = deckConfig.map(fixture => {
+        if (fixture.cutoutId === cutoutId) {
+          return {
+            ...fixture,
+            cutoutFixtureId: requiredFixtureId,
+            opentronsModuleSerialNumber: undefined,
+          }
+        } else if (
+          isThermocyclerCurrentFixture &&
+          ((cutoutId === 'cutoutA1' && fixture.cutoutId === 'cutoutB1') ||
+            (cutoutId === 'cutoutB1' && fixture.cutoutId === 'cutoutA1'))
+        ) {
+          /**
+           * special-case for removing current thermocycler:
+           * set paired cutout (B1 for A1, A1 for B1) to single slot left fixture
+           */
+          return {
+            ...fixture,
+            cutoutFixtureId: SINGLE_LEFT_SLOT_FIXTURE,
+            opentronsModuleSerialNumber: undefined,
+          }
+        } else {
+          return fixture
+        }
+      })
+
       updateDeckConfiguration(newRequiredFixtureDeckConfig)
       onCloseClick()
     } else {
@@ -154,7 +187,7 @@ export const LocationConflictModal = (
     protocolSpecifiesDisplayName = getModuleDisplayName(requiredModule)
   }
 
-  const displaySlotName = isThermocycler
+  const displaySlotName = isThermocyclerRequired
     ? 'A1 + B1'
     : getCutoutDisplayName(cutoutId)
 
@@ -189,7 +222,7 @@ export const LocationConflictModal = (
           <Trans
             t={t}
             i18nKey={
-              isThermocycler
+              isThermocyclerRequired
                 ? 'deck_conflict_info_thermocycler'
                 : 'deck_conflict_info'
             }
@@ -298,7 +331,7 @@ export const LocationConflictModal = (
           <Trans
             t={t}
             i18nKey={
-              isThermocycler
+              isThermocyclerRequired
                 ? 'deck_conflict_info_thermocycler'
                 : 'deck_conflict_info'
             }
@@ -350,9 +383,7 @@ export const LocationConflictModal = (
                   {t('currently_configured')}
                 </LegacyStyledText>
                 <LegacyStyledText as="label" flex="1">
-                  {isThermocycler
-                    ? currentThermocyclerFixtureDisplayName
-                    : currentFixtureDisplayName}
+                  {currentFixtureDisplayName}
                 </LegacyStyledText>
               </Flex>
             </Flex>


### PR DESCRIPTION
# Overview

when removing a thermocycler, to issue a valid deck configuration update we must update both cutouts A1 and B1. this substitutes a single left slot fixture in the paired cutout of the target location conflict cutout id. previously the `LocationConflictModal` was sending an update to remove the thermocycler module from only cutout A1 or cutout B1 and receiving a 422 response. This issue has likely been around since modules were added as fixtures, and updates some [special case logic that was intended to be altered](https://github.com/Opentrons/opentrons/pull/14425).

closes RQA-3074

## Test Plan and Hands on Testing

manually verified the fix

## Changelog

 - Updates both thermocycler cutouts when removing for location conflict

## Review requests

Add a thermocycler to deck configuration, then load a protocol with labware/other modules in A1 and/or B1. Fix the conflict in protocol setup.

## Risk assessment

low
