### PR TITLE
fix(app): fix factory mode advanced setting style

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
@@ -7,6 +7,7 @@ import last from 'lodash/last'
 import { GET, request } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
+  ALIGN_END,
   Box,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
@@ -130,6 +131,7 @@ export function Troubleshooting({
         marginLeft={SPACING_AUTO}
         onClick={handleClick}
         id="AdvancedSettings_downloadLogsButton"
+        alignSelf={ALIGN_END}
       >
         {t('download_logs')}
       </TertiaryButton>

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -220,14 +220,15 @@ export function RobotSettingsAdvanced({
             handleUpdateBuildroot(robot)
           }}
         />
+        <Divider marginY={SPACING.spacing16} />
         {isFlex ? (
           <>
-            <Divider marginY={SPACING.spacing16} />
             <FactoryMode
               isRobotBusy={isRobotBusy || isEstopNotDisengaged}
               setShowFactoryModeSlideout={setShowFactoryModeSlideout}
               sn={sn}
             />
+            <Divider marginY={SPACING.spacing16} />
           </>
         ) : null}
         <Troubleshooting robotName={robotName} />


### PR DESCRIPTION
# Overview

In robot advanced settings, add divider under 'Factory Mode' advanced setting. Also, align 'Download logs' button to end of flex container.

Closes RQA-3127

## Test Plan and Hands on Testing

- navigate to Flex robot advanced settings page and verify that there is a divider under "Factory Mode" settings
- verify that "Download logs" button on "Troubleshooting" section is aligned with left text

Flex
<img width="678" alt="Screenshot 2024-08-29 at 12 06 29 PM" src="https://github.com/user-attachments/assets/a1aff291-4e78-4540-9b82-f4a4ce2590c7">

OT-2
<img width="670" alt="Screenshot 2024-08-29 at 12 06 36 PM" src="https://github.com/user-attachments/assets/bcfe3ee5-03bc-4479-9b9a-85684fcbfef2">



## Changelog

- add divider
- realign button

## Review requests

see test plan

## Risk assessment

low