### PR TITLE
fix(app): fix fallback polling not working on select notifications

### DIFF
--- a/app/src/resources/__tests__/useNotifyDataReady.test.ts
+++ b/app/src/resources/__tests__/useNotifyDataReady.test.ts
@@ -73,7 +73,8 @@ describe('useNotifyDataReady', () => {
         options: { ...MOCK_OPTIONS, forceHttpPolling: true },
       } as any)
     )
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.isNotifyEnabled).toEqual(false)
     expect(appShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
@@ -85,7 +86,8 @@ describe('useNotifyDataReady', () => {
         options: { ...MOCK_OPTIONS, enabled: false },
       } as any)
     )
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.isNotifyEnabled).toEqual(false)
     expect(appShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
@@ -97,12 +99,13 @@ describe('useNotifyDataReady', () => {
         options: { ...MOCK_OPTIONS, staleTime: Infinity },
       } as any)
     )
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.isNotifyEnabled).toEqual(false)
     expect(appShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('should set HTTP refetch to always if there is an error', () => {
+  it('should set isNotifyEnabled to false if there is an error', () => {
     vi.mocked(useHost).mockReturnValue({ hostname: null } as any)
     const errorSpy = vi.spyOn(console, 'error')
     errorSpy.mockImplementation(() => {})
@@ -115,10 +118,11 @@ describe('useNotifyDataReady', () => {
       } as any)
     )
 
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.isNotifyEnabled).toEqual(false)
   })
 
-  it('should return set HTTP refetch to always and fire an analytics reporting event if the connection was refused', () => {
+  it('should return set isNotifyEnabled to false and fire an analytics reporting event if the connection was refused', () => {
     vi.mocked(appShellListener).mockImplementation(function ({
       callback,
     }): any {
@@ -134,7 +138,7 @@ describe('useNotifyDataReady', () => {
     )
     expect(mockTrackEvent).toHaveBeenCalled()
     rerender()
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.isNotifyEnabled).toEqual(false)
   })
 
   it('should trigger a single HTTP refetch if the refetch flag was returned', () => {
@@ -153,6 +157,7 @@ describe('useNotifyDataReady', () => {
     )
     rerender()
     expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.isNotifyEnabled).toEqual(true)
   })
 
   it('should trigger a single HTTP refetch if the unsubscribe flag was returned', () => {
@@ -170,6 +175,7 @@ describe('useNotifyDataReady', () => {
     )
     rerender()
     expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.isNotifyEnabled).toEqual(true)
   })
 
   it('should clean up the listener on dismount', () => {
@@ -210,7 +216,8 @@ describe('useNotifyDataReady', () => {
       } as any)
     )
 
-    expect(result.current.shouldRefetch).toEqual(true)
+    expect(result.current.shouldRefetch).toEqual(false)
+    expect(result.current.isNotifyEnabled).toEqual(false)
     expect(appShellListener).not.toHaveBeenCalled()
   })
 })

--- a/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
+++ b/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
@@ -14,7 +14,11 @@ export function useNotifyClientDataRecovery(
     AxiosError
   > = {}
 ): UseQueryResult<ClientDataResponse<ClientDataRecovery>, AxiosError> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const {
+    notifyOnSettled,
+    shouldRefetch,
+    isNotifyEnabled,
+  } = useNotifyDataReady({
     topic: `robot-server/clientData/${KEYS.ERROR_RECOVERY}`,
     options,
   })
@@ -23,7 +27,8 @@ export function useNotifyClientDataRecovery(
     KEYS.ERROR_RECOVERY,
     {
       ...options,
-      enabled: options?.enabled !== false && shouldRefetch,
+      enabled:
+        options?.enabled !== false && (shouldRefetch || !isNotifyEnabled),
       onSettled: notifyOnSettled,
     }
   )

--- a/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
+++ b/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
@@ -9,14 +9,18 @@ import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
 export function useNotifyDeckConfigurationQuery(
   options: QueryOptionsWithPolling<DeckConfiguration, unknown> = {}
 ): UseQueryResult<DeckConfiguration> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const {
+    notifyOnSettled,
+    shouldRefetch,
+    isNotifyEnabled,
+  } = useNotifyDataReady({
     topic: 'robot-server/deck_configuration',
     options,
   })
 
   const httpQueryResult = useDeckConfigurationQuery({
     ...options,
-    enabled: options?.enabled !== false && shouldRefetch,
+    enabled: options?.enabled !== false && (shouldRefetch || !isNotifyEnabled),
     onSettled: notifyOnSettled,
   })
 

--- a/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
+++ b/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
@@ -9,14 +9,18 @@ import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
 export function useNotifyCurrentMaintenanceRun(
   options: QueryOptionsWithPolling<MaintenanceRun, Error> = {}
 ): UseQueryResult<MaintenanceRun> | UseQueryResult<MaintenanceRun, Error> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const {
+    notifyOnSettled,
+    shouldRefetch,
+    isNotifyEnabled,
+  } = useNotifyDataReady({
     topic: 'robot-server/maintenance_runs/current_run',
     options,
   })
 
   const httpQueryResult = useCurrentMaintenanceRun({
     ...options,
-    enabled: options?.enabled !== false && shouldRefetch,
+    enabled: options?.enabled !== false && (shouldRefetch || !isNotifyEnabled),
     onSettled: notifyOnSettled,
   })
 

--- a/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
@@ -12,14 +12,18 @@ export function useNotifyAllCommandsAsPreSerializedList(
   params?: GetCommandsParams | null,
   options: QueryOptionsWithPolling<CommandsData, AxiosError> = {}
 ): UseQueryResult<CommandsData, AxiosError> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const {
+    notifyOnSettled,
+    shouldRefetch,
+    isNotifyEnabled,
+  } = useNotifyDataReady({
     topic: `robot-server/runs/pre_serialized_commands/${runId}`,
     options,
   })
 
   const httpResponse = useAllCommandsAsPreSerializedList(runId, params, {
     ...options,
-    enabled: options?.enabled !== false && shouldRefetch,
+    enabled: options?.enabled !== false && (shouldRefetch || !isNotifyEnabled),
     onSettled: notifyOnSettled,
   })
 

--- a/app/src/resources/runs/useNotifyAllCommandsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsQuery.ts
@@ -17,14 +17,18 @@ export function useNotifyAllCommandsQuery<TError = Error>(
   // running to succeeded, that may change the useAllCommandsQuery response, but it
   // will not necessarily change the command links. We might need an MQTT topic
   // covering "any change in `GET /runs/{id}/commands`".
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const {
+    notifyOnSettled,
+    shouldRefetch,
+    isNotifyEnabled,
+  } = useNotifyDataReady({
     topic: 'robot-server/runs/commands_links',
     options,
   })
 
   const httpResponse = useAllCommandsQuery(runId, params, {
     ...options,
-    enabled: options?.enabled !== false && shouldRefetch,
+    enabled: options?.enabled !== false && (shouldRefetch || !isNotifyEnabled),
     onSettled: notifyOnSettled,
   })
 


### PR DESCRIPTION
Closes [RQA-3110](https://opentrons.atlassian.net/browse/RQA-3110) and [RQA-3108](https://opentrons.atlassian.net/browse/RQA-3108)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We overhauled a couple MQTT hooks in https://github.com/Opentrons/opentrons/pull/16084 (see that PR for context), but there were some lower level `useNotifyDataReady` changes that did not account for notify hooks that we did not change (which we didn't refactor to reduce potential bugs for this release). 

This PR is a stop-gap - we'll fully refactor the old notify hooks after 8.0. While the old `shouldRefetch` implictly returned true if notifications are enabled AND there's a valid notification update, the new `shouldRefetch` only handles the latter case. To persist the old `shouldRefetch` behavior, we simply need to check `isNotifyEnabled` as well. 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
If testing on a real robot...
- On the `chore_release` branch, on the desktop app, go to Settings > Feature Flags > Enable “Poll all network requests instead of using MQTT”
- Go to any robot and repro [RQA-3110](https://opentrons.atlassian.net/browse/RQA-3110) (play with the deck on `DeviceDetails`). You should be able to easily now.
- Switch to this branch. Ensure the polling feature flag is enabled.
- The deck should update when you test it.

If testing on dev server...
- Simply validate this branch solves the issue, since the dev server defaults to polling by default.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed an issue in which deck configuration would not properly reflect the latest deck.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Medium. I think the big thing is just making sure we are covering all the notify hooks which are not `useNotifyAllRunsQuery` and `useNotifyRunQuery`.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3110]: https://opentrons.atlassian.net/browse/RQA-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-3108]: https://opentrons.atlassian.net/browse/RQA-3108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ