### PR TITLE
fix(app): fix labware location on labware details modal

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -205,6 +205,7 @@
   "offset_data": "Offset Data",
   "offsets_applied_plural": "{{count}} offsets applied",
   "offsets_applied": "{{count}} offset applied",
+  "offsets_confirmed": "Offsets confirmed",
   "offsets_ready": "Offsets ready",
   "on_adapter_in_mod": "on {{adapterName}} in {{moduleName}}",
   "on_adapter": "on {{adapterName}}",

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -130,13 +130,20 @@ export function ProtocolSetupLabware({
       const nickName = onDeckItems.find(
         item => getLabwareDefURI(item.definition) === foundLabware.definitionUri
       )?.nickName
-      setSelectedLabware({
-        ...labwareDef,
-        location: foundLabware.location,
-        nickName: nickName ?? null,
-        id: labwareId,
-      })
-      setShowLabwareDetailsModal(true)
+      const location = onDeckItems.find(
+        item => item.labwareId === foundLabware.id
+      )?.initialLocation
+      if (location != null) {
+        setSelectedLabware({
+          ...labwareDef,
+          location: location,
+          nickName: nickName ?? null,
+          id: labwareId,
+        })
+        setShowLabwareDetailsModal(true)
+      } else {
+        console.warn('no initial labware location found')
+      }
     }
   }
   const selectedLabwareIsTopOfStack = mostRecentAnalysis?.commands.some(

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -183,9 +183,8 @@ export function ProtocolSetupLabware({
           <Chip
             background
             iconName="ot-check"
-            text={t('placements_ready')}
+            text={t('placements_confirmed')}
             type="success"
-            chipSize="small"
           />
         ) : (
           <SmallButton

--- a/app/src/organisms/ProtocolSetupLiquids/index.tsx
+++ b/app/src/organisms/ProtocolSetupLiquids/index.tsx
@@ -65,7 +65,6 @@ export function ProtocolSetupLiquids({
             iconName="ot-check"
             text={t('liquids_confirmed')}
             type="success"
-            chipSize="small"
           />
         ) : (
           <SmallButton

--- a/app/src/organisms/ProtocolSetupOffsets/index.tsx
+++ b/app/src/organisms/ProtocolSetupOffsets/index.tsx
@@ -90,9 +90,8 @@ export function ProtocolSetupOffsets({
               <Chip
                 background
                 iconName="ot-check"
-                text={t('placements_ready')}
+                text={t('offsets_confirmed')}
                 type="success"
-                chipSize="small"
               />
             ) : (
               <SmallButton
@@ -107,7 +106,7 @@ export function ProtocolSetupOffsets({
             )}
           </Flex>
           <Flex marginTop={SPACING.spacing32} flexDirection={DIRECTION_COLUMN}>
-            {nonIdentityOffsets.length > 0 ? (
+            {nonIdentityOffsets.length >= 0 ? (
               <>
                 <StyledText
                   oddStyle="level4HeaderSemiBold"

--- a/app/src/organisms/ProtocolSetupOffsets/index.tsx
+++ b/app/src/organisms/ProtocolSetupOffsets/index.tsx
@@ -106,7 +106,7 @@ export function ProtocolSetupOffsets({
             )}
           </Flex>
           <Flex marginTop={SPACING.spacing32} flexDirection={DIRECTION_COLUMN}>
-            {nonIdentityOffsets.length >= 0 ? (
+            {nonIdentityOffsets.length > 0 ? (
               <>
                 <StyledText
                   oddStyle="level4HeaderSemiBold"


### PR DESCRIPTION
# Overview

On ProtocolSetupLabware, we open a labware modal, either single or stacked, when a labware is clicked. That modal's header contains a location icon that is meant to specify that labware's/stack's initial position. The bug here arises because the location used for the modal header is the analysis's labware location, which contains the labware's final location. Here, I pull the location from load commands.

Closes RQA-2800, Closes RQA-3132

## Test Plan and Hands on Testing

- upload a protocol that moves labware to ODD ([example](https://github.com/user-attachments/files/16803949/Foundry.Lux.json.zip))
- proceed to protocol setup
- select labware > map view
- click around all labware and ensure that the modal header location reflects the actual load location
- verify chip style after confirming offsets, labware, and liquids

<img width="988" alt="Screenshot 2024-08-29 at 2 19 18 PM" src="https://github.com/user-attachments/assets/ba3392ef-721e-4999-9424-85656a0a85e0">
<img width="963" alt="Screenshot 2024-08-29 at 2 19 25 PM" src="https://github.com/user-attachments/assets/94dcdb15-54d4-432d-9cdf-f7b00fa331d8">
<img width="983" alt="Screenshot 2024-08-29 at 2 19 30 PM" src="https://github.com/user-attachments/assets/2d0b4b90-c977-4a98-8e0c-debaa17262f9">

## Changelog

- get labware location from on deck items (initial load)
- fix confirmation tip on LPC, labware, and liquids setup steps

## Review requests

check logic in `handleClickLabware`

## Risk assessment

low