### PR TITLE
fix(app): Fix run cancel redirection, pipette path copy

### DIFF
--- a/app/src/assets/localization/en/quick_transfer.json
+++ b/app/src/assets/localization/en/quick_transfer.json
@@ -96,7 +96,7 @@
   "pipette_path": "Pipette path",
   "pipette_path_multi_aspirate": "Multi-aspirate",
   "pipette_path_multi_dispense": "Multi-dispense",
-  "pipette_path_multi_dispense_volume_blowout": "Multi-dispense, {{volume}} disposal volume, blowout into {{blowOutLocation}}",
+  "pipette_path_multi_dispense_volume_blowout": "Multi-dispense, {{volume}} disposal volume, blowout {{blowOutLocation}}",
   "pipette_path_single": "Single transfers",
   "pre_wet_tip": "Pre-wet tip",
   "quick_transfer": "Quick transfer",

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -56,16 +56,8 @@ export function ConfirmCancelRunModal({
     isLoading: isDismissing,
   } = useDismissCurrentRunMutation({
     onSettled: () => {
-      if (isQuickTransfer && protocolId != null) {
+      if (isQuickTransfer) {
         deleteRun(runId)
-        navigate(`/quick-transfer/${protocolId}`)
-      } else if (isQuickTransfer) {
-        deleteRun(runId)
-        navigate('/quick-transfer')
-      } else if (protocolId != null) {
-        navigate(`/protocols/${protocolId}`)
-      } else {
-        navigate('/protocols')
       }
     },
   })
@@ -97,6 +89,15 @@ export function ConfirmCancelRunModal({
       trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
       if (!isActiveRun) {
         dismissCurrentRun(runId)
+        if (isQuickTransfer && protocolId != null) {
+          navigate(`/quick-transfer/${protocolId}`)
+        } else if (isQuickTransfer) {
+          navigate('/quick-transfer')
+        } else if (protocolId != null) {
+          navigate(`/protocols/${protocolId}`)
+        } else {
+          navigate('/protocols')
+        }
       }
     }
   }, [runStatus])

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
@@ -148,6 +148,21 @@ describe('ConfirmCancelRunModal', () => {
 
     expect(mockDismissCurrentRun).toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith('/protocols')
+  })
+
+  it('when quick transfer run is stopped, the run is dismissed and the modal closes if the run is not yet active', () => {
+    props = {
+      ...props,
+      isActiveRun: false,
+      isQuickTransfer: true,
+    }
+    when(useRunStatus).calledWith(RUN_ID).thenReturn(RUN_STATUS_STOPPED)
+    render(props)
+
+    expect(mockDismissCurrentRun).toHaveBeenCalled()
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith('/quick-transfer')
   })
 
   it('when run is stopped, the run is not dismissed if the run is active', () => {

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import isEqual from 'lodash/isEqual'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import {
@@ -197,7 +198,10 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
           {blowOutLocationItems.map(blowOutLocationItem => (
             <RadioButton
               key={blowOutLocationItem.description}
-              isSelected={blowOutLocation === blowOutLocationItem.location}
+              isSelected={
+                isEqual(blowOutLocation, blowOutLocationItem.location) ||
+                blowOutLocation === blowOutLocationItem.location
+              }
               onChange={() => {
                 setBlowOutLocation(
                   blowOutLocationItem.location as BlowOutLocation

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import isEqual from 'lodash/isEqual'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import {
@@ -218,7 +219,10 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
           {blowOutLocationItems.map(option => (
             <RadioButton
               key={option.description}
-              isSelected={blowOutLocation === option.location}
+              isSelected={
+                isEqual(blowOutLocation, option.location) ||
+                blowOutLocation === option.location
+              }
               onChange={() => {
                 setBlowOutLocation(option.location)
               }}


### PR DESCRIPTION
fix RQA-3125, RQA-3126, RQA-3119
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Move post-cancellation of not started run back to `useEffect` since moving it to `onSettled` caused a race condition with other navigation logic.
Also fix duplicative copy in pipette path summary and use lodash `isEquals` when comparing blowout location objects
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
1. With no trash or waste chute in your deck config, create a quick transfer and look at the blowout location options. Select "Trash bin in A3" and confirm button highlights as expected when it is selected
2. Initiate a run for a quick transfer protocol and cancel the run before starting. When the cancellation modal closes you should be redirected to the quick transfer details page
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Remove duplicate "into" copy from pipette path mutli-dispense description
2. Use lodash.isEquals to check for object equality for blowout location items
3. Move `navigate` logic sequence back to `useEffect` from `onSettled` so it will happen before the cancellation modal closes
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over changes
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
