### PR TITLE
fix(app): filter qt out of recent runs to show emptyruns tate

### DIFF
--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -39,8 +39,7 @@ export function RecentProtocolRuns({
     const protocol = protocols?.data?.data.find(
       protocol => protocol.id === run.protocolId
     )
-    const isQuickTransfer = protocol?.protocolKind === 'quick-transfer'
-    return !isQuickTransfer
+    return protocol?.protocolKind !== 'quick-transfer'
   })
 
   return (

--- a/app/src/organisms/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Devices/RecentProtocolRuns.tsx
@@ -35,6 +35,13 @@ export function RecentProtocolRuns({
   const currentRunId = useCurrentRunId()
   const { isRunTerminal } = useRunStatuses()
   const robotIsBusy = currentRunId != null ? !isRunTerminal : false
+  const nonQuickTransferRuns = runs?.filter(run => {
+    const protocol = protocols?.data?.data.find(
+      protocol => protocol.id === run.protocolId
+    )
+    const isQuickTransfer = protocol?.protocolKind === 'quick-transfer'
+    return !isQuickTransfer
+  })
 
   return (
     <Flex
@@ -64,83 +71,83 @@ export function RecentProtocolRuns({
         paddingX={SPACING.spacing16}
         width="100%"
       >
-        {isRobotViewable && runs && runs.length > 0 && (
-          <>
-            <Flex
-              justifyContent={JUSTIFY_FLEX_START}
-              padding={SPACING.spacing8}
-              width="88%"
-              marginRight="12%"
-              gridGap={SPACING.spacing20}
-              color={COLORS.grey60}
-            >
-              <LegacyStyledText
-                as="p"
-                width="25%"
-                data-testid="RecentProtocolRuns_RunTitle"
+        {isRobotViewable &&
+          nonQuickTransferRuns &&
+          nonQuickTransferRuns?.length > 0 && (
+            <>
+              <Flex
+                justifyContent={JUSTIFY_FLEX_START}
+                padding={SPACING.spacing8}
+                width="88%"
+                marginRight="12%"
+                gridGap={SPACING.spacing20}
+                color={COLORS.grey60}
               >
-                {t('run')}
-              </LegacyStyledText>
-              <LegacyStyledText
-                as="p"
-                width="27%"
-                data-testid="RecentProtocolRuns_ProtocolTitle"
-              >
-                {t('protocol')}
-              </LegacyStyledText>
-              <LegacyStyledText
-                as="p"
-                width="5%"
-                data-testid="RecentProtocolRuns_FilesTitle"
-              >
-                {t('files')}
-              </LegacyStyledText>
-              <LegacyStyledText
-                as="p"
-                width="14%"
-                data-testid="RecentProtocolRuns_StatusTitle"
-              >
-                {t('status')}
-              </LegacyStyledText>
-              <LegacyStyledText
-                as="p"
-                width="14%"
-                data-testid="RecentProtocolRuns_DurationTitle"
-              >
-                {t('run_duration')}
-              </LegacyStyledText>
-            </Flex>
-            {runs
-              .sort(
-                (a, b) =>
-                  new Date(b.createdAt).getTime() -
-                  new Date(a.createdAt).getTime()
-              )
-              .map((run, index) => {
-                const protocol = protocols?.data?.data.find(
-                  protocol => protocol.id === run.protocolId
+                <LegacyStyledText
+                  as="p"
+                  width="25%"
+                  data-testid="RecentProtocolRuns_RunTitle"
+                >
+                  {t('run')}
+                </LegacyStyledText>
+                <LegacyStyledText
+                  as="p"
+                  width="27%"
+                  data-testid="RecentProtocolRuns_ProtocolTitle"
+                >
+                  {t('protocol')}
+                </LegacyStyledText>
+                <LegacyStyledText
+                  as="p"
+                  width="5%"
+                  data-testid="RecentProtocolRuns_FilesTitle"
+                >
+                  {t('files')}
+                </LegacyStyledText>
+                <LegacyStyledText
+                  as="p"
+                  width="14%"
+                  data-testid="RecentProtocolRuns_StatusTitle"
+                >
+                  {t('status')}
+                </LegacyStyledText>
+                <LegacyStyledText
+                  as="p"
+                  width="14%"
+                  data-testid="RecentProtocolRuns_DurationTitle"
+                >
+                  {t('run_duration')}
+                </LegacyStyledText>
+              </Flex>
+              {nonQuickTransferRuns
+                .sort(
+                  (a, b) =>
+                    new Date(b.createdAt).getTime() -
+                    new Date(a.createdAt).getTime()
                 )
-                const isQuickTransfer =
-                  protocol?.protocolKind === 'quick-transfer'
-                const protocolName =
-                  protocol?.metadata.protocolName ??
-                  protocol?.files[0].name ??
-                  t('shared:loading') ??
-                  ''
+                .map((run, index) => {
+                  const protocol = protocols?.data?.data.find(
+                    protocol => protocol.id === run.protocolId
+                  )
+                  const protocolName =
+                    protocol?.metadata.protocolName ??
+                    protocol?.files[0].name ??
+                    t('shared:loading') ??
+                    ''
 
-                return !isQuickTransfer ? (
-                  <HistoricalProtocolRun
-                    run={run}
-                    protocolName={protocolName}
-                    protocolKey={protocol?.key}
-                    robotName={robotName}
-                    robotIsBusy={robotIsBusy}
-                    key={index}
-                  />
-                ) : null
-              })}
-          </>
-        )}
+                  return (
+                    <HistoricalProtocolRun
+                      run={run}
+                      protocolName={protocolName}
+                      protocolKey={protocol?.key}
+                      robotName={robotName}
+                      robotIsBusy={robotIsBusy}
+                      key={index}
+                    />
+                  )
+                })}
+            </>
+          )}
         {!isRobotViewable && (
           <LegacyStyledText
             as="p"
@@ -153,17 +160,19 @@ export function RecentProtocolRuns({
             {t('offline_recent_protocol_runs')}
           </LegacyStyledText>
         )}
-        {isRobotViewable && (runs == null || runs.length === 0) && (
-          <LegacyStyledText
-            as="p"
-            alignItems={ALIGN_CENTER}
-            display={DISPLAY_FLEX}
-            flex="1 0"
-            id="RecentProtocolRuns_no_runs"
-          >
-            {t('no_protocol_runs')}
-          </LegacyStyledText>
-        )}
+        {isRobotViewable &&
+          (nonQuickTransferRuns == null ||
+            nonQuickTransferRuns.length === 0) && (
+            <LegacyStyledText
+              as="p"
+              alignItems={ALIGN_CENTER}
+              display={DISPLAY_FLEX}
+              flex="1 0"
+              id="RecentProtocolRuns_no_runs"
+            >
+              {t('no_protocol_runs')}
+            </LegacyStyledText>
+          )}
       </Flex>
     </Flex>
   )

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -51,8 +51,7 @@ export function RecentRunProtocolCard({
   const { data, isLoading } = useProtocolQuery(runData.protocolId ?? null)
   const protocolData = data?.data ?? null
   const isProtocolFetching = isLoading
-  return protocolData == null ||
-    protocolData.protocolKind === 'quick-transfer' ? null : (
+  return protocolData == null ? null : (
     <ProtocolWithLastRun
       protocolData={protocolData}
       runData={runData}

--- a/app/src/pages/RobotDashboard/index.tsx
+++ b/app/src/pages/RobotDashboard/index.tsx
@@ -10,6 +10,7 @@ import {
   LegacyStyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { useAllProtocolsQuery } from '@opentrons/react-api-client'
 
 import { Navigation } from '../../organisms/Navigation'
 import {
@@ -30,6 +31,7 @@ export function RobotDashboard(): JSX.Element {
     data: allRunsQueryData,
     error: allRunsQueryError,
   } = useNotifyAllRunsQuery()
+  const protocols = useAllProtocolsQuery()
 
   const { unfinishedUnboxingFlowRoute } = useSelector(
     getOnDeviceDisplaySettings
@@ -43,6 +45,11 @@ export function RobotDashboard(): JSX.Element {
     .reduce<RunData[]>((acc, run) => {
       if (
         acc.some(collectedRun => collectedRun.protocolId === run.protocolId)
+      ) {
+        return acc
+      } else if (
+        protocols?.data?.data.find(protocol => protocol.id === run.protocolId)
+          ?.protocolKind === 'quick-transfer'
       ) {
         return acc
       } else {


### PR DESCRIPTION
fix RQA-3130

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
If all previous runs are quick transfer runs, the runs were getting filtered out but the empty run state was not displaying. We need to do the run filtration at a higher level to properly show an empty run history on both ODD and desktop
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
On a robot with no run history, run a quick transfer. See that the run dashboard still shows no run history. Ensure that the run dashboard still appears as expected for robots with non-quick transfer runs
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. In `RecentProtocolRuns` on desktop, use a filtered runs list throughout the file instead of returning a null list item for quick transfer runs
2. On ODD, add a query for protocols at the top level dashboard and use this to further pair down `recentRunsOfUniqueProtocols` list
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over code changes
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low-Med, we should test that adding a query for protocols at the top level of the RobotDashboard doesn't visibly increase loading time
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
