### PR TITLE
fix(app): handle dtwiz after estop

### DIFF
--- a/api/src/opentrons/hardware_control/protocols/motion_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/motion_controller.py
@@ -204,6 +204,10 @@ class MotionController(Protocol[MountArgType]):
         """Disengage some axes."""
         ...
 
+    async def engage_axes(self, which: List[Axis]) -> None:
+        """Engage some axes."""
+        ...
+
     async def retract(self, mount: MountArgType, margin: float = 10) -> None:
         """Pull the specified mount up to its home position.
 

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -391,6 +391,7 @@ Command = Annotated[
         unsafe.UnsafeBlowOutInPlace,
         unsafe.UnsafeDropTipInPlace,
         unsafe.UpdatePositionEstimators,
+        unsafe.UnsafeEngageAxes,
     ],
     Field(discriminator="commandType"),
 ]
@@ -463,6 +464,7 @@ CommandParams = Union[
     unsafe.UnsafeBlowOutInPlaceParams,
     unsafe.UnsafeDropTipInPlaceParams,
     unsafe.UpdatePositionEstimatorsParams,
+    unsafe.UnsafeEngageAxesParams,
 ]
 
 CommandType = Union[
@@ -533,6 +535,7 @@ CommandType = Union[
     unsafe.UnsafeBlowOutInPlaceCommandType,
     unsafe.UnsafeDropTipInPlaceCommandType,
     unsafe.UpdatePositionEstimatorsCommandType,
+    unsafe.UnsafeEngageAxesCommandType,
 ]
 
 CommandCreate = Annotated[
@@ -604,6 +607,7 @@ CommandCreate = Annotated[
         unsafe.UnsafeBlowOutInPlaceCreate,
         unsafe.UnsafeDropTipInPlaceCreate,
         unsafe.UpdatePositionEstimatorsCreate,
+        unsafe.UnsafeEngageAxesCreate,
     ],
     Field(discriminator="commandType"),
 ]
@@ -676,6 +680,7 @@ CommandResult = Union[
     unsafe.UnsafeBlowOutInPlaceResult,
     unsafe.UnsafeDropTipInPlaceResult,
     unsafe.UpdatePositionEstimatorsResult,
+    unsafe.UnsafeEngageAxesResult,
 ]
 
 # todo(mm, 2024-06-12): Ideally, command return types would have specific

--- a/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
@@ -23,6 +23,14 @@ from .update_position_estimators import (
     UpdatePositionEstimatorsCreate,
 )
 
+from .unsafe_engage_axes import (
+    UnsafeEngageAxesCommandType,
+    UnsafeEngageAxesParams,
+    UnsafeEngageAxesResult,
+    UnsafeEngageAxes,
+    UnsafeEngageAxesCreate,
+)
+
 __all__ = [
     # Unsafe blow-out-in-place command models
     "UnsafeBlowOutInPlaceCommandType",
@@ -42,4 +50,10 @@ __all__ = [
     "UpdatePositionEstimatorsResult",
     "UpdatePositionEstimators",
     "UpdatePositionEstimatorsCreate",
+    # Unsafe engage axes
+    "UnsafeEngageAxesCommandType",
+    "UnsafeEngageAxesParams",
+    "UnsafeEngageAxesResult",
+    "UnsafeEngageAxes",
+    "UnsafeEngageAxesCreate",
 ]

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_engage_axes.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_engage_axes.py
@@ -1,0 +1,83 @@
+"""Update position estimators payload, result, and implementaiton."""
+
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import TYPE_CHECKING, Optional, List, Type
+from typing_extensions import Literal
+
+from ...types import MotorAxis
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
+from ...resources import ensure_ot3_hardware
+
+from opentrons.hardware_control import HardwareControlAPI
+
+if TYPE_CHECKING:
+    from ...execution import GantryMover
+
+
+UnsafeEngageAxesCommandType = Literal["unsafe/engageAxes"]
+
+
+class UnsafeEngageAxesParams(BaseModel):
+    """Payload required for an UnsafeEngageAxes command."""
+
+    axes: List[MotorAxis] = Field(..., description="The axes for which to enable.")
+
+
+class UnsafeEngageAxesResult(BaseModel):
+    """Result data from the execution of an UnsafeEngageAxes command."""
+
+
+class UnsafeEngageAxesImplementation(
+    AbstractCommandImpl[
+        UnsafeEngageAxesParams,
+        SuccessData[UnsafeEngageAxesResult, None],
+    ]
+):
+    """Enable axes command implementation."""
+
+    def __init__(
+        self,
+        hardware_api: HardwareControlAPI,
+        gantry_mover: GantryMover,
+        **kwargs: object,
+    ) -> None:
+        self._hardware_api = hardware_api
+        self._gantry_mover = gantry_mover
+
+    async def execute(
+        self, params: UnsafeEngageAxesParams
+    ) -> SuccessData[UnsafeEngageAxesResult, None]:
+        """Enable exes."""
+        ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
+        await ot3_hardware_api.engage_axes(
+            [
+                self._gantry_mover.motor_axis_to_hardware_axis(axis)
+                for axis in params.axes
+            ]
+        )
+        return SuccessData(public=UnsafeEngageAxesResult(), private=None)
+
+
+class UnsafeEngageAxes(
+    BaseCommand[UnsafeEngageAxesParams, UnsafeEngageAxesResult, ErrorOccurrence]
+):
+    """UnsafeEngageAxes command model."""
+
+    commandType: UnsafeEngageAxesCommandType = "unsafe/engageAxes"
+    params: UnsafeEngageAxesParams
+    result: Optional[UnsafeEngageAxesResult]
+
+    _ImplementationCls: Type[
+        UnsafeEngageAxesImplementation
+    ] = UnsafeEngageAxesImplementation
+
+
+class UnsafeEngageAxesCreate(BaseCommandCreate[UnsafeEngageAxesParams]):
+    """UnsafeEngageAxes command request model."""
+
+    commandType: UnsafeEngageAxesCommandType = "unsafe/engageAxes"
+    params: UnsafeEngageAxesParams
+
+    _CommandCls: Type[UnsafeEngageAxes] = UnsafeEngageAxes

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_engage_axes.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_engage_axes.py
@@ -1,0 +1,52 @@
+"""Test update-position-estimator commands."""
+from decoy import Decoy
+
+from opentrons.protocol_engine.commands.unsafe.unsafe_engage_axes import (
+    UnsafeEngageAxesParams,
+    UnsafeEngageAxesResult,
+    UnsafeEngageAxesImplementation,
+)
+from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.execution import GantryMover
+from opentrons.protocol_engine.types import MotorAxis
+from opentrons.hardware_control import OT3HardwareControlAPI
+from opentrons.hardware_control.types import Axis
+
+
+async def test_engage_axes_implementation(
+    decoy: Decoy, ot3_hardware_api: OT3HardwareControlAPI, gantry_mover: GantryMover
+) -> None:
+    """Test EngageAxes command execution."""
+    subject = UnsafeEngageAxesImplementation(
+        hardware_api=ot3_hardware_api, gantry_mover=gantry_mover
+    )
+
+    data = UnsafeEngageAxesParams(
+        axes=[MotorAxis.LEFT_Z, MotorAxis.LEFT_PLUNGER, MotorAxis.X, MotorAxis.Y]
+    )
+
+    decoy.when(gantry_mover.motor_axis_to_hardware_axis(MotorAxis.LEFT_Z)).then_return(
+        Axis.Z_L
+    )
+    decoy.when(
+        gantry_mover.motor_axis_to_hardware_axis(MotorAxis.LEFT_PLUNGER)
+    ).then_return(Axis.P_L)
+    decoy.when(gantry_mover.motor_axis_to_hardware_axis(MotorAxis.X)).then_return(
+        Axis.X
+    )
+    decoy.when(gantry_mover.motor_axis_to_hardware_axis(MotorAxis.Y)).then_return(
+        Axis.Y
+    )
+    decoy.when(
+        await ot3_hardware_api.update_axis_position_estimations(
+            [Axis.Z_L, Axis.P_L, Axis.X, Axis.Y]
+        )
+    ).then_return(None)
+
+    result = await subject.execute(data)
+
+    assert result == SuccessData(public=UnsafeEngageAxesResult(), private=None)
+
+    decoy.verify(
+        await ot3_hardware_api.engage_axes([Axis.Z_L, Axis.P_L, Axis.X, Axis.Y]),
+    )

--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -36,7 +36,7 @@ import { ProtocolTimeline } from '../pages/Protocols/ProtocolDetails/ProtocolTim
 import { PortalRoot as ModalPortalRoot } from './portal'
 import { DesktopAppFallback } from './DesktopAppFallback'
 
-import type { RouteProps, DesktopRouteParams } from './types'
+import type { RouteProps } from './types'
 
 export const DesktopApp = (): JSX.Element => {
   useSoftwareUpdatePoll()

--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -158,11 +158,10 @@ export const DesktopApp = (): JSX.Element => {
 }
 
 function RobotControlTakeover(): JSX.Element | null {
-  const deviceRouteMatch = useMatch('/devices/:robotName')
-  const params = deviceRouteMatch?.params as DesktopRouteParams
-  const robotName = params?.robotName
+  const deviceRouteMatch = useMatch('/devices/:robotName/*')
+  const params = deviceRouteMatch?.params
+  const robotName = params?.robotName ?? null
   const robot = useRobot(robotName)
-
   if (deviceRouteMatch == null || robot == null || robotName == null)
     return null
 

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -118,6 +118,7 @@ export function useDropTipCommands({
         return chainRunCommands(
           isFlex
             ? [
+                ENGAGE_AXES,
                 HOME_EXCEPT_PLUNGERS,
                 UPDATE_ESTIMATORS_EXCEPT_PLUNGERS,
                 moveToAACommand,
@@ -290,6 +291,11 @@ export function useDropTipCommands({
 const HOME: CreateCommand = {
   commandType: 'home' as const,
   params: {},
+}
+
+const ENGAGE_AXES: CreateCommand = {
+  commandType: 'unsafe/engageAxes' as const,
+  params: { axes: ['leftZ', 'rightZ', 'x', 'y'] },
 }
 
 const HOME_EXCEPT_PLUNGERS: CreateCommand = {

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -117,12 +117,7 @@ export function useDropTipCommands({
         )
         return chainRunCommands(
           isFlex
-            ? [
-                ENGAGE_AXES,
-                HOME_EXCEPT_PLUNGERS,
-                UPDATE_ESTIMATORS_EXCEPT_PLUNGERS,
-                moveToAACommand,
-              ]
+            ? [ENGAGE_AXES, UPDATE_ESTIMATORS_EXCEPT_PLUNGERS, moveToAACommand]
             : [moveToAACommand],
           true
         )
@@ -295,7 +290,9 @@ const HOME: CreateCommand = {
 
 const ENGAGE_AXES: CreateCommand = {
   commandType: 'unsafe/engageAxes' as const,
-  params: { axes: ['leftZ', 'rightZ', 'x', 'y'] },
+  params: {
+    axes: ['leftZ', 'rightZ', 'x', 'y', 'leftPlunger', 'rightPlunger'],
+  },
 }
 
 const HOME_EXCEPT_PLUNGERS: CreateCommand = {
@@ -306,6 +303,11 @@ const HOME_EXCEPT_PLUNGERS: CreateCommand = {
 const UPDATE_ESTIMATORS_EXCEPT_PLUNGERS: CreateCommand = {
   commandType: 'unsafe/updatePositionEstimators' as const,
   params: { axes: ['leftZ', 'rightZ', 'x', 'y'] },
+}
+
+const UPDATE_PLUNGER_ESTIMATORS: CreateCommand = {
+  commandType: 'unsafe/updatePositionEstimators' as const,
+  params: { axes: ['leftPlunger', 'rightPlunger'] },
 }
 
 const buildDropTipInPlaceCommand = (
@@ -333,6 +335,8 @@ const buildBlowoutCommands = (
 ): CreateCommand[] =>
   isFlex
     ? [
+        ENGAGE_AXES,
+        UPDATE_PLUNGER_ESTIMATORS,
         {
           commandType: 'unsafe/blowOutInPlace',
           params: {
@@ -352,6 +356,8 @@ const buildBlowoutCommands = (
         },
       ]
     : [
+        ENGAGE_AXES,
+        UPDATE_PLUNGER_ESTIMATORS,
         {
           commandType: 'blowOutInPlace',
           params: {

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -117,7 +117,11 @@ export function useDropTipCommands({
         )
         return chainRunCommands(
           isFlex
-            ? [UPDATE_ESTIMATORS_EXCEPT_PLUNGERS, moveToAACommand]
+            ? [
+                HOME_EXCEPT_PLUNGERS,
+                UPDATE_ESTIMATORS_EXCEPT_PLUNGERS,
+                moveToAACommand,
+              ]
             : [moveToAACommand],
           true
         )

--- a/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
+++ b/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
@@ -186,7 +186,7 @@ function DesktopModal({
         },
         onError: (error: any) => {
           setIsResuming(false)
-          console.log(error)
+          console.error(error)
         },
       }
     )

--- a/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
+++ b/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
@@ -42,6 +42,8 @@ interface EstopPressedModalProps {
   closeModal: () => void
   isDismissedModal?: boolean
   setIsDismissedModal?: (isDismissedModal: boolean) => void
+  isWaitingForLogicalDisengage: boolean
+  setShouldSeeLogicalDisengage: () => void
 }
 
 export function EstopPressedModal({
@@ -49,11 +51,18 @@ export function EstopPressedModal({
   closeModal,
   isDismissedModal,
   setIsDismissedModal,
+  isWaitingForLogicalDisengage,
+  setShouldSeeLogicalDisengage,
 }: EstopPressedModalProps): JSX.Element {
   const isOnDevice = useSelector(getIsOnDevice)
   return createPortal(
     isOnDevice ? (
-      <TouchscreenModal isEngaged={isEngaged} closeModal={closeModal} />
+      <TouchscreenModal
+        isEngaged={isEngaged}
+        closeModal={closeModal}
+        isWaitingForLogicalDisengage={isWaitingForLogicalDisengage}
+        setShouldSeeLogicalDisengage={setShouldSeeLogicalDisengage}
+      />
     ) : (
       <>
         {isDismissedModal === false ? (
@@ -61,6 +70,8 @@ export function EstopPressedModal({
             isEngaged={isEngaged}
             closeModal={closeModal}
             setIsDismissedModal={setIsDismissedModal}
+            isWaitingForLogicalDisengage={isWaitingForLogicalDisengage}
+            setShouldSeeLogicalDisengage={setShouldSeeLogicalDisengage}
           />
         ) : null}
       </>
@@ -72,6 +83,8 @@ export function EstopPressedModal({
 function TouchscreenModal({
   isEngaged,
   closeModal,
+  isWaitingForLogicalDisengage,
+  setShouldSeeLogicalDisengage,
 }: EstopPressedModalProps): JSX.Element {
   const { t } = useTranslation(['device_settings', 'branded'])
   const [isResuming, setIsResuming] = React.useState<boolean>(false)
@@ -88,6 +101,7 @@ function TouchscreenModal({
   const handleClick = (): void => {
     setIsResuming(true)
     acknowledgeEstopDisengage(null)
+    setShouldSeeLogicalDisengage()
     closeModal()
   }
   return (
@@ -116,10 +130,16 @@ function TouchscreenModal({
         <SmallButton
           data-testid="Estop_pressed_button"
           width="100%"
-          iconName={isResuming ? 'ot-spinner' : undefined}
-          iconPlacement={isResuming ? 'startIcon' : undefined}
+          iconName={
+            isResuming || isWaitingForLogicalDisengage
+              ? 'ot-spinner'
+              : undefined
+          }
+          iconPlacement={
+            isResuming || isWaitingForLogicalDisengage ? 'startIcon' : undefined
+          }
           buttonText={t('resume_robot_operations')}
-          disabled={isEngaged || isResuming}
+          disabled={isEngaged || isResuming || isWaitingForLogicalDisengage}
           onClick={handleClick}
         />
       </Flex>
@@ -131,6 +151,8 @@ function DesktopModal({
   isEngaged,
   closeModal,
   setIsDismissedModal,
+  isWaitingForLogicalDisengage,
+  setShouldSeeLogicalDisengage,
 }: EstopPressedModalProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const [isResuming, setIsResuming] = React.useState<boolean>(false)
@@ -155,14 +177,19 @@ function DesktopModal({
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e): void => {
     e.preventDefault()
     setIsResuming(true)
-    acknowledgeEstopDisengage({
-      onSuccess: () => {
-        closeModal()
-      },
-      onError: () => {
-        setIsResuming(false)
-      },
-    })
+    acknowledgeEstopDisengage(
+      {},
+      {
+        onSuccess: () => {
+          setShouldSeeLogicalDisengage()
+          closeModal()
+        },
+        onError: (error: any) => {
+          setIsResuming(false)
+          console.log(error)
+        },
+      }
+    )
   }
 
   return (
@@ -177,14 +204,16 @@ function DesktopModal({
         <Flex justifyContent={JUSTIFY_FLEX_END}>
           <PrimaryButton
             onClick={handleClick}
-            disabled={isEngaged || isResuming}
+            disabled={isEngaged || isResuming || isWaitingForLogicalDisengage}
           >
             <Flex
               flexDirection={DIRECTION_ROW}
               gridGap={SPACING.spacing8}
               alignItems={ALIGN_CENTER}
             >
-              {isResuming ? <Icon size="1rem" spin name="ot-spinner" /> : null}
+              {isResuming || isWaitingForLogicalDisengage ? (
+                <Icon size="1rem" spin name="ot-spinner" />
+              ) : null}
               {t('resume_robot_operations')}
             </Flex>
           </PrimaryButton>

--- a/app/src/organisms/EmergencyStop/EstopTakeover.tsx
+++ b/app/src/organisms/EmergencyStop/EstopTakeover.tsx
@@ -40,7 +40,6 @@ export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
       setIsWaitingForLogicalDisengage(false)
     },
   })
-  console.log(`estop status: ${estopStatus?.data.status}`)
 
   const {
     isEmergencyStopModalDismissed,

--- a/app/src/organisms/EmergencyStop/EstopTakeover.tsx
+++ b/app/src/organisms/EmergencyStop/EstopTakeover.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { useEstopQuery } from '@opentrons/react-api-client'
+import { useEstopQuery, useHost } from '@opentrons/react-api-client'
 
 import { EstopPressedModal } from './EstopPressedModal'
 import { EstopMissingModal } from './EstopMissingModal'
@@ -14,16 +14,35 @@ import {
   DISENGAGED,
 } from './constants'
 
-const ESTOP_REFETCH_INTERVAL_MS = 10000
+const ESTOP_CURRENTLY_DISENGAGED_REFETCH_INTERVAL_MS = 10000
+const ESTOP_CURRENTLY_ENGAGED_REFETCH_INTERVAL_MS = 1000
 
 interface EstopTakeoverProps {
   robotName?: string
 }
 
 export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
+  const [estopEngaged, setEstopEngaged] = React.useState<boolean>(false)
+  const [
+    isWaitingForLogicalDisengage,
+    setIsWaitingForLogicalDisengage,
+  ] = React.useState<boolean>(false)
   const { data: estopStatus } = useEstopQuery({
-    refetchInterval: ESTOP_REFETCH_INTERVAL_MS,
+    refetchInterval: estopEngaged
+      ? ESTOP_CURRENTLY_ENGAGED_REFETCH_INTERVAL_MS
+      : ESTOP_CURRENTLY_DISENGAGED_REFETCH_INTERVAL_MS,
+    onSuccess: response => {
+      setEstopEngaged(
+        [PHYSICALLY_ENGAGED || LOGICALLY_ENGAGED].includes(
+          response?.data.status
+        )
+      )
+      setIsWaitingForLogicalDisengage(false)
+    },
   })
+  console.log(`estop status: ${estopStatus?.data.status}`)
+  const host = useHost()
+
   const {
     isEmergencyStopModalDismissed,
     setIsEmergencyStopModalDismissed,
@@ -47,6 +66,10 @@ export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
             closeModal={closeModal}
             isDismissedModal={isEmergencyStopModalDismissed}
             setIsDismissedModal={setIsEmergencyStopModalDismissed}
+            isWaitingForLogicalDisengage={isWaitingForLogicalDisengage}
+            setShouldSeeLogicalDisengage={() => {
+              setIsWaitingForLogicalDisengage(true)
+            }}
           />
         )
       case NOT_PRESENT:

--- a/app/src/organisms/EmergencyStop/EstopTakeover.tsx
+++ b/app/src/organisms/EmergencyStop/EstopTakeover.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { useEstopQuery, useHost } from '@opentrons/react-api-client'
+import { useEstopQuery } from '@opentrons/react-api-client'
 
 import { EstopPressedModal } from './EstopPressedModal'
 import { EstopMissingModal } from './EstopMissingModal'
@@ -41,7 +41,6 @@ export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
     },
   })
   console.log(`estop status: ${estopStatus?.data.status}`)
-  const host = useHost()
 
   const {
     isEmergencyStopModalDismissed,

--- a/app/src/organisms/EmergencyStop/__tests__/EstopPressedModal.test.tsx
+++ b/app/src/organisms/EmergencyStop/__tests__/EstopPressedModal.test.tsx
@@ -25,6 +25,8 @@ describe('EstopPressedModal - Touchscreen', () => {
     props = {
       isEngaged: true,
       closeModal: vi.fn(),
+      isWaitingForLogicalDisengage: false,
+      setShouldSeeLogicalDisengage: vi.fn(),
     }
     vi.mocked(getIsOnDevice).mockReturnValue(true)
     vi.mocked(useAcknowledgeEstopDisengageMutation).mockReturnValue({
@@ -69,6 +71,8 @@ describe('EstopPressedModal - Desktop', () => {
       closeModal: vi.fn(),
       isDismissedModal: false,
       setIsDismissedModal: vi.fn(),
+      isWaitingForLogicalDisengage: false,
+      setShouldSeeLogicalDisengage: vi.fn(),
     }
     vi.mocked(getIsOnDevice).mockReturnValue(false)
     vi.mocked(useAcknowledgeEstopDisengageMutation).mockReturnValue({

--- a/react-api-client/src/maintenance_runs/useCreateMaintenanceCommandMutation.ts
+++ b/react-api-client/src/maintenance_runs/useCreateMaintenanceCommandMutation.ts
@@ -50,16 +50,21 @@ export function useCreateMaintenanceCommandMutation(): UseCreateMaintenanceComma
     createMaintenanceCommand(host as HostConfig, maintenanceRunId, command, {
       waitUntilComplete,
       timeout,
-    }).then(response => {
-      queryClient
-        .invalidateQueries([host, 'maintenance_runs'])
-        .catch((e: Error) => {
-          console.error(
-            `error invalidating maintenance runs query: ${e.message}`
-          )
-        })
-      return response.data
     })
+      .then(response => {
+        queryClient
+          .invalidateQueries([host, 'maintenance_runs'])
+          .catch((e: Error) => {
+            console.error(
+              `error invalidating maintenance runs query: ${e.message}`
+            )
+          })
+        return response.data
+      })
+      .catch((e: any) => {
+        queryClient.invalidateQueries([host, 'robot/control/estopStatus'])
+        throw e
+      })
   )
 
   return {

--- a/react-api-client/src/maintenance_runs/useCreateMaintenanceRunMutation.ts
+++ b/react-api-client/src/maintenance_runs/useCreateMaintenanceRunMutation.ts
@@ -1,5 +1,5 @@
 import { createMaintenanceRun } from '@opentrons/api-client'
-import { useMutation } from 'react-query'
+import { useMutation, useQueryClient } from 'react-query'
 import { useHost } from '../api'
 import type { AxiosError } from 'axios'
 import type {
@@ -40,6 +40,7 @@ export function useCreateMaintenanceRunMutation(
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
+  const queryClient = useQueryClient()
   const mutation = useMutation<
     MaintenanceRun,
     AxiosError,
@@ -50,6 +51,7 @@ export function useCreateMaintenanceRunMutation(
       createMaintenanceRun(host as HostConfig, createMaintenanceRunData)
         .then(response => response.data)
         .catch(e => {
+          queryClient.invalidateQueries([host, 'robot/control/estopStatus'])
           throw e
         }),
     options

--- a/react-api-client/src/robot/useEstopQuery.ts
+++ b/react-api-client/src/robot/useEstopQuery.ts
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query'
 import { getEstopStatus } from '@opentrons/api-client'
 import { useHost } from '../api'
 
-import type { UseQueryResult, UseQueryOptions } from 'react-query'
+import type { UseQueryResult, UseQueryOptions, QueryKey } from 'react-query'
 import type { HostConfig, EstopStatus } from '@opentrons/api-client'
 
 export type UseEstopQueryOptions<TError = Error> = UseQueryOptions<

--- a/react-api-client/src/robot/useEstopQuery.ts
+++ b/react-api-client/src/robot/useEstopQuery.ts
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query'
 import { getEstopStatus } from '@opentrons/api-client'
 import { useHost } from '../api'
 
-import type { UseQueryResult, UseQueryOptions, QueryKey } from 'react-query'
+import type { UseQueryResult, UseQueryOptions } from 'react-query'
 import type { HostConfig, EstopStatus } from '@opentrons/api-client'
 
 export type UseEstopQueryOptions<TError = Error> = UseQueryOptions<

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -1,6 +1,9 @@
 import { getRun } from '@opentrons/api-client'
-import { useQuery } from 'react-query'
+import { useQuery, useQueryClient } from 'react-query'
 import { useHost } from '../api'
+import { useEffect } from 'react'
+import { some } from 'lodash'
+import type { RunError } from '@opentrons/api-client'
 
 import type { UseQueryResult, UseQueryOptions } from 'react-query'
 import type { HostConfig, Run } from '@opentrons/api-client'
@@ -13,6 +16,7 @@ export function useRunQuery<TError = Error>(
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
+  const queryClient = useQueryClient()
   const query = useQuery<Run, TError>(
     [host, 'runs', runId, 'details'],
     () =>
@@ -24,6 +28,30 @@ export function useRunQuery<TError = Error>(
       ...options,
     }
   )
+
+  const estopInErrorTree = (error: RunError): boolean =>
+    error?.errorCode === '3008' ||
+    (error?.wrappedErrors ?? []).map((wrapped: RunError) =>
+      estopInErrorTree(wrapped)
+    )
+
+  // If the run contains an estop error, invalidate the estop query so we get the
+  // estop modal as fast as we can
+  useEffect(() => {
+    if (
+      query.data?.data?.current &&
+      some(
+        ((query.data?.data?.errors ?? []) as RunError[]).map(estopInErrorTree)
+      )
+    ) {
+      queryClient.invalidateQueries([host, '/robot/control'])
+    }
+  }, [
+    runId,
+    query.isSuccess,
+    query.data?.data?.current,
+    query.data?.data?.errors,
+  ])
 
   return query
 }

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -3,10 +3,9 @@ import { useQuery, useQueryClient } from 'react-query'
 import { useHost } from '../api'
 import { useEffect } from 'react'
 import { some } from 'lodash'
-import type { RunError } from '@opentrons/api-client'
+import type { HostConfig, Run, RunError } from '@opentrons/api-client'
 
 import type { UseQueryResult, UseQueryOptions } from 'react-query'
-import type { HostConfig, Run } from '@opentrons/api-client'
 
 export function useRunQuery<TError = Error>(
   runId: string | null,
@@ -31,8 +30,10 @@ export function useRunQuery<TError = Error>(
 
   const estopInErrorTree = (error: RunError): boolean =>
     error?.errorCode === '3008' ||
-    (error?.wrappedErrors ?? []).map((wrapped: RunError) =>
-      estopInErrorTree(wrapped)
+    some(
+      (error?.wrappedErrors ?? []).map((wrapped: RunError) =>
+        estopInErrorTree(wrapped)
+      )
     )
 
   // If the run contains an estop error, invalidate the estop query so we get the

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -71,7 +71,8 @@
       "calibration/moveToMaintenancePosition": "#/definitions/MoveToMaintenancePositionCreate",
       "unsafe/blowOutInPlace": "#/definitions/UnsafeBlowOutInPlaceCreate",
       "unsafe/dropTipInPlace": "#/definitions/UnsafeDropTipInPlaceCreate",
-      "unsafe/updatePositionEstimators": "#/definitions/UpdatePositionEstimatorsCreate"
+      "unsafe/updatePositionEstimators": "#/definitions/UpdatePositionEstimatorsCreate",
+      "unsafe/engageAxes": "#/definitions/UnsafeEngageAxesCreate"
     }
   },
   "oneOf": [
@@ -275,13 +276,20 @@
     },
     {
       "$ref": "#/definitions/UpdatePositionEstimatorsCreate"
+    },
+    {
+      "$ref": "#/definitions/UnsafeEngageAxesCreate"
     }
   ],
   "definitions": {
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": ["top", "bottom", "center"],
+      "enum": [
+        "top",
+        "bottom",
+        "center"
+      ],
       "type": "string"
     },
     "WellOffset": {
@@ -366,12 +374,22 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": ["protocol", "setup", "fixit"],
+      "enum": [
+        "protocol",
+        "setup",
+        "fixit"
+      ],
       "type": "string"
     },
     "AspirateCreate": {
@@ -382,7 +400,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": ["aspirate"],
+          "enum": [
+            "aspirate"
+          ],
           "type": "string"
         },
         "params": {
@@ -402,7 +422,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -427,7 +449,11 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -437,7 +463,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": ["aspirateInPlace"],
+          "enum": [
+            "aspirateInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -457,7 +485,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -470,7 +500,9 @@
           "type": "string"
         }
       },
-      "required": ["message"]
+      "required": [
+        "message"
+      ]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -480,7 +512,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": ["comment"],
+          "enum": [
+            "comment"
+          ],
           "type": "string"
         },
         "params": {
@@ -500,7 +534,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ConfigureForVolumeParams": {
       "title": "ConfigureForVolumeParams",
@@ -524,7 +560,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "volume"]
+      "required": [
+        "pipetteId",
+        "volume"
+      ]
     },
     "ConfigureForVolumeCreate": {
       "title": "ConfigureForVolumeCreate",
@@ -534,7 +573,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureForVolume",
-          "enum": ["configureForVolume"],
+          "enum": [
+            "configureForVolume"
+          ],
           "type": "string"
         },
         "params": {
@@ -554,7 +595,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AllNozzleLayoutConfiguration": {
       "title": "AllNozzleLayoutConfiguration",
@@ -564,7 +607,9 @@
         "style": {
           "title": "Style",
           "default": "ALL",
-          "enum": ["ALL"],
+          "enum": [
+            "ALL"
+          ],
           "type": "string"
         }
       }
@@ -577,17 +622,26 @@
         "style": {
           "title": "Style",
           "default": "SINGLE",
-          "enum": ["SINGLE"],
+          "enum": [
+            "SINGLE"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "RowNozzleLayoutConfiguration": {
       "title": "RowNozzleLayoutConfiguration",
@@ -597,17 +651,26 @@
         "style": {
           "title": "Style",
           "default": "ROW",
-          "enum": ["ROW"],
+          "enum": [
+            "ROW"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "ColumnNozzleLayoutConfiguration": {
       "title": "ColumnNozzleLayoutConfiguration",
@@ -617,17 +680,26 @@
         "style": {
           "title": "Style",
           "default": "COLUMN",
-          "enum": ["COLUMN"],
+          "enum": [
+            "COLUMN"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "QuadrantNozzleLayoutConfiguration": {
       "title": "QuadrantNozzleLayoutConfiguration",
@@ -637,13 +709,20 @@
         "style": {
           "title": "Style",
           "default": "QUADRANT",
-          "enum": ["QUADRANT"],
+          "enum": [
+            "QUADRANT"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         },
         "frontRightNozzle": {
@@ -659,7 +738,11 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"]
+      "required": [
+        "primaryNozzle",
+        "frontRightNozzle",
+        "backLeftNozzle"
+      ]
     },
     "ConfigureNozzleLayoutParams": {
       "title": "ConfigureNozzleLayoutParams",
@@ -692,7 +775,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "configurationParams"]
+      "required": [
+        "pipetteId",
+        "configurationParams"
+      ]
     },
     "ConfigureNozzleLayoutCreate": {
       "title": "ConfigureNozzleLayoutCreate",
@@ -702,7 +788,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureNozzleLayout",
-          "enum": ["configureNozzleLayout"],
+          "enum": [
+            "configureNozzleLayout"
+          ],
           "type": "string"
         },
         "params": {
@@ -722,7 +810,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -738,7 +828,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": ["custom"],
+          "enum": [
+            "custom"
+          ],
           "type": "string"
         },
         "params": {
@@ -758,7 +850,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -807,7 +901,13 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -817,7 +917,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": ["dispense"],
+          "enum": [
+            "dispense"
+          ],
           "type": "string"
         },
         "params": {
@@ -837,7 +939,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -867,7 +971,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -877,7 +985,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": ["dispenseInPlace"],
+          "enum": [
+            "dispenseInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -897,7 +1007,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -935,7 +1047,12 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -945,7 +1062,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": ["blowout"],
+          "enum": [
+            "blowout"
+          ],
           "type": "string"
         },
         "params": {
@@ -965,7 +1084,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -984,7 +1105,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"]
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -994,7 +1118,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": ["blowOutInPlace"],
+          "enum": [
+            "blowOutInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -1014,12 +1140,19 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": ["top", "bottom", "center", "default"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "default"
+      ],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -1081,7 +1214,11 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"]
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -1091,7 +1228,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": ["dropTip"],
+          "enum": [
+            "dropTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -1111,7 +1250,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -1129,7 +1270,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -1139,7 +1282,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": ["dropTipInPlace"],
+          "enum": [
+            "dropTipInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -1159,7 +1304,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -1179,7 +1326,11 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": ["left", "right", "extension"],
+      "enum": [
+        "left",
+        "right",
+        "extension"
+      ],
       "type": "string"
     },
     "HomeParams": {
@@ -1212,7 +1363,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": ["home"],
+          "enum": [
+            "home"
+          ],
           "type": "string"
         },
         "params": {
@@ -1232,7 +1385,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -1248,7 +1403,9 @@
           ]
         }
       },
-      "required": ["axis"]
+      "required": [
+        "axis"
+      ]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -1258,7 +1415,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": ["retractAxis"],
+          "enum": [
+            "retractAxis"
+          ],
           "type": "string"
         },
         "params": {
@@ -1278,7 +1437,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1324,7 +1485,9 @@
           ]
         }
       },
-      "required": ["slotName"]
+      "required": [
+        "slotName"
+      ]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1337,7 +1500,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -1350,7 +1515,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"]
+      "required": [
+        "labwareId"
+      ]
     },
     "AddressableAreaLocation": {
       "title": "AddressableAreaLocation",
@@ -1363,7 +1530,9 @@
           "type": "string"
         }
       },
-      "required": ["addressableAreaName"]
+      "required": [
+        "addressableAreaName"
+      ]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1384,7 +1553,9 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             },
             {
@@ -1418,7 +1589,12 @@
           "type": "string"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"]
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1428,7 +1604,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": ["loadLabware"],
+          "enum": [
+            "loadLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1448,7 +1626,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ReloadLabwareParams": {
       "title": "ReloadLabwareParams",
@@ -1461,7 +1641,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"]
+      "required": [
+        "labwareId"
+      ]
     },
     "ReloadLabwareCreate": {
       "title": "ReloadLabwareCreate",
@@ -1471,7 +1653,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "reloadLabware",
-          "enum": ["reloadLabware"],
+          "enum": [
+            "reloadLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1491,7 +1675,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1517,7 +1703,11 @@
           }
         }
       },
-      "required": ["liquidId", "labwareId", "volumeByWell"]
+      "required": [
+        "liquidId",
+        "labwareId",
+        "volumeByWell"
+      ]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1527,7 +1717,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": ["loadLiquid"],
+          "enum": [
+            "loadLiquid"
+          ],
           "type": "string"
         },
         "params": {
@@ -1547,7 +1739,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1593,7 +1787,10 @@
           "type": "string"
         }
       },
-      "required": ["model", "location"]
+      "required": [
+        "model",
+        "location"
+      ]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1603,7 +1800,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": ["loadModule"],
+          "enum": [
+            "loadModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -1623,7 +1822,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1686,7 +1887,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteName", "mount"]
+      "required": [
+        "pipetteName",
+        "mount"
+      ]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1696,7 +1900,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": ["loadPipette"],
+          "enum": [
+            "loadPipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -1716,12 +1922,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
+      "enum": [
+        "usingGripper",
+        "manualMoveWithPause",
+        "manualMoveWithoutPause"
+      ],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1742,7 +1954,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1768,7 +1984,9 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             },
             {
@@ -1803,7 +2021,11 @@
           ]
         }
       },
-      "required": ["labwareId", "newLocation", "strategy"]
+      "required": [
+        "labwareId",
+        "newLocation",
+        "strategy"
+      ]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -1813,7 +2035,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": ["moveLabware"],
+          "enum": [
+            "moveLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1833,12 +2057,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": ["x", "y", "z"],
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -1865,7 +2095,11 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "axis", "distance"]
+      "required": [
+        "pipetteId",
+        "axis",
+        "distance"
+      ]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -1875,7 +2109,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": ["moveRelative"],
+          "enum": [
+            "moveRelative"
+          ],
           "type": "string"
         },
         "params": {
@@ -1895,7 +2131,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -1915,7 +2153,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -1953,7 +2195,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "coordinates"]
+      "required": [
+        "pipetteId",
+        "coordinates"
+      ]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -1963,7 +2208,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": ["moveToCoordinates"],
+          "enum": [
+            "moveToCoordinates"
+          ],
           "type": "string"
         },
         "params": {
@@ -1983,7 +2230,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -2031,7 +2280,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -2041,7 +2294,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": ["moveToWell"],
+          "enum": [
+            "moveToWell"
+          ],
           "type": "string"
         },
         "params": {
@@ -2061,7 +2316,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AddressableOffsetVector": {
       "title": "AddressableOffsetVector",
@@ -2081,7 +2338,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveToAddressableAreaParams": {
       "title": "MoveToAddressableAreaParams",
@@ -2135,7 +2396,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"]
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ]
     },
     "MoveToAddressableAreaCreate": {
       "title": "MoveToAddressableAreaCreate",
@@ -2145,7 +2409,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableArea",
-          "enum": ["moveToAddressableArea"],
+          "enum": [
+            "moveToAddressableArea"
+          ],
           "type": "string"
         },
         "params": {
@@ -2165,7 +2431,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MoveToAddressableAreaForDropTipParams": {
       "title": "MoveToAddressableAreaForDropTipParams",
@@ -2225,7 +2493,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"]
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ]
     },
     "MoveToAddressableAreaForDropTipCreate": {
       "title": "MoveToAddressableAreaForDropTipCreate",
@@ -2235,7 +2506,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableAreaForDropTip",
-          "enum": ["moveToAddressableAreaForDropTip"],
+          "enum": [
+            "moveToAddressableAreaForDropTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2255,7 +2528,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PrepareToAspirateParams": {
       "title": "PrepareToAspirateParams",
@@ -2268,7 +2543,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "PrepareToAspirateCreate": {
       "title": "PrepareToAspirateCreate",
@@ -2278,7 +2555,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "prepareToAspirate",
-          "enum": ["prepareToAspirate"],
+          "enum": [
+            "prepareToAspirate"
+          ],
           "type": "string"
         },
         "params": {
@@ -2298,7 +2577,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -2320,7 +2601,10 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": ["waitForResume", "pause"],
+          "enum": [
+            "waitForResume",
+            "pause"
+          ],
           "type": "string"
         },
         "params": {
@@ -2340,7 +2624,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -2358,7 +2644,9 @@
           "type": "string"
         }
       },
-      "required": ["seconds"]
+      "required": [
+        "seconds"
+      ]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -2368,7 +2656,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": ["waitForDuration"],
+          "enum": [
+            "waitForDuration"
+          ],
           "type": "string"
         },
         "params": {
@@ -2388,7 +2678,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -2420,7 +2712,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -2430,7 +2726,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": ["pickUpTip"],
+          "enum": [
+            "pickUpTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2450,7 +2748,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -2474,7 +2774,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -2484,7 +2786,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": ["savePosition"],
+          "enum": [
+            "savePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -2504,7 +2808,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2517,7 +2823,9 @@
           "type": "boolean"
         }
       },
-      "required": ["on"]
+      "required": [
+        "on"
+      ]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2527,7 +2835,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": ["setRailLights"],
+          "enum": [
+            "setRailLights"
+          ],
           "type": "string"
         },
         "params": {
@@ -2547,7 +2857,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2590,7 +2902,11 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2600,7 +2916,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": ["touchTip"],
+          "enum": [
+            "touchTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2620,12 +2938,20 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": ["idle", "confirm", "updating", "disco", "off"]
+      "enum": [
+        "idle",
+        "confirm",
+        "updating",
+        "disco",
+        "off"
+      ]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2641,7 +2967,9 @@
           ]
         }
       },
-      "required": ["animation"]
+      "required": [
+        "animation"
+      ]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2651,7 +2979,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": ["setStatusBar"],
+          "enum": [
+            "setStatusBar"
+          ],
           "type": "string"
         },
         "params": {
@@ -2671,18 +3001,28 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TipPresenceStatus": {
       "title": "TipPresenceStatus",
       "description": "Tip presence status reported by a pipette.",
-      "enum": ["present", "absent", "unknown"],
+      "enum": [
+        "present",
+        "absent",
+        "unknown"
+      ],
       "type": "string"
     },
     "InstrumentSensorId": {
       "title": "InstrumentSensorId",
       "description": "Primary and secondary sensor ids.",
-      "enum": ["primary", "secondary", "both"],
+      "enum": [
+        "primary",
+        "secondary",
+        "both"
+      ],
       "type": "string"
     },
     "VerifyTipPresenceParams": {
@@ -2712,7 +3052,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "expectedState"]
+      "required": [
+        "pipetteId",
+        "expectedState"
+      ]
     },
     "VerifyTipPresenceCreate": {
       "title": "VerifyTipPresenceCreate",
@@ -2722,7 +3065,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "verifyTipPresence",
-          "enum": ["verifyTipPresence"],
+          "enum": [
+            "verifyTipPresence"
+          ],
           "type": "string"
         },
         "params": {
@@ -2742,7 +3087,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "GetTipPresenceParams": {
       "title": "GetTipPresenceParams",
@@ -2755,7 +3102,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "GetTipPresenceCreate": {
       "title": "GetTipPresenceCreate",
@@ -2765,7 +3114,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "getTipPresence",
-          "enum": ["getTipPresence"],
+          "enum": [
+            "getTipPresence"
+          ],
           "type": "string"
         },
         "params": {
@@ -2785,7 +3136,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LiquidProbeParams": {
       "title": "LiquidProbeParams",
@@ -2817,7 +3170,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "LiquidProbeCreate": {
       "title": "LiquidProbeCreate",
@@ -2827,7 +3184,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "liquidProbe",
-          "enum": ["liquidProbe"],
+          "enum": [
+            "liquidProbe"
+          ],
           "type": "string"
         },
         "params": {
@@ -2847,7 +3206,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TryLiquidProbeParams": {
       "title": "TryLiquidProbeParams",
@@ -2879,7 +3240,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "TryLiquidProbeCreate": {
       "title": "TryLiquidProbeCreate",
@@ -2889,7 +3254,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "tryLiquidProbe",
-          "enum": ["tryLiquidProbe"],
+          "enum": [
+            "tryLiquidProbe"
+          ],
           "type": "string"
         },
         "params": {
@@ -2909,7 +3276,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2927,7 +3296,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2937,7 +3308,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": ["heaterShaker/waitForTemperature"],
+          "enum": [
+            "heaterShaker/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2957,7 +3330,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2975,7 +3350,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2985,7 +3363,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": ["heaterShaker/setTargetTemperature"],
+          "enum": [
+            "heaterShaker/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3005,7 +3385,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -3018,7 +3400,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -3028,7 +3412,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": ["heaterShaker/deactivateHeater"],
+          "enum": [
+            "heaterShaker/deactivateHeater"
+          ],
           "type": "string"
         },
         "params": {
@@ -3048,7 +3434,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -3066,7 +3454,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "rpm"]
+      "required": [
+        "moduleId",
+        "rpm"
+      ]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -3076,7 +3467,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
+          "enum": [
+            "heaterShaker/setAndWaitForShakeSpeed"
+          ],
           "type": "string"
         },
         "params": {
@@ -3096,7 +3489,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -3109,7 +3504,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -3119,7 +3516,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": ["heaterShaker/deactivateShaker"],
+          "enum": [
+            "heaterShaker/deactivateShaker"
+          ],
           "type": "string"
         },
         "params": {
@@ -3139,7 +3538,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -3152,7 +3553,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -3162,7 +3565,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": ["heaterShaker/openLabwareLatch"],
+          "enum": [
+            "heaterShaker/openLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -3182,7 +3587,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -3195,7 +3602,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -3205,7 +3614,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": ["heaterShaker/closeLabwareLatch"],
+          "enum": [
+            "heaterShaker/closeLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -3225,7 +3636,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -3238,7 +3651,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -3248,7 +3663,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": ["magneticModule/disengage"],
+          "enum": [
+            "magneticModule/disengage"
+          ],
           "type": "string"
         },
         "params": {
@@ -3268,7 +3685,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -3286,7 +3705,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "height"]
+      "required": [
+        "moduleId",
+        "height"
+      ]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -3296,7 +3718,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": ["magneticModule/engage"],
+          "enum": [
+            "magneticModule/engage"
+          ],
           "type": "string"
         },
         "params": {
@@ -3316,7 +3740,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3334,7 +3760,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3344,7 +3773,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": ["temperatureModule/setTargetTemperature"],
+          "enum": [
+            "temperatureModule/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3364,7 +3795,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3382,7 +3815,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3392,7 +3827,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": ["temperatureModule/waitForTemperature"],
+          "enum": [
+            "temperatureModule/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3412,7 +3849,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -3425,7 +3864,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -3435,7 +3876,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": ["temperatureModule/deactivate"],
+          "enum": [
+            "temperatureModule/deactivate"
+          ],
           "type": "string"
         },
         "params": {
@@ -3455,7 +3898,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -3483,7 +3928,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -3493,7 +3941,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": ["thermocycler/setTargetBlockTemperature"],
+          "enum": [
+            "thermocycler/setTargetBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3513,7 +3963,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -3526,7 +3978,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -3536,7 +3990,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": ["thermocycler/waitForBlockTemperature"],
+          "enum": [
+            "thermocycler/waitForBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3556,7 +4012,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -3574,7 +4032,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -3584,7 +4045,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": ["thermocycler/setTargetLidTemperature"],
+          "enum": [
+            "thermocycler/setTargetLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3604,7 +4067,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -3617,7 +4082,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -3627,7 +4094,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": ["thermocycler/waitForLidTemperature"],
+          "enum": [
+            "thermocycler/waitForLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3647,7 +4116,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -3660,7 +4131,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -3670,7 +4143,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": ["thermocycler/deactivateBlock"],
+          "enum": [
+            "thermocycler/deactivateBlock"
+          ],
           "type": "string"
         },
         "params": {
@@ -3690,7 +4165,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -3703,7 +4180,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -3713,7 +4192,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": ["thermocycler/deactivateLid"],
+          "enum": [
+            "thermocycler/deactivateLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -3733,7 +4214,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -3746,7 +4229,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -3756,7 +4241,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": ["thermocycler/openLid"],
+          "enum": [
+            "thermocycler/openLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -3776,7 +4263,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -3789,7 +4278,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -3799,7 +4290,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": ["thermocycler/closeLid"],
+          "enum": [
+            "thermocycler/closeLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -3819,7 +4312,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -3837,7 +4332,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"]
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -3863,7 +4361,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "profile"]
+      "required": [
+        "moduleId",
+        "profile"
+      ]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -3873,7 +4374,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": ["thermocycler/runProfile"],
+          "enum": [
+            "thermocycler/runProfile"
+          ],
           "type": "string"
         },
         "params": {
@@ -3893,7 +4396,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "InitializeParams": {
       "title": "InitializeParams",
@@ -3911,7 +4416,10 @@
           "type": "integer"
         }
       },
-      "required": ["moduleId", "sampleWavelength"]
+      "required": [
+        "moduleId",
+        "sampleWavelength"
+      ]
     },
     "InitializeCreate": {
       "title": "InitializeCreate",
@@ -3921,7 +4429,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/initialize",
-          "enum": ["absorbanceReader/initialize"],
+          "enum": [
+            "absorbanceReader/initialize"
+          ],
           "type": "string"
         },
         "params": {
@@ -3941,7 +4451,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MeasureAbsorbanceParams": {
       "title": "MeasureAbsorbanceParams",
@@ -3959,7 +4471,10 @@
           "type": "integer"
         }
       },
-      "required": ["moduleId", "sampleWavelength"]
+      "required": [
+        "moduleId",
+        "sampleWavelength"
+      ]
     },
     "MeasureAbsorbanceCreate": {
       "title": "MeasureAbsorbanceCreate",
@@ -3969,7 +4484,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/measure",
-          "enum": ["absorbanceReader/measure"],
+          "enum": [
+            "absorbanceReader/measure"
+          ],
           "type": "string"
         },
         "params": {
@@ -3989,12 +4506,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": ["front", "rear"]
+      "enum": [
+        "front",
+        "rear"
+      ]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -4014,7 +4536,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -4039,7 +4565,9 @@
           ]
         }
       },
-      "required": ["jaw"]
+      "required": [
+        "jaw"
+      ]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -4049,7 +4577,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": ["calibration/calibrateGripper"],
+          "enum": [
+            "calibration/calibrateGripper"
+          ],
           "type": "string"
         },
         "params": {
@@ -4069,7 +4599,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -4085,7 +4617,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -4095,7 +4629,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": ["calibration/calibratePipette"],
+          "enum": [
+            "calibration/calibratePipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -4115,7 +4651,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -4141,7 +4679,11 @@
           ]
         }
       },
-      "required": ["moduleId", "labwareId", "mount"]
+      "required": [
+        "moduleId",
+        "labwareId",
+        "mount"
+      ]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -4151,7 +4693,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": ["calibration/calibrateModule"],
+          "enum": [
+            "calibration/calibrateModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -4171,12 +4715,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": ["attachPlate", "attachInstrument"]
+      "enum": [
+        "attachPlate",
+        "attachInstrument"
+      ]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -4201,7 +4750,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -4211,7 +4762,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": ["calibration/moveToMaintenancePosition"],
+          "enum": [
+            "calibration/moveToMaintenancePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -4231,7 +4784,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "UnsafeBlowOutInPlaceParams": {
       "title": "UnsafeBlowOutInPlaceParams",
@@ -4250,7 +4805,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"]
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "UnsafeBlowOutInPlaceCreate": {
       "title": "UnsafeBlowOutInPlaceCreate",
@@ -4260,7 +4818,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/blowOutInPlace",
-          "enum": ["unsafe/blowOutInPlace"],
+          "enum": [
+            "unsafe/blowOutInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -4280,7 +4840,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "UnsafeDropTipInPlaceParams": {
       "title": "UnsafeDropTipInPlaceParams",
@@ -4298,7 +4860,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "UnsafeDropTipInPlaceCreate": {
       "title": "UnsafeDropTipInPlaceCreate",
@@ -4308,7 +4872,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/dropTipInPlace",
-          "enum": ["unsafe/dropTipInPlace"],
+          "enum": [
+            "unsafe/dropTipInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -4328,7 +4894,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "UpdatePositionEstimatorsParams": {
       "title": "UpdatePositionEstimatorsParams",
@@ -4343,7 +4911,9 @@
           }
         }
       },
-      "required": ["axes"]
+      "required": [
+        "axes"
+      ]
     },
     "UpdatePositionEstimatorsCreate": {
       "title": "UpdatePositionEstimatorsCreate",
@@ -4353,7 +4923,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/updatePositionEstimators",
-          "enum": ["unsafe/updatePositionEstimators"],
+          "enum": [
+            "unsafe/updatePositionEstimators"
+          ],
           "type": "string"
         },
         "params": {
@@ -4373,7 +4945,60 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
+    },
+    "UnsafeEngageAxesParams": {
+      "title": "UnsafeEngageAxesParams",
+      "description": "Payload required for an UnsafeEngageAxes command.",
+      "type": "object",
+      "properties": {
+        "axes": {
+          "description": "The axes for which to enable.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MotorAxis"
+          }
+        }
+      },
+      "required": [
+        "axes"
+      ]
+    },
+    "UnsafeEngageAxesCreate": {
+      "title": "UnsafeEngageAxesCreate",
+      "description": "UnsafeEngageAxes command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "unsafe/engageAxes",
+          "enum": [
+            "unsafe/engageAxes"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/UnsafeEngageAxesParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
     }
   },
   "$id": "opentronsCommandSchemaV9",

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -285,11 +285,7 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center"
-      ],
+      "enum": ["top", "bottom", "center"],
       "type": "string"
     },
     "WellOffset": {
@@ -374,22 +370,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": [
-        "protocol",
-        "setup",
-        "fixit"
-      ],
+      "enum": ["protocol", "setup", "fixit"],
       "type": "string"
     },
     "AspirateCreate": {
@@ -400,9 +386,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": [
-            "aspirate"
-          ],
+          "enum": ["aspirate"],
           "type": "string"
         },
         "params": {
@@ -422,9 +406,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -449,11 +431,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -463,9 +441,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": [
-            "aspirateInPlace"
-          ],
+          "enum": ["aspirateInPlace"],
           "type": "string"
         },
         "params": {
@@ -485,9 +461,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -500,9 +474,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message"
-      ]
+      "required": ["message"]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -512,9 +484,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": [
-            "comment"
-          ],
+          "enum": ["comment"],
           "type": "string"
         },
         "params": {
@@ -534,9 +504,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ConfigureForVolumeParams": {
       "title": "ConfigureForVolumeParams",
@@ -560,10 +528,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "volume"
-      ]
+      "required": ["pipetteId", "volume"]
     },
     "ConfigureForVolumeCreate": {
       "title": "ConfigureForVolumeCreate",
@@ -573,9 +538,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureForVolume",
-          "enum": [
-            "configureForVolume"
-          ],
+          "enum": ["configureForVolume"],
           "type": "string"
         },
         "params": {
@@ -595,9 +558,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AllNozzleLayoutConfiguration": {
       "title": "AllNozzleLayoutConfiguration",
@@ -607,9 +568,7 @@
         "style": {
           "title": "Style",
           "default": "ALL",
-          "enum": [
-            "ALL"
-          ],
+          "enum": ["ALL"],
           "type": "string"
         }
       }
@@ -622,26 +581,17 @@
         "style": {
           "title": "Style",
           "default": "SINGLE",
-          "enum": [
-            "SINGLE"
-          ],
+          "enum": ["SINGLE"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "RowNozzleLayoutConfiguration": {
       "title": "RowNozzleLayoutConfiguration",
@@ -651,26 +601,17 @@
         "style": {
           "title": "Style",
           "default": "ROW",
-          "enum": [
-            "ROW"
-          ],
+          "enum": ["ROW"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "ColumnNozzleLayoutConfiguration": {
       "title": "ColumnNozzleLayoutConfiguration",
@@ -680,26 +621,17 @@
         "style": {
           "title": "Style",
           "default": "COLUMN",
-          "enum": [
-            "COLUMN"
-          ],
+          "enum": ["COLUMN"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "QuadrantNozzleLayoutConfiguration": {
       "title": "QuadrantNozzleLayoutConfiguration",
@@ -709,20 +641,13 @@
         "style": {
           "title": "Style",
           "default": "QUADRANT",
-          "enum": [
-            "QUADRANT"
-          ],
+          "enum": ["QUADRANT"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         },
         "frontRightNozzle": {
@@ -738,11 +663,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle",
-        "frontRightNozzle",
-        "backLeftNozzle"
-      ]
+      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"]
     },
     "ConfigureNozzleLayoutParams": {
       "title": "ConfigureNozzleLayoutParams",
@@ -775,10 +696,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "configurationParams"
-      ]
+      "required": ["pipetteId", "configurationParams"]
     },
     "ConfigureNozzleLayoutCreate": {
       "title": "ConfigureNozzleLayoutCreate",
@@ -788,9 +706,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureNozzleLayout",
-          "enum": [
-            "configureNozzleLayout"
-          ],
+          "enum": ["configureNozzleLayout"],
           "type": "string"
         },
         "params": {
@@ -810,9 +726,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -828,9 +742,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": [
-            "custom"
-          ],
+          "enum": ["custom"],
           "type": "string"
         },
         "params": {
@@ -850,9 +762,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -901,13 +811,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -917,9 +821,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": [
-            "dispense"
-          ],
+          "enum": ["dispense"],
           "type": "string"
         },
         "params": {
@@ -939,9 +841,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -971,11 +871,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -985,9 +881,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": [
-            "dispenseInPlace"
-          ],
+          "enum": ["dispenseInPlace"],
           "type": "string"
         },
         "params": {
@@ -1007,9 +901,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -1047,12 +939,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -1062,9 +949,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": [
-            "blowout"
-          ],
+          "enum": ["blowout"],
           "type": "string"
         },
         "params": {
@@ -1084,9 +969,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -1105,10 +988,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "pipetteId"]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -1118,9 +998,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": [
-            "blowOutInPlace"
-          ],
+          "enum": ["blowOutInPlace"],
           "type": "string"
         },
         "params": {
@@ -1140,19 +1018,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "default"
-      ],
+      "enum": ["top", "bottom", "center", "default"],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -1214,11 +1085,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ]
+      "required": ["pipetteId", "labwareId", "wellName"]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -1228,9 +1095,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": [
-            "dropTip"
-          ],
+          "enum": ["dropTip"],
           "type": "string"
         },
         "params": {
@@ -1250,9 +1115,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -1270,9 +1133,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -1282,9 +1143,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": [
-            "dropTipInPlace"
-          ],
+          "enum": ["dropTipInPlace"],
           "type": "string"
         },
         "params": {
@@ -1304,9 +1163,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -1326,11 +1183,7 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": [
-        "left",
-        "right",
-        "extension"
-      ],
+      "enum": ["left", "right", "extension"],
       "type": "string"
     },
     "HomeParams": {
@@ -1363,9 +1216,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": [
-            "home"
-          ],
+          "enum": ["home"],
           "type": "string"
         },
         "params": {
@@ -1385,9 +1236,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -1403,9 +1252,7 @@
           ]
         }
       },
-      "required": [
-        "axis"
-      ]
+      "required": ["axis"]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -1415,9 +1262,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": [
-            "retractAxis"
-          ],
+          "enum": ["retractAxis"],
           "type": "string"
         },
         "params": {
@@ -1437,9 +1282,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1485,9 +1328,7 @@
           ]
         }
       },
-      "required": [
-        "slotName"
-      ]
+      "required": ["slotName"]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1500,9 +1341,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -1515,9 +1354,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ]
+      "required": ["labwareId"]
     },
     "AddressableAreaLocation": {
       "title": "AddressableAreaLocation",
@@ -1530,9 +1367,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "addressableAreaName"
-      ]
+      "required": ["addressableAreaName"]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1553,9 +1388,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
@@ -1589,12 +1422,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ]
+      "required": ["location", "loadName", "namespace", "version"]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1604,9 +1432,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": [
-            "loadLabware"
-          ],
+          "enum": ["loadLabware"],
           "type": "string"
         },
         "params": {
@@ -1626,9 +1452,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ReloadLabwareParams": {
       "title": "ReloadLabwareParams",
@@ -1641,9 +1465,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ]
+      "required": ["labwareId"]
     },
     "ReloadLabwareCreate": {
       "title": "ReloadLabwareCreate",
@@ -1653,9 +1475,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "reloadLabware",
-          "enum": [
-            "reloadLabware"
-          ],
+          "enum": ["reloadLabware"],
           "type": "string"
         },
         "params": {
@@ -1675,9 +1495,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1703,11 +1521,7 @@
           }
         }
       },
-      "required": [
-        "liquidId",
-        "labwareId",
-        "volumeByWell"
-      ]
+      "required": ["liquidId", "labwareId", "volumeByWell"]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1717,9 +1531,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": [
-            "loadLiquid"
-          ],
+          "enum": ["loadLiquid"],
           "type": "string"
         },
         "params": {
@@ -1739,9 +1551,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1787,10 +1597,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "model",
-        "location"
-      ]
+      "required": ["model", "location"]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1800,9 +1607,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": [
-            "loadModule"
-          ],
+          "enum": ["loadModule"],
           "type": "string"
         },
         "params": {
@@ -1822,9 +1627,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1887,10 +1690,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteName",
-        "mount"
-      ]
+      "required": ["pipetteName", "mount"]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1900,9 +1700,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": [
-            "loadPipette"
-          ],
+          "enum": ["loadPipette"],
           "type": "string"
         },
         "params": {
@@ -1922,18 +1720,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": [
-        "usingGripper",
-        "manualMoveWithPause",
-        "manualMoveWithoutPause"
-      ],
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1954,11 +1746,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1984,9 +1772,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
@@ -2021,11 +1807,7 @@
           ]
         }
       },
-      "required": [
-        "labwareId",
-        "newLocation",
-        "strategy"
-      ]
+      "required": ["labwareId", "newLocation", "strategy"]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -2035,9 +1817,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": [
-            "moveLabware"
-          ],
+          "enum": ["moveLabware"],
           "type": "string"
         },
         "params": {
@@ -2057,18 +1837,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": [
-        "x",
-        "y",
-        "z"
-      ],
+      "enum": ["x", "y", "z"],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -2095,11 +1869,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "axis",
-        "distance"
-      ]
+      "required": ["pipetteId", "axis", "distance"]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -2109,9 +1879,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": [
-            "moveRelative"
-          ],
+          "enum": ["moveRelative"],
           "type": "string"
         },
         "params": {
@@ -2131,9 +1899,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -2153,11 +1919,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -2195,10 +1957,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "coordinates"
-      ]
+      "required": ["pipetteId", "coordinates"]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -2208,9 +1967,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": [
-            "moveToCoordinates"
-          ],
+          "enum": ["moveToCoordinates"],
           "type": "string"
         },
         "params": {
@@ -2230,9 +1987,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -2280,11 +2035,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -2294,9 +2045,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": [
-            "moveToWell"
-          ],
+          "enum": ["moveToWell"],
           "type": "string"
         },
         "params": {
@@ -2316,9 +2065,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AddressableOffsetVector": {
       "title": "AddressableOffsetVector",
@@ -2338,11 +2085,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToAddressableAreaParams": {
       "title": "MoveToAddressableAreaParams",
@@ -2396,10 +2139,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ]
+      "required": ["pipetteId", "addressableAreaName"]
     },
     "MoveToAddressableAreaCreate": {
       "title": "MoveToAddressableAreaCreate",
@@ -2409,9 +2149,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableArea",
-          "enum": [
-            "moveToAddressableArea"
-          ],
+          "enum": ["moveToAddressableArea"],
           "type": "string"
         },
         "params": {
@@ -2431,9 +2169,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToAddressableAreaForDropTipParams": {
       "title": "MoveToAddressableAreaForDropTipParams",
@@ -2493,10 +2229,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ]
+      "required": ["pipetteId", "addressableAreaName"]
     },
     "MoveToAddressableAreaForDropTipCreate": {
       "title": "MoveToAddressableAreaForDropTipCreate",
@@ -2506,9 +2239,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableAreaForDropTip",
-          "enum": [
-            "moveToAddressableAreaForDropTip"
-          ],
+          "enum": ["moveToAddressableAreaForDropTip"],
           "type": "string"
         },
         "params": {
@@ -2528,9 +2259,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PrepareToAspirateParams": {
       "title": "PrepareToAspirateParams",
@@ -2543,9 +2272,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "PrepareToAspirateCreate": {
       "title": "PrepareToAspirateCreate",
@@ -2555,9 +2282,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "prepareToAspirate",
-          "enum": [
-            "prepareToAspirate"
-          ],
+          "enum": ["prepareToAspirate"],
           "type": "string"
         },
         "params": {
@@ -2577,9 +2302,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -2601,10 +2324,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": [
-            "waitForResume",
-            "pause"
-          ],
+          "enum": ["waitForResume", "pause"],
           "type": "string"
         },
         "params": {
@@ -2624,9 +2344,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -2644,9 +2362,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "seconds"
-      ]
+      "required": ["seconds"]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -2656,9 +2372,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": [
-            "waitForDuration"
-          ],
+          "enum": ["waitForDuration"],
           "type": "string"
         },
         "params": {
@@ -2678,9 +2392,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -2712,11 +2424,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -2726,9 +2434,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": [
-            "pickUpTip"
-          ],
+          "enum": ["pickUpTip"],
           "type": "string"
         },
         "params": {
@@ -2748,9 +2454,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -2774,9 +2478,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -2786,9 +2488,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": [
-            "savePosition"
-          ],
+          "enum": ["savePosition"],
           "type": "string"
         },
         "params": {
@@ -2808,9 +2508,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2823,9 +2521,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "on"
-      ]
+      "required": ["on"]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2835,9 +2531,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": [
-            "setRailLights"
-          ],
+          "enum": ["setRailLights"],
           "type": "string"
         },
         "params": {
@@ -2857,9 +2551,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2902,11 +2594,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2916,9 +2604,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": [
-            "touchTip"
-          ],
+          "enum": ["touchTip"],
           "type": "string"
         },
         "params": {
@@ -2938,20 +2624,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": [
-        "idle",
-        "confirm",
-        "updating",
-        "disco",
-        "off"
-      ]
+      "enum": ["idle", "confirm", "updating", "disco", "off"]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2967,9 +2645,7 @@
           ]
         }
       },
-      "required": [
-        "animation"
-      ]
+      "required": ["animation"]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2979,9 +2655,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": [
-            "setStatusBar"
-          ],
+          "enum": ["setStatusBar"],
           "type": "string"
         },
         "params": {
@@ -3001,28 +2675,18 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TipPresenceStatus": {
       "title": "TipPresenceStatus",
       "description": "Tip presence status reported by a pipette.",
-      "enum": [
-        "present",
-        "absent",
-        "unknown"
-      ],
+      "enum": ["present", "absent", "unknown"],
       "type": "string"
     },
     "InstrumentSensorId": {
       "title": "InstrumentSensorId",
       "description": "Primary and secondary sensor ids.",
-      "enum": [
-        "primary",
-        "secondary",
-        "both"
-      ],
+      "enum": ["primary", "secondary", "both"],
       "type": "string"
     },
     "VerifyTipPresenceParams": {
@@ -3052,10 +2716,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "expectedState"
-      ]
+      "required": ["pipetteId", "expectedState"]
     },
     "VerifyTipPresenceCreate": {
       "title": "VerifyTipPresenceCreate",
@@ -3065,9 +2726,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "verifyTipPresence",
-          "enum": [
-            "verifyTipPresence"
-          ],
+          "enum": ["verifyTipPresence"],
           "type": "string"
         },
         "params": {
@@ -3087,9 +2746,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "GetTipPresenceParams": {
       "title": "GetTipPresenceParams",
@@ -3102,9 +2759,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "GetTipPresenceCreate": {
       "title": "GetTipPresenceCreate",
@@ -3114,9 +2769,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "getTipPresence",
-          "enum": [
-            "getTipPresence"
-          ],
+          "enum": ["getTipPresence"],
           "type": "string"
         },
         "params": {
@@ -3136,9 +2789,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LiquidProbeParams": {
       "title": "LiquidProbeParams",
@@ -3170,11 +2821,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "LiquidProbeCreate": {
       "title": "LiquidProbeCreate",
@@ -3184,9 +2831,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "liquidProbe",
-          "enum": [
-            "liquidProbe"
-          ],
+          "enum": ["liquidProbe"],
           "type": "string"
         },
         "params": {
@@ -3206,9 +2851,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TryLiquidProbeParams": {
       "title": "TryLiquidProbeParams",
@@ -3240,11 +2883,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TryLiquidProbeCreate": {
       "title": "TryLiquidProbeCreate",
@@ -3254,9 +2893,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "tryLiquidProbe",
-          "enum": [
-            "tryLiquidProbe"
-          ],
+          "enum": ["tryLiquidProbe"],
           "type": "string"
         },
         "params": {
@@ -3276,9 +2913,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3296,9 +2931,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3308,9 +2941,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": [
-            "heaterShaker/waitForTemperature"
-          ],
+          "enum": ["heaterShaker/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -3330,9 +2961,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3350,10 +2979,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3363,9 +2989,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": [
-            "heaterShaker/setTargetTemperature"
-          ],
+          "enum": ["heaterShaker/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -3385,9 +3009,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -3400,9 +3022,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -3412,9 +3032,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": [
-            "heaterShaker/deactivateHeater"
-          ],
+          "enum": ["heaterShaker/deactivateHeater"],
           "type": "string"
         },
         "params": {
@@ -3434,9 +3052,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -3454,10 +3070,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ]
+      "required": ["moduleId", "rpm"]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -3467,9 +3080,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": [
-            "heaterShaker/setAndWaitForShakeSpeed"
-          ],
+          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
           "type": "string"
         },
         "params": {
@@ -3489,9 +3100,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -3504,9 +3113,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -3516,9 +3123,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": [
-            "heaterShaker/deactivateShaker"
-          ],
+          "enum": ["heaterShaker/deactivateShaker"],
           "type": "string"
         },
         "params": {
@@ -3538,9 +3143,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -3553,9 +3156,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -3565,9 +3166,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": [
-            "heaterShaker/openLabwareLatch"
-          ],
+          "enum": ["heaterShaker/openLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -3587,9 +3186,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -3602,9 +3199,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -3614,9 +3209,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": [
-            "heaterShaker/closeLabwareLatch"
-          ],
+          "enum": ["heaterShaker/closeLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -3636,9 +3229,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -3651,9 +3242,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -3663,9 +3252,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": [
-            "magneticModule/disengage"
-          ],
+          "enum": ["magneticModule/disengage"],
           "type": "string"
         },
         "params": {
@@ -3685,9 +3272,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -3705,10 +3290,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "height"
-      ]
+      "required": ["moduleId", "height"]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -3718,9 +3300,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": [
-            "magneticModule/engage"
-          ],
+          "enum": ["magneticModule/engage"],
           "type": "string"
         },
         "params": {
@@ -3740,9 +3320,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3760,10 +3338,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3773,9 +3348,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": [
-            "temperatureModule/setTargetTemperature"
-          ],
+          "enum": ["temperatureModule/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -3795,9 +3368,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3815,9 +3386,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3827,9 +3396,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": [
-            "temperatureModule/waitForTemperature"
-          ],
+          "enum": ["temperatureModule/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -3849,9 +3416,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -3864,9 +3429,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -3876,9 +3439,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": [
-            "temperatureModule/deactivate"
-          ],
+          "enum": ["temperatureModule/deactivate"],
           "type": "string"
         },
         "params": {
@@ -3898,9 +3459,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -3928,10 +3487,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -3941,9 +3497,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": [
-            "thermocycler/setTargetBlockTemperature"
-          ],
+          "enum": ["thermocycler/setTargetBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -3963,9 +3517,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -3978,9 +3530,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -3990,9 +3540,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": [
-            "thermocycler/waitForBlockTemperature"
-          ],
+          "enum": ["thermocycler/waitForBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -4012,9 +3560,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -4032,10 +3578,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -4045,9 +3588,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": [
-            "thermocycler/setTargetLidTemperature"
-          ],
+          "enum": ["thermocycler/setTargetLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -4067,9 +3608,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -4082,9 +3621,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -4094,9 +3631,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": [
-            "thermocycler/waitForLidTemperature"
-          ],
+          "enum": ["thermocycler/waitForLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -4116,9 +3651,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -4131,9 +3664,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -4143,9 +3674,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": [
-            "thermocycler/deactivateBlock"
-          ],
+          "enum": ["thermocycler/deactivateBlock"],
           "type": "string"
         },
         "params": {
@@ -4165,9 +3694,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -4180,9 +3707,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -4192,9 +3717,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": [
-            "thermocycler/deactivateLid"
-          ],
+          "enum": ["thermocycler/deactivateLid"],
           "type": "string"
         },
         "params": {
@@ -4214,9 +3737,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -4229,9 +3750,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -4241,9 +3760,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": [
-            "thermocycler/openLid"
-          ],
+          "enum": ["thermocycler/openLid"],
           "type": "string"
         },
         "params": {
@@ -4263,9 +3780,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -4278,9 +3793,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -4290,9 +3803,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": [
-            "thermocycler/closeLid"
-          ],
+          "enum": ["thermocycler/closeLid"],
           "type": "string"
         },
         "params": {
@@ -4312,9 +3823,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -4332,10 +3841,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ]
+      "required": ["celsius", "holdSeconds"]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -4361,10 +3867,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ]
+      "required": ["moduleId", "profile"]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -4374,9 +3877,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": [
-            "thermocycler/runProfile"
-          ],
+          "enum": ["thermocycler/runProfile"],
           "type": "string"
         },
         "params": {
@@ -4396,9 +3897,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "InitializeParams": {
       "title": "InitializeParams",
@@ -4416,10 +3915,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "moduleId",
-        "sampleWavelength"
-      ]
+      "required": ["moduleId", "sampleWavelength"]
     },
     "InitializeCreate": {
       "title": "InitializeCreate",
@@ -4429,9 +3925,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/initialize",
-          "enum": [
-            "absorbanceReader/initialize"
-          ],
+          "enum": ["absorbanceReader/initialize"],
           "type": "string"
         },
         "params": {
@@ -4451,9 +3945,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MeasureAbsorbanceParams": {
       "title": "MeasureAbsorbanceParams",
@@ -4471,10 +3963,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "moduleId",
-        "sampleWavelength"
-      ]
+      "required": ["moduleId", "sampleWavelength"]
     },
     "MeasureAbsorbanceCreate": {
       "title": "MeasureAbsorbanceCreate",
@@ -4484,9 +3973,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/measure",
-          "enum": [
-            "absorbanceReader/measure"
-          ],
+          "enum": ["absorbanceReader/measure"],
           "type": "string"
         },
         "params": {
@@ -4506,17 +3993,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": [
-        "front",
-        "rear"
-      ]
+      "enum": ["front", "rear"]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -4536,11 +4018,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -4565,9 +4043,7 @@
           ]
         }
       },
-      "required": [
-        "jaw"
-      ]
+      "required": ["jaw"]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -4577,9 +4053,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": [
-            "calibration/calibrateGripper"
-          ],
+          "enum": ["calibration/calibrateGripper"],
           "type": "string"
         },
         "params": {
@@ -4599,9 +4073,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -4617,9 +4089,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -4629,9 +4099,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": [
-            "calibration/calibratePipette"
-          ],
+          "enum": ["calibration/calibratePipette"],
           "type": "string"
         },
         "params": {
@@ -4651,9 +4119,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -4679,11 +4145,7 @@
           ]
         }
       },
-      "required": [
-        "moduleId",
-        "labwareId",
-        "mount"
-      ]
+      "required": ["moduleId", "labwareId", "mount"]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -4693,9 +4155,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": [
-            "calibration/calibrateModule"
-          ],
+          "enum": ["calibration/calibrateModule"],
           "type": "string"
         },
         "params": {
@@ -4715,17 +4175,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": [
-        "attachPlate",
-        "attachInstrument"
-      ]
+      "enum": ["attachPlate", "attachInstrument"]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -4750,9 +4205,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -4762,9 +4215,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": [
-            "calibration/moveToMaintenancePosition"
-          ],
+          "enum": ["calibration/moveToMaintenancePosition"],
           "type": "string"
         },
         "params": {
@@ -4784,9 +4235,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "UnsafeBlowOutInPlaceParams": {
       "title": "UnsafeBlowOutInPlaceParams",
@@ -4805,10 +4254,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "pipetteId"]
     },
     "UnsafeBlowOutInPlaceCreate": {
       "title": "UnsafeBlowOutInPlaceCreate",
@@ -4818,9 +4264,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/blowOutInPlace",
-          "enum": [
-            "unsafe/blowOutInPlace"
-          ],
+          "enum": ["unsafe/blowOutInPlace"],
           "type": "string"
         },
         "params": {
@@ -4840,9 +4284,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "UnsafeDropTipInPlaceParams": {
       "title": "UnsafeDropTipInPlaceParams",
@@ -4860,9 +4302,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "UnsafeDropTipInPlaceCreate": {
       "title": "UnsafeDropTipInPlaceCreate",
@@ -4872,9 +4312,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/dropTipInPlace",
-          "enum": [
-            "unsafe/dropTipInPlace"
-          ],
+          "enum": ["unsafe/dropTipInPlace"],
           "type": "string"
         },
         "params": {
@@ -4894,9 +4332,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "UpdatePositionEstimatorsParams": {
       "title": "UpdatePositionEstimatorsParams",
@@ -4911,9 +4347,7 @@
           }
         }
       },
-      "required": [
-        "axes"
-      ]
+      "required": ["axes"]
     },
     "UpdatePositionEstimatorsCreate": {
       "title": "UpdatePositionEstimatorsCreate",
@@ -4923,9 +4357,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/updatePositionEstimators",
-          "enum": [
-            "unsafe/updatePositionEstimators"
-          ],
+          "enum": ["unsafe/updatePositionEstimators"],
           "type": "string"
         },
         "params": {
@@ -4945,9 +4377,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "UnsafeEngageAxesParams": {
       "title": "UnsafeEngageAxesParams",
@@ -4962,9 +4392,7 @@
           }
         }
       },
-      "required": [
-        "axes"
-      ]
+      "required": ["axes"]
     },
     "UnsafeEngageAxesCreate": {
       "title": "UnsafeEngageAxesCreate",
@@ -4974,9 +4402,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/engageAxes",
-          "enum": [
-            "unsafe/engageAxes"
-          ],
+          "enum": ["unsafe/engageAxes"],
           "type": "string"
         },
         "params": {
@@ -4996,9 +4422,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     }
   },
   "$id": "opentronsCommandSchemaV9",

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -63,13 +63,12 @@ export interface UnsafeEngageAxesParams {
   axes: MotorAxes
 }
 
-export interface UnsafeEngageAxesCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeEngageAxesCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/engageAxes'
   params: UnsafeUpdatePositionEstimatorsParams
 }
 export interface UnsafeEngageAxesRunTimeCommand
   extends CommonCommandRunTimeInfo,
-  UnsafeEngageAxesCreateCommand {
+    UnsafeEngageAxesCreateCommand {
   result?: any
 }

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -5,11 +5,13 @@ export type UnsafeRunTimeCommand =
   | UnsafeBlowoutInPlaceRunTimeCommand
   | UnsafeDropTipInPlaceRunTimeCommand
   | UnsafeUpdatePositionEstimatorsRunTimeCommand
+  | UnsafeEngageAxesRunTimeCommand
 
 export type UnsafeCreateCommand =
   | UnsafeBlowoutInPlaceCreateCommand
   | UnsafeDropTipInPlaceCreateCommand
   | UnsafeUpdatePositionEstimatorsCreateCommand
+  | UnsafeEngageAxesCreateCommand
 
 export interface UnsafeBlowoutInPlaceParams {
   pipetteId: string
@@ -54,5 +56,20 @@ export interface UnsafeUpdatePositionEstimatorsCreateCommand
 export interface UnsafeUpdatePositionEstimatorsRunTimeCommand
   extends CommonCommandRunTimeInfo,
     UnsafeUpdatePositionEstimatorsCreateCommand {
+  result?: any
+}
+
+export interface UnsafeEngageAxesParams {
+  axes: MotorAxes
+}
+
+export interface UnsafeEngageAxesCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'unsafe/engageAxes'
+  params: UnsafeUpdatePositionEstimatorsParams
+}
+export interface UnsafeEngageAxesRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+  UnsafeEngageAxesCreateCommand {
   result?: any
 }


### PR DESCRIPTION
# Overview

Fixes some issues around estop and drop tip. Specifically,
- When you hit the estop, we surface an error and lose positioning - normal for errors like this - but we also turn off the motors, and they need to be turned back on, so add a command to do that and use it in dtwiz
- on desktop, the estop takeover wouldn't work if you were anywhere but the top level devices page because of either the react-router update or because of an oversight that was made during the flex launch
- the estop takeover is polling, and slowly. we should add notifications at some point but for now we can do some strategic query invalidations and fast polling when the estop is triggered to make it more responsive

Closes RQA-3103, RQA-3133

## Test Plan and Hands on Testing

- run a protocol, stop it with estop, and check that the modal fires; is responsive; and leaves you to a dtwiz, which opertaes correctly
  - [x] on desktop, viewing the run, while network connected
  - [x] on desktop, viewing the run, while usb connected
  - [x] on odd
