### PR TITLE
fix(app): command correct mounts in detach

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -13,6 +13,7 @@ import {
   SINGLE_MOUNT_PIPETTES,
   WEIGHT_OF_96_CHANNEL,
   WASTE_CHUTE_CUTOUT,
+  LEFT,
 } from '@opentrons/shared-data'
 import { Banner } from '../../atoms/Banner'
 import {
@@ -31,7 +32,11 @@ import {
   NINETY_SIX_CHANNEL_MOUNTING_PLATE,
   BODY_STYLE,
 } from './constants'
-import { getIsGantryEmpty, getPipetteCoveringMount } from './utils'
+import {
+  getIsGantryEmpty,
+  getPipetteCoveringMount,
+  pipetteIs96Channel,
+} from './utils'
 import { useNotifyDeckConfigurationQuery } from '../../resources/deck_configuration'
 
 import type { UseMutateFunction } from 'react-query'
@@ -86,6 +91,8 @@ export const BeforeBeginning = (
   }, [])
   const pipetteCoveringMount = getPipetteCoveringMount(attachedPipettes, mount)
   const pipetteId = pipetteCoveringMount?.serialNumber
+  const is96 = pipetteIs96Channel(pipetteCoveringMount)
+  const mountForDetach = is96 ? LEFT : mount
   const isGantryEmpty = getIsGantryEmpty(attachedPipettes)
   const isGantryEmptyFor96ChannelAttachment =
     isGantryEmpty &&
@@ -177,14 +184,14 @@ export const BeforeBeginning = (
         params: {
           pipetteName: pipetteCoveringMount?.instrumentName ?? '',
           pipetteId: pipetteId ?? '',
-          mount,
+          mount: mountForDetach,
         },
       },
       { commandType: 'home' as const, params: {} },
       {
         commandType: 'calibration/moveToMaintenancePosition' as const,
         params: {
-          mount,
+          mount: mountForDetach,
         },
       },
     ]
@@ -203,7 +210,7 @@ export const BeforeBeginning = (
     {
       commandType: 'calibration/moveToMaintenancePosition' as const,
       params: {
-        mount,
+        mount: mountForDetach,
       },
     },
   ]

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -31,7 +31,7 @@ import {
   NINETY_SIX_CHANNEL_MOUNTING_PLATE,
   BODY_STYLE,
 } from './constants'
-import { getIsGantryEmpty } from './utils'
+import { getIsGantryEmpty, getPipetteCoveringMount } from './utils'
 import { useNotifyDeckConfigurationQuery } from '../../resources/deck_configuration'
 
 import type { UseMutateFunction } from 'react-query'
@@ -84,7 +84,8 @@ export const BeforeBeginning = (
       createMaintenanceRun({})
     }
   }, [])
-  const pipetteId = attachedPipettes[mount]?.serialNumber
+  const pipetteCoveringMount = getPipetteCoveringMount(attachedPipettes, mount)
+  const pipetteId = pipetteCoveringMount?.serialNumber
   const isGantryEmpty = getIsGantryEmpty(attachedPipettes)
   const isGantryEmptyFor96ChannelAttachment =
     isGantryEmpty &&
@@ -174,7 +175,7 @@ export const BeforeBeginning = (
       {
         commandType: 'loadPipette' as const,
         params: {
-          pipetteName: attachedPipettes[mount]?.instrumentName ?? '',
+          pipetteName: pipetteCoveringMount?.instrumentName ?? '',
           pipetteId: pipetteId ?? '',
           mount,
         },

--- a/app/src/organisms/PipetteWizardFlows/utils.tsx
+++ b/app/src/organisms/PipetteWizardFlows/utils.tsx
@@ -24,8 +24,27 @@ import zAxisDetach96 from '../../assets/videos/pipette-wizard-flows/Pipette_Zaxi
 import attachProbe96 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_96.webm'
 import detachProbe96 from '../../assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_96.webm'
 
-import type { AttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
+import type {
+  AttachedPipettesFromInstrumentsQuery,
+  PipetteInformation,
+} from '../Devices/hooks'
 import type { PipetteWizardFlow, PipetteWizardStep } from './types'
+import type { Mount } from '../../redux/pipettes/types'
+
+export function pipetteIs96Channel(
+  pipette: PipetteInformation | null
+): boolean {
+  return pipette?.data?.channels === 96
+}
+
+export function getPipetteCoveringMount(
+  attachedPipettes: AttachedPipettesFromInstrumentsQuery,
+  mount: Mount
+): PipetteInformation | null {
+  return pipetteIs96Channel(attachedPipettes[LEFT])
+    ? attachedPipettes[LEFT]
+    : attachedPipettes[mount]
+}
 
 export function getIsGantryEmpty(
   attachedPipette: AttachedPipettesFromInstrumentsQuery


### PR DESCRIPTION
When the pipette wizard flows - which we use both in the instruments flows and in the protocol setup flows - are instantiated, they get a mount, and then they were using that mount blindly for all commands. That's not always correct, though - if there's a 96 channel attached, and the pipette wizard flow is instantiated to make sure there's an 8 channel on the right mount, then it needs to move the left mount to the maintenance position to detach the 96.

to fix this, add a util that can get the "covering pipette" - i.e., a 96 if there is one and whatever's on the mount otherwise - and use that for the pre-detach commands rather than whatever might or might not be on the target mount.

Closes RQA-3123
