### PR TITLE
fix(app): make module calibration location not editable during run setup

### DIFF
--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -265,6 +265,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
           closeFlow={() => {
             setShowCalModal(false)
           }}
+          isLoadedInRun={isLoadedInRun}
           isPrepCommandLoading={isCommandMutationLoading}
           prepCommandErrorMessage={
             prepCommandErrorMessage === '' ? undefined : prepCommandErrorMessage

--- a/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
@@ -47,6 +47,7 @@ interface SelectLocationProps extends ModuleCalibrationWizardStepProps {
   occupiedCutouts: CutoutConfig[]
   deckConfig: DeckConfiguration
   configuredFixtureIdByCutoutId: { [cutoutId in CutoutId]?: CutoutFixtureId }
+  isLoadedInRun: boolean
 }
 export const SelectLocation = (
   props: SelectLocationProps
@@ -56,6 +57,7 @@ export const SelectLocation = (
     attachedModule,
     deckConfig,
     configuredFixtureIdByCutoutId,
+    isLoadedInRun,
   } = props
   const { t } = useTranslation('module_wizard_flows')
   const moduleName = getModuleDisplayName(attachedModule.moduleModel)
@@ -93,6 +95,8 @@ export const SelectLocation = (
           cutoutFixtureId
         ) && attachedModule.serialNumber === opentronsModuleSerialNumber
       if (
+        // in run setup, module calibration only available when module location is already correctly configured
+        !isLoadedInRun &&
         mayMountToCutoutIds.includes(cutoutId) &&
         (isCurrentConfiguration ||
           SINGLE_SLOT_FIXTURES.includes(cutoutFixtureId))

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -50,6 +50,7 @@ interface ModuleWizardFlowsProps {
   attachedModule: AttachedModule
   closeFlow: () => void
   isPrepCommandLoading: boolean
+  isLoadedInRun?: boolean
   onComplete?: () => void
   prepCommandErrorMessage?: string
 }
@@ -61,6 +62,7 @@ export const ModuleWizardFlows = (
 ): JSX.Element | null => {
   const {
     attachedModule,
+    isLoadedInRun = false,
     isPrepCommandLoading,
     closeFlow,
     onComplete,
@@ -317,6 +319,7 @@ export const ModuleWizardFlows = (
         {...calibrateBaseProps}
         availableSlotNames={availableSlotNames}
         deckConfig={deckConfig}
+        isLoadedInRun={isLoadedInRun}
         occupiedCutouts={occupiedCutouts}
         configuredFixtureIdByCutoutId={fixtureIdByCutoutId}
       />


### PR DESCRIPTION
# Overview

in run setup, module calibration is only available when module location is already correctly configured. removing the existing (correct) module location unmounts the module card component and module wizard flows modal. this removes editable cutout ids from the module calibration select location component when the module card `isLoadedInRun`, making module location "read only".

closes RQA-2942

<img width="1136" alt="Screen Shot 2024-08-29 at 3 54 07 PM" src="https://github.com/user-attachments/assets/3a26169b-624c-432b-8f4b-89b40214b637">


## Test Plan and Hands on Testing

manually verified the read only module deck location during run setup

## Changelog

 - Makes module calibration location not editable during run setup

## Review requests

try out module calibration in the run setup module controls tab

## Risk assessment

low
