### PR TITLE
fix(app): handle detaching 96 when attaching right

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -108,10 +108,15 @@ class MoveToMaintenancePositionImplementation(
                 await ot3_api.move_axes(
                     {
                         Axis.Z_L: max_motion_range + _LEFT_MOUNT_Z_MARGIN,
+                    }
+                )
+                await ot3_api.disengage_axes([Axis.Z_L])
+                await ot3_api.move_axes(
+                    {
                         Axis.Z_R: max_motion_range + _RIGHT_MOUNT_Z_MARGIN,
                     }
                 )
-                await ot3_api.disengage_axes([Axis.Z_L, Axis.Z_R])
+                await ot3_api.disengage_axes([Axis.Z_R])
 
         return SuccessData(public=MoveToMaintenancePositionResult(), private=None)
 

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
@@ -17,6 +17,9 @@ const mockPipetteInfo = [
 const mockPipettesInProtocolNotEmpty = [
   { id: '123', pipetteName: 'p1000_single_flex', mount: 'left' },
 ]
+const mockPipettesInProtocolOnRight = [
+  { id: '123', pipetteName: 'p1000_single_flex', mount: 'right' },
+]
 const mockPipettesInProtocolMulti = [
   { id: '123', pipetteName: 'p1000_multi_flex', mount: 'left' },
 ]
@@ -113,7 +116,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
     ).toStrictEqual(mockFlowSteps)
   })
 
-  it('returns the correct array of info when the attached 96-channel pipette needs to be switched out for single mount', () => {
+  it('returns the correct array of info when the attached 96-channel pipette needs to be switched out for single mount on left', () => {
     const mockFlowSteps = [
       {
         section: SECTIONS.BEFORE_BEGINNING,
@@ -173,6 +176,69 @@ describe('getPipetteWizardStepsForProtocol', () => {
         { left: mock96ChannelAttachedPipetteInformation, right: null },
         mockPipettesInProtocolNotEmpty as any,
         LEFT
+      )
+    ).toStrictEqual(mockFlowSteps)
+  })
+  it('returns the correct array of info when the attached 96-channel pipette needs to be switched out for single mount on right', () => {
+    const mockFlowSteps = [
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+      {
+        section: SECTIONS.DETACH_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+      {
+        section: SECTIONS.MOUNTING_PLATE,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+      {
+        section: SECTIONS.CARRIAGE,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+        nextMount: RIGHT,
+      },
+      {
+        section: SECTIONS.MOUNT_PIPETTE,
+        mount: RIGHT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.FIRMWARE_UPDATE,
+        mount: RIGHT,
+        flowType: FLOWS.ATTACH,
+      },
+      { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.ATTACH },
+      {
+        section: SECTIONS.ATTACH_PROBE,
+        mount: RIGHT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.DETACH_PROBE,
+        mount: RIGHT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: RIGHT,
+        flowType: FLOWS.CALIBRATE,
+      },
+    ] as PipetteWizardStep[]
+    expect(
+      getPipetteWizardStepsForProtocol(
+        { left: mock96ChannelAttachedPipetteInformation, right: null },
+        mockPipettesInProtocolOnRight as any,
+        RIGHT
       )
     ).toStrictEqual(mockFlowSteps)
   })

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -5,6 +5,382 @@ import type { Mount } from '../../redux/pipettes/types'
 import type { AttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
 import type { PipetteWizardStep } from './types'
 
+const calibrateAlreadyAttachedPipetteOn = (
+  mount: Mount
+): PipetteWizardStep[] => [
+  {
+    section: SECTIONS.BEFORE_BEGINNING,
+    mount,
+    flowType: FLOWS.CALIBRATE,
+  },
+  {
+    section: SECTIONS.ATTACH_PROBE,
+    mount,
+    flowType: FLOWS.CALIBRATE,
+  },
+  {
+    section: SECTIONS.DETACH_PROBE,
+    mount,
+    flowType: FLOWS.CALIBRATE,
+  },
+  { section: SECTIONS.RESULTS, mount, flowType: FLOWS.CALIBRATE },
+]
+
+const detachNinetySixAndAttachSingleMountOn = (
+  mount: Mount
+): PipetteWizardStep[] => [
+  {
+    section: SECTIONS.BEFORE_BEGINNING,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.DETACH_PIPETTE,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.MOUNTING_PLATE,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.CARRIAGE,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+    nextMount: mount,
+  },
+  {
+    section: SECTIONS.MOUNT_PIPETTE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.FIRMWARE_UPDATE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  { section: SECTIONS.RESULTS, mount, flowType: FLOWS.ATTACH },
+  {
+    section: SECTIONS.ATTACH_PROBE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.DETACH_PROBE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount,
+    flowType: FLOWS.CALIBRATE,
+  },
+]
+
+const detachSingleMountAndAttachSingleMountOn = (
+  mount: Mount
+): PipetteWizardStep[] => [
+  {
+    section: SECTIONS.BEFORE_BEGINNING,
+    mount,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.DETACH_PIPETTE,
+    mount,
+    flowType: FLOWS.DETACH,
+  },
+  { section: SECTIONS.RESULTS, mount, flowType: FLOWS.DETACH },
+  {
+    section: SECTIONS.MOUNT_PIPETTE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.FIRMWARE_UPDATE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  { section: SECTIONS.RESULTS, mount, flowType: FLOWS.ATTACH },
+  {
+    section: SECTIONS.ATTACH_PROBE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.DETACH_PROBE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount,
+    flowType: FLOWS.CALIBRATE,
+  },
+]
+
+const detachTwoSingleMountsAndAttachNinetySix = (): PipetteWizardStep[] => [
+  {
+    section: SECTIONS.BEFORE_BEGINNING,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.DETACH_PIPETTE,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+    nextMount: RIGHT,
+  },
+  {
+    section: SECTIONS.DETACH_PIPETTE,
+    mount: RIGHT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: RIGHT,
+    flowType: FLOWS.DETACH,
+    nextMount: 'both',
+  },
+  {
+    section: SECTIONS.CARRIAGE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNTING_PLATE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNT_PIPETTE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.FIRMWARE_UPDATE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+  {
+    section: SECTIONS.ATTACH_PROBE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.DETACH_PROBE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: LEFT,
+    flowType: FLOWS.CALIBRATE,
+  },
+]
+
+const detachSingleMountOnLeftAndAttachNinetySix = (): PipetteWizardStep[] => [
+  {
+    section: SECTIONS.BEFORE_BEGINNING,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.DETACH_PIPETTE,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: LEFT,
+    flowType: FLOWS.DETACH,
+    nextMount: 'both',
+  },
+  {
+    section: SECTIONS.CARRIAGE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNTING_PLATE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNT_PIPETTE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.FIRMWARE_UPDATE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+  {
+    section: SECTIONS.ATTACH_PROBE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.DETACH_PROBE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: LEFT,
+    flowType: FLOWS.CALIBRATE,
+  },
+]
+
+const detachSingleMountOnRightAndAttachNinetySix = (): PipetteWizardStep[] => [
+  {
+    section: SECTIONS.BEFORE_BEGINNING,
+    mount: RIGHT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.DETACH_PIPETTE,
+    mount: RIGHT,
+    flowType: FLOWS.DETACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: RIGHT,
+    flowType: FLOWS.DETACH,
+    nextMount: 'both',
+  },
+  {
+    section: SECTIONS.CARRIAGE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNTING_PLATE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNT_PIPETTE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.FIRMWARE_UPDATE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+  {
+    section: SECTIONS.ATTACH_PROBE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.DETACH_PROBE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: LEFT,
+    flowType: FLOWS.CALIBRATE,
+  },
+]
+
+const fromEmptyGantryAttachNinetySix = (): PipetteWizardStep[] => [
+  {
+    section: SECTIONS.BEFORE_BEGINNING,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.CARRIAGE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNTING_PLATE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNT_PIPETTE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.FIRMWARE_UPDATE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+  {
+    section: SECTIONS.ATTACH_PROBE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.DETACH_PROBE,
+    mount: LEFT,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount: LEFT,
+    flowType: FLOWS.CALIBRATE,
+  },
+]
+
+const fromEmptyGantryAttachSingleMountOn = (
+  mount: Mount
+): PipetteWizardStep[] => [
+  {
+    section: SECTIONS.BEFORE_BEGINNING,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.MOUNT_PIPETTE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.FIRMWARE_UPDATE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  { section: SECTIONS.RESULTS, mount, flowType: FLOWS.ATTACH },
+  {
+    section: SECTIONS.ATTACH_PROBE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.DETACH_PROBE,
+    mount,
+    flowType: FLOWS.ATTACH,
+  },
+  {
+    section: SECTIONS.RESULTS,
+    mount,
+    flowType: FLOWS.CALIBRATE,
+  },
+]
+
 export const getPipetteWizardStepsForProtocol = (
   attachedPipettes: AttachedPipettesFromInstrumentsQuery,
   pipetteInfo: LoadedPipette[],
@@ -13,7 +389,6 @@ export const getPipetteWizardStepsForProtocol = (
   const requiredPipette = pipetteInfo.find(pipette => pipette.mount === mount)
   const nintySixChannelAttached =
     attachedPipettes[LEFT]?.instrumentName === 'p1000_96'
-
   //  return empty array if no pipette is required in the protocol
   if (requiredPipette == null) {
     return null
@@ -21,125 +396,18 @@ export const getPipetteWizardStepsForProtocol = (
   } else if (
     requiredPipette?.pipetteName === attachedPipettes[mount]?.instrumentName
   ) {
-    return [
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount,
-        flowType: FLOWS.CALIBRATE,
-      },
-      {
-        section: SECTIONS.ATTACH_PROBE,
-        mount,
-        flowType: FLOWS.CALIBRATE,
-      },
-      {
-        section: SECTIONS.DETACH_PROBE,
-        mount,
-        flowType: FLOWS.CALIBRATE,
-      },
-      { section: SECTIONS.RESULTS, mount, flowType: FLOWS.CALIBRATE },
-    ]
+    return calibrateAlreadyAttachedPipetteOn(mount)
   } else if (
     requiredPipette.pipetteName !== 'p1000_96' &&
     attachedPipettes[mount] != null
   ) {
     //    96-channel pipette attached and need to attach single mount pipette
+
     if (nintySixChannelAttached) {
-      return [
-        {
-          section: SECTIONS.BEFORE_BEGINNING,
-          mount: LEFT,
-          flowType: FLOWS.DETACH,
-        },
-        {
-          section: SECTIONS.DETACH_PIPETTE,
-          mount: LEFT,
-          flowType: FLOWS.DETACH,
-        },
-        {
-          section: SECTIONS.MOUNTING_PLATE,
-          mount: LEFT,
-          flowType: FLOWS.DETACH,
-        },
-        {
-          section: SECTIONS.CARRIAGE,
-          mount: LEFT,
-          flowType: FLOWS.DETACH,
-        },
-        {
-          section: SECTIONS.RESULTS,
-          mount: LEFT,
-          flowType: FLOWS.DETACH,
-          nextMount: mount,
-        },
-        {
-          section: SECTIONS.MOUNT_PIPETTE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.FIRMWARE_UPDATE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        { section: SECTIONS.RESULTS, mount, flowType: FLOWS.ATTACH },
-        {
-          section: SECTIONS.ATTACH_PROBE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.DETACH_PROBE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.RESULTS,
-          mount,
-          flowType: FLOWS.CALIBRATE,
-        },
-      ]
+      return detachNinetySixAndAttachSingleMountOn(mount)
       //    Single mount pipette attached and need to attach new single mount pipette
     } else {
-      return [
-        {
-          section: SECTIONS.BEFORE_BEGINNING,
-          mount,
-          flowType: FLOWS.DETACH,
-        },
-        {
-          section: SECTIONS.DETACH_PIPETTE,
-          mount,
-          flowType: FLOWS.DETACH,
-        },
-        { section: SECTIONS.RESULTS, mount, flowType: FLOWS.DETACH },
-        {
-          section: SECTIONS.MOUNT_PIPETTE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.FIRMWARE_UPDATE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        { section: SECTIONS.RESULTS, mount, flowType: FLOWS.ATTACH },
-        {
-          section: SECTIONS.ATTACH_PROBE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.DETACH_PROBE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.RESULTS,
-          mount,
-          flowType: FLOWS.CALIBRATE,
-        },
-      ]
+      return detachSingleMountAndAttachSingleMountOn(mount)
     }
     //  Single mount pipette attached to both mounts and need to attach 96-channel pipette
   } else if (
@@ -147,273 +415,29 @@ export const getPipetteWizardStepsForProtocol = (
     attachedPipettes[LEFT] != null &&
     attachedPipettes[RIGHT] != null
   ) {
-    return [
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.DETACH,
-      },
-      {
-        section: SECTIONS.DETACH_PIPETTE,
-        mount: LEFT,
-        flowType: FLOWS.DETACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: LEFT,
-        flowType: FLOWS.DETACH,
-        nextMount: RIGHT,
-      },
-      {
-        section: SECTIONS.DETACH_PIPETTE,
-        mount: RIGHT,
-        flowType: FLOWS.DETACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: RIGHT,
-        flowType: FLOWS.DETACH,
-        nextMount: 'both',
-      },
-      {
-        section: SECTIONS.CARRIAGE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.MOUNTING_PLATE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.MOUNT_PIPETTE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.FIRMWARE_UPDATE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
-      {
-        section: SECTIONS.ATTACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.DETACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: LEFT,
-        flowType: FLOWS.CALIBRATE,
-      },
-    ]
+    return detachTwoSingleMountsAndAttachNinetySix()
     //  Single mount pipette attached to left mount and need to attach 96-channel pipette
   } else if (
     requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] != null &&
     attachedPipettes[RIGHT] == null
   ) {
-    return [
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.DETACH,
-      },
-      {
-        section: SECTIONS.DETACH_PIPETTE,
-        mount: LEFT,
-        flowType: FLOWS.DETACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: LEFT,
-        flowType: FLOWS.DETACH,
-        nextMount: 'both',
-      },
-      {
-        section: SECTIONS.CARRIAGE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.MOUNTING_PLATE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.MOUNT_PIPETTE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.FIRMWARE_UPDATE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
-      {
-        section: SECTIONS.ATTACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.DETACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: LEFT,
-        flowType: FLOWS.CALIBRATE,
-      },
-    ]
+    return detachSingleMountOnLeftAndAttachNinetySix()
     //  Single mount pipette attached to right mount and need to attach 96-channel pipette
   } else if (
     requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] == null &&
     attachedPipettes[RIGHT] != null
   ) {
-    return [
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: RIGHT,
-        flowType: FLOWS.DETACH,
-      },
-      {
-        section: SECTIONS.DETACH_PIPETTE,
-        mount: RIGHT,
-        flowType: FLOWS.DETACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: RIGHT,
-        flowType: FLOWS.DETACH,
-        nextMount: 'both',
-      },
-      {
-        section: SECTIONS.CARRIAGE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.MOUNTING_PLATE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.MOUNT_PIPETTE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.FIRMWARE_UPDATE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
-      {
-        section: SECTIONS.ATTACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.DETACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: LEFT,
-        flowType: FLOWS.CALIBRATE,
-      },
-    ]
+    return detachSingleMountOnRightAndAttachNinetySix()
     //  if no pipette is attached to gantry
   } else {
     //  Gantry empty and need to attach 96-channel pipette
     if (requiredPipette.pipetteName === 'p1000_96') {
-      return [
-        {
-          section: SECTIONS.BEFORE_BEGINNING,
-          mount: LEFT,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.CARRIAGE,
-          mount: LEFT,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.MOUNTING_PLATE,
-          mount: LEFT,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.MOUNT_PIPETTE,
-          mount: LEFT,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.FIRMWARE_UPDATE,
-          mount: LEFT,
-          flowType: FLOWS.ATTACH,
-        },
-        { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
-        {
-          section: SECTIONS.ATTACH_PROBE,
-          mount: LEFT,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.DETACH_PROBE,
-          mount: LEFT,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.RESULTS,
-          mount: LEFT,
-          flowType: FLOWS.CALIBRATE,
-        },
-      ]
+      return fromEmptyGantryAttachNinetySix()
       //    Gantry empty and need to attach single mount pipette
     } else {
-      return [
-        {
-          section: SECTIONS.BEFORE_BEGINNING,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.MOUNT_PIPETTE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.FIRMWARE_UPDATE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        { section: SECTIONS.RESULTS, mount, flowType: FLOWS.ATTACH },
-        {
-          section: SECTIONS.ATTACH_PROBE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.DETACH_PROBE,
-          mount,
-          flowType: FLOWS.ATTACH,
-        },
-        {
-          section: SECTIONS.RESULTS,
-          mount,
-          flowType: FLOWS.CALIBRATE,
-        },
-      ]
+      return fromEmptyGantryAttachSingleMountOn(mount)
     }
   }
 }

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -345,7 +345,7 @@ const fromEmptyGantryAttachNinetySix = (): PipetteWizardStep[] => [
   },
 ]
 
-const fromEmptyGantryAttachSingleMountOn = (
+const fromEmptyMountAttachSingleMountOn = (
   mount: Mount
 ): PipetteWizardStep[] => [
   {
@@ -380,6 +380,31 @@ const fromEmptyGantryAttachSingleMountOn = (
     flowType: FLOWS.CALIBRATE,
   },
 ]
+/**
++-------------+-----------------------------------------------+----------------------------------------------+-----------------------------------------------+
+|             |96                                             |left                                          |right                                          |
+|             |                                               |                                              |                                               |
+|             |                                               |                                              |                                               |
++-------------+-----------------------------------------------+----------------------------------------------+-----------------------------------------------+
+| 96          | calibrateAlreadyAttachedPipetteOn(left)       | detachNinetySixAndAttachSingleMountOn(left)  |                  X1                           |
++-------------+-----------------------------------------------+----------------------------------------------+-----------------------------------------------+
+|             |                                               | calibrateAlreadyAttachedPipetteOn(left) or   | fromEmptyMountAttachSingleMountOn(right)      |
+| left only   | detachSingleMountOnLeftAndAttachNinetySix()   | detachSingleMountAndAttachSingleMountOn(left)|                                               |
+|             |                                               |                                              |                                               |
++-------------+-----------------------------------------------+----------------------------------------------+-----------------------------------------------+
+|             |                                               |                                              | calibrateAlreadyAttachedPipetteOn(right) or   |
+| right only  | detachSingleMountOnRightAndAttachNinetySix()  |fromEmptyMountAttachSingleMountOn(left)       | detachSingleMountAndAttachSingleMountOn(right)|
+|             |                                               |                                              |                                               |
++-------------+-----------------------------------------------+----------------------------------------------+-----------------------------------------------+
+| left and    |                                               | calibrateAlreadyAttachedPipetteOn(left) or   | calibrateAlreadyAttachedPipetteOn(right) or   |
+| right       | detachTwoSingleMountsAndAttachNinetySix()     | detachSingleMountAndAttachSingleMountOn(left)| detachSingleMountAndAttachSingleMountOn(right)|
+|             |                                               |                                              |                                               |
++-------------+-----------------------------------------------+----------------------------------------------+-----------------------------------------------+
+|             |                                               |                                              |                                               |
+| nothing     | fromEmptyGantryAttachNinetySix()              | fromEmptyMountAttachSingleMountOn(left)      | fromEmptyMountAttachSingleMountOn(right)      |
+|             |                                               |                                              |                                               |
++-------------+-----------------------------------------------+----------------------------------------------+-----------------------------------------------+
+ **/
 
 export const getPipetteWizardStepsForProtocol = (
   attachedPipettes: AttachedPipettesFromInstrumentsQuery,
@@ -401,8 +426,9 @@ export const getPipetteWizardStepsForProtocol = (
     requiredPipette.pipetteName !== 'p1000_96' &&
     attachedPipettes[mount] != null
   ) {
-    //    96-channel pipette attached and need to attach single mount pipette
-
+    // 96-channel pipette attached and need to attach single mount pipette
+    // X1: this check can only be reached if mount is LEFT, because if mount is RIGHT
+    // then the 96 won't show up in attached pipettes
     if (nintySixChannelAttached) {
       return detachNinetySixAndAttachSingleMountOn(mount)
       //    Single mount pipette attached and need to attach new single mount pipette
@@ -437,7 +463,7 @@ export const getPipetteWizardStepsForProtocol = (
       return fromEmptyGantryAttachNinetySix()
       //    Gantry empty and need to attach single mount pipette
     } else {
-      return fromEmptyGantryAttachSingleMountOn(mount)
+      return fromEmptyMountAttachSingleMountOn(mount)
     }
   }
 }


### PR DESCRIPTION
When we're switching pipettes from a preprotocol flow, we were not
properly handling the case where a 96 is attached and we want to take it
off and attach a pipette to the right mount. Add handling for that.

I'm not really sure how this survived so long because it sure seems like it's always been there.

When reviewing, go commit by commit to see the flow of refactors. Also the logic table looks awful in the diff view unless you make your screen really wide but it's fine if you're just looking at the file 

## testing
- [x] if you have a 96 channel attached, and you set up a protocol with a multi or single on the right mount, does the flow for detaching the 96 and attaching the right mount pipette go correctly

Closes RQA-3123
