### PR TITLE
fix(hardware): Ignore the Hepa/UV when resolving attached tools.

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/tools/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/detector.py
@@ -82,6 +82,8 @@ async def _await_responses(
                 node = await _handle_hepa_uv_info(
                     response_queue, response, arbitration_id
                 )
+                seen.add(node)
+                break
             elif isinstance(response, message_definitions.ErrorMessage):
                 log.error(f"Received error message {str(response)}")
 
@@ -215,7 +217,6 @@ async def _resolve_with_stimulus_retries(
         should_respond
     )
     expected_gripper = {NodeId.gripper}.intersection(should_respond)
-    expected_hepa_uv = {NodeId.hepa_uv}.intersection(should_respond)
 
     while True:
         pipettes, gripper, hepa_uv = await _do_tool_resolve(
@@ -224,12 +225,10 @@ async def _resolve_with_stimulus_retries(
         output_queue.put_nowait((pipettes, gripper, hepa_uv))
         seen_pipettes = set([k.application_for() for k in pipettes.keys()])
         seen_gripper = set([k.application_for() for k in gripper.keys()])
-        seen_hepa_uv = set([k.application_for() for k in hepa_uv.keys()])
         if all(
             [
                 seen_pipettes == expected_pipettes,
                 seen_gripper == expected_gripper,
-                seen_hepa_uv == expected_hepa_uv,
             ]
         ):
             return


### PR DESCRIPTION
# Overview

The Hepa/UV is not detected through the head attachment/detachment mechanism like the rest of the tools (pipettes, grippers, etc) since the device is not physically attached to the head, instead, it's connected via the second AUX port and detected on startup via a broadcast `DeviceInfoRequest` CAN message. Since we are using the `ToolDetectionResult` to resolve the attached Nodes (which does not include Hepa/UV right now), we are running into an infinite loop when comparing the expected nodes (pipettes, gripper) vs the seen nodes (pipettes, gripper, hepa_uv). So let's ignore the Hepa/UV when resolving the attached tools so we don't run into this issue, eventually we will want to add a resolving mechanism for the Hepa/UV.

Related to: [RQA-3064](https://opentrons.atlassian.net/browse/RQA-3064)
This was found while looking into the above issue and could be causing problems related to whats being seen.

## Test Plan and Hands on Testing

- [x] Make sure that we don't run into an infinite loop when attaching/detaching instruments while the Hepa/UV is connected and powered on.

## Changelog

- Don't expect the Hepa/UV to respond when resolving attached tools

## Review requests

Makes sense?

## Risk assessment

Low, does not change response.

[RQA-3064]: https://opentrons.atlassian.net/browse/RQA-3064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ