### PR TITLE
fix(api): Opentrons simulate pick up tip message formatting

### DIFF
--- a/api/src/opentrons/legacy_commands/commands.py
+++ b/api/src/opentrons/legacy_commands/commands.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Union, overload
 
 
-from .helpers import stringify_location, stringify_disposal_location, listify
+from .helpers import (
+    stringify_location,
+    stringify_disposal_location,
+    listify,
+    stringify_pickup_location_range,
+)
 from . import types as command_types
 
 from opentrons.types import Location
@@ -247,7 +252,12 @@ def return_tip() -> command_types.ReturnTipCommand:
 def pick_up_tip(
     instrument: InstrumentContext, location: Well
 ) -> command_types.PickUpTipCommand:
-    location_text = stringify_location(location)
+    if instrument._core.get_active_channels() < instrument.channels:
+        location_text = stringify_pickup_location_range(
+            instrument._core.get_nozzle_map(), location
+        )
+    else:
+        location_text = stringify_location(location)
     text = f"Picking up tip from {location_text}"
     return {
         "name": command_types.PICK_UP_TIP,

--- a/api/src/opentrons/legacy_commands/helpers.py
+++ b/api/src/opentrons/legacy_commands/helpers.py
@@ -82,19 +82,15 @@ def stringify_pickup_location_range(  # noqa: C901
             loc_str_list = [location.well_name + "-" + _stringify_new_loc(last_well)]
 
         elif nozzle_map.starting_nozzle == "H1":
-            datastr = ""
             first_well_col = len(labware_columns) - 1
             first_well_row = 0
             if critical_column + len(nozzle_map.columns) < len(labware_columns):
                 first_well_col = critical_column + (len(nozzle_map.columns) - 1)
             if critical_row - len(nozzle_map.rows) >= 0:
-                datastr = "This should be true"
                 first_well_row = critical_row - (len(nozzle_map.rows) - 1)
 
             first_well = labware_columns[first_well_col][first_well_row]
-            loc_str_list = [
-                first_well.well_name + "-" + _stringify_new_loc(location) + datastr
-            ]
+            loc_str_list = [first_well.well_name + "-" + _stringify_new_loc(location)]
 
         elif nozzle_map.starting_nozzle == "H12":
             first_well_col = 0

--- a/api/src/opentrons/legacy_commands/helpers.py
+++ b/api/src/opentrons/legacy_commands/helpers.py
@@ -5,7 +5,7 @@ from opentrons.protocol_api.module_contexts import ModuleContext
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
 from opentrons.protocol_api._types import OffDeckType
 from opentrons.types import Location, DeckLocation
-
+from opentrons.hardware_control.nozzle_manager import NozzleConfigurationType, NozzleMap
 
 CommandLocation = Union[Location, Well]
 
@@ -38,6 +38,75 @@ def _stringify_new_loc(loc: CommandLocation) -> str:
 
 def stringify_location(location: Union[CommandLocation, List[CommandLocation]]) -> str:
     loc_str_list = [_stringify_new_loc(loc) for loc in listify(location)]
+    return ", ".join(loc_str_list)
+
+
+def stringify_pickup_location_range(  # noqa: C901
+    nozzle_map: NozzleMap, location: Well
+) -> str:
+    if nozzle_map.configuration == NozzleConfigurationType.SINGLE:
+        loc_str_list = [_stringify_new_loc(location)]
+    else:
+        labware_columns = location.parent.columns()
+        critical_column = 0
+        critical_row = 0
+        for column in labware_columns:
+            if location in column:
+                critical_row = column.index(location)
+                critical_column = labware_columns.index(column)
+
+        if nozzle_map.starting_nozzle == "A1":
+            last_well_col = len(labware_columns) - 1
+            last_well_row = len(labware_columns[0]) - 1
+            if critical_column + len(nozzle_map.columns) < len(labware_columns):
+                last_well_col = critical_column + (len(nozzle_map.columns) - 1)
+            if critical_row + len(nozzle_map.rows) < len(
+                labware_columns[critical_column]
+            ):
+                last_well_row = critical_row + (len(nozzle_map.rows) - 1)
+
+            last_well = labware_columns[last_well_col][last_well_row]
+            loc_str_list = [location.well_name + "-" + _stringify_new_loc(last_well)]
+
+        elif nozzle_map.starting_nozzle == "A12":
+            last_well_col = 0
+            last_well_row = len(labware_columns[0]) - 1
+            if critical_column - len(nozzle_map.columns) >= 0:
+                last_well_col = critical_column - (len(nozzle_map.columns) - 1)
+            if critical_row + len(nozzle_map.rows) < len(
+                labware_columns[critical_column]
+            ):
+                last_well_row = critical_row + (len(nozzle_map.rows) - 1)
+
+            last_well = labware_columns[last_well_col][last_well_row]
+            loc_str_list = [location.well_name + "-" + _stringify_new_loc(last_well)]
+
+        elif nozzle_map.starting_nozzle == "H1":
+            datastr = ""
+            first_well_col = len(labware_columns) - 1
+            first_well_row = 0
+            if critical_column + len(nozzle_map.columns) < len(labware_columns):
+                first_well_col = critical_column + (len(nozzle_map.columns) - 1)
+            if critical_row - len(nozzle_map.rows) >= 0:
+                datastr = "This should be true"
+                first_well_row = critical_row - (len(nozzle_map.rows) - 1)
+
+            first_well = labware_columns[first_well_col][first_well_row]
+            loc_str_list = [
+                first_well.well_name + "-" + _stringify_new_loc(location) + datastr
+            ]
+
+        elif nozzle_map.starting_nozzle == "H12":
+            first_well_col = 0
+            first_well_row = 0
+            if critical_column - len(nozzle_map.columns) >= 0:
+                first_well_col = critical_column - (len(nozzle_map.columns) - 1)
+            if critical_row - len(nozzle_map.rows) >= 0:
+                first_well_row = critical_row - (len(nozzle_map.rows) - 1)
+
+            first_well = labware_columns[first_well_col][first_well_row]
+            loc_str_list = [first_well.well_name + "-" + _stringify_new_loc(location)]
+
     return ", ".join(loc_str_list)
 
 


### PR DESCRIPTION

# Overview
Cover RQA-3129

Originally we were printing only the primary well referenced in a pick up tip action in simulate. This has lead to confusion and incomplete information when engaging in partial tip extraction. This PR seeks to ensure we trace the selecition of tips being removed back to the edge-well of a given cluster of tips.

As a result, the follow case would be true:

Flex 8ch Partial tip Pickup using 2 nozzles picking up from a tiprack would print:
`Picking up tips from A1-B1 of Opentrons Flex 96 Tip Rack 1000 µL on slot B2`

## Test Plan and Hands on Testing

Ensure all configurations of pipette layout list tip extraction well reference in sensible order.

## Changelog
String formatting on outgoing pick up tip command.

## Review requests

## Risk assessment
Low - only effects outgoing string.

This has had the unfortunate knock-on effect of making the simulate print log more accurate than the current run-preview log.