### PR TITLE
feat(protocol-designer): deckThumbnail in Protocol overview

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -1,0 +1,211 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import {
+  ALIGN_CENTER,
+  BORDERS,
+  COLORS,
+  DeckFromLayers,
+  Flex,
+  FlexTrash,
+  JUSTIFY_CENTER,
+  RobotCoordinateSpaceWithRef,
+  SingleSlotFixture,
+  SlotLabels,
+  StagingAreaFixture,
+  WasteChuteFixture,
+  WasteChuteStagingAreaFixture,
+} from '@opentrons/components'
+import {
+  getCutoutIdForAddressableArea,
+  getDeckDefFromRobotType,
+  isAddressableAreaStandardSlot,
+  OT2_ROBOT_TYPE,
+  STAGING_AREA_CUTOUTS,
+  TRASH_BIN_ADAPTER_FIXTURE,
+  WASTE_CHUTE_CUTOUT,
+} from '@opentrons/shared-data'
+import { getRobotType } from '../../file-data/selectors'
+import { getInitialDeckSetup } from '../../step-forms/selectors'
+import { DeckThumbnailDetails } from './DeckThumbnailDetails'
+import type { StagingAreaLocation, TrashCutoutId } from '@opentrons/components'
+import type { CutoutId, DeckSlotId } from '@opentrons/shared-data'
+import type { AdditionalEquipmentEntity } from '@opentrons/step-generation'
+
+const WASTE_CHUTE_SPACE = 30
+const OT2_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST: string[] = [
+  'calibrationMarkings',
+  'fixedBase',
+  'doorStops',
+  'metalFrame',
+  'removalHandle',
+  'removableDeckOutline',
+  'screwHoles',
+  'fixedTrash',
+]
+
+const lightFill = COLORS.grey35
+const darkFill = COLORS.grey60
+
+interface DeckThumbnailProps {
+  hoverSlot: DeckSlotId | null
+  setHoverSlot: React.Dispatch<React.SetStateAction<string | null>>
+}
+export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
+  const { hoverSlot, setHoverSlot } = props
+  const initialDeckSetup = useSelector(getInitialDeckSetup)
+  const robotType = useSelector(getRobotType)
+  const deckDef = React.useMemo(() => getDeckDefFromRobotType(robotType), [])
+  const trash = Object.values(initialDeckSetup.additionalEquipmentOnDeck).find(
+    ae => ae.name === 'trashBin'
+  )
+  const trashBinFixtures = [
+    {
+      cutoutId: trash?.location as CutoutId,
+      cutoutFixtureId: TRASH_BIN_ADAPTER_FIXTURE,
+    },
+  ]
+  const wasteChuteFixtures = Object.values(
+    initialDeckSetup.additionalEquipmentOnDeck
+  ).filter(
+    aE =>
+      WASTE_CHUTE_CUTOUT.includes(aE.location as CutoutId) &&
+      aE.name === 'wasteChute'
+  )
+  const stagingAreaFixtures: AdditionalEquipmentEntity[] = Object.values(
+    initialDeckSetup.additionalEquipmentOnDeck
+  ).filter(
+    aE =>
+      STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
+      aE.name === 'stagingArea'
+  )
+
+  const wasteChuteStagingAreaFixtures = Object.values(
+    initialDeckSetup.additionalEquipmentOnDeck
+  ).filter(
+    aE =>
+      STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
+      aE.name === 'stagingArea' &&
+      aE.location === WASTE_CHUTE_CUTOUT &&
+      wasteChuteFixtures.length > 0
+  )
+
+  const hasWasteChute =
+    wasteChuteFixtures.length > 0 || wasteChuteStagingAreaFixtures.length > 0
+
+  const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
+    aa => isAddressableAreaStandardSlot(aa.id, deckDef)
+  )
+  return (
+    <Flex
+      height="404px"
+      width="520px"
+      alignItems={ALIGN_CENTER}
+      justifyContent={JUSTIFY_CENTER}
+      backgroundColor={COLORS.grey10}
+      borderRadius={BORDERS.borderRadius8}
+    >
+      <RobotCoordinateSpaceWithRef
+        height="80%"
+        width="100%"
+        deckDef={deckDef}
+        viewBox={`${deckDef.cornerOffsetFromOrigin[0]} ${
+          hasWasteChute
+            ? deckDef.cornerOffsetFromOrigin[1] - WASTE_CHUTE_SPACE
+            : deckDef.cornerOffsetFromOrigin[1]
+        } ${deckDef.dimensions[0]} ${deckDef.dimensions[1]}`}
+      >
+        {() => (
+          <>
+            {robotType === OT2_ROBOT_TYPE ? (
+              <DeckFromLayers
+                robotType={robotType}
+                layerBlocklist={OT2_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST}
+              />
+            ) : (
+              <>
+                {filteredAddressableAreas.map(addressableArea => {
+                  const cutoutId = getCutoutIdForAddressableArea(
+                    addressableArea.id,
+                    deckDef.cutoutFixtures
+                  )
+                  return cutoutId != null ? (
+                    <SingleSlotFixture
+                      key={addressableArea.id}
+                      cutoutId={cutoutId}
+                      deckDefinition={deckDef}
+                      showExpansion={cutoutId === 'cutoutA1'}
+                      fixtureBaseColor={lightFill}
+                      slotClipColor={darkFill}
+                    />
+                  ) : null
+                })}
+                {stagingAreaFixtures.map(fixture => (
+                  <StagingAreaFixture
+                    key={fixture.id}
+                    cutoutId={fixture.location as StagingAreaLocation}
+                    deckDefinition={deckDef}
+                    slotClipColor={darkFill}
+                    fixtureBaseColor={lightFill}
+                  />
+                ))}
+                {trash != null
+                  ? trashBinFixtures.map(({ cutoutId }) =>
+                      cutoutId != null ? (
+                        <React.Fragment key={cutoutId}>
+                          <SingleSlotFixture
+                            cutoutId={cutoutId}
+                            deckDefinition={deckDef}
+                            slotClipColor={COLORS.transparent}
+                            fixtureBaseColor={lightFill}
+                          />
+                          <FlexTrash
+                            robotType={robotType}
+                            trashIconColor={lightFill}
+                            trashCutoutId={cutoutId as TrashCutoutId}
+                            backgroundColor={COLORS.grey50}
+                          />
+                        </React.Fragment>
+                      ) : null
+                    )
+                  : null}
+                {wasteChuteFixtures.map(fixture => (
+                  <WasteChuteFixture
+                    key={fixture.id}
+                    cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
+                    deckDefinition={deckDef}
+                    fixtureBaseColor={lightFill}
+                  />
+                ))}
+                {wasteChuteStagingAreaFixtures.map(fixture => (
+                  <WasteChuteStagingAreaFixture
+                    key={fixture.id}
+                    cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
+                    deckDefinition={deckDef}
+                    slotClipColor={darkFill}
+                    fixtureBaseColor={lightFill}
+                  />
+                ))}
+              </>
+            )}
+            <DeckThumbnailDetails
+              robotType={robotType}
+              hover={hoverSlot}
+              setHover={setHoverSlot}
+              initialDeckSetup={initialDeckSetup}
+              stagingAreaCutoutIds={stagingAreaFixtures.map(
+                areas => areas.location as CutoutId
+              )}
+              {...{
+                deckDef,
+              }}
+            />
+            <SlotLabels
+              robotType={robotType}
+              show4thColumn={stagingAreaFixtures.length > 0}
+            />
+          </>
+        )}
+      </RobotCoordinateSpaceWithRef>
+    </Flex>
+  )
+}

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
@@ -1,0 +1,249 @@
+import * as React from 'react'
+import values from 'lodash/values'
+
+import { Module } from '@opentrons/components'
+import {
+  getAddressableAreaFromSlotId,
+  getLabwareHasQuirk,
+  getModuleDef2,
+  getPositionFromSlotId,
+  inferModuleOrientationFromXCoordinate,
+  isAddressableAreaStandardSlot,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import { LabwareOnDeck } from '../../components/DeckSetup/LabwareOnDeck'
+import { getStagingAreaAddressableAreas } from '../../utils'
+import {
+  getSlotIdsBlockedBySpanningForThermocycler,
+  getSlotIsEmpty,
+} from '../../step-forms'
+import { SlotHover } from './SlotHover'
+import type {
+  CutoutId,
+  DeckDefinition,
+  RobotType,
+} from '@opentrons/shared-data'
+import type {
+  InitialDeckSetup,
+  ModuleOnDeck,
+  LabwareOnDeck as LabwareOnDeckType,
+} from '../../step-forms'
+
+interface DeckSetupDetailsProps {
+  initialDeckSetup: InitialDeckSetup
+  deckDef: DeckDefinition
+  stagingAreaCutoutIds: CutoutId[]
+  hover: string | null
+  setHover: React.Dispatch<React.SetStateAction<string | null>>
+  robotType: RobotType
+}
+
+export const DeckThumbnailDetails = (
+  props: DeckSetupDetailsProps
+): JSX.Element => {
+  const {
+    initialDeckSetup,
+    deckDef,
+    stagingAreaCutoutIds,
+    robotType,
+    hover,
+    setHover,
+  } = props
+  const slotIdsBlockedBySpanning = getSlotIdsBlockedBySpanningForThermocycler(
+    initialDeckSetup,
+    robotType
+  )
+
+  const allLabware: LabwareOnDeckType[] = Object.keys(
+    initialDeckSetup.labware
+  ).reduce<LabwareOnDeckType[]>((acc, labwareId) => {
+    const labware = initialDeckSetup.labware[labwareId]
+    return getLabwareHasQuirk(labware.def, 'fixedTrash')
+      ? acc
+      : [...acc, labware]
+  }, [])
+
+  const allModules: ModuleOnDeck[] = values(initialDeckSetup.modules)
+
+  return (
+    <>
+      {/* all modules */}
+      {allModules.map(moduleOnDeck => {
+        const slotId = moduleOnDeck.slot
+
+        const slotPosition = getPositionFromSlotId(slotId, deckDef)
+        if (slotPosition == null) {
+          console.warn(`no slot ${slotId} for module ${moduleOnDeck.id}`)
+          return null
+        }
+        const moduleDef = getModuleDef2(moduleOnDeck.model)
+        const labwareLoadedOnModule = allLabware.find(
+          lw => lw.slot === moduleOnDeck.id
+        )
+        return (
+          <React.Fragment key={moduleOnDeck.id}>
+            <Module
+              key={moduleOnDeck.slot}
+              x={slotPosition[0]}
+              y={slotPosition[1]}
+              def={moduleDef}
+              orientation={inferModuleOrientationFromXCoordinate(
+                slotPosition[0]
+              )}
+              innerProps={
+                moduleOnDeck.moduleState.type === THERMOCYCLER_MODULE_TYPE
+                  ? { lidMotorState: 'open' }
+                  : {}
+              }
+              targetSlotId={slotId}
+              targetDeckId={deckDef.otId}
+            >
+              {labwareLoadedOnModule != null ? (
+                <>
+                  <LabwareOnDeck
+                    x={0}
+                    y={0}
+                    labwareOnDeck={labwareLoadedOnModule}
+                  />
+                  <SlotHover
+                    robotType={robotType}
+                    hover={hover}
+                    setHover={setHover}
+                    slotPosition={[0, 0, 0]}
+                    slotId={slotId}
+                  />
+                </>
+              ) : null}
+              {labwareLoadedOnModule == null ? (
+                <SlotHover
+                  robotType={robotType}
+                  hover={hover}
+                  setHover={setHover}
+                  slotPosition={[0, 0, 0]}
+                  slotId={slotId}
+                />
+              ) : null}
+            </Module>
+          </React.Fragment>
+        )
+      })}
+      {/* all labware on deck NOT those in modules */}
+      {allLabware.map(labware => {
+        if (
+          labware.slot === 'offDeck' ||
+          allModules.some(m => m.id === labware.slot) ||
+          allLabware.some(lab => lab.id === labware.slot)
+        )
+          return null
+
+        const slotPosition = getPositionFromSlotId(labware.slot, deckDef)
+        const slotBoundingBox = getAddressableAreaFromSlotId(
+          labware.slot,
+          deckDef
+        )?.boundingBox
+        if (slotPosition == null || slotBoundingBox == null) {
+          console.warn(`no slot ${labware.slot} for labware ${labware.id}!`)
+          return null
+        }
+        return (
+          <React.Fragment key={labware.id}>
+            <LabwareOnDeck
+              x={slotPosition[0]}
+              y={slotPosition[1]}
+              labwareOnDeck={labware}
+            />
+            <SlotHover
+              robotType={robotType}
+              hover={hover}
+              setHover={setHover}
+              slotPosition={slotPosition}
+              slotId={labware.slot}
+            />
+          </React.Fragment>
+        )
+      })}
+
+      {/* all nested labwares on deck  */}
+      {allLabware.map(labware => {
+        if (
+          allModules.some(m => m.id === labware.slot) ||
+          labware.slot === 'offDeck'
+        )
+          return null
+        if (
+          deckDef.locations.addressableAreas.some(
+            addressableArea => addressableArea.id === labware.slot
+          )
+        ) {
+          return null
+        }
+        const slotForOnTheDeck = allLabware.find(lab => lab.id === labware.slot)
+          ?.slot
+        const slotForOnMod = allModules.find(mod => mod.id === slotForOnTheDeck)
+          ?.slot
+        let slotPosition = null
+        if (slotForOnMod != null) {
+          slotPosition = getPositionFromSlotId(slotForOnMod, deckDef)
+        } else if (slotForOnTheDeck != null) {
+          slotPosition = getPositionFromSlotId(slotForOnTheDeck, deckDef)
+        }
+        if (slotPosition == null) {
+          console.warn(`no slot ${labware.slot} for labware ${labware.id}!`)
+          return null
+        }
+        const slotOnDeck =
+          slotForOnTheDeck != null
+            ? allModules.find(module => module.id === slotForOnTheDeck)?.slot
+            : null
+        return (
+          <React.Fragment key={labware.id}>
+            <LabwareOnDeck
+              x={slotPosition[0]}
+              y={slotPosition[1]}
+              labwareOnDeck={labware}
+            />
+            <SlotHover
+              robotType={robotType}
+              hover={hover}
+              setHover={setHover}
+              slotPosition={slotPosition}
+              slotId={slotOnDeck ?? ''}
+            />
+          </React.Fragment>
+        )
+      })}
+
+      {/* SlotControls for all empty deck */}
+      {deckDef.locations.addressableAreas
+        .filter(addressableArea => {
+          const stagingAreaAddressableAreas = getStagingAreaAddressableAreas(
+            stagingAreaCutoutIds
+          )
+          const addressableAreas =
+            isAddressableAreaStandardSlot(addressableArea.id, deckDef) ||
+            stagingAreaAddressableAreas.includes(addressableArea.id)
+          return (
+            addressableAreas &&
+            !slotIdsBlockedBySpanning.includes(addressableArea.id) &&
+            getSlotIsEmpty(initialDeckSetup, addressableArea.id)
+          )
+        })
+        .map(addressableArea => {
+          return (
+            <React.Fragment key={addressableArea.id}>
+              <SlotHover
+                robotType={robotType}
+                hover={hover}
+                setHover={setHover}
+                slotPosition={getPositionFromSlotId(
+                  addressableArea.id,
+                  deckDef
+                )}
+                slotId={addressableArea.id}
+              />
+            </React.Fragment>
+          )
+        })}
+    </>
+  )
+}

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
@@ -13,10 +13,7 @@ import {
 } from '@opentrons/shared-data'
 import { LabwareOnDeck } from '../../components/DeckSetup/LabwareOnDeck'
 import { getStagingAreaAddressableAreas } from '../../utils'
-import {
-  getSlotIdsBlockedBySpanningForThermocycler,
-  getSlotIsEmpty,
-} from '../../step-forms'
+import { getSlotIdsBlockedBySpanningForThermocycler } from '../../step-forms'
 import { SlotHover } from './SlotHover'
 import type {
   CutoutId,
@@ -224,8 +221,7 @@ export const DeckThumbnailDetails = (
             stagingAreaAddressableAreas.includes(addressableArea.id)
           return (
             addressableAreas &&
-            !slotIdsBlockedBySpanning.includes(addressableArea.id) &&
-            getSlotIsEmpty(initialDeckSetup, addressableArea.id)
+            !slotIdsBlockedBySpanning.includes(addressableArea.id)
           )
         })
         .map(addressableArea => {

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -51,12 +51,8 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
       deckDef.cutoutFixtures
     ) ?? 'cutoutD1'
 
-  //  return null for TC slots and 4th column slots
-  if (
-    slotPosition === null ||
-    FOURTH_COLUMN_SLOTS.includes(slotId) ||
-    (hasTCOnSlot && tcSlots.includes(slotId))
-  )
+  //  return null for TC slots
+  if (slotPosition === null || (hasTCOnSlot && tcSlots.includes(slotId)))
     return null
 
   const hoverOpacity = hover != null && hover === slotId ? '1' : '0'
@@ -78,7 +74,8 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
     const X_ADJUSTMENT_LEFT_SIDE = -101.5
     const X_ADJUSTMENT = -17
     const X_DIMENSION_MIDDLE_SLOTS = 160.3
-    const X_DIMENSION_OUTER_SLOTS = hasStagingArea ? 340.8 : 246.5
+    const X_DIMENSION_OUTER_SLOTS = hasStagingArea ? 160.0 : 246.5
+    const X_DIMENSION_4TH_COLUMN_SLOTS = 175.0
     const Y_DIMENSION = hasTCOnSlot ? 294.0 : 106.0
 
     const slotFromCutout = slotId
@@ -96,9 +93,12 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
     const isMiddleOfDeck =
       slotId === 'A2' || slotId === 'B2' || slotId === 'C2' || slotId === 'D2'
 
-    const xDimension = isMiddleOfDeck
-      ? X_DIMENSION_MIDDLE_SLOTS
-      : X_DIMENSION_OUTER_SLOTS
+    let xDimension = X_DIMENSION_OUTER_SLOTS
+    if (isMiddleOfDeck) {
+      xDimension = X_DIMENSION_MIDDLE_SLOTS
+    } else if (FOURTH_COLUMN_SLOTS.includes(slotId)) {
+      xDimension = X_DIMENSION_4TH_COLUMN_SLOTS
+    }
     const yDimension = Y_DIMENSION
 
     return (

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import {
+  ALIGN_CENTER,
+  BORDERS,
+  COLORS,
+  Flex,
+  JUSTIFY_CENTER,
+  RobotCoordsForeignObject,
+  SPACING,
+} from '@opentrons/components'
+import {
+  getCutoutIdForAddressableArea,
+  getDeckDefFromRobotType,
+  THERMOCYCLER_MODULE_TYPE,
+  FLEX_ROBOT_TYPE,
+} from '@opentrons/shared-data'
+import { getInitialDeckSetup } from '../../step-forms/selectors'
+import type {
+  CoordinateTuple,
+  DeckSlotId,
+  AddressableAreaName,
+  RobotType,
+} from '@opentrons/shared-data'
+
+interface SlotHoverProps {
+  hover: string | null
+  setHover: React.Dispatch<React.SetStateAction<string | null>>
+  slotId: DeckSlotId
+  slotPosition: CoordinateTuple | null
+  robotType: RobotType
+}
+const FOURTH_COLUMN_SLOTS = ['A4', 'B4', 'C4', 'D4']
+
+export function SlotHover(props: SlotHoverProps): JSX.Element | null {
+  const { hover, setHover, slotId, slotPosition, robotType } = props
+  const deckSetup = useSelector(getInitialDeckSetup)
+  const { additionalEquipmentOnDeck, modules } = deckSetup
+  const deckDef = React.useMemo(() => getDeckDefFromRobotType(robotType), [])
+  const hasTCOnSlot = Object.values(modules).find(
+    module => module.slot === slotId && module.type === THERMOCYCLER_MODULE_TYPE
+  )
+  const tcSlots = robotType === FLEX_ROBOT_TYPE ? ['A1'] : ['8', '10', '11']
+  const stagingAreaLocations = Object.values(additionalEquipmentOnDeck)
+    .filter(ae => ae.name === 'stagingArea')
+    ?.map(ae => ae.location as string)
+
+  const cutoutId =
+    getCutoutIdForAddressableArea(
+      slotId as AddressableAreaName,
+      deckDef.cutoutFixtures
+    ) ?? 'cutoutD1'
+
+  //  return null for TC slots and 4th column slots
+  if (
+    slotPosition === null ||
+    FOURTH_COLUMN_SLOTS.includes(slotId) ||
+    (hasTCOnSlot && tcSlots.includes(slotId))
+  )
+    return null
+
+  const hoverOpacity = hover != null && hover === slotId ? '1' : '0'
+  const slotFill = (
+    <Flex
+      alignItems={ALIGN_CENTER}
+      backgroundColor={`${COLORS.black90}cc`}
+      borderRadius={BORDERS.borderRadius4}
+      color={COLORS.white}
+      gridGap={SPACING.spacing8}
+      justifyContent={JUSTIFY_CENTER}
+      width="100%"
+    />
+  )
+
+  if (robotType === FLEX_ROBOT_TYPE) {
+    const hasStagingArea = stagingAreaLocations.includes(cutoutId)
+
+    const X_ADJUSTMENT_LEFT_SIDE = -101.5
+    const X_ADJUSTMENT = -17
+    const X_DIMENSION_MIDDLE_SLOTS = 160.3
+    const X_DIMENSION_OUTER_SLOTS = hasStagingArea ? 340.8 : 246.5
+    const Y_DIMENSION = hasTCOnSlot ? 294.0 : 106.0
+
+    const slotFromCutout = slotId
+    const isLeftSideofDeck =
+      slotFromCutout === 'A1' ||
+      slotFromCutout === 'B1' ||
+      slotFromCutout === 'C1' ||
+      slotFromCutout === 'D1'
+    const xAdjustment = isLeftSideofDeck ? X_ADJUSTMENT_LEFT_SIDE : X_ADJUSTMENT
+    const x = slotPosition[0] + xAdjustment
+
+    const yAdjustment = -10
+    const y = slotPosition[1] + yAdjustment
+
+    const isMiddleOfDeck =
+      slotId === 'A2' || slotId === 'B2' || slotId === 'C2' || slotId === 'D2'
+
+    const xDimension = isMiddleOfDeck
+      ? X_DIMENSION_MIDDLE_SLOTS
+      : X_DIMENSION_OUTER_SLOTS
+    const yDimension = Y_DIMENSION
+
+    return (
+      <RobotCoordsForeignObject
+        key="flex_hover"
+        width={xDimension}
+        height={yDimension}
+        x={hasTCOnSlot ? x + 20 : x}
+        y={hasTCOnSlot ? y - 70 : y}
+        flexProps={{ flex: '1' }}
+        foreignObjectProps={{
+          opacity: hoverOpacity,
+          flex: '1',
+          onMouseEnter: () => {
+            setHover(slotId)
+          },
+          onMouseLeave: () => {
+            setHover(null)
+          },
+        }}
+      >
+        {slotFill}
+      </RobotCoordsForeignObject>
+    )
+  } else {
+    const y = slotPosition[1]
+    const x = slotPosition[0]
+
+    return (
+      <RobotCoordsForeignObject
+        key="ot2_hover"
+        width={hasTCOnSlot ? 260 : 128}
+        height={hasTCOnSlot ? 178 : 85}
+        x={x}
+        y={hasTCOnSlot ? y - 72 : y}
+        flexProps={{ flex: '1' }}
+        foreignObjectProps={{
+          opacity: hoverOpacity,
+          flex: '1',
+          onMouseEnter: () => {
+            setHover(slotId)
+          },
+          onMouseLeave: () => {
+            setHover(null)
+          },
+        }}
+      >
+        {slotFill}
+      </RobotCoordsForeignObject>
+    )
+  }
+}

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/DeckThumbnail.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/DeckThumbnail.test.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import { describe, it, vi, beforeEach, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { screen } from '@testing-library/react'
+import { FLEX_ROBOT_TYPE, fixture12Trough } from '@opentrons/shared-data'
+import { renderWithProviders } from '../../../__testing-utils__'
+import { getInitialDeckSetup } from '../../../step-forms/selectors'
+import { LabwareOnDeck } from '../../../components/DeckSetup/LabwareOnDeck'
+import { getRobotType } from '../../../file-data/selectors'
+import { DeckThumbnail } from '../DeckThumbnail'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type * as Components from '@opentrons/components'
+
+vi.mock('../../../components/DeckSetup/LabwareOnDeck')
+vi.mock('../../../file-data/selectors')
+vi.mock('../../../step-forms/selectors')
+vi.mock('@opentrons/components', async importOriginal => {
+  const actual = await importOriginal<typeof Components>()
+  return {
+    ...actual,
+    SingleSlotFixture: () => <div>mock single slot fixture</div>,
+    Module: () => <div>mock module</div>,
+  }
+})
+
+const render = (props: React.ComponentProps<typeof DeckThumbnail>) => {
+  return renderWithProviders(<DeckThumbnail {...props} />)[0]
+}
+
+describe('DeckThumbnail', () => {
+  let props: React.ComponentProps<typeof DeckThumbnail>
+
+  beforeEach(() => {
+    props = {
+      hoverSlot: null,
+      setHoverSlot: vi.fn(),
+    }
+    vi.mocked(LabwareOnDeck).mockReturnValue(<div>mock LabwareOnDeck</div>)
+    vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {},
+      additionalEquipmentOnDeck: {},
+      pipettes: {},
+      labware: {
+        labware: {
+          id: 'mockId',
+          def: fixture12Trough as LabwareDefinition2,
+          labwareDefURI: 'mockDefUri',
+          slot: 'A1',
+        },
+      },
+    })
+  })
+
+  it('renders a flex deck with a labware and all single slot fixutres', () => {
+    render(props)
+    screen.getByText('mock LabwareOnDeck')
+    expect(screen.getAllByText('mock single slot fixture')).toHaveLength(12)
+  })
+})

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -33,8 +33,10 @@ import { resetScrollElements } from '../../ui/steps/utils'
 import { useBlockingHint } from '../../components/Hints/useBlockingHint'
 import { v8WarningContent } from '../../components/FileSidebar/FileSidebar'
 import { EditProtocolMetadataModal } from '../../organisms'
+import { DeckThumbnail } from './DeckThumbnail'
 
 import type { CreateCommand, PipetteName } from '@opentrons/shared-data'
+import type { DeckSlot } from '@opentrons/step-generation'
 import type { ThunkDispatch } from '../../types'
 import type { HintKey } from '../../tutorial'
 
@@ -66,6 +68,8 @@ export function ProtocolOverview(): JSX.Element {
   const deckSetup = useSelector(getInitialDeckSetup)
 
   const dispatch: ThunkDispatch<any> = useDispatch()
+  const [hoverSlot, setHoverSlot] = React.useState<DeckSlot | null>(null)
+  // TODO: wire up the slot information from hoverSlot
   const [showBlockingHint, setShowBlockingHint] = React.useState<boolean>(false)
   const fileData = useSelector(fileSelectors.createFile)
   const initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
@@ -393,8 +397,15 @@ export function ProtocolOverview(): JSX.Element {
                 </StyledText>
               </Btn>
             </Flex>
-            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-              TODO: wire this up
+            <Flex
+              flexDirection={DIRECTION_COLUMN}
+              gridGap={SPACING.spacing4}
+              alignItems={ALIGN_CENTER}
+            >
+              <DeckThumbnail
+                hoverSlot={hoverSlot}
+                setHoverSlot={setHoverSlot}
+              />
             </Flex>
           </Flex>
         </Flex>

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -9,6 +9,7 @@ import {
   THERMOCYCLER_MODULE_V2,
   WASTE_CHUTE_CUTOUT,
   FLEX_ROBOT_TYPE,
+  OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import { SPAN7_8_10_11_SLOT, TC_SPAN_SLOTS } from '../../constants'
 import { hydrateField } from '../../steplist/fieldLevel'
@@ -22,6 +23,7 @@ import type {
   LoadModuleCreateCommand,
   ModuleType,
   MoveLabwareCreateCommand,
+  RobotType,
 } from '@opentrons/shared-data'
 import type {
   NormalizedPipette,
@@ -168,6 +170,23 @@ export const getSlotIdsBlockedBySpanning = (
 
   return []
 }
+
+export const getSlotIdsBlockedBySpanningForThermocycler = (
+  initialDeckSetup: InitialDeckSetup,
+  robotType: RobotType
+): DeckSlot[] => {
+  const loadedThermocycler = values(initialDeckSetup.modules).find(
+    ({ type }: ModuleOnDeck) => type === THERMOCYCLER_MODULE_TYPE
+  )
+  if (loadedThermocycler != null && robotType === FLEX_ROBOT_TYPE) {
+    return ['A1', 'B1']
+  } else if (loadedThermocycler != null && robotType === OT2_ROBOT_TYPE) {
+    return ['7', '8', '10', '11']
+  }
+
+  return []
+}
+
 //  TODO(jr, 3/13/24): refactor this util it is messy and confusing
 export const getSlotIsEmpty = (
   initialDeckSetup: InitialDeckSetup,


### PR DESCRIPTION
closes AUTH-678

# Overview

Wires up the deck map thumbnail in the protocol overview page! when you hover over a slot, it has the overlay but the slot information part is not wired up yet (@koji  will likely do that afterwards!)

## Test Plan and Hands on Testing

Make a flex and ot-2 protocol and add a thermocycler. Hover over the slots on the deck thumbnail and the overlay should work as expected. 

## Changelog

- add deck map thumbnail, details, and slot hover components
- make a test

## Risk assessment

low
