### PR TITLE
refactor(app): Clean up notification hooks

### DIFF
--- a/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
+++ b/app/src/resources/client_data/recovery/useNotifyClientDataRecovery.ts
@@ -14,19 +14,19 @@ export function useNotifyClientDataRecovery(
     AxiosError
   > = {}
 ): UseQueryResult<ClientDataResponse<ClientDataRecovery>, AxiosError> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/clientData/${KEYS.ERROR_RECOVERY}`,
     options,
   })
 
   const httpQueryResult = useClientData<ClientDataRecovery>(
     KEYS.ERROR_RECOVERY,
-    {
-      ...options,
-      enabled: options?.enabled !== false && shouldRefetch,
-      onSettled: notifyOnSettled,
-    }
+    queryOptionsNotify
   )
+
+  if (shouldRefetch) {
+    void httpQueryResult.refetch()
+  }
 
   return httpQueryResult
 }

--- a/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
+++ b/app/src/resources/deck_configuration/useNotifyDeckConfigurationQuery.ts
@@ -9,16 +9,16 @@ import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
 export function useNotifyDeckConfigurationQuery(
   options: QueryOptionsWithPolling<DeckConfiguration, unknown> = {}
 ): UseQueryResult<DeckConfiguration> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/deck_configuration',
     options,
   })
 
-  const httpQueryResult = useDeckConfigurationQuery({
-    ...options,
-    enabled: options?.enabled !== false && shouldRefetch,
-    onSettled: notifyOnSettled,
-  })
+  const httpQueryResult = useDeckConfigurationQuery(queryOptionsNotify)
+
+  if (shouldRefetch) {
+    void httpQueryResult.refetch()
+  }
 
   return httpQueryResult
 }

--- a/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
+++ b/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
@@ -9,16 +9,16 @@ import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
 export function useNotifyCurrentMaintenanceRun(
   options: QueryOptionsWithPolling<MaintenanceRun, Error> = {}
 ): UseQueryResult<MaintenanceRun> | UseQueryResult<MaintenanceRun, Error> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/maintenance_runs/current_run',
     options,
   })
 
-  const httpQueryResult = useCurrentMaintenanceRun({
-    ...options,
-    enabled: options?.enabled !== false && shouldRefetch,
-    onSettled: notifyOnSettled,
-  })
+  const httpQueryResult = useCurrentMaintenanceRun(queryOptionsNotify)
+
+  if (shouldRefetch) {
+    void httpQueryResult.refetch()
+  }
 
   return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsAsPreSerializedList.ts
@@ -12,16 +12,20 @@ export function useNotifyAllCommandsAsPreSerializedList(
   params?: GetCommandsParams | null,
   options: QueryOptionsWithPolling<CommandsData, AxiosError> = {}
 ): UseQueryResult<CommandsData, AxiosError> {
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/runs/pre_serialized_commands/${runId}`,
     options,
   })
 
-  const httpResponse = useAllCommandsAsPreSerializedList(runId, params, {
-    ...options,
-    enabled: options?.enabled !== false && shouldRefetch,
-    onSettled: notifyOnSettled,
-  })
+  const httpQueryResult = useAllCommandsAsPreSerializedList(
+    runId,
+    params,
+    queryOptionsNotify
+  )
 
-  return httpResponse
+  if (shouldRefetch) {
+    void httpQueryResult.refetch()
+  }
+
+  return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllCommandsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsQuery.ts
@@ -17,16 +17,16 @@ export function useNotifyAllCommandsQuery<TError = Error>(
   // running to succeeded, that may change the useAllCommandsQuery response, but it
   // will not necessarily change the command links. We might need an MQTT topic
   // covering "any change in `GET /runs/{id}/commands`".
-  const { notifyOnSettled, shouldRefetch } = useNotifyDataReady({
+  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/runs/commands_links',
     options,
   })
 
-  const httpResponse = useAllCommandsQuery(runId, params, {
-    ...options,
-    enabled: options?.enabled !== false && shouldRefetch,
-    onSettled: notifyOnSettled,
-  })
+  const httpQueryResult = useAllCommandsQuery(runId, params, queryOptionsNotify)
 
-  return httpResponse
+  if (shouldRefetch) {
+    void httpQueryResult.refetch()
+  }
+
+  return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyAllRunsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllRunsQuery.ts
@@ -14,30 +14,21 @@ export function useNotifyAllRunsQuery(
   options: QueryOptionsWithPolling<UseAllRunsQueryOptions, AxiosError> = {},
   hostOverride?: HostConfig | null
 ): UseQueryResult<Runs, AxiosError> {
-  const {
-    notifyOnSettled,
-    shouldRefetch,
-    isNotifyEnabled,
-  } = useNotifyDataReady({
+  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
     topic: 'robot-server/runs',
     options,
     hostOverride,
   })
 
-  const queryOptions = {
-    ...options,
-    onSettled: isNotifyEnabled ? notifyOnSettled : options.onSettled,
-    refetchInterval: isNotifyEnabled ? false : options.refetchInterval,
-  }
-  const httpResponse = useAllRunsQuery(
+  const httpQueryResult = useAllRunsQuery(
     params,
-    queryOptions as UseAllRunsQueryOptions,
+    queryOptionsNotify as UseAllRunsQueryOptions,
     hostOverride
   )
 
-  if (isNotifyEnabled && shouldRefetch) {
-    httpResponse.refetch()
+  if (shouldRefetch) {
+    void httpQueryResult.refetch()
   }
 
-  return httpResponse
+  return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -7,32 +7,22 @@ import type { Run, HostConfig } from '@opentrons/api-client'
 import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
 import type { NotifyTopic } from '../../redux/shell/types'
 
-// TODO(jh, 08-21-24): Abstract harder.
 export function useNotifyRunQuery<TError = Error>(
   runId: string | null,
   options: QueryOptionsWithPolling<Run, TError> = {},
   hostOverride?: HostConfig | null
 ): UseQueryResult<Run, TError> {
-  const {
-    notifyOnSettled,
-    shouldRefetch,
-    isNotifyEnabled,
-  } = useNotifyDataReady({
+  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
     topic: `robot-server/runs/${runId}` as NotifyTopic,
     options,
     hostOverride,
   })
 
-  const queryOptions = {
-    ...options,
-    onSettled: isNotifyEnabled ? notifyOnSettled : options.onSettled,
-    refetchInterval: isNotifyEnabled ? false : options.refetchInterval,
-  }
-  const httpResponse = useRunQuery(runId, queryOptions, hostOverride)
+  const httpQueryResult = useRunQuery(runId, queryOptionsNotify, hostOverride)
 
-  if (isNotifyEnabled && shouldRefetch) {
-    httpResponse.refetch()
+  if (shouldRefetch) {
+    void httpQueryResult.refetch()
   }
 
-  return httpResponse
+  return httpQueryResult
 }


### PR DESCRIPTION
Closes [EXEC-696](https://opentrons.atlassian.net/browse/EXEC-696)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In https://github.com/Opentrons/opentrons/pull/16084, it was noted in the TODO section that we should clean up the notification hooks, and make ALL the notification hooks use the newer logic that was introduced in that PR. In order to give ourselves as much time as possible for testing these networking changes, the plan is to get them into `edge` now. That being said, these really aren't that risky.

This PR does just that: migrate the remaining app notification hooks to the new refetch logic. Also, the `useNotifyDataReady` abstraction was starting to leak a bit, so this PR tightens it up.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Smoke tested both the app and ODD on notifications.
- Smoke tested both the app and ODD on the fallback polling logic.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
mediumish? these changes are partially implemented already, but with networking refactors, it would be good to dogfood this as long as we can!
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-696]: https://opentrons.atlassian.net/browse/EXEC-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ