### PR TITLE
fix(robot-server): ignore trailing empty lines in csv rtps

### DIFF
--- a/api/src/opentrons/protocols/parameters/csv_parameter_interface.py
+++ b/api/src/opentrons/protocols/parameters/csv_parameter_interface.py
@@ -84,4 +84,7 @@ class CSVParameter:
                 rows.append(row)
         except (UnicodeDecodeError, csv.Error):
             raise ParameterValueError("Cannot parse provided CSV contents.")
+        # Remove any trailing empty rows at the end of the parsed rows
+        while rows and rows[-1] == []:
+            rows.pop()
         return rows

--- a/api/src/opentrons/protocols/parameters/csv_parameter_interface.py
+++ b/api/src/opentrons/protocols/parameters/csv_parameter_interface.py
@@ -85,6 +85,11 @@ class CSVParameter:
         except (UnicodeDecodeError, csv.Error):
             raise ParameterValueError("Cannot parse provided CSV contents.")
         # Remove any trailing empty rows at the end of the parsed rows
+        return self._remove_trailing_empty_rows(rows)
+
+    @staticmethod
+    def _remove_trailing_empty_rows(rows: List[List[str]]) -> List[List[str]]:
+        """Removes any trailing empty rows."""
         while rows and rows[-1] == []:
             rows.pop()
         return rows

--- a/api/src/opentrons/protocols/parameters/csv_parameter_interface.py
+++ b/api/src/opentrons/protocols/parameters/csv_parameter_interface.py
@@ -84,7 +84,6 @@ class CSVParameter:
                 rows.append(row)
         except (UnicodeDecodeError, csv.Error):
             raise ParameterValueError("Cannot parse provided CSV contents.")
-        # Remove any trailing empty rows at the end of the parsed rows
         return self._remove_trailing_empty_rows(rows)
 
     @staticmethod

--- a/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
+++ b/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
@@ -180,7 +180,9 @@ def test_csv_parameter_trailing_empties(
     csv_file_fixture: str,
 ) -> None:
     """It should load the rows as all strings.  Empty rows are allowed in the middle of the data but all trailing empty rows are removed."""
-    # Get the fixture value (tuple of bytes and expected output)
+    # Get the fixture value
+    csv_file: bytes
+    expected_output: List[List[str]]
     csv_file, expected_output = request.getfixturevalue(csv_file_fixture)
 
     subject = CSVParameter(csv_file, api_version)

--- a/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
+++ b/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
@@ -179,7 +179,7 @@ def test_csv_parameter_trailing_empties(
     request: pytest.FixtureRequest,
     csv_file_fixture: str,
 ) -> None:
-    """It should load the rows as all strings.  Empty rows are allowed in the middle if the data but all trailing empty rows are removed."""
+    """It should load the rows as all strings.  Empty rows are allowed in the middle of the data but all trailing empty rows are removed."""
     # Get the fixture value (tuple of bytes and expected output)
     csv_file, expected_output = request.getfixturevalue(csv_file_fixture)
 

--- a/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
+++ b/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
@@ -62,6 +62,12 @@ def csv_file_empty_row_and_trailing_empty() -> bytes:
     return b'"x","y","z"\n\n"b",3,4\n"c",5,6\n'
 
 
+@pytest.fixture
+def csv_file_windows_empty_row_trailing_empty() -> bytes:
+    """A basic CSV file with quotes around strings."""
+    return b'"x","y","z"\r\n\r\n"b",3,4\r\n"c",5,6\r\n'
+
+
 def test_csv_parameter(
     decoy: Decoy, api_version: APIVersion, csv_file_basic: bytes
 ) -> None:
@@ -151,6 +157,7 @@ def test_csv_parameter_dont_detect_dialect(
         lazy_fixture("csv_file_basic_trailing_empty"),
         lazy_fixture("csv_file_basic_three_trailing_empty"),
         lazy_fixture("csv_file_empty_row_and_trailing_empty"),
+        lazy_fixture("csv_file_windows_empty_row_trailing_empty"),
     ],
 )
 def test_csv_parameter_trailing_empties(
@@ -160,5 +167,4 @@ def test_csv_parameter_trailing_empties(
 ) -> None:
     """It should load the rows as all strings even with no quotes or leading spaces."""
     subject = CSVParameter(csv_file, api_version)
-
     assert len(subject.parse_as_csv()) == 4

--- a/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
+++ b/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
@@ -179,7 +179,7 @@ def test_csv_parameter_trailing_empties(
     request: pytest.FixtureRequest,
     csv_file_fixture: str,
 ) -> None:
-    """It should load the rows as all strings even with no quotes or leading spaces."""
+    """It should load the rows as all strings.  Empty rows are allowed in the middle if the data but all trailing empty rows are removed."""
     # Get the fixture value (tuple of bytes and expected output)
     csv_file, expected_output = request.getfixturevalue(csv_file_fixture)
 

--- a/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
+++ b/api/tests/opentrons/protocols/parameters/test_csv_parameter_interface.py
@@ -44,6 +44,24 @@ def csv_file_different_delimiter() -> bytes:
     return b"x:y:z\na,:1,:2\nb,:3,:4\nc,:5,:6"
 
 
+@pytest.fixture
+def csv_file_basic_trailing_empty() -> bytes:
+    """A basic CSV file with quotes around strings."""
+    return b'"x","y","z"\n"a",1,2\n"b",3,4\n"c",5,6\n'
+
+
+@pytest.fixture
+def csv_file_basic_three_trailing_empty() -> bytes:
+    """A basic CSV file with quotes around strings."""
+    return b'"x","y","z"\n"a",1,2\n"b",3,4\n"c",5,6\n\n\n'
+
+
+@pytest.fixture
+def csv_file_empty_row_and_trailing_empty() -> bytes:
+    """A basic CSV file with quotes around strings."""
+    return b'"x","y","z"\n\n"b",3,4\n"c",5,6\n'
+
+
 def test_csv_parameter(
     decoy: Decoy, api_version: APIVersion, csv_file_basic: bytes
 ) -> None:
@@ -125,3 +143,22 @@ def test_csv_parameter_dont_detect_dialect(
 
     assert rows[0] == ["x", ' "y"', ' "z"']
     assert rows[1] == ["a", " 1", " 2"]
+
+
+@pytest.mark.parametrize(
+    "csv_file",
+    [
+        lazy_fixture("csv_file_basic_trailing_empty"),
+        lazy_fixture("csv_file_basic_three_trailing_empty"),
+        lazy_fixture("csv_file_empty_row_and_trailing_empty"),
+    ],
+)
+def test_csv_parameter_trailing_empties(
+    decoy: Decoy,
+    api_version: APIVersion,
+    csv_file: bytes,
+) -> None:
+    """It should load the rows as all strings even with no quotes or leading spaces."""
+    subject = CSVParameter(csv_file, api_version)
+
+    assert len(subject.parse_as_csv()) == 4


### PR DESCRIPTION
# Overview

<https://opentrons.atlassian.net/browse/RQA-3134>

> Since it’s commonplace to put an empty line at the end of a file, parse_as_csv() should ignore such lines.

## Test Plan and Hands on Testing

Unit tests cover the scenarios.  Will test actual CSV file in bug verification on the next alpha.

## Risk assessment

- Low other than this deviates from how the standard library `csv.reader` behaves.
