### PR TITLE
fix(app): display correct pipette configuration names in run preview

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -8,7 +8,7 @@
   "closing_tc_lid": "Closing Thermocycler lid",
   "comment": "Comment",
   "configure_for_volume": "Configure {{pipette}} to aspirate {{volume}} µL",
-  "configure_nozzle_layout": "Configure {{pipette}} to use {{amount}} nozzles",
+  "configure_nozzle_layout": "Configure {{pipette}} to use {{layout}}",
   "confirm_and_resume": "Confirm and resume",
   "deactivate_hs_shake": "Deactivating shaker",
   "deactivate_temperature_module": "Deactivating Temperature Module",

--- a/app/src/molecules/Command/hooks/useCommandTextString/utils/getConfigureNozzleLayoutCommandText.ts
+++ b/app/src/molecules/Command/hooks/useCommandTextString/utils/getConfigureNozzleLayoutCommandText.ts
@@ -13,6 +13,7 @@ export function getConfigureNozzleLayoutCommandText({
     pip => pip.id === pipetteId
   )?.pipetteName
 
+  // TODO(cb, 2024-09-10): confirm these strings for copy consistency and add them to i18n
   const ConfigAmount = {
     SINGLE: 'single nozzle layout',
     COLUMN: 'column layout',

--- a/app/src/molecules/Command/hooks/useCommandTextString/utils/getConfigureNozzleLayoutCommandText.ts
+++ b/app/src/molecules/Command/hooks/useCommandTextString/utils/getConfigureNozzleLayoutCommandText.ts
@@ -13,8 +13,16 @@ export function getConfigureNozzleLayoutCommandText({
     pip => pip.id === pipetteId
   )?.pipetteName
 
+  const ConfigAmount = {
+    SINGLE: '1',
+    COLUMN: '8',
+    ROW: '12',
+    QUADRANT: 'partial',
+    ALL: 'all',
+  }
+
   return t('configure_nozzle_layout', {
-    amount: configurationParams.style === 'SINGLE' || 'ROW' || 'COLUMN' || 'PARTIAL_COLUMN' ? '8' : 'all',
+    amount: ConfigAmount[configurationParams.style],
     pipette:
       pipetteName != null ? getPipetteSpecsV2(pipetteName)?.displayName : '',
   })

--- a/app/src/molecules/Command/hooks/useCommandTextString/utils/getConfigureNozzleLayoutCommandText.ts
+++ b/app/src/molecules/Command/hooks/useCommandTextString/utils/getConfigureNozzleLayoutCommandText.ts
@@ -14,7 +14,7 @@ export function getConfigureNozzleLayoutCommandText({
   )?.pipetteName
 
   return t('configure_nozzle_layout', {
-    amount: configurationParams.style === 'COLUMN' ? '8' : 'all',
+    amount: configurationParams.style === 'SINGLE' || 'ROW' || 'COLUMN' || 'PARTIAL_COLUMN' ? '8' : 'all',
     pipette:
       pipetteName != null ? getPipetteSpecsV2(pipetteName)?.displayName : '',
   })

--- a/app/src/molecules/Command/hooks/useCommandTextString/utils/getConfigureNozzleLayoutCommandText.ts
+++ b/app/src/molecules/Command/hooks/useCommandTextString/utils/getConfigureNozzleLayoutCommandText.ts
@@ -14,15 +14,15 @@ export function getConfigureNozzleLayoutCommandText({
   )?.pipetteName
 
   const ConfigAmount = {
-    SINGLE: '1',
-    COLUMN: '8',
-    ROW: '12',
-    QUADRANT: 'partial',
-    ALL: 'all',
+    SINGLE: 'single nozzle layout',
+    COLUMN: 'column layout',
+    ROW: 'row layout',
+    QUADRANT: 'partial layout',
+    ALL: 'all nozzles',
   }
 
   return t('configure_nozzle_layout', {
-    amount: ConfigAmount[configurationParams.style],
+    layout: ConfigAmount[configurationParams.style],
     pipette:
       pipetteName != null ? getPipetteSpecsV2(pipetteName)?.displayName : '',
   })

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -175,9 +175,10 @@ interface LoadLiquidResult {
 }
 
 export const COLUMN = 'COLUMN'
-const SINGLE = 'SINGLE'
-const ROW = 'ROW'
+export const SINGLE = 'SINGLE'
+export const ROW = 'ROW'
 const QUADRANT = 'QUADRANT'
+export const PARTIAL_COLUMN = 'PARTIAL_COLUMN'
 export const ALL = 'ALL'
 
 export type NozzleConfigurationStyle =
@@ -185,6 +186,7 @@ export type NozzleConfigurationStyle =
   | typeof SINGLE
   | typeof ROW
   | typeof QUADRANT
+  | typeof PARTIAL_COLUMN
   | typeof ALL
 
 interface NozzleConfigurationParams {

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -177,8 +177,7 @@ interface LoadLiquidResult {
 export const COLUMN = 'COLUMN'
 export const SINGLE = 'SINGLE'
 export const ROW = 'ROW'
-const QUADRANT = 'QUADRANT'
-export const PARTIAL_COLUMN = 'PARTIAL_COLUMN'
+export const QUADRANT = 'QUADRANT'
 export const ALL = 'ALL'
 
 export type NozzleConfigurationStyle =
@@ -186,7 +185,6 @@ export type NozzleConfigurationStyle =
   | typeof SINGLE
   | typeof ROW
   | typeof QUADRANT
-  | typeof PARTIAL_COLUMN
   | typeof ALL
 
 interface NozzleConfigurationParams {


### PR DESCRIPTION

# Overview
Covers RQA-3128

Previously we only accepted Column, All, and 8ch configs. This opens the door to cover our newest configurations in the run preview.

## Test Plan and Hands on Testing
Uploa partial tip protocols to a flex utilizing Single, Row, and partial column. Ensure the run preview displays the expected configuration name at each.

## Changelog


## Review requests
Is this the proper way to expand this coverage? We will probably need to do some coverage checking in the future for other areas on the app end that reference the COLUMN type.

## Risk assessment
Low - updates text information on the UI in pattern with existing behavior.