### PR TITLE
fix(api): Restrict 96ch single tip pickup to only support 1000ul

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional, Type, Union
 from typing_extensions import Literal
 
 from opentrons.protocol_engine.errors.exceptions import TipNotAttachedError
+from opentrons.hardware_control.nozzle_manager import NozzleConfigurationType
 
 from ..errors import ErrorOccurrence
 from ..resources import ModelUtils
@@ -131,6 +132,17 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 labware_id=labware_id,
                 well_name=well_name,
             )
+
+            # todo(cb, 2024-09-05): Remove this once we support 50uL single channel pickup on the 96ch
+            if (
+                tip_geometry.volume == 50.0
+                and self._state_view.pipettes.get_channels(pipette_id) == 96
+                and self._state_view.pipettes.get_nozzle_layout_type(pipette_id)
+                == NozzleConfigurationType.SINGLE
+            ):
+                raise NotImplementedError(
+                    "The 96ch Pipette does not current support picking up 50uL tips in a Single Channel pickup configuration."
+                )
         except TipNotAttachedError as e:
             return DefinedErrorData(
                 public=TipPhysicallyMissingError(

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -135,13 +135,13 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
 
             # todo(cb, 2024-09-05): Remove this once we support 50uL single channel pickup on the 96ch
             if (
-                tip_geometry.volume == 50.0
+                (tip_geometry.volume == 50.0 or tip_geometry.volume == 200.0)
                 and self._state_view.pipettes.get_channels(pipette_id) == 96
                 and self._state_view.pipettes.get_nozzle_layout_type(pipette_id)
                 == NozzleConfigurationType.SINGLE
             ):
                 raise NotImplementedError(
-                    "The 96ch Pipette does not current support picking up 50uL tips in a Single Channel pickup configuration."
+                    "The 96ch Pipette does not current support picking up 50uL or 200uL tips in a Single Channel pickup configuration."
                 )
         except TipNotAttachedError as e:
             return DefinedErrorData(


### PR DESCRIPTION

# Overview
This PR should only be merged if it is deemed by hardware testing that allowing the 96ch to pickup 50ul tips in single channel pickup configuration would cause damage or undesired behavior.

This PR introduces a "NotImplementedError" for the specific case mentioned above. All other 96ch configurations support 50ul tips. All 8ch configurations support 50ul tips.

## Test Plan and Hands on Testing
Ensure that no other configuration/tip type pair has been interuppted by this. 
Ensure that we raise an error during analysis

Ensure that we raise an error on robot-side analysis

## Changelog
Introduced a new error case to the engine side pick up tip function.

## Review requests
If hardware testing and QA agree that this is appropriate, feel free to review and merge.

## Risk assessment
Low - forbids a new edge case feature we were introducing.