### PR TITLE
feat(protocol-designer): add base router url for sandbox deploys

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -162,7 +162,7 @@ jobs:
           OT_PD_MIXPANEL_ID: ${{ secrets.OT_PD_MIXPANEL_ID }}
           OT_PD_MIXPANEL_DEV_ID: ${{ secrets.OT_PD_MIXPANEL_DEV_ID }}
         run: |
-          make -C protocol-designer
+          make -C protocol-designer NODE_ENV=development
       - name: 'upload github artifact'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -215,5 +215,7 @@ jobs:
           aws configure set role_arn ${{ secrets.OT_PD_DEPLOY_ROLE }} --profile deploy
           aws configure set source_profile identity --profile deploy
           aws s3 sync ./dist s3://sandbox.designer.opentrons.com/${{ env.OT_BRANCH }} --acl=public-read --profile=deploy
+          # invalidate both sandbox.opentrons.com and www.sandbox.opentrons.com cloudfront caches
           aws cloudfront create-invalidation --distribution-id ${{ secrets.PD_CLOUDFRONT_SANDBOX_DISTRIBUTION_ID }} --paths "/*" --profile deploy
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.PD_CLOUDFRONT_SANDBOX_WWW_DISTRIBUTION_ID }} --paths "/*" --profile deploy
         shell: bash

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -215,4 +215,5 @@ jobs:
           aws configure set role_arn ${{ secrets.OT_PD_DEPLOY_ROLE }} --profile deploy
           aws configure set source_profile identity --profile deploy
           aws s3 sync ./dist s3://sandbox.designer.opentrons.com/${{ env.OT_BRANCH }} --acl=public-read --profile=deploy
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.PD_CLOUDFRONT_SANDBOX_DISTRIBUTION_ID }} --paths "/*" --profile deploy
         shell: bash

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -124,7 +124,7 @@ jobs:
         run: make -C protocol-designer test-e2e
   build-pd:
     name: 'build protocol designer artifact'
-    # needs: ['js-unit-test'] uncomment this before undrafting PR
+    needs: ['js-unit-test']
     runs-on: 'ubuntu-22.04'
     if: github.event_name != 'pull_request'
     steps:
@@ -171,7 +171,7 @@ jobs:
   deploy-pd:
     name: 'deploy PD artifact to S3'
     runs-on: 'ubuntu-22.04'
-    needs: ['build-pd'] # revert this before undrafting PR
+    needs: ['js-unit-test', 'build-pd']
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v3'

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -124,7 +124,7 @@ jobs:
         run: make -C protocol-designer test-e2e
   build-pd:
     name: 'build protocol designer artifact'
-    needs: ['js-unit-test']
+    # needs: ['js-unit-test'] uncomment this before undrafting PR
     runs-on: 'ubuntu-22.04'
     if: github.event_name != 'pull_request'
     steps:
@@ -171,7 +171,7 @@ jobs:
   deploy-pd:
     name: 'deploy PD artifact to S3'
     runs-on: 'ubuntu-22.04'
-    needs: ['js-unit-test', 'build-pd']
+    needs: ['build-pd'] # revert this before undrafting PR
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v3'

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -44,7 +44,11 @@ function ProtocolEditorComponent(): JSX.Element {
   const enableRedesign = useSelector(getEnableRedesign)
 
   const prereleaseModeEnabled = flags.PRERELEASE_MODE === true
+
+  const browserRouterProps =
+    routerBaseName != null ? { baseName: routerBaseName } : {}
   console.log({ routerBaseName })
+  console.log({ browserRouterProps })
 
   return (
     <div id="protocol-editor">
@@ -52,9 +56,7 @@ function ProtocolEditorComponent(): JSX.Element {
       {enableRedesign ? (
         <Flex flexDirection={DIRECTION_COLUMN}>
           {prereleaseModeEnabled ? <Bouncing /> : null}
-          <BrowserRouter
-            {...(routerBaseName != null ? { baseName: routerBaseName } : {})}
-          >
+          <BrowserRouter {...browserRouterProps}>
             <ProtocolRoutes />
           </BrowserRouter>
         </Flex>

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -47,8 +47,6 @@ function ProtocolEditorComponent(): JSX.Element {
 
   const browserRouterProps =
     routerBaseName != null ? { baseName: routerBaseName } : {}
-  console.log({ routerBaseName })
-  console.log({ browserRouterProps })
 
   return (
     <div id="protocol-editor">

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -47,6 +47,8 @@ function ProtocolEditorComponent(): JSX.Element {
 
   const browserRouterProps =
     routerBaseName != null ? { baseName: routerBaseName } : {}
+  console.log({ routerBaseName })
+  console.log({ browserRouterProps })
 
   return (
     <div id="protocol-editor">

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -37,7 +37,7 @@ const showGateModal =
 const routerBaseName =
   process.env.NODE_ENV === 'production'
     ? null
-    : window.location.pathname.split('/')[1]
+    : `/${window.location.pathname.split('/')[1]}`
 
 console.log({ routerBaseName })
 

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -39,6 +39,8 @@ const routerBaseName =
     ? null
     : window.location.pathname.split('/')[1]
 
+console.log({ routerBaseName })
+
 function ProtocolEditorComponent(): JSX.Element {
   const flags = useSelector(getFeatureFlagData)
   const enableRedesign = useSelector(getEnableRedesign)
@@ -51,7 +53,9 @@ function ProtocolEditorComponent(): JSX.Element {
       {enableRedesign ? (
         <Flex flexDirection={DIRECTION_COLUMN}>
           {prereleaseModeEnabled ? <Bouncing /> : null}
-          <BrowserRouter {...(routerBaseName != null ? {baseName: routerBaseName} : {})}>
+          <BrowserRouter
+            {...(routerBaseName != null ? { baseName: routerBaseName } : {})}
+          >
             <ProtocolRoutes />
           </BrowserRouter>
         </Flex>

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -29,6 +29,8 @@ import { Bouncing } from './Bouncing'
 import styles from './components/ProtocolEditor.module.css'
 import './css/reset.module.css'
 
+import type { BrowserRouterProps } from 'react-router-dom'
+
 const showGateModal =
   process.env.NODE_ENV === 'production' || process.env.OT_PD_SHOW_GATE
 
@@ -45,8 +47,8 @@ function ProtocolEditorComponent(): JSX.Element {
 
   const prereleaseModeEnabled = flags.PRERELEASE_MODE === true
 
-  const browserRouterProps =
-    routerBaseName != null ? { basdename: routerBaseName } : {}
+  const browserRouterProps: BrowserRouterProps =
+    routerBaseName != null ? { basename: routerBaseName } : {}
 
   return (
     <div id="protocol-editor">

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -32,6 +32,13 @@ import './css/reset.module.css'
 const showGateModal =
   process.env.NODE_ENV === 'production' || process.env.OT_PD_SHOW_GATE
 
+// sandbox urls get deployed to subdirectories in sandbox.designer.opentrons.com/${subFolder}
+// prod urls get deployed to designer.opentrons.com with no subdir, so we don't need to add a base name
+const routerBaseName =
+  process.env.NODE_ENV === 'production'
+    ? ''
+    : window.location.pathname.split('/')[1]
+
 function ProtocolEditorComponent(): JSX.Element {
   const flags = useSelector(getFeatureFlagData)
   const enableRedesign = useSelector(getEnableRedesign)
@@ -44,7 +51,7 @@ function ProtocolEditorComponent(): JSX.Element {
       {enableRedesign ? (
         <Flex flexDirection={DIRECTION_COLUMN}>
           {prereleaseModeEnabled ? <Bouncing /> : null}
-          <BrowserRouter>
+          <BrowserRouter basename={routerBaseName}>
             <ProtocolRoutes />
           </BrowserRouter>
         </Flex>

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -46,9 +46,7 @@ function ProtocolEditorComponent(): JSX.Element {
   const prereleaseModeEnabled = flags.PRERELEASE_MODE === true
 
   const browserRouterProps =
-    routerBaseName != null ? { basename: routerBaseName } : {}
-  console.log({ routerBaseName })
-  console.log({ browserRouterProps })
+    routerBaseName != null ? { basdename: routerBaseName } : {}
 
   return (
     <div id="protocol-editor">

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -36,7 +36,7 @@ const showGateModal =
 // prod urls get deployed to designer.opentrons.com with no subdir, so we don't need to add a base name
 const routerBaseName =
   process.env.NODE_ENV === 'production'
-    ? ''
+    ? null
     : window.location.pathname.split('/')[1]
 
 function ProtocolEditorComponent(): JSX.Element {
@@ -51,7 +51,7 @@ function ProtocolEditorComponent(): JSX.Element {
       {enableRedesign ? (
         <Flex flexDirection={DIRECTION_COLUMN}>
           {prereleaseModeEnabled ? <Bouncing /> : null}
-          <BrowserRouter basename={routerBaseName}>
+          <BrowserRouter {...(routerBaseName != null ? {baseName: routerBaseName} : {})}>
             <ProtocolRoutes />
           </BrowserRouter>
         </Flex>

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -39,13 +39,12 @@ const routerBaseName =
     ? null
     : `/${window.location.pathname.split('/')[1]}`
 
-console.log({ routerBaseName })
-
 function ProtocolEditorComponent(): JSX.Element {
   const flags = useSelector(getFeatureFlagData)
   const enableRedesign = useSelector(getEnableRedesign)
 
   const prereleaseModeEnabled = flags.PRERELEASE_MODE === true
+  console.log({ routerBaseName })
 
   return (
     <div id="protocol-editor">

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -46,7 +46,7 @@ function ProtocolEditorComponent(): JSX.Element {
   const prereleaseModeEnabled = flags.PRERELEASE_MODE === true
 
   const browserRouterProps =
-    routerBaseName != null ? { baseName: routerBaseName } : {}
+    routerBaseName != null ? { basename: routerBaseName } : {}
   console.log({ routerBaseName })
   console.log({ browserRouterProps })
 

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Route, Navigate, Routes } from 'react-router-dom'
+import { Route, Navigate, Routes, useLocation } from 'react-router-dom'
 import { Box } from '@opentrons/components'
 import { Landing } from './pages/Landing'
 import { ProtocolOverview } from './pages/ProtocolOverview'
@@ -15,7 +15,7 @@ import {
 
 import type { RouteProps } from './types'
 
-const LANDING_ROUTE = './'
+const LANDING_ROUTE = '/'
 const pdRoutes: RouteProps[] = [
   {
     Component: ProtocolOverview,
@@ -51,6 +51,9 @@ export function ProtocolRoutes(): JSX.Element {
     path: '/',
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
+  const { pathname } = useLocation()
+  console.log({ pathname })
+  console.log({ rootPath: `/${location.pathname}/${LANDING_ROUTE}` })
 
   return (
     <>
@@ -63,7 +66,12 @@ export function ProtocolRoutes(): JSX.Element {
             {allRoutes.map(({ Component, path }: RouteProps) => {
               return <Route key={path} path={path} element={<Component />} />
             })}
-            <Route path="*" element={<Navigate to={LANDING_ROUTE} />} />
+            <Route
+              path="*"
+              element={
+                <Navigate to={`/${location.pathname}/${LANDING_ROUTE}`} />
+              }
+            />
           </Routes>
         </Box>
       </Kitchen>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -66,10 +66,7 @@ export function ProtocolRoutes(): JSX.Element {
             {allRoutes.map(({ Component, path }: RouteProps) => {
               return <Route key={path} path={path} element={<Component />} />
             })}
-            <Route
-              path="*"
-              element={<Navigate to={"/"} />}
-            />
+            <Route path="*" element={<Navigate to={'/'} />} />
           </Routes>
         </Box>
       </Kitchen>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -52,6 +52,8 @@ export function ProtocolRoutes(): JSX.Element {
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
 
+  console.log('default route backtick slash')
+
   return (
     <>
       <NavigationBar />
@@ -63,7 +65,7 @@ export function ProtocolRoutes(): JSX.Element {
             {allRoutes.map(({ Component, path }: RouteProps) => {
               return <Route key={path} path={path} element={<Component />} />
             })}
-            <Route path="*" element={<Navigate to={landingPage.path} />} />
+            <Route path="*" element={<Navigate to={`/`} />} />
           </Routes>
         </Box>
       </Kitchen>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Route, Navigate, Routes, useLocation } from 'react-router-dom'
+import { Route, Navigate, Routes } from 'react-router-dom'
 import { Box } from '@opentrons/components'
 import { Landing } from './pages/Landing'
 import { ProtocolOverview } from './pages/ProtocolOverview'
@@ -43,7 +43,6 @@ const pdRoutes: RouteProps[] = [
 ]
 
 export function ProtocolRoutes(): JSX.Element {
-  console.log('in protocol routes')
   const landingPage: RouteProps = {
     Component: Landing,
     name: 'Landing',
@@ -51,9 +50,6 @@ export function ProtocolRoutes(): JSX.Element {
     path: '/',
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
-  const { pathname } = useLocation()
-  console.log({ pathname })
-  console.log({ rootPath: location.pathname })
 
   return (
     <>
@@ -66,7 +62,7 @@ export function ProtocolRoutes(): JSX.Element {
             {allRoutes.map(({ Component, path }: RouteProps) => {
               return <Route key={path} path={path} element={<Component />} />
             })}
-            <Route path="*" element={<Navigate to={'/'} />} />
+            <Route path="*" element={<Navigate to={landingPage.path} />} />
           </Routes>
         </Box>
       </Kitchen>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -52,8 +52,7 @@ export function ProtocolRoutes(): JSX.Element {
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
 
-  console.log('default route location.pathname')
-  console.log({ location: location.pathname })
+  console.log('default navigation to root with basename fix')
 
   return (
     <>
@@ -68,7 +67,7 @@ export function ProtocolRoutes(): JSX.Element {
             })}
             <Route
               path="*"
-              element={<Navigate to={`${location.pathname}`} />}
+              element={<Navigate to={`/`} />}
             />
           </Routes>
         </Box>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -15,7 +15,7 @@ import {
 
 import type { RouteProps } from './types'
 
-const LANDING_ROUTE = '/'
+const LANDING_ROUTE = './'
 const pdRoutes: RouteProps[] = [
   {
     Component: ProtocolOverview,

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -43,6 +43,7 @@ const pdRoutes: RouteProps[] = [
 ]
 
 export function ProtocolRoutes(): JSX.Element {
+  console.log('in protocol routes')
   const landingPage: RouteProps = {
     Component: Landing,
     name: 'Landing',

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -68,7 +68,7 @@ export function ProtocolRoutes(): JSX.Element {
             })}
             <Route
               path="*"
-              element={<Navigate to={`${location.pathname}`} />}
+              element={<Navigate to={"/"} />}
             />
           </Routes>
         </Box>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -44,6 +44,7 @@ const pdRoutes: RouteProps[] = [
 ]
 
 export function ProtocolRoutes(): JSX.Element {
+  console.log('in protocol routes')
   const landingPage: RouteProps = {
     Component: Landing,
     name: 'Landing',

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -43,7 +43,6 @@ const pdRoutes: RouteProps[] = [
 ]
 
 export function ProtocolRoutes(): JSX.Element {
-  console.log('in protocol routes')
   const landingPage: RouteProps = {
     Component: Landing,
     name: 'Landing',
@@ -63,10 +62,7 @@ export function ProtocolRoutes(): JSX.Element {
             {allRoutes.map(({ Component, path }: RouteProps) => {
               return <Route key={path} path={path} element={<Component />} />
             })}
-            <Route
-              path="*"
-              element={<Navigate to={`/`} />}
-            />
+            <Route path="*" element={<Navigate to={landingPage.path} />} />
           </Routes>
         </Box>
       </Kitchen>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -15,7 +15,6 @@ import {
 
 import type { RouteProps } from './types'
 
-const LANDING_ROUTE = '/'
 const pdRoutes: RouteProps[] = [
   {
     Component: ProtocolOverview,
@@ -54,7 +53,7 @@ export function ProtocolRoutes(): JSX.Element {
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
   const { pathname } = useLocation()
   console.log({ pathname })
-  console.log({ rootPath: `/${location.pathname}/${LANDING_ROUTE}` })
+  console.log({ rootPath: location.pathname })
 
   return (
     <>
@@ -69,9 +68,7 @@ export function ProtocolRoutes(): JSX.Element {
             })}
             <Route
               path="*"
-              element={
-                <Navigate to={`/${location.pathname}/${LANDING_ROUTE}`} />
-              }
+              element={<Navigate to={`${location.pathname}`} />}
             />
           </Routes>
         </Box>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -52,8 +52,6 @@ export function ProtocolRoutes(): JSX.Element {
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
 
-  console.log('default navigation to root with basename fix')
-
   return (
     <>
       <NavigationBar />

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -52,7 +52,8 @@ export function ProtocolRoutes(): JSX.Element {
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
 
-  console.log('default route backtick slash')
+  console.log('default route location.pathname')
+  console.log({ location: location.pathname })
 
   return (
     <>
@@ -65,7 +66,10 @@ export function ProtocolRoutes(): JSX.Element {
             {allRoutes.map(({ Component, path }: RouteProps) => {
               return <Route key={path} path={path} element={<Component />} />
             })}
-            <Route path="*" element={<Navigate to={`/`} />} />
+            <Route
+              path="*"
+              element={<Navigate to={`${location.pathname}`} />}
+            />
           </Routes>
         </Box>
       </Kitchen>

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -26,9 +26,9 @@ export function Landing(): JSX.Element {
 
   React.useEffect(() => {
     if (metadata?.created != null) {
-      navigate('/overview')
+      console.log('would notmally navigate to /overview')
     } else {
-      navigate('/')
+      console.log('would notmally navigate to /')
     }
   }, [metadata, navigate])
 

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -28,9 +28,8 @@ export function Landing(): JSX.Element {
 
   React.useEffect(() => {
     if (metadata?.created != null) {
-      console.log('would notmally navigate to /overview')
-    } else {
-      console.log('would notmally navigate to /')
+      console.warn('protocol already exists, navigating to overview')
+      navigate('/overview')
     }
   }, [metadata, navigate])
 

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -24,8 +24,6 @@ export function Landing(): JSX.Element {
   const metadata = useSelector(getFileMetadata)
   const navigate = useNavigate()
 
-  console.log('in landing')
-
   React.useEffect(() => {
     if (metadata?.created != null) {
       console.warn('protocol already exists, navigating to overview')

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -24,6 +24,8 @@ export function Landing(): JSX.Element {
   const metadata = useSelector(getFileMetadata)
   const navigate = useNavigate()
 
+  console.log('in landing')
+
   React.useEffect(() => {
     if (metadata?.created != null) {
       console.log('would notmally navigate to /overview')


### PR DESCRIPTION
# Overview

This PR adds a base router url for sandbox deploys. This is so that we preserve the full url route in sandbox builds. Prior to this PR, if you hit `sandbox.designer.opentrons.com/${BRANCH_NAME}`, react router dom would redirect you to `sandbox.designer.opentrons.com/${ROUTE}` instead of `sandbox.designer.opentrons.com/${BRANCH_NAME}/${ROUTE}`

## Changelog

- add base name to router for sandbox artifacts

## Review requests

- make sure sandbox routes are preserved in PD at https://sandbox.designer.opentrons.com/pd_add-base-route-to-router/

## Risk assessment

Medium, but also this isn't in prod yet
