### PR TITLE
fix(app): fix labware location on labware details modal (ODD protocol details)

### DIFF
--- a/app/src/pages/ProtocolDetails/Deck.tsx
+++ b/app/src/pages/ProtocolDetails/Deck.tsx
@@ -71,7 +71,6 @@ export const Deck = (props: { protocolId: string }): JSX.Element => {
       }
     }
   }
-  console.log(selectedLabware)
 
   const selectedLabwareIsTopOfStack = mostRecentAnalysis?.commands.some(
     command =>

--- a/app/src/pages/ProtocolDetails/Deck.tsx
+++ b/app/src/pages/ProtocolDetails/Deck.tsx
@@ -52,18 +52,26 @@ export const Deck = (props: { protocolId: string }): JSX.Element => {
       labware => labware.id === labwareId
     )
     if (foundLabware != null) {
+      const location = onDeckItems.find(
+        item => item.labwareId === foundLabware.id
+      )?.initialLocation
       const nickName = onDeckItems.find(
         item => getLabwareDefURI(item.definition) === foundLabware.definitionUri
       )?.nickName
-      setSelectedLabware({
-        ...labwareDef,
-        location: foundLabware.location,
-        nickName: nickName ?? null,
-        id: labwareId,
-      })
-      setShowLabwareDetailsModal(true)
+      if (location != null) {
+        setSelectedLabware({
+          ...labwareDef,
+          location: location,
+          nickName: nickName ?? null,
+          id: labwareId,
+        })
+        setShowLabwareDetailsModal(true)
+      } else {
+        console.warn('no initial labware location found')
+      }
     }
   }
+  console.log(selectedLabware)
 
   const selectedLabwareIsTopOfStack = mostRecentAnalysis?.commands.some(
     command =>


### PR DESCRIPTION
# Overview

On ODD Protocol Details > Deck tab, we render the protocol deck with clickable labware. Clicking a
labware or stack should render the appropriate modal, whose header should be the location of that
labware or stack. However, similar to how we handle this in Protocol Setup, we need to find the
__initial__ locaiton of the labware at load time, rather than the final location of the labware.
Here, I access that initial location to properly display the slot location icon for labware that is
moved.

Closes [RQA-3149](https://opentrons.atlassian.net/browse/RQA-3149)

## Test Plan and Hands on Testing

- Send a protocol to ODD ([example](https://github.com/user-attachments/files/16898278/Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke.2.py.zip)) and click to open protocol details
- Select 'Deck' tab and verify that deck renders
- Click around on all labware, some of which are moved during the protocol from their initial locations if using the attached protocol. Verify that their initial location displays on the modal header.

https://github.com/user-attachments/assets/022393c5-0f57-4e00-927a-b2df8656e6a8


## Changelog

- get labware location from on deck items (initial load)

## Review requests

- see test plan and check logic

## Risk assessment

low

[RQA-3149]: https://opentrons.atlassian.net/browse/RQA-3149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ