### PR TITLE
fix(app): fix "rerun protocol now" redirection delay

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -134,7 +134,10 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   }
   const trackEvent = useTrackEvent()
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
-  const { reset, isRunControlLoading } = useRunControls(runId, onResetSuccess)
+  const { reset, isResetRunLoading, isRunControlLoading } = useRunControls(
+    runId,
+    onResetSuccess
+  )
   const { deleteRun } = useDeleteRunMutation()
   const robot = useRobot(robotName)
   const robotSerialNumber =
@@ -189,7 +192,18 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
         }
         data-testid="RecentProtocolRun_OverflowMenu_rerunNow"
       >
-        {t('rerun_now')}
+        <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
+          {t('rerun_now')}
+          {isResetRunLoading ? (
+            <Icon
+              name="ot-spinner"
+              size={SIZE_1}
+              color={COLORS.grey50}
+              aria-label="spinner"
+              spin
+            />
+          ) : null}
+        </Flex>
       </MenuItem>
       {isRobotOnWrongVersionOfSoftware && (
         <Tooltip tooltipProps={tooltipProps}>

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -36,13 +36,12 @@ export function useCloneRun(
         'protocols',
         protocolKey,
       ])
-      Promise.all([invalidateRuns, invalidateProtocols])
-        .then(() => {
-          onSuccessCallback?.(response)
-        })
-        .catch((e: Error) => {
-          console.error(`error invalidating runs query: ${e.message}`)
-        })
+      Promise.all([invalidateRuns, invalidateProtocols]).catch((e: Error) => {
+        console.error(`error invalidating runs query: ${e.message}`)
+      })
+      // The onSuccess callback is not awaited until query invalidation, because currently, in every instance this
+      // onSuccessCallback is utilized, we only use it for navigating. We may need to revisit this.
+      onSuccessCallback?.(response)
     },
   })
   const { createProtocolAnalysis } = useCreateProtocolAnalysisMutation(


### PR DESCRIPTION
Closes [RQA-3152](https://opentrons.atlassian.net/browse/RQA-3152)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In #16094, it was thought that invoking the `onSuccess` callback without awaiting the query invalidation was probably a mistake, but turns out, it did do something: the "rerun protocol now" button in `HistoricalProtocolRunOverflowMenu` does not have a loading state, so it's a bit confusing when a user clicks the button and isn't near-immediately redirected. 

To fix this, let's just revert the changes from earlier (this time with an explanatory comment), and also add a runner spinner when "rerun protocol now" is clicked, since the redirect may take some time.

This problem really isn't that noticeable on the Flex, but it's quite noticeable on the OT-2, so the desire to eagerly route here makes sense.

### Current Behavior

https://github.com/user-attachments/assets/05a859b0-1d5c-461d-9abf-a437745543cc

### Fixed behavior

https://github.com/user-attachments/assets/88d57930-abbe-49e1-a0eb-d51972dac54e


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
- Verified that the spots in the app/ODD that make use of `useCloneRun` / `reset` in `runControls` are not affected by the change.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the app taking a while to direct users to the protocol run after clicking "rerun protocol now".
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3152]: https://opentrons.atlassian.net/browse/RQA-3152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ