### PR TITLE
fix(app): Don't initialize the keyboard with an invalid value when creating Quick Transfer protocols.

### DIFF
--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
@@ -205,7 +205,7 @@ export function AirGap(props: AirGapProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
-              initialValue={String(volume)}
+              initialValue={String(volume ?? '')}
               onChange={e => {
                 setVolume(Number(e))
               }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
@@ -222,6 +222,7 @@ export function Delay(props: DelayProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
+              initialValue={String(delayDuration ?? '')}
               onChange={e => {
                 setDelayDuration(Number(e))
               }}
@@ -262,7 +263,7 @@ export function Delay(props: DelayProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
-              initialValue={String(position)}
+              initialValue={String(position ?? '')}
               onChange={e => {
                 setPosition(Number(e))
               }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
@@ -141,7 +141,7 @@ export function FlowRateEntry(props: FlowRateEntryProps): JSX.Element {
         >
           <NumericalKeyboard
             keyboardRef={keyboardRef}
-            initialValue={String(flowRate)}
+            initialValue={String(flowRate ?? '')}
             onChange={e => {
               setFlowRate(Number(e))
             }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
@@ -202,7 +202,7 @@ export function Mix(props: MixProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
-              initialValue={String(mixVolume)}
+              initialValue={String(mixVolume ?? '')}
               onChange={e => {
                 setMixVolume(Number(e))
               }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -200,7 +200,7 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
-              initialValue={String(disposalVolume)}
+              initialValue={String(disposalVolume ?? '')}
               onChange={e => {
                 setDisposalVolume(Number(e))
               }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
@@ -132,7 +132,7 @@ export function TipPositionEntry(props: TipPositionEntryProps): JSX.Element {
         >
           <NumericalKeyboard
             keyboardRef={keyboardRef}
-            initialValue={String(tipPosition)}
+            initialValue={String(tipPosition ?? '')}
             onChange={e => {
               setTipPosition(Number(e))
             }}

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
@@ -194,7 +194,7 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
-              initialValue={String(position)}
+              initialValue={String(position ?? '')}
               onChange={e => {
                 setPosition(Number(e))
               }}


### PR DESCRIPTION
# Overview

Pull request [Opentrons/opentrons#16147](https://github.com/Opentrons/opentrons/pull/16147) fixed an issue where the keyboard was not aware of the value seen on the input box, so you could not delete the initial value until you selected a value with the keyboard. While this fixed the problem it caused an issue where we were initializing the keyboard value with the string `"null"` because we were not checking the value before casting to a string. This pull request fixes this problem.

Closes: [RQA-3144](https://opentrons.atlassian.net/browse/RQA-3144)

## Test Plan and Hands on Testing

- [x] Test all the Advanced Settings options and make sure we can input a value for all of them.
- [x] Test all the Advanced Settings options with initial values and that they can be changed with the keyboard.
- [x] Test all the Advanced Settings options with initial values and that they can be deleted with the keyboard.

## Changelog

- Check that the option value is not `null` before casting to string.
- Add the initial keyboard value to the repeat settings of the Delay component.

## Review requests

Am I missing something?

## Risk assessment

low, unreleased

[RQA-3146]: https://opentrons.atlassian.net/browse/RQA-3146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-3144]: https://opentrons.atlassian.net/browse/RQA-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ