### PR TITLE
fix(app): Fix scrolling behind long press modals

### DIFF
--- a/app/src/atoms/MenuList/index.tsx
+++ b/app/src/atoms/MenuList/index.tsx
@@ -8,6 +8,8 @@ import {
   BORDERS,
   JUSTIFY_CENTER,
 } from '@opentrons/components'
+import { createPortal } from 'react-dom'
+import { getTopPortalEl } from '../../App/portal'
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 
 interface MenuListProps {
@@ -19,19 +21,22 @@ interface MenuListProps {
 export const MenuList = (props: MenuListProps): JSX.Element | null => {
   const { children, isOnDevice = false, onClick = null } = props
   return isOnDevice && onClick != null ? (
-    <LegacyModalShell
-      borderRadius={BORDERS.borderRadius16}
-      width="max-content"
-      onOutsideClick={onClick}
-    >
-      <Flex
-        boxShadow={BORDERS.shadowSmall}
-        flexDirection={DIRECTION_COLUMN}
-        justifyContent={JUSTIFY_CENTER}
+    createPortal(
+      <LegacyModalShell
+        borderRadius={BORDERS.borderRadius16}
+        width="max-content"
+        onOutsideClick={onClick}
       >
-        {children}
-      </Flex>
-    </LegacyModalShell>
+        <Flex
+          boxShadow={BORDERS.shadowSmall}
+          flexDirection={DIRECTION_COLUMN}
+          justifyContent={JUSTIFY_CENTER}
+        >
+          {children}
+        </Flex>
+      </LegacyModalShell>,
+      getTopPortalEl()
+    )
   ) : (
     <Flex
       borderRadius="4px 4px 0px 0px"


### PR DESCRIPTION
fix RQA-3139
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
On both protocol details and now quick transfer on ODD, if you have enough protocols for the page to be scrollable, you are able to scroll the long press modal and overlay out of view when it is open. This has likely been the case on the protocols page since this change https://github.com/Opentrons/opentrons/pull/15166
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
On ODD, look at protocol tab and long press a protocol. See that the page is locked and you can't scroll the background. Repeat for quick transfer tab
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Put the `LegacyModalShell` in a top level portal where used in `MenuList` which is the container for the long press modals
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick code check, I tested this out
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
