### PR TITLE
fix(app): fix browser layer notification error handling

### DIFF
--- a/app/src/resources/useNotifyDataReady.ts
+++ b/app/src/resources/useNotifyDataReady.ts
@@ -74,7 +74,7 @@ export function useNotifyDataReady<TData, TError = Error>({
       setRefetch('once')
       appShellListener({
         hostname,
-        topic,
+        notifyTopic: topic,
         callback: onDataEvent,
       })
       dispatch(notifySubscribeAction(hostname, topic))
@@ -87,7 +87,7 @@ export function useNotifyDataReady<TData, TError = Error>({
       if (seenHostname.current != null) {
         appShellListener({
           hostname: seenHostname.current,
-          topic,
+          notifyTopic: topic,
           callback: onDataEvent,
           isDismounting: true,
         })


### PR DESCRIPTION
Closes [RQA-3108](https://opentrons.atlassian.net/browse/RQA-3108) (for the third time)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes an issue in which browser layer error messages were dropped. The app shell sends MQTT error event messages on the `ALL_TOPICS` topic, but browser layer callbacks do not ever subscribe to the `ALL_TOPICS` topic, just their individual topic. This means when the app receives a disconnect event that is applicable to all topics, those topics do not default back to polling.

We know this fixes the ticket (all of the prior fixes are valid for this specific issue, too!), because you can see the error message at `2024-09-05T18:57:34.783Z` in the Windows App Logs (attached in the ticket). The app, however, never defaults to polling, as evidence by the lack of network requests in the server logs after this time (only the ODD network requests show up). 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
CURRENT BEHAVIOR REPRO
- On the built version of the desktop app (or any other branch -- much easier to do this on the desktop than the ODD), run a protocol with a manual move, such as [this one](https://github.com/user-attachments/files/16910564/manual_move_then_gripper_move.py.zip). 
- Once at the manual move step, SSH into the robot and do a `systemctl stop mosquitto`. 
- Verify in the app-shell that the `Error - Error: read ECONNRESET` message appears.
- Click continue on the manual move modal.
- You'll see the modal never dissapears.

PR FIX VALDIATION
- After switching to this branch, FULLY close out of the app and re-open(need to do this based on how notification connectivity works).
- Perform the above sequence of steps.
- After clicking continue, you should see the modal disappear!

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the desktop/app not falling back to polling in some spots.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- lowish. It's networking, which is always scary, but the fix is quite localized.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3108]: https://opentrons.atlassian.net/browse/RQA-3108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ