### PR TITLE
fix(app): ApiHostProvider in protocols page run

### DIFF
--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -320,7 +320,7 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
       runCreatedAt: '2022-05-11T13:33:51.012179+00:00',
     }
     when(vi.mocked(useOffsetCandidatesForAnalysis))
-      .calledWith(storedProtocolDataFixture.mostRecentAnalysis, '127.0.0.1')
+      .calledWith(storedProtocolDataFixture.mostRecentAnalysis, null)
       .thenReturn([mockOffsetCandidate])
     vi.mocked(getConnectableRobots).mockReturnValue([
       mockConnectableRobot,
@@ -333,7 +333,7 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     })
     expect(vi.mocked(useCreateRunFromProtocol)).toHaveBeenCalledWith(
       expect.any(Object),
-      { hostname: '127.0.0.1' },
+      null,
       [
         {
           vector: mockOffsetCandidate.vector,
@@ -369,11 +369,8 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
       runCreatedAt: '2022-05-11T13:33:51.012179+00:00',
     }
     when(vi.mocked(useOffsetCandidatesForAnalysis))
-      .calledWith(storedProtocolDataFixture.mostRecentAnalysis, '127.0.0.1')
+      .calledWith(storedProtocolDataFixture.mostRecentAnalysis, null)
       .thenReturn([mockOffsetCandidate])
-    when(vi.mocked(useOffsetCandidatesForAnalysis))
-      .calledWith(storedProtocolDataFixture.mostRecentAnalysis, 'otherIp')
-      .thenReturn([])
     vi.mocked(getConnectableRobots).mockReturnValue([
       mockConnectableRobot,
       { ...mockConnectableRobot, name: 'otherRobot', ip: 'otherIp' },
@@ -393,10 +390,9 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     })
     fireEvent.click(proceedButton)
     fireEvent.click(screen.getByRole('button', { name: 'Confirm values' }))
-    expect(vi.mocked(useCreateRunFromProtocol)).nthCalledWith(
-      3,
+    expect(vi.mocked(useCreateRunFromProtocol)).toHaveBeenLastCalledWith(
       expect.any(Object),
-      { hostname: '127.0.0.1' },
+      null,
       [
         {
           vector: mockOffsetCandidate.vector,
@@ -404,11 +400,6 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
           definitionUri: mockOffsetCandidate.definitionUri,
         },
       ]
-    )
-    expect(vi.mocked(useCreateRunFromProtocol)).toHaveBeenLastCalledWith(
-      expect.any(Object),
-      { hostname: 'otherIp' },
-      []
     )
   })
 

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -100,7 +100,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     null
   )
 
-  const { uploadCsvFile } = useUploadCsvFileMutation({}, {})
+  const { uploadCsvFile } = useUploadCsvFileMutation()
 
   const {
     createRunFromProtocolSource,

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -16,7 +16,10 @@ import {
   SPACING,
   useHoverTooltip,
 } from '@opentrons/components'
-import { useUploadCsvFileMutation } from '@opentrons/react-api-client'
+import {
+  useUploadCsvFileMutation,
+  ApiHostProvider,
+} from '@opentrons/react-api-client'
 
 import { Tooltip } from '../../atoms/Tooltip'
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
@@ -46,11 +49,23 @@ interface ChooseRobotToRunProtocolSlideoutProps extends StyleProps {
   showSlideout: boolean
 }
 
+interface ChooseRobotToRunProtocolSlideoutComponentProps
+  extends ChooseRobotToRunProtocolSlideoutProps {
+  selectedRobot: Robot | null
+  setSelectedRobot: (robot: Robot | null) => void
+}
+
 export function ChooseRobotToRunProtocolSlideoutComponent(
-  props: ChooseRobotToRunProtocolSlideoutProps
+  props: ChooseRobotToRunProtocolSlideoutComponentProps
 ): JSX.Element | null {
   const { t } = useTranslation(['protocol_details', 'shared', 'app_settings'])
-  const { storedProtocolData, showSlideout, onCloseClick } = props
+  const {
+    storedProtocolData,
+    showSlideout,
+    onCloseClick,
+    selectedRobot,
+    setSelectedRobot,
+  } = props
   const navigate = useNavigate()
   const [shouldApplyOffsets, setShouldApplyOffsets] = React.useState<boolean>(
     true
@@ -62,7 +77,6 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     mostRecentAnalysis,
   } = storedProtocolData
   const [currentPage, setCurrentPage] = React.useState<number>(1)
-  const [selectedRobot, setSelectedRobot] = React.useState<Robot | null>(null)
   const { trackCreateProtocolRunEvent } = useTrackCreateProtocolRunEvent(
     storedProtocolData,
     selectedRobot?.name ?? ''
@@ -83,19 +97,10 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
 
   const offsetCandidates = useOffsetCandidatesForAnalysis(
     mostRecentAnalysis,
-    selectedRobot?.ip ?? null
+    null
   )
 
-  const { uploadCsvFile } = useUploadCsvFileMutation(
-    {},
-    selectedRobot != null
-      ? {
-          hostname: selectedRobot.ip,
-          requestor:
-            selectedRobot?.ip === OPENTRONS_USB ? appShellRequestor : undefined,
-        }
-      : null
-  )
+  const { uploadCsvFile } = useUploadCsvFileMutation({}, {})
 
   const {
     createRunFromProtocolSource,
@@ -121,13 +126,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
         })
       },
     },
-    selectedRobot != null
-      ? {
-          hostname: selectedRobot.ip,
-          requestor:
-            selectedRobot?.ip === OPENTRONS_USB ? appShellRequestor : undefined,
-        }
-      : null,
+    null,
     shouldApplyOffsets
       ? offsetCandidates.map(({ vector, location, definitionUri }) => ({
           vector,
@@ -360,5 +359,18 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
 export function ChooseRobotToRunProtocolSlideout(
   props: ChooseRobotToRunProtocolSlideoutProps
 ): JSX.Element | null {
-  return <ChooseRobotToRunProtocolSlideoutComponent {...props} />
+  const [selectedRobot, setSelectedRobot] = React.useState<Robot | null>(null)
+  return (
+    <ApiHostProvider
+      hostname={selectedRobot?.ip ?? null}
+      port={selectedRobot?.port ?? null}
+      requestor={
+        selectedRobot?.ip === OPENTRONS_USB ? appShellRequestor : undefined
+      }
+    >
+      <ChooseRobotToRunProtocolSlideoutComponent
+        {...{ ...props, selectedRobot, setSelectedRobot }}
+      />
+    </ApiHostProvider>
+  )
 }


### PR DESCRIPTION
So, we indicate that a robot is connected via USB by setting its ip to 'opentrons-usb'. However, this doesn't do anything on its own, beyond making http requests to http://opentrons-usb:31950 fail in a funny way. It only works if you're making a request inside a mounted <ApiHostProvider> component, which will provide a react context provider for all the useHost hooks mounted underneath it to go look up the right request function to use.

This generally works on anything under the devices page. Where it most certainly didn't work was anything under the Protocols page, including the CHooseRobotToRunProtocolSlideout component, which is the menu you get when you start a protocol from the protocols page.

This only wasn't _comprehensively_ broken because at various times various people had noticed the problem for various HTTP requests and added a specific host override to the mutations used there... but nobody had gotten around to doing that for the queries that get old runs and scrape LPC data for them, and therefore that would never happen.

Instead, let's put an ApiHostProvider with the appropriate parameters over the component, rip out the per-query/per-mutation host overries, and have them all work through the magic of nonlocal state.

Closes RQA-2723
