### PR TITLE
fix(protocol-designer): fix style of `LiquidsOverflowMenu`

### DIFF
--- a/protocol-designer/src/pages/Designer/LiquidsOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/LiquidsOverflowMenu.tsx
@@ -73,7 +73,9 @@ export function LiquidsOverflowMenu(
           </MenuButton>
         )
       })}
-      <Box width="100%" border={`1px solid ${COLORS.grey20}`} />
+      {liquids.length > 0 ? (
+        <Box width="100%" border={`1px solid ${COLORS.grey20}`} />
+      ) : null}
       <MenuButton
         data-testid="defineLiquid"
         onClick={() => {
@@ -98,6 +100,7 @@ const MenuButton = styled.button`
   cursor: pointer;
   padding: ${SPACING.spacing8} ${SPACING.spacing12};
   border: none;
+  border-radius: inherit;
   &:hover {
     background-color: ${COLORS.blue10};
   }


### PR DESCRIPTION
# Overview

Update style of floating LiquidsOverflowMenu rendered by clicking "Liquids" in protocol edit view. `MenuButton` inherits border radius from parent, and the Divider only shows if custom liquids have been added.

## Test Plan and Hands on Testing

- Create protocol and select to 'Edit protocol'
- Click `Liquids` button
- Verify that dropdown menu does not show a divider above "Define a liquid" and hovering maintains border radius
- Add at least two liquids and verify that divider shows only above "Define a liquid"

#### Before fix

<img width="195" alt="Screenshot 2024-09-09 at 9 49 22 AM" src="https://github.com/user-attachments/assets/d33346a1-f56c-4a46-8109-99eec76a4ef7">

#### After fix

<img width="194" alt="Screenshot 2024-09-09 at 9 25 57 AM" src="https://github.com/user-attachments/assets/373ee341-5ee6-458a-8ada-5336791b929e">

<img width="195" alt="Screenshot 2024-09-09 at 9 12 49 AM" src="https://github.com/user-attachments/assets/a8a049fa-8ef5-420f-bb63-47f586c10aea">


## Changelog

- on `MenuItem`, inherit border radius from parent
- conditionally render divider if at least one liquid has been added

## Review requests

see test plan

## Risk assessment

low