### PR TITLE
fix(app): fix undismissable calibration modals after e-stop event

### DIFF
--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -120,12 +120,13 @@ export function GripperWizardFlows(
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)
 
   const handleClose = (): void => {
-    if (props?.onComplete != null) props.onComplete()
+    if (props?.onComplete != null) {
+      props.onComplete()
+    }
     if (maintenanceRunData != null) {
       deleteMaintenanceRun(maintenanceRunData?.data.id)
-    } else {
-      closeFlow()
     }
+    closeFlow()
   }
 
   const {
@@ -141,19 +142,20 @@ export function GripperWizardFlows(
   })
 
   const handleCleanUpAndClose = (): void => {
-    if (maintenanceRunData?.data.id == null) handleClose()
-    else {
+    if (maintenanceRunData?.data.id == null) {
+      handleClose()
+    } else {
       chainRunCommands(
         maintenanceRunData?.data.id,
         [{ commandType: 'home' as const, params: {} }],
         false
       )
-        .then(() => {
-          handleClose()
-        })
         .catch(error => {
           setIsExiting(true)
           setErrorMessage(error.message as string)
+        })
+        .finally(() => {
+          handleClose()
         })
     }
   }

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -182,12 +182,13 @@ export const PipetteWizardFlows = (
     }
   }
   const handleClose = (): void => {
-    if (onComplete != null) onComplete()
+    if (onComplete != null) {
+      onComplete()
+    }
     if (maintenanceRunData != null) {
       deleteMaintenanceRun(maintenanceRunData?.data.id)
-    } else {
-      closeFlow()
     }
+    closeFlow()
   }
 
   const {
@@ -210,12 +211,12 @@ export const PipetteWizardFlows = (
         [{ commandType: 'home' as const, params: {} }],
         false
       )
-        .then(() => {
-          handleClose()
-        })
         .catch(error => {
           setIsExiting(true)
           setShowErrorMessage(error.message as string)
+        })
+        .finally(() => {
+          handleClose()
         })
     }
   }


### PR DESCRIPTION
Closes [RQA-3155](https://opentrons.atlassian.net/browse/RQA-3155)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If you throw an estop event during pipette or gripper calibration flows, the "exit" button in the modal header does not properly fire the `onClose` event, making it impossible to exit the modal. Currently, `onClose` requires the `home` command to succeed in order to close the modal. Instead, let's just make the modal close regardless of whether the `home` command succeeds or fails.

Note that module calibration flows already have this logic, it's just these two flows that don't.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified the modal closes after reproing the steps outlined in the linked ticket.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- It's now possible to exit the pipette and gripper calibration flows after an e-stop event occurs.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3155]: https://opentrons.atlassian.net/browse/RQA-3155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ