### PR TITLE
 feat(components, protocol-designer): labware render for assigning liquids in pd

### DIFF
--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -98,7 +98,6 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
       </g>
     )
   }
-  console.log('wellStroke', props.wellStroke)
   return (
     <g
       transform={`translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`}
@@ -109,8 +108,8 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
         onMouseEnterWell={props.onMouseEnterWell}
         onMouseLeaveWell={props.onMouseLeaveWell}
         onLabwareClick={props.onLabwareClick}
-        // highlight={props.highlight}
-        highlightShadow={props.highlightShadow}
+        highlight={props.highlight}
+        // highlightShadow={props.highlightShadow}
         wellStroke={props.wellStroke}
       />
       {props.wellStroke != null ? (

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -59,6 +59,8 @@ export interface LabwareRenderProps {
   onMouseLeaveWell?: (e: WellMouseEvent) => unknown
   gRef?: React.RefObject<SVGGElement>
   onLabwareClick?: () => void
+  showBorder?: boolean
+  strokeColor?: string
 }
 
 export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
@@ -104,12 +106,13 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
       ref={gRef}
     >
       <StaticLabware
+        showBorder={props.showBorder}
         definition={props.definition}
         onMouseEnterWell={props.onMouseEnterWell}
         onMouseLeaveWell={props.onMouseLeaveWell}
         onLabwareClick={props.onLabwareClick}
         highlight={props.highlight}
-        // highlightShadow={props.highlightShadow}
+        highlightShadow={props.highlightShadow}
         wellStroke={props.wellStroke}
       />
       {props.wellStroke != null ? (
@@ -122,7 +125,7 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
         <FilledWells
           definition={props.definition}
           fillByWell={props.wellFill}
-          strokeColor={'transparent'}
+          strokeColor={props.strokeColor}
         />
       ) : null}
       {props.disabledWells != null

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -98,7 +98,7 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
       </g>
     )
   }
-
+  console.log('wellStroke', props.wellStroke)
   return (
     <g
       transform={`translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`}
@@ -109,8 +109,9 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
         onMouseEnterWell={props.onMouseEnterWell}
         onMouseLeaveWell={props.onMouseLeaveWell}
         onLabwareClick={props.onLabwareClick}
-        highlight={props.highlight}
+        // highlight={props.highlight}
         highlightShadow={props.highlightShadow}
+        wellStroke={props.wellStroke}
       />
       {props.wellStroke != null ? (
         <StrokedWells
@@ -122,6 +123,7 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
         <FilledWells
           definition={props.definition}
           fillByWell={props.wellFill}
+          strokeColor={'transparent'}
         />
       ) : null}
       {props.disabledWells != null

--- a/components/src/hardware-sim/Labware/labwareInternals/FilledWells.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/FilledWells.tsx
@@ -8,10 +8,11 @@ import type { CSSProperties } from 'styled-components'
 export interface FilledWellsProps {
   definition: LabwareDefinition2
   fillByWell: Record<string, CSSProperties['fill']>
+  strokeColor?: string
 }
 
 function FilledWellsComponent(props: FilledWellsProps): JSX.Element {
-  const { definition, fillByWell } = props
+  const { definition, fillByWell, strokeColor = COLORS.black90 } = props
   return (
     <>
       {map<Record<string, CSSProperties['fill']>, React.ReactNode>(
@@ -23,7 +24,7 @@ function FilledWellsComponent(props: FilledWellsProps): JSX.Element {
               wellName={wellName}
               well={definition.wells[wellName]}
               fill={color}
-              stroke={COLORS.black90}
+              stroke={strokeColor}
               strokeWidth="0.6"
             />
           )

--- a/components/src/hardware-sim/Labware/labwareInternals/StaticLabware.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StaticLabware.tsx
@@ -28,6 +28,8 @@ export interface StaticLabwareProps {
   fill?: CSSProperties['fill']
   showRadius?: boolean
   wellStroke?: WellStroke
+  /** optional show of labware border, defaulted to true */
+  showBorder?: boolean
 }
 
 const TipDecoration = React.memo(function TipDecoration(props: {
@@ -65,20 +67,23 @@ export function StaticLabwareComponent(props: StaticLabwareProps): JSX.Element {
     fill,
     showRadius = true,
     wellStroke = {},
+    showBorder = true,
   } = props
 
   const { isTiprack } = definition.parameters
   return (
     <g onClick={onLabwareClick}>
-      {/* <LabwareDetailGroup>
-        <LabwareOutline
-          definition={definition}
-          highlight={highlight}
-          highlightShadow={highlightShadow}
-          fill={fill}
-          showRadius={showRadius}
-        />
-      </LabwareDetailGroup> */}
+      {!showBorder ? null : (
+        <LabwareDetailGroup>
+          <LabwareOutline
+            definition={definition}
+            highlight={highlight}
+            highlightShadow={highlightShadow}
+            fill={fill}
+            showRadius={showRadius}
+          />
+        </LabwareDetailGroup>
+      )}
       <g>
         {flatMap(
           definition.ordering,

--- a/components/src/hardware-sim/Labware/labwareInternals/StaticLabware.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StaticLabware.tsx
@@ -9,7 +9,7 @@ import { STYLE_BY_WELL_CONTENTS } from './StyledWells'
 import { COLORS } from '../../../helix-design-system'
 
 import type { LabwareDefinition2, LabwareWell } from '@opentrons/shared-data'
-import type { WellMouseEvent } from './types'
+import type { WellMouseEvent, WellStroke } from './types'
 import type { CSSProperties } from 'styled-components'
 
 export interface StaticLabwareProps {
@@ -27,6 +27,7 @@ export interface StaticLabwareProps {
   onMouseLeaveWell?: (e: WellMouseEvent) => unknown
   fill?: CSSProperties['fill']
   showRadius?: boolean
+  wellStroke?: WellStroke
 }
 
 const TipDecoration = React.memo(function TipDecoration(props: {
@@ -63,6 +64,7 @@ export function StaticLabwareComponent(props: StaticLabwareProps): JSX.Element {
     onMouseLeaveWell,
     fill,
     showRadius = true,
+    wellStroke = {},
   } = props
 
   const { isTiprack } = definition.parameters
@@ -93,6 +95,7 @@ export function StaticLabwareComponent(props: StaticLabwareProps): JSX.Element {
                       ? STYLE_BY_WELL_CONTENTS.tipPresent
                       : STYLE_BY_WELL_CONTENTS.defaultWell)}
                     fill={fill}
+                    stroke={wellStroke[wellName] ?? undefined}
                   />
 
                   {isTiprack ? (

--- a/components/src/hardware-sim/Labware/labwareInternals/StaticLabware.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StaticLabware.tsx
@@ -70,7 +70,7 @@ export function StaticLabwareComponent(props: StaticLabwareProps): JSX.Element {
   const { isTiprack } = definition.parameters
   return (
     <g onClick={onLabwareClick}>
-      <LabwareDetailGroup>
+      {/* <LabwareDetailGroup>
         <LabwareOutline
           definition={definition}
           highlight={highlight}
@@ -78,7 +78,7 @@ export function StaticLabwareComponent(props: StaticLabwareProps): JSX.Element {
           fill={fill}
           showRadius={showRadius}
         />
-      </LabwareDetailGroup>
+      </LabwareDetailGroup> */}
       <g>
         {flatMap(
           definition.ordering,

--- a/components/src/hardware-sim/Labware/labwareInternals/StyledWells.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StyledWells.tsx
@@ -25,8 +25,8 @@ export const STYLE_BY_WELL_CONTENTS: {
   }
 } = {
   highlightedWell: {
-    stroke: COLORS.blue50,
-    fill: `${COLORS.blue50}33`, // 20% opacity
+    stroke: 'transparent',
+    fill: COLORS.blue50, // 20% opacity
     strokeWidth: 1,
   },
   disabledWell: {
@@ -37,7 +37,7 @@ export const STYLE_BY_WELL_CONTENTS: {
   selectedWell: {
     stroke: COLORS.blue50,
     fill: COLORS.transparent,
-    strokeWidth: 1,
+    strokeWidth: 0,
   },
   tipMissing: {
     stroke: '#A4A4A4', // LEGACY --c-near-black
@@ -51,7 +51,7 @@ export const STYLE_BY_WELL_CONTENTS: {
   },
   defaultWell: {
     fill: COLORS.white,
-    stroke: COLORS.black90,
+    stroke: 'transparent',
     strokeWidth: 0.6,
   },
 }

--- a/components/src/hardware-sim/Labware/labwareInternals/StyledWells.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StyledWells.tsx
@@ -25,9 +25,9 @@ export const STYLE_BY_WELL_CONTENTS: {
   }
 } = {
   highlightedWell: {
-    stroke: 'transparent',
-    fill: COLORS.blue50, // 20% opacity
-    strokeWidth: 1,
+    stroke: COLORS.blue50,
+    fill: `transparent`, // 20% opacity
+    strokeWidth: 0.5,
   },
   disabledWell: {
     stroke: '#C6C6C6', // LEGACY --light-grey-hover
@@ -37,7 +37,7 @@ export const STYLE_BY_WELL_CONTENTS: {
   selectedWell: {
     stroke: COLORS.blue50,
     fill: COLORS.transparent,
-    strokeWidth: 0,
+    strokeWidth: 0.5,
   },
   tipMissing: {
     stroke: '#A4A4A4', // LEGACY --c-near-black

--- a/components/src/hardware-sim/Labware/labwareInternals/StyledWells.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StyledWells.tsx
@@ -26,7 +26,7 @@ export const STYLE_BY_WELL_CONTENTS: {
 } = {
   highlightedWell: {
     stroke: COLORS.blue50,
-    fill: `transparent`, // 20% opacity
+    fill: COLORS.transparent,
     strokeWidth: 0.5,
   },
   disabledWell: {
@@ -51,7 +51,7 @@ export const STYLE_BY_WELL_CONTENTS: {
   },
   defaultWell: {
     fill: COLORS.white,
-    stroke: 'transparent',
+    stroke: COLORS.black90,
     strokeWidth: 0.6,
   },
 }

--- a/components/src/hardware-sim/Labware/labwareInternals/Well.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/Well.tsx
@@ -59,13 +59,23 @@ export function WellComponent(props: WellProps): JSX.Element {
 
   const { xDimension, yDimension } = well
   return (
-    <rect
-      {...commonProps}
-      x={x - xDimension / 2}
-      y={y - yDimension / 2}
-      width={xDimension}
-      height={yDimension}
-    />
+    <>
+      <rect
+        {...commonProps}
+        x={x - xDimension / 2}
+        y={y - yDimension / 2}
+        width={xDimension}
+        height={yDimension}
+      />
+      <rect
+        strokeWidth={5}
+        stroke={COLORS.yellow20}
+        x={x - xDimension / 2 + 10}
+        y={y - yDimension / 2 + 10}
+        width={xDimension + 10}
+        height={yDimension + 10}
+      />
+    </>
   )
 }
 

--- a/components/src/hardware-sim/Labware/labwareInternals/Well.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/Well.tsx
@@ -59,23 +59,13 @@ export function WellComponent(props: WellProps): JSX.Element {
 
   const { xDimension, yDimension } = well
   return (
-    <>
-      <rect
-        {...commonProps}
-        x={x - xDimension / 2}
-        y={y - yDimension / 2}
-        width={xDimension}
-        height={yDimension}
-      />
-      <rect
-        strokeWidth={5}
-        stroke={COLORS.yellow20}
-        x={x - xDimension / 2 + 10}
-        y={y - yDimension / 2 + 10}
-        width={xDimension + 10}
-        height={yDimension + 10}
-      />
-    </>
+    <rect
+      {...commonProps}
+      x={x - xDimension / 2}
+      y={y - yDimension / 2}
+      width={xDimension}
+      height={yDimension}
+    />
   )
 }
 

--- a/protocol-designer/src/assets/localization/en/liquids.json
+++ b/protocol-designer/src/assets/localization/en/liquids.json
@@ -2,7 +2,7 @@
   "add_liquid": "Add liquid",
   "add": "Add",
   "clear_wells": "Clear wells",
-  "click_and_drag": "Click and drag to select wells, hold shift and click to deselect",
+  "click_and_drag": "Click and drag to select wells",
   "define_liquid": "Define a liquid",
   "delete_liquid": "Delete liquid",
   "description": "Description",

--- a/protocol-designer/src/assets/localization/en/well_selection.json
+++ b/protocol-designer/src/assets/localization/en/well_selection.json
@@ -1,4 +1,3 @@
 {
-  "select_instructions": "Click + Drag to select multiple.",
-  "deselect_instructions": "Shift + Click to de-select."
+  "select_instructions": "Click + Drag to select multiple."
 }

--- a/protocol-designer/src/components/LiquidPlacementModal.tsx
+++ b/protocol-designer/src/components/LiquidPlacementModal.tsx
@@ -55,6 +55,7 @@ export function LiquidPlacementModal(): JSX.Element | null {
       {labwareDef && (
         <div className={styles.labware}>
           <SelectableLabware
+            showBorder
             labwareProps={{
               wellLabelOption: WELL_LABEL_OPTIONS.SHOW_LABEL_INSIDE,
               definition: labwareDef,

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionModal.tsx
@@ -95,6 +95,7 @@ const WellSelectionModalComponent = (
 
       {labwareDef != null ? (
         <SelectableLabware
+          showBorder
           labwareProps={{
             wellLabelOption: WELL_LABEL_OPTIONS.SHOW_LABEL_INSIDE,
             definition: labwareDef,

--- a/protocol-designer/src/components/WellSelectionInstructions.tsx
+++ b/protocol-designer/src/components/WellSelectionInstructions.tsx
@@ -10,7 +10,6 @@ export function WellSelectionInstructions(): JSX.Element {
       <Icon className={styles.click_drag_icon} name="ot-click-and-drag" />
       <div className={styles.instructional_text}>
         <p>{t('select_instructions')}</p>
-        <p>{t('deselect_instructions')}</p>
       </div>
     </div>
   )

--- a/protocol-designer/src/components/labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/labware/SelectableLabware.tsx
@@ -130,7 +130,11 @@ export const SelectableLabware = (props: Props): JSX.Element => {
     rect
   ) => {
     const wells = _wellsFromSelected(_getWellsFromRect(rect))
-    if (e.shiftKey) {
+    const areWellsAlreadySelected = Object.keys(wells).every(
+      well => well in selectedPrimaryWells
+    )
+
+    if (areWellsAlreadySelected) {
       deselectWells(wells)
     } else {
       selectWells(wells)

--- a/protocol-designer/src/components/labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/labware/SelectableLabware.tsx
@@ -37,6 +37,7 @@ export interface Props {
   nozzleType: NozzleType | null
   ingredNames: WellIngredientNames
   wellContents: ContentsByWell
+  showBorder: boolean
 }
 
 type ChannelType = 8 | 96
@@ -59,6 +60,7 @@ export const SelectableLabware = (props: Props): JSX.Element => {
     nozzleType,
     ingredNames,
     wellContents,
+    showBorder,
   } = props
   const labwareDef = labwareProps.definition
 
@@ -203,6 +205,8 @@ export const SelectableLabware = (props: Props): JSX.Element => {
         }) => (
           <SingleLabware
             {...labwareProps}
+            showBorder={showBorder}
+            strokeColor={COLORS.transparent}
             wellStroke={wellStroke}
             wellFill={wellFillWithLiq}
             selectedWells={allSelectedWells}

--- a/protocol-designer/src/components/labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/labware/SelectableLabware.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import reduce from 'lodash/reduce'
 
 import { COLUMN } from '@opentrons/shared-data'
+import { COLORS } from '@opentrons/components'
+
 import {
   arrayToWellGroup,
   getCollidingWells,
@@ -11,7 +13,12 @@ import { SingleLabware } from './SingleLabware'
 import { SelectionRect } from '../SelectionRect'
 import { WellTooltip } from './WellTooltip'
 
-import type { WellMouseEvent, WellGroup } from '@opentrons/components'
+import type {
+  WellMouseEvent,
+  WellGroup,
+  WellFill,
+  WellStroke,
+} from '@opentrons/components'
 import type { ContentsByWell } from '../../labware-ingred/types'
 import type { WellIngredientNames } from '../../steplist/types'
 import type { GenericRect } from '../../collision-types'
@@ -162,6 +169,27 @@ export const SelectableLabware = (props: Props): JSX.Element => {
         )
       : selectedPrimaryWells
 
+  const wellFillWithLiq: WellFill = {}
+  const wellStroke: WellStroke = {}
+  Object.keys(labwareDef.wells).forEach(wellName => {
+    wellFillWithLiq[wellName] = COLORS.blue35
+    wellStroke[wellName] = COLORS.transparent
+  })
+  Object.keys(allSelectedWells).forEach(wellName => {
+    wellFillWithLiq[wellName] = COLORS.blue50
+    wellStroke[wellName] = COLORS.transparent
+  })
+  Object.keys(selectedPrimaryWells).forEach(wellName => {
+    wellFillWithLiq[wellName] = COLORS.blue50
+    wellStroke[wellName] = COLORS.transparent
+  })
+  const wellFill = labwareProps.wellFill != null ? labwareProps.wellFill : null
+  if (wellFill != null) {
+    Object.keys(wellFill).forEach(wellName => {
+      wellFillWithLiq[wellName] = wellFill[wellName]
+    })
+  }
+
   return (
     <SelectionRect
       onSelectionMove={handleSelectionMove}
@@ -175,6 +203,8 @@ export const SelectableLabware = (props: Props): JSX.Element => {
         }) => (
           <SingleLabware
             {...labwareProps}
+            wellStroke={wellStroke}
+            wellFill={wellFillWithLiq}
             selectedWells={allSelectedWells}
             onMouseLeaveWell={mouseEventArgs => {
               handleMouseLeaveWell(mouseEventArgs)

--- a/protocol-designer/src/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/index.tsx
@@ -82,6 +82,7 @@ export function AssignLiquidsModal(): JSX.Element | null {
             </StyledText>
           </Flex>
           <SelectableLabware
+            showBorder={false}
             labwareProps={{
               wellLabelOption: WELL_LABEL_OPTIONS.SHOW_LABEL_INSIDE,
               definition: labwareDef,

--- a/protocol-designer/src/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/index.tsx
@@ -81,7 +81,6 @@ export function AssignLiquidsModal(): JSX.Element | null {
               {t('click_and_drag')}
             </StyledText>
           </Flex>
-          {/* TODO(ja, 8/29/24): update this styling to match designs */}
           <SelectableLabware
             labwareProps={{
               wellLabelOption: WELL_LABEL_OPTIONS.SHOW_LABEL_INSIDE,


### PR DESCRIPTION
closes AUTH-755

# Overview

Updates the labware render for assigning liquids in PD's redesign. Should retain previous designs for usage of Labware Render outside of PD

<img width="803" alt="Screenshot 2024-09-09 at 12 01 50" src="https://github.com/user-attachments/assets/467dba7a-fe76-4369-94c8-0f1483e02eda">

## Test Plan and Hands on Testing

- Test PD redesign assigning liquids and make sure it matches the designs
- test old PD assigning liquids and make sure the border of the labware still shows 
- test LL and desktop app labware renders (like liquid setup) and make sure the labware render looks as expected

## Changelog

- Add optional border, and remove the black well outline and modify the hover well outline
- fix the text in assign liquid modal
- make sure old PD still shows the labware outline

## Risk assessment

medium? touches a few shared components for labware render used across the stack