### PR TITLE
fix(app): initialize disposal volume field with correct value

### DIFF
--- a/app/src/assets/localization/en/quick_transfer.json
+++ b/app/src/assets/localization/en/quick_transfer.json
@@ -96,7 +96,7 @@
   "pipette_path": "Pipette path",
   "pipette_path_multi_aspirate": "Multi-aspirate",
   "pipette_path_multi_dispense": "Multi-dispense",
-  "pipette_path_multi_dispense_volume_blowout": "Multi-dispense, {{volume}} disposal volume, blowout {{blowOutLocation}}",
+  "pipette_path_multi_dispense_volume_blowout": "Multi-dispense, {{volume}} µL disposal volume, blowout {{blowOutLocation}}",
   "pipette_path_single": "Single transfers",
   "pre_wet_tip": "Pre-wet tip",
   "quick_transfer": "Quick transfer",

--- a/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -45,9 +45,9 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
     BlowOutLocation | undefined
   >(state.blowOut)
 
-  const [disposalVolume, setDisposalVolume] = React.useState<number>(
-    state.volume
-  )
+  const [disposalVolume, setDisposalVolume] = React.useState<
+    number | undefined
+  >(state?.disposalVolume)
   const maxPipetteVolume = Object.values(state.pipette.liquids)[0].maxVolume
   const tipVolume = Object.values(state.tipRack.wells)[0].totalLiquidVolume
 
@@ -121,7 +121,7 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
   const volumeRange = { min: 1, max: maxDisposalCapacity }
 
   const volumeError =
-    disposalVolume !== null &&
+    disposalVolume != null &&
     (disposalVolume < volumeRange.min || disposalVolume > volumeRange.max)
       ? t(`value_out_of_range`, {
           min: volumeRange.min,
@@ -200,7 +200,7 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
           >
             <NumericalKeyboard
               keyboardRef={keyboardRef}
-              initialValue={String(disposalVolume)}
+              initialValue={String(disposalVolume ?? '')}
               onChange={e => {
                 setDisposalVolume(Number(e))
               }}


### PR DESCRIPTION
fix RQA-3158

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We were initializing the input field for disposal volume with `state.volume` instead of `state.disposalVolume` - I updated that in this PR 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Set a disposal volume that is different than the volume per well
Re-enter the pipette path setting and see that when you get to the disposal volume step, the previously set volume persists instead of the volume per well
See that pipette path setting copy now includes unit for disposal volume
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Initialize input field with `state.disposalVolume`
2. Add uL unit to pipette path string
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick code check and test
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
