### PR TITLE
feat(components, protocol-designer): tab through protocol onboarding …

### DIFF
--- a/components/src/atoms/buttons/EmptySelectorButton.tsx
+++ b/components/src/atoms/buttons/EmptySelectorButton.tsx
@@ -13,6 +13,7 @@ import {
   FLEX_MAX_CONTENT,
 } from '../..'
 import type { IconName } from '../..'
+import { css } from 'styled-components'
 
 interface EmptySelectorButtonProps {
   onClick: () => void
@@ -38,7 +39,18 @@ export function EmptySelectorButton(
   const buttonSizing = size === 'large' ? '100%' : FLEX_MAX_CONTENT
 
   return (
-    <Btn onClick={onClick} width={buttonSizing} height={buttonSizing}>
+    <Btn
+      onClick={onClick}
+      width={buttonSizing}
+      height={buttonSizing}
+      css={css`
+        &:focus-visible {
+          outline: 2px solid ${COLORS.white};
+          box-shadow: 0 0 0 4px ${COLORS.blue50};
+          border-radius: ${BORDERS.borderRadius8};
+        }
+      `}
+    >
       <Flex
         gridGap={SPACING.spacing4}
         padding={SPACING.spacing12}

--- a/components/src/atoms/buttons/EmptySelectorButton.tsx
+++ b/components/src/atoms/buttons/EmptySelectorButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import styled from 'styled-components'
 import { Flex } from '../../primitives'
 import {
   BORDERS,
@@ -6,14 +7,12 @@ import {
   Icon,
   SPACING,
   StyledText,
-  Btn,
   JUSTIFY_CENTER,
   JUSTIFY_START,
   ALIGN_CENTER,
   FLEX_MAX_CONTENT,
 } from '../..'
 import type { IconName } from '../..'
-import { css } from 'styled-components'
 
 interface EmptySelectorButtonProps {
   onClick: () => void
@@ -38,19 +37,19 @@ export function EmptySelectorButton(
   } = props
   const buttonSizing = size === 'large' ? '100%' : FLEX_MAX_CONTENT
 
+  const StyledButton = styled.button`
+    border: none;
+    width: ${buttonSizing};
+    height: ${buttonSizing};
+    &:focus-visible {
+      outline: 2px solid ${COLORS.white};
+      box-shadow: 0 0 0 4px ${COLORS.blue50};
+      border-radius: ${BORDERS.borderRadius8};
+    }
+  `
+
   return (
-    <Btn
-      onClick={onClick}
-      width={buttonSizing}
-      height={buttonSizing}
-      css={css`
-        &:focus-visible {
-          outline: 2px solid ${COLORS.white};
-          box-shadow: 0 0 0 4px ${COLORS.blue50};
-          border-radius: ${BORDERS.borderRadius8};
-        }
-      `}
-    >
+    <StyledButton onClick={onClick}>
       <Flex
         gridGap={SPACING.spacing4}
         padding={SPACING.spacing12}
@@ -75,6 +74,6 @@ export function EmptySelectorButton(
         ) : null}
         <StyledText desktopStyle="bodyDefaultSemiBold">{text}</StyledText>
       </Flex>
-    </Btn>
+    </StyledButton>
   )
 }

--- a/components/src/atoms/buttons/RadioButton.tsx
+++ b/components/src/atoms/buttons/RadioButton.tsx
@@ -84,17 +84,19 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
   `
 
   const SettingButtonLabel = styled.label`
-      border-radius: ${
-        !largeDesktopBorderRadius
-          ? BORDERS.borderRadius40
-          : BORDERS.borderRadius8
-      };
-      cursor: pointer;
-      padding: ${SPACING.spacing12} ${SPACING.spacing16};
-      width: 100%;
+    border-radius: ${
+      !largeDesktopBorderRadius ? BORDERS.borderRadius40 : BORDERS.borderRadius8
+    };
+    cursor: pointer;
+    padding: ${SPACING.spacing12} ${SPACING.spacing16};
+    width: 100%;
 
-      ${isSelected ? SELECTED_BUTTON_STYLE : AVAILABLE_BUTTON_STYLE}
-      ${disabled && DISABLED_BUTTON_STYLE}
+    ${isSelected ? SELECTED_BUTTON_STYLE : AVAILABLE_BUTTON_STYLE}
+    ${disabled && DISABLED_BUTTON_STYLE}
+
+    &:focus-visible {
+      outline: 2px solid ${COLORS.blue55};
+    }
 
     @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
        cursor: default;
@@ -112,6 +114,7 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
     <Flex
       css={css`
         width: auto;
+
         @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
           width: 100%;
         }
@@ -126,6 +129,7 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
         value={buttonValue}
       />
       <SettingButtonLabel
+        tabIndex={0}
         role="label"
         htmlFor={id}
         onMouseEnter={setHovered}

--- a/components/src/interaction-enhancers/HandleKeypress.tsx
+++ b/components/src/interaction-enhancers/HandleKeypress.tsx
@@ -25,7 +25,22 @@ const matchHandler = (e: KeyboardEvent) => (h: KeypressHandler) =>
  */
 export class HandleKeypress extends React.Component<HandleKeypressProps> {
   handlePressIfKey = (event: KeyboardEvent): void => {
-    this.props.handlers.filter(matchHandler(event)).forEach(h => h.onPress())
+    const pressHandlers = this.props.handlers.filter(matchHandler(event))
+
+    // Check if any element is currently focused
+    const focusedElement = document.activeElement as HTMLElement
+
+    if (pressHandlers.length > 0) {
+      if (
+        focusedElement &&
+        event.key === 'Enter' &&
+        focusedElement.matches(':focus-visible')
+      ) {
+        focusedElement.click()
+      } else if (!focusedElement || !focusedElement.matches(':focus-visible')) {
+        pressHandlers.forEach(h => h.onPress())
+      }
+    }
   }
 
   preventDefaultIfKey = (event: KeyboardEvent): void => {

--- a/protocol-designer/src/assets/localization/en/create_new_protocol.json
+++ b/protocol-designer/src/assets/localization/en/create_new_protocol.json
@@ -22,7 +22,6 @@
   "pip_vol": "Pipette volume",
   "pip": "{{mount}} pipette",
   "quantity": "Quantity",
-  "questions": "We’re going to ask a few questions to help you get started building your protocol.",
   "remove": "Remove",
   "rename_labware": "Rename labware",
   "robot_pips": "Robot pipettes",

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectRobot.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectRobot.tsx
@@ -23,7 +23,6 @@ export function SelectRobot(props: WizardTileProps): JSX.Element {
       <WizardBody
         stepNumber={1}
         header={t('basics')}
-        subHeader={t('questions')}
         disabled={false}
         proceed={() => {
           proceed(1)


### PR DESCRIPTION
…flow

closes AUTH-689 AUTH-734

# Overview

Allows the ability to tab through the protocol onboarding flow and click enter to select the button! Also updates some copy and adds `focus-visible` to a few components. Also, I modified the `HandleKeypress` logic to take `focus-visible` buttons into account

## Test Plan and Hands on Testing

Go through the PD onboarding flow and make sure it works as expected by tabbing through.

## Changelog

- modify the `HandleKeypress` class to take `focus-visible` buttons into account
- add a few focus-visible states
- remove copy that is no longer in the onboarding flow

## Risk assessment

low