### PR TITLE
feat(protocol-designer): too long labware nickname error

### DIFF
--- a/protocol-designer/src/assets/localization/en/create_new_protocol.json
+++ b/protocol-designer/src/assets/localization/en/create_new_protocol.json
@@ -24,6 +24,7 @@
   "quantity": "Quantity",
   "questions": "We’re going to ask a few questions to help you get started building your protocol.",
   "remove": "Remove",
+  "rename_error": "Labware names must be 115 characters or fewer.",
   "rename_labware": "Rename labware",
   "robot_pips": "Robot pipettes",
   "robot_type": "What kind of robot do you have?",

--- a/protocol-designer/src/organisms/EditNickNameModal/__tests__/EditNickNameModal.test.tsx
+++ b/protocol-designer/src/organisms/EditNickNameModal/__tests__/EditNickNameModal.test.tsx
@@ -42,4 +42,15 @@ describe('EditNickNameModal', () => {
     expect(vi.mocked(renameLabware)).toHaveBeenCalled()
     expect(props.onClose).toHaveBeenCalled()
   })
+  it('renders the too long nickname error', () => {
+    render(props)
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, {
+      target: {
+        value:
+          'mockNickNameisthelongestnicknameihaveeverseen mockNickNameisthelongestnicknameihaveeverseen mockNickNameisthelongest',
+      },
+    })
+    screen.getByText('Labware names must be 115 characters or fewer.')
+  })
 })

--- a/protocol-designer/src/organisms/EditNickNameModal/index.tsx
+++ b/protocol-designer/src/organisms/EditNickNameModal/index.tsx
@@ -19,6 +19,7 @@ import { getTopPortalEl } from '../../components/portals/TopPortal'
 import { renameLabware } from '../../labware-ingred/actions'
 import type { ThunkDispatch } from '../../types'
 
+const MAX_NICK_NAME_LENGTH = 115
 interface EditNickNameModalProps {
   labwareId: string
   onClose: () => void
@@ -55,7 +56,7 @@ export function EditNickNameModal(props: EditNickNameModalProps): JSX.Element {
           </SecondaryButton>
           <PrimaryButton
             onClick={saveNickname}
-            disabled={nickName.length >= 115}
+            disabled={nickName.length >= MAX_NICK_NAME_LENGTH}
           >
             {t('shared:save')}
           </PrimaryButton>
@@ -73,7 +74,9 @@ export function EditNickNameModal(props: EditNickNameModalProps): JSX.Element {
           </StyledText>
         </Flex>
         <InputField
-          error={nickName.length >= 115 ? t('rename_error') : null}
+          error={
+            nickName.length >= MAX_NICK_NAME_LENGTH ? t('rename_error') : null
+          }
           data-testid="renameLabware_inputField"
           name="renameLabware"
           onChange={e => {

--- a/protocol-designer/src/organisms/EditNickNameModal/index.tsx
+++ b/protocol-designer/src/organisms/EditNickNameModal/index.tsx
@@ -53,7 +53,10 @@ export function EditNickNameModal(props: EditNickNameModalProps): JSX.Element {
           >
             {t('shared:cancel')}
           </SecondaryButton>
-          <PrimaryButton onClick={saveNickname}>
+          <PrimaryButton
+            onClick={saveNickname}
+            disabled={nickName.length >= 115}
+          >
             {t('shared:save')}
           </PrimaryButton>
         </Flex>

--- a/protocol-designer/src/organisms/EditNickNameModal/index.tsx
+++ b/protocol-designer/src/organisms/EditNickNameModal/index.tsx
@@ -59,13 +59,18 @@ export function EditNickNameModal(props: EditNickNameModalProps): JSX.Element {
         </Flex>
       }
     >
-      <Flex flexDirection={DIRECTION_COLUMN} girGap={SPACING.spacing4}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        girGap={SPACING.spacing12}
+        height="3.75rem"
+      >
         <Flex color={COLORS.grey60}>
           <StyledText desktopStyle="bodyDefaultRegular">
             {t('labware_name')}
           </StyledText>
         </Flex>
         <InputField
+          error={nickName.length >= 115 ? t('rename_error') : null}
           data-testid="renameLabware_inputField"
           name="renameLabware"
           onChange={e => {


### PR DESCRIPTION
closes AUTH-774

# Overview

add too long nickname error

<img width="512" alt="Screenshot 2024-09-09 at 14 01 07" src="https://github.com/user-attachments/assets/921d9ba1-2b96-4ee4-98f4-8db43a9a4190">

## Test Plan and Hands on Testing

Add a labware to the deck and edit the name. add a nickname that is 115 characters or longer and should see the error. The save button should be disabled.

## Changelog

- wire up error and add a test

## Risk assessment

low