### PR TITLE
feat(protocol engine): calculate well volumetric capacities from labware defs 

### DIFF
--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -149,4 +149,5 @@ __all__ = [
     "ErrorOccurrence",
     "CommandNotAllowedError",
     "InvalidLiquidHeightFound",
+    "InvalidWellDefinitionError",
 ]

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -70,6 +70,7 @@ from .exceptions import (
     NotSupportedOnRobotType,
     CommandNotAllowedError,
     InvalidLiquidHeightFound,
+    InvalidWellDefinitionError,
 )
 
 from .error_occurrence import ErrorOccurrence, ProtocolCommandFailedError

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -1056,3 +1056,16 @@ class TipNotEmptyError(ProtocolEngineError):
     ) -> None:
         """Build a TipNotEmptyError."""
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
+
+class InvalidWellDefinitionError(ProtocolEngineError):
+    """Raised when an InnerWellGeometry definition is invalid."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an InvalidWellDefinitionError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -1,5 +1,5 @@
 """Helper functions for liquid-level related calculations inside a given frustum."""
-from typing import List, Tuple, Dict, Iterator, Sequence, Any
+from typing import List, Tuple, Iterator, Sequence, Any
 from numpy import pi, iscomplex, roots, real
 
 from ..errors.exceptions import InvalidLiquidHeightFound
@@ -192,11 +192,11 @@ def get_boundary_cross_sections(frusta: Sequence[Any]) -> Iterator[Tuple[Any, An
 
 def get_well_volumetric_capacity(
     well_geometry: InnerWellGeometry,
-) -> Dict[float, float]:
+) -> List[Tuple[float, float]]:
     """Return the total volumetric capacity of a well as a map of height borders to volume."""
     # dictionary map of heights to volumetric capacities within their respective segment
     # {top_height_0: volume_0, top_height_1: volume_1, top_height_2: volume_2}
-    well_volume = {}
+    well_volume = []
     if well_geometry.bottomShape is not None:
         if well_geometry.bottomShape.shape == "spherical":
             bottom_spherical_section_depth = well_geometry.bottomShape.depth
@@ -204,7 +204,7 @@ def get_well_volumetric_capacity(
                 radius_of_curvature=well_geometry.bottomShape.radius_of_curvature,
                 target_height=bottom_spherical_section_depth,
             )
-            well_volume[bottom_spherical_section_depth] = bottom_sphere_volume
+            well_volume.append((bottom_spherical_section_depth, bottom_sphere_volume))
 
     # get the volume of remaining frusta sorted in ascending order
     sorted_frusta = sorted(well_geometry.frusta, key=lambda section: section.topHeight)
@@ -225,7 +225,7 @@ def get_well_volumetric_capacity(
                 top_width=top_cross_section_width,
             )
 
-            well_volume[next_f["topHeight"]] = frustum_volume
+            well_volume.append((next_f["topHeight"], frustum_volume))
     elif is_circular_frusta_list(sorted_frusta):
         for f, next_f in get_boundary_cross_sections(sorted_frusta):
             top_cross_section_radius = next_f["diameter"] / 2.0
@@ -238,6 +238,6 @@ def get_well_volumetric_capacity(
                 top_radius=top_cross_section_radius,
             )
 
-            well_volume[next_f["topHeight"]] = frustum_volume
+            well_volume.append((next_f["topHeight"], frustum_volume))
 
     return well_volume

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -232,10 +232,6 @@ def get_well_volumetric_capacity(
 
             well_volume[next_f["topHeight"]] = frustum_volume
     elif is_circular_frusta_list(sorted_frusta):
-        # get height from 0 to 1, 1 to 2, ...
-        # assuming that from this point on, well cross-sections won't change between
-        # circular and rectangular or vise versa
-        # for i in range(len(sorted_frusta) - 1):
         for f, next_f in get_boundary_cross_sections(sorted_frusta):
             top_cross_section_radius = next_f["diameter"] / 2.0
             bottom_cross_section_radius = f["diameter"] / 2.0

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -1,8 +1,13 @@
 """Helper functions for liquid-level related calculations inside a given frustum."""
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 from numpy import pi, iscomplex, roots, real
 
 from ..errors.exceptions import InvalidLiquidHeightFound
+from opentrons_shared_data.labware.types import (
+    is_circular_frusta_list,
+    is_rectangular_frusta_list,
+)
+from opentrons_shared_data.labware.labware_definition import InnerWellGeometry
 
 
 def reject_unacceptable_heights(
@@ -174,3 +179,62 @@ def height_from_volume_spherical(
         max_height=total_frustum_height,
     )
     return height
+
+
+def get_well_volumetric_capacity(
+    well_geometry: InnerWellGeometry,
+) -> Dict[float, float]:
+    """Return the total volumetric capacity of a well as a map of height borders to volume."""
+    # dictionary map of heights to volumetric capacities within their respective segment
+    # {top_height_0: volume_0, top_height_1: volume_1, top_height_2: volume_2}
+    well_volume = {}
+    if well_geometry.bottomShape is not None:
+        if well_geometry.bottomShape.shape == "spherical":
+            bottom_spherical_section_depth = well_geometry.bottomShape.depth
+            bottom_sphere_volume = volume_from_height_spherical(
+                radius_of_curvature=well_geometry.bottomShape.radius_of_curvature,
+                target_height=bottom_spherical_section_depth,
+            )
+            well_volume[bottom_spherical_section_depth] = bottom_sphere_volume
+
+    # get the volume of remaining frusta sorted in ascending order
+    sorted_frusta = sorted(well_geometry.frusta, key=lambda section: section.topHeight)
+    if is_rectangular_frusta_list(sorted_frusta):
+        for i in range(len(sorted_frusta) - 1):
+            top_cross_section_width = sorted_frusta[i + 1]["xDimension"]
+            top_cross_section_length = sorted_frusta[i + 1]["yDimension"]
+            bottom_cross_section_width = sorted_frusta[i]["xDimension"]
+            bottom_cross_section_length = sorted_frusta[i]["yDimension"]
+            frustum_height = (
+                sorted_frusta[i + 1]["topHeight"] - sorted_frusta[i]["topHeight"]
+            )
+            frustum_volume = volume_from_height_rectangular(
+                target_height=frustum_height,
+                total_frustum_height=frustum_height,
+                bottom_length=bottom_cross_section_length,
+                bottom_width=bottom_cross_section_width,
+                top_length=top_cross_section_length,
+                top_width=top_cross_section_width,
+            )
+
+            well_volume[sorted_frusta[i + 1]["topHeight"]] = frustum_volume
+    elif is_circular_frusta_list(sorted_frusta):
+        # get height from 0 to 1, 1 to 2, ...
+        # assuming that from this point on, well cross-sections won't change between
+        # circular and rectangular or vise versa
+        for i in range(len(sorted_frusta) - 1):
+            top_cross_section_radius = sorted_frusta[i + 1]["diameter"] / 2.0
+            bottom_cross_section_radius = sorted_frusta[i]["diameter"] / 2.0
+            frustum_height = (
+                sorted_frusta[i + 1]["topHeight"] - sorted_frusta[i]["topHeight"]
+            )
+            frustum_volume = volume_from_height_circular(
+                target_height=frustum_height,
+                total_frustum_height=frustum_height,
+                bottom_radius=bottom_cross_section_radius,
+                top_radius=top_cross_section_radius,
+            )
+
+            well_volume[sorted_frusta[i + 1]["topHeight"]] = frustum_volume
+
+    return well_volume

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -177,6 +177,7 @@ def height_from_volume_spherical(
 
 
 def spherical_cross_section_radius(volume: float, depth: float) -> float:
+    """Find the radius of a spherical section given the volume and depth."""
     cross_section_radius = float(
         sqrt((6 * volume - pi * (depth**3)) / (3 * pi * depth))
     )

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for liquid-level related calculations inside a given frustum."""
 from typing import List, Tuple
-from numpy import pi, iscomplex, roots, real
+from numpy import pi, iscomplex, roots, real, sqrt
 
 from ..errors.exceptions import InvalidLiquidHeightFound
 
@@ -174,3 +174,10 @@ def height_from_volume_spherical(
         max_height=total_frustum_height,
     )
     return height
+
+
+def spherical_cross_section_radius(volume: float, depth: float) -> float:
+    cross_section_radius = float(
+        sqrt((6 * volume - pi * (depth**3)) / (3 * pi * depth))
+    )
+    return cross_section_radius

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for liquid-level related calculations inside a given frustum."""
 from typing import List, Tuple
-from numpy import pi, iscomplex, roots, real, sqrt
+from numpy import pi, iscomplex, roots, real
 
 from ..errors.exceptions import InvalidLiquidHeightFound
 
@@ -174,11 +174,3 @@ def height_from_volume_spherical(
         max_height=total_frustum_height,
     )
     return height
-
-
-def spherical_cross_section_radius(volume: float, depth: float) -> float:
-    """Find the radius of a spherical section given the volume and depth."""
-    cross_section_radius = float(
-        sqrt((6 * volume - pi * (depth**3)) / (3 * pi * depth))
-    )
-    return cross_section_radius

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -185,14 +185,9 @@ def get_boundary_cross_sections(frusta: Sequence[Any]) -> Iterator[Tuple[Any, An
     """Yield tuples representing two cross-section boundaries of a segment of a well."""
     iter_f = iter(frusta)
     el = next(iter_f)
-    next_el = next(iter_f)
-    while True:
+    for next_el in iter_f:
         yield el, next_el
         el = next_el
-        try:
-            next_el = next(iter_f)
-        except StopIteration:
-            break
 
 
 def get_well_volumetric_capacity(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1204,9 +1204,10 @@ class GeometryView:
 
     def get_well_volumetric_capacity(
         self, labware_id: str, well_id: str
-    ) -> Dict[Tuple[float, float], float]:
+    ) -> Dict[float, float]:
         """Return the total volumetric capacity of a well as a map of height borders to volume."""
-        # dictionary map of heights to volumetric capacities
+        # dictionary map of heights to volumetric capacities within their respective segment
+        # {top_height_0: volume_0, top_height_1: volume_1, top_height_2: volume_2}
         labware_def = self._labware.get_definition(labware_id)
         if labware_def.innerLabwareGeometry is None:
             raise InvalidWellDefinitionError(message="No InnerLabwareGeometry found.")
@@ -1224,7 +1225,7 @@ class GeometryView:
                     radius_of_curvature=well_geometry.bottomShape.radius_of_curvature,
                     target_height=bottom_spherical_section_depth,
                 )
-                well_volume[0.0, bottom_spherical_section_depth] = bottom_sphere_volume
+                well_volume[bottom_spherical_section_depth] = bottom_sphere_volume
 
         # get the volume of remaining frusta sorted in ascending order
         sorted_frusta = sorted(
@@ -1248,10 +1249,7 @@ class GeometryView:
                     top_width=top_cross_section_width,
                 )
 
-                well_volume[
-                    sorted_frusta[i]["topHeight"],
-                    sorted_frusta[i + 1]["topHeight"],
-                ] = frustum_volume
+                well_volume[sorted_frusta[i + 1]["topHeight"]] = frustum_volume
         elif is_circular_frusta_list(sorted_frusta):
             # get height from 0 to 1, 1 to 2, ...
             # assuming that from this point on, well cross-sections won't change between
@@ -1269,9 +1267,6 @@ class GeometryView:
                     top_radius=top_cross_section_radius,
                 )
 
-                well_volume[
-                    sorted_frusta[i]["topHeight"],
-                    sorted_frusta[i + 1]["topHeight"],
-                ] = frustum_volume
+                well_volume[sorted_frusta[i + 1]["topHeight"]] = frustum_volume
 
         return well_volume

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1194,7 +1194,7 @@ class GeometryView:
 
     def get_well_volumetric_capacity(
         self, labware_id: str, well_id: str
-    ) -> Dict[float, float]:
+    ) -> List[Tuple[float, float]]:
         """Return a map of heights to partial volumes."""
         labware_def = self._labware.get_definition(labware_id)
         if labware_def.innerLabwareGeometry is None:

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -9,7 +9,6 @@ from functools import cached_property
 from opentrons.types import Point, DeckSlotName, StagingSlotName, MountType
 
 from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
-
 from opentrons_shared_data.deck.types import CutoutFixture
 from opentrons_shared_data.pipette import PIPETTE_X_SPAN
 from opentrons_shared_data.pipette.types import ChannelCount

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1231,7 +1231,7 @@ class GeometryView:
         if all([f.geometry.shape == "circular" for f in sorted_frusta]):
             # get height from 0 to 1, 1 to 2, ...
             # assuming that from this point on, well cross-sections won't change between
-            # circular and rectangular or vise versa
+            # circular and rectangular or vice versa
             for i in range(len(sorted_frusta) - 1):
                 top_circular_cs = cast(
                     CircularCrossSection, sorted_frusta[i + 1].geometry

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -13,8 +13,7 @@ from opentrons_shared_data.labware.labware_definition import (
     Group,
     Metadata1,
     WellDefinition,
-    BoundedSection,
-    RectangularCrossSection,
+    RectangularBoundedSection,
     InnerWellGeometry,
     SphericalSegment,
 )
@@ -692,20 +691,16 @@ def _load_labware_definition_data() -> LabwareDefinition:
         innerLabwareGeometry={
             "welldefinition1111": InnerWellGeometry(
                 frusta=[
-                    BoundedSection(
-                        geometry=RectangularCrossSection(
-                            shape="rectangular",
-                            xDimension=7.6,
-                            yDimension=8.5,
-                        ),
+                    RectangularBoundedSection(
+                        shape="rectangular",
+                        xDimension=7.6,
+                        yDimension=8.5,
                         topHeight=45,
                     ),
-                    BoundedSection(
-                        geometry=RectangularCrossSection(
-                            shape="rectangular",
-                            xDimension=5.6,
-                            yDimension=6.5,
-                        ),
+                    RectangularBoundedSection(
+                        shape="rectangular",
+                        xDimension=5.6,
+                        yDimension=6.5,
                         topHeight=20,
                     ),
                 ],

--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -37,7 +37,7 @@ const checkGeometryDefinitions = (
       const topFrustumHeight =
         labwareDef.innerLabwareGeometry[wellGeometryId].frusta[0].topHeight
       const topFrustumShape =
-        labwareDef.innerLabwareGeometry[wellGeometryId].frusta[0].geometry.shape
+        labwareDef.innerLabwareGeometry[wellGeometryId].frusta[0].shape
 
       expect(wellDepth).toEqual(topFrustumHeight)
       expect(wellShape).toEqual(topFrustumShape)

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -159,38 +159,28 @@ export type LabwareWell = LabwareWellProperties & {
   geometryDefinitionId?: string
 }
 
-export interface CircularCrossSection {
-  shape: 'circular'
-  diameter: number
-}
-
-export interface RectangularCrossSection {
-  shape: 'rectangular'
-  xDimension: number
-  yDimension: number
-}
-
 export interface SphericalSegment {
   shape: 'spherical'
   radiusOfCurvature: number
   depth: number
 }
 
-export type TopCrossSection = CircularCrossSection | RectangularCrossSection
+export interface CircularBoundedSection {
+  shape: 'circular'
+  diameter: number
+  topHeight: number
+}
 
-export type BottomShape =
-  | CircularCrossSection
-  | RectangularCrossSection
-  | SphericalSegment
-
-export interface BoundedSection {
-  geometry: TopCrossSection
+export interface RectangularBoundedSection {
+  shape: 'rectangular'
+  xDimension: number
+  yDimension: number
   topHeight: number
 }
 
 export interface InnerWellGeometry {
-  frusta: BoundedSection[]
-  bottomShape: BottomShape
+  frusta: CircularBoundedSection[] | RectangularBoundedSection[]
+  bottomShape?: SphericalSegment | null
 }
 
 // TODO(mc, 2019-03-21): exact object is tough to use with the initial value in

--- a/shared-data/labware/fixtures/3/fixture_2_plate.json
+++ b/shared-data/labware/fixtures/3/fixture_2_plate.json
@@ -64,42 +64,29 @@
     "daiwudhadfhiew": {
       "frusta": [
         {
-          "geometry": {
-            "shape": "rectangular",
-            "xDimension": 127.76,
-            "yDimension": 85.8
-          },
+          "shape": "rectangular",
+          "xDimension": 127.76,
+          "yDimension": 85.8,
           "topHeight": 42.16
         },
         {
-          "geometry": {
-            "shape": "rectangular",
-            "xDimension": 70.0,
-            "yDimension": 50.0
-          },
+          "shape": "rectangular",
+          "xDimension": 70.0,
+          "yDimension": 50.0,
           "topHeight": 20.0
         }
-      ],
-      "bottomShape": {
-        "shape": "rectangular",
-        "xDimension": 2.0,
-        "yDimension": 3.0
-      }
+      ]
     },
     "iuweofiuwhfn": {
       "frusta": [
         {
-          "geometry": {
-            "shape": "circular",
-            "diameter": 35.0
-          },
+          "shape": "circular",
+          "diameter": 35.0,
           "topHeight": 42.16
         },
         {
-          "geometry": {
-            "shape": "circular",
-            "diameter": 22.0
-          },
+          "shape": "circular",
+          "diameter": 35.0,
           "topHeight": 20.0
         }
       ],

--- a/shared-data/labware/fixtures/3/fixture_corning_24_plate.json
+++ b/shared-data/labware/fixtures/3/fixture_corning_24_plate.json
@@ -325,17 +325,16 @@
     "venirhgerug": {
       "frusta": [
         {
-          "geometry": {
-            "shape": "circular",
-            "diameter": 16.26
-          },
+          "shape": "circular",
+          "diameter": 16.26,
           "topHeight": 17.4
+        },
+        {
+          "shape": "circular",
+          "diameter": 16.26,
+          "topHeight": 0.0
         }
-      ],
-      "bottomShape": {
-        "shape": "circular",
-        "diameter": 16.26
-      }
+      ]
     }
   }
 }

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -65,37 +65,9 @@
         }
       }
     },
-    "CircularCrossSection": {
-      "type": "object",
-      "required": ["shape", "diameter"],
-      "properties": {
-        "shape": {
-          "type": "string",
-          "enum": ["circular"]
-        },
-        "diameter": {
-          "type": "number"
-        }
-      }
-    },
-    "RectangularCrossSection": {
-      "type": "object",
-      "required": ["shape", "xDimension", "yDimension"],
-      "properties": {
-        "shape": {
-          "type": "string",
-          "enum": ["rectangular"]
-        },
-        "xDimension": {
-          "type": "number"
-        },
-        "yDimension": {
-          "type": "number"
-        }
-      }
-    },
     "SphericalSegment": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["shape", "radiusOfCurvature", "depth"],
       "properties": {
         "shape": {
@@ -110,19 +82,36 @@
         }
       }
     },
-    "BoundedSection": {
+    "CircularBoundedSection": {
       "type": "object",
-      "required": ["geometry", "topHeight"],
+      "required": ["shape", "diameter", "topHeight"],
       "properties": {
-        "geometry": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/CircularCrossSection"
-            },
-            {
-              "$ref": "#/definitions/RectangularCrossSection"
-            }
-          ]
+        "shape": {
+          "type": "string",
+          "enum": ["circular"]
+        },
+        "diameter": {
+          "type": "number"
+        },
+        "topHeight": {
+          "type": "number",
+          "description": "The height at the top of a bounded subsection of a well, relative to the bottom"
+        }
+      }
+    },
+    "RectangularBoundedSection": {
+      "type": "object",
+      "required": ["shape", "xDimension", "yDimension", "topHeight"],
+      "properties": {
+        "shape": {
+          "type": "string",
+          "enum": ["rectangular"]
+        },
+        "xDimension": {
+          "type": "number"
+        },
+        "yDimension": {
+          "type": "number"
         },
         "topHeight": {
           "type": "number",
@@ -132,28 +121,26 @@
     },
     "InnerWellGeometry": {
       "type": "object",
-      "required": ["frusta", "bottomShape"],
+      "required": ["frusta"],
       "properties": {
         "frusta": {
           "description": "A list of all of the sections of the well that have a contiguous shape",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/BoundedSection"
+            "oneOf": [
+              {
+                "$ref": "#/definitions/CircularBoundedSection"
+              },
+              {
+                "$ref": "#/definitions/RectangularBoundedSection"
+              }
+            ]
           }
         },
         "bottomShape": {
+          "type": "object",
           "description": "The shape at the bottom of the well: either a spherical segment or a cross-section",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/CircularCrossSection"
-            },
-            {
-              "$ref": "#/definitions/RectangularCrossSection"
-            },
-            {
-              "$ref": "#/definitions/SphericalSegment"
-            }
-          ]
+          "$ref": "#/definitions/SphericalSegment"
         }
       }
     }

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -238,12 +238,12 @@ class RectangularCrossSection(BaseModel):
     shape: Literal["rectangular"] = Field(
         ..., description="Denote shape as rectangular"
     )
-    xDimension: Optional[_NonNegativeNumber] = Field(
-        None,
+    xDimension: _NonNegativeNumber = Field(
+        ...,
         description="x dimension of a subsection of wells",
     )
-    yDimension: Optional[_NonNegativeNumber] = Field(
-        None,
+    yDimension: _NonNegativeNumber = Field(
+        ...,
         description="y dimension of a subsection of wells",
     )
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -307,7 +307,6 @@ class InnerWellGeometry(BaseModel):
     bottomShape: Optional[SphericalSegment] = Field(
         None,
         description="The shape at the bottom of the well: either a spherical segment or a cross-section",
-        discriminator="shape",
     )
 
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -298,7 +298,9 @@ class Group(BaseModel):
 
 
 class InnerWellGeometry(BaseModel):
-    frusta: Union[List[CircularBoundedSection], List[RectangularBoundedSection]] = Field(
+    frusta: Union[
+        List[CircularBoundedSection], List[RectangularBoundedSection]
+    ] = Field(
         ...,
         description="A list of all of the sections of the well that have a contiguous shape",
     )

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -227,27 +227,6 @@ class WellDefinition(BaseModel):
     )
 
 
-class CircularCrossSection(BaseModel):
-    shape: Literal["circular"] = Field(..., description="Denote shape as circular")
-    diameter: _NonNegativeNumber = Field(
-        ..., description="The diameter of a circular cross section of a well"
-    )
-
-
-class RectangularCrossSection(BaseModel):
-    shape: Literal["rectangular"] = Field(
-        ..., description="Denote shape as rectangular"
-    )
-    xDimension: _NonNegativeNumber = Field(
-        ...,
-        description="x dimension of a subsection of wells",
-    )
-    yDimension: _NonNegativeNumber = Field(
-        ...,
-        description="y dimension of a subsection of wells",
-    )
-
-
 class SphericalSegment(BaseModel):
     shape: Literal["spherical"] = Field(..., description="Denote shape as spherical")
     radius_of_curvature: _NonNegativeNumber = Field(
@@ -259,15 +238,29 @@ class SphericalSegment(BaseModel):
     )
 
 
-TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
-BottomShape = Union[CircularCrossSection, RectangularCrossSection, SphericalSegment]
-
-
-class BoundedSection(BaseModel):
-    geometry: TopCrossSection = Field(
+class CircularBoundedSection(BaseModel):
+    shape: Literal["circular"] = Field(..., description="Denote shape as circular")
+    diameter: _NonNegativeNumber = Field(
+        ..., description="The diameter of a circular cross section of a well"
+    )
+    topHeight: _NonNegativeNumber = Field(
         ...,
-        description="Geometrical information needed to calculate the volume of a subsection of a well",
-        discriminator="shape",
+        description="The height at the top of a bounded subsection of a well, relative to the bottom"
+        "of the well",
+    )
+
+
+class RectangularBoundedSection(BaseModel):
+    shape: Literal["rectangular"] = Field(
+        ..., description="Denote shape as rectangular"
+    )
+    xDimension: _NonNegativeNumber = Field(
+        ...,
+        description="x dimension of a subsection of wells",
+    )
+    yDimension: _NonNegativeNumber = Field(
+        ...,
+        description="y dimension of a subsection of wells",
     )
     topHeight: _NonNegativeNumber = Field(
         ...,
@@ -305,12 +298,12 @@ class Group(BaseModel):
 
 
 class InnerWellGeometry(BaseModel):
-    frusta: List[BoundedSection] = Field(
+    frusta: Union[List[CircularBoundedSection], List[RectangularBoundedSection]] = Field(
         ...,
         description="A list of all of the sections of the well that have a contiguous shape",
     )
-    bottomShape: BottomShape = Field(
-        ...,
+    bottomShape: Optional[SphericalSegment] = Field(
+        None,
         description="The shape at the bottom of the well: either a spherical segment or a cross-section",
         discriminator="shape",
     )

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -139,11 +139,15 @@ class CircularBoundedSection(TypedDict):
     topHeight: float
 
 
-def is_circular_frusta_list(items: List[Any]) -> TypeGuard[List[CircularBoundedSection]]:
+def is_circular_frusta_list(
+    items: List[Any],
+) -> TypeGuard[List[CircularBoundedSection]]:
     return all(item.shape == "circular" for item in items)
 
 
-def is_rectangular_frusta_list(items: List[Any]) -> TypeGuard[List[RectangularBoundedSection]]:
+def is_rectangular_frusta_list(
+    items: List[Any],
+) -> TypeGuard[List[RectangularBoundedSection]]:
     return all(item.shape == "rectangular" for item in items)
 
 

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -3,8 +3,8 @@
 types in this file by and large require the use of typing_extensions.
 this module shouldn't be imported unless typing.TYPE_CHECKING is true.
 """
-from typing import Dict, List, NewType, Union
-from typing_extensions import Literal, TypedDict, NotRequired
+from typing import Dict, List, NewType, Union, Optional, Any
+from typing_extensions import Literal, TypedDict, NotRequired, TypeGuard
 
 
 LabwareUri = NewType("LabwareUri", str)
@@ -120,37 +120,36 @@ class WellGroup(TypedDict, total=False):
     brand: LabwareBrandData
 
 
-class CircularCrossSection(TypedDict):
-    shape: Circular
-    diameter: float
-
-
-class RectangularCrossSection(TypedDict):
-    shape: Rectangular
-    xDimension: float
-    yDimension: float
-
-
 class SphericalSegment(TypedDict):
     shape: Spherical
     radiusOfCurvature: float
     depth: float
 
 
-TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
-# todo(cm): make bottomShape just an option spherical segment
-BottomShape = Union[CircularCrossSection, RectangularCrossSection, SphericalSegment]
-
-
-# todo(cm): break out BoundedSection into CircularBoundedSection and RectangularBoundedSection
-class BoundedSection(TypedDict):
-    geometry: TopCrossSection
+class RectangularBoundedSection(TypedDict):
+    shape: Rectangular
+    xDimension: float
+    yDimension: float
     topHeight: float
 
 
+class CircularBoundedSection(TypedDict):
+    shape: Circular
+    diameter: float
+    topHeight: float
+
+
+def is_circular_frusta_list(items: List[Any]) -> TypeGuard[List[CircularBoundedSection]]:
+    return all(item.shape == "circular" for item in items)
+
+
+def is_rectangular_frusta_list(items: List[Any]) -> TypeGuard[List[RectangularBoundedSection]]:
+    return all(item.shape == "rectangular" for item in items)
+
+
 class InnerWellGeometry(TypedDict):
-    frusta: List[BoundedSection]
-    bottomShape: BottomShape
+    frusta: Union[List[CircularBoundedSection], List[RectangularBoundedSection]]
+    bottomShape: Optional[SphericalSegment]
 
 
 class LabwareDefinition(TypedDict):

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -138,7 +138,7 @@ class SphericalSegment(TypedDict):
 
 
 TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
-# todo(cm): make bottom section always a cross section + an optional spherical segment
+# todo(cm): make bottomShape just an option spherical segment
 BottomShape = Union[CircularCrossSection, RectangularCrossSection, SphericalSegment]
 
 

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -142,6 +142,7 @@ TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
 BottomShape = Union[CircularCrossSection, RectangularCrossSection, SphericalSegment]
 
 
+# todo(cm): break out BoundedSection into CircularBoundedSection and RectangularBoundedSection
 class BoundedSection(TypedDict):
     geometry: TopCrossSection
     topHeight: float

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -138,6 +138,7 @@ class SphericalSegment(TypedDict):
 
 
 TopCrossSection = Union[CircularCrossSection, RectangularCrossSection]
+# todo(cm): make bottom section always a cross section + an optional spherical segment
 BottomShape = Union[CircularCrossSection, RectangularCrossSection, SphericalSegment]
 
 


### PR DESCRIPTION
## Overview
This adds a function in `GeometryView` that allows us to calculate the total volumetric capacity inside a given well. We'll traverse all of the listed segments of the well in shared-data, calculate the volume of each one, and map the height at the top of each segment, to the volume contained within the segment. So, the return value will be a Tuple that's something like `[(height_0, volume_0), (height_1: volume_1)]`, where the volume between the bottom of the well and `height_0` will be `volume_0`, the volume contained between `height_0` and `height_1` will be `volume_1`, and the total volume of the well will be the sum of `volume_0` and `volume_1`.

The idea in mapping out heights to volumes rather than just returning the total volume or even a list of volumes, is that we'll likely call this when trying to figure out an unknown volume at some arbitrary height. In this case, we can:

- determine which two cross-sections our target height lies between
- find the volume within whatever frustum the target height is in
- add this volume to the complete volumes of every frustum beneath our target height  

## Changelog

- `bottomShape` is now only an `Optional[SphericalSegment]`
- the first cross-section in `frusta` is now considered to be either a flat bottom of a well (if there is one), or alternatively the cross-section at the top of the `SphericalSegment` on the bottom
- `BoundedSection` is now broken up into either `CircularBoundedSection` or `RectangularBoundedSection`
- `frusta` is expected to contain either only `RectangularBoundedSection`s or only `CircularBoundedSection`s, since this makes the math easier and also reflects how the wells we'll be dealing with are
- some more math in `frustum_helpers.py`


## TODO
- Write some tests