### PR TITLE
fix(app): fix gray run status when pressing "return to dash" on `RunSummary`

### DIFF
--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -147,7 +147,7 @@ export function RunSummary(): JSX.Element {
   const trackEvent = useTrackEvent()
   const { trackEventWithRobotSerial } = useTrackEventWithRobotSerial()
 
-  const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
+  const { closeCurrentRun } = useCloseCurrentRun()
   // Close the current run only if it's active and then execute the onSuccess callback. Prefer this wrapper over
   // closeCurrentRun directly, since the callback is swallowed if currentRun is null.
   const closeCurrentRunIfValid = (onSuccess?: () => void): void => {
@@ -386,7 +386,6 @@ export function RunSummary(): JSX.Element {
       flexDirection={DIRECTION_COLUMN}
       position={POSITION_RELATIVE}
       overflow={OVERFLOW_HIDDEN}
-      disabled={isClosingCurrentRun}
       onClick={handleClickSplash}
     >
       {showSplash ? (


### PR DESCRIPTION
Closes [RQA-3159](https://opentrons.atlassian.net/browse/RQA-3159)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes the run status changing to gray when clicking "return to dashboard" on the ODD `RunSummary` page. 

The run status graying on button click has always been in the code, but because we used to navigate immediately after clicking "return to dashboard", this wasn't a user-visible problem.

It's hard to tell what the original intention of this disabled state was, but from my testing, it doesn't seem to impact anything negatively.

### Current Behavior

https://github.com/user-attachments/assets/75a76d41-6500-446b-b110-74ebde383914

### Fixed Behavior

https://github.com/user-attachments/assets/982fd029-75d5-4a09-b3e5-561b001f7215


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the run status changing color when clicking "return to dashboard" on the ODD.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low...assuming the disabled state wasn't doing anything.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3159]: https://opentrons.atlassian.net/browse/RQA-3159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ