### PR TITLE
refactor(protocol-designer): hardware toast only renders on first time

### DIFF
--- a/protocol-designer/src/labware-ingred/actions/actions.ts
+++ b/protocol-designer/src/labware-ingred/actions/actions.ts
@@ -282,3 +282,16 @@ export const selectZoomedIntoSlot: (
   type: 'ZOOMED_INTO_SLOT',
   payload,
 })
+
+export interface GenerateNewProtocolAction {
+  type: 'GENERATE_NEW_PROTOCOL'
+  payload: {
+    isNewProtocol: boolean
+  }
+}
+export const generateNewProtocol: (
+  payload: GenerateNewProtocolAction['payload']
+) => GenerateNewProtocolAction = payload => ({
+  type: 'GENERATE_NEW_PROTOCOL',
+  payload,
+})

--- a/protocol-designer/src/labware-ingred/reducers/index.ts
+++ b/protocol-designer/src/labware-ingred/reducers/index.ts
@@ -16,6 +16,7 @@ import type {
   LiquidGroupsById,
   DisplayLabware,
   ZoomedIntoSlotInfoState,
+  GenerateNewProtocolState,
 } from '../types'
 import type { LoadFileAction } from '../../load-file'
 import type {
@@ -38,6 +39,7 @@ import type {
   SelectModuleAction,
   SelectFixtureAction,
   ZoomedIntoSlotAction,
+  GenerateNewProtocolAction,
 } from '../actions'
 // REDUCERS
 // modeLabwareSelection: boolean. If true, we're selecting labware to add to a slot
@@ -402,6 +404,24 @@ export const zoomedInSlotInfo = (
       return state
   }
 }
+
+const initialGenerateNewProtocolState: GenerateNewProtocolState = {
+  isNewProtocol: false,
+}
+
+export const generateNewProtocol = (
+  state: GenerateNewProtocolState = initialGenerateNewProtocolState,
+  action: GenerateNewProtocolAction
+): GenerateNewProtocolState => {
+  switch (action.type) {
+    case 'GENERATE_NEW_PROTOCOL': {
+      const { isNewProtocol } = action.payload
+      return { ...state, isNewProtocol }
+    }
+    default:
+      return state
+  }
+}
 export interface RootState {
   zoomedInSlotInfo: ZoomedIntoSlotInfoState
   modeLabwareSelection: DeckSlot | false
@@ -412,6 +432,7 @@ export interface RootState {
   selectedLiquidGroup: SelectedLiquidGroupState
   ingredients: IngredientsState
   ingredLocations: LocationsState
+  generateNewProtocol: GenerateNewProtocolState
 }
 // TODO Ian 2018-01-15 factor into separate files
 export const rootReducer: Reducer<RootState, Action> = combineReducers({
@@ -424,4 +445,5 @@ export const rootReducer: Reducer<RootState, Action> = combineReducers({
   savedLabware,
   ingredients,
   ingredLocations,
+  generateNewProtocol,
 })

--- a/protocol-designer/src/labware-ingred/selectors.ts
+++ b/protocol-designer/src/labware-ingred/selectors.ts
@@ -173,6 +173,11 @@ const getZoomedInSlot: Selector<
   rootState => rootState.zoomedInSlotInfo.selectedSlot
 )
 
+const getIsNewProtocol: Selector<RootSlice, boolean> = createSelector(
+  rootSelector,
+  rootState => rootState.generateNewProtocol.isNewProtocol
+)
+
 // TODO: prune selectors
 export const selectors = {
   rootSelector,
@@ -195,4 +200,5 @@ export const selectors = {
   getLiquidDisplayColors,
   getZoomedInSlotInfo,
   getZoomedInSlot,
+  getIsNewProtocol,
 }

--- a/protocol-designer/src/labware-ingred/types.ts
+++ b/protocol-designer/src/labware-ingred/types.ts
@@ -58,3 +58,7 @@ export interface ZoomedIntoSlotInfoState {
   selectedFixture: Fixture | null
   selectedSlot: { slot: DeckSlot | null; cutout: CutoutId | null }
 }
+
+export interface GenerateNewProtocolState {
+  isNewProtocol: boolean
+}

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/index.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/index.tsx
@@ -355,6 +355,7 @@ export function CreateNewProtocolWizard(): JSX.Element | null {
         )
       })
     }
+    dispatch(labwareIngredActions.generateNewProtocol({ isNewProtocol: true }))
   }
 
   const currentWizardStep = wizardSteps[currentStepIndex]

--- a/protocol-designer/src/pages/Designer/__tests__/Designer.test.tsx
+++ b/protocol-designer/src/pages/Designer/__tests__/Designer.test.tsx
@@ -5,9 +5,10 @@ import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
 import { i18n } from '../../../assets/localization'
 import { renderWithProviders } from '../../../__testing-utils__'
-import { getFileMetadata } from '../../../file-data/selectors'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import { selectors } from '../../../labware-ingred/selectors'
+import { getFileMetadata } from '../../../file-data/selectors'
+import { generateNewProtocol } from '../../../labware-ingred/actions'
 import { DeckSetupContainer } from '../DeckSetup'
 import { Designer } from '../index'
 import { LiquidsOverflowMenu } from '../LiquidsOverflowMenu'
@@ -16,6 +17,7 @@ import type { NavigateFunction } from 'react-router-dom'
 
 const mockNavigate = vi.fn()
 
+vi.mock('../../../labware-ingred/actions')
 vi.mock('../../../labware-ingred/selectors')
 vi.mock('../LiquidsOverflowMenu')
 vi.mock('../DeckSetup')
@@ -45,6 +47,7 @@ describe('Designer', () => {
     vi.mocked(getFileMetadata).mockReturnValue({
       protocolName: 'mockProtocolName',
     })
+    vi.mocked(selectors.getIsNewProtocol).mockReturnValue(true)
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
       modules: {},
       additionalEquipmentOnDeck: {},
@@ -79,6 +82,20 @@ describe('Designer', () => {
     render()
     fireEvent.click(screen.getByText('Liquids'))
     screen.getByText('mock LiquidsOverflowMenu')
+  })
+
+  it('calls generateNewProtocol when hardware has been placed for a new protocol', () => {
+    vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
+      modules: {},
+      additionalEquipmentOnDeck: {
+        wasteChute: { name: 'wasteChute', id: 'mockId', location: 'cutoutD3' },
+        trashBin: { name: 'trashBin', id: 'mockId', location: 'cutoutA3' },
+      },
+      labware: {},
+      pipettes: {},
+    })
+    render()
+    expect(vi.mocked(generateNewProtocol)).toHaveBeenCalled()
   })
 
   it.todo('renders the protocol steps page')

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -21,7 +21,7 @@ import {
 } from '@opentrons/components'
 import { useKitchen } from '../../organisms/Kitchen/hooks'
 import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
-import { getFileMetadata } from '../../file-data/selectors'
+import { generateNewProtocol } from '../../labware-ingred/actions'
 import { DefineLiquidsModal, ProtocolMetadataNav } from '../../organisms'
 import { DeckSetupContainer } from './DeckSetup'
 import { selectors } from '../../labware-ingred/selectors'
@@ -44,9 +44,10 @@ export function Designer(): JSX.Element {
   ])
   const { bakeToast } = useKitchen()
   const navigate = useNavigate()
+  const dispatch = useDispatch()
   const zoomIn = useSelector(selectors.getZoomedInSlot)
   const deckSetup = useSelector(getDeckSetupForActiveItem)
-  const metadata = useSelector(getFileMetadata)
+  const isNewProtocol = useSelector(selectors.getIsNewProtocol)
   const [liquidOverflowMenu, showLiquidOverflowMenu] = React.useState<boolean>(
     false
   )
@@ -84,13 +85,14 @@ export function Designer(): JSX.Element {
     // greater than 1 to account for the default loaded trashBin
     Object.values(additionalEquipmentOnDeck).length > 1
 
-  // only display toast if its a newly made protocol
+  // only display toast if its a newly made protocol and has hardware
   React.useEffect(() => {
-    if (hasHardware && metadata?.lastModified == null) {
+    if (hasHardware && isNewProtocol) {
       bakeToast(t('add_rest') as string, INFO_TOAST, {
         heading: t('we_added_hardware'),
         closeButton: true,
       })
+      dispatch(generateNewProtocol({ isNewProtocol: false }))
     }
   }, [])
 


### PR DESCRIPTION
closes AUTH-786

# Overview

The previous logic was not good enough and the toast rendered whenever it was a new protocol with hardware and you navigate back to the deck setup page. This new logic renders it only if you have a new protocol with hardware and you navigate to the deck setup page for the first time.

## Test Plan and Hands on Testing

Create a new protocol with deck hardware (not including the trash bin) and go to the deck setup page. should see the banner. Then go back to overview and then back to the deck setup page, should not see the banner

Then import a protocol and go to the deck setup page, should not see the banner

Then create a new protocol with no hardware and go to the deck setup page and should not see the banner.

## Changelog

create a new redux key boolean state that defaults to false unless you go through the onboarding flow.

## Risk assessment

low