### PR TITLE
fix(app): display only one conflict with thermocycler in run setup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
@@ -191,9 +191,10 @@ export const LocationConflictModal = (
     protocolSpecifiesDisplayName = getModuleDisplayName(requiredModule)
   }
 
-  const displaySlotName = isThermocyclerRequired
-    ? 'A1 + B1'
-    : getCutoutDisplayName(cutoutId)
+  const displaySlotName =
+    isThermocyclerRequired || isThermocyclerCurrentFixture
+      ? 'A1 + B1'
+      : getCutoutDisplayName(cutoutId)
 
   if (showModuleSelect && requiredModule != null) {
     return createPortal(
@@ -232,7 +233,7 @@ export const LocationConflictModal = (
             }
             values={{
               currentFixture: currentFixtureDisplayName,
-              cutout: getCutoutDisplayName(cutoutId),
+              cutout: displaySlotName,
             }}
             components={{
               block: <LegacyStyledText as="p" />,
@@ -341,7 +342,7 @@ export const LocationConflictModal = (
             }
             values={{
               currentFixture: currentFixtureDisplayName,
-              cutout: getCutoutDisplayName(cutoutId),
+              cutout: displaySlotName,
             }}
             components={{
               block: <LegacyStyledText fontSize={TYPOGRAPHY.fontSizeH4} />,

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupFixtureList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupFixtureList.tsx
@@ -23,6 +23,9 @@ import {
   getCutoutDisplayName,
   getDeckDefFromRobotType,
   getFixtureDisplayName,
+  TC_MODULE_LOCATION_OT3,
+  THERMOCYCLER_V2_FRONT_FIXTURE,
+  THERMOCYCLER_V2_REAR_FIXTURE,
 } from '@opentrons/shared-data'
 import { StatusLabel } from '../../../../atoms/StatusLabel'
 import { TertiaryButton } from '../../../../atoms/buttons/TertiaryButton'
@@ -47,9 +50,32 @@ interface SetupFixtureListProps {
 export const SetupFixtureList = (props: SetupFixtureListProps): JSX.Element => {
   const { deckConfigCompatibility, robotName } = props
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+
+  const hasTwoLabwareThermocyclerConflicts =
+    deckConfigCompatibility.some(
+      ({ cutoutFixtureId, missingLabwareDisplayName }) =>
+        cutoutFixtureId === THERMOCYCLER_V2_FRONT_FIXTURE &&
+        missingLabwareDisplayName != null
+    ) &&
+    deckConfigCompatibility.some(
+      ({ cutoutFixtureId, missingLabwareDisplayName }) =>
+        cutoutFixtureId === THERMOCYCLER_V2_REAR_FIXTURE &&
+        missingLabwareDisplayName != null
+    )
+
+  // if there are two labware conflicts with the thermocycler, don't show the conflict with the thermocycler rear fixture
+  const filteredDeckConfigCompatibility = deckConfigCompatibility.filter(
+    ({ cutoutFixtureId }) => {
+      return (
+        !hasTwoLabwareThermocyclerConflicts ||
+        !(cutoutFixtureId === THERMOCYCLER_V2_REAR_FIXTURE)
+      )
+    }
+  )
+
   return (
     <>
-      {deckConfigCompatibility.map(cutoutConfigAndCompatibility => {
+      {filteredDeckConfigCompatibility.map(cutoutConfigAndCompatibility => {
         // filter out all fixtures that only provide usb module addressable areas
         // (i.e. everything but MagBlockV1 and StagingAreaWithMagBlockV1)
         // as they're handled in the Modules Table
@@ -89,6 +115,11 @@ export function FixtureListItem({
   const isRequiredSingleSlotMissing = missingLabwareDisplayName != null
   const isConflictingFixtureConfigured =
     cutoutFixtureId != null && !SINGLE_SLOT_FIXTURES.includes(cutoutFixtureId)
+
+  const isThermocyclerCurrentFixture =
+    cutoutFixtureId === THERMOCYCLER_V2_FRONT_FIXTURE ||
+    cutoutFixtureId === THERMOCYCLER_V2_REAR_FIXTURE
+
   let statusLabel
   if (!isCurrentFixtureCompatible) {
     statusLabel = (
@@ -215,7 +246,9 @@ export function FixtureListItem({
             </Flex>
           </Flex>
           <LegacyStyledText as="p" width="15%">
-            {getCutoutDisplayName(cutoutId)}
+            {isThermocyclerCurrentFixture && isRequiredSingleSlotMissing
+              ? TC_MODULE_LOCATION_OT3
+              : getCutoutDisplayName(cutoutId)}
           </LegacyStyledText>
           <Flex
             width="15%"

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
@@ -20,6 +20,9 @@ import {
   getFixtureDisplayName,
   getSimplestDeckConfigForProtocol,
   SINGLE_SLOT_FIXTURES,
+  TC_MODULE_LOCATION_OT3,
+  THERMOCYCLER_V2_FRONT_FIXTURE,
+  THERMOCYCLER_V2_REAR_FIXTURE,
 } from '@opentrons/shared-data'
 
 import { SmallButton } from '../../atoms/buttons'
@@ -74,8 +77,30 @@ export function FixtureTable({
     deckConfigCompatibility
   )
 
+  const hasTwoLabwareThermocyclerConflicts =
+    requiredDeckConfigCompatibility.some(
+      ({ cutoutFixtureId, missingLabwareDisplayName }) =>
+        cutoutFixtureId === THERMOCYCLER_V2_FRONT_FIXTURE &&
+        missingLabwareDisplayName != null
+    ) &&
+    requiredDeckConfigCompatibility.some(
+      ({ cutoutFixtureId, missingLabwareDisplayName }) =>
+        cutoutFixtureId === THERMOCYCLER_V2_REAR_FIXTURE &&
+        missingLabwareDisplayName != null
+    )
+
+  // if there are two labware conflicts with the thermocycler, don't show the conflict with the thermocycler rear fixture
+  const filteredDeckConfigCompatibility = requiredDeckConfigCompatibility.filter(
+    ({ cutoutFixtureId }) => {
+      return (
+        !hasTwoLabwareThermocyclerConflicts ||
+        !(cutoutFixtureId === THERMOCYCLER_V2_REAR_FIXTURE)
+      )
+    }
+  )
+
   // list not configured/conflicted fixtures first
-  const sortedDeckConfigCompatibility = requiredDeckConfigCompatibility.sort(
+  const sortedDeckConfigCompatibility = filteredDeckConfigCompatibility.sort(
     a =>
       a.cutoutFixtureId != null &&
       a.compatibleCutoutFixtureIds.includes(a.cutoutFixtureId)
@@ -139,6 +164,11 @@ function FixtureTableItem({
     cutoutFixtureId != null &&
     compatibleCutoutFixtureIds.includes(cutoutFixtureId)
   const isRequiredSingleSlotMissing = missingLabwareDisplayName != null
+
+  const isThermocyclerCurrentFixture =
+    cutoutFixtureId === THERMOCYCLER_V2_FRONT_FIXTURE ||
+    cutoutFixtureId === THERMOCYCLER_V2_REAR_FIXTURE
+
   let chipLabel: JSX.Element
   if (!isCurrentFixtureCompatible) {
     const isConflictingFixtureConfigured =
@@ -219,7 +249,13 @@ function FixtureTableItem({
           </LegacyStyledText>
         </Flex>
         <Flex flex="2 0 0" alignItems={ALIGN_CENTER}>
-          <DeckInfoLabel deckLabel={getCutoutDisplayName(cutoutId)} />
+          <DeckInfoLabel
+            deckLabel={
+              isThermocyclerCurrentFixture && isRequiredSingleSlotMissing
+                ? TC_MODULE_LOCATION_OT3
+                : getCutoutDisplayName(cutoutId)
+            }
+          />
         </Flex>
         <Flex
           flex="4 0 0"


### PR DESCRIPTION
# Overview

there are several combinations of labware, fixtures, and modules in A1 and B1 that generate two conflicts with a configured thermocycler. this PR filters out one of 2 conflicts from display when both conflicts are with single slot labware in a protocol. other scenarios should be covered by the modules or fixtures lists.

this behavior is related to our approach to surfacing and resolving a [single slot location conflict](https://github.com/Opentrons/opentrons/pull/14158) and has probably been around since 7.1.

closes RQA-3112

![Screen Shot 2024-09-10 at 12 57 24 PM](https://github.com/user-attachments/assets/0f41f21e-a035-47a6-b699-a300dbe841dc)
![Screen Shot 2024-09-10 at 12 57 31 PM](https://github.com/user-attachments/assets/2649db73-46d3-4f03-8c96-1a9319c5010e)
<img width="1136" alt="Screen Shot 2024-09-10 at 1 40 29 PM" src="https://github.com/user-attachments/assets/a4c81612-7006-4e96-8fce-182f75417f06">
<img width="1136" alt="Screen Shot 2024-09-10 at 1 26 51 PM" src="https://github.com/user-attachments/assets/5c8118cc-7b9d-4c37-aa75-bb16c7c88fb9">


## Test Plan and Hands on Testing

manually verified display of a single conflict with a current thermocycler. 

## Changelog

 - Display only one conflict with thermocycler in run setup

## Review requests

configure a thermocycler, and check a few protocols that have module, fixture, and labware conflicts in A1 and/or B1

## Risk assessment

low
