### PR TITLE
fix(protocol-designer): material list deck location fix

### DIFF
--- a/protocol-designer/src/organisms/MaterialsListModal/__tests__/MaterialsListModal.test.tsx
+++ b/protocol-designer/src/organisms/MaterialsListModal/__tests__/MaterialsListModal.test.tsx
@@ -8,12 +8,14 @@ import { i18n } from '../../../assets/localization'
 import { selectors as labwareIngredSelectors } from '../../../labware-ingred/selectors'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { getRobotType } from '../../../file-data/selectors'
+import { getInitialDeckSetup } from '../../../step-forms/selectors'
 import { MaterialsListModal } from '..'
 
 import type { InfoScreen } from '@opentrons/components'
 import type { LabwareOnDeck, ModuleOnDeck } from '../../../step-forms'
 import type { FixtureInList } from '..'
 
+vi.mock('../../../step-forms/selectors')
 vi.mock('../../../labware-ingred/selectors')
 vi.mock('../../../file-data/selectors')
 vi.mock('@opentrons/components', async importOriginal => {
@@ -78,6 +80,12 @@ describe('MaterialsListModal', () => {
       liquids: [],
       setShowMaterialsListModal: mockSetShowMaterialsListModal,
     }
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      labware: {},
+      modules: {},
+      additionalEquipmentOnDeck: {},
+      pipettes: {},
+    })
     vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
     vi.mocked(labwareIngredSelectors.getLiquidsByLabwareId).mockReturnValue({})
   })


### PR DESCRIPTION
closes AUTH-788

# Overview

Fix up the deck location information for labware not directly on the deck

## Test Plan and Hands on Testing

Create a protocol and add a labware on a module, labware on a labware on a deck, and labware on a labware on a module. Look at the materials list in the overview page. Should see the correct deck location.

## Changelog

- add deck location information for labware on a module and on another labware
- some random materials list clean up

## Risk assessment

low