### PR TITLE
fix(api): Maintain existing nozzle manager for reloaded virtual pipettes

### DIFF
--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -193,9 +193,12 @@ class VirtualPipetteDataProvider:
             pipette_model.pipette_channels,
             pipette_model.pipette_version,
         )
-        nozzle_manager = NozzleConfigurationManager.build_from_config(
-            config, valid_nozzle_maps
-        )
+        if pipette_id not in self._nozzle_manager_layout_by_id:
+            nozzle_manager = NozzleConfigurationManager.build_from_config(
+                config, valid_nozzle_maps
+            )
+        else:
+            nozzle_manager = self._nozzle_manager_layout_by_id[pipette_id]
 
         tip_overlap_dict_for_tip_type = None
         for configuration in (


### PR DESCRIPTION
# Overview
Covers RQA-3160

We had an issue where certain pipette errors (out of bounds and return tip forbidden) that depended on checking the nozzle map were not happening during client side analysis because the virtual static pipette was being overwritten when calling `configure_for_volume()`. This revealed an issue in the pipette data provider for virtual pipettes where the nozzle manager was being erroneously recreated and overwritten under certain edge cases in analysis. 

This PR ensures that we use ay existing nozzle manager whenever a virtual pipette is loaded/built. 

## Test Plan and Hands on Testing
Ensure protocol from the linked ticket raises expected Out of Bounds and Return Tip errors for a given single channel configuration of a 96ch pipette *AFTER* executing a `configure_for_volume(...)` command.

## Changelog
Updated `_get_virtual_pipette_static_config_by_model(...)` to utilize existing nozzle managers by pipette ID. 

## Review requests
Does this raise red flags for where we may be missing similar assignment elsewhere?

## Risk assessment
Low - we were already doing this kind of coverage for liquid classes, this naturally extends it for nozzle managers. 