### PR TITLE
fix(protocol-designer): fix slot info for liquids and adapters

### DIFF
--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -1,4 +1,5 @@
 {
+  "adapter": "Adapter",
   "add": "add",
   "amount": "Amount:",
   "ask_for_labware_overwrite": "Duplicate labware name",

--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -1,5 +1,4 @@
 {
-  "adapter": "Adapter",
   "add": "add",
   "amount": "Amount:",
   "ask_for_labware_overwrite": "Duplicate labware name",

--- a/protocol-designer/src/organisms/SlotDetailsContainer/index.tsx
+++ b/protocol-designer/src/organisms/SlotDetailsContainer/index.tsx
@@ -17,7 +17,7 @@ import type { ContentsByWell } from '../../labware-ingred/types'
 interface SlotDetailContainerProps {
   robotType: RobotType
   slot: DeckSlotId | null
-  offDeckLabwareId?: string
+  offDeckLabwareId?: string | null
 }
 
 export function SlotDetailsContainer(
@@ -91,14 +91,15 @@ export function SlotDetailsContainer(
     .filter(Boolean)
 
   const labwares: string[] = []
+  const adapters: string[] = []
   if (offDeckLabwareNickName != null) {
     labwares.push(offDeckLabwareNickName)
   } else {
-    if (labwareOnSlot != null) {
-      labwares.push(nickNames[labwareOnSlot.id])
-    }
-    if (nestedLabwareOnSlot != null) {
+    if (nestedLabwareOnSlot != null && labwareOnSlot != null) {
+      adapters.push(nickNames[labwareOnSlot.id])
       labwares.push(nickNames[nestedLabwareOnSlot.id])
+    } else if (nestedLabwareOnSlot == null && labwareOnSlot != null) {
+      labwares.push(nickNames[labwareOnSlot.id])
     }
   }
 
@@ -116,6 +117,7 @@ export function SlotDetailsContainer(
         labwares={labwares}
         fixtures={fixtureDisplayNames}
         liquids={liquidNamesOnLabware}
+        adapters={adapters}
       />
     </RobotCoordsForeignObject>
   ) : (
@@ -124,6 +126,7 @@ export function SlotDetailsContainer(
       robotType={robotType}
       modules={moduleDisplayName != null ? [moduleDisplayName] : []}
       labwares={labwares}
+      adapters={adapters}
       fixtures={fixtureDisplayNames}
       liquids={liquidNamesOnLabware}
     />

--- a/protocol-designer/src/organisms/SlotInformation/__tests__/SlotInformation.test.tsx
+++ b/protocol-designer/src/organisms/SlotInformation/__tests__/SlotInformation.test.tsx
@@ -10,7 +10,8 @@ import { SlotInformation } from '..'
 import type { NavigateFunction } from 'react-router-dom'
 
 const mockLiquids = ['Mastermix', 'Ethanol', 'Water']
-const mockLabwares = ['96 Well Plate', 'Adapter']
+const mockLabwares = ['96 Well Plate']
+const mockAdapters = ['Adapter']
 const mockModules = ['Thermocycler Module Gen2', 'Heater-Shaker Module']
 
 const mockLocation = vi.fn()
@@ -38,6 +39,7 @@ describe('SlotInformation', () => {
       location: 'A1',
       liquids: [],
       labwares: [],
+      adapters: [],
       modules: [],
       fixtures: [],
     }
@@ -63,11 +65,16 @@ describe('SlotInformation', () => {
       ...props,
       liquids: mockLiquids,
       labwares: mockLabwares,
+      adapters: mockAdapters,
       modules: mockModules,
     }
     render(props)
+    screen.debug()
+
     expect(screen.getAllByText('Liquid').length).toBe(1)
-    expect(screen.getAllByText('Labware').length).toBe(mockLabwares.length)
+    expect(screen.getAllByText('Labware').length).toBe(
+      mockLabwares.length + mockAdapters.length
+    )
     expect(screen.getAllByText('Module').length).toBe(mockModules.length)
     screen.getByText('Mastermix, Ethanol, Water')
     screen.getByText('96 Well Plate')

--- a/protocol-designer/src/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/organisms/SlotInformation/index.tsx
@@ -20,6 +20,7 @@ interface SlotInformationProps {
   robotType: RobotType
   liquids?: string[]
   labwares?: string[]
+  adapters?: string[]
   modules?: string[]
   fixtures?: string[]
 }
@@ -29,6 +30,7 @@ export const SlotInformation: React.FC<SlotInformationProps> = ({
   robotType,
   liquids = [],
   labwares = [],
+  adapters = [],
   modules = [],
   fixtures = [],
 }) => {
@@ -59,6 +61,9 @@ export const SlotInformation: React.FC<SlotInformationProps> = ({
           <StackInfoList title={t('liquid')} items={liquids} />
         )}
         <StackInfoList title={t('labware')} items={labwares} />
+        {adapters.length > 0 ? (
+          <StackInfoList title={t('labware')} items={adapters} />
+        ) : null}
         {isOffDeck ? null : (
           <StackInfoList title={t('module')} items={modules} />
         )}

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckItemHover.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckItemHover.tsx
@@ -87,6 +87,7 @@ export function DeckItemHover(props: DeckItemHoverProps): JSX.Element | null {
           color: COLORS.white,
           fontSize: PRODUCT.TYPOGRAPHY.fontSizeBodyDefaultSemiBold,
           borderRadius: BORDERS.borderRadius8,
+          cursor: 'pointer',
         },
         onMouseEnter: () => {
           setHover(itemId)

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -366,10 +366,13 @@ export const DeckSetupDetails = (props: DeckSetupDetailsProps): JSX.Element => {
           yDimension: labware.def.dimensions.yDimension,
           zDimension: labware.def.dimensions.zDimension,
         }
+        const moduleParent = allModules.find(
+          module => module.id === slotForOnTheDeck
+        )
         const slotOnDeck =
-          slotForOnTheDeck != null
-            ? allModules.find(module => module.id === slotForOnTheDeck)?.slot
-            : null
+          moduleParent == null
+            ? slotForOnTheDeck
+            : allModules.find(module => module.id === slotForOnTheDeck)?.slot
         return (
           <React.Fragment key={labware.id}>
             <LabwareOnDeck

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -205,7 +205,9 @@ export function SlotOverflowMenu(
             </MenuButton>
             <MenuButton
               onClick={() => {
-                if (labwareOnSlot != null) {
+                if (nestedLabwareOnSlot != null) {
+                  dispatch(openIngredientSelector(nestedLabwareOnSlot.id))
+                } else if (labwareOnSlot != null) {
                   dispatch(openIngredientSelector(labwareOnSlot.id))
                 }
                 navigate('/liquids')

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -524,7 +524,7 @@ export function ProtocolOverview(): JSX.Element {
               <SlotDetailsContainer
                 robotType={robotType}
                 slot={isOffDeckHover ? 'offDeck' : hover}
-                offDeckLabwareId={hover ?? undefined}
+                offDeckLabwareId={isOffDeckHover ? hover : null}
               />
             </Flex>
           </Flex>


### PR DESCRIPTION
# Overview

This PR addresses several bugs stemming from the `SlotInformation` component rendered when hovering a slot, both in `Deck/OffDeckThumbnail ` and `DeckSetupContainer`. Specifically, when adding liquid to an aadapter-nested labware, we produce a liquid setup modal for the top-most labware. Also, `SlotInformation` properly shows liquids and adapters in module/labware/adapter stacks.

Closes AUTH-781, Closes AUTH-782

## Test Plan and Hands on Testing

Add combinations of modules, labware, adapters, and liquids, and inspect `SlotInformation`, both at protocol overview and protocol edit components, for on- and off-deck labware

https://github.com/user-attachments/assets/344e522d-da5f-4adc-888e-363bf3eae170

## Changelog

- refactor `SlotInformation` to accept adapters
- fix nested labware liquid logic in `DeckSetupDetails`
- fix offdeck prop passing to `SlotDetailsContainer` from `ProtocolOverview` that was producing liquids bug

## Review requests

see test plan. 

## Risk assessment
low
