### PR TITLE
refactor(protocol-designer): change trash bin snackbar required rendering

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -62,12 +62,6 @@ interface DeckSetupToolsProps {
   } | null
 }
 
-const TRASH_TYPES: Fixture[] = [
-  'wasteChute',
-  'trashBin',
-  'wasteChuteAndStagingArea',
-]
-
 export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   const { onCloseClick, setHoveredLabware, onDeckProps } = props
   const { t, i18n } = useTranslation(['starting_deck_state', 'shared'])
@@ -117,9 +111,6 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   } = deckSetup
   const hasTrash = Object.values(additionalEquipmentOnDeck).some(
     ae => ae.name === 'trashBin'
-  )
-  const trashyEntities = Object.values(additionalEquipmentOnDeck).filter(
-    ae => ae.name === 'trashBin' || ae.name === 'wasteChute'
   )
 
   const {
@@ -268,15 +259,8 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       }
       closeButtonText={t('clear')}
       onCloseClick={() => {
-        if (
-          trashyEntities.length === 1 &&
-          TRASH_TYPES.includes(selectedFixture as Fixture)
-        ) {
-          makeSnackbar(t('trash_required') as string)
-        } else {
-          handleClear()
-          handleResetToolbox()
-        }
+        handleClear()
+        handleResetToolbox()
       }}
       onConfirmClick={() => {
         handleConfirm()
@@ -374,11 +358,6 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
                         )
                       } else if (collisionError != null) {
                         makeSnackbar(t(`${collisionError}`) as string)
-                      } else if (
-                        trashyEntities.length === 1 &&
-                        TRASH_TYPES.includes(selectedFixture as Fixture)
-                      ) {
-                        makeSnackbar(t('trash_required') as string)
                       } else {
                         setHardware(model)
                         dispatch(selectModule({ moduleModel: model }))
@@ -428,11 +407,6 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
                             hardware: t('shared:trashBin'),
                           }) as string
                         )
-                      } else if (
-                        trashyEntities.length === 1 &&
-                        TRASH_TYPES.includes(selectedFixture as Fixture)
-                      ) {
-                        makeSnackbar(t('trash_required') as string)
                       } else {
                         setHardware(fixture)
                         dispatch(selectFixture({ fixture: fixture }))

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -105,9 +105,7 @@ export function SlotOverflowMenu(
 
   const hasNoItems =
     moduleOnSlot == null && labwareOnSlot == null && fixturesOnSlot.length === 0
-  const hasTrashOnSlot = fixturesOnSlot.some(
-    fixture => fixture.name === 'trashBin'
-  )
+
   const handleClear = (): void => {
     //  clear module from slot
     if (moduleOnSlot != null) {
@@ -238,7 +236,7 @@ export function SlotOverflowMenu(
           </MenuButton>
         ) : null}
         <MenuButton
-          disabled={hasNoItems || hasTrashOnSlot}
+          disabled={hasNoItems}
           onClick={() => {
             handleClear()
             setShowMenuList(false)

--- a/protocol-designer/src/pages/Designer/__tests__/Designer.test.tsx
+++ b/protocol-designer/src/pages/Designer/__tests__/Designer.test.tsx
@@ -50,7 +50,9 @@ describe('Designer', () => {
     vi.mocked(selectors.getIsNewProtocol).mockReturnValue(true)
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
       modules: {},
-      additionalEquipmentOnDeck: {},
+      additionalEquipmentOnDeck: {
+        trash: { name: 'trashBin', location: 'cutoutA3', id: 'mockId' },
+      },
       labware: {},
       pipettes: {},
     })

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -42,7 +42,7 @@ export function Designer(): JSX.Element {
     'protocol_steps',
     'shared',
   ])
-  const { bakeToast } = useKitchen()
+  const { bakeToast, makeSnackbar } = useKitchen()
   const navigate = useNavigate()
   const dispatch = useDispatch()
   const zoomIn = useSelector(selectors.getZoomedInSlot)
@@ -65,6 +65,11 @@ export function Designer(): JSX.Element {
   >(leftString)
 
   const { modules, additionalEquipmentOnDeck } = deckSetup
+
+  const hasTrashEntity = Object.values(additionalEquipmentOnDeck).some(
+    ae => ae.name === 'trashBin' || ae.name === 'wasteChute'
+  )
+
   const startingDeckTab = {
     text: t('protocol_starting_deck'),
     isActive: tab === 'startingDeck',
@@ -76,7 +81,11 @@ export function Designer(): JSX.Element {
     text: t('protocol_steps:protocol_steps'),
     isActive: tab === 'protocolSteps',
     onClick: () => {
-      setTab('protocolSteps')
+      if (hasTrashEntity) {
+        setTab('protocolSteps')
+      } else {
+        makeSnackbar(t('trash_required') as string)
+      }
     },
   }
 
@@ -153,7 +162,11 @@ export function Designer(): JSX.Element {
 
             <SecondaryButton
               onClick={() => {
-                navigate('/overview')
+                if (hasTrashEntity) {
+                  navigate('/overview')
+                } else {
+                  makeSnackbar(t('trash_required') as string)
+                }
               }}
             >
               {t('shared:done')}


### PR DESCRIPTION
closes AUTH-789

# Overview

Move logic for trash bin required to the Done and Protocol Steps buttons instead of the deck setup tools. This allows for the user to move their trash bin around without having to first add the waste chute.


https://github.com/user-attachments/assets/1d451dff-dfaf-4aae-b6f1-02e5135c26d0



## Test Plan and Hands on Testing

Create a flex protocol and go to the deck map and delete the trash bin. try to select "done" and "protocol steps" and see that the snackbar renders. Then add a trash bin or waste chute and see that you can select "done" and "protocol steps"

## Changelog

- move logic for trash bin required to the done and protocol steps buttons instead of the deck setup tools.
- fix test

## Risk assessment

low
