### PR TITLE
fix(app): disable save button once clicked on name transfer screen

### DIFF
--- a/app/src/organisms/QuickTransferFlow/NameQuickTransfer.tsx
+++ b/app/src/organisms/QuickTransferFlow/NameQuickTransfer.tsx
@@ -25,6 +25,7 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
   const { t } = useTranslation('quick_transfer')
   const [name, setName] = React.useState('')
   const keyboardRef = React.useRef(null)
+  const [isSaving, setIsSaving] = React.useState<boolean>(false)
 
   let error: string | null = null
   if (name.length > 60) {
@@ -38,9 +39,10 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
         header={t('name_your_transfer')}
         buttonText={t('save')}
         onClickButton={() => {
+          setIsSaving(true)
           onSave(name)
         }}
-        buttonIsDisabled={name === '' || error != null}
+        buttonIsDisabled={name === '' || error != null || isSaving}
       />
       <Flex
         // height of ChildNavigation

--- a/app/src/organisms/QuickTransferFlow/SaveOrRunModal.tsx
+++ b/app/src/organisms/QuickTransferFlow/SaveOrRunModal.tsx
@@ -19,7 +19,8 @@ interface SaveOrRunModalProps {
 
 export const SaveOrRunModal = (props: SaveOrRunModalProps): JSX.Element => {
   const { t } = useTranslation('quick_transfer')
-  const [showNameTransfer, setShowNameTransfer] = React.useState(false)
+  const [showNameTransfer, setShowNameTransfer] = React.useState<boolean>(false)
+  const [isLoading, setIsLoading] = React.useState<boolean>(false)
 
   return showNameTransfer ? (
     <NameQuickTransfer onSave={props.onSave} />
@@ -43,6 +44,7 @@ export const SaveOrRunModal = (props: SaveOrRunModalProps): JSX.Element => {
           <SmallButton
             width="50%"
             buttonText={t('save_for_later')}
+            disabled={isLoading}
             onClick={() => {
               setShowNameTransfer(true)
             }}
@@ -51,7 +53,11 @@ export const SaveOrRunModal = (props: SaveOrRunModalProps): JSX.Element => {
           <SmallButton
             width="50%"
             buttonText={t('run_now')}
-            onClick={props.onRun}
+            disabled={isLoading}
+            onClick={() => {
+              setIsLoading(true)
+              props.onRun()
+            }}
           />
         </Flex>
       </Flex>

--- a/app/src/organisms/QuickTransferFlow/__tests__/NameQuickTransfer.test.tsx
+++ b/app/src/organisms/QuickTransferFlow/__tests__/NameQuickTransfer.test.tsx
@@ -52,6 +52,7 @@ describe('NameQuickTransfer', () => {
     expect(saveBtn).toBeEnabled()
     fireEvent.click(saveBtn)
     expect(props.onSave).toHaveBeenCalled()
+    expect(saveBtn).toBeDisabled()
   })
 
   it('disables save if you enter more than 60 characters', () => {


### PR DESCRIPTION
fix RQA-3165

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Because of the variable time it takes to create and save a protocol file, it was possible to press the "Save" button multiple times in rapid succession on the name transfer screen. This PR disables the button once it has been pressed to prevent duplication
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Created a transfer, selected "save to run later" and named it. Pressed the Save CTA and saw it was immediately disabled
Added test coverage
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Disable save button once pressed
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick code check
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
