### PR TITLE
refactor(components): make LiquidIcon an optional btn

### DIFF
--- a/components/src/molecules/LiquidIcon/LiquidIcon.stories.tsx
+++ b/components/src/molecules/LiquidIcon/LiquidIcon.stories.tsx
@@ -42,6 +42,7 @@ export const MediumIcon: Story = {
   args: {
     size: 'medium',
     color: 'green',
+    onClick: () => {},
   },
 }
 

--- a/components/src/molecules/LiquidIcon/index.tsx
+++ b/components/src/molecules/LiquidIcon/index.tsx
@@ -1,30 +1,41 @@
 import * as React from 'react'
-import { Flex } from '../../primitives'
+import { css } from 'styled-components'
+import { Btn, Flex } from '../../primitives'
 import { SPACING } from '../../ui-style-constants'
 import { BORDERS, COLORS } from '../../helix-design-system'
-import { css } from 'styled-components'
 import { Icon } from '../../icons'
+import { FLEX_MAX_CONTENT } from '../../styles'
 
 type LiquidIconSize = 'small' | 'medium'
 
 interface LiquidIconProps {
   color: string
   size?: LiquidIconSize
+  onClick?: () => void
+  hasError?: boolean
 }
 
-const LIQUID_ICON_CONTAINER_STYLE = css`
-  height: max-content;
-  width: max-content;
-  background-color: ${COLORS.white};
-  border-style: ${BORDERS.styleSolid};
-  border-width: 1px;
-  border-color: ${COLORS.grey30};
-  border-radius: ${BORDERS.borderRadius4};
-`
-
 export function LiquidIcon(props: LiquidIconProps): JSX.Element {
-  const { color, size = 'small' } = props
-  return (
+  const { color, size = 'small', onClick, hasError = false } = props
+
+  const LIQUID_ICON_CONTAINER_STYLE = css`
+    height: max-content;
+    width: max-content;
+    background-color: ${COLORS.white};
+    border-style: ${BORDERS.styleSolid};
+    border-width: 1px;
+    border-color: ${hasError ? COLORS.red50 : COLORS.grey30};
+    border-radius: ${BORDERS.borderRadius4};
+
+    &:hover {
+      border-color: ${onClick != null ? COLORS.grey35 : COLORS.grey30};
+    }
+    &:active {
+      border-color: ${onClick != null ? COLORS.grey40 : COLORS.grey30};
+    }
+  `
+
+  const liquid = (
     <Flex
       css={LIQUID_ICON_CONTAINER_STYLE}
       padding={size === 'medium' ? SPACING.spacing12 : SPACING.spacing8}
@@ -36,5 +47,23 @@ export function LiquidIcon(props: LiquidIconProps): JSX.Element {
         size={size === 'medium' ? '1rem' : '0.5rem'}
       />
     </Flex>
+  )
+
+  return onClick != null ? (
+    <Btn
+      css={css`
+        width: ${FLEX_MAX_CONTENT};
+        &:focus-visible {
+          outline: 2px solid ${COLORS.white};
+          box-shadow: 0 0 0 4px ${COLORS.blue50};
+          border-radius: ${BORDERS.borderRadius4};
+        }
+      `}
+      onClick={onClick}
+    >
+      {liquid}
+    </Btn>
+  ) : (
+    liquid
   )
 }

--- a/protocol-designer/src/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/organisms/DefineLiquidsModal/index.tsx
@@ -240,13 +240,14 @@ export function DefineLiquidsModal(
                 <StyledText desktopStyle="bodyDefaultRegular">
                   {t('display_color')}
                 </StyledText>
-                <Btn
+
+                <LiquidIcon
                   onClick={() => {
                     setShowColorPicker(prev => !prev)
                   }}
-                >
-                  <LiquidIcon color={color} size="medium" />
-                </Btn>
+                  color={color}
+                  size="medium"
+                />
               </Flex>
               {/* NOTE: this is for serialization if we decide to add it back */}
               {/* <Controller


### PR DESCRIPTION
closes AUTH-778

# Overview

Add the css states to `LiquidIcon`

## Test Plan and Hands on Testing

Test the liquid icon storybook, the medium story should have the hover, active and focus visible states

## Changelog

- make an optional onClick prop that turns liquid icon into a btn

## Risk assessment

low
