### PR TITLE
refactor(protocol-designer): remove h-s adapter/labware combos

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
@@ -132,9 +132,6 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
       const isSmallYDimension = yDimension < STANDARD_Y_DIMENSION
       const isIrregularSize = isSmallXDimension && isSmallYDimension
       const isAdapter = labwareDef.allowedRoles?.includes('adapter')
-      const isGripperIncompatible = labwareDef.parameters.quirks?.includes(
-        'gripperIncompatible'
-      )
       const isAdapter96Channel = parameters.loadName === ADAPTER_96_CHANNEL
       return (
         (filterRecommended &&
@@ -149,7 +146,7 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
           isIrregularSize &&
           moduleType !== HEATERSHAKER_MODULE_TYPE) ||
         (isAdapter96Channel && !has96Channel) ||
-        (slot === 'offDeck' && (isAdapter || isGripperIncompatible)) ||
+        (slot === 'offDeck' && isAdapter) ||
         (PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE)
       )

--- a/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
@@ -20,6 +20,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
+  ABSORBANCE_READER_TYPE,
   HEATERSHAKER_MODULE_TYPE,
   MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM,
   OT2_ROBOT_TYPE,
@@ -60,6 +61,8 @@ import type { LabwareDefByDefURI } from '../../../labware-defs'
 const CUSTOM_CATEGORY = 'custom'
 const STANDARD_X_DIMENSION = 127.75
 const STANDARD_Y_DIMENSION = 85.48
+const PLATE_READER_LOADNAME =
+  'opentrons_flex_lid_absorbance_plate_reader_module'
 interface LabwareToolsProps {
   slot: DeckSlotId
   setHoveredLabware: (defUri: string | null) => void
@@ -128,10 +131,11 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
       const isSmallXDimension = xDimension < STANDARD_X_DIMENSION
       const isSmallYDimension = yDimension < STANDARD_Y_DIMENSION
       const isIrregularSize = isSmallXDimension && isSmallYDimension
-
       const isAdapter = labwareDef.allowedRoles?.includes('adapter')
+      const isGripperIncompatible = labwareDef.parameters.quirks?.includes(
+        'gripperIncompatible'
+      )
       const isAdapter96Channel = parameters.loadName === ADAPTER_96_CHANNEL
-
       return (
         (filterRecommended &&
           !getLabwareIsRecommended(labwareDef, selectedModuleModel)) ||
@@ -145,7 +149,9 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
           isIrregularSize &&
           moduleType !== HEATERSHAKER_MODULE_TYPE) ||
         (isAdapter96Channel && !has96Channel) ||
-        (slot === 'offDeck' && isAdapter)
+        (slot === 'offDeck' && (isAdapter || isGripperIncompatible)) ||
+        (PLATE_READER_LOADNAME === parameters.loadName &&
+          moduleType !== ABSORBANCE_READER_TYPE)
       )
     },
     [filterRecommended, filterHeight, getLabwareCompatible, moduleType, slot]

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -90,7 +90,9 @@ export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'nest_96_wellplate_2ml_deep',
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
-  [ABSORBANCE_READER_TYPE]: [],
+  [ABSORBANCE_READER_TYPE]: [
+    'opentrons_flex_lid_absorbance_plate_reader_module',
+  ],
 }
 
 export const MOAM_MODELS_WITH_FF: ModuleModel[] = [TEMPERATURE_MODULE_V2]

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -67,7 +67,9 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
     'armadillo_96_wellplate_200ul_pcr_full_skirt',
     'biorad_96_wellplate_200ul_pcr',
   ],
-  [ABSORBANCE_READER_TYPE]: [],
+  [ABSORBANCE_READER_TYPE]: [
+    'opentrons_flex_lid_absorbance_plate_reader_module',
+  ],
 }
 export const getLabwareIsCompatible = (
   def: LabwareDefinition2,

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -46,14 +46,17 @@ export const LABWAREV2_DO_NOT_LIST = [
   'opentrons_flex_lid_absorbance_plate_reader_module',
 ]
 // NOTE(sa, 2020-7-14): in PD we do not want to list calibration blocks
-// but we still might want the rest of the labware in LABWAREV2_DO_NOT_LIST
-// because of legacy protocols that might use them
+// or the adapter/labware combos since we migrated to splitting them up
 export const PD_DO_NOT_LIST = [
   'opentrons_calibrationblock_short_side_left',
   'opentrons_calibrationblock_short_side_right',
   'opentrons_96_aluminumblock_biorad_wellplate_200ul',
   'opentrons_96_aluminumblock_nest_wellplate_100ul',
-  'opentrons_flex_lid_absorbance_plate_reader_module',
+  'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat',
+  'opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt',
+  'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat',
+  'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
+  'opentrons_96_pcr_adapter_armadillo_wellplate_200ul',
 ]
 
 export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {


### PR DESCRIPTION
closes AUTH-776

# Overview

Filter out the heater-shaker labware/adapter combos. with the adapter/aluminum block re-categorization, these combos were no longer being filtered on the deck, but only fitlered on the module. before the re-categorization, not filtered on the deck was fine because these were not considered adapters. So this PR fixes that

## Test Plan and Hands on Testing

Test that those heater-shaker adapter/labware combos are not selectable to add directly to the deck

## Changelog

- add the adapter/labware combos to the PD_NO_LIST 
- also i randomly added the plate reader labware lol

## Risk assessment

low