### PR TITLE
feat(protocol-designer): use hash router instead of browser router

### DIFF
--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { DndProvider } from 'react-dnd'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { DIRECTION_COLUMN, Flex } from '@opentrons/components'
@@ -44,9 +44,9 @@ function ProtocolEditorComponent(): JSX.Element {
       {enableRedesign ? (
         <Flex flexDirection={DIRECTION_COLUMN}>
           {prereleaseModeEnabled ? <Bouncing /> : null}
-          <BrowserRouter>
+          <HashRouter>
             <ProtocolRoutes />
-          </BrowserRouter>
+          </HashRouter>
         </Flex>
       ) : (
         <div className="container">


### PR DESCRIPTION
# Overview

This PR replaces PD's [BrowserRouter](https://reactrouter.com/en/main/router-components/browser-router) with a [HashRouter](https://reactrouter.com/en/main/router-components/hash-router). This is so that if you're on a route like `https://sandbox.designer.opentrons.com/edge/designer` and refresh your web page, or if you copy this url and open it into a new web browser, you won't get a 404. 

HashRouter stores the current location in the hash portion of the current URL so it doesnt get sent to the server (which we want, cuz the server has no idea about react router dom routes)


## Changelog

- Replace BrowserRouter with HashRouter

## Review requests

- Verify that refreshing your browser under each new PD route does not result in a 404

## Risk assessment

Low
