### PR TITLE
fix(api, shared-data): Disable tip presence on single tip pickup with 96ch and update press distance

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -20,6 +20,8 @@ from ..errors import (
     ProtocolEngineError,
 )
 
+from opentrons.hardware_control.nozzle_manager import NozzleConfigurationType
+
 
 PRIMARY_NOZZLE_TO_ENDING_NOZZLE_MAP = {
     "A1": {"COLUMN": "H1", "ROW": "A12"},
@@ -300,6 +302,13 @@ class HardwareTipHandler(TipHandler):
         This function will raise an exception if the specified tip presence status
         isn't matched.
         """
+        if (
+            self._state_view.pipettes.get_nozzle_layout_type(pipette_id)
+            == NozzleConfigurationType.SINGLE
+            and self._state_view.pipettes.get_channels(pipette_id) == 96
+        ):
+            # Tip presence sensing is not supported for single tip pick up on the 96ch Flex Pipette
+            return
         try:
             ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)
             hw_mount = self._state_view.pipettes.get_mount(pipette_id).to_hw_mount()

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_4.json
@@ -119,7 +119,7 @@
         "SingleA1": {
           "default": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -144,7 +144,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -161,7 +161,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -178,7 +178,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -197,7 +197,7 @@
         "SingleH1": {
           "default": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -222,7 +222,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -239,7 +239,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -256,7 +256,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -275,7 +275,7 @@
         "SingleA12": {
           "default": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -300,7 +300,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -317,7 +317,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -334,7 +334,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -353,7 +353,7 @@
         "SingleH12": {
           "default": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -378,7 +378,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -395,7 +395,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {
@@ -412,7 +412,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 13.0,
+            "distance": 10.5,
             "current": 0.2,
             "tipOverlaps": {
               "v0": {

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
@@ -147,7 +147,7 @@
         "SingleA1": {
           "default": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -172,7 +172,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -189,7 +189,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -206,7 +206,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.85,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -225,7 +225,7 @@
         "SingleH1": {
           "default": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -250,7 +250,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -267,7 +267,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -284,7 +284,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.85,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -303,7 +303,7 @@
         "SingleA12": {
           "default": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -328,7 +328,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -345,7 +345,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -362,7 +362,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.85,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -381,7 +381,7 @@
         "SingleH12": {
           "default": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -406,7 +406,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -423,7 +423,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -440,7 +440,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.85,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_6.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_6.json
@@ -147,7 +147,7 @@
         "SingleA1": {
           "default": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -172,7 +172,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -189,7 +189,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -206,7 +206,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.85,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -225,7 +225,7 @@
         "SingleH1": {
           "default": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -250,7 +250,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -267,7 +267,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -284,7 +284,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.85,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -303,7 +303,7 @@
         "SingleA12": {
           "default": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -328,7 +328,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -345,7 +345,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -362,7 +362,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.85,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -381,7 +381,7 @@
         "SingleH12": {
           "default": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -406,7 +406,7 @@
           },
           "t1000": {
             "speed": 10.0,
-            "distance": 12,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -423,7 +423,7 @@
           },
           "t200": {
             "speed": 10.0,
-            "distance": 11,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {
@@ -440,7 +440,7 @@
           },
           "t50": {
             "speed": 10.0,
-            "distance": 10.85,
+            "distance": 10.5,
             "current": 0.4,
             "tipOverlaps": {
               "v0": {


### PR DESCRIPTION
# Overview
Covers RABR-617

In order to support effective single tip pick up with the 96ch, this PR disables the tip presence sensor when the 96ch pipette is in single tip pickup configuration. This PR also bumps the press distance values for 1000/200/50 uL down to 10.5mm, the original values identified by hardware testing when tested without the tip presence sensor.

## Test Plan and Hands on Testing
Rerun testing rounds on single tip pickup of the 96ch with all tip types.

## Changelog


## Review requests


## Risk assessment
Low-Medium: This only effects a new feature that is launching with 8.0.0. The primary risk is that without tip presence sensing we're assuming the tips attached successfully. This has a low risk of failure, given the values identified by hardware testing had a good performance rate. 
