### PR TITLE
feat(protocol-designer): display required app version in overview

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_overview.json
+++ b/protocol-designer/src/assets/localization/en/protocol_overview.json
@@ -1,5 +1,6 @@
 {
   "add_gripper": "Add a gripper",
+  "app_version": "{{version}} or higher",
   "author": "Organization/Author",
   "created": "Date created",
   "deck_hardware": "Deck hardware",
@@ -24,6 +25,7 @@
   "no_liquids": "No liquids",
   "no_steps": "No steps defined",
   "protocol_metadata": "Protocol Metadata",
+  "required_app_version": "Required app version",
   "right_pip": "Right pipette",
   "robotType": "Robot type",
   "starting_deck": "Protocol Starting Deck",

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolOverview.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolOverview.test.tsx
@@ -94,6 +94,8 @@ describe('ProtocolOverview', () => {
     screen.getByText('mockAuthor')
     screen.getByText('Date created')
     screen.getByText('Last exported')
+    screen.getByText('Required app version')
+    screen.getByText('8.0.0 or higher')
     //  instruments
     screen.getByText('Instruments')
     screen.getByText('Robot type')

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -58,6 +58,7 @@ import type { DeckSlot } from '@opentrons/step-generation'
 import type { ThunkDispatch } from '../../types'
 import type { HintKey } from '../../tutorial'
 
+const REQUIRED_APP_VERSION = '8.0.0'
 const DATE_ONLY_FORMAT = 'MMMM dd, yyyy'
 const DATETIME_FORMAT = 'MMMM dd, yyyy | h:mm a'
 
@@ -330,7 +331,11 @@ export function ProtocolOverview(): JSX.Element {
                   </StyledText>
                 </Btn>
               </Flex>
-              <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                gridGap={SPACING.spacing4}
+                marginBottom={SPACING.spacing4}
+              >
                 {metaDataInfo.map(info => {
                   const [title, value] = Object.entries(info)[0]
 
@@ -345,6 +350,15 @@ export function ProtocolOverview(): JSX.Element {
                   )
                 })}
               </Flex>
+              <ListItem type="noActive" key="ProtocolOverview_robotVersion">
+                <ListItemDescriptor
+                  type="default"
+                  description={t('required_app_version')}
+                  content={t('app_version', {
+                    version: REQUIRED_APP_VERSION,
+                  })}
+                />
+              </ListItem>
             </Flex>
             <Flex flexDirection={DIRECTION_COLUMN}>
               <Flex


### PR DESCRIPTION
closes AUTH-796

# Overview

Add the required app version to the protocol overview: 

<img width="635" alt="Screenshot 2024-09-16 at 14 19 23" src="https://github.com/user-attachments/assets/5b438376-2ca2-4b9a-99c4-22b69df8c91d">

## Test Plan and Hands on Testing

Create a protocol with the redesign ff turned on and look at the overview section, should see the app version required in the metadata

## Changelog

- add the list item for app version required

## Risk assessment

low
