### PR TITLE
refactor(protocol-designer): remove basename from router

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -124,7 +124,7 @@ jobs:
         run: make -C protocol-designer test-e2e
   build-pd:
     name: 'build protocol designer artifact'
-    needs: ['js-unit-test']
+    # needs: ['js-unit-test']
     runs-on: 'ubuntu-22.04'
     if: github.event_name != 'pull_request'
     steps:
@@ -171,7 +171,7 @@ jobs:
   deploy-pd:
     name: 'deploy PD artifact to S3'
     runs-on: 'ubuntu-22.04'
-    needs: ['js-unit-test', 'build-pd']
+    needs: [ 'build-pd']
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v3'

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -124,7 +124,7 @@ jobs:
         run: make -C protocol-designer test-e2e
   build-pd:
     name: 'build protocol designer artifact'
-    # needs: ['js-unit-test']
+    needs: ['js-unit-test']
     runs-on: 'ubuntu-22.04'
     if: github.event_name != 'pull_request'
     steps:
@@ -171,7 +171,7 @@ jobs:
   deploy-pd:
     name: 'deploy PD artifact to S3'
     runs-on: 'ubuntu-22.04'
-    needs: [ 'build-pd']
+    needs: ['js-unit-test', 'build-pd']
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v3'

--- a/protocol-designer/src/ProtocolEditor.tsx
+++ b/protocol-designer/src/ProtocolEditor.tsx
@@ -29,17 +29,8 @@ import { Bouncing } from './Bouncing'
 import styles from './components/ProtocolEditor.module.css'
 import './css/reset.module.css'
 
-import type { BrowserRouterProps } from 'react-router-dom'
-
 const showGateModal =
   process.env.NODE_ENV === 'production' || process.env.OT_PD_SHOW_GATE
-
-// sandbox urls get deployed to subdirectories in sandbox.designer.opentrons.com/${subFolder}
-// prod urls get deployed to designer.opentrons.com with no subdir, so we don't need to add a base name
-const routerBaseName =
-  process.env.NODE_ENV === 'production'
-    ? null
-    : `/${window.location.pathname.split('/')[1]}`
 
 function ProtocolEditorComponent(): JSX.Element {
   const flags = useSelector(getFeatureFlagData)
@@ -47,16 +38,13 @@ function ProtocolEditorComponent(): JSX.Element {
 
   const prereleaseModeEnabled = flags.PRERELEASE_MODE === true
 
-  const browserRouterProps: BrowserRouterProps =
-    routerBaseName != null ? { basename: routerBaseName } : {}
-
   return (
     <div id="protocol-editor">
       <TopPortalRoot />
       {enableRedesign ? (
         <Flex flexDirection={DIRECTION_COLUMN}>
           {prereleaseModeEnabled ? <Bouncing /> : null}
-          <HashRouter {...browserRouterProps}>
+          <HashRouter>
             <ProtocolRoutes />
           </HashRouter>
         </Flex>


### PR DESCRIPTION
# Overview

I guess hash router does not need a basename 🤷🏽  This PR fixes an issue where no route gets picked up by the router due to the route not matching a basename. This only affects sandbox links. 

## Test Plan and Hands on Testing

Visit https://sandbox.designer.opentrons.com/pd_fix-router and play around with the different routes and try refreshing/copying urls and pasting them into the browser. you should not get a 404.


## Risk assessment

Low
