### PR TITLE
fix(app): fix auto transitioning run from recovery-paused to waiting recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
@@ -62,10 +62,11 @@ export function useRecoverySplash(
 type RecoverySplashProps = ErrorRecoveryFlowsProps &
   ERUtilsResults & {
     isOnDevice: boolean
-    isWizardActive: boolean
     failedCommand: ReturnType<typeof useRetainedFailedCommandBySource>
     robotType: RobotType
     robotName: string
+    /* Whether the app should resume any paused recovery state without user action. */
+    resumePausedRecovery: boolean
     toggleERWizAsActiveUser: UseRecoveryTakeoverResult['toggleERWizAsActiveUser']
     analytics: UseRecoveryAnalyticsResult
   }
@@ -79,7 +80,7 @@ export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
     robotName,
     runStatus,
     recoveryActionMutationUtils,
-    isWizardActive,
+    resumePausedRecovery,
   } = props
   const { t } = useTranslation('error_recovery')
   const errorKind = getErrorKind(failedCommand?.byRunRecord ?? null)
@@ -99,12 +100,15 @@ export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
 
   // Resume recovery when the run when the door is closed.
   // The CTA/flow for handling a door open event within the ER wizard is different, and because this splash always renders
-  // behind the wizard, we want to ensure we only implicitly resume recovery when only viewing the splash.
+  // behind the wizard, we want to ensure we only implicitly resume recovery when only viewing the splash from this app.
   React.useEffect(() => {
-    if (runStatus === RUN_STATUS_AWAITING_RECOVERY_PAUSED && !isWizardActive) {
+    if (
+      runStatus === RUN_STATUS_AWAITING_RECOVERY_PAUSED &&
+      resumePausedRecovery
+    ) {
       recoveryActionMutationUtils.resumeRecovery()
     }
-  }, [runStatus, isWizardActive])
+  }, [runStatus, resumePausedRecovery])
   const buildDoorOpenAlert = (): void => {
     makeToast(t('close_door_to_resume') as string, WARNING_TOAST)
   }

--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/RecoverySplash.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/RecoverySplash.test.tsx
@@ -95,7 +95,7 @@ describe('RecoverySplash', () => {
       recoveryActionMutationUtils: {
         resumeRecovery: mockResumeRecovery,
       } as any,
-      isWizardActive: false,
+      resumePausedRecovery: true,
     }
 
     vi.mocked(StepInfo).mockReturnValue(<div>MOCK STEP INFO</div>)
@@ -177,7 +177,7 @@ describe('RecoverySplash', () => {
     expect(mockMakeToast).toHaveBeenCalled()
   })
 
-  it(`should transition the run status from ${RUN_STATUS_AWAITING_RECOVERY_PAUSED} to ${RUN_STATUS_AWAITING_RECOVERY}`, () => {
+  it(`should transition the run status from ${RUN_STATUS_AWAITING_RECOVERY_PAUSED} to ${RUN_STATUS_AWAITING_RECOVERY} when resumePausedRecovery is true`, () => {
     props = { ...props, runStatus: RUN_STATUS_AWAITING_RECOVERY_PAUSED }
 
     render(props)

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -147,6 +147,8 @@ export function ErrorRecoveryFlows(
     failedCommand: failedCommandBySource,
   })
 
+  console.log('=>(index.tsx:180) showTakeover', showTakeover)
+
   return (
     <>
       {showTakeover ? (
@@ -176,7 +178,7 @@ export function ErrorRecoveryFlows(
           isOnDevice={isOnDevice}
           toggleERWizAsActiveUser={toggleERWizAsActiveUser}
           failedCommand={failedCommandBySource}
-          isWizardActive={renderWizard}
+          resumePausedRecovery={!renderWizard && !showTakeover}
         />
       ) : null}
     </>


### PR DESCRIPTION
Closes [EXEC-702](https://opentrons.atlassian.net/browse/EXEC-702)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In https://github.com/Opentrons/opentrons/pull/16245, we made sure to block an open door while on the recovery splash view, but the logic for automatically transition a run from paused -> awaiting recovery is not quite right, which results in the app seemingly automatically issuing a `POST` play to transition a run from a recovery paused state to awaiting recovery whenever a user opens the door during error recovery flows (ie, anywhere but the splash screen). The tricky part is that when checking the network tab, there are no `POST` requests to initiate the transition.

 This problem occurs because another app issues the `POST` request. The logic for dispatching this `POST` in the `useEffect` condition within `RecoverySplash` is to check if the error recovery wizard is active, but this doesn't account for any other app that isn't doing the recovery. The solution: if the current app displays the takeover modal (which is true for any app except the sole app controlling the robot), then don't fire the `POST` request. 

Note that this regression is recent - there hasn't been an alpha containing this bug yet.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified the door open modal during error recovery no longer automatically resumes. To verify, have the desktop app open and following along the ODD (you'll need to push this branch to an ODD). 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the app automatically "clicking" resume after closing a robot door during Error Recovery. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-702]: https://opentrons.atlassian.net/browse/EXEC-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ