### PR TITLE
fix(labware-library): increase click area of LC stacking offset field

### DIFF
--- a/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
+++ b/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
@@ -248,7 +248,6 @@ export function StackingOffsets(): JSX.Element | null {
                       {isChecked ? (
                         <div
                           style={{
-                            marginTop: '-1.2rem',
                             height: '2.0rem',
                             fontSize: '0.75rem',
                           }}


### PR DESCRIPTION
# Overview
This PR increases the click area of the stacking offset text field in labware creator. It also adds some extra margin (which I personally think looks better and less scrunched up). 

closes RQA-3173

![Screenshot 2024-09-16 at 3 10 05 PM](https://github.com/user-attachments/assets/980bf0a2-fd93-4f3c-9731-763333cfd12e)


## Review requests


Make sure you can click the stacking offset text field in LC

## Risk assessment

Low
