### PR TITLE
refactor(api): Port `touchTip`, `liquidProbe`, and `tryLiquidProbe` location updates to `StateUpdate`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -11,7 +11,6 @@ from .command import DefinedErrorData
 from .pipetting_common import (
     OverpressureError,
     LiquidNotFoundError,
-    LiquidNotFoundErrorInternalData,
 )
 
 from . import absorbance_reader
@@ -706,7 +705,7 @@ CommandPrivateResult = Union[
 CommandDefinedErrorData = Union[
     DefinedErrorData[TipPhysicallyMissingError, None],
     DefinedErrorData[OverpressureError, None],
-    DefinedErrorData[LiquidNotFoundError, LiquidNotFoundErrorInternalData],
+    DefinedErrorData[LiquidNotFoundError, None],
 ]
 
 

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -1,8 +1,9 @@
 """The liquidProbe and tryLiquidProbe commands."""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Type, Union
 from opentrons.protocol_engine.errors.exceptions import MustHomeError, TipNotEmptyError
+from opentrons.protocol_engine.state import update_types
 from opentrons.types import MountType
 from opentrons_shared_data.errors.exceptions import (
     PipetteLiquidNotFoundError,
@@ -14,7 +15,6 @@ from pydantic import Field
 from ..types import DeckPoint
 from .pipetting_common import (
     LiquidNotFoundError,
-    LiquidNotFoundErrorInternalData,
     PipetteIdMixin,
     WellLocationMixin,
     DestinationPositionResult,
@@ -80,9 +80,60 @@ class TryLiquidProbeResult(DestinationPositionResult):
 
 _LiquidProbeExecuteReturn = Union[
     SuccessData[LiquidProbeResult, None],
-    DefinedErrorData[LiquidNotFoundError, LiquidNotFoundErrorInternalData],
+    DefinedErrorData[LiquidNotFoundError, None],
 ]
 _TryLiquidProbeExecuteReturn = SuccessData[TryLiquidProbeResult, None]
+
+
+async def _execute_common(
+    movement: MovementHandler, pipetting: PipettingHandler, params: _CommonParams
+) -> Tuple[float | PipetteLiquidNotFoundError, update_types.StateUpdate, DeckPoint]:
+    pipette_id = params.pipetteId
+    labware_id = params.labwareId
+    well_name = params.wellName
+
+    state_update = update_types.StateUpdate()
+
+    # _validate_tip_attached in pipetting.py is a private method so we're using
+    # get_is_ready_to_aspirate as an indirect way to throw a TipNotAttachedError if appropriate
+    pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)
+
+    if pipetting.get_is_empty(pipette_id=pipette_id) is False:
+        raise TipNotEmptyError(
+            message="This operation requires a tip with no liquid in it."
+        )
+
+    if await movement.check_for_valid_position(mount=MountType.LEFT) is False:
+        raise MustHomeError(
+            message="Current position of pipette is invalid. Please home."
+        )
+
+    # liquid_probe process start position
+    position = await movement.move_to_well(
+        pipette_id=pipette_id,
+        labware_id=labware_id,
+        well_name=well_name,
+        well_location=params.wellLocation,
+    )
+    deck_point = DeckPoint.construct(x=position.x, y=position.y, z=position.z)
+    state_update.set_pipette_location(
+        pipette_id=pipette_id,
+        new_labware_id=labware_id,
+        new_well_name=well_name,
+        new_deck_point=deck_point,
+    )
+
+    try:
+        z_pos = await pipetting.liquid_probe_in_place(
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=params.wellLocation,
+        )
+    except PipetteLiquidNotFoundError as e:
+        return e, state_update, deck_point
+    else:
+        return z_pos, state_update, deck_point
 
 
 class LiquidProbeImplementation(
@@ -115,40 +166,10 @@ class LiquidProbeImplementation(
             MustHomeError: as an undefined error, if the plunger is not in a valid
                 position.
         """
-        pipette_id = params.pipetteId
-        labware_id = params.labwareId
-        well_name = params.wellName
-
-        # _validate_tip_attached in pipetting.py is a private method so we're using
-        # get_is_ready_to_aspirate as an indirect way to throw a TipNotAttachedError if appropriate
-        self._pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)
-
-        if self._pipetting.get_is_empty(pipette_id=pipette_id) is False:
-            raise TipNotEmptyError(
-                message="This operation requires a tip with no liquid in it."
-            )
-
-        if await self._movement.check_for_valid_position(mount=MountType.LEFT) is False:
-            raise MustHomeError(
-                message="Current position of pipette is invalid. Please home."
-            )
-
-        # liquid_probe process start position
-        position = await self._movement.move_to_well(
-            pipette_id=pipette_id,
-            labware_id=labware_id,
-            well_name=well_name,
-            well_location=params.wellLocation,
+        z_pos_or_error, state_update, deck_point = await _execute_common(
+            self._movement, self._pipetting, params
         )
-
-        try:
-            z_pos = await self._pipetting.liquid_probe_in_place(
-                pipette_id=pipette_id,
-                labware_id=labware_id,
-                well_name=well_name,
-                well_location=params.wellLocation,
-            )
-        except PipetteLiquidNotFoundError as e:
+        if isinstance(z_pos_or_error, PipetteLiquidNotFoundError):
             return DefinedErrorData(
                 public=LiquidNotFoundError(
                     id=self._model_utils.generate_id(),
@@ -157,21 +178,20 @@ class LiquidProbeImplementation(
                         ErrorOccurrence.from_failed(
                             id=self._model_utils.generate_id(),
                             createdAt=self._model_utils.get_timestamp(),
-                            error=e,
+                            error=z_pos_or_error,
                         )
                     ],
                 ),
-                private=LiquidNotFoundErrorInternalData(
-                    position=DeckPoint(x=position.x, y=position.y, z=position.z)
-                ),
+                private=None,
+                state_update=state_update,
             )
         else:
             return SuccessData(
                 public=LiquidProbeResult(
-                    z_position=z_pos,
-                    position=DeckPoint(x=position.x, y=position.y, z=position.z),
+                    z_position=z_pos_or_error, position=deck_point
                 ),
                 private=None,
+                state_update=state_update,
             )
 
 
@@ -184,12 +204,10 @@ class TryLiquidProbeImplementation(
         self,
         movement: MovementHandler,
         pipetting: PipettingHandler,
-        model_utils: ModelUtils,
         **kwargs: object,
     ) -> None:
         self._movement = movement
         self._pipetting = pipetting
-        self._model_utils = model_utils
 
     async def execute(self, params: _CommonParams) -> _TryLiquidProbeExecuteReturn:
         """Execute a `tryLiquidProbe` command.
@@ -198,39 +216,23 @@ class TryLiquidProbeImplementation(
         found, `tryLiquidProbe` returns a success result with `z_position=null` instead
         of a defined error.
         """
-        # We defer to the `liquidProbe` implementation. If it returns a defined
-        # `liquidNotFound` error, we remap that to a success result.
-        # Otherwise, we return the result or propagate the exception unchanged.
-
-        original_impl = LiquidProbeImplementation(
-            movement=self._movement,
-            pipetting=self._pipetting,
-            model_utils=self._model_utils,
+        z_pos_or_error, state_update, deck_point = await _execute_common(
+            self._movement, self._pipetting, params
         )
-        original_result = await original_impl.execute(params)
 
-        match original_result:
-            case DefinedErrorData(
-                public=LiquidNotFoundError(),
-                private=LiquidNotFoundErrorInternalData() as original_private,
-            ):
-                return SuccessData(
-                    public=TryLiquidProbeResult(
-                        z_position=None,
-                        position=original_private.position,
-                    ),
-                    private=None,
-                )
-            case SuccessData(
-                public=LiquidProbeResult() as original_public, private=None
-            ):
-                return SuccessData(
-                    public=TryLiquidProbeResult(
-                        position=original_public.position,
-                        z_position=original_public.z_position,
-                    ),
-                    private=None,
-                )
+        z_pos = (
+            None
+            if isinstance(z_pos_or_error, PipetteLiquidNotFoundError)
+            else z_pos_or_error
+        )
+        return SuccessData(
+            public=TryLiquidProbeResult(
+                z_position=z_pos,
+                position=deck_point,
+            ),
+            private=None,
+            state_update=state_update,
+        )
 
 
 class LiquidProbe(

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -1,5 +1,4 @@
 """Common pipetting command base models."""
-from dataclasses import dataclass
 from opentrons_shared_data.errors import ErrorCodes
 from pydantic import BaseModel, Field
 from typing import Literal, Optional, Tuple, TypedDict
@@ -169,11 +168,3 @@ class LiquidNotFoundError(ErrorOccurrence):
 
     errorCode: str = ErrorCodes.PIPETTE_LIQUID_NOT_FOUND.value.code
     detail: str = ErrorCodes.PIPETTE_LIQUID_NOT_FOUND.value.detail
-
-
-@dataclass(frozen=True)
-class LiquidNotFoundErrorInternalData:
-    """Internal-to-ProtocolEngine data about a LiquidNotFoundError."""
-
-    position: DeckPoint
-    """Same meaning as DestinationPositionResult.position."""

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -322,7 +322,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                commands.TouchTipResult,
                 commands.LiquidProbeResult,
                 commands.TryLiquidProbeResult,
             ),
@@ -440,7 +439,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 commands.MoveRelativeResult,
                 commands.MoveToAddressableAreaResult,
                 commands.MoveToAddressableAreaForDropTipResult,
-                commands.TouchTipResult,
             ),
         ):
             pipette_id = action.command.params.pipetteId

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -22,7 +22,6 @@ from opentrons.hardware_control.nozzle_manager import (
 )
 from opentrons.protocol_engine.actions.actions import FailCommandAction
 from opentrons.protocol_engine.commands.command import DefinedErrorData
-from opentrons.protocol_engine.commands.pipetting_common import LiquidNotFoundError
 from opentrons.types import MountType, Mount as HwMount, Point
 
 from . import update_types
@@ -320,32 +319,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         # These commands leave the pipette in a new location.
         # Update current_location to reflect that.
         if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (
-                commands.LiquidProbeResult,
-                commands.TryLiquidProbeResult,
-            ),
-        ):
-            self._state.current_location = CurrentWell(
-                pipette_id=action.command.params.pipetteId,
-                labware_id=action.command.params.labwareId,
-                well_name=action.command.params.wellName,
-            )
-        elif isinstance(action, FailCommandAction) and (
-            isinstance(action.error, DefinedErrorData)
-            and (
-                (
-                    isinstance(action.running_command, commands.LiquidProbe)
-                    and isinstance(action.error.public, LiquidNotFoundError)
-                )
-            )
-        ):
-            self._state.current_location = CurrentWell(
-                pipette_id=action.running_command.params.pipetteId,
-                labware_id=action.running_command.params.labwareId,
-                well_name=action.running_command.params.wellName,
-            )
-        elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
                 commands.MoveToAddressableAreaResult,

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -30,14 +30,12 @@ from opentrons.protocol_engine.commands.liquid_probe import (
 )
 from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
 
-from opentrons.protocol_engine.state.state import StateView
 
 from opentrons.protocol_engine.execution import (
     MovementHandler,
     PipettingHandler,
 )
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
-from opentrons.protocol_engine.types import LoadedPipette
 
 
 EitherImplementationType = Union[
@@ -96,7 +94,7 @@ def subject(
     )
 
 
-async def test_liquid_probe_implementation_no_prep(
+async def test_liquid_probe_implementation(
     decoy: Decoy,
     movement: MovementHandler,
     pipetting: PipettingHandler,
@@ -104,7 +102,7 @@ async def test_liquid_probe_implementation_no_prep(
     params_type: EitherParamsType,
     result_type: EitherResultType,
 ) -> None:
-    """A Liquid Probe should have an execution implementation without preparing to aspirate."""
+    """It should move to the destination and do a liquid probe there."""
     location = WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1))
 
     data = params_type(
@@ -140,67 +138,6 @@ async def test_liquid_probe_implementation_no_prep(
     assert result == SuccessData(
         public=result_type(z_position=15.0, position=DeckPoint(x=1, y=2, z=3)),
         private=None,
-    )
-
-
-async def test_liquid_probe_implementation_with_prep(
-    decoy: Decoy,
-    state_view: StateView,
-    movement: MovementHandler,
-    pipetting: PipettingHandler,
-    subject: EitherImplementation,
-    params_type: EitherParamsType,
-    result_type: EitherResultType,
-) -> None:
-    """A Liquid Probe should have an execution implementation with preparing to aspirate."""
-    location = WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2))
-
-    data = params_type(
-        pipetteId="abc",
-        labwareId="123",
-        wellName="A3",
-        wellLocation=location,
-    )
-
-    decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id="abc")).then_return(False)
-
-    decoy.when(state_view.pipettes.get(pipette_id="abc")).then_return(
-        LoadedPipette.construct(  # type:ignore[call-arg]
-            mount=MountType.LEFT
-        )
-    )
-    decoy.when(
-        await movement.move_to_well(
-            pipette_id="abc", labware_id="123", well_name="A3", well_location=location
-        ),
-    ).then_return(Point(x=1, y=2, z=3))
-
-    decoy.when(
-        await pipetting.liquid_probe_in_place(
-            pipette_id="abc",
-            labware_id="123",
-            well_name="A3",
-            well_location=location,
-        ),
-    ).then_return(15.0)
-
-    result = await subject.execute(data)
-
-    assert type(result.public) is result_type  # Pydantic v1 only compares the fields.
-    assert result == SuccessData(
-        public=result_type(z_position=15.0, position=DeckPoint(x=1, y=2, z=3)),
-        private=None,
-    )
-
-    decoy.verify(
-        await movement.move_to_well(
-            pipette_id="abc",
-            labware_id="123",
-            well_name="A3",
-            well_location=WellLocation(
-                origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
-            ),
-        ),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
@@ -6,6 +6,7 @@ from opentrons.hardware_control.types import CriticalPoint
 from opentrons.motion_planning import Waypoint
 from opentrons.protocol_engine import WellLocation, WellOffset, DeckPoint, errors
 from opentrons.protocol_engine.execution import MovementHandler, GantryMover
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.types import Point
 
@@ -122,7 +123,15 @@ async def test_touch_tip_implementation(
     result = await subject.execute(params)
 
     assert result == SuccessData(
-        public=TouchTipResult(position=DeckPoint(x=4, y=5, z=6)), private=None
+        public=TouchTipResult(position=DeckPoint(x=4, y=5, z=6)),
+        private=None,
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="abc",
+                new_location=update_types.Well(labware_id="123", well_name="A3"),
+                new_deck_point=DeckPoint(x=4, y=5, z=6),
+            )
+        ),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -54,7 +54,6 @@ from .command_fixtures import (
     create_drop_tip_in_place_command,
     create_succeeded_command,
     create_unsafe_drop_tip_in_place_command,
-    create_touch_tip_command,
     create_move_to_well_command,
     create_blow_out_command,
     create_blow_out_in_place_command,
@@ -897,15 +896,6 @@ def test_add_pipette_config(
 @pytest.mark.parametrize(
     "action",
     (
-        SucceedCommandAction(
-            command=create_touch_tip_command(
-                pipette_id="pipette-id",
-                labware_id="labware-id",
-                well_name="well-name",
-                destination=DeckPoint(x=11, y=22, z=33),
-            ),
-            private_result=None,
-        ),
         SucceedCommandAction(
             command=create_move_to_coordinates_command(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -9,12 +9,6 @@ from opentrons_shared_data.pipette import pipette_definition
 from opentrons.protocol_engine.state import update_types
 from opentrons.types import DeckSlotName, MountType, Point
 from opentrons.protocol_engine import commands as cmd
-from opentrons.protocol_engine.commands.command import DefinedErrorData
-from opentrons.protocol_engine.commands.pipetting_common import (
-    LiquidNotFoundError,
-    LiquidNotFoundErrorInternalData,
-)
-from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 from opentrons.protocol_engine.types import (
     CurrentAddressableArea,
     DeckPoint,
@@ -438,120 +432,6 @@ def test_blow_out_clears_volume(
     )
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] is None
-
-
-@pytest.mark.parametrize(
-    ("action", "expected_location"),
-    (
-        # liquidProbe and tryLiquidProbe succeeding and with overpressure error
-        (
-            SucceedCommandAction(
-                command=cmd.LiquidProbe(
-                    id="command-id",
-                    createdAt=datetime.now(),
-                    startedAt=datetime.now(),
-                    completedAt=datetime.now(),
-                    key="command-key",
-                    status=cmd.CommandStatus.SUCCEEDED,
-                    params=cmd.LiquidProbeParams(
-                        labwareId="liquid-probe-labware-id",
-                        wellName="liquid-probe-well-name",
-                        pipetteId="pipette-id",
-                    ),
-                    result=cmd.LiquidProbeResult(
-                        position=DeckPoint(x=0, y=0, z=0), z_position=0
-                    ),
-                ),
-                private_result=None,
-            ),
-            CurrentWell(
-                pipette_id="pipette-id",
-                labware_id="liquid-probe-labware-id",
-                well_name="liquid-probe-well-name",
-            ),
-        ),
-        (
-            FailCommandAction(
-                running_command=cmd.LiquidProbe(
-                    id="command-id",
-                    createdAt=datetime.now(),
-                    startedAt=datetime.now(),
-                    key="command-key",
-                    status=cmd.CommandStatus.RUNNING,
-                    params=cmd.LiquidProbeParams(
-                        labwareId="liquid-probe-labware-id",
-                        wellName="liquid-probe-well-name",
-                        pipetteId="pipette-id",
-                    ),
-                ),
-                error=DefinedErrorData(
-                    public=LiquidNotFoundError(
-                        id="error-id",
-                        createdAt=datetime.now(),
-                    ),
-                    private=LiquidNotFoundErrorInternalData(
-                        position=DeckPoint(x=0, y=0, z=0)
-                    ),
-                ),
-                command_id="command-id",
-                error_id="error-id",
-                failed_at=datetime.now(),
-                notes=[],
-                type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
-            ),
-            CurrentWell(
-                pipette_id="pipette-id",
-                labware_id="liquid-probe-labware-id",
-                well_name="liquid-probe-well-name",
-            ),
-        ),
-        (
-            SucceedCommandAction(
-                command=cmd.TryLiquidProbe(
-                    id="command-id",
-                    createdAt=datetime.now(),
-                    startedAt=datetime.now(),
-                    completedAt=datetime.now(),
-                    key="command-key",
-                    status=cmd.CommandStatus.SUCCEEDED,
-                    params=cmd.TryLiquidProbeParams(
-                        labwareId="try-liquid-probe-labware-id",
-                        wellName="try-liquid-probe-well-name",
-                        pipetteId="pipette-id",
-                    ),
-                    result=cmd.TryLiquidProbeResult(
-                        position=DeckPoint(x=0, y=0, z=0),
-                        z_position=0,
-                    ),
-                ),
-                private_result=None,
-            ),
-            CurrentWell(
-                pipette_id="pipette-id",
-                labware_id="try-liquid-probe-labware-id",
-                well_name="try-liquid-probe-well-name",
-            ),
-        ),
-    ),
-)
-def test_movement_commands_update_current_well(
-    action: Union[SucceedCommandAction, FailCommandAction],
-    expected_location: CurrentWell,
-    subject: PipetteStore,
-) -> None:
-    """It should save the last used pipette, labware, and well for movement commands."""
-    load_pipette_command = create_load_pipette_command(
-        pipette_id="pipette-id",
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_pipette_command)
-    )
-    subject.handle_action(action)
-
-    assert subject.state.current_location == expected_location
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/runs/test_error_recovery_mapping.py
+++ b/robot-server/tests/runs/test_error_recovery_mapping.py
@@ -3,10 +3,7 @@ import pytest
 from decoy import Decoy
 
 
-from opentrons.protocol_engine.commands.pipetting_common import (
-    LiquidNotFoundError,
-    LiquidNotFoundErrorInternalData,
-)
+from opentrons.protocol_engine.commands.pipetting_common import LiquidNotFoundError
 from opentrons.protocol_engine.commands.command import (
     DefinedErrorData,
 )
@@ -38,9 +35,7 @@ def mock_command(decoy: Decoy) -> LiquidProbe:
 @pytest.fixture
 def mock_error_data(decoy: Decoy) -> CommandDefinedErrorData:
     """Get a mock TipPhysicallyMissingError."""
-    mock = decoy.mock(
-        cls=DefinedErrorData[LiquidNotFoundError, LiquidNotFoundErrorInternalData]
-    )
+    mock = decoy.mock(cls=DefinedErrorData[LiquidNotFoundError, None])
     mock_lnfe = decoy.mock(cls=LiquidNotFoundError)
     decoy.when(mock.public).then_return(mock_lnfe)
     decoy.when(mock_lnfe.errorType).then_return("liquidNotFound")


### PR DESCRIPTION
## Overview

More incremental work towards EXEC-652.

## Test Plan and Hands on Testing

* [ ] Run some protocols that do liquid probes and touch-tips. Make sure the path planning still looks right.

## Changelog

This continues the pattern started in #16160. The following commands now use the new `StateUpdate` mechanism to update the pipette's logical state for the purposes of path planning:

* `touchTip`
* `liquidProbe`
* `tryLiquidProbe`

## Review requests

Double-check that the behavior of the code that I'm removing from `PipetteStore` is exactly preserved by the code I'm adding to `TouchTipImplementation`, `LiquidProbeImplementation`, and `TryLiquidProbeImplementation`.

## Risk assessment

Medium.