### PR TITLE
refactor(api): Delete `DefinedErrorData.private`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -53,7 +53,7 @@ class AspirateResult(BaseLiquidHandlingResult, DestinationPositionResult):
 
 _ExecuteReturn = Union[
     SuccessData[AspirateResult, None],
-    DefinedErrorData[OverpressureError, None],
+    DefinedErrorData[OverpressureError],
 ]
 
 
@@ -148,7 +148,6 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
                     ],
                     errorInfo={"retryLocation": (position.x, position.y, position.z)},
                 ),
-                private=None,
                 state_update=state_update,
             )
         else:

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -48,7 +48,7 @@ class AspirateInPlaceResult(BaseLiquidHandlingResult):
 
 _ExecuteReturn = Union[
     SuccessData[AspirateInPlaceResult, None],
-    DefinedErrorData[OverpressureError, None],
+    DefinedErrorData[OverpressureError],
 ]
 
 
@@ -121,7 +121,6 @@ class AspirateInPlaceImplementation(
                         }
                     ),
                 ),
-                private=None,
             )
         else:
             return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -130,7 +130,7 @@ class SuccessData(Generic[_ResultT_co, _PrivateResultT_co]):
 
 
 @dataclasses.dataclass(frozen=True)
-class DefinedErrorData(Generic[_ErrorT_co, _PrivateResultT_co]):
+class DefinedErrorData(Generic[_ErrorT_co]):
     """Data from a command that failed with a defined error.
 
     This should only be used for "defined" errors, not any error.
@@ -139,13 +139,6 @@ class DefinedErrorData(Generic[_ErrorT_co, _PrivateResultT_co]):
 
     public: _ErrorT_co
     """Public error data. Exposed over HTTP and stored in databases."""
-
-    private: _PrivateResultT_co
-    """Additional error data, only given to `opentrons.protocol_engine` internals.
-
-    Deprecated:
-        Use `state_update` instead.
-    """
 
     state_update: StateUpdate = dataclasses.field(
         # todo(mm, 2024-08-22): Remove the default once all command implementations
@@ -246,9 +239,9 @@ class BaseCommand(
                     object,
                 ],
                 DefinedErrorData[
-                    # Likewise, for our `error` field:
+                    # Our _ImplementationCls must return public error data that can fit
+                    # in our `error` field:
                     _ErrorT,
-                    object,
                 ],
             ],
         ]
@@ -259,7 +252,7 @@ _ExecuteReturnT_co = TypeVar(
     "_ExecuteReturnT_co",
     bound=Union[
         SuccessData[BaseModel, object],
-        DefinedErrorData[ErrorOccurrence, object],
+        DefinedErrorData[ErrorOccurrence],
     ],
     covariant=True,
 )

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -703,9 +703,9 @@ CommandPrivateResult = Union[
 
 # All `DefinedErrorData`s that implementations will actually return in practice.
 CommandDefinedErrorData = Union[
-    DefinedErrorData[TipPhysicallyMissingError, None],
-    DefinedErrorData[OverpressureError, None],
-    DefinedErrorData[LiquidNotFoundError, None],
+    DefinedErrorData[TipPhysicallyMissingError],
+    DefinedErrorData[OverpressureError],
+    DefinedErrorData[LiquidNotFoundError],
 ]
 
 

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -54,7 +54,7 @@ class DispenseResult(BaseLiquidHandlingResult, DestinationPositionResult):
 
 _ExecuteReturn = Union[
     SuccessData[DispenseResult, None],
-    DefinedErrorData[OverpressureError, None],
+    DefinedErrorData[OverpressureError],
 ]
 
 
@@ -111,7 +111,6 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
                     ],
                     errorInfo={"retryLocation": (position.x, position.y, position.z)},
                 ),
-                private=None,
                 state_update=state_update,
             )
         else:

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -47,7 +47,7 @@ class DispenseInPlaceResult(BaseLiquidHandlingResult):
 
 _ExecuteReturn = Union[
     SuccessData[DispenseInPlaceResult, None],
-    DefinedErrorData[OverpressureError, None],
+    DefinedErrorData[OverpressureError],
 ]
 
 
@@ -99,7 +99,6 @@ class DispenseInPlaceImplementation(
                         }
                     ),
                 ),
-                private=None,
             )
         else:
             return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -81,7 +81,7 @@ class TryLiquidProbeResult(DestinationPositionResult):
 
 _LiquidProbeExecuteReturn = Union[
     SuccessData[LiquidProbeResult, None],
-    DefinedErrorData[LiquidNotFoundError, None],
+    DefinedErrorData[LiquidNotFoundError],
 ]
 _TryLiquidProbeExecuteReturn = SuccessData[TryLiquidProbeResult, None]
 
@@ -197,7 +197,6 @@ class LiquidProbeImplementation(
                         )
                     ],
                 ),
-                private=None,
                 state_update=state_update,
             )
         else:

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -79,7 +79,7 @@ class TipPhysicallyMissingError(ErrorOccurrence):
 
 _ExecuteReturn = Union[
     SuccessData[PickUpTipResult, None],
-    DefinedErrorData[TipPhysicallyMissingError, None],
+    DefinedErrorData[TipPhysicallyMissingError],
 ]
 
 
@@ -143,7 +143,6 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                         )
                     ],
                 ),
-                private=None,
                 state_update=state_update,
             )
         else:

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -291,7 +291,6 @@ async def test_overpressure_error(
             wrappedErrors=[matchers.Anything()],
             errorInfo={"retryLocation": (position.x, position.y, position.z)},
         ),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id=pipette_id,

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
@@ -201,5 +201,4 @@ async def test_overpressure_error(
             wrappedErrors=[matchers.Anything()],
             errorInfo={"retryLocation": (position.x, position.y, position.z)},
         ),
-        private=None,
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -142,7 +142,6 @@ async def test_overpressure_error(
             wrappedErrors=[matchers.Anything()],
             errorInfo={"retryLocation": (position.x, position.y, position.z)},
         ),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
@@ -93,5 +93,4 @@ async def test_overpressure_error(
             wrappedErrors=[matchers.Anything()],
             errorInfo={"retryLocation": (position.x, position.y, position.z)},
         ),
-        private=None,
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -215,7 +215,6 @@ async def test_liquid_not_found_error(
                 createdAt=error_timestamp,
                 wrappedErrors=[matchers.Anything()],
             ),
-            private=None,
             state_update=expected_state_update,
         )
     else:

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -128,7 +128,6 @@ async def test_tip_physically_missing_error(
         public=TipPhysicallyMissingError.construct(
             id=error_id, createdAt=error_created_at, wrappedErrors=[matchers.Anything()]
         ),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -219,7 +219,7 @@ class _TestCommandDefinedError(ErrorOccurrence):
 
 _TestCommandReturn = Union[
     SuccessData[_TestCommandResult, None],
-    DefinedErrorData[_TestCommandDefinedError, None],
+    DefinedErrorData[_TestCommandDefinedError],
 ]
 
 
@@ -561,7 +561,6 @@ async def test_execute_defined_error(
     error_id = "error-id"
     returned_error = DefinedErrorData(
         public=_TestCommandDefinedError(id=error_id, createdAt=failed_at),
-        private=None,
     )
     queued_command = cast(
         Command,

--- a/robot-server/tests/runs/test_error_recovery_mapping.py
+++ b/robot-server/tests/runs/test_error_recovery_mapping.py
@@ -35,7 +35,7 @@ def mock_command(decoy: Decoy) -> LiquidProbe:
 @pytest.fixture
 def mock_error_data(decoy: Decoy) -> CommandDefinedErrorData:
     """Get a mock TipPhysicallyMissingError."""
-    mock = decoy.mock(cls=DefinedErrorData[LiquidNotFoundError, None])
+    mock = decoy.mock(cls=DefinedErrorData[LiquidNotFoundError])
     mock_lnfe = decoy.mock(cls=LiquidNotFoundError)
     decoy.when(mock.public).then_return(mock_lnfe)
     decoy.when(mock_lnfe.errorType).then_return("liquidNotFound")


### PR DESCRIPTION
## Overview

A trivial refactor as part of EXEC-652.

## Changelog

The `DefinedErrorData.private` attribute was obsoleted by PR #16160's `StateUpdate` mechanism. PR #16261 deleted the last use of it, so we can delete the attribute now.

`DefinedErrorData`'s sibling class, `SuccessData`, also has an identical `private` attribute. We're not quite ready to delete that one, though.

## Test Plan and Hands on Testing

Automated tests should be sufficient.

## Review requests

None in particular.

## Risk assessment

Very low.
