### PR TITLE
fix(app): fix ODD drop tip modal overflow not dismissing

### DIFF
--- a/app/src/pages/InstrumentDetail/__tests__/InstrumentDetail.test.tsx
+++ b/app/src/pages/InstrumentDetail/__tests__/InstrumentDetail.test.tsx
@@ -13,9 +13,21 @@ import {
   usePipetteModelSpecs,
 } from '../../../resources/instruments/hooks'
 import { useIsOEMMode } from '../../../resources/robot-settings/hooks'
+import {
+  DropTipWizardFlows,
+  useDropTipWizardFlows,
+} from '../../../organisms/DropTipWizardFlows'
 
 import type { Instruments } from '@opentrons/api-client'
+import type * as SharedData from '@opentrons/shared-data'
 
+vi.mock('@opentrons/shared-data', async importOriginal => {
+  const actual = await importOriginal<typeof SharedData>()
+  return {
+    ...actual,
+    getPipetteModelSpecs: vi.fn(),
+  }
+})
 vi.mock('@opentrons/react-api-client')
 vi.mock('react-router-dom', () => ({
   useParams: vi.fn(),
@@ -23,6 +35,7 @@ vi.mock('react-router-dom', () => ({
 }))
 vi.mock('../../../resources/instruments/hooks')
 vi.mock('../../../resources/robot-settings/hooks')
+vi.mock('../../../organisms/DropTipWizardFlows')
 
 const render = () => {
   return renderWithProviders(<InstrumentDetail />, {
@@ -98,6 +111,11 @@ describe('InstrumentDetail', () => {
     vi.mocked(useGripperDisplayName).mockReturnValue('mockGripper')
     vi.mocked(useParams).mockReturnValue({ mount: 'left' })
     vi.mocked(useIsOEMMode).mockReturnValue(false)
+    vi.mocked(useDropTipWizardFlows).mockReturnValue({
+      toggleDTWiz: () => null,
+      showDTWiz: false,
+    })
+    vi.mocked(DropTipWizardFlows).mockReturnValue(<div>MOCK_DROP_TIP_WIZ</div>)
   })
 
   afterEach(() => {

--- a/app/src/pages/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
+++ b/app/src/pages/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
@@ -11,9 +11,7 @@ import { handleInstrumentDetailOverflowMenu } from '../InstrumentDetailOverflowM
 import { useNotifyCurrentMaintenanceRun } from '../../../resources/maintenance_runs'
 import { PipetteWizardFlows } from '../../../organisms/PipetteWizardFlows'
 import { GripperWizardFlows } from '../../../organisms/GripperWizardFlows'
-import { useDropTipWizardFlows } from '../../../organisms/DropTipWizardFlows'
 
-import type { Mock } from 'vitest'
 import type {
   PipetteData,
   GripperData,
@@ -31,7 +29,6 @@ vi.mock('@opentrons/shared-data', async importOriginal => {
 vi.mock('../../../resources/maintenance_runs')
 vi.mock('../../../organisms/PipetteWizardFlows')
 vi.mock('../../../organisms/GripperWizardFlows')
-vi.mock('../../../organisms/DropTipWizardFlows')
 
 const MOCK_PIPETTE = {
   mount: 'left',
@@ -103,13 +100,18 @@ const MOCK_GRIPPER = {
 } as GripperData
 
 const MOCK_HOST: HostConfig = { hostname: 'TEST_HOST' }
+const mockToggleDTWiz = vi.fn()
 
 const render = (pipetteOrGripper: PipetteData | GripperData) => {
   return renderWithProviders(
     <NiceModal.Provider>
       <button
         onClick={() =>
-          handleInstrumentDetailOverflowMenu(pipetteOrGripper, MOCK_HOST)
+          handleInstrumentDetailOverflowMenu(
+            pipetteOrGripper,
+            MOCK_HOST,
+            mockToggleDTWiz
+          )
         }
         data-testid="testButton"
       />
@@ -120,11 +122,7 @@ const render = (pipetteOrGripper: PipetteData | GripperData) => {
   )
 }
 
-let mockToggleDTWiz: Mock
-
-describe('UpdateBuildroot', () => {
-  mockToggleDTWiz = vi.fn()
-
+describe('InstrumentDetailOverFlowMenu', () => {
   beforeEach(() => {
     vi.mocked(getPipetteModelSpecs).mockReturnValue({
       displayName: 'mockPipette',
@@ -136,10 +134,6 @@ describe('UpdateBuildroot', () => {
         },
       },
     } as any)
-    vi.mocked(useDropTipWizardFlows).mockReturnValue({
-      showDTWiz: false,
-      toggleDTWiz: mockToggleDTWiz,
-    })
   })
 
   afterEach(() => {
@@ -181,13 +175,15 @@ describe('UpdateBuildroot', () => {
     expect(vi.mocked(PipetteWizardFlows)).toHaveBeenCalled()
   })
 
-  it('renders the drop tip wizard  when Drop tips is clicked', () => {
+  it('toggles the drop tip wizard toggle when Drop tips is clicked', () => {
     render(MOCK_PIPETTE)
     const btn = screen.getByTestId('testButton')
     fireEvent.click(btn)
-    fireEvent.click(screen.getByText('Drop tips'))
 
-    expect(vi.mocked(mockToggleDTWiz)).toHaveBeenCalled()
+    const dtBtn = screen.getByRole('button', { name: /Drop tips/ })
+    fireEvent.click(dtBtn)
+
+    expect(mockToggleDTWiz).toHaveBeenCalled()
   })
 
   it('renders the gripper calibration wizard when recalibrate is clicked', () => {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Thank you @CaseyBatten for reporting this! 

On the ODD, if you go to Instruments > Overflow Menu > Drop tips, the overflow menu modal renders above the drop tip wizard.

This required a good bit of playing around with to find an adequate solution, but relocating the modal rendering outside of the nice-modal provider works without too systemic of a change. Unfortunately, there are just too many conflicting modals now, and this is just another sign we should tackle this more thoroughly in the future.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- On the ODD, go to Instruments > Overflow Menu > Drop tips. You should see that the overflow menu dismisses, and the modal renders appropriately.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the ODD instrument details modal not dismissing.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
