### PR TITLE
fix(protocol-designer): if metadata is lost, navigate to landing

### DIFF
--- a/protocol-designer/src/pages/Designer/__tests__/Designer.test.tsx
+++ b/protocol-designer/src/pages/Designer/__tests__/Designer.test.tsx
@@ -46,6 +46,7 @@ describe('Designer', () => {
   beforeEach(() => {
     vi.mocked(getFileMetadata).mockReturnValue({
       protocolName: 'mockProtocolName',
+      created: 123,
     })
     vi.mocked(selectors.getIsNewProtocol).mockReturnValue(true)
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -24,6 +24,7 @@ import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations
 import { generateNewProtocol } from '../../labware-ingred/actions'
 import { DefineLiquidsModal, ProtocolMetadataNav } from '../../organisms'
 import { SettingsIcon } from '../../molecules'
+import { getFileMetadata } from '../../file-data/selectors'
 import { DeckSetupContainer } from './DeckSetup'
 import { selectors } from '../../labware-ingred/selectors'
 import { OffDeck } from './Offdeck'
@@ -46,6 +47,7 @@ export function Designer(): JSX.Element {
   const { bakeToast, makeSnackbar } = useKitchen()
   const navigate = useNavigate()
   const dispatch = useDispatch()
+  const fileMetadata = useSelector(getFileMetadata)
   const zoomIn = useSelector(selectors.getZoomedInSlot)
   const deckSetup = useSelector(getDeckSetupForActiveItem)
   const isNewProtocol = useSelector(selectors.getIsNewProtocol)
@@ -105,6 +107,15 @@ export function Designer(): JSX.Element {
       dispatch(generateNewProtocol({ isNewProtocol: false }))
     }
   }, [])
+
+  React.useEffect(() => {
+    if (fileMetadata?.created == null) {
+      console.warn(
+        'fileMetadata was refreshed while on the designer page, redirecting to landing page'
+      )
+      navigate('/')
+    }
+  }, [fileMetadata])
 
   const overflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => {

--- a/protocol-designer/src/pages/Liquids/__tests__/Liquids.test.tsx
+++ b/protocol-designer/src/pages/Liquids/__tests__/Liquids.test.tsx
@@ -53,7 +53,7 @@ describe('Liquids', () => {
   it('calls navigate when there is no active labware', () => {
     vi.mocked(labwareIngredSelectors.getSelectedLabwareId).mockReturnValue(null)
     render()
-    expect(mockNavigate).toHaveBeenCalledWith('/overview')
+    expect(mockNavigate).toHaveBeenCalledWith('/designer')
   })
 
   it('renders nav and assign liquids modal', () => {

--- a/protocol-designer/src/pages/Liquids/index.tsx
+++ b/protocol-designer/src/pages/Liquids/index.tsx
@@ -43,7 +43,8 @@ export function Liquids(): JSX.Element {
 
   React.useEffect(() => {
     if (selectedLabware == null) {
-      navigate('/overview')
+      console.warn('selectedLabware was lost, navigate to deisgner page')
+      navigate('/designer')
     }
   })
 

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolOverview.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolOverview.test.tsx
@@ -66,6 +66,7 @@ describe('ProtocolOverview', () => {
       protocolName: 'mockName',
       author: 'mockAuthor',
       description: 'mockDescription',
+      created: 123,
     })
     vi.mocked(useBlockingHint).mockReturnValue(null)
     vi.mocked(MaterialsListModal).mockReturnValue(

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -117,6 +117,15 @@ export function ProtocolOverview(): JSX.Element {
     typeof leftString | typeof rightString
   >(leftString)
 
+  React.useEffect(() => {
+    if (formValues?.created == null) {
+      console.warn(
+        'formValues was refreshed while on the overview page, redirecting to landing page'
+      )
+      navigate('/')
+    }
+  }, [formValues])
+
   const {
     modules: modulesOnDeck,
     labware: labwaresOnDeck,


### PR DESCRIPTION
closes AUTH-823

# Overview

Fixing some nav issues, mainly if you refresh and lose the metadata, it will redirect you to the landing page instead of leaving you in a weird empty state on the designer/overview pages

## Test Plan and Hands on Testing

Go to the overview page, the designer page, and liquids page (if you're assigning a liquid to labware) and refresh the page, it should navigate you to landing for all 3 cases

## Changelog

added a use effect at the pages to redirect to the correct area, added console.warns to help debug if there are issues in the future

## Risk assessment

low
