### PR TITLE
refactor(api): Port `moveToCoordinates`, `moveRelative`, and `moveToAddressableArea` location updates to `StateUpdate`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from ..errors import LocationNotAccessibleByPipetteError
+from ..state import update_types
 from ..types import DeckPoint, AddressableOffsetVector
 from ..resources import fixture_validation
 from .pipetting_common import (
@@ -88,6 +89,8 @@ class MoveToAddressableAreaImplementation(
         self, params: MoveToAddressableAreaParams
     ) -> SuccessData[MoveToAddressableAreaResult, None]:
         """Move the requested pipette to the requested addressable area."""
+        state_update = update_types.StateUpdate()
+
         self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
             params.addressableAreaName
         )
@@ -106,10 +109,17 @@ class MoveToAddressableAreaImplementation(
             speed=params.speed,
             stay_at_highest_possible_z=params.stayAtHighestPossibleZ,
         )
+        deck_point = DeckPoint.construct(x=x, y=y, z=z)
+        state_update.set_pipette_location(
+            pipette_id=params.pipetteId,
+            new_addressable_area_name=params.addressableAreaName,
+            new_deck_point=deck_point,
+        )
 
         return SuccessData(
             public=MoveToAddressableAreaResult(position=DeckPoint(x=x, y=y, z=z)),
             private=None,
+            state_update=state_update,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from ..errors import LocationNotAccessibleByPipetteError
+from ..state import update_types
 from ..types import DeckPoint, AddressableOffsetVector
 from ..resources import fixture_validation
 from .pipetting_common import (
@@ -100,6 +101,8 @@ class MoveToAddressableAreaForDropTipImplementation(
         self, params: MoveToAddressableAreaForDropTipParams
     ) -> SuccessData[MoveToAddressableAreaForDropTipResult, None]:
         """Move the requested pipette to the requested addressable area in preperation of a drop tip."""
+        state_update = update_types.StateUpdate()
+
         self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
             params.addressableAreaName
         )
@@ -126,12 +129,19 @@ class MoveToAddressableAreaForDropTipImplementation(
             speed=params.speed,
             ignore_tip_configuration=params.ignoreTipConfiguration,
         )
+        deck_point = DeckPoint.construct(x=x, y=y, z=z)
+        state_update.set_pipette_location(
+            pipette_id=params.pipetteId,
+            new_addressable_area_name=params.addressableAreaName,
+            new_deck_point=deck_point,
+        )
 
         return SuccessData(
             public=MoveToAddressableAreaForDropTipResult(
                 position=DeckPoint(x=x, y=y, z=z)
             ),
             private=None,
+            state_update=state_update,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -5,6 +5,8 @@ from pydantic import Field
 from typing import Optional, Type, TYPE_CHECKING
 from typing_extensions import Literal
 
+
+from ..state import update_types
 from ..types import DeckPoint
 from .pipetting_common import PipetteIdMixin, MovementMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
@@ -50,6 +52,8 @@ class MoveToCoordinatesImplementation(
         self, params: MoveToCoordinatesParams
     ) -> SuccessData[MoveToCoordinatesResult, None]:
         """Move the requested pipette to the requested coordinates."""
+        state_update = update_types.StateUpdate()
+
         x, y, z = await self._movement.move_to_coordinates(
             pipette_id=params.pipetteId,
             deck_coordinates=params.coordinates,
@@ -57,10 +61,15 @@ class MoveToCoordinatesImplementation(
             additional_min_travel_z=params.minimumZHeight,
             speed=params.speed,
         )
+        deck_point = DeckPoint.construct(x=x, y=y, z=z)
+        state_update.pipette_location = update_types.PipetteLocationUpdate(
+            pipette_id=params.pipetteId, new_location=None, new_deck_point=deck_point
+        )
 
         return SuccessData(
             public=MoveToCoordinatesResult(position=DeckPoint(x=x, y=y, z=z)),
             private=None,
+            state_update=state_update,
         )
 
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -316,20 +316,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         # todo(mm, 2024-08-29): Port the following isinstance() checks to
         # use `state_update`. https://opentrons.atlassian.net/browse/EXEC-639
 
-        # These commands leave the pipette in a new location.
-        # Update current_location to reflect that.
-        if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (
-                commands.MoveToAddressableAreaResult,
-                commands.MoveToAddressableAreaForDropTipResult,
-            ),
-        ):
-            self._state.current_location = CurrentAddressableArea(
-                pipette_id=action.command.params.pipetteId,
-                addressable_area_name=action.command.params.addressableAreaName,
-            )
-
         # These commands leave the pipette in a place that we can't logically associate
         # with a well. Clear current_location to reflect the fact that it's now unknown.
         #
@@ -410,8 +396,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             (
                 commands.MoveToCoordinatesResult,
                 commands.MoveRelativeResult,
-                commands.MoveToAddressableAreaResult,
-                commands.MoveToAddressableAreaForDropTipResult,
             ),
         ):
             pipette_id = action.command.params.pipetteId

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -320,7 +320,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         # with a well. Clear current_location to reflect the fact that it's now unknown.
         #
         # TODO(mc, 2021-11-12): Wipe out current_location on movement failures, too.
-        # TODO(jbl 2023-02-14): Need to investigate whether move relative should clear current location
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
@@ -393,10 +392,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
         if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
-            (
-                commands.MoveToCoordinatesResult,
-                commands.MoveRelativeResult,
-            ),
+            commands.MoveToCoordinatesResult,
         ):
             pipette_id = action.command.params.pipetteId
             deck_point = action.command.result.position

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -325,7 +325,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             (
                 commands.HomeResult,
                 commands.RetractAxisResult,
-                commands.MoveToCoordinatesResult,
                 commands.thermocycler.OpenLidResult,
                 commands.thermocycler.CloseLidResult,
             ),
@@ -363,7 +362,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             ):
                 self._state.current_location = None
 
-    def _update_deck_point(  # noqa: C901
+    def _update_deck_point(
         self, action: Union[SucceedCommandAction, FailCommandAction]
     ) -> None:
         if isinstance(action, SucceedCommandAction):
@@ -389,17 +388,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         #
         # These isinstance() checks mostly mirror self._update_current_location().
         # See there for explanations.
-
-        if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            commands.MoveToCoordinatesResult,
-        ):
-            pipette_id = action.command.params.pipetteId
-            deck_point = action.command.result.position
-            loaded_pipette = self._state.pipettes_by_id[pipette_id]
-            self._state.current_deck_point = CurrentDeckPoint(
-                mount=loaded_pipette.mount, deck_point=deck_point
-            )
 
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,

--- a/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
@@ -1,6 +1,7 @@
 """Test move relative commands."""
 from decoy import Decoy
 
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.types import DeckPoint, MovementAxis
 from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.types import Point
@@ -36,5 +37,13 @@ async def test_move_relative_implementation(
     result = await subject.execute(data)
 
     assert result == SuccessData(
-        public=MoveRelativeResult(position=DeckPoint(x=1, y=2, z=3)), private=None
+        public=MoveRelativeResult(position=DeckPoint(x=1, y=2, z=3)),
+        private=None,
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="pipette-id",
+                new_location=update_types.NO_CHANGE,
+                new_deck_point=DeckPoint(x=1, y=2, z=3),
+            )
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.protocol_engine import DeckPoint, AddressableOffsetVector
 from opentrons.protocol_engine.execution import MovementHandler
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.types import Point
 
@@ -51,4 +52,11 @@ async def test_move_to_addressable_area_implementation(
     assert result == SuccessData(
         public=MoveToAddressableAreaResult(position=DeckPoint(x=9, y=8, z=7)),
         private=None,
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="abc",
+                new_location=update_types.AddressableArea(addressable_area_name="123"),
+                new_deck_point=DeckPoint(x=9, y=8, z=7),
+            )
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.protocol_engine import DeckPoint, AddressableOffsetVector
 from opentrons.protocol_engine.execution import MovementHandler
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.types import Point
 
@@ -58,4 +59,11 @@ async def test_move_to_addressable_area_for_drop_tip_implementation(
     assert result == SuccessData(
         public=MoveToAddressableAreaForDropTipResult(position=DeckPoint(x=9, y=8, z=7)),
         private=None,
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="abc",
+                new_location=update_types.AddressableArea(addressable_area_name="123"),
+                new_deck_point=DeckPoint(x=9, y=8, z=7),
+            )
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.execution import MovementHandler
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.types import DeckPoint
 from opentrons.types import Point
@@ -58,4 +59,11 @@ async def test_move_to_coordinates_implementation(
     assert result == SuccessData(
         public=MoveToCoordinatesResult(position=DeckPoint(x=4.44, y=5.55, z=6.66)),
         private=None,
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="pipette-id",
+                new_location=None,
+                new_deck_point=DeckPoint(x=4.44, y=5.55, z=6.66),
+            )
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -53,7 +53,6 @@ from .command_fixtures import (
     create_blow_out_in_place_command,
     create_move_labware_command,
     create_move_to_coordinates_command,
-    create_move_relative_command,
     create_prepare_to_aspirate_command,
     create_unsafe_blow_out_in_place_command,
 )
@@ -780,13 +779,6 @@ def test_add_pipette_config(
             command=create_move_to_coordinates_command(
                 pipette_id="pipette-id",
                 coordinates=DeckPoint(x=11, y=22, z=33),
-            ),
-            private_result=None,
-        ),
-        SucceedCommandAction(
-            command=create_move_relative_command(
-                pipette_id="pipette-id",
-                destination=DeckPoint(x=11, y=22, z=33),
             ),
             private_result=None,
         ),


### PR DESCRIPTION
## Overview

Even more incremental work towards EXEC-652.

## Test Plan and Hands on Testing

* [x] Run some protocols that use these commands. Make sure the path planning still looks right.

## Changelog

This continues the pattern started in #16160. The following commands now use the new `StateUpdate` mechanism to update the pipette's logical state for the purposes of path planning:

* `moveToCoordinates`
* `moveRelative`
* `moveToAddressableArea`
* `moveToAddressableAreaForDropTip`

## Review requests

Double-check that the behavior of the code that I'm removing from `PipetteStore` is exactly preserved by the code I'm adding to the command implementations.

## Risk assessment

Medium.