### PR TITLE
refactor(api): Port location-clearing commands to `StateUpdate`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ...errors.error_occurrence import ErrorOccurrence
+from ...state import update_types
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state.state import StateView
@@ -54,6 +55,8 @@ class OpenLabwareLatchImpl(
         self, params: OpenLabwareLatchParams
     ) -> SuccessData[OpenLabwareLatchResult, None]:
         """Open a Heater-Shaker's labware latch."""
+        state_update = update_types.StateUpdate()
+
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
@@ -72,6 +75,7 @@ class OpenLabwareLatchImpl(
             await self._movement.home(
                 axes=self._state_view.motion.get_robot_mount_axes()
             )
+            state_update.clear_all_pipette_locations()
 
         # Allow propagation of ModuleNotAttachedError.
         hs_hardware_module = self._equipment.get_module_hardware_api(
@@ -84,6 +88,7 @@ class OpenLabwareLatchImpl(
         return SuccessData(
             public=OpenLabwareLatchResult(pipetteRetracted=pipette_should_retract),
             private=None,
+            state_update=state_update,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -6,7 +6,9 @@ from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from opentrons.types import Point
+from ..state import update_types
 from ..types import (
+    CurrentWell,
     LabwareLocation,
     DeckSlotLocation,
     OnLabwareLocation,
@@ -96,6 +98,8 @@ class MoveLabwareImplementation(
         self, params: MoveLabwareParams
     ) -> SuccessData[MoveLabwareResult, None]:
         """Move a loaded labware to a new location."""
+        state_update = update_types.StateUpdate()
+
         # Allow propagation of LabwareNotLoadedError.
         current_labware = self._state_view.labware.get(labware_id=params.labwareId)
         current_labware_definition = self._state_view.labware.get_definition(
@@ -209,12 +213,28 @@ class MoveLabwareImplementation(
                 user_offset_data=user_offset_data,
                 post_drop_slide_offset=post_drop_slide_offset,
             )
+            # All mounts will have been retracted as part of the gripper move.
+            state_update.clear_all_pipette_locations()
         elif params.strategy == LabwareMovementStrategy.MANUAL_MOVE_WITH_PAUSE:
             # Pause to allow for manual labware movement
             await self._run_control.wait_for_resume()
 
+        # We may have just moved the labware that contains the current well out from
+        # under the pipette. Clear the current location to reflect the fact that the
+        # pipette is no longer over any labware. This is necessary for safe path
+        # planning in case the next movement goes to the same labware (now in a new
+        # place).
+        pipette_location = self._state_view.pipettes.get_current_location()
+        if (
+            isinstance(pipette_location, CurrentWell)
+            and pipette_location.labware_id == params.labwareId
+        ):
+            state_update.clear_all_pipette_locations()
+
         return SuccessData(
-            public=MoveLabwareResult(offsetId=new_offset_id), private=None
+            public=MoveLabwareResult(offsetId=new_offset_id),
+            private=None,
+            state_update=state_update,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
+from ..state import update_types
 from ..types import MotorAxis
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors.error_occurrence import ErrorOccurrence
@@ -49,8 +50,12 @@ class RetractAxisImplementation(
         self, params: RetractAxisParams
     ) -> SuccessData[RetractAxisResult, None]:
         """Retract the specified axis."""
+        state_update = update_types.StateUpdate()
         await self._movement.retract_axis(axis=params.axis)
-        return SuccessData(public=RetractAxisResult(), private=None)
+        state_update.clear_all_pipette_locations()
+        return SuccessData(
+            public=RetractAxisResult(), private=None, state_update=state_update
+        )
 
 
 class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
@@ -6,6 +6,7 @@ from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...state import update_types
 from ...errors.error_occurrence import ErrorOccurrence
 from opentrons.protocol_engine.types import MotorAxis
 
@@ -43,6 +44,8 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, 
 
     async def execute(self, params: OpenLidParams) -> SuccessData[OpenLidResult, None]:
         """Open a Thermocycler's lid."""
+        state_update = update_types.StateUpdate()
+
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
         )
@@ -57,11 +60,14 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, 
             MotorAxis.Y,
         ] + self._state_view.motion.get_robot_mount_axes()
         await self._movement.home(axes=axes_to_home)
+        state_update.clear_all_pipette_locations()
 
         if thermocycler_hardware is not None:
             await thermocycler_hardware.open()
 
-        return SuccessData(public=OpenLidResult(), private=None)
+        return SuccessData(
+            public=OpenLidResult(), private=None, state_update=state_update
+        )
 
 
 class OpenLid(BaseCommand[OpenLidParams, OpenLidResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -317,29 +317,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 case update_types.NO_CHANGE:
                     pass
 
-        # todo(mm, 2024-08-29): Port the following isinstance() checks to
-        # use `state_update`. https://opentrons.atlassian.net/browse/EXEC-639
-
         # TODO(mc, 2021-11-12): Wipe out current_location on movement failures, too.
-
-        # A moveLabware command may have moved the labware that contains the current
-        # well out from under the pipette. Clear the current location to reflect the
-        # fact that the pipette is no longer over any labware.
-        #
-        # This is necessary for safe motion planning in case the next movement
-        # goes to the same labware (now in a new place).
-        if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, commands.MoveLabwareResult
-        ):
-            moved_labware_id = action.command.params.labwareId
-            if action.command.params.strategy == "usingGripper":
-                # All mounts will have been retracted.
-                self._state.current_location = None
-            elif (
-                isinstance(self._state.current_location, CurrentWell)
-                and self._state.current_location.labware_id == moved_labware_id
-            ):
-                self._state.current_location = None
 
     def _update_deck_point(
         self, action: Union[SucceedCommandAction, FailCommandAction]
@@ -364,19 +342,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                     mount=loaded_pipette.mount,
                     deck_point=location_update.new_deck_point,
                 )
-
-        # todo(mm, 2024-08-29): Port the following isinstance() checks to
-        # use `state_update`. https://opentrons.atlassian.net/browse/EXEC-639
-        #
-        # These isinstance() checks mostly mirror self._update_current_location().
-        # See there for explanations.
-
-        if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, commands.MoveLabwareResult
-        ):
-            if action.command.params.strategy == "usingGripper":
-                # All mounts will have been retracted.
-                self._clear_deck_point()
 
     def _update_volumes(
         self, action: Union[SucceedCommandAction, FailCommandAction]

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -320,22 +320,11 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         # todo(mm, 2024-08-29): Port the following isinstance() checks to
         # use `state_update`. https://opentrons.atlassian.net/browse/EXEC-639
 
-        # These commands leave the pipette in a place that we can't logically associate
-        # with a well. Clear current_location to reflect the fact that it's now unknown.
-        #
         # TODO(mc, 2021-11-12): Wipe out current_location on movement failures, too.
-        if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (
-                commands.thermocycler.OpenLidResult,
-                commands.thermocycler.CloseLidResult,
-            ),
-        ):
-            self._state.current_location = None
 
         # Heater-Shaker commands may have left the pipette in a place that we can't
         # associate with a logical location, depending on their result.
-        elif isinstance(action, SucceedCommandAction) and isinstance(
+        if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
                 commands.heater_shaker.SetAndWaitForShakeSpeedResult,
@@ -395,15 +384,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         # See there for explanations.
 
         if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (
-                commands.thermocycler.OpenLidResult,
-                commands.thermocycler.CloseLidResult,
-            ),
-        ):
-            self._clear_deck_point()
-
-        elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
                 commands.heater_shaker.SetAndWaitForShakeSpeedResult,

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -327,7 +327,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                commands.RetractAxisResult,
                 commands.thermocycler.OpenLidResult,
                 commands.thermocycler.CloseLidResult,
             ),
@@ -398,7 +397,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                commands.RetractAxisResult,
                 commands.thermocycler.OpenLidResult,
                 commands.thermocycler.CloseLidResult,
             ),

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -326,8 +326,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                     mount=loaded_pipette.mount, deck_point=new_deck_point
                 )
 
-        # TODO(mc, 2021-11-12): Wipe out current_location on movement failures, too.
-
     def _update_volumes(
         self, action: Union[SucceedCommandAction, FailCommandAction]
     ) -> None:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -281,7 +281,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                     default_dispense=tip_configuration.default_dispense_flowrate.values_by_api_level,
                 )
 
-    def _update_current_location(  # noqa: C901
+    def _update_current_location(
         self, action: Union[SucceedCommandAction, FailCommandAction]
     ) -> None:
         if isinstance(action, SucceedCommandAction):
@@ -322,25 +322,13 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
         # TODO(mc, 2021-11-12): Wipe out current_location on movement failures, too.
 
-        # Heater-Shaker commands may have left the pipette in a place that we can't
-        # associate with a logical location, depending on their result.
-        if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (
-                commands.heater_shaker.SetAndWaitForShakeSpeedResult,
-                commands.heater_shaker.OpenLabwareLatchResult,
-            ),
-        ):
-            if action.command.result.pipetteRetracted:
-                self._state.current_location = None
-
         # A moveLabware command may have moved the labware that contains the current
         # well out from under the pipette. Clear the current location to reflect the
         # fact that the pipette is no longer over any labware.
         #
         # This is necessary for safe motion planning in case the next movement
         # goes to the same labware (now in a new place).
-        elif isinstance(action, SucceedCommandAction) and isinstance(
+        if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result, commands.MoveLabwareResult
         ):
             moved_labware_id = action.command.params.labwareId
@@ -353,7 +341,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             ):
                 self._state.current_location = None
 
-    def _update_deck_point(  # noqa: C901
+    def _update_deck_point(
         self, action: Union[SucceedCommandAction, FailCommandAction]
     ) -> None:
         if isinstance(action, SucceedCommandAction):
@@ -384,16 +372,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         # See there for explanations.
 
         if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (
-                commands.heater_shaker.SetAndWaitForShakeSpeedResult,
-                commands.heater_shaker.OpenLabwareLatchResult,
-            ),
-        ):
-            if action.command.result.pipetteRetracted:
-                self._clear_deck_point()
-
-        elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result, commands.MoveLabwareResult
         ):
             if action.command.params.strategy == "usingGripper":

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -327,7 +327,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                commands.HomeResult,
                 commands.RetractAxisResult,
                 commands.thermocycler.OpenLidResult,
                 commands.thermocycler.CloseLidResult,
@@ -399,7 +398,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         if isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,
             (
-                commands.HomeResult,
                 commands.RetractAxisResult,
                 commands.thermocycler.OpenLidResult,
                 commands.thermocycler.CloseLidResult,

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -26,6 +26,24 @@ Unfortunately, mypy doesn't let us write `Literal[NO_CHANGE]`. Use this instead.
 """
 
 
+class _ClearEnum(enum.Enum):
+    CLEAR = enum.auto()
+
+
+CLEAR: typing.Final = _ClearEnum.CLEAR
+"""A sentinel value to indicate that a value should be cleared.
+
+Useful when `None` is semantically unclear or has some other meaning.
+"""
+
+
+ClearType: typing.TypeAlias = typing.Literal[_ClearEnum.CLEAR]
+"""The type of `CLEAR`, as `NoneType` is to `None`.
+
+Unfortunately, mypy doesn't let us write `Literal[CLEAR]`. Use this instead.
+"""
+
+
 @dataclasses.dataclass(frozen=True)
 class Well:
     """Designates a well in a labware."""
@@ -61,10 +79,7 @@ class PipetteLocationUpdate:
 class StateUpdate:
     """Represents an update to perform on engine state."""
 
-    # todo(mm, 2024-08-29): Extend this with something to represent clearing both the
-    # deck point and the logical location, for e.g. home commands. Consider an explicit
-    # `CLEAR` sentinel if `None` is confusing.
-    pipette_location: PipetteLocationUpdate | NoChangeType = NO_CHANGE
+    pipette_location: PipetteLocationUpdate | NoChangeType | ClearType = NO_CHANGE
 
     # These convenience functions let the caller avoid the boilerplate of constructing a
     # complicated dataclass tree, and they give us a
@@ -118,3 +133,7 @@ class StateUpdate:
                 new_location=Well(labware_id=new_labware_id, well_name=new_well_name),
                 new_deck_point=new_deck_point,
             )
+
+    def clear_all_pipette_locations(self) -> None:
+        """Mark all pipettes as having an unknown location."""
+        self.pipette_location = CLEAR

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_labware_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_labware_latch.py
@@ -1,8 +1,10 @@
 """Test Heater Shaker open labware latch command implementation."""
 from decoy import Decoy
+import pytest
 
 from opentrons.hardware_control.modules import HeaterShaker
 
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
@@ -17,11 +19,20 @@ from opentrons.protocol_engine.commands.heater_shaker.open_labware_latch import 
 from opentrons.protocol_engine.types import MotorAxis
 
 
+@pytest.mark.parametrize(
+    ("pipette_blocking_hs_latch", "expect_pipette_retracted"),
+    [
+        (False, False),
+        (True, True),
+    ],
+)
 async def test_open_labware_latch(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
     movement: MovementHandler,
+    pipette_blocking_hs_latch: bool,
+    expect_pipette_retracted: bool,
 ) -> None:
     """It should be able to open the module's labware latch."""
     subject = OpenLabwareLatchImpl(
@@ -46,7 +57,7 @@ async def test_open_labware_latch(
         state_view.motion.check_pipette_blocking_hs_latch(
             HeaterShakerModuleId("heater-shaker-id")
         )
-    ).then_return(True)
+    ).then_return(pipette_blocking_hs_latch)
 
     # Get stubbed hardware module
     decoy.when(
@@ -55,14 +66,23 @@ async def test_open_labware_latch(
     decoy.when(state_view.motion.get_robot_mount_axes()).then_return(
         [MotorAxis.EXTENSION_Z]
     )
+
     result = await subject.execute(data)
-    decoy.verify(
-        hs_module_substate.raise_if_shaking(),
-        await movement.home(
-            [MotorAxis.EXTENSION_Z],
-        ),
-        await hs_hardware.open_labware_latch(),
-    )
+
+    decoy.verify(hs_module_substate.raise_if_shaking())
+    if expect_pipette_retracted:
+        decoy.verify(
+            await movement.home(
+                [MotorAxis.EXTENSION_Z],
+            )
+        )
+    decoy.verify(await hs_hardware.open_labware_latch())
     assert result == SuccessData(
-        public=heater_shaker.OpenLabwareLatchResult(pipetteRetracted=True), private=None
+        public=heater_shaker.OpenLabwareLatchResult(
+            pipetteRetracted=expect_pipette_retracted
+        ),
+        private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR)
+        if expect_pipette_retracted
+        else update_types.StateUpdate(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_and_wait_for_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_and_wait_for_shake_speed.py
@@ -1,8 +1,10 @@
 """Test Heater Shaker set shake speed command implementation."""
 from decoy import Decoy
+import pytest
 
 from opentrons.hardware_control.modules import HeaterShaker
 
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state.module_substates import (
     HeaterShakerModuleSubState,
@@ -17,11 +19,20 @@ from opentrons.protocol_engine.commands.heater_shaker.set_and_wait_for_shake_spe
 from opentrons.protocol_engine.types import MotorAxis
 
 
+@pytest.mark.parametrize(
+    ("pipette_blocking_hs_shaker", "expect_pipette_retracted"),
+    [
+        (False, False),
+        (True, True),
+    ],
+)
 async def test_set_and_wait_for_shake_speed(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
     movement: MovementHandler,
+    pipette_blocking_hs_shaker: bool,
+    expect_pipette_retracted: bool,
 ) -> None:
     """It should be able to set the module's shake speed."""
     subject = SetAndWaitForShakeSpeedImpl(
@@ -49,7 +60,7 @@ async def test_set_and_wait_for_shake_speed(
         state_view.motion.check_pipette_blocking_hs_shaker(
             HeaterShakerModuleId("heater-shaker-id")
         )
-    ).then_return(True)
+    ).then_return(pipette_blocking_hs_shaker)
 
     # Stub speed validation from hs module view
     decoy.when(hs_module_substate.validate_target_speed(rpm=1234.56)).then_return(1234)
@@ -61,15 +72,20 @@ async def test_set_and_wait_for_shake_speed(
     decoy.when(state_view.motion.get_robot_mount_axes()).then_return(
         [MotorAxis.EXTENSION_Z]
     )
+
     result = await subject.execute(data)
-    decoy.verify(
-        hs_module_substate.raise_if_labware_latch_not_closed(),
-        await movement.home(
-            [MotorAxis.EXTENSION_Z],
-        ),
-        await hs_hardware.set_speed(rpm=1234),
-    )
+
+    decoy.verify(hs_module_substate.raise_if_labware_latch_not_closed())
+    if expect_pipette_retracted:
+        decoy.verify(await movement.home([MotorAxis.EXTENSION_Z]))
+    decoy.verify(await hs_hardware.set_speed(rpm=1234))
+
     assert result == SuccessData(
-        public=heater_shaker.SetAndWaitForShakeSpeedResult(pipetteRetracted=True),
+        public=heater_shaker.SetAndWaitForShakeSpeedResult(
+            pipetteRetracted=expect_pipette_retracted
+        ),
         private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR)
+        if expect_pipette_retracted
+        else update_types.StateUpdate(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_home.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_home.py
@@ -1,6 +1,7 @@
 """Test home commands."""
 from decoy import Decoy
 
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.types import MotorAxis
 from opentrons.types import MountType
 from opentrons.protocol_engine.execution import MovementHandler
@@ -21,7 +22,11 @@ async def test_home_implementation(decoy: Decoy, movement: MovementHandler) -> N
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=HomeResult(), private=None)
+    assert result == SuccessData(
+        public=HomeResult(),
+        private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+    )
     decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]))
 
 
@@ -33,7 +38,11 @@ async def test_home_all_implementation(decoy: Decoy, movement: MovementHandler) 
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=HomeResult(), private=None)
+    assert result == SuccessData(
+        public=HomeResult(),
+        private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+    )
     decoy.verify(await movement.home(axes=None))
 
 
@@ -52,7 +61,11 @@ async def test_home_with_invalid_position(
     )
 
     result = await subject.execute(data)
-    assert result == SuccessData(public=HomeResult(), private=None)
+    assert result == SuccessData(
+        public=HomeResult(),
+        private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+    )
 
     decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]), times=1)
     decoy.reset()
@@ -61,6 +74,10 @@ async def test_home_with_invalid_position(
         await movement.check_for_valid_position(mount=MountType.LEFT)
     ).then_return(True)
     result = await subject.execute(data)
-    assert result == SuccessData(public=HomeResult(), private=None)
+    assert result == SuccessData(
+        public=HomeResult(),
+        private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+    )
 
     decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]), times=0)

--- a/api/tests/opentrons/protocol_engine/commands/test_retract_axis.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_retract_axis.py
@@ -1,6 +1,7 @@
 """Test retractAxis command."""
 from decoy import Decoy
 
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.types import MotorAxis
 from opentrons.protocol_engine.execution import MovementHandler
 
@@ -22,5 +23,9 @@ async def test_retract_axis_implementation(
     data = RetractAxisParams(axis=MotorAxis.Y)
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=RetractAxisResult(), private=None)
+    assert result == SuccessData(
+        public=RetractAxisResult(),
+        private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+    )
     decoy.verify(await movement.retract_axis(axis=MotorAxis.Y))

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_close_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_close_lid.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control.modules import Thermocycler
 
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.types import MotorAxis
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state.module_substates import (
@@ -55,4 +56,8 @@ async def test_close_lid(
         await tc_hardware.close(),
         times=1,
     )
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(
+        public=expected_result,
+        private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+    )

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_open_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_open_lid.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control.modules import Thermocycler
 
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.types import MotorAxis
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state.module_substates import (
@@ -53,4 +54,8 @@ async def test_open_lid(
         await tc_hardware.open(),
         times=1,
     )
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(
+        public=expected_result,
+        private=None,
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -466,14 +466,6 @@ def test_blow_out_clears_volume(
 @pytest.mark.parametrize(
     "command",
     [
-        cmd.Home(
-            id="command-id-2",
-            key="command-key-2",
-            status=cmd.CommandStatus.SUCCEEDED,
-            createdAt=datetime(year=2021, month=1, day=1),
-            params=cmd.HomeParams(),
-            result=cmd.HomeResult(),
-        ),
         cmd.thermocycler.OpenLid(
             id="command-id-2",
             key="command-key-2",
@@ -794,14 +786,6 @@ def test_add_pipette_config(
 @pytest.mark.parametrize(
     "command",
     (
-        cmd.Home(
-            id="command-id-2",
-            key="command-key-2",
-            status=cmd.CommandStatus.SUCCEEDED,
-            createdAt=datetime(year=2021, month=1, day=1),
-            params=cmd.HomeParams(),
-            result=cmd.HomeResult(),
-        ),
         cmd.thermocycler.OpenLid(
             id="command-id-2",
             key="command-key-2",

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -466,22 +466,6 @@ def test_blow_out_clears_volume(
 @pytest.mark.parametrize(
     "command",
     [
-        cmd.thermocycler.OpenLid(
-            id="command-id-2",
-            key="command-key-2",
-            status=cmd.CommandStatus.SUCCEEDED,
-            createdAt=datetime(year=2021, month=1, day=1),
-            params=cmd.thermocycler.OpenLidParams(moduleId="xyz"),
-            result=cmd.thermocycler.OpenLidResult(),
-        ),
-        cmd.thermocycler.CloseLid(
-            id="command-id-2",
-            key="command-key-2",
-            status=cmd.CommandStatus.SUCCEEDED,
-            createdAt=datetime(year=2021, month=1, day=1),
-            params=cmd.thermocycler.CloseLidParams(moduleId="xyz"),
-            result=cmd.thermocycler.CloseLidResult(),
-        ),
         cmd.heater_shaker.SetAndWaitForShakeSpeed(
             id="command-id-2",
             key="command-key-2",
@@ -786,22 +770,6 @@ def test_add_pipette_config(
 @pytest.mark.parametrize(
     "command",
     (
-        cmd.thermocycler.OpenLid(
-            id="command-id-2",
-            key="command-key-2",
-            status=cmd.CommandStatus.SUCCEEDED,
-            createdAt=datetime(year=2021, month=1, day=1),
-            params=cmd.thermocycler.OpenLidParams(moduleId="xyz"),
-            result=cmd.thermocycler.OpenLidResult(),
-        ),
-        cmd.thermocycler.CloseLid(
-            id="command-id-2",
-            key="command-key-2",
-            status=cmd.CommandStatus.SUCCEEDED,
-            createdAt=datetime(year=2021, month=1, day=1),
-            params=cmd.thermocycler.CloseLidParams(moduleId="xyz"),
-            result=cmd.thermocycler.CloseLidResult(),
-        ),
         cmd.heater_shaker.SetAndWaitForShakeSpeed(
             id="command-id-2",
             key="command-key-2",

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -188,6 +188,38 @@ def test_location_state_update(subject: PipetteStore) -> None:
         mount=MountType.RIGHT, deck_point=DeckPoint(x=333, y=444, z=555)
     )
 
+    # Repopulate the locations, then test clearing all pipette locations:
+    subject.handle_action(
+        SucceedCommandAction(
+            command=dummy_command,
+            private_result=None,
+            state_update=update_types.StateUpdate(
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id",
+                    new_location=update_types.AddressableArea(
+                        addressable_area_name="na na na na na"
+                    ),
+                    new_deck_point=DeckPoint(x=333, y=444, z=555),
+                )
+            ),
+        )
+    )
+    assert subject.state.current_location is not None
+    assert subject.state.current_deck_point != CurrentDeckPoint(
+        mount=None, deck_point=None
+    )
+    subject.handle_action(
+        SucceedCommandAction(
+            command=dummy_command,
+            private_result=None,
+            state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+        )
+    )
+    assert subject.state.current_location is None
+    assert subject.state.current_deck_point == CurrentDeckPoint(
+        mount=None, deck_point=None
+    )
+
 
 def test_handles_load_pipette(subject: PipetteStore) -> None:
     """It should add the pipette data to the state."""


### PR DESCRIPTION
## Overview

Still more incremental work towards EXEC-652.

## Test Plan and Hands on Testing

* [x] Run some protocols that use these commands. Make sure the path planning still looks right.

## Changelog

The following commands clear the current pipette location, sometimes conditionally. This can be surprising and sneaky, but they need to do this because they do things like home implicitly.

* `home`
* `retractAxis`
* `thermocycler/openLid`
* `thermocycler/closeLid`
* `heaterShaker/openLabwareLatch`
* `heaterShaker/setAndWaitForShakeSpeed`

They now use the `StateUpdate` mechanism to do this instead of `PipetteStore` having to mirror their logic. This continues the pattern started in #16160.

This completes the location update part of EXEC-652. What remains after this PR is volume updates and pipette loads.

## Review requests

This will be easier to review commit-by-commit.

* Double-check that the behavior of the code that I'm removing from `PipetteStore` is exactly preserved by the code I'm adding to the command implementations.
* Any thoughts on this PR's extensions to `update_types.py`?

## Risk assessment

Medium.