### PR TITLE
feat(protocol-designer): add off-deck view when on protocol steps

### DIFF
--- a/protocol-designer/src/pages/Designer/Offdeck/OffDeckDetails.tsx
+++ b/protocol-designer/src/pages/Designer/Offdeck/OffDeckDetails.tsx
@@ -50,7 +50,7 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
     <Flex
       backgroundColor={COLORS.white}
       borderRadius={BORDERS.borderRadius8}
-      width="100%"
+      width={tab === 'startingDeck' ? '100%' : '90%'}
       height="70vh"
       padding={`${SPACING.spacing40} ${SPACING.spacing24}`}
       justifyContent={JUSTIFY_CENTER}
@@ -148,15 +148,17 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
               </Flex>
             )
           })}
-          <Flex width="9.5625rem" height="6.375rem">
-            <EmptySelectorButton
-              onClick={addLabware}
-              text={t('add_labware')}
-              textAlignment="middle"
-              size="large"
-              iconName="plus"
-            />
-          </Flex>
+          {tab === 'startingDeck' ? (
+            <Flex width="9.5625rem" height="6.375rem">
+              <EmptySelectorButton
+                onClick={addLabware}
+                text={t('add_labware')}
+                textAlignment="middle"
+                size="large"
+                iconName="plus"
+              />
+            </Flex>
+          ) : null}
         </Flex>
       </Flex>
     </Flex>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react'
-import { describe, it, vi } from 'vitest'
-import { screen } from '@testing-library/react'
+import { describe, it, vi, beforeEach, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '../../../../__testing-utils__'
+import { getUnsavedForm } from '../../../../step-forms/selectors'
 import { DeckSetupContainer } from '../../DeckSetup'
-import { TimelineToolbox } from '../Timeline'
+import { OffDeck } from '../../Offdeck'
 import { ProtocolSteps } from '..'
+import { TimelineToolbox } from '../Timeline'
 
+vi.mock('../../Offdeck')
+vi.mock('../../../../step-forms/selectors')
 vi.mock('../StepForm')
 vi.mock('../../DeckSetup')
 vi.mock('../Timeline')
@@ -14,13 +19,34 @@ const render = () => {
 }
 
 describe('ProtocolSteps', () => {
-  it('renders each component in ProtocolSteps', () => {
+  beforeEach(() => {
     vi.mocked(TimelineToolbox).mockReturnValue(<div>mock TimelineToolbox</div>)
     vi.mocked(DeckSetupContainer).mockReturnValue(
       <div>mock DeckSetupContainer</div>
     )
+    vi.mocked(OffDeck).mockReturnValue(<div>mock OffDeck</div>)
+    vi.mocked(getUnsavedForm).mockReturnValue(null)
+  })
+
+  it('renders each component in ProtocolSteps', () => {
     render()
     screen.getByText('mock TimelineToolbox')
     screen.getByText('mock DeckSetupContainer')
+  })
+
+  it('renders the toggle when formData is null', () => {
+    render()
+    screen.getByText('mock DeckSetupContainer')
+    fireEvent.click(screen.getByText('offDeck'))
+    screen.getByText('mock OffDeck')
+  })
+
+  it('renders no toggle when formData does not equal moveLabware type', () => {
+    vi.mocked(getUnsavedForm).mockReturnValue({
+      stepType: 'magnet',
+      id: 'mockId',
+    })
+    render()
+    expect(screen.queryByText('offDeck')).not.toBeInTheDocument()
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -22,7 +22,9 @@ export function ProtocolSteps(): JSX.Element {
   const leftString = t('onDeck')
   const rightString = t('offDeck')
 
-  const [deckView, setDeckView] = React.useState<string>(leftString)
+  const [deckView, setDeckView] = React.useState<
+    typeof leftString | typeof rightString
+  >(leftString)
 
   const formType = formData?.stepType
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -1,18 +1,70 @@
 import * as React from 'react'
-import { COLORS, Flex, POSITION_ABSOLUTE, SPACING } from '@opentrons/components'
+import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+import {
+  ALIGN_CENTER,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  JUSTIFY_CENTER,
+  SPACING,
+  ToggleGroup,
+} from '@opentrons/components'
+import { getUnsavedForm } from '../../../step-forms/selectors'
 import { DeckSetupContainer } from '../DeckSetup'
+import { OffDeck } from '../Offdeck'
 import { TimelineToolbox } from './Timeline'
 import { StepForm } from './StepForm'
 
 export function ProtocolSteps(): JSX.Element {
+  const { t } = useTranslation(['starting_deck_state'])
+  const formData = useSelector(getUnsavedForm)
+  const leftString = t('onDeck')
+  const rightString = t('offDeck')
+
+  const [deckView, setDeckView] = React.useState<
+    typeof leftString | typeof rightString
+  >(leftString)
+
+  const formType = formData?.stepType
+
+  React.useEffect(() => {
+    if (formData != null && formType !== 'moveLabware') {
+      setDeckView(leftString)
+    }
+  }, [formData, deckView])
+
   return (
     <>
-      <Flex position={POSITION_ABSOLUTE} right="0" zIndex={10}>
-        <StepForm />
-      </Flex>
-      <Flex padding={SPACING.spacing12} backgroundColor={COLORS.grey10}>
+      <StepForm />
+      <Flex
+        backgroundColor={COLORS.grey10}
+        alignItems={ALIGN_CENTER}
+        width="100%"
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing16}
+        height="calc(100vh - 64px)"
+        justifyContent={JUSTIFY_CENTER}
+      >
         <TimelineToolbox />
-        <DeckSetupContainer tab="protocolSteps" />
+        {formData == null || formType === 'moveLabware' ? (
+          <ToggleGroup
+            selectedValue={deckView}
+            leftText={leftString}
+            rightText={rightString}
+            leftClick={() => {
+              setDeckView(leftString)
+            }}
+            rightClick={() => {
+              setDeckView(rightString)
+            }}
+          />
+        ) : null}
+        {deckView === leftString ? (
+          <DeckSetupContainer tab="protocolSteps" />
+        ) : (
+          <OffDeck tab="protocolSteps" />
+        )}
       </Flex>
     </>
   )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -22,9 +22,7 @@ export function ProtocolSteps(): JSX.Element {
   const leftString = t('onDeck')
   const rightString = t('offDeck')
 
-  const [deckView, setDeckView] = React.useState<
-    typeof leftString | typeof rightString
-  >(leftString)
+  const [deckView, setDeckView] = React.useState<string>(leftString)
 
   const formType = formData?.stepType
 
@@ -32,7 +30,7 @@ export function ProtocolSteps(): JSX.Element {
     if (formData != null && formType !== 'moveLabware') {
       setDeckView(leftString)
     }
-  }, [formData, deckView])
+  }, [formData, formType, deckView])
 
   return (
     <>


### PR DESCRIPTION
closes AUTH-801

# Overview

Add the off-deck labware view when on the protocol steps tab of the designer route

<img width="1507" alt="Screenshot 2024-09-18 at 16 17 28" src="https://github.com/user-attachments/assets/53027469-f546-46ee-9e72-7e09692520f7">

## Test Plan and Hands on Testing

Make a flex or ot-2 protocol and go to the protocol steps tab. The on/off-deck tab should be visible only if you are on the starting deck state, final deck state or in the process of making a movelabware step. Otherwise, it should not be visible. The toggle should work as expected (note: doesn't really match designs atm in terms of sizing and padding but i think it'll be easier to fix that once we remove the margins from `OffdeckDetails`)

## Changelog

- add off-deck view and toggle to the protocol steps and it should only be visible for starting deck state, ending deck state and a movelabware step form
- add to test 

## Risk assessment

low
