### PR TITLE
fix(app): use css grid for run setup accordion transition

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -184,7 +184,7 @@ export function SetupLabwareMap({
   )
 
   return (
-    <Flex flex="1" maxHeight="180vh" flexDirection={DIRECTION_COLUMN}>
+    <Flex flex="1" flexDirection={DIRECTION_COLUMN}>
       <Flex flexDirection={DIRECTION_COLUMN} marginY={SPACING.spacing16}>
         <Box margin="0 auto" maxWidth="46.25rem" width="100%">
           <BaseDeck

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -76,7 +76,6 @@ export function SetupLiquidsList(props: SetupLiquidsListProps): JSX.Element {
     <Flex
       css={HIDE_SCROLLBAR}
       flexDirection={DIRECTION_COLUMN}
-      maxHeight="31.25rem"
       overflowY="auto"
       data-testid="SetupLiquidsList_ListView"
       gridGap={SPACING.spacing8}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
@@ -127,7 +127,6 @@ export function SetupLiquidsMap(
   })
   return (
     <Flex
-      maxHeight="80vh"
       flexDirection={DIRECTION_COLUMN}
       alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_CENTER}

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesMap.tsx
@@ -78,7 +78,6 @@ export const SetupModulesMap = ({
   return (
     <Flex
       flex="1"
-      maxHeight="180vh"
       marginTop={SPACING.spacing16}
       flexDirection={DIRECTION_COLUMN}
     >

--- a/app/src/organisms/Devices/ProtocolRun/SetupStep.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupStep.tsx
@@ -8,9 +8,11 @@ import {
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
+  DISPLAY_GRID,
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
+  OVERFLOW_HIDDEN,
   SPACING,
   StyledText,
   TYPOGRAPHY,
@@ -32,16 +34,14 @@ interface SetupStepProps {
 }
 
 const EXPANDED_STYLE = css`
-  transition: max-height 300ms ease-in, visibility 400ms ease;
+  transition: grid-template-rows 300ms ease-in, visibility 400ms ease;
+  grid-template-rows: 1fr;
   visibility: visible;
-  max-height: 180vh;
-  overflow: hidden;
 `
 const COLLAPSED_STYLE = css`
-  transition: max-height 500ms ease-out, visibility 600ms ease;
+  transition: grid-template-rows 500ms ease-out, visibility 600ms ease;
+  grid-template-rows: 0fr;
   visibility: hidden;
-  max-height: 0vh;
-  overflow: hidden;
 `
 const ACCORDION_STYLE = css`
   border-radius: 50%;
@@ -104,7 +104,12 @@ export function SetupStep({
           </Flex>
         </Flex>
       </Btn>
-      <Box css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}>{children}</Box>
+      <Box
+        display={DISPLAY_GRID}
+        css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}
+      >
+        <Box overflow={OVERFLOW_HIDDEN}>{children}</Box>
+      </Box>
     </Flex>
   )
 }

--- a/components/src/styles/layout.ts
+++ b/components/src/styles/layout.ts
@@ -7,6 +7,7 @@ export const DISPLAY_FLEX = 'flex'
 export const DISPLAY_TABLE = 'table'
 export const DISPLAY_TABLE_ROW = 'table-row'
 export const DISPLAY_TABLE_CELL = 'table-cell'
+export const DISPLAY_GRID = 'grid'
 
 // powers-of-two size scale
 export const SIZE_AUTO = 'auto'


### PR DESCRIPTION
# Overview

We've been implementing the expanding/collapsing run setup step accordion transition using a `max-height` approach that isn't ideal because it limits the height of content. When protocols have a large number of labware, content in the labware step overflows.

This is a [well-known problem](https://css-tricks.com/using-css-transitions-auto-dimensions/) without a clear solution until recently: since [chromium 107 added support](https://chromestatus.com/feature/6037871692611584), we can now use css grid's `grid-template-rows` property to transition to the height of content.

closes RQA-2901

https://github.com/user-attachments/assets/721f202a-bc69-4192-ac3e-2efeb2fcd90c


## Test Plan and Hands on Testing

manually verified the transition (screen recording); checked the other setup tabs including liquids for regressions

## Changelog

 -  Uses css grid for run setup accordion transition

## Review requests

check out the setup step accordion transition with protocols with lots of labware (see RQA-2901) and lots of liquids as well. check list view and map view.

## Risk assessment

low
