### PR TITLE
fix(app): disable run again button when old run is being dismissed

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -830,6 +830,9 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
   if (isProtocolAnalyzing) {
     buttonIconName = 'ot-spinner'
     buttonText = t('analyzing_on_robot')
+  } else if (isClosingCurrentRun) {
+    buttonIconName = 'ot-spinner'
+    buttonText = t('canceling_run')
   } else if (
     runStatus === RUN_STATUS_RUNNING ||
     (runStatus != null && RECOVERY_STATUSES.includes(runStatus))
@@ -909,7 +912,8 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
             spin={
               isProtocolAnalyzing ||
               runStatus === RUN_STATUS_STOP_REQUESTED ||
-              isResetRunLoading
+              isResetRunLoading ||
+              isClosingCurrentRun
             }
           />
         ) : null}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -507,6 +507,7 @@ export function ProtocolRunHeader({
               isFixtureMismatch={isFixtureMismatch}
               isResetRunLoadingRef={isResetRunLoadingRef}
               missingSetupSteps={missingSetupSteps}
+              isClosingCurrentRun={isClosingCurrentRun}
             />
           </Flex>
         </Box>
@@ -668,6 +669,7 @@ interface ActionButtonProps {
   isFixtureMismatch: boolean
   isResetRunLoadingRef: React.MutableRefObject<boolean>
   missingSetupSteps: string[]
+  isClosingCurrentRun: boolean
 }
 
 // TODO(jh, 04-22-2024): Refactor switch cases into separate factories to increase readability and testability.
@@ -681,6 +683,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
     isFixtureMismatch,
     isResetRunLoadingRef,
     missingSetupSteps,
+    isClosingCurrentRun,
   } = props
   const navigate = useNavigate()
   const { t } = useTranslation(['run_details', 'shared'])
@@ -737,6 +740,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
     isPlayRunActionLoading ||
     isPauseRunActionLoading ||
     isResetRunLoading ||
+    isClosingCurrentRun ||
     isOtherRunCurrent ||
     isProtocolAnalyzing ||
     isFixtureMismatch ||
@@ -814,6 +818,8 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
     START_RUN_STATUSES.includes(runStatus)
   ) {
     disableReason = t('close_door')
+  } else if (isClosingCurrentRun) {
+    disableReason = t('shared:robot_is_busy')
   }
 
   const shouldShowHSConfirm =


### PR DESCRIPTION
# Overview

This PR disables the run again button while an old run is being dismissed. This was causing a race condition where the robot was not able to fully clean up an old run before a new one was created.

closes RQA-3202

pairing credit to @mjhuff (thank you!!)

## Test Plan and Hands on Testing

On an OT-2 create a protocol, start it, cancel it, then restart it
## Changelog

- Disable run again button while old run is being dismissed
## Review requests

See above
## Risk assessment

Low
