### PR TITLE
docs(api): remaining updates to Versioning page for 2.20

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -137,6 +137,8 @@ Changes in API Versions
 Version 2.20
 ------------
 
+- Detect liquid presence within a well. The :py:meth:`.InstrumentContext.detect_liquid_presence()` and :py:meth:`.InstrumentContext.detect_liquid_presence()` building block commands let you do this at any point in your protocol. Or you can :ref:`enable liquid presence detection <lpd>` for all aspirations when loading a pipette (although this will add significant time to your protocol).
+- Define CSV runtime parameters and use their contents in a protocol with new :ref:`data manipulation methods <rtp-csv-data>`. See the :ref:`cherrypicking use case <use-case-cherrypicking>` for a full example.
 - :py:meth:`.configure_nozzle_layout` now accepts row, single, and partial column layout constants. See :ref:`partial-tip-pickup`.
 - You can now call :py:obj:`.ProtocolContext.define_liquid()` without supplying a ``description`` or ``display_color``.
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -137,7 +137,7 @@ Changes in API Versions
 Version 2.20
 ------------
 
-- Detect liquid presence within a well. The :py:meth:`.InstrumentContext.detect_liquid_presence()` and :py:meth:`.InstrumentContext.detect_liquid_presence()` building block commands let you do this at any point in your protocol. Or you can :ref:`enable liquid presence detection <lpd>` for all aspirations when loading a pipette (although this will add significant time to your protocol).
+- Detect liquid presence within a well. The :py:meth:`.InstrumentContext.detect_liquid_presence()` and :py:meth:`.InstrumentContext.require_liquid_presence()` building block commands check for liquid any point in your protocol. You can also :ref:`enable liquid presence detection <lpd>` for all aspirations when loading a pipette, although this will add significant time to your protocol.
 - Define CSV runtime parameters and use their contents in a protocol with new :ref:`data manipulation methods <rtp-csv-data>`. See the :ref:`cherrypicking use case <use-case-cherrypicking>` for a full example.
 - :py:meth:`.configure_nozzle_layout` now accepts row, single, and partial column layout constants. See :ref:`partial-tip-pickup`.
 - You can now call :py:obj:`.ProtocolContext.define_liquid()` without supplying a ``description`` or ``display_color``.


### PR DESCRIPTION


# Overview

Add items to the Versioning docs page that weren't already included in previous feature-based PRs.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-versioning-2.20/v2/versioning.html#version-2-20)

## Changelog

2 bullets (LPD features, CSV RTP features).

## Review requests

Anything missing?

## Risk assessment

nil