### PR TITLE
fix(app): fix stale error data displaying

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useCurrentlyRecoveringFrom.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useCurrentlyRecoveringFrom.test.ts
@@ -1,5 +1,6 @@
-import { vi, describe, it, expect } from 'vitest'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
+import { useQueryClient } from 'react-query'
 
 import { useCommandQuery } from '@opentrons/react-api-client'
 import {
@@ -10,13 +11,25 @@ import {
 import { useNotifyAllCommandsQuery } from '../../../../resources/runs'
 import { useCurrentlyRecoveringFrom } from '../useCurrentlyRecoveringFrom'
 
+import type { Mock } from 'vitest'
+
 vi.mock('@opentrons/react-api-client')
 vi.mock('../../../../resources/runs')
+vi.mock('react-query')
 
 const MOCK_RUN_ID = 'runId'
 const MOCK_COMMAND_ID = 'commandId'
 
 describe('useCurrentlyRecoveringFrom', () => {
+  let mockInvalidateQueries: Mock
+
+  beforeEach(() => {
+    mockInvalidateQueries = vi.fn()
+    vi.mocked(useQueryClient).mockReturnValue({
+      invalidateQueries: mockInvalidateQueries,
+    } as any)
+  })
+
   it('disables all queries if the run is not awaiting-recovery', () => {
     vi.mocked(useNotifyAllCommandsQuery).mockReturnValue({
       data: {
@@ -96,5 +109,13 @@ describe('useCurrentlyRecoveringFrom', () => {
       { enabled: true }
     )
     expect(result.current).toStrictEqual('mockCommandDetails')
+  })
+
+  it('calls invalidateQueries when the run enters recovery mode', () => {
+    renderHook(() =>
+      useCurrentlyRecoveringFrom(MOCK_RUN_ID, RUN_STATUS_AWAITING_RECOVERY)
+    )
+
+    expect(mockInvalidateQueries).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
@@ -1,9 +1,12 @@
+import * as React from 'react'
+import { useQueryClient } from 'react-query'
+
 import {
   RUN_STATUS_AWAITING_RECOVERY,
   RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR,
   RUN_STATUS_AWAITING_RECOVERY_PAUSED,
 } from '@opentrons/api-client'
-import { useCommandQuery } from '@opentrons/react-api-client'
+import { useCommandQuery, useHost } from '@opentrons/react-api-client'
 
 import { useNotifyAllCommandsQuery } from '../../../resources/runs'
 
@@ -25,9 +28,18 @@ export function useCurrentlyRecoveringFrom(
   runId: string,
   runStatus: RunStatus | null
 ): FailedCommand | null {
+  const queryClient = useQueryClient()
+  const host = useHost()
   // There can only be a currentlyRecoveringFrom command when the run is in recovery mode.
   // In case we're falling back to polling, only enable queries when that is the case.
   const isRunInRecoveryMode = VALID_RECOVERY_FETCH_STATUSES.includes(runStatus)
+
+  // Prevent stale data on subsequent recoveries by clearing the query cache at the start of each recovery.
+  React.useEffect(() => {
+    if (isRunInRecoveryMode) {
+      void queryClient.invalidateQueries([host, 'runs', runId])
+    }
+  }, [isRunInRecoveryMode, host, runId])
 
   const { data: allCommandsQueryData } = useNotifyAllCommandsQuery(
     runId,

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -147,8 +147,6 @@ export function ErrorRecoveryFlows(
     failedCommand: failedCommandBySource,
   })
 
-  console.log('=>(index.tsx:180) showTakeover', showTakeover)
-
   return (
     <>
       {showTakeover ? (


### PR DESCRIPTION
Closes [RQA-3213](https://opentrons.atlassian.net/browse/RQA-3213)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Before the network request completes when entering ER the 2nd time + in a run, `useCurrentlyRecoveringFrom` uses stale data. If the command that failed previously is the same command that failed currently, this gives it a flickering effect of "correct error, wrong error, correct error", but the stale data is more noticeable if you previously failed a command that wasn't the same kind as the current failure.

To fix, let's just clear the query cache when we first enter recovery.

### Current Behavior

https://github.com/user-attachments/assets/ac6d7c9f-5696-4034-b66c-f950933188fe

### Fixed Behavior

https://github.com/user-attachments/assets/f4ea36cb-dd60-4d72-91c0-42da22e67c5b


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the error recovery splash screen quickly displaying stale information when first entering error recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3213]: https://opentrons.atlassian.net/browse/RQA-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ