### PR TITLE
fix(app): fix MoveInterventionModal labware begin location not updating properly

### DIFF
--- a/app/src/organisms/InterventionModal/index.tsx
+++ b/app/src/organisms/InterventionModal/index.tsx
@@ -112,7 +112,8 @@ export function InterventionModal({
   const isOnDevice = useSelector(getIsOnDevice)
 
   const robotType = useRobotType(robotName)
-  const childContent = React.useMemo(() => {
+  // TODO(jh 09-19-24): Make this into its own component.
+  const childContent = (() => {
     switch (command.commandType) {
       case 'waitForResume':
       case 'pause': // legacy pause command
@@ -136,12 +137,7 @@ export function InterventionModal({
         )
         return null
     }
-  }, [
-    command.id,
-    analysis?.status,
-    run.labware.map(l => l.id).join(),
-    run.modules.map(m => m.id).join(),
-  ])
+  })()
 
   const { iconName, headerTitle, headerTitleOnDevice } = (() => {
     switch (command.commandType) {


### PR DESCRIPTION
Closes [RQA-3216](https://opentrons.atlassian.net/browse/RQA-3216)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When the app is polling, and there are two back-to-back manual move interventions, the labware start location doesn't update correctly due to the memoization of some of the content and the way rendering works in React. For some reason, this problem does not seem to occur consistently when the app is on notifications (but it does occur sometimes).

Looking back when this memoization logic was initially added (which was long before the `InterventionModal` partial refactor), I don't think we really need it anymore. If anything, this child content should be made into its own component at some point.

As to why different texts seem to render at different timings, I think that has to do with some of the utility functions themselves...revisiting these would be a good idea in the future.

### Current Behavior

https://github.com/user-attachments/assets/913e887d-d3fa-46ec-a1d0-50a9ffcd7fb1

### Fixed Behavior

https://github.com/user-attachments/assets/05950198-5218-4690-b5f4-ae992be12808

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Turn on polling in app settings > feature flags. This makes it easy to reproduce.
- Run a protocol with back-to-back manual move commands (see ticket for protocol).
- Validate the fix.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the initial labware location sometimes not displaying the correct location when  running back to back manual move labware commands.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3216]: https://opentrons.atlassian.net/browse/RQA-3216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ