### PR TITLE
volume at arbitrary height for most above spherical section heights

### DIFF
--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -355,13 +355,19 @@ def _find_volume_in_partial_frustum(
 ) -> Optional[float]:
     """Look through a sorted list of frusta for a target height, and find the volume at that height."""
     partial_volume: Optional[float] = None
-    for f, next_f in get_boundary_pairs(sorted_frusta):
-        if f["topHeight"] < target_height < next_f["targetHeight"]:
-            relative_target_height = target_height - f["topHeight"]
-            frustum_height = next_f["topHeight"] - f["topHeight"]
+    for bottom_cross_section, top_cross_section in get_boundary_pairs(sorted_frusta):
+        if (
+            bottom_cross_section["topHeight"]
+            < target_height
+            < top_cross_section["targetHeight"]
+        ):
+            relative_target_height = target_height - bottom_cross_section["topHeight"]
+            frustum_height = (
+                top_cross_section["topHeight"] - bottom_cross_section["topHeight"]
+            )
             partial_volume = volume_at_height_within_section(
-                top_cross_section=next_f,
-                bottom_cross_section=f,
+                top_cross_section=top_cross_section,
+                bottom_cross_section=bottom_cross_section,
                 target_height_relative=relative_target_height,
                 frustum_height=frustum_height,
             )
@@ -420,10 +426,10 @@ def _find_height_in_partial_frustum(
     ):
         bottom_cross_section, top_cross_section = cross_sections
         (bottom_height, bottom_volume), (top_height, top_volume) = capacity
-        relative_target_volume = target_volume - bottom_volume
-        frustum_height = top_height - bottom_height
 
         if bottom_volume < target_volume < top_volume:
+            relative_target_volume = target_volume - bottom_volume
+            frustum_height = top_height - bottom_height
             partial_height = height_at_volume_within_section(
                 top_cross_section=top_cross_section,
                 bottom_cross_section=bottom_cross_section,

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -356,11 +356,7 @@ def _find_volume_in_partial_frustum(
     """Look through a sorted list of frusta for a target height, and find the volume at that height."""
     partial_volume: Optional[float] = None
     for f, next_f in get_boundary_pairs(sorted_frusta):
-        if target_height < f["topHeight"] and f["shape"] == "spherical":
-            partial_volume = volume_from_height_spherical(
-                target_height=target_height, radius_of_curvature=f["radiusOfCurvature"]
-            )
-        elif f["topHeight"] < target_height < next_f["targetHeight"]:
+        if f["topHeight"] < target_height < next_f["targetHeight"]:
             relative_target_height = target_height - f["topHeight"]
             frustum_height = next_f["topHeight"] - f["topHeight"]
             partial_volume = volume_at_height_within_section(

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -317,6 +317,10 @@ def height_at_volume_within_section(
             top_width=top_cross_section["xDimension"],
             top_length=top_cross_section["yDimension"],
         )
+    else:
+        raise NotImplementedError(
+            "Height from volume calculation not yet implemented for this well shape."
+        )
     return frustum_height
 
 
@@ -343,9 +347,12 @@ def volume_at_height_within_section(
             top_width=top_cross_section["xDimension"],
             top_length=top_cross_section["yDimension"],
         )
-    # else:
     # TODO(cm): this would be the NEST-96 2uL wells referenced in EXEC-712
     # we need to input the math attached to that issue
+    else:
+        raise NotImplementedError(
+            "Height from volume calculation not yet implemented for this well shape."
+        )
     return frustum_volume
 
 
@@ -406,6 +413,7 @@ def find_volume_at_well_height(
                 radius_of_curvature=well_geometry.bottomShape.radiusOfCurvature,
             )
     sorted_frusta = sorted(well_geometry.frusta, key=lambda section: section.topHeight)
+    # TODO(cm): handle non-frustum section that is not at the bottom.
     partial_volume = _find_volume_in_partial_frustum(
         sorted_frusta=sorted_frusta,
         target_height=target_height,

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -436,7 +436,7 @@ def _find_height_in_partial_frustum(
             )
     return partial_height
 
-
+    
 def find_height_at_well_volume(
     target_volume: float, well_geometry: InnerWellGeometry
 ) -> float:
@@ -468,6 +468,8 @@ def find_height_at_well_volume(
                 radius_of_curvature=well_geometry.bottomShape.radiusOfCurvature,
                 total_frustum_height=well_geometry.bottomShape.depth,
             )
+        # we need to look through the volumetric capacity list without the bottom shape
+        volumetric_capacity.pop(0)
     partial_height = _find_height_in_partial_frustum(
         sorted_frusta=sorted_frusta,
         volumetric_capacity=volumetric_capacity,

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -436,7 +436,7 @@ def _find_height_in_partial_frustum(
             )
     return partial_height
 
-    
+
 def find_height_at_well_volume(
     target_volume: float, well_geometry: InnerWellGeometry
 ) -> float:

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -1,7 +1,7 @@
 """Helper functions for liquid-level related calculations inside a given frustum."""
 from typing import List, Tuple, Iterator, Sequence, Any, Union, Optional
 from numpy import pi, iscomplex, roots, real
-from math import sqrt, isclose
+from math import isclose
 
 from ..errors.exceptions import InvalidLiquidHeightFound, InvalidWellDefinitionError
 from opentrons_shared_data.labware.types import (
@@ -58,18 +58,6 @@ def cross_section_area_circular(diameter: float) -> float:
 def cross_section_area_rectangular(x_dimension: float, y_dimension: float) -> float:
     """Get the area of a rectangular cross-section."""
     return x_dimension * y_dimension
-
-
-def volume_from_frustum_formula(area_1: float, area_2: float, height: float) -> float:
-    """Get the area of a section with differently shaped boundary cross-sections."""
-    area_term = area_1 + area_2 + sqrt(area_1 * area_2)
-    return (height / 3) * area_term
-
-
-def height_from_frustum_formula(area_1: float, area_2: float, volume: float) -> float:
-    """Get the volume within a section with differently shaped boundary cross-sections."""
-    area_term = area_1 + area_2 + sqrt(area_1 * area_2)
-    return 3 * volume / area_term
 
 
 def rectangular_frustum_polynomial_roots(
@@ -283,14 +271,9 @@ def get_well_volumetric_capacity(
 
             well_volume.append((next_f["topHeight"], frustum_volume))
     else:
-        for f, next_f in get_boundary_pairs(sorted_frusta):
-            bottom_cross_section_area = get_cross_section_area(f)
-            top_cross_section_area = get_cross_section_area(next_f)
-            section_height = next_f["topHeight"] - f["topHeight"]
-            bounded_volume = volume_from_frustum_formula(
-                bottom_cross_section_area, top_cross_section_area, section_height
-            )
-            well_volume.append((next_f["topHeight"], bounded_volume))
+        raise NotImplementedError(
+            "Well section with differing boundary shapes not yet implemented."
+        )
     return well_volume
 
 

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -374,7 +374,7 @@ def find_volume_at_well_height(
             target_volume = volume_from_height_spherical(
                 target_height=target_height, radius_of_curvature=f["radiusOfCurvature"]
             )
-        if f["topHeight"] < target_height < next_f["targetHeight"]:
+        elif f["topHeight"] < target_height < next_f["targetHeight"]:
             relative_target_height = target_height - f["topHeight"]
             frustum_height = next_f["topHeight"] - f["topHeight"]
             target_volume = volume_at_height_within_section(
@@ -414,19 +414,19 @@ def find_height_at_well_volume(
     ):
         bottom_cross_section, top_cross_section = cross_sections
         (bottom_height, bottom_volume), (top_height, top_volume) = capacity
+        relative_target_volume = target_volume - bottom_volume
+        frustum_height = top_height - bottom_height
 
         if (
             target_volume < bottom_volume
             and bottom_cross_section["shape"] == "spherical"
         ):
-            target_height = height_from_frustum_formula(
-                area_1=bottom_cross_section,
-                area_2=top_cross_section,
+            target_height = height_from_volume_spherical(
                 volume=target_volume,
+                radius_of_curvature=bottom_cross_section["radiusOfCurvature"],
+                total_frustum_height=frustum_height,
             )
-        if bottom_volume < target_volume < top_volume:
-            relative_target_volume = target_volume - bottom_volume
-            frustum_height = top_height - bottom_height
+        elif bottom_volume < target_volume < top_volume:
             target_height = height_at_volume_within_section(
                 top_cross_section=top_cross_section,
                 bottom_cross_section=bottom_cross_section,
@@ -435,4 +435,4 @@ def find_height_at_well_volume(
             )
     if not target_height:
         raise InvalidLiquidHeightFound("Unable to find height at given well-volume.")
-    return closed_section_height + target_height
+    return target_height + closed_section_height

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -55,7 +55,8 @@ from .pipettes import PipetteView
 from .addressable_areas import AddressableAreaView
 from .frustum_helpers import (
     get_well_volumetric_capacity,
-    find_volume_at_non_boundary_height,
+    find_volume_at_well_height,
+    find_height_at_well_volume,
 )
 
 
@@ -1225,7 +1226,7 @@ class GeometryView:
     def get_volume_at_height(
         self, labware_id: str, well_id: str, target_height: float
     ) -> float:
-        """Find the volume at any known height within a well."""
+        """Find the volume at any height within a well."""
         labware_def = self._labware.get_definition(labware_id)
         if labware_def.innerLabwareGeometry is None:
             raise InvalidWellDefinitionError(message="No InnerLabwareGeometry found.")
@@ -1234,6 +1235,22 @@ class GeometryView:
             raise InvalidWellDefinitionError(
                 message=f"No InnerWellGeometry found for well id: {well_id}"
             )
-        return find_volume_at_non_boundary_height(
+        return find_volume_at_well_height(
             target_height=target_height, well_geometry=well_geometry
+        )
+
+    def get_height_at_volume(
+        self, labware_id: str, well_id: str, target_volume: float
+    ) -> float:
+        """Find the height from any volume in a well."""
+        labware_def = self._labware.get_definition(labware_id)
+        if labware_def.innerLabwareGeometry is None:
+            raise InvalidWellDefinitionError(message="No InnerLabwareGeometry found.")
+        well_geometry = labware_def.innerLabwareGeometry.get(well_id)
+        if well_geometry is None:
+            raise InvalidWellDefinitionError(
+                message=f"No InnerWellGeometry found for well id: {well_id}"
+            )
+        return find_height_at_well_volume(
+            target_volume=target_volume, well_geometry=well_geometry
         )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -53,7 +53,10 @@ from .wells import WellView
 from .modules import ModuleView
 from .pipettes import PipetteView
 from .addressable_areas import AddressableAreaView
-from .frustum_helpers import get_well_volumetric_capacity
+from .frustum_helpers import (
+    get_well_volumetric_capacity,
+    find_volume_at_non_boundary_height,
+)
 
 
 SLOT_WIDTH = 128
@@ -1218,3 +1221,19 @@ class GeometryView:
                 message=f"No InnerWellGeometry found for well id: {well_id}"
             )
         return get_well_volumetric_capacity(well_geometry)
+
+    def get_volume_at_height(
+        self, labware_id: str, well_id: str, target_height: float
+    ) -> float:
+        """Find the volume at any known height within a well."""
+        labware_def = self._labware.get_definition(labware_id)
+        if labware_def.innerLabwareGeometry is None:
+            raise InvalidWellDefinitionError(message="No InnerLabwareGeometry found.")
+        well_geometry = labware_def.innerLabwareGeometry.get(well_id)
+        if well_geometry is None:
+            raise InvalidWellDefinitionError(
+                message=f"No InnerWellGeometry found for well id: {well_id}"
+            )
+        return find_volume_at_non_boundary_height(
+            target_height=target_height, well_geometry=well_geometry
+        )

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -706,7 +706,7 @@ def _load_labware_definition_data() -> LabwareDefinition:
                 ],
                 bottomShape=SphericalSegment(
                     shape="spherical",
-                    radius_of_curvature=6,
+                    radiusOfCurvature=6,
                     depth=10,
                 ),
             )

--- a/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
+++ b/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine.state.frustum_helpers import (
     cross_section_area_rectangular,
     cross_section_area_circular,
     reject_unacceptable_heights,
-    get_boundary_cross_sections,
+    get_boundary_pairs,
     get_cross_section_area,
     volume_from_frustum_formula,
     circular_frustum_polynomial_roots,
@@ -138,7 +138,7 @@ def test_cross_section_area_rectangular(x_dimension: float, y_dimension: float) 
 def test_get_cross_section_boundaries(well: List[List[Any]]) -> None:
     """Make sure get_cross_section_boundaries returns the expected list indices."""
     i = 0
-    for f, next_f in get_boundary_cross_sections(well):
+    for f, next_f in get_boundary_pairs(well):
         assert f == well[i]
         assert next_f == well[i + 1]
         i += 1
@@ -147,7 +147,7 @@ def test_get_cross_section_boundaries(well: List[List[Any]]) -> None:
 @pytest.mark.parametrize("well", fake_frusta())
 def test_frustum_formula_volume(well: List[Any]) -> None:
     """Test volume-of-a-frustum formula calculation."""
-    for f, next_f in get_boundary_cross_sections(well):
+    for f, next_f in get_boundary_pairs(well):
         if f["shape"] == "spherical" or next_f["shape"] == "spherical":
             # not going to use formula on spherical segments
             continue
@@ -169,7 +169,7 @@ def test_volume_and_height_circular(well: List[Any]) -> None:
     if well[-1]["shape"] == "spherical":
         return
     total_height = well[0]["topHeight"]
-    for f, next_f in get_boundary_cross_sections(well):
+    for f, next_f in get_boundary_pairs(well):
         if f["shape"] == next_f["shape"] == "circular":
             top_radius = next_f["diameter"] / 2
             bottom_radius = f["diameter"] / 2
@@ -211,7 +211,7 @@ def test_volume_and_height_rectangular(well: List[Any]) -> None:
     if well[-1]["shape"] == "spherical":
         return
     total_height = well[0]["topHeight"]
-    for f, next_f in get_boundary_cross_sections(well):
+    for f, next_f in get_boundary_pairs(well):
         if f["shape"] == next_f["shape"] == "rectangular":
             top_length = next_f["yDimension"]
             top_width = next_f["xDimension"]
@@ -284,3 +284,8 @@ def test_volume_and_height_spherical(well: List[Any]) -> None:
                 total_frustum_height=well[0]["depth"],
             )
             assert isclose(found_height, target_height)
+
+
+# test that volumetric capacity is always sorted
+# test that errors are raised every time and only when given invalid height values for volume_from_height
+# test that errors are raised every time and only when given invalid volume values for height_from_volume

--- a/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
+++ b/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
@@ -284,8 +284,3 @@ def test_volume_and_height_spherical(well: List[Any]) -> None:
                 total_frustum_height=well[0]["depth"],
             )
             assert isclose(found_height, target_height)
-
-
-# test that volumetric capacity is always sorted
-# test that errors are raised every time and only when given invalid height values for volume_from_height
-# test that errors are raised every time and only when given invalid volume values for height_from_volume

--- a/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
+++ b/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
@@ -1,7 +1,6 @@
 import pytest
-from math import pi, sqrt, isclose
+from math import pi, isclose
 from typing import Any, List
-from hypothesis import given, strategies
 
 from opentrons_shared_data.labware.types import (
     RectangularBoundedSection,
@@ -13,8 +12,6 @@ from opentrons.protocol_engine.state.frustum_helpers import (
     cross_section_area_circular,
     reject_unacceptable_heights,
     get_boundary_pairs,
-    get_cross_section_area,
-    volume_from_frustum_formula,
     circular_frustum_polynomial_roots,
     rectangular_frustum_polynomial_roots,
     volume_from_height_rectangular,
@@ -23,7 +20,6 @@ from opentrons.protocol_engine.state.frustum_helpers import (
     height_from_volume_circular,
     height_from_volume_rectangular,
     height_from_volume_spherical,
-    height_from_frustum_formula,
 )
 from opentrons.protocol_engine.errors.exceptions import InvalidLiquidHeightFound
 
@@ -144,49 +140,6 @@ def test_get_cross_section_boundaries(well: List[List[Any]]) -> None:
         assert f == well[i]
         assert next_f == well[i + 1]
         i += 1
-
-
-@pytest.mark.parametrize("well", fake_frusta())
-def test_frustum_formula_volume(well: List[Any]) -> None:
-    """Test volume-of-a-frustum formula calculation."""
-    for f, next_f in get_boundary_pairs(well):
-        if f["shape"] == "spherical" or next_f["shape"] == "spherical":
-            # not going to use formula on spherical segments
-            continue
-        f_area = get_cross_section_area(f)
-        next_f_area = get_cross_section_area(next_f)
-        frustum_height = next_f["topHeight"] - f["topHeight"]
-        expected_volume = (f_area + next_f_area + sqrt(f_area * next_f_area)) * (
-            frustum_height / 3
-        )
-        found_volume = volume_from_frustum_formula(
-            area_1=f_area, area_2=next_f_area, height=frustum_height
-        )
-        assert found_volume == expected_volume
-
-
-@pytest.mark.parametrize("well", fake_frusta())
-@given(target_volume=strategies.floats(min_value=0, max_value=10))
-def test_frustum_formula_height(well: List[Any], target_volume: float) -> None:
-    """Test volume-of-a-frustum formula calculation for height."""
-    for f, next_f in get_boundary_pairs(well):
-        if f["shape"] == "spherical" or next_f["shape"] == "spherical":
-            # not going to use formula on spherical segments
-            continue
-        f_area = get_cross_section_area(f)
-        next_f_area = get_cross_section_area(next_f)
-        area_term = f_area + next_f_area + sqrt(f_area * next_f_area)
-        expected_height = 3 * target_volume / area_term
-        found_height = height_from_frustum_formula(
-            area_1=f_area,
-            area_2=next_f_area,
-            volume=target_volume,
-        )
-        assert found_height == expected_height
-        found_volume = volume_from_frustum_formula(
-            area_1=f_area, area_2=next_f_area, height=found_height
-        )
-        assert isclose(round(found_volume, 4), round(target_volume, 4))
 
 
 @pytest.mark.parametrize("well", fake_frusta())

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -229,7 +229,7 @@ class WellDefinition(BaseModel):
 
 class SphericalSegment(BaseModel):
     shape: Literal["spherical"] = Field(..., description="Denote shape as spherical")
-    radius_of_curvature: _NonNegativeNumber = Field(
+    radiusOfCurvature: _NonNegativeNumber = Field(
         ...,
         description="radius of curvature of bottom subsection of wells",
     )


### PR DESCRIPTION
## Overview
Here are the protocol engine functions to find the volume or height at any arbitrary height/volume within a well. 

## Changelog

- add functions to find non-border heights and volumes in `geometry.py`
-  logic to look through every section of a well for our target height/volume 
- `SphericalSegment.radius_of_curvature` should have been `radiusOfCurvature`
- added a height to volume function using the volume-of-a-frustum formula

## TODO
I'm going to add tests in a follow-up pr if that's alright. I want to get these functions merged first though so I can unblock [Peter's pr](https://github.com/Opentrons/opentrons/pull/16302)