### PR TITLE
fix(api): Disable tip presence check on 8ch single and partial 2 thru 3 nozzle

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -312,6 +312,7 @@ class HardwareTipHandler(TipHandler):
             NozzleConfigurationType.SINGLE,
             NozzleConfigurationType.COLUMN,
         ]
+        # NOTE: (09-20-2024) Current on multi-channel pipettes, utilizing less than 4 nozzles risks false positives on the tip presence sensor
         supported_partial_nozzle_minimum = 4
 
         if (
@@ -321,7 +322,9 @@ class HardwareTipHandler(TipHandler):
             and nozzle_configuration.configuration in unsupported_layout_types
             and len(nozzle_configuration.map_store) < supported_partial_nozzle_minimum
         ):
-            # Tip presence sensing is not supported for single tip pick up on the 96ch Flex Pipette, nor with single and some partial layous of the 8ch Flex Pipette
+            # Tip presence sensing is not supported for single tip pick up on the 96ch Flex Pipette, nor with single and some partial layous of the 8ch Flex Pipette.
+            # This is due in part to a press distance tolerance which creates a risk case for false positives. In the case of single tip, the mechanical tolerance
+            # for presses with 100% success is below the minimum average achieved press distance for a given multi channel pipette in that configuration.
             return
         try:
             ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -302,12 +302,26 @@ class HardwareTipHandler(TipHandler):
         This function will raise an exception if the specified tip presence status
         isn't matched.
         """
+        nozzle_configuration = (
+            self._state_view.pipettes.state.nozzle_configuration_by_id[pipette_id]
+        )
+
+        # Configuration metrics by which tip presence checking is ignored
+        unsupported_pipette_types = [8, 96]
+        unsupported_layout_types = [
+            NozzleConfigurationType.SINGLE,
+            NozzleConfigurationType.COLUMN,
+        ]
+        supported_partial_nozzle_minimum = 4
+
         if (
-            self._state_view.pipettes.get_nozzle_layout_type(pipette_id)
-            == NozzleConfigurationType.SINGLE
-            and self._state_view.pipettes.get_channels(pipette_id) == 96
+            nozzle_configuration is not None
+            and self._state_view.pipettes.get_channels(pipette_id)
+            in unsupported_pipette_types
+            and nozzle_configuration.configuration in unsupported_layout_types
+            and len(nozzle_configuration.map_store) < supported_partial_nozzle_minimum
         ):
-            # Tip presence sensing is not supported for single tip pick up on the 96ch Flex Pipette
+            # Tip presence sensing is not supported for single tip pick up on the 96ch Flex Pipette, nor with single and some partial layous of the 8ch Flex Pipette
             return
         try:
             ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)


### PR DESCRIPTION
# Overview
Covers RABR-623, RABR-624

Disable tip presence sensing on the 8ch Flex pipette for Single tip configuration and for Partial Column

## Test Plan and Hands on Testing
Tested on Flex with 8ch pipette to confirm tip presence no used for 1-3 nozzle configurations.

Re-tested Flex 96ch to ensure tip presence sensing not used for single nozzle configuration.

## Changelog
Expanded tip handle tip presence validation to screen for 8ch configurations.

## Review requests
Does this offer sufficient coverage?

## Risk assessment
Low - disables tip presence check exclusively on some new features to 8.0.0.