### PR TITLE
docs(api): further guidance on LPD – time consumption and using clean tips

### DIFF
--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -265,12 +265,15 @@ Detect Liquids
 
 The :py:meth:`.InstrumentContext.detect_liquid_presence` method tells a Flex pipette to check for liquid in a well. It returns ``True`` if the pressure sensors in the pipette detect a liquid and ``False`` if the sensors do not. 
 
-Aspiration isn't required to use ``detect_liquid_presence()``. This is a standalone method that can be called when you want the robot to record the presence or absence of a liquid. When ``detect_liquid_presence()`` finds an empty well it won't raise an error or stop your protocol.
+``detect_liquid_presence()`` is a standalone method that can be called when you want the robot to record the presence or absence of a liquid. You should always call :py:meth:`.pick_up_tip` immediately prior, in order to ensure that the pipette uses a clean, dry tip. 
+
+When ``detect_liquid_presence()`` finds an empty well it won't raise an error or stop your protocol. You don't have to aspirate after detecting liquid presence.
 
 A potential use of liquid detection is to try aspirating from another well if the first well is found to contain no liquid.
 
 .. code-block:: python
     
+    pipette.pick_up_tip()
     if pipette.detect_liquid_presence(reservoir["A1"]):
         pipette.aspirate(100, reservoir["A1"])
     else:
@@ -285,11 +288,16 @@ Require Liquids
 
 The :py:meth:`.InstrumentContext.require_liquid_presence` method tells a Flex pipette to check for `and require` liquid in a well. 
 
-Aspiration isn't required to use ``require_liquid_presence()``. This is a standalone method that can be called when you want the robot to react to a missing liquid or empty well. When ``require_liquid_presence()`` finds an empty well, it raises an error and pauses the protocol to let you resolve the problem. See also :ref:`lpd`.
+``require_liquid_presence()`` is a standalone method that can be called when you want the robot to react to a missing liquid or empty well. You should always call :py:meth:`.pick_up_tip` immediately prior, in order to ensure that the pipette uses a clean, dry tip. 
+
+When ``require_liquid_presence()`` finds an empty well, it raises an error and pauses the protocol to let you resolve the problem. You don't have to aspirate after requiring liquid presence.
 
 .. code-block:: python
 
+    pipette.pick_up_tip()
     pipette.require_liquid_presence(reservoir["A1"])
     pipette.aspirate(100, reservoir["A1"])  # only occurs if liquid found
+
+You can also require liquid presence for all aspirations performed with a given pipette. See :ref:`lpd`.
 
 .. versionadded:: 2.20

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -263,11 +263,9 @@ This example aspirates enough air to fill the remaining volume in a pipette::
 Detect Liquids
 ==============
 
-The :py:meth:`.InstrumentContext.detect_liquid_presence` method tells a Flex pipette to check for liquid in a well. It returns ``True`` if the pressure sensors in the pipette detect a liquid and ``False`` if the sensors do not. 
+The :py:meth:`.InstrumentContext.detect_liquid_presence` method tells a Flex pipette to check for liquid in a well. It returns ``True`` if the pressure sensors in the pipette detect a liquid and ``False`` if the sensors do not. When ``detect_liquid_presence()`` finds an empty well it won't raise an error or stop your protocol. 
 
-``detect_liquid_presence()`` is a standalone method that can be called when you want the robot to record the presence or absence of a liquid. You should always call :py:meth:`.pick_up_tip` immediately prior, in order to ensure that the pipette uses a clean, dry tip. 
-
-When ``detect_liquid_presence()`` finds an empty well it won't raise an error or stop your protocol. You don't have to aspirate after detecting liquid presence.
+``detect_liquid_presence()`` is a standalone method to record the presence or absence of a liquid. You don't have to aspirate after detecting liquid presence. However, you should always pick up a tip immediately prior to checking for liquid, and either aspirate or drop the tip immediately after. This ensures that the pipette uses a clean, dry tip to check for liquid, and prevents cross-contamination.
 
 A potential use of liquid detection is to try aspirating from another well if the first well is found to contain no liquid.
 
@@ -286,11 +284,9 @@ A potential use of liquid detection is to try aspirating from another well if th
 Require Liquids
 ===============
 
-The :py:meth:`.InstrumentContext.require_liquid_presence` method tells a Flex pipette to check for `and require` liquid in a well. 
+The :py:meth:`.InstrumentContext.require_liquid_presence` method tells a Flex pipette to check for `and require` liquid in a well. When ``require_liquid_presence()`` finds an empty well, it raises an error and pauses the protocol to let you resolve the problem.
 
-``require_liquid_presence()`` is a standalone method that can be called when you want the robot to react to a missing liquid or empty well. You should always call :py:meth:`.pick_up_tip` immediately prior, in order to ensure that the pipette uses a clean, dry tip. 
-
-When ``require_liquid_presence()`` finds an empty well, it raises an error and pauses the protocol to let you resolve the problem. You don't have to aspirate after requiring liquid presence.
+``require_liquid_presence()`` is a standalone method to react to a missing liquid or empty well. You don't have to aspirate after requiring liquid presence. However, you should always pick up a tip immediately prior to checking for liquid, and either aspirate or drop the tip immediately after. This ensures that the pipette uses a clean, dry tip to check for liquid, and prevents cross-contamination.
 
 .. code-block:: python
 

--- a/api/docs/v2/pipettes/loading.rst
+++ b/api/docs/v2/pipettes/loading.rst
@@ -223,7 +223,7 @@ Liquid Presence Detection
 
 Liquid presence detection is a pressure-based feature that allows Opentrons Flex pipettes to detect the presence or absence of liquids in a well, reservoir, tube, or other container. It gives you the ability to identify, avoid, and recover from liquid-related protocol errors.
 
-When detecting liquid, the pipette slowly moves a fresh, empty tip downward from the top of the well until it contacts the liquid meniscus. The downward probing motion can take anywhere from 5 to 50 seconds, depending on the depth of the well and how much liquid it contains. For example, it will take much less time to detect liquid in a full flat well plate than in an empty (or nearly empty) large tube.
+When detecting liquid, the pipette slowly moves a fresh, empty tip downward from the top of the well until it contacts the liquid. The downward probing motion can take anywhere from 5 to 50 seconds, depending on the depth of the well and how much liquid it contains. For example, it will take much less time to detect liquid in a full flat well plate than in an empty (or nearly empty) large tube.
 
 You can enable this feature for an entire protocol run or toggle it on and off as required. Consider the amount of time automatic detection will add to your protocol. If you only need to detect liquid infrequently, use the :ref:`corresponding building block commands <detect-liquid-presence>` instead. Automatic liquid presence detection is disabled by default.
 

--- a/api/docs/v2/pipettes/loading.rst
+++ b/api/docs/v2/pipettes/loading.rst
@@ -221,14 +221,16 @@ Another example is a Flex protocol that uses a waste chute. Say you want to only
 Liquid Presence Detection
 =========================
 
-Liquid presence detection is a pressure-based feature that allows Opentrons Flex pipettes to detect the presence or absence of liquids in a well, reservoir, tube, or other container. It gives you the ability to identify, avoid, and recover from liquid-related protocol errors. You can enable this feature for an entire protocol run or toggle it on and off as required. Liquid presence detection is disabled by default.
+Liquid presence detection is a pressure-based feature that allows Opentrons Flex pipettes to detect the presence or absence of liquids in a well, reservoir, tube, or other container. It gives you the ability to identify, avoid, and recover from liquid-related protocol errors.
+
+When detecting liquid, the pipette slowly moves a fresh, empty tip downward from the top of the well until it contacts the liquid meniscus. The downward probing motion can take anywhere from 5 to 50 seconds, depending on the depth of the well and how much liquid it contains. For example, it will take much less time to detect liquid in a full flat well plate than in an empty (or nearly empty) large tube.
+
+You can enable this feature for an entire protocol run or toggle it on and off as required. Consider the amount of time automatic detection will add to your protocol. If you only need to detect liquid infrequently, use the :ref:`corresponding building block commands <detect-liquid-presence>` instead. Automatic liquid presence detection is disabled by default.
 
 Pipette Compatibility
 ---------------------
 
 Liquid presence detection works with Flex 1-, 8-, and 96-channel pipettes only. 1-channel pipettes have one pressure sensor. The 8-channel pipette pressure sensors are on channels 1 and 8 (positions A1 and H1). The 96-channel pipette pressure sensors are on channels 1 and 96 (positions A1 and H12). Other channels on multi-channel pipettes do not have sensors and cannot detect liquid.
-
-.. add text with link to revised pipette sensor section in manual?
 
 Enabling Globally
 -----------------
@@ -245,9 +247,11 @@ To automatically use liquid presence detection, add the optional Boolean argumen
     )
 
 .. note::
-    Accurate liquid detection requires fresh, dry pipette tips. Protocols using this feature must discard used tips after an aspirate/dispense cycle and pick up new tips before the next cycle. The API will raise an error if liquid detection is active and your protocol attempts to reuse a pipette tip or if the robot thinks the tip is wet.
+    Accurate liquid detection requires fresh, dry pipette tips. Protocols using this feature must discard used tips after an aspirate/dispense cycle and pick up new tips before the next cycle. :ref:`Complex commands <v2-complex-commands>` may include aspirate steps after a tip is already wet. When global liquid detection is enabled, use :ref:`building block commands <v2-atomic-commands>` to ensure that your protocol picks up a tip immediately before aspiration.
 
-Let's take a look at how all this works. First, tell the robot to pick up a clean tip, aspirate 100 µL from a reservoir, and dispense that volume into a well plate.
+    The API will not raise an error during liquid detection if a tip is empty but wet. It will raise an error if liquid detection is active and your protocol attempts to aspirate with liquid in the tip.
+
+Let's take a look at how all this works. With automatic liquid detection enabled, tell the robot to pick up a clean tip, aspirate 100 µL from a reservoir, and dispense that volume into a well plate:
 
 .. code-block:: python
     


### PR DESCRIPTION
# Overview

Provide more clarity on LPD requiring fresh, dry tips. Also note that it takes quite some time, so protocol authors should be cautious about enabling it globally.

## Test Plan and Hands on Testing

Sandbox links
- [Global LPD](http://sandbox.docs.opentrons.com/docs-lpd-timing-and-wet-tips/v2/pipettes/loading.html#liquid-presence-detection)
- [Atomic LPD](http://sandbox.docs.opentrons.com/docs-lpd-timing-and-wet-tips/v2/basic_commands/liquids.html#detect-liquids)

## Changelog

- Additions to both sections where we talk about LPD.
- Removed an old RST comment.

## Review requests

Is this clear enough about the risks/downsides of using global LPD, especially with complex commands?

## Risk assessment

none