### PR TITLE
fix(api): dont move gen1s all the way up

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -151,6 +151,7 @@ class MovementHandler:
         speed: Optional[float] = None,
         stay_at_highest_possible_z: bool = False,
         ignore_tip_configuration: Optional[bool] = True,
+        highest_possible_z_extra_offset: Optional[float] = None,
     ) -> Point:
         """Move to a specific addressable area."""
         # Check for presence of heater shakers on deck, and if planned
@@ -201,6 +202,7 @@ class MovementHandler:
             minimum_z_height=minimum_z_height,
             stay_at_max_travel_z=stay_at_highest_possible_z,
             ignore_tip_configuration=ignore_tip_configuration,
+            max_travel_z_extra_margin=highest_possible_z_extra_offset,
         )
 
         speed = self._state_store.pipettes.get_movement_speed(

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -151,6 +151,7 @@ class MotionView:
         minimum_z_height: Optional[float] = None,
         stay_at_max_travel_z: bool = False,
         ignore_tip_configuration: Optional[bool] = True,
+        max_travel_z_extra_margin: Optional[float] = None,
     ) -> List[motion_planning.Waypoint]:
         """Calculate waypoints to a destination that's specified as an addressable area."""
         location = self._pipettes.get_current_location()
@@ -169,7 +170,9 @@ class MotionView:
                 # beneath max_travel_z. Investigate why motion_planning.get_waypoints() does not
                 # let us travel at max_travel_z, and whether it's safe to make it do that.
                 # Possibly related: https://github.com/Opentrons/opentrons/pull/6882#discussion_r514248062
-                max_travel_z - motion_planning.waypoints.MINIMUM_Z_MARGIN,
+                max_travel_z
+                - motion_planning.waypoints.MINIMUM_Z_MARGIN
+                - (max_travel_z_extra_margin or 0.0),
             )
             destination = base_destination_at_max_z + Point(
                 offset.x, offset.y, offset.z

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
@@ -1,11 +1,13 @@
 """Test move to addressable area commands."""
 from decoy import Decoy
+import pytest
 
-from opentrons.protocol_engine import DeckPoint, AddressableOffsetVector
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons.protocol_engine import DeckPoint, AddressableOffsetVector, LoadedPipette
 from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
-from opentrons.types import Point
+from opentrons.types import Point, MountType
 
 from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.move_to_addressable_area import (
@@ -15,10 +17,28 @@ from opentrons.protocol_engine.commands.move_to_addressable_area import (
 )
 
 
-async def test_move_to_addressable_area_implementation(
+@pytest.mark.parametrize(
+    "pipette_name",
+    (
+        pipette_name
+        for pipette_name in PipetteNameType
+        if pipette_name
+        not in (
+            PipetteNameType.P10_SINGLE,
+            PipetteNameType.P10_MULTI,
+            PipetteNameType.P50_MULTI,
+            PipetteNameType.P50_SINGLE,
+            PipetteNameType.P300_SINGLE,
+            PipetteNameType.P300_MULTI,
+            PipetteNameType.P1000_SINGLE,
+        )
+    ),
+)
+async def test_move_to_addressable_area_implementation_non_gen1(
     decoy: Decoy,
     state_view: StateView,
     movement: MovementHandler,
+    pipette_name: PipetteNameType,
 ) -> None:
     """A MoveToAddressableArea command should have an execution implementation."""
     subject = MoveToAddressableAreaImplementation(
@@ -35,6 +55,9 @@ async def test_move_to_addressable_area_implementation(
         stayAtHighestPossibleZ=True,
     )
 
+    decoy.when(state_view.pipettes.get("abc")).then_return(
+        LoadedPipette(id="abc", pipetteName=pipette_name, mount=MountType.LEFT)
+    )
     decoy.when(
         await movement.move_to_addressable_area(
             pipette_id="abc",
@@ -44,6 +67,64 @@ async def test_move_to_addressable_area_implementation(
             minimum_z_height=4.56,
             speed=7.89,
             stay_at_highest_possible_z=True,
+            highest_possible_z_extra_offset=None,
+        )
+    ).then_return(Point(x=9, y=8, z=7))
+
+    result = await subject.execute(data)
+
+    assert result == SuccessData(
+        public=MoveToAddressableAreaResult(position=DeckPoint(x=9, y=8, z=7)),
+        private=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "pipette_name",
+    (
+        PipetteNameType.P10_SINGLE,
+        PipetteNameType.P10_MULTI,
+        PipetteNameType.P50_MULTI,
+        PipetteNameType.P50_SINGLE,
+        PipetteNameType.P300_SINGLE,
+        PipetteNameType.P300_MULTI,
+        PipetteNameType.P1000_SINGLE,
+    ),
+)
+async def test_move_to_addressable_area_implementation_with_gen1(
+    decoy: Decoy,
+    state_view: StateView,
+    movement: MovementHandler,
+    pipette_name: PipetteNameType,
+) -> None:
+    """A MoveToAddressableArea command should have an execution implementation."""
+    subject = MoveToAddressableAreaImplementation(
+        movement=movement, state_view=state_view
+    )
+
+    data = MoveToAddressableAreaParams(
+        pipetteId="abc",
+        addressableAreaName="123",
+        offset=AddressableOffsetVector(x=1, y=2, z=3),
+        forceDirect=True,
+        minimumZHeight=4.56,
+        speed=7.89,
+        stayAtHighestPossibleZ=True,
+    )
+
+    decoy.when(state_view.pipettes.get("abc")).then_return(
+        LoadedPipette(id="abc", pipetteName=pipette_name, mount=MountType.LEFT)
+    )
+    decoy.when(
+        await movement.move_to_addressable_area(
+            pipette_id="abc",
+            addressable_area_name="123",
+            offset=AddressableOffsetVector(x=1, y=2, z=3),
+            force_direct=True,
+            minimum_z_height=4.56,
+            speed=7.89,
+            stay_at_highest_possible_z=True,
+            highest_possible_z_extra_offset=5.0,
         )
     ).then_return(Point(x=9, y=8, z=7))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
@@ -76,6 +76,13 @@ async def test_move_to_addressable_area_implementation_non_gen1(
     assert result == SuccessData(
         public=MoveToAddressableAreaResult(position=DeckPoint(x=9, y=8, z=7)),
         private=None,
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="abc",
+                new_location=update_types.AddressableArea(addressable_area_name="123"),
+                new_deck_point=DeckPoint(x=9, y=8, z=7),
+            )
+        ),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -1,7 +1,7 @@
 """MovementHandler command subject."""
 import pytest
 from decoy import Decoy
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 from opentrons.types import MountType, Point, DeckSlotName, Mount
 from opentrons.hardware_control import API as HardwareAPI
@@ -297,6 +297,10 @@ async def test_move_to_well_from_starting_location(
     )
 
 
+@pytest.mark.parametrize(
+    "stay_at_max_z,z_extra_offset",
+    [(True, None), (True, 5.0), (False, None), (False, 5.0)],
+)
 async def test_move_to_addressable_area(
     decoy: Decoy,
     state_store: StateStore,
@@ -304,6 +308,8 @@ async def test_move_to_addressable_area(
     heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
     mock_gantry_mover: GantryMover,
     subject: MovementHandler,
+    stay_at_max_z: bool,
+    z_extra_offset: Optional[float],
 ) -> None:
     """Move requests should call hardware controller with movement data."""
     decoy.when(
@@ -353,8 +359,9 @@ async def test_move_to_addressable_area(
             max_travel_z=42.0,
             force_direct=True,
             minimum_z_height=12.3,
-            stay_at_max_travel_z=True,
+            stay_at_max_travel_z=stay_at_max_z,
             ignore_tip_configuration=False,
+            max_travel_z_extra_margin=z_extra_offset,
         )
     ).then_return(
         [Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER), Waypoint(Point(4, 5, 6))]
@@ -378,8 +385,9 @@ async def test_move_to_addressable_area(
         force_direct=True,
         minimum_z_height=12.3,
         speed=45.6,
-        stay_at_highest_possible_z=True,
+        stay_at_highest_possible_z=stay_at_max_z,
         ignore_tip_configuration=False,
+        highest_possible_z_extra_offset=z_extra_offset,
     )
 
     assert result == Point(x=4, y=5, z=6)


### PR DESCRIPTION
Gen1 pipettes need more z margin than usual when moving around at maximum z for some reason.

## testing
- [x] run through dtwiz with a gen1 of any kind

Closes RQA-3229
