### PR TITLE
chore(robot-server): Work around tests hanging because server shutdown is hanging

### DIFF
--- a/robot-server/tests/integration/http_api/persistence/test_reset.py
+++ b/robot-server/tests/integration/http_api/persistence/test_reset.py
@@ -4,10 +4,11 @@ from pathlib import Path
 from shutil import copytree
 from tempfile import TemporaryDirectory
 
+import anyio
 import httpx
 
 from tests.integration.dev_server import DevServer
-from tests.integration.robot_client import RobotClient
+from tests.integration.robot_client import RobotClient, poll_until_all_analyses_complete
 from tests.integration.protocol_files import get_py_protocol, get_json_protocol
 
 from .persistence_snapshots_dir import PERSISTENCE_SNAPSHOTS_DIR
@@ -97,6 +98,13 @@ async def test_upload_protocols_and_reset_persistence_dir() -> None:
 
             with get_json_protocol(secrets.token_urlsafe(16)) as file:
                 await robot_client.post_protocol([Path(file.name)])
+
+            with anyio.fail_after(30):
+                # todo(mm, 2024-09-20): This works around a bug where robot-server
+                # shutdown will hang if there is an ongoing analysis. This slows down
+                # this test and should be removed when that bug is fixed.
+                # https://opentrons.atlassian.net/browse/EXEC-716
+                await poll_until_all_analyses_complete(robot_client)
 
             await robot_client.post_setting_reset_options({"runsHistory": True})
 

--- a/robot-server/tests/integration/http_api/protocols/test_persistence.py
+++ b/robot-server/tests/integration/http_api/protocols/test_persistence.py
@@ -8,7 +8,7 @@ import pytest
 from robot_server.persistence.file_and_directory_names import LATEST_VERSION_DIRECTORY
 
 from tests.integration.dev_server import DevServer
-from tests.integration.robot_client import RobotClient
+from tests.integration.robot_client import RobotClient, poll_until_all_analyses_complete
 from tests.integration.protocol_files import get_py_protocol, get_json_protocol
 
 
@@ -39,7 +39,7 @@ async def test_protocols_and_analyses_persist(
                     await robot_client.post_protocol([Path(file.name)])
 
             await asyncio.wait_for(
-                _wait_for_all_analyses_to_complete(robot_client), timeout=30
+                poll_until_all_analyses_complete(robot_client), timeout=30
             )
 
             # The protocols response will include analysis statuses. Fetch it
@@ -168,16 +168,3 @@ async def _get_all_analyses(robot_client: RobotClient) -> Dict[str, List[object]
         analyses_by_protocol_id[protocol_id] = analyses_on_this_protocol
 
     return analyses_by_protocol_id
-
-
-async def _wait_for_all_analyses_to_complete(robot_client: RobotClient) -> None:
-    async def _all_analyses_are_complete() -> bool:
-        protocols = (await robot_client.get_protocols()).json()
-        for protocol in protocols["data"]:
-            for analysis_summary in protocol["analysisSummaries"]:
-                if analysis_summary["status"] != "completed":
-                    return False
-        return True
-
-    while not await _all_analyses_are_complete():
-        await asyncio.sleep(0.1)

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -14,6 +14,7 @@ _STARTUP_WAIT = 20
 _SHUTDOWN_WAIT = 20
 
 _RUN_POLL_INTERVAL = 0.1
+_ANALYSIS_POLL_INTERVAL = 0.1
 
 
 class RobotClient:
@@ -398,3 +399,24 @@ async def poll_until_run_completes(
         else:
             # The run is still ongoing. Wait a beat, then poll again.
             await asyncio.sleep(poll_interval)
+
+
+async def poll_until_all_analyses_complete(
+    robot_client: RobotClient, poll_interval: float = _ANALYSIS_POLL_INTERVAL
+) -> None:
+    """Wait until all pending analyses have completed.
+
+    You probably want to wrap this in an `anyio.fail_after()` timeout in case something causes
+    an analysis to hang forever.
+    """
+
+    async def _all_analyses_are_complete() -> bool:
+        protocols = (await robot_client.get_protocols()).json()
+        for protocol in protocols["data"]:
+            for analysis_summary in protocol["analysisSummaries"]:
+                if analysis_summary["status"] != "completed":
+                    return False
+        return True
+
+    while not await _all_analyses_are_complete():
+        await asyncio.sleep(poll_interval)


### PR DESCRIPTION
## Overview

This tries to work around robot-server tests hanging on `edge`'s CI checks.

## Test Plan and Hands on Testing

See if CI passes now.

## Details

It seems like server shutdown hangs when there is an ongoing analysis. I think this is the same problem that @sanni-t identified in #16171. Unfortunately, simply cherry-picking #16171 into `edge` [does *not* solve the problem](https://github.com/Opentrons/opentrons/pull/16306).

The last lines from server shutdown:

```
2024-09-20 15:40:13,172 robot_server.protocols.protocol_analyzer WARNING [Line 154] Analyzer is no longer in use but orchestrator is busy. Cannot stop the orchestrator currently.
2024-09-20 15:40:13,172 uvicorn.error INFO [Line 76] Application shutdown complete.
2024-09-20 15:40:13,172 uvicorn.error INFO [Line 87] Finished server process [2836]
2024-09-20 15:40:13,173 robot_server.service.notifications.publisher_notifier ERROR [Line 55] PublisherNotifer notify task failed
Traceback (most recent call last):
  File "/home/runner/work/opentrons/opentrons/robot-server/robot_server/service/notifications/publisher_notifier.py", line 46, in _wait_for_event
    await self._change_notifier.wait()
  File "/home/runner/work/opentrons/opentrons/api/src/opentrons/util/change_notifier.py", line 18, in wait
    await self._event.wait()
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/asyncio/locks.py", line 214, in wait
    await fut
asyncio.exceptions.CancelledError
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/asyncio/base_events.py:674: RuntimeWarning: coroutine 'LegacyContextPlugin._dispatch_action_list' was never awaited
  self._ready.clear()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
[hang]
```

I think resolving this properly will involve merging `chore_release-8.0.0` into `edge` and then rethinking how `ProtocolAnalyzer`+`RunOrchestrator`+`ProtocolEngine` get cleaned up.

The workaround in this PR is to make the tests wait for all analyses to complete before restarting the server.

## Review requests

Does this workaround make sense for now?

## Risk assessment

No risk. Changes are just to tests.