### PR TITLE
docs(api):docs-pipette-flow-rates-mismatch

### DIFF
--- a/api/docs/v2/pipettes/characteristics.rst
+++ b/api/docs/v2/pipettes/characteristics.rst
@@ -158,8 +158,8 @@ These flow rate properties operate independently. This means you can specify dif
 
 Let's tell the robot to aspirate, dispense, and blow out the liquid using default flow rates. Notice how you don't need to specify a ``flow_rate`` attribute to use the defaults::
 
-        pipette.aspirate(200, plate["A1"])  # 160 µL/s
-        pipette.dispense(200, plate["A2"])  # 160 µL/s
+        pipette.aspirate(200, plate["A1"])  # 716 µL/s
+        pipette.dispense(200, plate["A2"])  # 716 µL/s
         pipette.blow_out()                  #  80 µL/s
 
 Now let's change the flow rates for each action::
@@ -184,7 +184,7 @@ These flow rates will remain in effect until you change the ``flow_rate`` attrib
 Flex Pipette Flow Rates
 -----------------------
 
-The default flow rates for Flex pipettes depend on the maximum volume of the pipette and the capacity of the currently attached tip. For each pipette–tip configuration, the default flow rate is the same for aspirate, dispense, and blowout actions.
+Flex pipette flow rates depend on pipette volume and tip capacity. Each pipette–tip combination has a default flow rate for aspirating, dispensing, and blowing out liquid. When using a 50 µL pipette, you should only use 50 µL tips.
 
 .. list-table::
     :header-rows: 1
@@ -193,7 +193,7 @@ The default flow rates for Flex pipettes depend on the maximum volume of the pip
       - Tip Capacity (µL)
       - Flow Rate (µL/s)
     * - 50 µL (1- and 8-channel)
-      - All capacities
+      - 50
       - 57
     * - 1000 µL (1-, 8-, and 96-channel)
       - 50

--- a/api/docs/v2/pipettes/characteristics.rst
+++ b/api/docs/v2/pipettes/characteristics.rst
@@ -160,16 +160,16 @@ Let's tell the robot to aspirate, dispense, and blow out the liquid using defaul
 
         pipette.aspirate(200, plate["A1"])  # 716 µL/s
         pipette.dispense(200, plate["A2"])  # 716 µL/s
-        pipette.blow_out()                  #  80 µL/s
+        pipette.blow_out()                  # 716 µL/s
 
 Now let's change the flow rates for each action::
 
         pipette.flow_rate.aspirate = 50
         pipette.flow_rate.dispense = 100
-        pipette.flow_rate.blow_out = 75
+        pipette.flow_rate.blow_out = 300
         pipette.aspirate(200, plate["A1"])  #  50 µL/s
         pipette.dispense(200, plate["A2"])  # 100 µL/s
-        pipette.blow_out()                  #  75 µL/s
+        pipette.blow_out()                  # 300 µL/s
         
 These flow rates will remain in effect until you change the ``flow_rate`` attribute again *or* call ``configure_for_volume()``. Calling ``configure_for_volume()`` always resets all pipette flow rates to the defaults for the mode that it sets.
 


### PR DESCRIPTION


# Overview

In [Pipette Flow Rates](https://docs.opentrons.com/v2/pipettes/characteristics.html#pipette-flow-rates) there's a code block that shows default flow rate for the 1000 µL pipette as 160 µL/s. Later on that same page the flow rate table lists the 1000 µL pipette flow rate as 716 µL, which is correct.

The fix here: Make sure the default flow rate listed in the code block on lines 161, 162 match the default flow rate published in a table later on the same page. Add info about 50 µL pipettes using 50 µL tips only.

Sandbox:

- [Pipette Flow Rates](http://sandbox.docs.opentrons.com/docs-pipette-flow-rates-mismatch/v2/pipettes/characteristics.html#pipette-flow-rates)
- [Flex Pipette Flow Rates](http://sandbox.docs.opentrons.com/docs-pipette-flow-rates-mismatch/v2/pipettes/characteristics.html#flex-pipette-flow-rates)

 Jira:  RTC-421

## Test Plan and Hands on Testing

Have another trusted source review the change.

## Changelog

- Code block at around lines 161, 162 show incorrect flow rate.
- Change code block sample code to 716 µL/s from 160 µL/s.
- Update flow rate table to indicate a 50 µL pipette should only use 50 µL tips.

## Review requests

Seem like 2 simple changes. Are these what you anticipated? 

## Risk assessment

Low. Docs changes only.
