### PR TITLE
feat(robot-server): Implement storage for "enable/disable error recovery" setting

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v6_to_v7.py
+++ b/robot-server/robot_server/persistence/_migrations/v6_to_v7.py
@@ -3,6 +3,7 @@
 Summary of changes from schema 6:
 
 - Adds a new command_intent to store the commands intent in the commands table
+- Adds the `boolean_setting` table.
 """
 
 import json

--- a/robot-server/robot_server/persistence/file_and_directory_names.py
+++ b/robot-server/robot_server/persistence/file_and_directory_names.py
@@ -8,7 +8,7 @@ v2/deck_configuration.json, etc.
 
 from typing import Final
 
-LATEST_VERSION_DIRECTORY: Final = "7"
+LATEST_VERSION_DIRECTORY: Final = "7.1"
 
 DECK_CONFIGURATION_FILE: Final = "deck_configuration.json"
 PROTOCOLS_DIRECTORY: Final = "protocols"

--- a/robot-server/robot_server/persistence/persistence_directory.py
+++ b/robot-server/robot_server/persistence/persistence_directory.py
@@ -52,6 +52,9 @@ async def prepare_active_subdirectory(prepared_root: Path) -> Path:
             v3_to_v4.Migration3to4(subdirectory="4"),
             v4_to_v5.Migration4to5(subdirectory="5"),
             v5_to_v6.Migration5to6(subdirectory="6"),
+            # TODO BEFORE MERGE: Double-check that I can make these changes in-place
+            # without breaking the robots that are on `edge` right now. Maybe rename
+            # LATEST_VERSION_DIRECTORY to 7.1/ and abandon the current 7/ directory.
             v6_to_v7.Migration6to7(subdirectory=LATEST_VERSION_DIRECTORY),
         ],
         temp_file_prefix="temp-",

--- a/robot-server/robot_server/persistence/persistence_directory.py
+++ b/robot-server/robot_server/persistence/persistence_directory.py
@@ -52,9 +52,9 @@ async def prepare_active_subdirectory(prepared_root: Path) -> Path:
             v3_to_v4.Migration3to4(subdirectory="4"),
             v4_to_v5.Migration4to5(subdirectory="5"),
             v5_to_v6.Migration5to6(subdirectory="6"),
-            # TODO BEFORE MERGE: Double-check that I can make these changes in-place
-            # without breaking the robots that are on `edge` right now. Maybe rename
-            # LATEST_VERSION_DIRECTORY to 7.1/ and abandon the current 7/ directory.
+            # Subdirectory "7" was previously used on our edge branch for an in-dev
+            # schema that was never released to the public. It may be present on
+            # internal robots.
             v6_to_v7.Migration6to7(subdirectory=LATEST_VERSION_DIRECTORY),
         ],
         temp_file_prefix="temp-",

--- a/robot-server/robot_server/persistence/tables/__init__.py
+++ b/robot-server/robot_server/persistence/tables/__init__.py
@@ -12,9 +12,10 @@ from .schema_7 import (
     action_table,
     run_csv_rtp_table,
     data_files_table,
-    enable_error_recovery_table,
+    boolean_setting_table,
     PrimitiveParamSQLEnum,
     ProtocolKindSQLEnum,
+    BooleanSettingKey,
 )
 
 
@@ -29,7 +30,8 @@ __all__ = [
     "action_table",
     "run_csv_rtp_table",
     "data_files_table",
-    "enable_error_recovery_table",
+    "boolean_setting_table",
     "PrimitiveParamSQLEnum",
     "ProtocolKindSQLEnum",
+    "BooleanSettingKey",
 ]

--- a/robot-server/robot_server/persistence/tables/__init__.py
+++ b/robot-server/robot_server/persistence/tables/__init__.py
@@ -12,6 +12,7 @@ from .schema_7 import (
     action_table,
     run_csv_rtp_table,
     data_files_table,
+    enable_error_recovery_table,
     PrimitiveParamSQLEnum,
     ProtocolKindSQLEnum,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "action_table",
     "run_csv_rtp_table",
     "data_files_table",
+    "enable_error_recovery_table",
     "PrimitiveParamSQLEnum",
     "ProtocolKindSQLEnum",
 ]

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -240,6 +240,8 @@ data_files_table = sqlalchemy.Table(
 )
 
 run_csv_rtp_table = sqlalchemy.Table(
+    # TODO BEFORE MERGE: If we need to rename the persistence directory anyway,
+    # take the opportunity to remove "table" from these SQL names?
     "run_csv_rtp_table",
     metadata,
     sqlalchemy.Column(
@@ -260,6 +262,25 @@ run_csv_rtp_table = sqlalchemy.Table(
     sqlalchemy.Column(
         "file_id",
         sqlalchemy.ForeignKey("data_files.id"),
+        nullable=True,
+    ),
+)
+
+# Single-row table to store the boolean "enable/disable error recovery" setting.
+enable_error_recovery_table = sqlalchemy.Table(
+    "enable_error_recovery",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.Integer,
+        # This `id=0` constraint, combined with the uniqueness constraint implicit in `primary_key=True`,
+        # is a trick to make sure this table only has at most 1 row.
+        sqlalchemy.CheckConstraint("id=0"),
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "enable_error_recovery",
+        sqlalchemy.Boolean,
         nullable=True,
     ),
 )

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -266,21 +266,29 @@ run_csv_rtp_table = sqlalchemy.Table(
     ),
 )
 
-# Single-row table to store the boolean "enable/disable error recovery" setting.
-enable_error_recovery_table = sqlalchemy.Table(
-    "enable_error_recovery",
+
+class BooleanSettingKey(enum.Enum):
+    """Keys for boolean settings."""
+
+    ENABLE_ERROR_RECOVERY = "enable_error_recovery"
+
+
+boolean_setting_table = sqlalchemy.Table(
+    "boolean_setting",
     metadata,
     sqlalchemy.Column(
-        "id",
-        sqlalchemy.Integer,
-        # This `id=0` constraint, combined with the uniqueness constraint implicit in `primary_key=True`,
-        # is a trick to make sure this table only has at most 1 row.
-        sqlalchemy.CheckConstraint("id=0"),
+        "key",
+        sqlalchemy.Enum(
+            BooleanSettingKey,
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+            create_constraint=True,
+        ),
         primary_key=True,
     ),
     sqlalchemy.Column(
-        "enable_error_recovery",
+        "value",
         sqlalchemy.Boolean,
-        nullable=True,
+        nullable=False,
     ),
 )

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -102,6 +102,7 @@ analysis_primitive_type_rtp_table = sqlalchemy.Table(
             PrimitiveParamSQLEnum,
             values_callable=lambda obj: [e.value for e in obj],
             create_constraint=True,
+            # todo(mm, 2024-09-24): Can we add validate_strings=True here?
         ),
         nullable=False,
     ),

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -269,7 +269,7 @@ run_csv_rtp_table = sqlalchemy.Table(
 class BooleanSettingKey(enum.Enum):
     """Keys for boolean settings."""
 
-    ENABLE_ERROR_RECOVERY = "enable_error_recovery"
+    DISABLE_ERROR_RECOVERY = "disable_error_recovery"
 
 
 boolean_setting_table = sqlalchemy.Table(

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -241,8 +241,6 @@ data_files_table = sqlalchemy.Table(
 )
 
 run_csv_rtp_table = sqlalchemy.Table(
-    # TODO BEFORE MERGE: If we need to rename the persistence directory anyway,
-    # take the opportunity to remove "table" from these SQL names?
     "run_csv_rtp_table",
     metadata,
     sqlalchemy.Column(

--- a/robot-server/robot_server/runs/error_recovery_setting_store.py
+++ b/robot-server/robot_server/runs/error_recovery_setting_store.py
@@ -1,0 +1,34 @@
+# noqa: D100
+
+
+import sqlalchemy
+
+from robot_server.persistence.tables import enable_error_recovery_table
+
+
+class ErrorRecoverySettingStore:
+    """Persistently stores settings related to error recovery."""
+
+    def __init__(self, sql_engine: sqlalchemy.engine.Engine) -> None:
+        self._sql_engine = sql_engine
+
+    def get_is_enabled(self) -> bool | None:
+        """Get the value of the "error recovery enabled" setting.
+
+        `None` is the default, i.e. it's never been explicitly set one way or the other.
+        """
+        with self._sql_engine.begin() as transaction:
+            return transaction.execute(
+                sqlalchemy.select(enable_error_recovery_table.c.enable_error_recovery)
+            ).scalar_one_or_none()
+
+    def set_is_enabled(self, is_enabled: bool) -> None:
+        """Set the value of the "error recovery enabled" setting."""
+        with self._sql_engine.begin() as transaction:
+            transaction.execute(sqlalchemy.delete(enable_error_recovery_table))
+            transaction.execute(
+                sqlalchemy.insert(enable_error_recovery_table).values(
+                    id=0,  # id=0 to match the single-row constraint trick in the table declaration.
+                    enable_error_recovery=is_enabled,
+                )
+            )

--- a/robot-server/robot_server/runs/error_recovery_setting_store.py
+++ b/robot-server/robot_server/runs/error_recovery_setting_store.py
@@ -3,7 +3,7 @@
 
 import sqlalchemy
 
-from robot_server.persistence.tables import enable_error_recovery_table
+from robot_server.persistence.tables import boolean_setting_table, BooleanSettingKey
 
 
 class ErrorRecoverySettingStore:
@@ -19,16 +19,24 @@ class ErrorRecoverySettingStore:
         """
         with self._sql_engine.begin() as transaction:
             return transaction.execute(
-                sqlalchemy.select(enable_error_recovery_table.c.enable_error_recovery)
+                sqlalchemy.select(boolean_setting_table.c.value).where(
+                    boolean_setting_table.c.key
+                    == BooleanSettingKey.ENABLE_ERROR_RECOVERY
+                )
             ).scalar_one_or_none()
 
     def set_is_enabled(self, is_enabled: bool) -> None:
         """Set the value of the "error recovery enabled" setting."""
         with self._sql_engine.begin() as transaction:
-            transaction.execute(sqlalchemy.delete(enable_error_recovery_table))
             transaction.execute(
-                sqlalchemy.insert(enable_error_recovery_table).values(
-                    id=0,  # id=0 to match the single-row constraint trick in the table declaration.
-                    enable_error_recovery=is_enabled,
+                sqlalchemy.delete(boolean_setting_table).where(
+                    boolean_setting_table.c.key
+                    == BooleanSettingKey.ENABLE_ERROR_RECOVERY
+                )
+            )
+            transaction.execute(
+                sqlalchemy.insert(boolean_setting_table).values(
+                    key=BooleanSettingKey.ENABLE_ERROR_RECOVERY,
+                    value=is_enabled,
                 )
             )

--- a/robot-server/robot_server/runs/error_recovery_setting_store.py
+++ b/robot-server/robot_server/runs/error_recovery_setting_store.py
@@ -12,7 +12,7 @@ class ErrorRecoverySettingStore:
     def __init__(self, sql_engine: sqlalchemy.engine.Engine) -> None:
         self._sql_engine = sql_engine
 
-    def get_is_enabled(self) -> bool | None:
+    def get_is_disabled(self) -> bool | None:
         """Get the value of the "error recovery enabled" setting.
 
         `None` is the default, i.e. it's never been explicitly set one way or the other.
@@ -21,22 +21,26 @@ class ErrorRecoverySettingStore:
             return transaction.execute(
                 sqlalchemy.select(boolean_setting_table.c.value).where(
                     boolean_setting_table.c.key
-                    == BooleanSettingKey.ENABLE_ERROR_RECOVERY
+                    == BooleanSettingKey.DISABLE_ERROR_RECOVERY
                 )
             ).scalar_one_or_none()
 
-    def set_is_enabled(self, is_enabled: bool) -> None:
-        """Set the value of the "error recovery enabled" setting."""
+    def set_is_disabled(self, is_disabled: bool | None) -> None:
+        """Set the value of the "error recovery enabled" setting.
+
+        `None` means revert to the default.
+        """
         with self._sql_engine.begin() as transaction:
             transaction.execute(
                 sqlalchemy.delete(boolean_setting_table).where(
                     boolean_setting_table.c.key
-                    == BooleanSettingKey.ENABLE_ERROR_RECOVERY
+                    == BooleanSettingKey.DISABLE_ERROR_RECOVERY
                 )
             )
-            transaction.execute(
-                sqlalchemy.insert(boolean_setting_table).values(
-                    key=BooleanSettingKey.ENABLE_ERROR_RECOVERY,
-                    value=is_enabled,
+            if is_disabled is not None:
+                transaction.execute(
+                    sqlalchemy.insert(boolean_setting_table).values(
+                        key=BooleanSettingKey.DISABLE_ERROR_RECOVERY,
+                        value=is_disabled,
+                    )
                 )
-            )

--- a/robot-server/tests/integration/http_api/persistence/test_reset.py
+++ b/robot-server/tests/integration/http_api/persistence/test_reset.py
@@ -30,22 +30,12 @@ def _get_corrupt_persistence_dir() -> Path:
 async def _assert_reset_was_successful(
     robot_client: RobotClient, persistence_directory: Path
 ) -> None:
-    # It should have no protocols.
+    # We really want to check that the server's persistence directory has been wiped
+    # clean, but testing that directly would rely on internal implementation details
+    # of file layout and tend to be brittle.
+    # As an approximation, just check that there are no protocols or runs left.
     assert (await robot_client.get_protocols()).json()["data"] == []
-
-    # It should have no runs.
     assert (await robot_client.get_runs()).json()["data"] == []
-
-    # There should be no files except for robot_server.db
-    # and an empty protocols/ directory.
-    all_files_and_directories = set(persistence_directory.glob("**/*"))
-    expected_files_and_directories = {
-        persistence_directory / "robot_server.db",
-        persistence_directory / "7",
-        persistence_directory / "7" / "protocols",
-        persistence_directory / "7" / "robot_server.db",
-    }
-    assert all_files_and_directories == expected_files_and_directories
 
 
 async def _wait_until_initialization_failed(robot_client: RobotClient) -> None:

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -142,7 +142,19 @@ EXPECTED_STATEMENTS_LATEST = [
         FOREIGN KEY(file_id) REFERENCES data_files (id)
     )
     """,
+    """
+    CREATE TABLE boolean_setting (
+        "key" VARCHAR(21) NOT NULL,
+        value BOOLEAN NOT NULL,
+        PRIMARY KEY ("key"),
+        CONSTRAINT booleansettingkey CHECK ("key" IN ('enable_error_recovery'))
+    )
+    """,
 ]
+
+
+EXPECTED_STATEMENTS_V7 = EXPECTED_STATEMENTS_LATEST
+
 
 EXPECTED_STATEMENTS_V6 = [
     """
@@ -257,8 +269,6 @@ EXPECTED_STATEMENTS_V6 = [
 ]
 
 
-EXPECTED_STATEMENTS_V7 = EXPECTED_STATEMENTS_LATEST
-
 EXPECTED_STATEMENTS_V5 = [
     """
     CREATE TABLE protocol (
@@ -333,6 +343,7 @@ EXPECTED_STATEMENTS_V5 = [
     )
     """,
 ]
+
 
 EXPECTED_STATEMENTS_V4 = [
     """

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -144,10 +144,10 @@ EXPECTED_STATEMENTS_LATEST = [
     """,
     """
     CREATE TABLE boolean_setting (
-        "key" VARCHAR(21) NOT NULL,
+        "key" VARCHAR(22) NOT NULL,
         value BOOLEAN NOT NULL,
         PRIMARY KEY ("key"),
-        CONSTRAINT booleansettingkey CHECK ("key" IN ('enable_error_recovery'))
+        CONSTRAINT booleansettingkey CHECK ("key" IN ('disable_error_recovery'))
     )
     """,
 ]

--- a/robot-server/tests/runs/test_error_recovery_setting_store.py
+++ b/robot-server/tests/runs/test_error_recovery_setting_store.py
@@ -1,0 +1,26 @@
+"""Tests for error_recovery_setting_store."""
+
+
+from robot_server.runs.error_recovery_setting_store import ErrorRecoverySettingStore
+
+import pytest
+import sqlalchemy
+
+
+@pytest.fixture
+def subject(
+    sql_engine: sqlalchemy.engine.Engine,
+) -> ErrorRecoverySettingStore:
+    """Return a test subject."""
+    return ErrorRecoverySettingStore(sql_engine=sql_engine)
+
+
+def test_error_recovery_setting_store(subject: ErrorRecoverySettingStore) -> None:
+    """Test `ErrorRecoverySettingStore`."""
+    assert subject.get_is_enabled() is None
+
+    subject.set_is_enabled(is_enabled=False)
+    assert subject.get_is_enabled() is False
+
+    subject.set_is_enabled(is_enabled=True)
+    assert subject.get_is_enabled() is True

--- a/robot-server/tests/runs/test_error_recovery_setting_store.py
+++ b/robot-server/tests/runs/test_error_recovery_setting_store.py
@@ -17,10 +17,13 @@ def subject(
 
 def test_error_recovery_setting_store(subject: ErrorRecoverySettingStore) -> None:
     """Test `ErrorRecoverySettingStore`."""
-    assert subject.get_is_enabled() is None
+    assert subject.get_is_disabled() is None
 
-    subject.set_is_enabled(is_enabled=False)
-    assert subject.get_is_enabled() is False
+    subject.set_is_disabled(is_disabled=False)
+    assert subject.get_is_disabled() is False
 
-    subject.set_is_enabled(is_enabled=True)
-    assert subject.get_is_enabled() is True
+    subject.set_is_disabled(is_disabled=True)
+    assert subject.get_is_disabled() is True
+
+    subject.set_is_disabled(is_disabled=None)
+    assert subject.get_is_disabled() is None


### PR DESCRIPTION
# Overview

This implements persistent storage for an "enable/disable error recovery" robot setting, as part of EXEC-719.

## Test Plan and Hands on Testing

* [x] ~~Use a dev server to double-check that our migration system will actually let me make this modification in-place.~~

## Changelog

This adds the setting as a boolean enable/disable flag. Alternatively, we could have added persistent storage for a whole error recovery policy structure (as in, we could have stored the whole request structure of `POST /runs/{id}/errorRecoveryPolicy`), but that seemed like overkill to me.

~~I've implemented this as a single-purpose table in our SQL database, containing one row with one boolean column. This feels to me like a misuse of a relational database, but [other people apparently think it's a normal thing to do sometimes](https://softwareengineering.stackexchange.com/a/350001/8810)? 🤷 The alternative would be to add a new JSON file to robot-server's persistence directory.~~ After discussion with @TamarZanzouri, I've implemented this as a table mapping setting-name string keys to boolean values. The only key right now is `"enable_error_recovery"`, and in the future we might add more keys for more settings / feature-flags.

## Review requests

~~Any thoughts on the single-row table thing?~~ See comments below.

## Risk assessment

Some risk of breaking robots in the office currently running `edge`—see test plan.
