### PR TITLE
fix(api): Dont throw ModuleNotFoundError while loading the plate reader substate when getting the default run orchestrator.

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -387,31 +387,31 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 module_id=MagneticBlockId(module_id)
             )
         elif ModuleModel.is_absorbance_reader(actual_model):
+            lid_labware_id = None
             slot = self._state.slot_by_module_id[module_id]
             if slot is not None:
                 reader_addressable_area = f"absorbanceReaderV1{slot.value}"
-                lid_labware_id = None
                 for labware in self._state.deck_fixed_labware:
                     if labware.location == AddressableAreaLocation(
                         addressableAreaName=reader_addressable_area
                     ):
                         lid_labware_id = labware.labware_id
                         break
-                self._state.substate_by_module_id[module_id] = AbsorbanceReaderSubState(
-                    module_id=AbsorbanceReaderId(module_id),
-                    configured=False,
-                    measured=False,
-                    is_lid_on=True,
-                    data=None,
-                    measure_mode=None,
-                    configured_wavelengths=None,
-                    reference_wavelength=None,
-                    lid_id=lid_labware_id,
-                )
-            else:
-                raise errors.ModuleNotOnDeckError(
-                    "Opentrons Plate Reader location did not return a valid Deck Slot."
-                )
+                else:
+                    raise errors.AreaNotInDeckConfigurationError(
+                        "Opentrons Plate Reader lid location not found."
+                    )
+            self._state.substate_by_module_id[module_id] = AbsorbanceReaderSubState(
+                module_id=AbsorbanceReaderId(module_id),
+                configured=False,
+                measured=False,
+                is_lid_on=True,
+                data=None,
+                measure_mode=None,
+                configured_wavelengths=None,
+                reference_wavelength=None,
+                lid_id=lid_labware_id,
+            )
 
     def _update_additional_slots_occupied_by_thermocycler(
         self,


### PR DESCRIPTION
# Overview

The heater-shaker and thermocycler latch and open/close lid commands are not working when the Plate Reader is attached to the Flex, this is because the `get_default_orchestrator` robot server route dependency creates a Plate Reader substate object expecting no location, but we explicitly raise `ModuleNotFoundError` if there is no location for the Plate Reader. We need a location to find the Plate Reader lid labware fixture we load in when the plate reader instance is created. However, we don't care about the location when loading a Module Substate from `use_attached_modules` method. This pull request allows us to load the Plate Reader substate without a location.

Closes: [PLAT-503](https://opentrons.atlassian.net/browse/PLAT-503)

## Test Plan and Hands on Testing

- [x] Make sure that the open/close lid/latch works while a Plate Reader and Heater-Shaker/Thermocycler are connected.
- [x] Connect a plate reader to the Flex and make sure we can successfully run the following protocol.

```
from typing import cast
from opentrons import protocol_api
from opentrons.protocol_api.module_contexts import AbsorbanceReaderContext

# metadata
metadata = {
    'protocolName': 'Absorbance Reader Multi read test',
    'author': 'Platform Expansion',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.21",
}

# protocol run function
def run(protocol: protocol_api.ProtocolContext):
    mod = cast(AbsorbanceReaderContext, protocol.load_module("absorbanceReaderV1", "C3"))
    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "C2")
    tiprack_1000 = protocol.load_labware(load_name='opentrons_flex_96_tiprack_1000ul', location="B2")
    trash_labware = protocol.load_trash_bin("B3")
    instrument = protocol.load_instrument("flex_8channel_1000", "right", tip_racks=[tiprack_1000])
    instrument.trash_container = trash_labware

    # pick up tip and perform action
    instrument.pick_up_tip(tiprack_1000.wells_by_name()['A1'])
    instrument.aspirate(100, plate.wells_by_name()['A1'])
    instrument.dispense(100, plate.wells_by_name()['B1'])
    instrument.return_tip()
   
    # Initialize to a single wavelength with reference wavelength
    mod.initialize('single', [600], 450)

    # NOTE: CANNOT INITIALIZE WITH THE LID OPEN

    # Remove the Plate Reader lid using the Gripper.
    mod.open_lid()
    protocol.move_labware(plate, mod, use_gripper=True)
    mod.close_lid()

    # Take a reading and show the resulting absorbance values.
    result = mod.read()
    msg = f"single: {result}"
    protocol.comment(msg=msg)
    protocol.pause(msg=msg)

    # Initialize to multiple wavelengths
    protocol.pause(msg="Perform Multi Read")
    mod.open_lid()
    protocol.move_labware(plate, "C2", use_gripper=True)
    mod.close_lid()
    # NOTE: There is currently a bug in the byonoy library which stops us
    # from using less than 6 wavelengths in multi measure mode.
    mod.initialize('multi', [450, 570, 600])

    mod.open_lid()
    protocol.move_labware(plate, mod, use_gripper=True)
    mod.close_lid()

    # Take reading
    result = mod.read()
    msg = f"multi: {result}"
    protocol.comment(msg=msg)
    protocol.pause(msg=msg)

    # Place the Plate Reader lid back on using the Gripper.
    mod.open_lid()
    protocol.move_labware(plate, "C2", use_gripper=True)
    mod.close_lid()
```

## Changelog

- Don't raise `ModuleNotFoundError` while loading the plate reader substate when getting the default run orchestrator.
- Raise `AreaNotInDeckConfigurationError` if the plate reader has a location but we cant find the plate reader lid location.

## Review requests

- Does this make sense?
- Is this the appropriate error code for this case?

## Risk assessment

Low, unreleased

[PLAT-503]: https://opentrons.atlassian.net/browse/PLAT-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ