### PR TITLE
feat(protocol-designer): temperature step form tools

### DIFF
--- a/components/src/atoms/buttons/RadioButton.tsx
+++ b/components/src/atoms/buttons/RadioButton.tsx
@@ -32,6 +32,8 @@ interface RadioButtonProps extends StyleProps {
   //  used for mouseEnter and mouseLeave
   setNoHover?: () => void
   setHovered?: () => void
+  // TODO wire up the error state for the radio button
+  error?: string | null
 }
 
 //  used for ODD and helix

--- a/protocol-designer/src/assets/localization/en/tooltip.json
+++ b/protocol-designer/src/assets/localization/en/tooltip.json
@@ -61,7 +61,8 @@
       "preWetTip": "Pre-wet pipette tip by aspirating and dispensing 2/3 of the tip's max volume",
       "volume": "Volume to dispense in each well",
       "blowout_z_offset": "The height at which blowout occurs from the top of the well",
-      "blowout_flowRate": "Blowout speed"
+      "blowout_flowRate": "Blowout speed",
+      "setTemperature": "Select the temperature to set your module to"
     },
     "indeterminate": {
       "aspirate_airGap_checkbox": "Not all selected steps are using this setting",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import {
@@ -28,7 +28,7 @@ export function TemperatureTools(props: StepFormProps): JSX.Element {
   const temperatureModuleIds = useSelector(getTemperatureModuleIds)
   const { setTemperature, moduleId } = formData
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (moduleLabwareOptions.length === 1) {
       propsForFields.moduleId.updateValue(moduleLabwareOptions[0].value)
     }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
@@ -22,12 +22,11 @@ import {
 import type { StepFormProps } from '../../types'
 
 export function TemperatureTools(props: StepFormProps): JSX.Element {
+  const { propsForFields, formData } = props
   const { t } = useTranslation(['application', 'form', 'protocol_steps'])
   const moduleLabwareOptions = useSelector(getTemperatureLabwareOptions)
   const temperatureModuleIds = useSelector(getTemperatureModuleIds)
-
-  const { propsForFields } = props
-  const { setTemperature, moduleId } = props.formData
+  const { setTemperature, moduleId } = formData
 
   useEffect(() => {
     if (moduleLabwareOptions.length === 1) {
@@ -70,10 +69,7 @@ export function TemperatureTools(props: StepFormProps): JSX.Element {
                 flexDirection={DIRECTION_COLUMN}
                 gridGap={SPACING.spacing4}
               >
-                <Flex
-                  padding={`${SPACING.spacing16} ${SPACING.spacing16} 0`}
-                  width="100%"
-                >
+                <Flex padding={`${SPACING.spacing16} ${SPACING.spacing16} 0`}>
                   <RadioButton
                     width="100%"
                     largeDesktopBorderRadius

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
@@ -1,3 +1,121 @@
-export function TemperatureTools(): JSX.Element {
-  return <div>TODO: wire this up</div>
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import {
+  Box,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  ListItem,
+  RadioButton,
+  SPACING,
+  StyledText,
+} from '@opentrons/components'
+import {
+  getTemperatureLabwareOptions,
+  getTemperatureModuleIds,
+} from '../../../../../../ui/modules/selectors'
+import {
+  DropdownStepFormField,
+  InputStepFormField,
+} from '../../../../../../molecules'
+import type { StepFormProps } from '../../types'
+
+export function TemperatureTools(props: StepFormProps): JSX.Element {
+  const { t } = useTranslation(['application', 'form', 'protocol_steps'])
+  const moduleLabwareOptions = useSelector(getTemperatureLabwareOptions)
+  const temperatureModuleIds = useSelector(getTemperatureModuleIds)
+
+  const { propsForFields } = props
+  const { setTemperature, moduleId } = props.formData
+
+  useEffect(() => {
+    if (moduleLabwareOptions.length === 1) {
+      propsForFields.moduleId.updateValue(moduleLabwareOptions[0].value)
+    }
+  }, [])
+
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN}>
+      {moduleLabwareOptions.length > 1 ? (
+        <DropdownStepFormField
+          {...propsForFields.moduleId}
+          options={moduleLabwareOptions}
+          title={t('protocol_steps:module')}
+        />
+      ) : (
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          padding={SPACING.spacing12}
+          gridGap={SPACING.spacing8}
+        >
+          <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+            {t('protocol_steps:module')}
+          </StyledText>
+          <ListItem type="noActive">
+            <Flex padding={SPACING.spacing12}>
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {moduleLabwareOptions[0].name}
+              </StyledText>
+            </Flex>
+          </ListItem>
+        </Flex>
+      )}
+      <Box borderBottom={`1px solid ${COLORS.grey30}`} />
+      {temperatureModuleIds != null
+        ? temperatureModuleIds.map(id =>
+            id === moduleId ? (
+              <Flex
+                key={id}
+                flexDirection={DIRECTION_COLUMN}
+                gridGap={SPACING.spacing4}
+              >
+                <Flex
+                  padding={`${SPACING.spacing16} ${SPACING.spacing16} 0`}
+                  width="100%"
+                >
+                  <RadioButton
+                    width="100%"
+                    largeDesktopBorderRadius
+                    onChange={(e: React.ChangeEvent<any>) => {
+                      propsForFields.setTemperature.updateValue(
+                        e.currentTarget.value
+                      )
+                    }}
+                    buttonLabel={t(
+                      'form:step_edit_form.field.setTemperature.options.true'
+                    )}
+                    buttonValue="true"
+                    isSelected={propsForFields.setTemperature.value === 'true'}
+                  />
+                </Flex>
+                {setTemperature === 'true' && (
+                  <InputStepFormField
+                    {...propsForFields.targetTemperature}
+                    title={'Temperature'}
+                    units={t('units.degrees')}
+                  />
+                )}
+                <Flex padding={`0 ${SPACING.spacing16}`} width="100%">
+                  <RadioButton
+                    width="100%"
+                    largeDesktopBorderRadius
+                    onChange={(e: React.ChangeEvent<any>) => {
+                      propsForFields.setTemperature.updateValue(
+                        e.currentTarget.value
+                      )
+                    }}
+                    buttonLabel={t(
+                      'form:step_edit_form.field.setTemperature.options.false'
+                    )}
+                    buttonValue="false"
+                    isSelected={propsForFields.setTemperature.value === 'false'}
+                  />
+                </Flex>
+              </Flex>
+            ) : null
+          )
+        : null}
+    </Flex>
+  )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/__tests__/TemperatureTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/__tests__/TemperatureTools.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { describe, it, vi, beforeEach } from 'vitest'
 import { screen } from '@testing-library/react'
 import { renderWithProviders } from '../../../../../../__testing-utils__'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/__tests__/TemperatureTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/__tests__/TemperatureTools.test.tsx
@@ -40,6 +40,7 @@ describe('TemperatureTools', () => {
         dirtyFields: [],
         focusedField: null,
       },
+      toolboxStep: 1,
       propsForFields: {
         moduleId: {
           onFieldFocus: vi.fn(),

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/__tests__/TemperatureTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/__tests__/TemperatureTools.test.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react'
+import { describe, it, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../../../../__testing-utils__'
+import { i18n } from '../../../../../../assets/localization'
+import {
+  getTemperatureLabwareOptions,
+  getTemperatureModuleIds,
+} from '../../../../../../ui/modules/selectors'
+import { TemperatureTools } from '../TemperatureTools'
+import type * as ModulesSelectors from '../../../../../../ui/modules/selectors'
+
+vi.mock('../../../../../../ui/modules/selectors', async importOriginal => {
+  const actualFields = await importOriginal<typeof ModulesSelectors>()
+  return {
+    ...actualFields,
+    getTemperatureLabwareOptions: vi.fn(),
+    getTemperatureModuleIds: vi.fn(),
+  }
+})
+const render = (props: React.ComponentProps<typeof TemperatureTools>) => {
+  return renderWithProviders(<TemperatureTools {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('TemperatureTools', () => {
+  let props: React.ComponentProps<typeof TemperatureTools>
+
+  beforeEach(() => {
+    props = {
+      formData: {
+        id: 'formId',
+        stepType: 'temperature',
+        moduleId: 'mockId',
+        setTemperature: true,
+      } as any,
+      focusHandlers: {
+        blur: vi.fn(),
+        focus: vi.fn(),
+        dirtyFields: [],
+        focusedField: null,
+      },
+      propsForFields: {
+        moduleId: {
+          onFieldFocus: vi.fn(),
+          onFieldBlur: vi.fn(),
+          errorToShow: null,
+          disabled: false,
+          name: 'setTemperature',
+          updateValue: vi.fn(),
+          value: 'mockId',
+        },
+        setTemperature: {
+          onFieldFocus: vi.fn(),
+          onFieldBlur: vi.fn(),
+          errorToShow: null,
+          disabled: false,
+          name: 'setTemperature',
+          updateValue: vi.fn(),
+          value: true,
+        },
+        targetTemperature: {
+          onFieldFocus: vi.fn(),
+          onFieldBlur: vi.fn(),
+          errorToShow: null,
+          disabled: false,
+          name: 'targetTemperature',
+          updateValue: vi.fn(),
+          value: null,
+        },
+      },
+    }
+
+    vi.mocked(getTemperatureModuleIds).mockReturnValue(['mockId'])
+    vi.mocked(getTemperatureLabwareOptions).mockReturnValue([
+      {
+        name: 'mock module',
+        value: 'mockId',
+      },
+    ])
+  })
+
+  it('renders a temperature module form with 1 module', () => {
+    render(props)
+    screen.getByText('Module')
+    screen.getByText('mock module')
+    screen.getByText('Deactivate module')
+    screen.getByText('Change to temperature')
+  })
+})


### PR DESCRIPTION
closes AUTH-813

# Overview
<img width="311" alt="Screenshot 2024-09-24 at 11 00 09" src="https://github.com/user-attachments/assets/a115a649-0b2d-4781-b7e8-c9a388d7b5ed">
<img width="313" alt="Screenshot 2024-09-24 at 11 00 23" src="https://github.com/user-attachments/assets/b8b6571d-72ce-4718-92e5-5ecc53311789">
iew

Wires up the temperature toolbox for single and multi temperatures

## Test Plan and Hands on Testing

Test a protocol with 1 temperature module and a protocol with multiple temperature modules and see that it works correctly. Note that there is a bug where the input field text does not get cut off correctly - i made a follow up ticket for that: https://opentrons.atlassian.net/browse/RQA-3238

## Changelog

- wire up the temperature tools for single and multi temperatures

## Risk assessment

low
