### PR TITLE
fix(api): Don't raise errors when updating the plate reader substate + make referenceWavelength default None.

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/initialize.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/initialize.py
@@ -28,7 +28,7 @@ class InitializeParams(BaseModel):
     )
     sampleWavelengths: List[int] = Field(..., description="Sample wavelengths in nm.")
     referenceWavelength: Optional[int] = Field(
-        ..., description="Optional reference wavelength in nm."
+        None, description="Optional reference wavelength in nm."
     )
 
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -397,10 +397,6 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                     ):
                         lid_labware_id = labware.labware_id
                         break
-                else:
-                    raise errors.AreaNotInDeckConfigurationError(
-                        "Opentrons Plate Reader lid location not found."
-                    )
             self._state.substate_by_module_id[module_id] = AbsorbanceReaderSubState(
                 module_id=AbsorbanceReaderId(module_id),
                 configured=False,

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -4023,12 +4023,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "moduleId",
-        "measureMode",
-        "sampleWavelengths",
-        "referenceWavelength"
-      ]
+      "required": ["moduleId", "measureMode", "sampleWavelengths"]
     },
     "InitializeCreate": {
       "title": "InitializeCreate",


### PR DESCRIPTION
# Overview

This pull request [Opentrons/opentrons/#16339](https://github.com/Opentrons/opentrons/pull/16339) fixed an issue where the plate reader was throwing an error when whenever we would open/close the lid/latch of other modules (heater-shaker/thermocycler). However, it introduced an issue where plate reader protocols would be analyzed forever. While testing this we also found another issue where we could not download the run logs, this pull request fixes both problems.

## Test Plan and Hands on Testing

- [x] Connect a plate reader to the Flex and make sure we can successfully run the following protocol.
- [x] Make sure we can download the run log from the following protocol from the desktop app.

```
from typing import cast
from opentrons import protocol_api
from opentrons.protocol_api.module_contexts import AbsorbanceReaderContext

# metadata
metadata = {
    'protocolName': 'Absorbance Reader Multi read test',
    'author': 'Platform Expansion',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.21",
}

# protocol run function
def run(protocol: protocol_api.ProtocolContext):
    mod = cast(AbsorbanceReaderContext, protocol.load_module("absorbanceReaderV1", "C3"))
    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "C2")
    tiprack_1000 = protocol.load_labware(load_name='opentrons_flex_96_tiprack_1000ul', location="B2")
    trash_labware = protocol.load_trash_bin("B3")
    instrument = protocol.load_instrument("flex_8channel_1000", "right", tip_racks=[tiprack_1000])
    instrument.trash_container = trash_labware

    # pick up tip and perform action
    instrument.pick_up_tip(tiprack_1000.wells_by_name()['A1'])
    instrument.aspirate(100, plate.wells_by_name()['A1'])
    instrument.dispense(100, plate.wells_by_name()['B1'])
    instrument.return_tip()
   
    # Initialize to a single wavelength with reference wavelength
    mod.initialize('single', [600], 450)

    # NOTE: CANNOT INITIALIZE WITH THE LID OPEN

    # Remove the Plate Reader lid using the Gripper.
    mod.open_lid()
    protocol.move_labware(plate, mod, use_gripper=True)
    mod.close_lid()

    # Take a reading and show the resulting absorbance values.
    result = mod.read()
    msg = f"single: {result}"
    protocol.comment(msg=msg)
    protocol.pause(msg=msg)

    # Initialize to multiple wavelengths
    protocol.pause(msg="Perform Multi Read")
    mod.open_lid()
    protocol.move_labware(plate, "C2", use_gripper=True)
    mod.close_lid()
    # NOTE: There is currently a bug in the byonoy library which stops us
    # from using less than 6 wavelengths in multi measure mode.
    mod.initialize('multi', [450, 570, 600])

    mod.open_lid()
    protocol.move_labware(plate, mod, use_gripper=True)
    mod.close_lid()

    # Take reading
    result = mod.read()
    msg = f"multi: {result}"
    protocol.comment(msg=msg)
    protocol.pause(msg=msg)

    # Place the Plate Reader lid back on using the Gripper.
    mod.open_lid()
    protocol.move_labware(plate, "C2", use_gripper=True)
    mod.close_lid()
```

## Changelog

- Dont raise an error when updating the plate reader substate
- Set the `referenceWavelength` Field param of the `Initialize` command to None by default.

## Review requests

- Is there a better way of doing this?
- Am I missing anything?

## Risk assessment
Low, unreleased.