### PR TITLE
fix(labware-library): fix CSS in link button

### DIFF
--- a/labware-library/src/labware-creator/styles.module.css
+++ b/labware-library/src/labware-creator/styles.module.css
@@ -63,16 +63,24 @@
 
 .labware_creator .labware_guide_button {
   /* from legacy --linkb-tn */
-  display: block;
-  width: 100%;
+  display: inline-block;
+  width: auto;
   margin: 1.5rem 0 0.5rem;
-  padding: 1rem;
+  padding: 1rem 2rem;
   border-radius: 3px;
+  background-color: var(--c-blue);
   font-size: var(--fs-body-2);
-  text-align: center;
+  color: white;
   font-family: 'AkkoPro-Regular', 'Ropa Sans', 'Open Sans', sans-serif;
   text-transform: uppercase;
-  cursor: pointer;
+
+  &:visited {
+    color: white;
+  }
+
+  &:hover {
+    background-color: #00f;
+  }
 }
 
 .start_creating_btn:focus {


### PR DESCRIPTION
# Overview
When we migrated from webpack to vite we had to copy a bunch of old preprocessed css from libraries that weren't actual css and it looks like we (meaning I) copied one incorrectly. Good catch @alexjoel42 

closes RQA-3170


## Changelog

- Fix CSS in link button
## Review requests

See bug in ticket, but the "Read the custom labware guide" button should be back now in labware creator

## Risk assessment

Low