### PR TITLE
refactor(components): update RadioButton for desktop use

### DIFF
--- a/components/src/atoms/buttons/RadioButton.tsx
+++ b/components/src/atoms/buttons/RadioButton.tsx
@@ -13,7 +13,6 @@ import {
   RESPONSIVENESS,
   SPACING,
   StyledText,
-  TYPOGRAPHY,
 } from '../..'
 import type { IconName } from '../..'
 import type { StyleProps } from '../../primitives'
@@ -83,7 +82,15 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
   const DISABLED_BUTTON_STYLE = css`
     background-color: ${COLORS.grey35};
     color: ${COLORS.grey50};
-    cursor: ${CURSOR_NOT_ALLOWED};
+
+    &:hover,
+    &:active {
+      background-color: ${COLORS.grey35};
+    }
+
+    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+      cursor: ${CURSOR_NOT_ALLOWED};
+    }
   `
 
   const SettingButtonLabel = styled.label`
@@ -111,6 +118,14 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
         word-wrap: break-word;
       }
     }
+  `
+
+  const SUBBUTTON_LABEL_STYLE = css`
+    color: ${disabled
+      ? COLORS.grey50
+      : isSelected
+      ? COLORS.white
+      : COLORS.grey60};
   `
 
   return (
@@ -154,7 +169,9 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
           {typeof buttonLabel === 'string' ? (
             <StyledText
               oddStyle={isLarge ? 'level4HeaderSemiBold' : 'bodyTextRegular'}
-              desktopStyle="bodyDefaultRegular"
+              desktopStyle={
+                isLarge ? 'bodyDefaultSemiBold' : 'bodyDefaultRegular'
+              }
             >
               {buttonLabel}
             </StyledText>
@@ -163,12 +180,14 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
           )}
         </Flex>
         {subButtonLabel != null ? (
-          <StyledText
-            oddStyle="level4HeaderRegular"
-            fontWeight={TYPOGRAPHY.fontWeightRegular}
-          >
-            {subButtonLabel}
-          </StyledText>
+          <Flex css={SUBBUTTON_LABEL_STYLE}>
+            <StyledText
+              oddStyle={isLarge ? 'level4HeaderRegular' : 'bodyTextRegular'}
+              desktopStyle="bodyDefaultRegular"
+            >
+              {subButtonLabel}
+            </StyledText>
+          </Flex>
         ) : null}
       </SettingButtonLabel>
     </Flex>


### PR DESCRIPTION
Closes [EXEC-735](https://opentrons.atlassian.net/browse/EXEC-735)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We've recently migrated `RadioButton` to `components`. While it used to be an ODD exclusive component, it's now used by the desktop app and utilized in places like drop tip flows, as seen [here](https://www.figma.com/design/OGssKRmCOvuXSqUpK2qXrV/Feature%3A-Error-Recovery-November-Release?node-id=9750-32076&t=IeNOzV9z7lsO7bNo-4). There were a couple styles that were missing/unhandled, so this PR just fixes a couple identified issues:

- Button subtext now has the proper colors.
- Disabled state works on button subtext.
- Hovering desktop `RadioButton` doesn't show the non-disabled active/hover state.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Smoke tested in storybook.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-735]: https://opentrons.atlassian.net/browse/EXEC-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ