### PR TITLE
fix: make relative links absolute in nav for docs subdomain

### DIFF
--- a/api/docs/templates/v2/remote-footer.html
+++ b/api/docs/templates/v2/remote-footer.html
@@ -232,7 +232,7 @@ a.bc-account-address__delete {
 				</div>
 
 				<div class="mt-12 md:mt-20 hidden sm:block">
-					<a href="/">
+					<a href="https://opentrons.com/">
 						<img class="h-8" src="https://opentrons.com/wp-content/uploads/2024/03/LOGO.svg" alt="Opentrons logo" />
 					</a>
 				</div>
@@ -276,11 +276,11 @@ a.bc-account-address__delete {
 									<div class="hidden md:block col-span-2 sm:col-span-1">
 						<p class="text-white opentrons-body"><strong>Products</strong></p>
 						<div class="mt-4 flex flex-col space-y-2">
-															<a href="/products/opentrons-flex-robot/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Opentrons Flex</a>
-															<a href="/products/categories/modules/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Modules</a>
-															<a href="/products/categories/workstations/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Workstations</a>
-															<a href="/instrument-services/" target="_blank" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Services</a>
-															<a href="/products/ot-2-robot/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">OT-2</a>
+															<a href="https://opentrons.com/products/opentrons-flex-robot/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Opentrons Flex</a>
+															<a href="https://opentrons.com/products/categories/modules/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Modules</a>
+															<a href="https://opentrons.com/products/categories/workstations/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Workstations</a>
+															<a href="https://opentrons.com/instrument-services/" target="_blank" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Services</a>
+															<a href="https://opentrons.com/products/ot-2-robot/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">OT-2</a>
 													</div>
 					</div>
 									<div class="hidden md:block col-span-2 sm:col-span-1">
@@ -305,15 +305,15 @@ a.bc-account-address__delete {
 									<div class="hidden md:block col-span-2 sm:col-span-1">
 						<p class="text-white opentrons-body"><strong>About</strong></p>
 						<div class="mt-4 flex flex-col space-y-2">
-															<a href="/about/mission/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Our Mission</a>
-															<a href="/about/events/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Events & Webinars</a>
-															<a href="/about/news/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">News</a>
-															<a href="/about/jobs/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Careers</a>
-															<a href="/partnerships/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">OEM Partnerships</a>
+															<a href="https://opentrons.com/about/mission/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Our Mission</a>
+															<a href="https://opentrons.com/about/events/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Events & Webinars</a>
+															<a href="https://opentrons.com/about/news/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">News</a>
+															<a href="https://opentrons.com/about/jobs/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">Careers</a>
+															<a href="https://opentrons.com/partnerships/" target="_self" class="opentrons-body text-brand-grey-light hover:text-brand-yellow">OEM Partnerships</a>
 													</div>
 					</div>
 								<div class="flex footer-app-button-container sm:col-span-4 col-span-2">
-				<a class="opentrons-outline rounded-full footer-app-button" href="/ot-app/">Download the Opentrons App</a>
+				<a class="opentrons-outline rounded-full footer-app-button" href="https://opentrons.com/ot-app/">Download the Opentrons App</a>
 			</div>
 	
 			</div>

--- a/api/docs/templates/v2/remote-nav.html
+++ b/api/docs/templates/v2/remote-nav.html
@@ -289,7 +289,7 @@ a.bc-account-address__delete {
 		<div class="bg-brand-blue-dark" x-data="{ searchOpen: false }">
 			<div class="max-w-7xl mx-auto flex justify-between px-4 py-3"  >
 				<div class="flex items-center space-x-16">
-					<a href="/">
+					<a href="https://opentrons.com/">
 						<img class="h-8 no-lazy min-w-[130px]" src="https://opentrons.com/wp-content/uploads/2024/06/LOGO2024.svg" id="opt-logo" alt="Opentrons" />
 					</a>
 					<nav class="flex items-center space-x-4 lg:space-x-10" aria-labelledby="primary-navigation" x-show="!searchOpen" x-data="{ menuOpen: false }">
@@ -314,15 +314,15 @@ a.bc-account-address__delete {
 																	<path d="M9 8L0 0H18L9 8Z" />
 																</svg>
 																<div class="grid  grid-cols-9  gap-10 pt-3 pb-7">
-																																																					<a href="/robots/flex/" target="_self" class="flex flex-col items-center group">
+																																																					<a href="https://opentrons.com/robots/flex/" target="_self" class="flex flex-col items-center group">
 																			<img width="68" height="68" src="https://opentrons.com/wp-content/uploads/2023/05/Flex-1.png" alt=""  class="h-16 w-16 no-lazy" alt="" style="object-fit: contain;" />
 																			<span class="mt-1 text-brand-blue-dark font-semibold text-xs group-hover:text-brand-blue text-center">Opentrons Flex</span>
 																		</a>
-																																																					<a href="/robots/ot-2/" target="_self" class="flex flex-col items-center group">
+																																																					<a href="https://opentrons.com/robots/ot-2/" target="_self" class="flex flex-col items-center group">
 																			<img width="68" height="68" src="https://opentrons.com/wp-content/uploads/2023/05/OT2-1.png" alt=""  class="h-16 w-16 no-lazy" alt="" style="object-fit: contain;" />
 																			<span class="mt-1 text-brand-blue-dark font-semibold text-xs group-hover:text-brand-blue text-center">OT-2</span>
 																		</a>
-																																																					<a href="/robots/" target="_self" class="flex flex-col items-center group">
+																																																					<a href="https://opentrons.com/robots/" target="_self" class="flex flex-col items-center group">
 																			<img width="68" height="68" src="https://opentrons.com/wp-content/uploads/2023/05/CKMpare.png" alt=""  class="h-16 w-16 no-lazy" alt="" style="object-fit: contain;" />
 																			<span class="mt-1 text-brand-blue-dark font-semibold text-xs group-hover:text-brand-blue text-center">Compare</span>
 																		</a>
@@ -330,23 +330,23 @@ a.bc-account-address__delete {
 															</div>
 														</div>
 													</div>
-																																																				<a href="/products/categories/workstations" target="_self" class="flex flex-col items-center group">
+																																																				<a href="https://opentrons.com/products/categories/workstations" target="_self" class="flex flex-col items-center group">
 															<img width="68" height="68" src="https://opentrons.com/wp-content/uploads/2023/05/WSnew.png" class="h-16 w-16 no-lazy" alt="" style="object-fit: contain;" />
 															<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center">Workstations</span>
 														</a>
-																																																																	<a href="/products/categories/pipettes" target="_self" class="flex flex-col items-center group">
+																																																																	<a href="https://opentrons.com/products/categories/pipettes" target="_self" class="flex flex-col items-center group">
 															<img width="68" height="68" src="https://opentrons.com/wp-content/uploads/2023/05/Pipettes-2.png" class="h-16 w-16 no-lazy" alt="" style="object-fit: contain;" />
 															<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center">Pipettes</span>
 														</a>
-																																																																	<a href="/products/categories/modules" target="_self" class="flex flex-col items-center group">
+																																																																	<a href="https://opentrons.com/products/categories/modules" target="_self" class="flex flex-col items-center group">
 															<img width="68" height="68" src="https://opentrons.com/wp-content/uploads/2023/05/Modules.png" class="h-16 w-16 no-lazy" alt="" style="object-fit: contain;" />
 															<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center">Modules</span>
 														</a>
-																																																																	<a href="/products/categories/tips-&-labware" target="_self" class="flex flex-col items-center group">
+																																																																	<a href="https://opentrons.com/products/categories/tips-&-labware" target="_self" class="flex flex-col items-center group">
 															<img width="68" height="68" src="https://opentrons.com/wp-content/uploads/2023/05/tiprack-1.png" class="h-16 w-16 no-lazy" alt="" style="object-fit: contain;" />
 															<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center">Tips & Labware</span>
 														</a>
-																																																																	<a href="/products/categories/automation-marketplace/" target="_self" class="flex flex-col items-center group">
+																																																																	<a href="https://opentrons.com/products/categories/automation-marketplace/" target="_self" class="flex flex-col items-center group">
 															<img width="68" height="68" src="https://opentrons.com/wp-content/uploads/2024/03/Marketplace-2.png" class="h-16 w-16 no-lazy" alt="" style="object-fit: contain;" />
 															<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center">Automation Marketplace</span>
 														</a>
@@ -387,7 +387,7 @@ a.bc-account-address__delete {
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/ELISA-1.svg" />
 													<span>ELISA</span>
 												</a>
-																							<a href="/applications/proteomics/" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
+																							<a href="https://opentrons.com/applications/proteomics/" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/Proteomics.svg" />
 													<span>Proteomics</span>
 												</a>
@@ -410,11 +410,11 @@ a.bc-account-address__delete {
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/07/OUR-PARTNERS.svg" />
 													<span>Our Partners</span>
 												</a>
-																							<a href="/partnerships" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
+																							<a href="https://opentrons.com/partnerships" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2023/10/OEM.svg" />
 													<span>OEM Partnerships</span>
 												</a>
-																							<a href="/education/" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
+																							<a href="https://opentrons.com/education/" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/01/Academic.svg" />
 													<span>Education</span>
 												</a>
@@ -450,7 +450,7 @@ a.bc-account-address__delete {
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/Careers.svg" />
 													<span>Careers</span>
 												</a>
-																							<a href="/globalcontacts/" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
+																							<a href="https://opentrons.com/globalcontacts/" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/Global.svg" />
 													<span>Global Contacts</span>
 												</a>
@@ -478,7 +478,7 @@ a.bc-account-address__delete {
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/04/Customer-Stories.svg" />
 													<span>Customer Stories</span>
 												</a>
-																							<a href="/ai/" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
+																							<a href="https://opentrons.com/ai/" target="_self" class="px-8 py-4 border-b border-brand-[#d0d3d5] text-xs font-semibold hover:text-brand-blue flex items-center space-x-3">
 													<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/Robot-Head.svg" />
 													<span>OpentronsAI</span>
 												</a>
@@ -530,7 +530,7 @@ a.bc-account-address__delete {
 						</div>
 
 						<!-- account icon start -->
-						<a type="button"  href="/account/?v=5084002" class="text-white hover:text-brand-yellow flex items-center" x-show="!searchOpen" >
+						<a type="button"  href="https://opentrons.com/account/?v=5084002" class="text-white hover:text-brand-yellow flex items-center" x-show="!searchOpen" >
 								<svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M16.2666 16.9508H16.3131L16.3071 16.9067C15.9722 14.4087 13.7202 12.4688 10.9996 12.4688H7.00067C4.28007 12.4688 2.0229 14.4086 1.69304 16.9068L1.72852 16.9111V16.9508H1.73363H1.76969H16.2666ZM0.0410156 18.4608V17.5518C0.0410156 13.916 3.1621 10.9589 7.00067 10.9589H10.9996C14.8381 10.9589 17.9592 13.916 17.9592 17.5518V18.4608H0.0410156ZM9.00011 8.98912C6.54221 8.98912 4.54102 7.0956 4.54102 4.7641C4.54102 2.4326 6.54221 0.539062 9.00011 0.539062C11.458 0.539062 13.4592 2.4326 13.4592 4.7641C13.4592 7.0956 11.458 8.98912 9.00011 8.98912ZM9.00011 2.04904C7.42832 2.04904 6.1467 3.26472 6.1467 4.7641C6.1467 6.26348 7.42832 7.47917 9.00011 7.47917C10.5719 7.47917 11.8535 6.26348 11.8535 4.7641C11.8535 3.26472 10.5719 2.04904 9.00011 2.04904Z" fill="white"/>
 </svg>
@@ -540,7 +540,7 @@ a.bc-account-address__delete {
 <!-- account icon end -->
 
 <!-- cart icon -->
-				<a x-show="!searchOpen"  id="cart-icon"  href="/cart" class="text-white hover:text-brand-yellow flex items-center">&nbsp;</a>
+				<a x-show="!searchOpen"  id="cart-icon"  href="https://opentrons.com/cart" class="text-white hover:text-brand-yellow flex items-center">&nbsp;</a>
 				<!-- cart icon end -->
 </div>
 
@@ -548,7 +548,7 @@ a.bc-account-address__delete {
 <a href="https://insights.opentrons.com/schedule-demo" class="button-sm bg-white text-brand-blue py-3 px-4 rounded hover:bg-white/60 demo_button">
 						Schedule a Demo
 					</a>
-<a href="/contact/" class="button-sm bg-brand-blue text-white py-3 px-4 rounded hover:bg-brand-blue/60 nav_contact_button">
+<a href="https://opentrons.com/contact/" class="button-sm bg-brand-blue text-white py-3 px-4 rounded hover:bg-brand-blue/60 nav_contact_button">
 						Contact Sales
 					</a>
 					
@@ -571,7 +571,7 @@ a.bc-account-address__delete {
 					<span :class="{ 'translate-y-0 -rotate-45': menuOpen, 'translate-y-2': !menuOpen }" class="transform transition w-full h-px bg-current absolute translate-y-2"></span>
 				</div>
 			</button>
-			<a href="/">
+			<a href="https://opentrons.com/">
 				<img class="h-9 no-lazy" src="https://opentrons.com/wp-content/themes/timberland/theme/assets/images/logo.png" alt="Opentrons logo" />
 			</a>
 			<!-- Search -->
@@ -620,15 +620,15 @@ a.bc-account-address__delete {
 																	<path d="M9 8L0 0H18L9 8Z" />
 																</svg>
 																<div class="flex space-x-8 py-6 overflow-x-scroll overflow-hidden">
-																																			<a href="/robots/flex/" target="_self" class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3" style="max-width:140px;">
+																																			<a href="https://opentrons.com/robots/flex/" target="_self" class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3" style="max-width:140px;">
 																			<img class="h-12 w-auto no-lazy" src="https://opentrons.com/wp-content/uploads/2023/05/Flex-1.png" alt="" />
 																			<span class="mt-1 text-brand-blue-dark font-semibold text-xs group-hover:text-brand-blue text-center">Opentrons Flex</span>
 																		</a>
-																																			<a href="/robots/ot-2/" target="_self" class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3" style="max-width:140px;">
+																																			<a href="https://opentrons.com/robots/ot-2/" target="_self" class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3" style="max-width:140px;">
 																			<img class="h-12 w-auto no-lazy" src="https://opentrons.com/wp-content/uploads/2023/05/OT2-1.png" alt="" />
 																			<span class="mt-1 text-brand-blue-dark font-semibold text-xs group-hover:text-brand-blue text-center">OT-2</span>
 																		</a>
-																																			<a href="/robots/" target="_self" class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3" style="max-width:140px;">
+																																			<a href="https://opentrons.com/robots/" target="_self" class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3" style="max-width:140px;">
 																			<img class="h-12 w-auto no-lazy" src="https://opentrons.com/wp-content/uploads/2023/05/CKMpare.png" alt="" />
 																			<span class="mt-1 text-brand-blue-dark font-semibold text-xs group-hover:text-brand-blue text-center">Compare</span>
 																		</a>
@@ -637,31 +637,31 @@ a.bc-account-address__delete {
 														</div>
 													</div>
 													
-																														<a href="/products/categories/workstations" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
+																														<a href="https://opentrons.com/products/categories/workstations" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
 												<img class="w-12 h-12 no-lazy" src="https://opentrons.com/wp-content/uploads/2023/05/WSnew.png" alt="" />
 												<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center py-1">Workstations</span>
 											</a>
 										
 										
-																														<a href="/products/categories/pipettes" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
+																														<a href="https://opentrons.com/products/categories/pipettes" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
 												<img class="w-12 h-12 no-lazy" src="https://opentrons.com/wp-content/uploads/2023/05/Pipettes-2.png" alt="" />
 												<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center py-1">Pipettes</span>
 											</a>
 										
 										
-																														<a href="/products/categories/modules" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
+																														<a href="https://opentrons.com/products/categories/modules" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
 												<img class="w-12 h-12 no-lazy" src="https://opentrons.com/wp-content/uploads/2023/05/Modules.png" alt="" />
 												<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center py-1">Modules</span>
 											</a>
 										
 										
-																														<a href="/products/categories/tips-&-labware" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
+																														<a href="https://opentrons.com/products/categories/tips-&-labware" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
 												<img class="w-12 h-12 no-lazy" src="https://opentrons.com/wp-content/uploads/2023/05/tiprack-1.png" alt="" />
 												<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center py-1">Tips & Labware</span>
 											</a>
 										
 										
-																														<a href="/products/categories/automation-marketplace/" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
+																														<a href="https://opentrons.com/products/categories/automation-marketplace/" target="_self"  class="flex flex-col items-center group shrink-0 grow-0 pl-3 pr-3">
 												<img class="w-12 h-12 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/03/Marketplace-2.png" alt="" />
 												<span class="mt-1 text-brand-blue-dark font-semibold text-xs text-center py-1">Automation Marketplace</span>
 											</a>
@@ -710,7 +710,7 @@ a.bc-account-address__delete {
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/ELISA-1.svg" />
 									<span>ELISA</span>
 								</a>
-																	<a href="/applications/proteomics/" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
+																	<a href="https://opentrons.com/applications/proteomics/" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/Proteomics.svg" />
 									<span>Proteomics</span>
 								</a>
@@ -736,11 +736,11 @@ a.bc-account-address__delete {
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/07/OUR-PARTNERS.svg" />
 									<span>Our Partners</span>
 								</a>
-																	<a href="/partnerships" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
+																	<a href="https://opentrons.com/partnerships" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2023/10/OEM.svg" />
 									<span>OEM Partnerships</span>
 								</a>
-																	<a href="/education/" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
+																	<a href="https://opentrons.com/education/" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/01/Academic.svg" />
 									<span>Education</span>
 								</a>
@@ -779,7 +779,7 @@ a.bc-account-address__delete {
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/Careers.svg" />
 									<span>Careers</span>
 								</a>
-																	<a href="/globalcontacts/" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
+																	<a href="https://opentrons.com/globalcontacts/" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/Global.svg" />
 									<span>Global Contacts</span>
 								</a>
@@ -810,7 +810,7 @@ a.bc-account-address__delete {
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/04/Customer-Stories.svg" />
 									<span>Customer Stories</span>
 								</a>
-																	<a href="/ai/" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
+																	<a href="https://opentrons.com/ai/" target="_self" class="py-4 px-5 text-lg font-semibold text-brand-blue-dark border-b border-brand-gray-medium flex items-center space-x-4">
 									<img class="w-7 h-7 no-lazy" src="https://opentrons.com/wp-content/uploads/2024/06/Robot-Head.svg" />
 									<span>OpentronsAI</span>
 								</a>
@@ -850,13 +850,13 @@ a.bc-account-address__delete {
 			<div class="bg-white px-4 py-4">
 				<div class="flex space-x-4 justify-center border-b border-brand-gray-medium pt-3 pb-8">
 					<a href="https://insights.opentrons.com/schedule-demo" class="border border-brand-blue text-brand-blue text-xs leading-none font-medium py-3 px-4 uppercase rounded font-serif demo_button" target="_blank">Schedule a Demo</a>
-					<a href="/contact/" class="bg-brand-blue text-white text-xs leading-none font-medium py-3 px-4 uppercase rounded font-serif nav_contact_button">Contact Sales</a>
+					<a href="https://opentrons.com/contact/" class="bg-brand-blue text-white text-xs leading-none font-medium py-3 px-4 uppercase rounded font-serif nav_contact_button">Contact Sales</a>
 				</div>
 
 				<div class="flex flex-row justify-evenly px-4 py-4">
 					
 					<!-- account icon start -->
-						<a type="button" class="mobile-account-links" href="/account/" class="text-blue-1100 hover:text-brand-yellow flex items-center">
+						<a type="button" class="mobile-account-links" href="https://opentrons.com/account/" class="text-blue-1100 hover:text-brand-yellow flex items-center">
 								<svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
 								<path d="M16.2666 16.9508H16.3131L16.3071 16.9067C15.9722 14.4087 13.7202 12.4688 10.9996 12.4688H7.00067C4.28007 12.4688 2.0229 14.4086 1.69304 16.9068L1.72852 16.9111V16.9508H1.73363H1.76969H16.2666ZM0.0410156 18.4608V17.5518C0.0410156 13.916 3.1621 10.9589 7.00067 10.9589H10.9996C14.8381 10.9589 17.9592 13.916 17.9592 17.5518V18.4608H0.0410156ZM9.00011 8.98912C6.54221 8.98912 4.54102 7.0956 4.54102 4.7641C4.54102 2.4326 6.54221 0.539062 9.00011 0.539062C11.458 0.539062 13.4592 2.4326 13.4592 4.7641C13.4592 7.0956 11.458 8.98912 9.00011 8.98912ZM9.00011 2.04904C7.42832 2.04904 6.1467 3.26472 6.1467 4.7641C6.1467 6.26348 7.42832 7.47917 9.00011 7.47917C10.5719 7.47917 11.8535 6.26348 11.8535 4.7641C11.8535 3.26472 10.5719 2.04904 9.00011 2.04904Z" fill="#006cfa"/>
 								</svg>
@@ -872,7 +872,7 @@ a.bc-account-address__delete {
 										<circle cx="17.5" cy="4.5" r="4.5" fill="#DE1B1B"/>
 									</svg>
 								</div>
-								<a href="/cart"><span id="cart-icon-mobile" class="text-blue-1100 hover:text-brand-yellow flex items-center">&nbsp;</span>
+								<a href="https://opentrons.com/cart"><span id="cart-icon-mobile" class="text-blue-1100 hover:text-brand-yellow flex items-center">&nbsp;</span>
 								<!-- cart icon end -->
 								<span>CART</span>
 							</a>


### PR DESCRIPTION
# Overview

Our shared nav resources have a mix of relative and absolute links. This is not great!

It means we have to edit the actual HTML for inclusion on the docs site. This PR does a find-and-replace to accomplish that.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-fix-nav-links/v2/)
I clicked on all the links this time.

## Changelog

Replace `href="/` with `href="https://opentrons.com/` across the board.

## Review requests

Any sneaky other link format I could have missed?

## Risk assessment

low. we will have to replicate this in the future if we have to update the nav (and its new version doesn't fix this problem)