### PR TITLE
feature(api): Put command implementations in charge of `PipetteStore` updates for tip state and pipette config

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -8,6 +8,7 @@ from .pipetting_common import PipetteIdMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors.error_occurrence import ErrorOccurrence
 from .configuring_common import PipetteConfigUpdateResultMixin
+from ..state.update_types import StateUpdate
 
 if TYPE_CHECKING:
     from ..execution import EquipmentHandler
@@ -67,6 +68,13 @@ class ConfigureForVolumeImplementation(
             tip_overlap_version=params.tipOverlapNotAfterVersion,
         )
 
+        state_update = StateUpdate()
+        state_update.update_pipette_config(
+            pipette_id=pipette_result.pipette_id,
+            config=pipette_result.static_config,
+            serial_number=pipette_result.serial_number,
+        )
+
         return SuccessData(
             public=ConfigureForVolumeResult(),
             private=ConfigureForVolumePrivateResult(
@@ -74,6 +82,7 @@ class ConfigureForVolumeImplementation(
                 serial_number=pipette_result.serial_number,
                 config=pipette_result.static_config,
             ),
+            state_update=state_update,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -1,5 +1,6 @@
 """Configure nozzle layout command request, result, and implementation models."""
 from __future__ import annotations
+from opentrons.protocol_engine.state.update_types import StateUpdate
 from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type, Union
 from typing_extensions import Literal
@@ -83,6 +84,11 @@ class ConfigureNozzleLayoutImplementation(
         nozzle_map = await self._equipment.configure_nozzle_layout(
             pipette_id=params.pipetteId,
             **nozzle_params,
+        )
+
+        update_state = StateUpdate()
+        update_state.update_pipette_nozzle(
+            pipette_id=params.pipetteId, nozzle_map=nozzle_map
         )
 
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -97,6 +97,7 @@ class ConfigureNozzleLayoutImplementation(
                 pipette_id=params.pipetteId,
                 nozzle_map=nozzle_map,
             ),
+            state_update=update_state,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -114,6 +114,8 @@ class DropTipImplementation(
 
         await self._tip_handler.drop_tip(pipette_id=pipette_id, home_after=home_after)
 
+        state_update.update_tip_state(pipette_id=params.pipetteId, tip_geometry=None)
+
         return SuccessData(
             public=DropTipResult(position=deck_point),
             private=None,

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -1,5 +1,7 @@
 """Drop tip in place command request, result, and implementation models."""
 from __future__ import annotations
+from opentrons.protocol_engine.state import update_types
+from opentrons.protocol_engine.types import TipGeometry
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
@@ -54,7 +56,13 @@ class DropTipInPlaceImplementation(
             pipette_id=params.pipetteId, home_after=params.homeAfter
         )
 
-        return SuccessData(public=DropTipInPlaceResult(), private=None)
+        state_update = update_types.StateUpdate()
+
+        state_update.update_tip_state(pipette_id=params.pipetteId, tip_geometry=None)
+
+        return SuccessData(
+            public=DropTipInPlaceResult(), private=None, state_update=state_update
+        )
 
 
 class DropTipInPlace(

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -1,7 +1,6 @@
 """Drop tip in place command request, result, and implementation models."""
 from __future__ import annotations
 from opentrons.protocol_engine.state import update_types
-from opentrons.protocol_engine.types import TipGeometry
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -1,6 +1,7 @@
 """Load pipette command request, result, and implementation models."""
 from __future__ import annotations
 
+from opentrons.protocol_engine.state.update_types import StateUpdate
 from opentrons_shared_data.pipette.pipette_load_name_conversions import (
     convert_to_pipette_name_type,
 )
@@ -121,6 +122,14 @@ class LoadPipetteImplementation(
             mount=params.mount,
             pipette_id=params.pipetteId,
             tip_overlap_version=params.tipOverlapNotAfterVersion,
+        )
+
+        state_update = StateUpdate()
+        state_update.set_load_pipette(
+            pipette_id=loaded_pipette.pipette_id,
+            pipette_name=params.pipetteName,
+            mount=params.mount,
+            liquid_presence_detection=params.liquidPresenceDetection,
         )
 
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -131,6 +131,11 @@ class LoadPipetteImplementation(
             mount=params.mount,
             liquid_presence_detection=params.liquidPresenceDetection,
         )
+        state_update.update_pipette_config(
+            pipette_id=loaded_pipette.pipette_id,
+            serial_number=loaded_pipette.serial_number,
+            config=loaded_pipette.static_config,
+        )
 
         return SuccessData(
             public=LoadPipetteResult(pipetteId=loaded_pipette.pipette_id),
@@ -139,6 +144,7 @@ class LoadPipetteImplementation(
                 serial_number=loaded_pipette.serial_number,
                 config=loaded_pipette.static_config,
             ),
+            state_update=state_update,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -9,7 +9,7 @@ from typing_extensions import Literal
 from ..errors import ErrorOccurrence, TipNotAttachedError
 from ..resources import ModelUtils
 from ..state import update_types
-from ..types import DeckPoint
+from ..types import DeckPoint, TipGeometry
 from .pipetting_common import (
     PipetteIdMixin,
     WellLocationMixin,
@@ -129,6 +129,14 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 pipette_id=pipette_id,
                 labware_id=labware_id,
                 well_name=well_name,
+            )
+            state_update.update_tip_state(
+                pipette_id=pipette_id,
+                tip_geometry=TipGeometry(
+                    volume=tip_geometry.volume,
+                    length=tip_geometry.length,
+                    diameter=tip_geometry.diameter,
+                ),
             )
         except TipNotAttachedError as e:
             return DefinedErrorData(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -1,5 +1,6 @@
 """Command models to drop tip in place while plunger positions are unknown."""
 from __future__ import annotations
+from opentrons.protocol_engine.state.update_types import StateUpdate
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
@@ -72,7 +73,12 @@ class UnsafeDropTipInPlaceImplementation(
             pipette_id=params.pipetteId, home_after=params.homeAfter
         )
 
-        return SuccessData(public=UnsafeDropTipInPlaceResult(), private=None)
+        state_update = StateUpdate()
+        state_update.update_tip_state(pipette_id=params.pipetteId, tip_geometry=None)
+
+        return SuccessData(
+            public=UnsafeDropTipInPlaceResult(), private=None, state_update=state_update
+        )
 
 
 class UnsafeDropTipInPlace(

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -38,9 +38,6 @@ from ..types import (
     CurrentPipetteLocation,
     TipGeometry,
 )
-from ..commands.configuring_common import (
-    PipetteNozzleLayoutResultMixin,
-)
 from ..actions import (
     Action,
     SetPipetteMovementSpeedAction,
@@ -148,7 +145,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(action, SetPipetteMovementSpeedAction):
             self._state.movement_speed_by_id[action.pipette_id] = action.speed
 
-    def _handle_command(  # noqa: C901
+    def _handle_command(
         self, action: Union[SucceedCommandAction, FailCommandAction]
     ) -> None:
         self._set_load_pipette(action)

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -5,6 +5,7 @@ import dataclasses
 import enum
 import typing
 
+from opentrons.protocol_engine.resources import pipette_data_provider
 from opentrons.protocol_engine.types import DeckPoint, LabwareLocation
 from opentrons.types import MountType
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
@@ -110,12 +111,21 @@ class LoadPipetteUpdate:
 
 
 @dataclasses.dataclass
+class PipetteConfigUpdate:
+    pipette_id: str
+    serial_number: str
+    config: pipette_data_provider.LoadedStaticPipetteData
+
+
+@dataclasses.dataclass
 class StateUpdate:
     """Represents an update to perform on engine state."""
 
     pipette_location: PipetteLocationUpdate | NoChangeType | ClearType = NO_CHANGE
 
     loaded_pipette: LoadPipetteUpdate | NoChangeType = NO_CHANGE
+
+    pipette_config: PipetteConfigUpdate | NoChangeType = NO_CHANGE
 
     labware_location: LabwareLocationUpdate | NoChangeType = NO_CHANGE
 
@@ -220,4 +230,14 @@ class StateUpdate:
             pipette_name=pipette_name,
             mount=mount,
             liquid_presence_detection=liquid_presence_detection,
+        )
+
+    def update_pipette_config(
+        self,
+        pipette_id: str,
+        config: pipette_data_provider.LoadedStaticPipetteData,
+        serial_number: str,
+    ) -> None:
+        self.pipette_config = PipetteConfigUpdate(
+            pipette_id=pipette_id, config=config, serial_number=serial_number
         )

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -214,6 +214,7 @@ class StateUpdate:
         new_location: LabwareLocation,
         new_offset_id: str | None,
     ) -> None:
+        """Set labware location."""
         self.labware_location = LabwareLocationUpdate(
             labware_id=labware_id,
             new_location=new_location,
@@ -248,6 +249,7 @@ class StateUpdate:
         mount: MountType,
         liquid_presence_detection: typing.Optional[bool],
     ) -> None:
+        """Add loaded pipette to state."""
         self.loaded_pipette = LoadPipetteUpdate(
             pipette_id=pipette_id,
             pipette_name=pipette_name,
@@ -261,11 +263,13 @@ class StateUpdate:
         config: pipette_data_provider.LoadedStaticPipetteData,
         serial_number: str,
     ) -> None:
+        """Update pipette config."""
         self.pipette_config = PipetteConfigUpdate(
             pipette_id=pipette_id, config=config, serial_number=serial_number
         )
 
     def update_pipette_nozzle(self, pipette_id: str, nozzle_map: NozzleMap) -> None:
+        """Update pipette nozzle map."""
         self.pipette_nozzle_map = PipetteNozzleMapUpdate(
             pipette_id=pipette_id, nozzle_map=nozzle_map
         )
@@ -273,6 +277,7 @@ class StateUpdate:
     def update_tip_state(
         self, pipette_id: str, tip_geometry: typing.Optional[TipGeometry]
     ) -> None:
+        """Update tip state."""
         self.pipette_tip_state = PipetteTipStateUpdate(
             pipette_id=pipette_id, tip_geometry=tip_geometry
         )

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -5,6 +5,7 @@ import dataclasses
 import enum
 import typing
 
+from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_engine.resources import pipette_data_provider
 from opentrons.protocol_engine.types import DeckPoint, LabwareLocation
 from opentrons.types import MountType
@@ -112,9 +113,19 @@ class LoadPipetteUpdate:
 
 @dataclasses.dataclass
 class PipetteConfigUpdate:
+    """Update pipette config."""
+
     pipette_id: str
     serial_number: str
     config: pipette_data_provider.LoadedStaticPipetteData
+
+
+@dataclasses.dataclass
+class PipetteNozzleMapUpdate:
+    """Update pipette nozzle map."""
+
+    pipette_id: str
+    nozzle_map: NozzleMap
 
 
 @dataclasses.dataclass
@@ -126,6 +137,8 @@ class StateUpdate:
     loaded_pipette: LoadPipetteUpdate | NoChangeType = NO_CHANGE
 
     pipette_config: PipetteConfigUpdate | NoChangeType = NO_CHANGE
+
+    pipette_nozzle_map: PipetteNozzleMapUpdate | NoChangeType = NO_CHANGE
 
     labware_location: LabwareLocationUpdate | NoChangeType = NO_CHANGE
 
@@ -240,4 +253,9 @@ class StateUpdate:
     ) -> None:
         self.pipette_config = PipetteConfigUpdate(
             pipette_id=pipette_id, config=config, serial_number=serial_number
+        )
+
+    def update_pipette_nozzle(self, pipette_id: str, nozzle_map: NozzleMap) -> None:
+        self.pipette_nozzle_map = PipetteNozzleMapUpdate(
+            pipette_id=pipette_id, nozzle_map=nozzle_map
         )

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -7,7 +7,7 @@ import typing
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_engine.resources import pipette_data_provider
-from opentrons.protocol_engine.types import DeckPoint, LabwareLocation
+from opentrons.protocol_engine.types import DeckPoint, LabwareLocation, TipGeometry
 from opentrons.types import MountType
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.pipette.types import PipetteNameType
@@ -129,6 +129,14 @@ class PipetteNozzleMapUpdate:
 
 
 @dataclasses.dataclass
+class PipetteTipStateUpdate:
+    """Update pipette tip state."""
+
+    pipette_id: str
+    tip_geometry: typing.Optional[TipGeometry]
+
+
+@dataclasses.dataclass
 class StateUpdate:
     """Represents an update to perform on engine state."""
 
@@ -139,6 +147,8 @@ class StateUpdate:
     pipette_config: PipetteConfigUpdate | NoChangeType = NO_CHANGE
 
     pipette_nozzle_map: PipetteNozzleMapUpdate | NoChangeType = NO_CHANGE
+
+    pipette_tip_state: PipetteTipStateUpdate | NoChangeType = NO_CHANGE
 
     labware_location: LabwareLocationUpdate | NoChangeType = NO_CHANGE
 
@@ -258,4 +268,11 @@ class StateUpdate:
     def update_pipette_nozzle(self, pipette_id: str, nozzle_map: NozzleMap) -> None:
         self.pipette_nozzle_map = PipetteNozzleMapUpdate(
             pipette_id=pipette_id, nozzle_map=nozzle_map
+        )
+
+    def update_tip_state(
+        self, pipette_id: str, tip_geometry: typing.Optional[TipGeometry]
+    ) -> None:
+        self.pipette_tip_state = PipetteTipStateUpdate(
+            pipette_id=pipette_id, tip_geometry=tip_geometry
         )

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -207,7 +207,7 @@ class StateUpdate:
                 new_deck_point=new_deck_point,
             )
 
-    def set_labware_location(  # noqa: D102
+    def set_labware_location(
         self,
         *,
         labware_id: str,

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -6,7 +6,9 @@ import enum
 import typing
 
 from opentrons.protocol_engine.types import DeckPoint, LabwareLocation
+from opentrons.types import MountType
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 
 class _NoChangeEnum(enum.Enum):
@@ -98,10 +100,22 @@ class LoadedLabwareUpdate(LabwareLocationUpdate):
 
 
 @dataclasses.dataclass
+class LoadPipetteUpdate:
+    """Update loaded pipette."""
+
+    pipette_id: str
+    pipette_name: PipetteNameType
+    mount: MountType
+    liquid_presence_detection: typing.Optional[bool]
+
+
+@dataclasses.dataclass
 class StateUpdate:
     """Represents an update to perform on engine state."""
 
     pipette_location: PipetteLocationUpdate | NoChangeType | ClearType = NO_CHANGE
+
+    loaded_pipette: LoadPipetteUpdate | NoChangeType = NO_CHANGE
 
     labware_location: LabwareLocationUpdate | NoChangeType = NO_CHANGE
 
@@ -193,3 +207,17 @@ class StateUpdate:
     def clear_all_pipette_locations(self) -> None:
         """Mark all pipettes as having an unknown location."""
         self.pipette_location = CLEAR
+
+    def set_load_pipette(
+        self,
+        pipette_id: str,
+        pipette_name: PipetteNameType,
+        mount: MountType,
+        liquid_presence_detection: typing.Optional[bool],
+    ) -> None:
+        self.loaded_pipette = LoadPipetteUpdate(
+            pipette_id=pipette_id,
+            pipette_name=pipette_name,
+            mount=mount,
+            liquid_presence_detection=liquid_presence_detection,
+        )

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -754,10 +754,17 @@ class LegacyCommandMapper:
             # We just set this above, so we know it's not None.
             started_at=succeeded_command.startedAt,  # type: ignore[arg-type]
         )
+        state_update = StateUpdate()
+        state_update.set_load_pipette(
+            pipette_id=pipette_id,
+            mount=succeeded_command.params.mount,
+            pipette_name=succeeded_command.params.pipetteName,
+            liquid_presence_detection=succeeded_command.params.liquidPresenceDetection,
+        )
         succeed_action = pe_actions.SucceedCommandAction(
             command=succeeded_command,
             private_result=pipette_config_result,
-            state_update=StateUpdate(),
+            state_update=state_update,
         )
 
         self._command_count["LOAD_PIPETTE"] = count + 1

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -1,4 +1,9 @@
 """Test load pipette commands."""
+from opentrons.protocol_engine.state.update_types import (
+    LoadPipetteUpdate,
+    PipetteConfigUpdate,
+    StateUpdate,
+)
 import pytest
 from decoy import Decoy
 
@@ -83,5 +88,10 @@ async def test_configure_for_volume_implementation(
         public=ConfigureForVolumeResult(),
         private=ConfigureForVolumePrivateResult(
             pipette_id="pipette-id", serial_number="some number", config=config
+        ),
+        state_update=StateUpdate(
+            pipette_config=PipetteConfigUpdate(
+                pipette_id="pipette-id", serial_number="some number", config=config
+            )
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -1,6 +1,5 @@
 """Test load pipette commands."""
 from opentrons.protocol_engine.state.update_types import (
-    LoadPipetteUpdate,
     PipetteConfigUpdate,
     StateUpdate,
 )

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
@@ -1,4 +1,8 @@
 """Test configure nozzle layout commands."""
+from opentrons.protocol_engine.state.update_types import (
+    PipetteNozzleMapUpdate,
+    StateUpdate,
+)
 import pytest
 from decoy import Decoy
 from typing import Union, Dict
@@ -145,5 +149,11 @@ async def test_configure_nozzle_layout_implementation(
         private=ConfigureNozzleLayoutPrivateResult(
             pipette_id="pipette-id",
             nozzle_map=expected_nozzlemap,
+        ),
+        state_update=StateUpdate(
+            pipette_nozzle_map=PipetteNozzleMapUpdate(
+                pipette_id="pipette-id",
+                nozzle_map=expected_nozzlemap,
+            )
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -123,6 +123,10 @@ async def test_drop_tip_implementation(
                     well_name="A3",
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
+            ),
+            pipette_tip_state=update_types.PipetteTipStateUpdate(
+                pipette_id="abc",
+                tip_geometry=None
             )
         ),
     )
@@ -196,6 +200,10 @@ async def test_drop_tip_with_alternating_locations(
                     well_name="A3",
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
+            ),
+            pipette_tip_state=update_types.PipetteTipStateUpdate(
+                pipette_id="abc",
+                tip_geometry=None
             )
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -125,9 +125,8 @@ async def test_drop_tip_implementation(
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
             pipette_tip_state=update_types.PipetteTipStateUpdate(
-                pipette_id="abc",
-                tip_geometry=None
-            )
+                pipette_id="abc", tip_geometry=None
+            ),
         ),
     )
 
@@ -202,8 +201,7 @@ async def test_drop_tip_with_alternating_locations(
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
             pipette_tip_state=update_types.PipetteTipStateUpdate(
-                pipette_id="abc",
-                tip_geometry=None
-            )
+                pipette_id="abc", tip_geometry=None
+            ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -1,4 +1,5 @@
 """Test drop tip in place commands."""
+from opentrons.protocol_engine.state.update_types import PipetteTipStateUpdate, StateUpdate
 import pytest
 from decoy import Decoy
 
@@ -29,7 +30,13 @@ async def test_drop_tip_implementation(
 
     result = await subject.execute(params)
 
-    assert result == SuccessData(public=DropTipInPlaceResult(), private=None)
+    assert result == SuccessData(public=DropTipInPlaceResult(), private=None,
+                                 state_update=StateUpdate(
+                                     pipette_tip_state=PipetteTipStateUpdate(
+                                         pipette_id="abc",
+                                         tip_geometry=None
+                                     )
+                                 ))
 
     decoy.verify(
         await mock_tip_handler.drop_tip(pipette_id="abc", home_after=False),

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -1,5 +1,8 @@
 """Test drop tip in place commands."""
-from opentrons.protocol_engine.state.update_types import PipetteTipStateUpdate, StateUpdate
+from opentrons.protocol_engine.state.update_types import (
+    PipetteTipStateUpdate,
+    StateUpdate,
+)
 import pytest
 from decoy import Decoy
 
@@ -30,13 +33,13 @@ async def test_drop_tip_implementation(
 
     result = await subject.execute(params)
 
-    assert result == SuccessData(public=DropTipInPlaceResult(), private=None,
-                                 state_update=StateUpdate(
-                                     pipette_tip_state=PipetteTipStateUpdate(
-                                         pipette_id="abc",
-                                         tip_geometry=None
-                                     )
-                                 ))
+    assert result == SuccessData(
+        public=DropTipInPlaceResult(),
+        private=None,
+        state_update=StateUpdate(
+            pipette_tip_state=PipetteTipStateUpdate(pipette_id="abc", tip_geometry=None)
+        ),
+    )
 
     decoy.verify(
         await mock_tip_handler.drop_tip(pipette_id="abc", home_after=False),

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -1,5 +1,9 @@
 """Test load pipette commands."""
-from opentrons.protocol_engine.state.update_types import LoadPipetteUpdate, StateUpdate
+from opentrons.protocol_engine.state.update_types import (
+    LoadPipetteUpdate,
+    PipetteConfigUpdate,
+    StateUpdate,
+)
 import pytest
 from decoy import Decoy
 
@@ -94,10 +98,14 @@ async def test_load_pipette_implementation(
                 pipette_name=PipetteNameType.P300_SINGLE,
                 mount=MountType.LEFT,
                 pipette_id="some id",
-                liquid_presence_detection=None
+                liquid_presence_detection=None,
             ),
-            pipette_config=config_data
-        )
+            pipette_config=PipetteConfigUpdate(
+                pipette_id="some id",
+                serial_number="some-serial-number",
+                config=config_data,
+            ),
+        ),
     )
 
 
@@ -153,15 +161,19 @@ async def test_load_pipette_implementation_96_channel(
         private=LoadPipettePrivateResult(
             pipette_id="pipette-id", serial_number="some id", config=config_data
         ),
-                state_update=StateUpdate(
+        state_update=StateUpdate(
             loaded_pipette=LoadPipetteUpdate(
-                pipette_name=PipetteNameType.P300_SINGLE,
+                pipette_name=PipetteNameType.P1000_96,
                 mount=MountType.LEFT,
-                pipette_id="some id",
-                liquid_presence_detection=None
+                pipette_id="pipette-id",
+                liquid_presence_detection=None,
             ),
-            pipette_config=config_data
-        )
+            pipette_config=PipetteConfigUpdate(
+                pipette_id="pipette-id",
+                serial_number="some id",
+                config=config_data,
+            ),
+        ),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -1,4 +1,5 @@
 """Test load pipette commands."""
+from opentrons.protocol_engine.state.update_types import LoadPipetteUpdate, StateUpdate
 import pytest
 from decoy import Decoy
 
@@ -88,6 +89,15 @@ async def test_load_pipette_implementation(
         private=LoadPipettePrivateResult(
             pipette_id="some id", serial_number="some-serial-number", config=config_data
         ),
+        state_update=StateUpdate(
+            loaded_pipette=LoadPipetteUpdate(
+                pipette_name=PipetteNameType.P300_SINGLE,
+                mount=MountType.LEFT,
+                pipette_id="some id",
+                liquid_presence_detection=None
+            ),
+            pipette_config=config_data
+        )
     )
 
 
@@ -143,6 +153,15 @@ async def test_load_pipette_implementation_96_channel(
         private=LoadPipettePrivateResult(
             pipette_id="pipette-id", serial_number="some id", config=config_data
         ),
+                state_update=StateUpdate(
+            loaded_pipette=LoadPipetteUpdate(
+                pipette_name=PipetteNameType.P300_SINGLE,
+                mount=MountType.LEFT,
+                pipette_id="some id",
+                liquid_presence_detection=None
+            ),
+            pipette_config=config_data
+        )
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -81,8 +81,8 @@ async def test_success(
             ),
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
-                tip_geometry=TipGeometry(length=42, diameter=5, volume=300)
-            )
+                tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -78,6 +78,10 @@ async def test_success(
                 pipette_id="pipette-id",
                 new_location=update_types.Well(labware_id="labware-id", well_name="A3"),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
+            ),
+            pipette_tip_state=update_types.PipetteTipStateUpdate(
+                pipette_id="pipette-id",
+                tip_geometry=TipGeometry(length=42, diameter=5, volume=300)
             )
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -1,4 +1,5 @@
 """Test unsafe drop tip in place commands."""
+from opentrons.protocol_engine.state.update_types import PipetteTipStateUpdate, StateUpdate
 import pytest
 from decoy import Decoy
 
@@ -44,7 +45,13 @@ async def test_drop_tip_implementation(
 
     result = await subject.execute(params)
 
-    assert result == SuccessData(public=UnsafeDropTipInPlaceResult(), private=None)
+    assert result == SuccessData(public=UnsafeDropTipInPlaceResult(), private=None,
+                                 state_update=StateUpdate(
+                                     pipette_tip_state=PipetteTipStateUpdate(
+                                         pipette_id="abc",
+                                         tip_geometry=None
+                                     )
+                                 ))
 
     decoy.verify(
         await ot3_hardware_api.update_axis_position_estimations([Axis.P_L]),

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -1,5 +1,8 @@
 """Test unsafe drop tip in place commands."""
-from opentrons.protocol_engine.state.update_types import PipetteTipStateUpdate, StateUpdate
+from opentrons.protocol_engine.state.update_types import (
+    PipetteTipStateUpdate,
+    StateUpdate,
+)
 import pytest
 from decoy import Decoy
 
@@ -45,13 +48,13 @@ async def test_drop_tip_implementation(
 
     result = await subject.execute(params)
 
-    assert result == SuccessData(public=UnsafeDropTipInPlaceResult(), private=None,
-                                 state_update=StateUpdate(
-                                     pipette_tip_state=PipetteTipStateUpdate(
-                                         pipette_id="abc",
-                                         tip_geometry=None
-                                     )
-                                 ))
+    assert result == SuccessData(
+        public=UnsafeDropTipInPlaceResult(),
+        private=None,
+        state_update=StateUpdate(
+            pipette_tip_state=PipetteTipStateUpdate(pipette_id="abc", tip_geometry=None)
+        ),
+    )
 
     decoy.verify(
         await ot3_hardware_api.update_axis_position_estimations([Axis.P_L]),

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -99,7 +99,13 @@ def test_location_state_update(subject: PipetteStore) -> None:
                         well_name="let's go party",
                     ),
                     new_deck_point=DeckPoint(x=111, y=222, z=333),
-                )
+                ),
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="pipette-id",
+                    liquid_presence_detection=None,
+                    pipette_name=PipetteNameType.P300_SINGLE,
+                    mount=MountType.RIGHT,
+                ),
             ),
         )
     )
@@ -193,7 +199,20 @@ def test_handles_load_pipette(subject: PipetteStore) -> None:
         mount=MountType.LEFT,
     )
 
-    subject.handle_action(SucceedCommandAction(private_result=None, command=command))
+    subject.handle_action(
+        SucceedCommandAction(
+            private_result=None,
+            command=command,
+            state_update=update_types.StateUpdate(
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="pipette-id",
+                    pipette_name=PipetteNameType.P300_SINGLE,
+                    mount=MountType.LEFT,
+                    liquid_presence_detection=None,
+                )
+            ),
+        )
+    )
 
     result = subject.state
 
@@ -224,10 +243,31 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
     )
 
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_pipette_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=load_pipette_command,
+            state_update=update_types.StateUpdate(
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="abc",
+                    pipette_name=PipetteNameType.P300_SINGLE,
+                    mount=MountType.LEFT,
+                    liquid_presence_detection=None,
+                )
+            ),
+        )
     )
+
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=pick_up_tip_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=pick_up_tip_command,
+            state_update=update_types.StateUpdate(
+                pipette_tip_state=update_types.PipetteTipStateUpdate(
+                    pipette_id="abc",
+                    tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                )
+            ),
+        )
     )
     assert subject.state.attached_tip_by_id["abc"] == TipGeometry(
         volume=42, length=101, diameter=8.0
@@ -235,7 +275,15 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
     assert subject.state.aspirated_volume_by_id["abc"] == 0
 
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=drop_tip_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=drop_tip_command,
+            state_update=update_types.StateUpdate(
+                pipette_tip_state=update_types.PipetteTipStateUpdate(
+                    pipette_id="abc", tip_geometry=None
+                )
+            ),
+        )
     )
     assert subject.state.attached_tip_by_id["abc"] is None
     assert subject.state.aspirated_volume_by_id["abc"] is None
@@ -258,10 +306,30 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
     )
 
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_pipette_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=load_pipette_command,
+            state_update=update_types.StateUpdate(
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="xyz",
+                    pipette_name=PipetteNameType.P300_SINGLE,
+                    mount=MountType.LEFT,
+                    liquid_presence_detection=None,
+                )
+            ),
+        )
     )
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=pick_up_tip_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=pick_up_tip_command,
+            state_update=update_types.StateUpdate(
+                pipette_tip_state=update_types.PipetteTipStateUpdate(
+                    pipette_id="xyz",
+                    tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                )
+            ),
+        )
     )
     assert subject.state.attached_tip_by_id["xyz"] == TipGeometry(
         volume=42, length=101, diameter=8.0
@@ -269,7 +337,15 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
     assert subject.state.aspirated_volume_by_id["xyz"] == 0
 
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=drop_tip_in_place_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=drop_tip_in_place_command,
+            state_update=update_types.StateUpdate(
+                pipette_tip_state=update_types.PipetteTipStateUpdate(
+                    pipette_id="xyz", tip_geometry=None
+                )
+            ),
+        )
     )
     assert subject.state.attached_tip_by_id["xyz"] is None
     assert subject.state.aspirated_volume_by_id["xyz"] is None
@@ -292,10 +368,30 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
     )
 
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_pipette_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=load_pipette_command,
+            state_update=update_types.StateUpdate(
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="xyz",
+                    pipette_name=PipetteNameType.P300_SINGLE,
+                    mount=MountType.LEFT,
+                    liquid_presence_detection=None,
+                )
+            ),
+        )
     )
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=pick_up_tip_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=pick_up_tip_command,
+            state_update=update_types.StateUpdate(
+                pipette_tip_state=update_types.PipetteTipStateUpdate(
+                    pipette_id="xyz",
+                    tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                )
+            ),
+        )
     )
     assert subject.state.attached_tip_by_id["xyz"] == TipGeometry(
         volume=42, length=101, diameter=8.0
@@ -304,7 +400,13 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None, command=unsafe_drop_tip_in_place_command
+            private_result=None,
+            command=unsafe_drop_tip_in_place_command,
+            state_update=update_types.StateUpdate(
+                pipette_tip_state=update_types.PipetteTipStateUpdate(
+                    pipette_id="xyz", tip_geometry=None
+                )
+            ),
         )
     )
     assert subject.state.attached_tip_by_id["xyz"] is None
@@ -331,7 +433,18 @@ def test_aspirate_adds_volume(
     )
 
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=load_command,
+            state_update=update_types.StateUpdate(
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="pipette-id",
+                    pipette_name=PipetteNameType.P300_SINGLE,
+                    mount=MountType.LEFT,
+                    liquid_presence_detection=None,
+                )
+            ),
+        )
     )
     subject.handle_action(
         SucceedCommandAction(private_result=None, command=aspirate_command)
@@ -373,7 +486,18 @@ def test_dispense_subtracts_volume(
     )
 
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=load_command,
+            state_update=update_types.StateUpdate(
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="pipette-id",
+                    pipette_name=PipetteNameType.P300_SINGLE,
+                    mount=MountType.LEFT,
+                    liquid_presence_detection=None,
+                )
+            ),
+        )
     )
     subject.handle_action(
         SucceedCommandAction(private_result=None, command=aspirate_command)
@@ -415,7 +539,18 @@ def test_blow_out_clears_volume(
     )
 
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=load_command,
+            state_update=update_types.StateUpdate(
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="pipette-id",
+                    pipette_name=PipetteNameType.P300_SINGLE,
+                    mount=MountType.LEFT,
+                    liquid_presence_detection=None,
+                )
+            ),
+        )
     )
     subject.handle_action(
         SucceedCommandAction(private_result=None, command=aspirate_command)
@@ -455,32 +590,42 @@ def test_add_pipette_config(
         ),
         result=cmd.LoadPipetteResult(pipetteId="pipette-id"),
     )
-    private_result = cmd.LoadPipettePrivateResult(
-        pipette_id="pipette-id",
-        serial_number="pipette-serial",
-        config=LoadedStaticPipetteData(
-            model="pipette-model",
-            display_name="pipette name",
-            min_volume=1.23,
-            max_volume=4.56,
-            channels=7,
-            flow_rates=FlowRates(
-                default_aspirate={"a": 1},
-                default_dispense={"b": 2},
-                default_blow_out={"c": 3},
-            ),
-            tip_configuration_lookup_table={4: supported_tip_fixture},
-            nominal_tip_overlap={"default": 5},
-            home_position=8.9,
-            nozzle_offset_z=10.11,
-            nozzle_map=get_default_nozzle_map(PipetteNameType.P300_SINGLE),
-            back_left_corner_offset=Point(x=1, y=2, z=3),
-            front_right_corner_offset=Point(x=4, y=5, z=6),
-            pipette_lld_settings={},
+    config = LoadedStaticPipetteData(
+        model="pipette-model",
+        display_name="pipette name",
+        min_volume=1.23,
+        max_volume=4.56,
+        channels=7,
+        flow_rates=FlowRates(
+            default_aspirate={"a": 1},
+            default_dispense={"b": 2},
+            default_blow_out={"c": 3},
         ),
+        tip_configuration_lookup_table={4: supported_tip_fixture},
+        nominal_tip_overlap={"default": 5},
+        home_position=8.9,
+        nozzle_offset_z=10.11,
+        nozzle_map=get_default_nozzle_map(PipetteNameType.P300_SINGLE),
+        back_left_corner_offset=Point(x=1, y=2, z=3),
+        front_right_corner_offset=Point(x=4, y=5, z=6),
+        pipette_lld_settings={},
+    )
+
+    private_result = cmd.LoadPipettePrivateResult(
+        pipette_id="pipette-id", serial_number="pipette-serial", config=config
     )
     subject.handle_action(
-        SucceedCommandAction(command=command, private_result=private_result)
+        SucceedCommandAction(
+            command=command,
+            private_result=private_result,
+            state_update=update_types.StateUpdate(
+                pipette_config=update_types.PipetteConfigUpdate(
+                    pipette_id="pipette-id",
+                    config=config,
+                    serial_number="pipette-serial",
+                )
+            ),
+        )
     )
 
     assert subject.state.static_config_by_id["pipette-id"] == StaticPipetteConfig(
@@ -532,13 +677,38 @@ def test_prepare_to_aspirate_marks_pipette_ready(
         pipette_id="pipette-id", tip_volume=42, tip_length=101, tip_diameter=8.0
     )
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_pipette_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=load_pipette_command,
+            state_update=update_types.StateUpdate(
+                loaded_pipette=update_types.LoadPipetteUpdate(
+                    pipette_id="pipette-id",
+                    pipette_name=PipetteNameType.P50_MULTI_FLEX,
+                    mount=MountType.LEFT,
+                    liquid_presence_detection=None,
+                )
+            ),
+        )
     )
     subject.handle_action(
-        SucceedCommandAction(private_result=None, command=pick_up_tip_command)
+        SucceedCommandAction(
+            private_result=None,
+            command=pick_up_tip_command,
+            state_update=update_types.StateUpdate(
+                pipette_tip_state=update_types.PipetteTipStateUpdate(
+                    pipette_id="pipette-id",
+                    tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                )
+            ),
+        )
     )
 
-    subject.handle_action(SucceedCommandAction(private_result=None, command=previous))
+    subject.handle_action(
+        SucceedCommandAction(
+            private_result=None,
+            command=previous,
+        )
+    )
 
     prepare_to_aspirate_command = create_prepare_to_aspirate_command(
         pipette_id="pipette-id"

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import cast
 
 from opentrons.protocol_engine.state.update_types import (
+    LoadPipetteUpdate,
     LoadedLabwareUpdate,
     StateUpdate,
 )
@@ -381,6 +382,14 @@ def test_map_instrument_load(decoy: Decoy) -> None:
         ),
         private_result=pe_commands.LoadPipettePrivateResult(
             pipette_id="pipette-0", serial_number="fizzbuzz", config=pipette_config
+        ),
+        state_update=StateUpdate(
+            loaded_pipette=LoadPipetteUpdate(
+                pipette_id="pipette-0",
+                mount=expected_params.mount,
+                pipette_name=expected_params.pipetteName,
+                liquid_presence_detection=expected_params.liquidPresenceDetection,
+            )
         ),
     )
 


### PR DESCRIPTION
# Overview

closes [EXEC-733](https://opentrons.atlassian.net/browse/EXEC-733)
update pipette store from command implementation for:
LoadPipetteResult
DropTipResult,               
DropTipInPlaceResult, 
unsafe.UnsafeDropTipInPlaceResult,
PickUpTipResult
PipetteNozzleLayoutResultMixin
PipetteConfigUpdateResultMixin for:

## Test Plan and Hands on Testing

upload a protocol with the following commands/side effects and make sure its acting as expected. 

## Review requests

did I miss anything?

## Risk assessment

Medium. need to smoke test to make sure nothing is affected. 


[EXEC-733]: https://opentrons.atlassian.net/browse/EXEC-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ