### PR TITLE
fix(labware-library): individual labware page routing

### DIFF
--- a/labware-library/src/components/App/index.tsx
+++ b/labware-library/src/components/App/index.tsx
@@ -1,9 +1,10 @@
 // main application wrapper component
 import { useRef, useEffect } from 'react'
 import cx from 'classnames'
-import { useLocation } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { DefinitionRoute } from '../../definitions'
 import { useFilters } from '../../filters'
+import { getPublicPath } from '../../public-path'
 import { Nav, Breadcrumbs } from '../Nav'
 import { Sidebar } from '../Sidebar'
 import { Page } from './Page'
@@ -50,5 +51,16 @@ export function AppComponent(props: DefinitionRouteRenderProps): JSX.Element {
 }
 
 export function App(): JSX.Element {
-  return <DefinitionRoute render={props => <AppComponent {...props} />} />
+  return (
+    <Routes>
+      <Route
+        path={`${getPublicPath()}:loadName?`}
+        element={
+          <DefinitionRoute render={props => <AppComponent {...props} />} />
+        }
+      />
+      <Route path="/labware" element={<AppComponent definition={null} />} />
+      <Route path="*" element={<Navigate to="/labware" />} />
+    </Routes>
+  )
 }


### PR DESCRIPTION
closes RESC-334

# Overview

this fixes a really bad `react-router-dom` bug that resulted in us rolling back the LL release.

## Test Plan and Hands on Testing

Test all the routing in LL to make sure it works! 
1. test going to labware creator
2. test the filtering of labware on labware library
3. test clicking on the labwares to render the loadname pages
4. test navigation back to the `/labware` route

## Changelog

- Routes and Route was never used properly so it never routed to the correct path when clicking on the labwares!!

## Risk assessment

high - we will cut a release candidate + release + have QA test from this commit once it is merged in
