### PR TITLE
fix(labware-library): use search params to route to labware

### DIFF
--- a/labware-library/src/components/App/index.tsx
+++ b/labware-library/src/components/App/index.tsx
@@ -1,10 +1,9 @@
 // main application wrapper component
 import { useRef, useEffect } from 'react'
 import cx from 'classnames'
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import { DefinitionRoute } from '../../definitions'
 import { useFilters } from '../../filters'
-import { getPublicPath } from '../../public-path'
 import { Nav, Breadcrumbs } from '../Nav'
 import { Sidebar } from '../Sidebar'
 import { Page } from './Page'
@@ -51,16 +50,5 @@ export function AppComponent(props: DefinitionRouteRenderProps): JSX.Element {
 }
 
 export function App(): JSX.Element {
-  return (
-    <Routes>
-      <Route
-        path={`${getPublicPath()}:loadName?`}
-        element={
-          <DefinitionRoute render={props => <AppComponent {...props} />} />
-        }
-      />
-      <Route path="/labware" element={<AppComponent definition={null} />} />
-      <Route path="*" element={<Navigate to="/labware" />} />
-    </Routes>
-  )
+  return <DefinitionRoute render={props => <AppComponent {...props} />} />
 }

--- a/labware-library/src/components/LabwareList/LabwareCard.tsx
+++ b/labware-library/src/components/LabwareList/LabwareCard.tsx
@@ -76,7 +76,7 @@ function Title(props: LabwareCardProps): JSX.Element {
   const { displayName } = props.definition.metadata
 
   return (
-    <Link to={`${getPublicPath()}${loadName}`}>
+    <Link to={`${getPublicPath()}`} search={`loadName=${loadName}`}>
       <h2 className={styles.title}>
         <span className={styles.title_text}>{displayName}</span>
         <Icon className={styles.title_icon} name="chevron-right" />

--- a/labware-library/src/components/ui/Link.tsx
+++ b/labware-library/src/components/ui/Link.tsx
@@ -1,7 +1,7 @@
 // internal link that preserves query parameters
 import { Link as BaseLink } from 'react-router-dom'
 
-import type {ReactNode} from "react";
+import type { ReactNode } from 'react'
 
 export interface LinkProps {
   to: string

--- a/labware-library/src/components/ui/Link.tsx
+++ b/labware-library/src/components/ui/Link.tsx
@@ -1,21 +1,23 @@
 // internal link that preserves query parameters
-import type * as React from 'react'
-import { Link as BaseLink, useLocation } from 'react-router-dom'
+import { Link as BaseLink } from 'react-router-dom'
+
+import type {ReactNode} from "react";
 
 export interface LinkProps {
   to: string
-  children?: React.ReactNode
+  search?: string
+  children?: ReactNode
   className?: string
 }
 
-export function Link({ to, children, className }: LinkProps): JSX.Element {
-  const location = useLocation()
-
+export function Link({
+  to,
+  children,
+  className,
+  search,
+}: LinkProps): JSX.Element {
   return (
-    <BaseLink
-      to={{ pathname: to, search: location.search }}
-      className={className}
-    >
+    <BaseLink to={{ pathname: to, search }} className={className}>
       {children}
     </BaseLink>
   )

--- a/labware-library/src/definitions.tsx
+++ b/labware-library/src/definitions.tsx
@@ -1,7 +1,7 @@
 // labware definition helpers
 // TODO(mc, 2019-03-18): move to shared-data?
 import type * as React from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import groupBy from 'lodash/groupBy'
 import uniq from 'lodash/uniq'
 import {
@@ -83,7 +83,8 @@ export interface DefinitionRouteProps {
 }
 
 export const DefinitionRoute: React.FC<DefinitionRouteProps> = ({ render }) => {
-  const { loadName } = useParams<{ loadName: string }>()
+  const location = useLocation()
+  const loadName = location.pathname.split('/')[1]
   const definition = getDefinition(loadName)
 
   // TODO: handle 404 if loadName exists but definition isn't found

--- a/labware-library/src/definitions.tsx
+++ b/labware-library/src/definitions.tsx
@@ -8,6 +8,7 @@ import {
   LABWAREV2_DO_NOT_LIST,
   getAllDefinitions as _getAllDefinitions,
 } from '@opentrons/shared-data'
+import { getLoadnamePath } from './public-path'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { LabwareList, LabwareDefinition } from './types'
@@ -84,7 +85,7 @@ export interface DefinitionRouteProps {
 
 export const DefinitionRoute: React.FC<DefinitionRouteProps> = ({ render }) => {
   const location = useLocation()
-  const loadName = location.pathname.split('/')[1]
+  const loadName = getLoadnamePath(location.pathname)
   const definition = getDefinition(loadName)
 
   // TODO: handle 404 if loadName exists but definition isn't found

--- a/labware-library/src/definitions.tsx
+++ b/labware-library/src/definitions.tsx
@@ -1,6 +1,5 @@
 // labware definition helpers
 // TODO(mc, 2019-03-18): move to shared-data?
-import type * as React from 'react'
 import { useLocation } from 'react-router-dom'
 import groupBy from 'lodash/groupBy'
 import uniq from 'lodash/uniq'
@@ -8,8 +7,8 @@ import {
   LABWAREV2_DO_NOT_LIST,
   getAllDefinitions as _getAllDefinitions,
 } from '@opentrons/shared-data'
-import { getLoadnamePath } from './public-path'
 
+import type * as React from 'react'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { LabwareList, LabwareDefinition } from './types'
 
@@ -85,7 +84,8 @@ export interface DefinitionRouteProps {
 
 export const DefinitionRoute: React.FC<DefinitionRouteProps> = ({ render }) => {
   const location = useLocation()
-  const loadName = getLoadnamePath(location.pathname)
+  const searchParams = new URLSearchParams(location.search)
+  const loadName = searchParams.get('loadName')
   const definition = getDefinition(loadName)
 
   // TODO: handle 404 if loadName exists but definition isn't found

--- a/labware-library/src/public-path.ts
+++ b/labware-library/src/public-path.ts
@@ -12,3 +12,14 @@ if (location.hostname.startsWith('sandbox')) {
 export function getPublicPath(): string {
   return _publicPath
 }
+
+export function getLoadnamePath(pathname: string): string {
+  let modifiedLoadName = ''
+  if (location.hostname.startsWith('sandbox')) {
+    modifiedLoadName = pathname.slice(1).split('/')[1] ?? ''
+  } else {
+    modifiedLoadName = pathname.split('/')[1]
+  }
+
+  return modifiedLoadName
+}

--- a/labware-library/src/public-path.ts
+++ b/labware-library/src/public-path.ts
@@ -12,14 +12,3 @@ if (location.hostname.startsWith('sandbox')) {
 export function getPublicPath(): string {
   return _publicPath
 }
-
-export function getLoadnamePath(pathname: string): string {
-  let modifiedLoadName = ''
-  if (location.hostname.startsWith('sandbox')) {
-    modifiedLoadName = pathname.slice(1).split('/')[1] ?? ''
-  } else {
-    modifiedLoadName = pathname.split('/')[1]
-  }
-
-  return modifiedLoadName
-}


### PR DESCRIPTION
closes RESC-334

# Overview

PR does 2 things:
1. correctly addresses the bug noted in RESC-334 by using search params to route to labware
2. reverts the changes made in https://github.com/Opentrons/opentrons/pull/16366 since that sort of fixed the problem but caused a full on white screen when running on the sandbox build

co-authored with @mjhuff 

Also as a follow up: Labware-library as a whole should be refactored to use modern React router paradigms. The code is OLD and this fix is using query strings for a route

## Test Plan and Hands on Testing

Test that the routing works using the sandbox build!

## Changelog

- reverts changes made to other pr
- use search params to route to labware

## Risk assessment

high-ish, we need to cut a candidate off of this commit