### PR TITLE
chore: 8.1.0 alpha release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -14,7 +14,7 @@ Welcome to the v8.1.0 release of the Opentrons robot software!
 
 ### Hardware Support
 
-- Latest model of Flex robots (serial numbers beginning `TKTKTK`)
+- Latest production version of Flex robots
 
 ---
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -8,6 +8,16 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ---
 
+## Opentrons Robot Software Changes in 8.1.0
+
+Welcome to the v8.1.0 release of the Opentrons robot software!
+
+### Hardware Support
+
+- Latest model of Flex robots (serial numbers beginning `TKTKTK`)
+
+---
+
 ## Opentrons Robot Software Changes in 8.0.0
 
 Welcome to the v8.0.0 release of the Opentrons robot software!

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -8,6 +8,14 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ---
 
+## Opentrons App Changes in 8.1.0
+
+Welcome to the v8.1.0 release of the Opentrons App!
+
+There are no changes to the Opentrons App in v8.1.0, but it is required for updating the robot software to support the latest model of Flex robots (serial numbers beginning `TKTKTK`).
+
+---
+
 ## Opentrons App Changes in 8.0.0
 
 Welcome to the v8.0.0 release of the Opentrons App!

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -12,7 +12,7 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 Welcome to the v8.1.0 release of the Opentrons App!
 
-There are no changes to the Opentrons App in v8.1.0, but it is required for updating the robot software to support the latest model of Flex robots (serial numbers beginning `TKTKTK`).
+There are no changes to the Opentrons App in v8.1.0, but it is required for updating the robot software to support the latest production version of Flex robots.
 
 ---
 


### PR DESCRIPTION
# Overview

Alpha release notes to indicate new Flex hardware support.

Still waiting on serial numbers to give a customer-facing indication of which units have the new SOM, so that will come in a follow-up PR before stable.

## Test Plan and Hands on Testing

Check in first alpha

## Changelog

1 bullet

## Review requests

:eyes:

## Risk assessment

nil