### PR TITLE
fix(labware-library): hide the descriptive icons for now

### DIFF
--- a/labware-library/src/components/ui/TableTitle.tsx
+++ b/labware-library/src/components/ui/TableTitle.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { LabelText, LABEL_LEFT } from './LabelText'
-import { ClickableIcon } from './ClickableIcon'
+// import { ClickableIcon } from './ClickableIcon'
 import styles from './styles.module.css'
 
 interface TableTitleProps {
@@ -29,12 +29,12 @@ export function TableTitle(props: TableTitleProps): JSX.Element {
     <>
       <div className={styles.table_title}>
         <LabelText position={LABEL_LEFT}>{label}</LabelText>
-        <ClickableIcon
+        {/* <ClickableIcon
           title="info"
           name="information"
           className={iconClassName}
           onClick={toggleGuide}
-        />
+        /> */}
       </div>
       <div className={contentClassName}>{diagram}</div>
     </>

--- a/labware-library/src/components/ui/TableTitle.tsx
+++ b/labware-library/src/components/ui/TableTitle.tsx
@@ -1,5 +1,4 @@
 // Table Title with expandable measurement diagrams
-import * as React from 'react'
 import cx from 'classnames'
 import { LabelText, LABEL_LEFT } from './LabelText'
 // import { ClickableIcon } from './ClickableIcon'
@@ -11,18 +10,20 @@ interface TableTitleProps {
 }
 
 export function TableTitle(props: TableTitleProps): JSX.Element {
-  const [guideVisible, setGuideVisible] = React.useState<boolean>(false)
-  const toggleGuide = (): void => {
-    setGuideVisible(!guideVisible)
-  }
+  // TODO(ja, 9/30/24): fix the actual bug. temporarily commenting it out for now since the images
+  //  rendered by the toggleGuide were not being copied into the build folder
+  //  see https://opentrons.atlassian.net/browse/AUTH-885 for more info
+  // const [guideVisible, setGuideVisible] = React.useState<boolean>(false)
+  // const toggleGuide = (): void => {
+  //   setGuideVisible(!guideVisible)
+  // }
+  //   const iconClassName = cx(styles.info_button, {
+  //   [styles.active]: guideVisible,
+  // })
   const { label, diagram } = props
 
-  const iconClassName = cx(styles.info_button, {
-    [styles.active]: guideVisible,
-  })
-
   const contentClassName = cx(styles.expandable_content, {
-    [styles.open]: guideVisible,
+    [styles.open]: false,
   })
 
   return (


### PR DESCRIPTION
closes RQA-3251

# Overview

This is a quick fix to not block the release. The real issue is the images hidden behind the icons are not being copied over into the build folder. I think its a vite issue but can't debug it fast enough so this is the alternative for now.


Before:
<img width="848" alt="Screenshot 2024-09-30 at 15 20 45" src="https://github.com/user-attachments/assets/133dd5b2-ecc5-4fe1-b46b-d00abc2b30ea">

After:
<img width="1178" alt="Screenshot 2024-09-30 at 15 20 32" src="https://github.com/user-attachments/assets/7b639250-396a-453f-a822-f3b0e1def5f8">

Here is the ticket outlining the actual issue: https://opentrons.atlassian.net/browse/AUTH-885

## Test Plan and Hands on Testing

Just test that when you click on a specific labware in the library, the icons are removed.

## Changelog

- temporarily comment out the icons

## Risk assessment

lowish
