### PR TITLE
fix(labware-library): remove negative margin and adjust flat bottom a…

### DIFF
--- a/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
+++ b/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
@@ -96,12 +96,15 @@ export function StackingOffsets(): JSX.Element | null {
   if (
     isFlatBottom &&
     isCircular &&
-    values.labwareType !== 'reservoir' &&
+    values.labwareType === 'wellPlate' &&
     has96Wells
   ) {
     modifiedAdapterDefinitions = adapterDefinitions.filter(
       definition =>
-        definition.parameters.loadName === 'opentrons_96_flat_bottom_adapter'
+        definition.parameters.loadName === 'opentrons_96_flat_bottom_adapter' ||
+        definition.parameters.loadName ===
+          'opentrons_aluminum_flat_bottom_plate' ||
+        definition.parameters.loadName === 'opentrons_universal_flat_adapter'
     )
   }
   if (!isCircular && isVBottom && has96Wells) {
@@ -332,7 +335,6 @@ export function StackingOffsets(): JSX.Element | null {
                       {isChecked ? (
                         <div
                           style={{
-                            marginTop: '-1.2rem',
                             height: '2.0rem',
                             fontSize: '0.75rem',
                           }}


### PR DESCRIPTION
…dapter criteria

closes RQA-3173

# Overview

In labware creator: 
- remove negative margin
- fix when the flat bottom adapters show up

Address additional bugs in the latest release candidate

## Test Plan and Hands on Testing

You can test on the sandbox: http://sandbox.labware.opentrons.com/ll_fix-margin/

First test the negative margin thing: make a well plate, height of 16, 8 rows and 12 columns evenly spaced, circular, v-bottom. check that you can modify the module input fields easily in the stacking offset section

Then, change the v-bottom to flat-bottom, should see 3 adapters selectable in the stacking offset section

## Changelog

remove negative margin
fix when the adapters are visible

## Risk assessment

low