### PR TITLE
chore(labware-library): merge 3.0.1 release branch into edge

### DIFF
--- a/labware-library/src/components/ui/TableTitle.tsx
+++ b/labware-library/src/components/ui/TableTitle.tsx
@@ -1,8 +1,7 @@
 // Table Title with expandable measurement diagrams
-import * as React from 'react'
 import cx from 'classnames'
 import { LabelText, LABEL_LEFT } from './LabelText'
-import { ClickableIcon } from './ClickableIcon'
+// import { ClickableIcon } from './ClickableIcon'
 import styles from './styles.module.css'
 
 interface TableTitleProps {
@@ -11,30 +10,32 @@ interface TableTitleProps {
 }
 
 export function TableTitle(props: TableTitleProps): JSX.Element {
-  const [guideVisible, setGuideVisible] = React.useState<boolean>(false)
-  const toggleGuide = (): void => {
-    setGuideVisible(!guideVisible)
-  }
+  // TODO(ja, 9/30/24): fix the actual bug. temporarily commenting it out for now since the images
+  //  rendered by the toggleGuide were not being copied into the build folder
+  //  see https://opentrons.atlassian.net/browse/AUTH-885 for more info
+  // const [guideVisible, setGuideVisible] = React.useState<boolean>(false)
+  // const toggleGuide = (): void => {
+  //   setGuideVisible(!guideVisible)
+  // }
+  //   const iconClassName = cx(styles.info_button, {
+  //   [styles.active]: guideVisible,
+  // })
   const { label, diagram } = props
 
-  const iconClassName = cx(styles.info_button, {
-    [styles.active]: guideVisible,
-  })
-
   const contentClassName = cx(styles.expandable_content, {
-    [styles.open]: guideVisible,
+    [styles.open]: false,
   })
 
   return (
     <>
       <div className={styles.table_title}>
         <LabelText position={LABEL_LEFT}>{label}</LabelText>
-        <ClickableIcon
+        {/* <ClickableIcon
           title="info"
           name="information"
           className={iconClassName}
           onClick={toggleGuide}
-        />
+        /> */}
       </div>
       <div className={contentClassName}>{diagram}</div>
     </>

--- a/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
+++ b/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
@@ -96,12 +96,15 @@ export function StackingOffsets(): JSX.Element | null {
   if (
     isFlatBottom &&
     isCircular &&
-    values.labwareType !== 'reservoir' &&
+    values.labwareType === 'wellPlate' &&
     has96Wells
   ) {
     modifiedAdapterDefinitions = adapterDefinitions.filter(
       definition =>
-        definition.parameters.loadName === 'opentrons_96_flat_bottom_adapter'
+        definition.parameters.loadName === 'opentrons_96_flat_bottom_adapter' ||
+        definition.parameters.loadName ===
+          'opentrons_aluminum_flat_bottom_plate' ||
+        definition.parameters.loadName === 'opentrons_universal_flat_adapter'
     )
   }
   if (!isCircular && isVBottom && has96Wells) {
@@ -332,7 +335,6 @@ export function StackingOffsets(): JSX.Element | null {
                       {isChecked ? (
                         <div
                           style={{
-                            marginTop: '-1.2rem',
                             height: '2.0rem',
                             fontSize: '0.75rem',
                           }}


### PR DESCRIPTION
# Overview

The labware-library release was originally based off of edge. But then there was a vite update merged in that resulted in all of labware-library's css being broken in builds. Due to time, I made the executive decision to create a release branch off of the commit of the latest 3.0.1 release candidate. This is the mergeback into edge. I will normal merge so the tags will be preserved. Once this merges in, I will delete this release branch.