### PR TITLE
feat(shared-data): add command schema 10

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/utils/getTipBasedLPCSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getTipBasedLPCSteps.ts
@@ -18,8 +18,8 @@ import type {
 import type {
   RunTimeCommand,
   ProtocolAnalysisOutput,
+  PickUpTipRunTimeCommand,
 } from '@opentrons/shared-data'
-import type { PickUpTipRunTimeCommand } from '@opentrons/shared-data'
 import type { LabwareLocationCombo } from '../../ApplyHistoricOffsets/hooks/getLabwareLocationCombos'
 
 interface LPCArgs {

--- a/app/src/organisms/LabwarePositionCheck/utils/getTipBasedLPCSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getTipBasedLPCSteps.ts
@@ -19,7 +19,7 @@ import type {
   RunTimeCommand,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
-import type { PickUpTipRunTimeCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
+import type { PickUpTipRunTimeCommand } from '@opentrons/shared-data'
 import type { LabwareLocationCombo } from '../../ApplyHistoricOffsets/hooks/getLabwareLocationCombos'
 
 interface LPCArgs {

--- a/shared-data/command/index.ts
+++ b/shared-data/command/index.ts
@@ -1,6 +1,8 @@
 import commandSchemaV7 from './schemas/7.json'
 import commandSchemaV8 from './schemas/8.json'
 import commandSchemaV9 from './schemas/9.json'
+import commandSchemaV10 from './schemas/10.json'
 export * from './types/index'
+export const commandSchemaLatest = commandSchemaV10
 
-export { commandSchemaV7, commandSchemaV8, commandSchemaV9 }
+export { commandSchemaV7, commandSchemaV8, commandSchemaV9, commandSchemaV10 }

--- a/shared-data/command/schemas/10.json
+++ b/shared-data/command/schemas/10.json
@@ -293,12 +293,7 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "meniscus"
-      ],
+      "enum": ["top", "bottom", "center", "meniscus"],
       "type": "string"
     },
     "WellOffset": {
@@ -383,22 +378,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": [
-        "protocol",
-        "setup",
-        "fixit"
-      ],
+      "enum": ["protocol", "setup", "fixit"],
       "type": "string"
     },
     "AspirateCreate": {
@@ -409,9 +394,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": [
-            "aspirate"
-          ],
+          "enum": ["aspirate"],
           "type": "string"
         },
         "params": {
@@ -431,9 +414,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -458,11 +439,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -472,9 +449,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": [
-            "aspirateInPlace"
-          ],
+          "enum": ["aspirateInPlace"],
           "type": "string"
         },
         "params": {
@@ -494,9 +469,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -509,9 +482,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message"
-      ]
+      "required": ["message"]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -521,9 +492,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": [
-            "comment"
-          ],
+          "enum": ["comment"],
           "type": "string"
         },
         "params": {
@@ -543,9 +512,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ConfigureForVolumeParams": {
       "title": "ConfigureForVolumeParams",
@@ -569,10 +536,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "volume"
-      ]
+      "required": ["pipetteId", "volume"]
     },
     "ConfigureForVolumeCreate": {
       "title": "ConfigureForVolumeCreate",
@@ -582,9 +546,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureForVolume",
-          "enum": [
-            "configureForVolume"
-          ],
+          "enum": ["configureForVolume"],
           "type": "string"
         },
         "params": {
@@ -604,9 +566,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AllNozzleLayoutConfiguration": {
       "title": "AllNozzleLayoutConfiguration",
@@ -616,9 +576,7 @@
         "style": {
           "title": "Style",
           "default": "ALL",
-          "enum": [
-            "ALL"
-          ],
+          "enum": ["ALL"],
           "type": "string"
         }
       }
@@ -631,26 +589,17 @@
         "style": {
           "title": "Style",
           "default": "SINGLE",
-          "enum": [
-            "SINGLE"
-          ],
+          "enum": ["SINGLE"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "RowNozzleLayoutConfiguration": {
       "title": "RowNozzleLayoutConfiguration",
@@ -660,26 +609,17 @@
         "style": {
           "title": "Style",
           "default": "ROW",
-          "enum": [
-            "ROW"
-          ],
+          "enum": ["ROW"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "ColumnNozzleLayoutConfiguration": {
       "title": "ColumnNozzleLayoutConfiguration",
@@ -689,26 +629,17 @@
         "style": {
           "title": "Style",
           "default": "COLUMN",
-          "enum": [
-            "COLUMN"
-          ],
+          "enum": ["COLUMN"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "QuadrantNozzleLayoutConfiguration": {
       "title": "QuadrantNozzleLayoutConfiguration",
@@ -718,20 +649,13 @@
         "style": {
           "title": "Style",
           "default": "QUADRANT",
-          "enum": [
-            "QUADRANT"
-          ],
+          "enum": ["QUADRANT"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         },
         "frontRightNozzle": {
@@ -747,11 +671,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle",
-        "frontRightNozzle",
-        "backLeftNozzle"
-      ]
+      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"]
     },
     "ConfigureNozzleLayoutParams": {
       "title": "ConfigureNozzleLayoutParams",
@@ -784,10 +704,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "configurationParams"
-      ]
+      "required": ["pipetteId", "configurationParams"]
     },
     "ConfigureNozzleLayoutCreate": {
       "title": "ConfigureNozzleLayoutCreate",
@@ -797,9 +714,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureNozzleLayout",
-          "enum": [
-            "configureNozzleLayout"
-          ],
+          "enum": ["configureNozzleLayout"],
           "type": "string"
         },
         "params": {
@@ -819,9 +734,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -837,9 +750,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": [
-            "custom"
-          ],
+          "enum": ["custom"],
           "type": "string"
         },
         "params": {
@@ -859,9 +770,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -910,13 +819,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -926,9 +829,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": [
-            "dispense"
-          ],
+          "enum": ["dispense"],
           "type": "string"
         },
         "params": {
@@ -948,9 +849,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -980,11 +879,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -994,9 +889,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": [
-            "dispenseInPlace"
-          ],
+          "enum": ["dispenseInPlace"],
           "type": "string"
         },
         "params": {
@@ -1016,9 +909,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -1056,12 +947,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -1071,9 +957,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": [
-            "blowout"
-          ],
+          "enum": ["blowout"],
           "type": "string"
         },
         "params": {
@@ -1093,9 +977,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -1114,10 +996,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "pipetteId"]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -1127,9 +1006,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": [
-            "blowOutInPlace"
-          ],
+          "enum": ["blowOutInPlace"],
           "type": "string"
         },
         "params": {
@@ -1149,19 +1026,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "default"
-      ],
+      "enum": ["top", "bottom", "center", "default"],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -1223,11 +1093,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ]
+      "required": ["pipetteId", "labwareId", "wellName"]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -1237,9 +1103,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": [
-            "dropTip"
-          ],
+          "enum": ["dropTip"],
           "type": "string"
         },
         "params": {
@@ -1259,9 +1123,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -1279,9 +1141,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -1291,9 +1151,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": [
-            "dropTipInPlace"
-          ],
+          "enum": ["dropTipInPlace"],
           "type": "string"
         },
         "params": {
@@ -1313,9 +1171,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -1335,11 +1191,7 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": [
-        "left",
-        "right",
-        "extension"
-      ],
+      "enum": ["left", "right", "extension"],
       "type": "string"
     },
     "HomeParams": {
@@ -1372,9 +1224,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": [
-            "home"
-          ],
+          "enum": ["home"],
           "type": "string"
         },
         "params": {
@@ -1394,9 +1244,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -1412,9 +1260,7 @@
           ]
         }
       },
-      "required": [
-        "axis"
-      ]
+      "required": ["axis"]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -1424,9 +1270,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": [
-            "retractAxis"
-          ],
+          "enum": ["retractAxis"],
           "type": "string"
         },
         "params": {
@@ -1446,9 +1290,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1494,9 +1336,7 @@
           ]
         }
       },
-      "required": [
-        "slotName"
-      ]
+      "required": ["slotName"]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1509,9 +1349,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -1524,9 +1362,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ]
+      "required": ["labwareId"]
     },
     "AddressableAreaLocation": {
       "title": "AddressableAreaLocation",
@@ -1539,9 +1375,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "addressableAreaName"
-      ]
+      "required": ["addressableAreaName"]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1562,9 +1396,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
@@ -1598,12 +1430,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ]
+      "required": ["location", "loadName", "namespace", "version"]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1613,9 +1440,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": [
-            "loadLabware"
-          ],
+          "enum": ["loadLabware"],
           "type": "string"
         },
         "params": {
@@ -1635,9 +1460,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ReloadLabwareParams": {
       "title": "ReloadLabwareParams",
@@ -1650,9 +1473,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ]
+      "required": ["labwareId"]
     },
     "ReloadLabwareCreate": {
       "title": "ReloadLabwareCreate",
@@ -1662,9 +1483,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "reloadLabware",
-          "enum": [
-            "reloadLabware"
-          ],
+          "enum": ["reloadLabware"],
           "type": "string"
         },
         "params": {
@@ -1684,9 +1503,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1712,11 +1529,7 @@
           }
         }
       },
-      "required": [
-        "liquidId",
-        "labwareId",
-        "volumeByWell"
-      ]
+      "required": ["liquidId", "labwareId", "volumeByWell"]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1726,9 +1539,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": [
-            "loadLiquid"
-          ],
+          "enum": ["loadLiquid"],
           "type": "string"
         },
         "params": {
@@ -1748,9 +1559,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1796,10 +1605,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "model",
-        "location"
-      ]
+      "required": ["model", "location"]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1809,9 +1615,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": [
-            "loadModule"
-          ],
+          "enum": ["loadModule"],
           "type": "string"
         },
         "params": {
@@ -1831,9 +1635,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1896,10 +1698,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteName",
-        "mount"
-      ]
+      "required": ["pipetteName", "mount"]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1909,9 +1708,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": [
-            "loadPipette"
-          ],
+          "enum": ["loadPipette"],
           "type": "string"
         },
         "params": {
@@ -1931,18 +1728,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": [
-        "usingGripper",
-        "manualMoveWithPause",
-        "manualMoveWithoutPause"
-      ],
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1963,11 +1754,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1993,9 +1780,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
@@ -2030,11 +1815,7 @@
           ]
         }
       },
-      "required": [
-        "labwareId",
-        "newLocation",
-        "strategy"
-      ]
+      "required": ["labwareId", "newLocation", "strategy"]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -2044,9 +1825,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": [
-            "moveLabware"
-          ],
+          "enum": ["moveLabware"],
           "type": "string"
         },
         "params": {
@@ -2066,18 +1845,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": [
-        "x",
-        "y",
-        "z"
-      ],
+      "enum": ["x", "y", "z"],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -2104,11 +1877,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "axis",
-        "distance"
-      ]
+      "required": ["pipetteId", "axis", "distance"]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -2118,9 +1887,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": [
-            "moveRelative"
-          ],
+          "enum": ["moveRelative"],
           "type": "string"
         },
         "params": {
@@ -2140,9 +1907,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -2162,11 +1927,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -2204,10 +1965,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "coordinates"
-      ]
+      "required": ["pipetteId", "coordinates"]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -2217,9 +1975,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": [
-            "moveToCoordinates"
-          ],
+          "enum": ["moveToCoordinates"],
           "type": "string"
         },
         "params": {
@@ -2239,9 +1995,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -2289,11 +2043,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -2303,9 +2053,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": [
-            "moveToWell"
-          ],
+          "enum": ["moveToWell"],
           "type": "string"
         },
         "params": {
@@ -2325,9 +2073,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AddressableOffsetVector": {
       "title": "AddressableOffsetVector",
@@ -2347,11 +2093,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToAddressableAreaParams": {
       "title": "MoveToAddressableAreaParams",
@@ -2405,10 +2147,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ]
+      "required": ["pipetteId", "addressableAreaName"]
     },
     "MoveToAddressableAreaCreate": {
       "title": "MoveToAddressableAreaCreate",
@@ -2418,9 +2157,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableArea",
-          "enum": [
-            "moveToAddressableArea"
-          ],
+          "enum": ["moveToAddressableArea"],
           "type": "string"
         },
         "params": {
@@ -2440,9 +2177,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToAddressableAreaForDropTipParams": {
       "title": "MoveToAddressableAreaForDropTipParams",
@@ -2502,10 +2237,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ]
+      "required": ["pipetteId", "addressableAreaName"]
     },
     "MoveToAddressableAreaForDropTipCreate": {
       "title": "MoveToAddressableAreaForDropTipCreate",
@@ -2515,9 +2247,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableAreaForDropTip",
-          "enum": [
-            "moveToAddressableAreaForDropTip"
-          ],
+          "enum": ["moveToAddressableAreaForDropTip"],
           "type": "string"
         },
         "params": {
@@ -2537,9 +2267,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PrepareToAspirateParams": {
       "title": "PrepareToAspirateParams",
@@ -2552,9 +2280,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "PrepareToAspirateCreate": {
       "title": "PrepareToAspirateCreate",
@@ -2564,9 +2290,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "prepareToAspirate",
-          "enum": [
-            "prepareToAspirate"
-          ],
+          "enum": ["prepareToAspirate"],
           "type": "string"
         },
         "params": {
@@ -2586,9 +2310,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -2610,10 +2332,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": [
-            "waitForResume",
-            "pause"
-          ],
+          "enum": ["waitForResume", "pause"],
           "type": "string"
         },
         "params": {
@@ -2633,9 +2352,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -2653,9 +2370,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "seconds"
-      ]
+      "required": ["seconds"]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -2665,9 +2380,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": [
-            "waitForDuration"
-          ],
+          "enum": ["waitForDuration"],
           "type": "string"
         },
         "params": {
@@ -2687,9 +2400,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -2721,11 +2432,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -2735,9 +2442,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": [
-            "pickUpTip"
-          ],
+          "enum": ["pickUpTip"],
           "type": "string"
         },
         "params": {
@@ -2757,9 +2462,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -2783,9 +2486,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -2795,9 +2496,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": [
-            "savePosition"
-          ],
+          "enum": ["savePosition"],
           "type": "string"
         },
         "params": {
@@ -2817,9 +2516,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2832,9 +2529,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "on"
-      ]
+      "required": ["on"]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2844,9 +2539,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": [
-            "setRailLights"
-          ],
+          "enum": ["setRailLights"],
           "type": "string"
         },
         "params": {
@@ -2866,9 +2559,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2911,11 +2602,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2925,9 +2612,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": [
-            "touchTip"
-          ],
+          "enum": ["touchTip"],
           "type": "string"
         },
         "params": {
@@ -2947,20 +2632,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": [
-        "idle",
-        "confirm",
-        "updating",
-        "disco",
-        "off"
-      ]
+      "enum": ["idle", "confirm", "updating", "disco", "off"]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2976,9 +2653,7 @@
           ]
         }
       },
-      "required": [
-        "animation"
-      ]
+      "required": ["animation"]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2988,9 +2663,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": [
-            "setStatusBar"
-          ],
+          "enum": ["setStatusBar"],
           "type": "string"
         },
         "params": {
@@ -3010,28 +2683,18 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TipPresenceStatus": {
       "title": "TipPresenceStatus",
       "description": "Tip presence status reported by a pipette.",
-      "enum": [
-        "present",
-        "absent",
-        "unknown"
-      ],
+      "enum": ["present", "absent", "unknown"],
       "type": "string"
     },
     "InstrumentSensorId": {
       "title": "InstrumentSensorId",
       "description": "Primary and secondary sensor ids.",
-      "enum": [
-        "primary",
-        "secondary",
-        "both"
-      ],
+      "enum": ["primary", "secondary", "both"],
       "type": "string"
     },
     "VerifyTipPresenceParams": {
@@ -3061,10 +2724,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "expectedState"
-      ]
+      "required": ["pipetteId", "expectedState"]
     },
     "VerifyTipPresenceCreate": {
       "title": "VerifyTipPresenceCreate",
@@ -3074,9 +2734,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "verifyTipPresence",
-          "enum": [
-            "verifyTipPresence"
-          ],
+          "enum": ["verifyTipPresence"],
           "type": "string"
         },
         "params": {
@@ -3096,9 +2754,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "GetTipPresenceParams": {
       "title": "GetTipPresenceParams",
@@ -3111,9 +2767,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "GetTipPresenceCreate": {
       "title": "GetTipPresenceCreate",
@@ -3123,9 +2777,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "getTipPresence",
-          "enum": [
-            "getTipPresence"
-          ],
+          "enum": ["getTipPresence"],
           "type": "string"
         },
         "params": {
@@ -3145,9 +2797,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LiquidProbeParams": {
       "title": "LiquidProbeParams",
@@ -3179,11 +2829,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "LiquidProbeCreate": {
       "title": "LiquidProbeCreate",
@@ -3193,9 +2839,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "liquidProbe",
-          "enum": [
-            "liquidProbe"
-          ],
+          "enum": ["liquidProbe"],
           "type": "string"
         },
         "params": {
@@ -3215,9 +2859,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TryLiquidProbeParams": {
       "title": "TryLiquidProbeParams",
@@ -3249,11 +2891,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TryLiquidProbeCreate": {
       "title": "TryLiquidProbeCreate",
@@ -3263,9 +2901,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "tryLiquidProbe",
-          "enum": [
-            "tryLiquidProbe"
-          ],
+          "enum": ["tryLiquidProbe"],
           "type": "string"
         },
         "params": {
@@ -3285,9 +2921,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3305,9 +2939,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3317,9 +2949,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": [
-            "heaterShaker/waitForTemperature"
-          ],
+          "enum": ["heaterShaker/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -3339,9 +2969,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3359,10 +2987,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3372,9 +2997,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": [
-            "heaterShaker/setTargetTemperature"
-          ],
+          "enum": ["heaterShaker/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -3394,9 +3017,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -3409,9 +3030,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -3421,9 +3040,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": [
-            "heaterShaker/deactivateHeater"
-          ],
+          "enum": ["heaterShaker/deactivateHeater"],
           "type": "string"
         },
         "params": {
@@ -3443,9 +3060,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -3463,10 +3078,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ]
+      "required": ["moduleId", "rpm"]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -3476,9 +3088,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": [
-            "heaterShaker/setAndWaitForShakeSpeed"
-          ],
+          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
           "type": "string"
         },
         "params": {
@@ -3498,9 +3108,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -3513,9 +3121,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -3525,9 +3131,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": [
-            "heaterShaker/deactivateShaker"
-          ],
+          "enum": ["heaterShaker/deactivateShaker"],
           "type": "string"
         },
         "params": {
@@ -3547,9 +3151,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -3562,9 +3164,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -3574,9 +3174,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": [
-            "heaterShaker/openLabwareLatch"
-          ],
+          "enum": ["heaterShaker/openLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -3596,9 +3194,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -3611,9 +3207,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -3623,9 +3217,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": [
-            "heaterShaker/closeLabwareLatch"
-          ],
+          "enum": ["heaterShaker/closeLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -3645,9 +3237,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -3660,9 +3250,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -3672,9 +3260,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": [
-            "magneticModule/disengage"
-          ],
+          "enum": ["magneticModule/disengage"],
           "type": "string"
         },
         "params": {
@@ -3694,9 +3280,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -3714,10 +3298,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "height"
-      ]
+      "required": ["moduleId", "height"]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -3727,9 +3308,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": [
-            "magneticModule/engage"
-          ],
+          "enum": ["magneticModule/engage"],
           "type": "string"
         },
         "params": {
@@ -3749,9 +3328,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3769,10 +3346,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3782,9 +3356,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": [
-            "temperatureModule/setTargetTemperature"
-          ],
+          "enum": ["temperatureModule/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -3804,9 +3376,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3824,9 +3394,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3836,9 +3404,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": [
-            "temperatureModule/waitForTemperature"
-          ],
+          "enum": ["temperatureModule/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -3858,9 +3424,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -3873,9 +3437,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -3885,9 +3447,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": [
-            "temperatureModule/deactivate"
-          ],
+          "enum": ["temperatureModule/deactivate"],
           "type": "string"
         },
         "params": {
@@ -3907,9 +3467,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -3937,10 +3495,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -3950,9 +3505,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": [
-            "thermocycler/setTargetBlockTemperature"
-          ],
+          "enum": ["thermocycler/setTargetBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -3972,9 +3525,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -3987,9 +3538,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -3999,9 +3548,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": [
-            "thermocycler/waitForBlockTemperature"
-          ],
+          "enum": ["thermocycler/waitForBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -4021,9 +3568,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -4041,10 +3586,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -4054,9 +3596,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": [
-            "thermocycler/setTargetLidTemperature"
-          ],
+          "enum": ["thermocycler/setTargetLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -4076,9 +3616,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -4091,9 +3629,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -4103,9 +3639,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": [
-            "thermocycler/waitForLidTemperature"
-          ],
+          "enum": ["thermocycler/waitForLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -4125,9 +3659,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -4140,9 +3672,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -4152,9 +3682,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": [
-            "thermocycler/deactivateBlock"
-          ],
+          "enum": ["thermocycler/deactivateBlock"],
           "type": "string"
         },
         "params": {
@@ -4174,9 +3702,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -4189,9 +3715,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -4201,9 +3725,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": [
-            "thermocycler/deactivateLid"
-          ],
+          "enum": ["thermocycler/deactivateLid"],
           "type": "string"
         },
         "params": {
@@ -4223,9 +3745,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams": {
       "title": "OpenLidParams",
@@ -4238,9 +3758,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -4250,9 +3768,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": [
-            "thermocycler/openLid"
-          ],
+          "enum": ["thermocycler/openLid"],
           "type": "string"
         },
         "params": {
@@ -4272,9 +3788,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams": {
       "title": "CloseLidParams",
@@ -4287,9 +3801,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -4299,9 +3811,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": [
-            "thermocycler/closeLid"
-          ],
+          "enum": ["thermocycler/closeLid"],
           "type": "string"
         },
         "params": {
@@ -4321,9 +3831,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -4341,10 +3849,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ]
+      "required": ["celsius", "holdSeconds"]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -4370,10 +3875,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ]
+      "required": ["moduleId", "profile"]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -4383,9 +3885,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": [
-            "thermocycler/runProfile"
-          ],
+          "enum": ["thermocycler/runProfile"],
           "type": "string"
         },
         "params": {
@@ -4405,9 +3905,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams": {
       "title": "CloseLidParams",
@@ -4420,9 +3918,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -4432,9 +3928,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/closeLid",
-          "enum": [
-            "absorbanceReader/closeLid"
-          ],
+          "enum": ["absorbanceReader/closeLid"],
           "type": "string"
         },
         "params": {
@@ -4454,9 +3948,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams": {
       "title": "OpenLidParams",
@@ -4469,9 +3961,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -4481,9 +3971,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/openLid",
-          "enum": [
-            "absorbanceReader/openLid"
-          ],
+          "enum": ["absorbanceReader/openLid"],
           "type": "string"
         },
         "params": {
@@ -4503,9 +3991,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "InitializeParams": {
       "title": "InitializeParams",
@@ -4520,10 +4006,7 @@
         "measureMode": {
           "title": "Measuremode",
           "description": "Initialize single or multi measurement mode.",
-          "enum": [
-            "single",
-            "multi"
-          ],
+          "enum": ["single", "multi"],
           "type": "string"
         },
         "sampleWavelengths": {
@@ -4540,11 +4023,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "moduleId",
-        "measureMode",
-        "sampleWavelengths"
-      ]
+      "required": ["moduleId", "measureMode", "sampleWavelengths"]
     },
     "InitializeCreate": {
       "title": "InitializeCreate",
@@ -4554,9 +4033,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/initialize",
-          "enum": [
-            "absorbanceReader/initialize"
-          ],
+          "enum": ["absorbanceReader/initialize"],
           "type": "string"
         },
         "params": {
@@ -4576,9 +4053,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ReadAbsorbanceParams": {
       "title": "ReadAbsorbanceParams",
@@ -4591,9 +4066,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "ReadAbsorbanceCreate": {
       "title": "ReadAbsorbanceCreate",
@@ -4603,9 +4076,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/read",
-          "enum": [
-            "absorbanceReader/read"
-          ],
+          "enum": ["absorbanceReader/read"],
           "type": "string"
         },
         "params": {
@@ -4625,17 +4096,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": [
-        "front",
-        "rear"
-      ]
+      "enum": ["front", "rear"]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -4655,11 +4121,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -4684,9 +4146,7 @@
           ]
         }
       },
-      "required": [
-        "jaw"
-      ]
+      "required": ["jaw"]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -4696,9 +4156,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": [
-            "calibration/calibrateGripper"
-          ],
+          "enum": ["calibration/calibrateGripper"],
           "type": "string"
         },
         "params": {
@@ -4718,9 +4176,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -4736,9 +4192,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -4748,9 +4202,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": [
-            "calibration/calibratePipette"
-          ],
+          "enum": ["calibration/calibratePipette"],
           "type": "string"
         },
         "params": {
@@ -4770,9 +4222,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -4798,11 +4248,7 @@
           ]
         }
       },
-      "required": [
-        "moduleId",
-        "labwareId",
-        "mount"
-      ]
+      "required": ["moduleId", "labwareId", "mount"]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -4812,9 +4258,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": [
-            "calibration/calibrateModule"
-          ],
+          "enum": ["calibration/calibrateModule"],
           "type": "string"
         },
         "params": {
@@ -4834,17 +4278,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": [
-        "attachPlate",
-        "attachInstrument"
-      ]
+      "enum": ["attachPlate", "attachInstrument"]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -4869,9 +4308,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -4881,9 +4318,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": [
-            "calibration/moveToMaintenancePosition"
-          ],
+          "enum": ["calibration/moveToMaintenancePosition"],
           "type": "string"
         },
         "params": {
@@ -4903,9 +4338,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "UnsafeBlowOutInPlaceParams": {
       "title": "UnsafeBlowOutInPlaceParams",
@@ -4924,10 +4357,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "pipetteId"]
     },
     "UnsafeBlowOutInPlaceCreate": {
       "title": "UnsafeBlowOutInPlaceCreate",
@@ -4937,9 +4367,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/blowOutInPlace",
-          "enum": [
-            "unsafe/blowOutInPlace"
-          ],
+          "enum": ["unsafe/blowOutInPlace"],
           "type": "string"
         },
         "params": {
@@ -4959,9 +4387,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "UnsafeDropTipInPlaceParams": {
       "title": "UnsafeDropTipInPlaceParams",
@@ -4979,9 +4405,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "UnsafeDropTipInPlaceCreate": {
       "title": "UnsafeDropTipInPlaceCreate",
@@ -4991,9 +4415,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/dropTipInPlace",
-          "enum": [
-            "unsafe/dropTipInPlace"
-          ],
+          "enum": ["unsafe/dropTipInPlace"],
           "type": "string"
         },
         "params": {
@@ -5013,9 +4435,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "UpdatePositionEstimatorsParams": {
       "title": "UpdatePositionEstimatorsParams",
@@ -5030,9 +4450,7 @@
           }
         }
       },
-      "required": [
-        "axes"
-      ]
+      "required": ["axes"]
     },
     "UpdatePositionEstimatorsCreate": {
       "title": "UpdatePositionEstimatorsCreate",
@@ -5042,9 +4460,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/updatePositionEstimators",
-          "enum": [
-            "unsafe/updatePositionEstimators"
-          ],
+          "enum": ["unsafe/updatePositionEstimators"],
           "type": "string"
         },
         "params": {
@@ -5064,9 +4480,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "UnsafeEngageAxesParams": {
       "title": "UnsafeEngageAxesParams",
@@ -5081,9 +4495,7 @@
           }
         }
       },
-      "required": [
-        "axes"
-      ]
+      "required": ["axes"]
     },
     "UnsafeEngageAxesCreate": {
       "title": "UnsafeEngageAxesCreate",
@@ -5093,9 +4505,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/engageAxes",
-          "enum": [
-            "unsafe/engageAxes"
-          ],
+          "enum": ["unsafe/engageAxes"],
           "type": "string"
         },
         "params": {
@@ -5115,9 +4525,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     }
   },
   "$id": "opentronsCommandSchemaV10",

--- a/shared-data/command/schemas/10.json
+++ b/shared-data/command/schemas/10.json
@@ -60,11 +60,13 @@
       "thermocycler/waitForLidTemperature": "#/definitions/WaitForLidTemperatureCreate",
       "thermocycler/deactivateBlock": "#/definitions/DeactivateBlockCreate",
       "thermocycler/deactivateLid": "#/definitions/DeactivateLidCreate",
-      "thermocycler/openLid": "#/definitions/OpenLidCreate",
-      "thermocycler/closeLid": "#/definitions/CloseLidCreate",
+      "thermocycler/openLid": "#/definitions/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidCreate",
+      "thermocycler/closeLid": "#/definitions/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidCreate",
       "thermocycler/runProfile": "#/definitions/RunProfileCreate",
+      "absorbanceReader/closeLid": "#/definitions/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidCreate",
+      "absorbanceReader/openLid": "#/definitions/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidCreate",
       "absorbanceReader/initialize": "#/definitions/InitializeCreate",
-      "absorbanceReader/measure": "#/definitions/MeasureAbsorbanceCreate",
+      "absorbanceReader/read": "#/definitions/ReadAbsorbanceCreate",
       "calibration/calibrateGripper": "#/definitions/CalibrateGripperCreate",
       "calibration/calibratePipette": "#/definitions/CalibratePipetteCreate",
       "calibration/calibrateModule": "#/definitions/CalibrateModuleCreate",
@@ -242,19 +244,25 @@
       "$ref": "#/definitions/DeactivateLidCreate"
     },
     {
-      "$ref": "#/definitions/OpenLidCreate"
+      "$ref": "#/definitions/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidCreate"
     },
     {
-      "$ref": "#/definitions/CloseLidCreate"
+      "$ref": "#/definitions/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidCreate"
     },
     {
       "$ref": "#/definitions/RunProfileCreate"
     },
     {
+      "$ref": "#/definitions/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidCreate"
+    },
+    {
+      "$ref": "#/definitions/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidCreate"
+    },
+    {
       "$ref": "#/definitions/InitializeCreate"
     },
     {
-      "$ref": "#/definitions/MeasureAbsorbanceCreate"
+      "$ref": "#/definitions/ReadAbsorbanceCreate"
     },
     {
       "$ref": "#/definitions/CalibrateGripperCreate"
@@ -285,7 +293,12 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": ["top", "bottom", "center"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "meniscus"
+      ],
       "type": "string"
     },
     "WellOffset": {
@@ -370,12 +383,22 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": ["protocol", "setup", "fixit"],
+      "enum": [
+        "protocol",
+        "setup",
+        "fixit"
+      ],
       "type": "string"
     },
     "AspirateCreate": {
@@ -386,7 +409,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": ["aspirate"],
+          "enum": [
+            "aspirate"
+          ],
           "type": "string"
         },
         "params": {
@@ -406,7 +431,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -431,7 +458,11 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -441,7 +472,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": ["aspirateInPlace"],
+          "enum": [
+            "aspirateInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -461,7 +494,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -474,7 +509,9 @@
           "type": "string"
         }
       },
-      "required": ["message"]
+      "required": [
+        "message"
+      ]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -484,7 +521,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": ["comment"],
+          "enum": [
+            "comment"
+          ],
           "type": "string"
         },
         "params": {
@@ -504,7 +543,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ConfigureForVolumeParams": {
       "title": "ConfigureForVolumeParams",
@@ -528,7 +569,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "volume"]
+      "required": [
+        "pipetteId",
+        "volume"
+      ]
     },
     "ConfigureForVolumeCreate": {
       "title": "ConfigureForVolumeCreate",
@@ -538,7 +582,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureForVolume",
-          "enum": ["configureForVolume"],
+          "enum": [
+            "configureForVolume"
+          ],
           "type": "string"
         },
         "params": {
@@ -558,7 +604,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AllNozzleLayoutConfiguration": {
       "title": "AllNozzleLayoutConfiguration",
@@ -568,7 +616,9 @@
         "style": {
           "title": "Style",
           "default": "ALL",
-          "enum": ["ALL"],
+          "enum": [
+            "ALL"
+          ],
           "type": "string"
         }
       }
@@ -581,17 +631,26 @@
         "style": {
           "title": "Style",
           "default": "SINGLE",
-          "enum": ["SINGLE"],
+          "enum": [
+            "SINGLE"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "RowNozzleLayoutConfiguration": {
       "title": "RowNozzleLayoutConfiguration",
@@ -601,17 +660,26 @@
         "style": {
           "title": "Style",
           "default": "ROW",
-          "enum": ["ROW"],
+          "enum": [
+            "ROW"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "ColumnNozzleLayoutConfiguration": {
       "title": "ColumnNozzleLayoutConfiguration",
@@ -621,17 +689,26 @@
         "style": {
           "title": "Style",
           "default": "COLUMN",
-          "enum": ["COLUMN"],
+          "enum": [
+            "COLUMN"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "QuadrantNozzleLayoutConfiguration": {
       "title": "QuadrantNozzleLayoutConfiguration",
@@ -641,13 +718,20 @@
         "style": {
           "title": "Style",
           "default": "QUADRANT",
-          "enum": ["QUADRANT"],
+          "enum": [
+            "QUADRANT"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         },
         "frontRightNozzle": {
@@ -663,7 +747,11 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"]
+      "required": [
+        "primaryNozzle",
+        "frontRightNozzle",
+        "backLeftNozzle"
+      ]
     },
     "ConfigureNozzleLayoutParams": {
       "title": "ConfigureNozzleLayoutParams",
@@ -696,7 +784,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "configurationParams"]
+      "required": [
+        "pipetteId",
+        "configurationParams"
+      ]
     },
     "ConfigureNozzleLayoutCreate": {
       "title": "ConfigureNozzleLayoutCreate",
@@ -706,7 +797,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureNozzleLayout",
-          "enum": ["configureNozzleLayout"],
+          "enum": [
+            "configureNozzleLayout"
+          ],
           "type": "string"
         },
         "params": {
@@ -726,7 +819,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -742,7 +837,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": ["custom"],
+          "enum": [
+            "custom"
+          ],
           "type": "string"
         },
         "params": {
@@ -762,7 +859,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -811,7 +910,13 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -821,7 +926,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": ["dispense"],
+          "enum": [
+            "dispense"
+          ],
           "type": "string"
         },
         "params": {
@@ -841,7 +948,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -871,7 +980,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -881,7 +994,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": ["dispenseInPlace"],
+          "enum": [
+            "dispenseInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -901,7 +1016,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -939,7 +1056,12 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -949,7 +1071,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": ["blowout"],
+          "enum": [
+            "blowout"
+          ],
           "type": "string"
         },
         "params": {
@@ -969,7 +1093,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -988,7 +1114,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"]
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -998,7 +1127,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": ["blowOutInPlace"],
+          "enum": [
+            "blowOutInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -1018,12 +1149,19 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": ["top", "bottom", "center", "default"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "default"
+      ],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -1085,7 +1223,11 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"]
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -1095,7 +1237,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": ["dropTip"],
+          "enum": [
+            "dropTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -1115,7 +1259,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -1133,7 +1279,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -1143,7 +1291,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": ["dropTipInPlace"],
+          "enum": [
+            "dropTipInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -1163,7 +1313,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -1183,7 +1335,11 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": ["left", "right", "extension"],
+      "enum": [
+        "left",
+        "right",
+        "extension"
+      ],
       "type": "string"
     },
     "HomeParams": {
@@ -1216,7 +1372,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": ["home"],
+          "enum": [
+            "home"
+          ],
           "type": "string"
         },
         "params": {
@@ -1236,7 +1394,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -1252,7 +1412,9 @@
           ]
         }
       },
-      "required": ["axis"]
+      "required": [
+        "axis"
+      ]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -1262,7 +1424,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": ["retractAxis"],
+          "enum": [
+            "retractAxis"
+          ],
           "type": "string"
         },
         "params": {
@@ -1282,7 +1446,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1328,7 +1494,9 @@
           ]
         }
       },
-      "required": ["slotName"]
+      "required": [
+        "slotName"
+      ]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1341,7 +1509,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -1354,7 +1524,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"]
+      "required": [
+        "labwareId"
+      ]
     },
     "AddressableAreaLocation": {
       "title": "AddressableAreaLocation",
@@ -1367,7 +1539,9 @@
           "type": "string"
         }
       },
-      "required": ["addressableAreaName"]
+      "required": [
+        "addressableAreaName"
+      ]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1388,7 +1562,9 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             },
             {
@@ -1422,7 +1598,12 @@
           "type": "string"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"]
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1432,7 +1613,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": ["loadLabware"],
+          "enum": [
+            "loadLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1452,7 +1635,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ReloadLabwareParams": {
       "title": "ReloadLabwareParams",
@@ -1465,7 +1650,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"]
+      "required": [
+        "labwareId"
+      ]
     },
     "ReloadLabwareCreate": {
       "title": "ReloadLabwareCreate",
@@ -1475,7 +1662,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "reloadLabware",
-          "enum": ["reloadLabware"],
+          "enum": [
+            "reloadLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1495,7 +1684,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1521,7 +1712,11 @@
           }
         }
       },
-      "required": ["liquidId", "labwareId", "volumeByWell"]
+      "required": [
+        "liquidId",
+        "labwareId",
+        "volumeByWell"
+      ]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1531,7 +1726,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": ["loadLiquid"],
+          "enum": [
+            "loadLiquid"
+          ],
           "type": "string"
         },
         "params": {
@@ -1551,7 +1748,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1597,7 +1796,10 @@
           "type": "string"
         }
       },
-      "required": ["model", "location"]
+      "required": [
+        "model",
+        "location"
+      ]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1607,7 +1809,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": ["loadModule"],
+          "enum": [
+            "loadModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -1627,7 +1831,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1690,7 +1896,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteName", "mount"]
+      "required": [
+        "pipetteName",
+        "mount"
+      ]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1700,7 +1909,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": ["loadPipette"],
+          "enum": [
+            "loadPipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -1720,12 +1931,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
+      "enum": [
+        "usingGripper",
+        "manualMoveWithPause",
+        "manualMoveWithoutPause"
+      ],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1746,7 +1963,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1772,7 +1993,9 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             },
             {
@@ -1807,7 +2030,11 @@
           ]
         }
       },
-      "required": ["labwareId", "newLocation", "strategy"]
+      "required": [
+        "labwareId",
+        "newLocation",
+        "strategy"
+      ]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -1817,7 +2044,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": ["moveLabware"],
+          "enum": [
+            "moveLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1837,12 +2066,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": ["x", "y", "z"],
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -1869,7 +2104,11 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "axis", "distance"]
+      "required": [
+        "pipetteId",
+        "axis",
+        "distance"
+      ]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -1879,7 +2118,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": ["moveRelative"],
+          "enum": [
+            "moveRelative"
+          ],
           "type": "string"
         },
         "params": {
@@ -1899,7 +2140,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -1919,7 +2162,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -1957,7 +2204,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "coordinates"]
+      "required": [
+        "pipetteId",
+        "coordinates"
+      ]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -1967,7 +2217,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": ["moveToCoordinates"],
+          "enum": [
+            "moveToCoordinates"
+          ],
           "type": "string"
         },
         "params": {
@@ -1987,7 +2239,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -2035,7 +2289,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -2045,7 +2303,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": ["moveToWell"],
+          "enum": [
+            "moveToWell"
+          ],
           "type": "string"
         },
         "params": {
@@ -2065,7 +2325,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AddressableOffsetVector": {
       "title": "AddressableOffsetVector",
@@ -2085,7 +2347,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveToAddressableAreaParams": {
       "title": "MoveToAddressableAreaParams",
@@ -2139,7 +2405,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"]
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ]
     },
     "MoveToAddressableAreaCreate": {
       "title": "MoveToAddressableAreaCreate",
@@ -2149,7 +2418,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableArea",
-          "enum": ["moveToAddressableArea"],
+          "enum": [
+            "moveToAddressableArea"
+          ],
           "type": "string"
         },
         "params": {
@@ -2169,7 +2440,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MoveToAddressableAreaForDropTipParams": {
       "title": "MoveToAddressableAreaForDropTipParams",
@@ -2229,7 +2502,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"]
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ]
     },
     "MoveToAddressableAreaForDropTipCreate": {
       "title": "MoveToAddressableAreaForDropTipCreate",
@@ -2239,7 +2515,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableAreaForDropTip",
-          "enum": ["moveToAddressableAreaForDropTip"],
+          "enum": [
+            "moveToAddressableAreaForDropTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2259,7 +2537,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PrepareToAspirateParams": {
       "title": "PrepareToAspirateParams",
@@ -2272,7 +2552,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "PrepareToAspirateCreate": {
       "title": "PrepareToAspirateCreate",
@@ -2282,7 +2564,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "prepareToAspirate",
-          "enum": ["prepareToAspirate"],
+          "enum": [
+            "prepareToAspirate"
+          ],
           "type": "string"
         },
         "params": {
@@ -2302,7 +2586,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -2324,7 +2610,10 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": ["waitForResume", "pause"],
+          "enum": [
+            "waitForResume",
+            "pause"
+          ],
           "type": "string"
         },
         "params": {
@@ -2344,7 +2633,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -2362,7 +2653,9 @@
           "type": "string"
         }
       },
-      "required": ["seconds"]
+      "required": [
+        "seconds"
+      ]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -2372,7 +2665,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": ["waitForDuration"],
+          "enum": [
+            "waitForDuration"
+          ],
           "type": "string"
         },
         "params": {
@@ -2392,7 +2687,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -2424,7 +2721,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -2434,7 +2735,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": ["pickUpTip"],
+          "enum": [
+            "pickUpTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2454,7 +2757,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -2478,7 +2783,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -2488,7 +2795,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": ["savePosition"],
+          "enum": [
+            "savePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -2508,7 +2817,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2521,7 +2832,9 @@
           "type": "boolean"
         }
       },
-      "required": ["on"]
+      "required": [
+        "on"
+      ]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2531,7 +2844,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": ["setRailLights"],
+          "enum": [
+            "setRailLights"
+          ],
           "type": "string"
         },
         "params": {
@@ -2551,7 +2866,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2594,7 +2911,11 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2604,7 +2925,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": ["touchTip"],
+          "enum": [
+            "touchTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2624,12 +2947,20 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": ["idle", "confirm", "updating", "disco", "off"]
+      "enum": [
+        "idle",
+        "confirm",
+        "updating",
+        "disco",
+        "off"
+      ]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2645,7 +2976,9 @@
           ]
         }
       },
-      "required": ["animation"]
+      "required": [
+        "animation"
+      ]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2655,7 +2988,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": ["setStatusBar"],
+          "enum": [
+            "setStatusBar"
+          ],
           "type": "string"
         },
         "params": {
@@ -2675,18 +3010,28 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TipPresenceStatus": {
       "title": "TipPresenceStatus",
       "description": "Tip presence status reported by a pipette.",
-      "enum": ["present", "absent", "unknown"],
+      "enum": [
+        "present",
+        "absent",
+        "unknown"
+      ],
       "type": "string"
     },
     "InstrumentSensorId": {
       "title": "InstrumentSensorId",
       "description": "Primary and secondary sensor ids.",
-      "enum": ["primary", "secondary", "both"],
+      "enum": [
+        "primary",
+        "secondary",
+        "both"
+      ],
       "type": "string"
     },
     "VerifyTipPresenceParams": {
@@ -2716,7 +3061,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "expectedState"]
+      "required": [
+        "pipetteId",
+        "expectedState"
+      ]
     },
     "VerifyTipPresenceCreate": {
       "title": "VerifyTipPresenceCreate",
@@ -2726,7 +3074,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "verifyTipPresence",
-          "enum": ["verifyTipPresence"],
+          "enum": [
+            "verifyTipPresence"
+          ],
           "type": "string"
         },
         "params": {
@@ -2746,7 +3096,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "GetTipPresenceParams": {
       "title": "GetTipPresenceParams",
@@ -2759,7 +3111,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "GetTipPresenceCreate": {
       "title": "GetTipPresenceCreate",
@@ -2769,7 +3123,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "getTipPresence",
-          "enum": ["getTipPresence"],
+          "enum": [
+            "getTipPresence"
+          ],
           "type": "string"
         },
         "params": {
@@ -2789,7 +3145,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LiquidProbeParams": {
       "title": "LiquidProbeParams",
@@ -2821,7 +3179,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "LiquidProbeCreate": {
       "title": "LiquidProbeCreate",
@@ -2831,7 +3193,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "liquidProbe",
-          "enum": ["liquidProbe"],
+          "enum": [
+            "liquidProbe"
+          ],
           "type": "string"
         },
         "params": {
@@ -2851,7 +3215,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TryLiquidProbeParams": {
       "title": "TryLiquidProbeParams",
@@ -2883,7 +3249,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "TryLiquidProbeCreate": {
       "title": "TryLiquidProbeCreate",
@@ -2893,7 +3263,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "tryLiquidProbe",
-          "enum": ["tryLiquidProbe"],
+          "enum": [
+            "tryLiquidProbe"
+          ],
           "type": "string"
         },
         "params": {
@@ -2913,7 +3285,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2931,7 +3305,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2941,7 +3317,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": ["heaterShaker/waitForTemperature"],
+          "enum": [
+            "heaterShaker/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2961,7 +3339,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2979,7 +3359,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2989,7 +3372,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": ["heaterShaker/setTargetTemperature"],
+          "enum": [
+            "heaterShaker/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3009,7 +3394,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -3022,7 +3409,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -3032,7 +3421,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": ["heaterShaker/deactivateHeater"],
+          "enum": [
+            "heaterShaker/deactivateHeater"
+          ],
           "type": "string"
         },
         "params": {
@@ -3052,7 +3443,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -3070,7 +3463,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "rpm"]
+      "required": [
+        "moduleId",
+        "rpm"
+      ]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -3080,7 +3476,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
+          "enum": [
+            "heaterShaker/setAndWaitForShakeSpeed"
+          ],
           "type": "string"
         },
         "params": {
@@ -3100,7 +3498,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -3113,7 +3513,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -3123,7 +3525,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": ["heaterShaker/deactivateShaker"],
+          "enum": [
+            "heaterShaker/deactivateShaker"
+          ],
           "type": "string"
         },
         "params": {
@@ -3143,7 +3547,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -3156,7 +3562,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -3166,7 +3574,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": ["heaterShaker/openLabwareLatch"],
+          "enum": [
+            "heaterShaker/openLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -3186,7 +3596,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -3199,7 +3611,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -3209,7 +3623,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": ["heaterShaker/closeLabwareLatch"],
+          "enum": [
+            "heaterShaker/closeLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -3229,7 +3645,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -3242,7 +3660,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -3252,7 +3672,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": ["magneticModule/disengage"],
+          "enum": [
+            "magneticModule/disengage"
+          ],
           "type": "string"
         },
         "params": {
@@ -3272,7 +3694,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -3290,7 +3714,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "height"]
+      "required": [
+        "moduleId",
+        "height"
+      ]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -3300,7 +3727,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": ["magneticModule/engage"],
+          "enum": [
+            "magneticModule/engage"
+          ],
           "type": "string"
         },
         "params": {
@@ -3320,7 +3749,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3338,7 +3769,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3348,7 +3782,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": ["temperatureModule/setTargetTemperature"],
+          "enum": [
+            "temperatureModule/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3368,7 +3804,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3386,7 +3824,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3396,7 +3836,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": ["temperatureModule/waitForTemperature"],
+          "enum": [
+            "temperatureModule/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3416,7 +3858,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -3429,7 +3873,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -3439,7 +3885,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": ["temperatureModule/deactivate"],
+          "enum": [
+            "temperatureModule/deactivate"
+          ],
           "type": "string"
         },
         "params": {
@@ -3459,7 +3907,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -3487,7 +3937,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -3497,7 +3950,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": ["thermocycler/setTargetBlockTemperature"],
+          "enum": [
+            "thermocycler/setTargetBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3517,7 +3972,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -3530,7 +3987,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -3540,7 +3999,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": ["thermocycler/waitForBlockTemperature"],
+          "enum": [
+            "thermocycler/waitForBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3560,7 +4021,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -3578,7 +4041,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -3588,7 +4054,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": ["thermocycler/setTargetLidTemperature"],
+          "enum": [
+            "thermocycler/setTargetLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3608,7 +4076,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -3621,7 +4091,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -3631,7 +4103,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": ["thermocycler/waitForLidTemperature"],
+          "enum": [
+            "thermocycler/waitForLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3651,7 +4125,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -3664,7 +4140,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -3674,7 +4152,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": ["thermocycler/deactivateBlock"],
+          "enum": [
+            "thermocycler/deactivateBlock"
+          ],
           "type": "string"
         },
         "params": {
@@ -3694,7 +4174,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -3707,7 +4189,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -3717,7 +4201,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": ["thermocycler/deactivateLid"],
+          "enum": [
+            "thermocycler/deactivateLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -3737,9 +4223,11 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
-    "OpenLidParams": {
+    "opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams": {
       "title": "OpenLidParams",
       "description": "Input parameters to open a Thermocycler's lid.",
       "type": "object",
@@ -3750,9 +4238,11 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
-    "OpenLidCreate": {
+    "opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidCreate": {
       "title": "OpenLidCreate",
       "description": "A request to open a Thermocycler's lid.",
       "type": "object",
@@ -3760,11 +4250,13 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": ["thermocycler/openLid"],
+          "enum": [
+            "thermocycler/openLid"
+          ],
           "type": "string"
         },
         "params": {
-          "$ref": "#/definitions/OpenLidParams"
+          "$ref": "#/definitions/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
@@ -3780,9 +4272,11 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
-    "CloseLidParams": {
+    "opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams": {
       "title": "CloseLidParams",
       "description": "Input parameters to close a Thermocycler's lid.",
       "type": "object",
@@ -3793,9 +4287,11 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
-    "CloseLidCreate": {
+    "opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidCreate": {
       "title": "CloseLidCreate",
       "description": "A request to close a Thermocycler's lid.",
       "type": "object",
@@ -3803,11 +4299,13 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": ["thermocycler/closeLid"],
+          "enum": [
+            "thermocycler/closeLid"
+          ],
           "type": "string"
         },
         "params": {
-          "$ref": "#/definitions/CloseLidParams"
+          "$ref": "#/definitions/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
@@ -3823,7 +4321,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -3841,7 +4341,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"]
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -3867,7 +4370,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "profile"]
+      "required": [
+        "moduleId",
+        "profile"
+      ]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -3877,7 +4383,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": ["thermocycler/runProfile"],
+          "enum": [
+            "thermocycler/runProfile"
+          ],
           "type": "string"
         },
         "params": {
@@ -3897,7 +4405,107 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
+    },
+    "opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams": {
+      "title": "CloseLidParams",
+      "description": "Input parameters to close the lid on an absorbance reading.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the absorbance reader.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidCreate": {
+      "title": "CloseLidCreate",
+      "description": "A request to execute an Absorbance Reader close lid command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "absorbanceReader/closeLid",
+          "enum": [
+            "absorbanceReader/closeLid"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams": {
+      "title": "OpenLidParams",
+      "description": "Input parameters to open the lid on an absorbance reading.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the absorbance reader.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidCreate": {
+      "title": "OpenLidCreate",
+      "description": "A request to execute an Absorbance Reader open lid command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "absorbanceReader/openLid",
+          "enum": [
+            "absorbanceReader/openLid"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
     },
     "InitializeParams": {
       "title": "InitializeParams",
@@ -3909,13 +4517,34 @@
           "description": "Unique ID of the absorbance reader.",
           "type": "string"
         },
-        "sampleWavelength": {
-          "title": "Samplewavelength",
-          "description": "Sample wavelength in nm.",
+        "measureMode": {
+          "title": "Measuremode",
+          "description": "Initialize single or multi measurement mode.",
+          "enum": [
+            "single",
+            "multi"
+          ],
+          "type": "string"
+        },
+        "sampleWavelengths": {
+          "title": "Samplewavelengths",
+          "description": "Sample wavelengths in nm.",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "referenceWavelength": {
+          "title": "Referencewavelength",
+          "description": "Optional reference wavelength in nm.",
           "type": "integer"
         }
       },
-      "required": ["moduleId", "sampleWavelength"]
+      "required": [
+        "moduleId",
+        "measureMode",
+        "sampleWavelengths"
+      ]
     },
     "InitializeCreate": {
       "title": "InitializeCreate",
@@ -3925,7 +4554,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/initialize",
-          "enum": ["absorbanceReader/initialize"],
+          "enum": [
+            "absorbanceReader/initialize"
+          ],
           "type": "string"
         },
         "params": {
@@ -3945,39 +4576,40 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
-    "MeasureAbsorbanceParams": {
-      "title": "MeasureAbsorbanceParams",
-      "description": "Input parameters for a single absorbance reading.",
+    "ReadAbsorbanceParams": {
+      "title": "ReadAbsorbanceParams",
+      "description": "Input parameters for an absorbance reading.",
       "type": "object",
       "properties": {
         "moduleId": {
           "title": "Moduleid",
           "description": "Unique ID of the Absorbance Reader.",
           "type": "string"
-        },
-        "sampleWavelength": {
-          "title": "Samplewavelength",
-          "description": "Sample wavelength in nm.",
-          "type": "integer"
         }
       },
-      "required": ["moduleId", "sampleWavelength"]
+      "required": [
+        "moduleId"
+      ]
     },
-    "MeasureAbsorbanceCreate": {
-      "title": "MeasureAbsorbanceCreate",
+    "ReadAbsorbanceCreate": {
+      "title": "ReadAbsorbanceCreate",
       "description": "A request to execute an Absorbance Reader measurement.",
       "type": "object",
       "properties": {
         "commandType": {
           "title": "Commandtype",
-          "default": "absorbanceReader/measure",
-          "enum": ["absorbanceReader/measure"],
+          "default": "absorbanceReader/read",
+          "enum": [
+            "absorbanceReader/read"
+          ],
           "type": "string"
         },
         "params": {
-          "$ref": "#/definitions/MeasureAbsorbanceParams"
+          "$ref": "#/definitions/ReadAbsorbanceParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
@@ -3993,12 +4625,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": ["front", "rear"]
+      "enum": [
+        "front",
+        "rear"
+      ]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -4018,7 +4655,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -4043,7 +4684,9 @@
           ]
         }
       },
-      "required": ["jaw"]
+      "required": [
+        "jaw"
+      ]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -4053,7 +4696,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": ["calibration/calibrateGripper"],
+          "enum": [
+            "calibration/calibrateGripper"
+          ],
           "type": "string"
         },
         "params": {
@@ -4073,7 +4718,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -4089,7 +4736,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -4099,7 +4748,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": ["calibration/calibratePipette"],
+          "enum": [
+            "calibration/calibratePipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -4119,7 +4770,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -4145,7 +4798,11 @@
           ]
         }
       },
-      "required": ["moduleId", "labwareId", "mount"]
+      "required": [
+        "moduleId",
+        "labwareId",
+        "mount"
+      ]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -4155,7 +4812,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": ["calibration/calibrateModule"],
+          "enum": [
+            "calibration/calibrateModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -4175,12 +4834,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": ["attachPlate", "attachInstrument"]
+      "enum": [
+        "attachPlate",
+        "attachInstrument"
+      ]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -4205,7 +4869,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -4215,7 +4881,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": ["calibration/moveToMaintenancePosition"],
+          "enum": [
+            "calibration/moveToMaintenancePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -4235,7 +4903,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "UnsafeBlowOutInPlaceParams": {
       "title": "UnsafeBlowOutInPlaceParams",
@@ -4254,7 +4924,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"]
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "UnsafeBlowOutInPlaceCreate": {
       "title": "UnsafeBlowOutInPlaceCreate",
@@ -4264,7 +4937,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/blowOutInPlace",
-          "enum": ["unsafe/blowOutInPlace"],
+          "enum": [
+            "unsafe/blowOutInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -4284,7 +4959,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "UnsafeDropTipInPlaceParams": {
       "title": "UnsafeDropTipInPlaceParams",
@@ -4302,7 +4979,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "UnsafeDropTipInPlaceCreate": {
       "title": "UnsafeDropTipInPlaceCreate",
@@ -4312,7 +4991,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/dropTipInPlace",
-          "enum": ["unsafe/dropTipInPlace"],
+          "enum": [
+            "unsafe/dropTipInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -4332,7 +5013,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "UpdatePositionEstimatorsParams": {
       "title": "UpdatePositionEstimatorsParams",
@@ -4347,7 +5030,9 @@
           }
         }
       },
-      "required": ["axes"]
+      "required": [
+        "axes"
+      ]
     },
     "UpdatePositionEstimatorsCreate": {
       "title": "UpdatePositionEstimatorsCreate",
@@ -4357,7 +5042,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/updatePositionEstimators",
-          "enum": ["unsafe/updatePositionEstimators"],
+          "enum": [
+            "unsafe/updatePositionEstimators"
+          ],
           "type": "string"
         },
         "params": {
@@ -4377,7 +5064,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "UnsafeEngageAxesParams": {
       "title": "UnsafeEngageAxesParams",
@@ -4392,7 +5081,9 @@
           }
         }
       },
-      "required": ["axes"]
+      "required": [
+        "axes"
+      ]
     },
     "UnsafeEngageAxesCreate": {
       "title": "UnsafeEngageAxesCreate",
@@ -4402,7 +5093,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "unsafe/engageAxes",
-          "enum": ["unsafe/engageAxes"],
+          "enum": [
+            "unsafe/engageAxes"
+          ],
           "type": "string"
         },
         "params": {
@@ -4422,9 +5115,11 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     }
   },
-  "$id": "opentronsCommandSchemaV9",
+  "$id": "opentronsCommandSchemaV10",
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/shared-data/command/types/gantry.ts
+++ b/shared-data/command/types/gantry.ts
@@ -1,5 +1,6 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
 import type { AddressableAreaName } from '../../deck'
+import type { WellLocation } from './support'
 import type {
   Coordinates,
   MotorAxes,
@@ -125,14 +126,7 @@ export interface MoveToWellParams {
   pipetteId: string
   labwareId: string
   wellName: string
-  wellLocation?: {
-    origin?: 'top' | 'bottom'
-    offset?: {
-      x?: number
-      y?: number
-      z?: number
-    }
-  }
+  wellLocation?: WellLocation
   minimumZHeight?: number
   forceDirect?: boolean
 }

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -1,5 +1,6 @@
 import type { AddressableAreaName } from '../../deck'
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+import type { DropTipWellLocation, WellLocation } from './support'
 export type PipettingRunTimeCommand =
   | AspirateInPlaceRunTimeCommand
   | AspirateInPlaceRunTimeCommand
@@ -226,17 +227,7 @@ export type BlowoutParams = FlowRateParams &
   PipetteAccessParams &
   WellLocationParam
 export type TouchTipParams = PipetteAccessParams & WellLocationParam
-export type DropTipParams = PipetteAccessParams & {
-  wellLocation?: {
-    origin?: 'default' | 'top' | 'center' | 'bottom'
-    offset?: {
-      // mm values all default to 0
-      x?: number
-      y?: number
-      z?: number
-    }
-  }
-}
+export type DropTipParams = PipetteAccessParams & DropTipWellLocationParam
 export type PickUpTipParams = TouchTipParams
 
 interface AddressableOffsetVector {
@@ -292,17 +283,11 @@ interface VolumeParams {
 }
 
 interface WellLocationParam {
-  wellLocation?: {
-    // default value is 'top'
-    origin?: 'top' | 'center' | 'bottom'
-    offset?: {
-      // mm
-      // all values default to 0
-      x?: number
-      y?: number
-      z?: number
-    }
-  }
+  wellLocation?: WellLocation
+}
+
+interface DropTipWellLocationParam {
+  wellLocation?: DropTipWellLocation
 }
 
 interface VerifyTipPresenceParams extends PipetteIdentityParams {

--- a/shared-data/command/types/support.ts
+++ b/shared-data/command/types/support.ts
@@ -1,0 +1,18 @@
+type BaseWellOrigin = 'top' | 'bottom' | 'center'
+export type WellOrigin = BaseWellOrigin | 'meniscus'
+export interface WellOffset {
+    x?: number
+    y?: number
+    z?: number
+}
+export interface WellLocation {
+    origin?: WellOrigin
+    offset?: WellOffset
+}
+
+export type DropTipWellOrigin = BaseWellOrigin | 'default'
+
+export interface DropTipWellLocation {
+    origin?: DropTipWellOrigin
+    offset?: WellOffset
+}

--- a/shared-data/command/types/support.ts
+++ b/shared-data/command/types/support.ts
@@ -1,18 +1,18 @@
 type BaseWellOrigin = 'top' | 'bottom' | 'center'
 export type WellOrigin = BaseWellOrigin | 'meniscus'
 export interface WellOffset {
-    x?: number
-    y?: number
-    z?: number
+  x?: number
+  y?: number
+  z?: number
 }
 export interface WellLocation {
-    origin?: WellOrigin
-    offset?: WellOffset
+  origin?: WellOrigin
+  offset?: WellOffset
 }
 
 export type DropTipWellOrigin = BaseWellOrigin | 'default'
 
 export interface DropTipWellLocation {
-    origin?: DropTipWellOrigin
-    offset?: WellOffset
+  origin?: DropTipWellOrigin
+  offset?: WellOffset
 }

--- a/shared-data/python/opentrons_shared_data/command/__init__.py
+++ b/shared-data/python/opentrons_shared_data/command/__init__.py
@@ -19,7 +19,7 @@ def get_newest_schema_version() -> str:
     for schema_file_name in command_schemas:
         schema_version_match = re.match(r"(\d+).json", schema_file_name)
         if schema_version_match is not None:
-            all_schema_versions.append(schema_version_match.group(1))
+            all_schema_versions.append(int(schema_version_match.group(1)))
 
     return str(max(all_schema_versions))
 

--- a/step-generation/src/__tests__/forAspirate.test.ts
+++ b/step-generation/src/__tests__/forAspirate.test.ts
@@ -15,7 +15,7 @@ import type {
   InvariantContext,
   RobotState,
 } from '../types'
-import type { AspDispAirgapParams } from '@opentrons/shared-data/lib/protocol/types/schemaV6/command/pipetting'
+import type { AspDispAirgapParams } from '@opentrons/shared-data'
 
 const forAspirate = makeImmutableStateUpdater(_forAspirate)
 

--- a/step-generation/src/__tests__/forBlowout.test.ts
+++ b/step-generation/src/__tests__/forBlowout.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../fixtures'
 import { forBlowout as _forBlowout } from '../getNextRobotStateAndWarnings/forBlowout'
 import { makeImmutableStateUpdater } from '../__utils__'
-import type { BlowoutParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
+import type { BlowoutParams } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
 
 const forBlowout = makeImmutableStateUpdater(_forBlowout)

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -10,8 +10,8 @@ import {
   getLocationTotalVolume,
 } from '../utils/misc'
 import * as warningCreators from '../warningCreators'
-import type { AspDispAirgapParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
+import type { AspDispAirgapParams } from '@opentrons/shared-data'
 export function forAspirate(
   params: AspDispAirgapParams,
   invariantContext: InvariantContext,

--- a/step-generation/src/getNextRobotStateAndWarnings/forBlowout.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forBlowout.ts
@@ -1,5 +1,5 @@
 import { dispenseUpdateLiquidState } from './dispenseUpdateLiquidState'
-import type { BlowoutParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
+import type { BlowoutParams } from '@opentrons/shared-data'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 export function forBlowout(
   params: BlowoutParams,

--- a/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
@@ -1,5 +1,5 @@
 import { dispenseUpdateLiquidState } from './dispenseUpdateLiquidState'
-import type { AspDispAirgapParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
+import type { AspDispAirgapParams } from '@opentrons/shared-data'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 export function forDispense(
   params: AspDispAirgapParams,

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import { ALL, COLUMN, getIsTiprack } from '@opentrons/shared-data'
-import type { PickUpTipParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
+import type { PickUpTipParams } from '@opentrons/shared-data'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 export function forPickUpTip(
   params: PickUpTipParams,

--- a/step-generation/src/utils/stripNoOpCommands.ts
+++ b/step-generation/src/utils/stripNoOpCommands.ts
@@ -1,6 +1,5 @@
 import { removePairs } from './removePairs'
-import type { AspDispAirgapParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
-import type { CreateCommand } from '@opentrons/shared-data'
+import type { AspDispAirgapParams, CreateCommand } from '@opentrons/shared-data'
 
 const _isEqualMix = (
   a: AspDispAirgapParams,


### PR DESCRIPTION
This is a new default command schema that we'll use for implementing static meniscus-relative pipetting.

There are a couple odd changes in step-generation to look at because the command types finally changed in a way that was incompatible with the schema v6 types there. However, there's not an incompatible change in the commands, it's just that the types were inappropriately wide.