### PR TITLE
feat(robot-server): Add `GET` `runs/:runId/currentState`

### DIFF
--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -487,7 +487,7 @@ class TipView(HasState[TipState]):
         return self._state.nozzle_map_by_pipette_id[pipette_id]
 
     def get_pipette_nozzle_maps(self) -> Dict[str, NozzleMap]:
-        """Get the current nozzle map keyed by attached pipette id."""
+        """Get current nozzle maps keyed by pipette id."""
         return self._state.nozzle_map_by_pipette_id
 
     def has_clean_tip(self, labware_id: str, well_name: str) -> bool:

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -486,6 +486,10 @@ class TipView(HasState[TipState]):
         """Get the current nozzle map the given pipette's configuration."""
         return self._state.nozzle_map_by_pipette_id[pipette_id]
 
+    def get_pipette_nozzle_maps(self) -> Dict[str, NozzleMap]:
+        """Get the current nozzle map keyed by attached pipette id."""
+        return self._state.nozzle_map_by_pipette_id
+
     def has_clean_tip(self, labware_id: str, well_name: str) -> bool:
         """Get whether a well in a labware has a clean tip.
 

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -14,6 +14,7 @@ from opentrons_shared_data.robot.types import RobotType
 from . import protocol_runner, RunResult, JsonRunner, PythonAndLegacyRunner
 from ..hardware_control import HardwareControlAPI
 from ..hardware_control.modules import AbstractModule as HardwareModuleAPI
+from ..hardware_control.nozzle_manager import NozzleMap
 from ..protocol_engine import (
     ProtocolEngine,
     CommandCreate,
@@ -396,6 +397,12 @@ class RunOrchestrator:
     def get_deck_type(self) -> DeckType:
         """Get engine deck type."""
         return self._protocol_engine.state_view.config.deck_type
+
+    def get_nozzle_map(self, pipette_id: str) -> NozzleMap:
+        """Get nozzle map for a pipette."""
+        return self._protocol_engine.state_view.tips.get_pipette_nozzle_map(
+            pipette_id=pipette_id
+        )
 
     def set_error_recovery_policy(self, policy: ErrorRecoveryPolicy) -> None:
         """Create error recovery policy for the run."""

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -399,7 +399,7 @@ class RunOrchestrator:
         return self._protocol_engine.state_view.config.deck_type
 
     def get_nozzle_maps(self) -> Dict[str, NozzleMap]:
-        """Get the current nozzle map keyed by pipette id."""
+        """Get current nozzle maps keyed by pipette id."""
         return self._protocol_engine.state_view.tips.get_pipette_nozzle_maps()
 
     def set_error_recovery_policy(self, policy: ErrorRecoveryPolicy) -> None:

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -398,11 +398,9 @@ class RunOrchestrator:
         """Get engine deck type."""
         return self._protocol_engine.state_view.config.deck_type
 
-    def get_nozzle_map(self, pipette_id: str) -> NozzleMap:
-        """Get nozzle map for a pipette."""
-        return self._protocol_engine.state_view.tips.get_pipette_nozzle_map(
-            pipette_id=pipette_id
-        )
+    def get_nozzle_maps(self) -> Dict[str, NozzleMap]:
+        """Get the current nozzle map keyed by pipette id."""
+        return self._protocol_engine.state_view.tips.get_pipette_nozzle_maps()
 
     def set_error_recovery_policy(self, policy: ErrorRecoveryPolicy) -> None:
         """Create error recovery policy for the run."""

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -111,7 +111,7 @@ class RunStopped(ErrorDetails):
 
 
 class NozzleMapNotFound(ErrorDetails):
-    """An error if one tries to modify a stopped run."""
+    """An error if a nozzle map is not found."""
 
     id: Literal["NozzleMapNotFound"] = "NozzleMapNotFound"
     title: str = "Nozzle Map Not Found"
@@ -548,9 +548,9 @@ async def get_run_commands_error(
     ),
     responses={
         status.HTTP_200_OK: {"model": SimpleBody[ActiveNozzleLayout]},
-        # status.HTTP_404_NOT_FOUND: {
-        #     "model": ErrorBody[Union[RunNotFound, PipetteNotFound]]
-        # },
+        status.HTTP_404_NOT_FOUND: {
+            "model": ErrorBody[Union[RunNotFound, NozzleMapNotFound]]
+        },
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunStopped]},
     },
 )

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -50,7 +50,11 @@ from ..run_models import RunNotFoundError, ActiveNozzleLayout
 from ..run_auto_deleter import RunAutoDeleter
 from ..run_models import Run, BadRun, RunCreate, RunUpdate
 from ..run_orchestrator_store import RunConflictError
-from ..run_data_manager import RunDataManager, RunNotCurrentError
+from ..run_data_manager import (
+    RunDataManager,
+    RunNotCurrentError,
+    NozzleMapNotFoundError,
+)
 from ..dependencies import (
     get_run_data_manager,
     get_run_auto_deleter,
@@ -103,6 +107,14 @@ class RunStopped(ErrorDetails):
 
     id: Literal["RunStopped"] = "RunStopped"
     title: str = "Run Stopped"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
+
+
+class NozzleMapNotFound(ErrorDetails):
+    """An error if one tries to modify a stopped run."""
+
+    id: Literal["NozzleMapNotFound"] = "NozzleMapNotFound"
+    title: str = "Nozzle Map Not Found"
     errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
 
 
@@ -558,9 +570,8 @@ async def get_active_nozzle_layout(
         active_nozzle_map = run_data_manager.get_nozzle_map(
             run_id=runId, pipette_id=pipetteId
         )
-    # TOME: Figure out which layer to put the pipettenotfoudnerror on.
-    # except PipetteNotFoundError as e:
-    #     raise PipetteNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+    except NozzleMapNotFoundError as e:
+        raise NozzleMapNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
     except RunNotCurrentError as e:
         raise RunStopped(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
 

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -52,6 +52,7 @@ from ..run_models import (
     ActiveNozzleLayout,
     RunCurrentState,
     CommandLinkNoMeta,
+    NozzleLayoutConfig,
 )
 from ..run_auto_deleter import RunAutoDeleter
 from ..run_models import Run, BadRun, RunCreate, RunUpdate
@@ -576,7 +577,7 @@ async def get_current_state(
             pipetteId: ActiveNozzleLayout.construct(
                 startingNozzle=nozzle_map.starting_nozzle,
                 activeNozzles=list(nozzle_map.map_store.keys()),
-                config=nozzle_map.configuration.value,
+                config=NozzleLayoutConfig(nozzle_map.configuration.value.lower()),
             )
             for pipetteId, nozzle_map in active_nozzle_maps.items()
         }

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -4,6 +4,9 @@ from typing import List, Optional, Callable, Union
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.errors.exceptions import InvalidStoredData, EnumeratedError
+
+from opentrons.hardware_control.nozzle_manager import NozzleMap
+
 from opentrons.protocol_engine import (
     EngineStatus,
     LabwareOffsetCreate,
@@ -471,6 +474,14 @@ class RunDataManager:
             return self._run_orchestrator_store.get_command_errors()
 
         # TODO(tz, 8-5-2024): Change this to return the error list from the DB when we implement https://opentrons.atlassian.net/browse/EXEC-655.
+        raise RunNotCurrentError()
+
+    # TOME: This may get renamed if you do the data transformation here.
+    def get_nozzle_map(self, run_id: str, pipette_id: str) -> NozzleMap:
+        """Get nozzle map for a pipette."""
+        if run_id == self._run_orchestrator_store.current_run_id:
+            return self._run_orchestrator_store.get_nozzle_map(pipette_id)
+
         raise RunNotCurrentError()
 
     def get_all_commands_as_preserialized_list(

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -477,7 +477,7 @@ class RunDataManager:
         raise RunNotCurrentError()
 
     def get_nozzle_maps(self, run_id: str) -> Dict[str, NozzleMap]:
-        """Get the current nozzle map keyed pipette id."""
+        """Get current nozzle maps keyed by pipette id."""
         if run_id == self._run_orchestrator_store.current_run_id:
             return self._run_orchestrator_store.get_nozzle_maps()
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -126,6 +126,10 @@ class RunNotCurrentError(ValueError):
     """Error raised when a requested run is not the current run."""
 
 
+class NozzleMapNotFoundError(ValueError):
+    """Error raised when a requested nozzle map cannot be found."""
+
+
 class PreSerializedCommandsNotAvailableError(LookupError):
     """Error raised when a run's commands are not available as pre-serialized list of commands."""
 
@@ -476,11 +480,13 @@ class RunDataManager:
         # TODO(tz, 8-5-2024): Change this to return the error list from the DB when we implement https://opentrons.atlassian.net/browse/EXEC-655.
         raise RunNotCurrentError()
 
-    # TOME: This may get renamed if you do the data transformation here.
     def get_nozzle_map(self, run_id: str, pipette_id: str) -> NozzleMap:
         """Get nozzle map for a pipette."""
         if run_id == self._run_orchestrator_store.current_run_id:
-            return self._run_orchestrator_store.get_nozzle_map(pipette_id)
+            try:
+                return self._run_orchestrator_store.get_nozzle_map(pipette_id)
+            except KeyError:
+                raise NozzleMapNotFoundError()
 
         raise RunNotCurrentError()
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -1,6 +1,6 @@
 """Manage current and historical run data."""
 from datetime import datetime
-from typing import List, Optional, Callable, Union
+from typing import List, Optional, Callable, Union, Dict
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.errors.exceptions import InvalidStoredData, EnumeratedError
@@ -124,10 +124,6 @@ def _build_run(
 
 class RunNotCurrentError(ValueError):
     """Error raised when a requested run is not the current run."""
-
-
-class NozzleMapNotFoundError(ValueError):
-    """Error raised when a requested nozzle map cannot be found."""
 
 
 class PreSerializedCommandsNotAvailableError(LookupError):
@@ -480,13 +476,10 @@ class RunDataManager:
         # TODO(tz, 8-5-2024): Change this to return the error list from the DB when we implement https://opentrons.atlassian.net/browse/EXEC-655.
         raise RunNotCurrentError()
 
-    def get_nozzle_map(self, run_id: str, pipette_id: str) -> NozzleMap:
-        """Get nozzle map for a pipette."""
+    def get_nozzle_maps(self, run_id: str) -> Dict[str, NozzleMap]:
+        """Get the current nozzle map keyed pipette id."""
         if run_id == self._run_orchestrator_store.current_run_id:
-            try:
-                return self._run_orchestrator_store.get_nozzle_map(pipette_id)
-            except KeyError:
-                raise NozzleMapNotFoundError()
+            return self._run_orchestrator_store.get_nozzle_maps()
 
         raise RunNotCurrentError()
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -285,14 +285,14 @@ class ActiveNozzleLayout(BaseModel):
     """Details about the active nozzle layout for a pipette."""
 
     configuration: "NozzleConfigurationType" = Field(
-        None, description="The active nozzle configuration."
+        ..., description="The active nozzle configuration."
     )
     columns: Dict[str, List[str]] = Field(
-        None,
+        ...,
         description="A map of all the pipette columns active in the current configuration.",
     )
     rows: Dict[str, List[str]] = Field(
-        None,
+        ...,
         description="A map of all the pipette rows active in the current configuration.",
     )
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -1,7 +1,7 @@
 """Request and response models for run resources."""
 from datetime import datetime
 from pydantic import BaseModel, Field
-from typing import List, Optional, Literal
+from typing import List, Optional, Literal, Dict
 
 from opentrons.protocol_engine import (
     CommandStatus,
@@ -24,6 +24,7 @@ from opentrons.protocol_engine.types import (
     CSVRunTimeParamFilesType,
 )
 from opentrons_shared_data.errors import GeneralError
+from opentrons.hardware_control.nozzle_manager import NozzleConfigurationType
 from robot_server.service.json_api import ResourceModel
 from robot_server.errors.error_responses import ErrorDetails
 from .action_models import RunAction
@@ -277,6 +278,22 @@ class LabwareDefinitionSummary(BaseModel):
     definitionUri: str = Field(
         ...,
         description="The definition's unique resource identifier in the run.",
+    )
+
+
+class ActiveNozzleLayout(BaseModel):
+    """Details about the active nozzle layout for a pipette."""
+
+    configuration: "NozzleConfigurationType" = Field(
+        None, description="The active nozzle configuration."
+    )
+    columns: Dict[str, List[str]] = Field(
+        None,
+        description="A map of all the pipette columns active in the current configuration.",
+    )
+    rows: Dict[str, List[str]] = Field(
+        None,
+        description="A map of all the pipette rows active in the current configuration.",
     )
 
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -299,6 +299,13 @@ class RunCurrentState(BaseModel):
     activeNozzleLayouts: Dict[str, ActiveNozzleLayout] = Field(..., description="")
 
 
+class CommandLinkNoMeta(BaseModel):
+    """A link to a command resource without a meta field."""
+
+    id: str = Field(..., description="The ID of the command.")
+    href: str = Field(..., description="The HTTP API path to the command.")
+
+
 class RunNotFoundError(GeneralError):
     """Error raised when a given Run ID is not found in the store."""
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -1,5 +1,7 @@
 """Request and response models for run resources."""
 from datetime import datetime
+
+from enum import Enum
 from pydantic import BaseModel, Field
 from typing import List, Optional, Literal, Dict
 
@@ -280,6 +282,16 @@ class LabwareDefinitionSummary(BaseModel):
     )
 
 
+class NozzleLayoutConfig(str, Enum):
+    """Possible valid nozzle configurations."""
+
+    COLUMN = "column"
+    ROW = "row"
+    SINGLE = "single"
+    FULL = "full"
+    SUBRECT = "subrect"
+
+
 class ActiveNozzleLayout(BaseModel):
     """Details about the active nozzle layout for a pipette used in the current run."""
 
@@ -290,7 +302,9 @@ class ActiveNozzleLayout(BaseModel):
         ...,
         description="A map of all the pipette nozzles active in the current configuration.",
     )
-    config: str = Field(..., description="The nozzle configuration type.")
+    config: NozzleLayoutConfig = Field(
+        ..., description="The active nozzle configuration."
+    )
 
 
 class RunCurrentState(BaseModel):

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -24,7 +24,6 @@ from opentrons.protocol_engine.types import (
     CSVRunTimeParamFilesType,
 )
 from opentrons_shared_data.errors import GeneralError
-from opentrons.hardware_control.nozzle_manager import NozzleConfigurationType
 from robot_server.service.json_api import ResourceModel
 from robot_server.errors.error_responses import ErrorDetails
 from .action_models import RunAction
@@ -282,19 +281,22 @@ class LabwareDefinitionSummary(BaseModel):
 
 
 class ActiveNozzleLayout(BaseModel):
-    """Details about the active nozzle layout for a pipette."""
+    """Details about the active nozzle layout for a pipette used in the current run."""
 
-    configuration: "NozzleConfigurationType" = Field(
-        ..., description="The active nozzle configuration."
+    startingNozzle: str = Field(
+        ..., description="The nozzle used when issuing pipette commands."
     )
-    columns: Dict[str, List[str]] = Field(
+    activeNozzles: List[str] = Field(
         ...,
-        description="A map of all the pipette columns active in the current configuration.",
+        description="A map of all the pipette nozzles active in the current configuration.",
     )
-    rows: Dict[str, List[str]] = Field(
-        ...,
-        description="A map of all the pipette rows active in the current configuration.",
-    )
+    config: str = Field(..., description="The nozzle configuration type.")
+
+
+class RunCurrentState(BaseModel):
+    """Current details about a run."""
+
+    activeNozzleLayouts: Dict[str, ActiveNozzleLayout] = Field(..., description="")
 
 
 class RunNotFoundError(GeneralError):

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -1,7 +1,7 @@
 """In-memory storage of ProtocolEngine instances."""
 import asyncio
 import logging
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Dict
 
 from opentrons.protocol_engine.errors.exceptions import EStopActivatedError
 from opentrons.protocol_engine.types import (
@@ -325,9 +325,9 @@ class RunOrchestratorStore:
         """Get loaded labware definitions."""
         return self.run_orchestrator.get_loaded_labware_definitions()
 
-    def get_nozzle_map(self, pipette_id: str) -> NozzleMap:
-        """Get nozzle map for a pipette."""
-        return self.run_orchestrator.get_nozzle_map(pipette_id=pipette_id)
+    def get_nozzle_maps(self) -> Dict[str, NozzleMap]:
+        """Get the current nozzle map keyed by pipette id."""
+        return self.run_orchestrator.get_nozzle_maps()
 
     def get_run_time_parameters(self) -> List[RunTimeParameter]:
         """Parameter definitions defined by protocol, if any. Will always be empty before execution."""

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -16,6 +16,7 @@ from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from opentrons.config import feature_flags
 from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.hardware_control.types import (
     EstopState,
     HardwareEvent,
@@ -323,6 +324,10 @@ class RunOrchestratorStore:
     def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
         """Get loaded labware definitions."""
         return self.run_orchestrator.get_loaded_labware_definitions()
+
+    def get_nozzle_map(self, pipette_id: str) -> NozzleMap:
+        """Get nozzle map for a pipette."""
+        return self.run_orchestrator.get_nozzle_map(pipette_id=pipette_id)
 
     def get_run_time_parameters(self) -> List[RunTimeParameter]:
         """Parameter definitions defined by protocol, if any. Will always be empty before execution."""

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -46,6 +46,7 @@ from robot_server.runs.run_models import (
     RunCurrentState,
     ActiveNozzleLayout,
     CommandLinkNoMeta,
+    NozzleLayoutConfig,
 )
 from robot_server.runs.run_orchestrator_store import RunConflictError
 from robot_server.runs.run_data_manager import (
@@ -868,7 +869,9 @@ async def test_get_current_state_success(
     assert result.content.data == RunCurrentState.construct(
         activeNozzleLayouts={
             "mock-pipette-id": ActiveNozzleLayout(
-                startingNozzle="A1", activeNozzles=["A1"], config="FULL"
+                startingNozzle="A1",
+                activeNozzles=["A1"],
+                config=NozzleLayoutConfig.FULL,
             )
         }
     )

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -1,15 +1,18 @@
 """Tests for base /runs routes."""
+from typing import Dict
+
 import pytest
 from datetime import datetime
 from decoy import Decoy
 from pathlib import Path
 
-from opentrons.types import DeckSlotName
+from opentrons.types import DeckSlotName, Point
 from opentrons.protocol_engine import (
     LabwareOffsetCreate,
     types as pe_types,
     errors as pe_errors,
     CommandErrorSlice,
+    CommandPointer,
 )
 from opentrons.protocol_reader import ProtocolSource, JsonProtocolConfig
 
@@ -36,12 +39,17 @@ from robot_server.protocols.protocol_store import (
 
 from robot_server.runs.run_auto_deleter import RunAutoDeleter
 
-from robot_server.runs.run_models import Run, RunCreate, RunUpdate, ActiveNozzleLayout
+from robot_server.runs.run_models import (
+    Run,
+    RunCreate,
+    RunUpdate,
+    RunCurrentState,
+    ActiveNozzleLayout,
+)
 from robot_server.runs.run_orchestrator_store import RunConflictError
 from robot_server.runs.run_data_manager import (
     RunDataManager,
     RunNotCurrentError,
-    NozzleMapNotFoundError,
 )
 from robot_server.runs.run_models import RunNotFoundError
 from robot_server.runs.router.base_router import (
@@ -54,7 +62,8 @@ from robot_server.runs.router.base_router import (
     update_run,
     put_error_recovery_policy,
     get_run_commands_error,
-    get_active_nozzle_layout,
+    get_current_state,
+    CurrentStateLinks,
 )
 
 from robot_server.deck_configuration.store import DeckConfigurationStore
@@ -92,18 +101,20 @@ def labware_offset_create() -> LabwareOffsetCreate:
 
 
 @pytest.fixture
-def mock_nozzle_map() -> NozzleMap:
-    """Get a mock NozzleMap."""
-    return NozzleMap(
-        configuration=NozzleConfigurationType.FULL,
-        columns={"1": ["A1"]},
-        rows={"A": ["A1"]},
-        map_store={},
-        starting_nozzle="A1",
-        valid_map_key="mock-key",
-        full_instrument_map_store={},
-        full_instrument_rows={},
-    )
+def mock_nozzle_maps() -> Dict[str, NozzleMap]:
+    """Get mock NozzleMaps."""
+    return {
+        "mock-pipette-id": NozzleMap(
+            configuration=NozzleConfigurationType.FULL,
+            columns={"1": ["A1"]},
+            rows={"A": ["A1"]},
+            map_store={"A1": Point(0, 0, 0)},
+            starting_nozzle="A1",
+            valid_map_key="mock-key",
+            full_instrument_map_store={},
+            full_instrument_rows={},
+        )
+    }
 
 
 async def test_create_run(
@@ -827,72 +838,60 @@ async def test_get_run_commands_errors_defualt_cursor(
     assert result.status_code == 200
 
 
-async def test_get_active_nozzle_layout_success(
+async def test_get_current_state_success(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
-    mock_nozzle_map: NozzleMap,
+    mock_nozzle_maps: Dict[str, NozzleMap],
 ) -> None:
     """It should return the active nozzle layout for a specific pipette."""
     run_id = "test-run-id"
-    pipette_id = "test-pipette-id"
 
-    decoy.when(
-        mock_run_data_manager.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)
-    ).then_return(mock_nozzle_map)
+    decoy.when(mock_run_data_manager.get_nozzle_maps(run_id=run_id)).then_return(
+        mock_nozzle_maps
+    )
+    decoy.when(mock_run_data_manager.get_current_command(run_id=run_id)).then_return(
+        CommandPointer(
+            command_id="current-command-id",
+            command_key="current-command-key",
+            created_at=datetime(year=2024, month=4, day=4),
+            index=101,
+        )
+    )
 
-    result = await get_active_nozzle_layout(
+    result = await get_current_state(
         runId=run_id,
-        pipetteId=pipette_id,
         run_data_manager=mock_run_data_manager,
     )
 
     assert result.status_code == 200
-    assert result.content.data == ActiveNozzleLayout(
-        configuration=NozzleConfigurationType.FULL,
-        columns={"1": ["A1"]},
-        rows={"A": ["A1"]},
+    assert result.content.data == RunCurrentState.construct(
+        activeNozzleLayouts={
+            "mock-pipette-id": ActiveNozzleLayout(
+                startingNozzle="A1", activeNozzles=["A1"], config="FULL"
+            )
+        }
+    )
+    assert result.content.links == CurrentStateLinks(
+        active_command=ResourceLink(
+            href="/runs/test-run-id/commands/current-command-id", meta=None
+        )
     )
 
 
-async def test_get_active_nozzle_layout_nozzle_map_not_found(
-    decoy: Decoy,
-    mock_run_data_manager: RunDataManager,
-) -> None:
-    """It should raise NozzleMapNotFound when the nozzle map is not found."""
-    run_id = "test-run-id"
-    pipette_id = "non-existent-pipette-id"
-
-    decoy.when(
-        mock_run_data_manager.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)
-    ).then_raise(NozzleMapNotFoundError("Nozzle map not found"))
-
-    with pytest.raises(ApiError) as exc_info:
-        await get_active_nozzle_layout(
-            runId=run_id,
-            pipetteId=pipette_id,
-            run_data_manager=mock_run_data_manager,
-        )
-
-    assert exc_info.value.status_code == 404
-    assert exc_info.value.content["errors"][0]["id"] == "NozzleMapNotFound"
-
-
-async def test_get_active_nozzle_layout_run_not_current(
+async def test_get_current_state_run_not_current(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
 ) -> None:
     """It should raise RunStopped when the run is not current."""
     run_id = "non-current-run-id"
-    pipette_id = "test-pipette-id"
 
-    decoy.when(
-        mock_run_data_manager.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)
-    ).then_raise(RunNotCurrentError("Run is not current"))
+    decoy.when(mock_run_data_manager.get_nozzle_maps(run_id=run_id)).then_raise(
+        RunNotCurrentError("Run is not current")
+    )
 
     with pytest.raises(ApiError) as exc_info:
-        await get_active_nozzle_layout(
+        await get_current_state(
             runId=run_id,
-            pipetteId=pipette_id,
             run_data_manager=mock_run_data_manager,
         )
 

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -837,7 +837,7 @@ async def test_get_active_nozzle_layout_success(
     pipette_id = "test-pipette-id"
 
     decoy.when(
-        mock_run_data_manager.get_nozzle_map(run_id=run_id, pipette_id=pipette_id)
+        mock_run_data_manager.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)
     ).then_return(mock_nozzle_map)
 
     result = await get_active_nozzle_layout(
@@ -863,7 +863,7 @@ async def test_get_active_nozzle_layout_nozzle_map_not_found(
     pipette_id = "non-existent-pipette-id"
 
     decoy.when(
-        mock_run_data_manager.get_nozzle_map(run_id=run_id, pipette_id=pipette_id)
+        mock_run_data_manager.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)
     ).then_raise(NozzleMapNotFoundError("Nozzle map not found"))
 
     with pytest.raises(ApiError) as exc_info:
@@ -886,7 +886,7 @@ async def test_get_active_nozzle_layout_run_not_current(
     pipette_id = "test-pipette-id"
 
     decoy.when(
-        mock_run_data_manager.get_nozzle_map(run_id=run_id, pipette_id=pipette_id)
+        mock_run_data_manager.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)
     ).then_raise(RunNotCurrentError("Run is not current"))
 
     with pytest.raises(ApiError) as exc_info:

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -45,6 +45,7 @@ from robot_server.runs.run_models import (
     RunUpdate,
     RunCurrentState,
     ActiveNozzleLayout,
+    CommandLinkNoMeta,
 )
 from robot_server.runs.run_orchestrator_store import RunConflictError
 from robot_server.runs.run_data_manager import (
@@ -872,8 +873,9 @@ async def test_get_current_state_success(
         }
     )
     assert result.content.links == CurrentStateLinks(
-        active_command=ResourceLink(
-            href="/runs/test-run-id/commands/current-command-id", meta=None
+        current=CommandLinkNoMeta(
+            href="/runs/test-run-id/commands/current-command-id",
+            id="current-command-id",
         )
     )
 

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -1168,11 +1168,11 @@ def test_get_nozzle_map_current_run(
     pipette_id = "pipette-id"
 
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
-    decoy.when(mock_run_orchestrator_store.get_nozzle_map(pipette_id)).then_return(
+    decoy.when(mock_run_orchestrator_store.get_nozzle_maps(pipette_id)).then_return(
         mock_nozzle_map
     )
 
-    result = subject.get_nozzle_map(run_id=run_id, pipette_id=pipette_id)
+    result = subject.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)
 
     assert result == mock_nozzle_map
 
@@ -1191,7 +1191,7 @@ def test_get_nozzle_map_not_current_run(
     )
 
     with pytest.raises(RunNotCurrentError):
-        subject.get_nozzle_map(run_id=run_id, pipette_id=pipette_id)
+        subject.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)
 
 
 def test_get_nozzle_map_not_found(
@@ -1204,9 +1204,9 @@ def test_get_nozzle_map_not_found(
     pipette_id = "non-existent-pipette-id"
 
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
-    decoy.when(mock_run_orchestrator_store.get_nozzle_map(pipette_id)).then_raise(
+    decoy.when(mock_run_orchestrator_store.get_nozzle_maps(pipette_id)).then_raise(
         KeyError("Pipette not found")
     )
 
     with pytest.raises(NozzleMapNotFoundError):
-        subject.get_nozzle_map(run_id=run_id, pipette_id=pipette_id)
+        subject.get_nozzle_maps(run_id=run_id, pipette_id=pipette_id)


### PR DESCRIPTION
Works toward [RSQ-161](https://opentrons.atlassian.net/browse/RSQ-161)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

To support partial tip during error recovery during certain flows, the server must expose details about the current pipetting tip layout for the current run. `NozzleMap` contains details the client is interested in, but we really shouldn't return the entirety of `NozzleMap`, since it is A) quite large and B) contains a lot of info irrelevant from a client perspective. To that end, we return an `ActiveNozzleLayout` derived from the `NozzleMap` for the pipette of interest. 

After deliberating a bit, I decided to throw this on its own endpoint, since we only use it one spot, we'll probably refactor a bunch of stuff to some sort of stateful runs endpoint soon, and we have to specify a `pipetteId` to get the `NozzleMap` for a pipette, anyway. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified the endpoint works as expected during a protocol run.
- Verified the endpoint returns correct 409/404 errors when expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added `GET` `runs/:runId/activeNozzleLayout/:pipetteId`
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Does this approach make sense? Are we ok with the new `NozzleMapNotFound` error? How do we feel about `ActiveNozzleLayout`?
- Note that I'll do the shared-data and api-client work in a separate PR.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- low I think
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RSQ-161]: https://opentrons.atlassian.net/browse/RSQ-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ