### PR TITLE
fix(components, app): Fix newly migrated `atoms` to `components` on the ODD

### DIFF
--- a/app/src/molecules/OddModal/OddModalHeader.tsx
+++ b/app/src/molecules/OddModal/OddModalHeader.tsx
@@ -34,7 +34,7 @@ export function OddModalHeader(props: OddModalHeaderBaseProps): JSX.Element {
       borderRadius={`${BORDERS.borderRadius12} ${BORDERS.borderRadius12} 0px 0px`}
       {...styleProps}
     >
-      <Flex flexDirection={DIRECTION_ROW}>
+      <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
         {iconName != null && iconColor != null ? (
           <Icon
             aria-label={`icon_${iconName}`}
@@ -42,7 +42,6 @@ export function OddModalHeader(props: OddModalHeaderBaseProps): JSX.Element {
             color={iconColor}
             size="2rem"
             alignSelf={ALIGN_CENTER}
-            marginRight={SPACING.spacing16}
           />
         ) : null}
         <LegacyStyledText

--- a/app/src/molecules/OddModal/OddModalHeader.tsx
+++ b/app/src/molecules/OddModal/OddModalHeader.tsx
@@ -42,6 +42,7 @@ export function OddModalHeader(props: OddModalHeaderBaseProps): JSX.Element {
             color={iconColor}
             size="2rem"
             alignSelf={ALIGN_CENTER}
+            marginRight={SPACING.spacing16}
           />
         ) : null}
         <LegacyStyledText

--- a/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
@@ -202,7 +202,7 @@ export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
             onClick={onCancelClick}
             buttonText={t('cancel_run')}
             iconName="remove"
-            disabled={isDisabled()}
+            ariaDisabled={isDisabled()}
             buttonType="alertAlt"
           />
           <LargeButton
@@ -210,7 +210,7 @@ export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
             onClick={onLaunchERClick}
             buttonText={t('launch_recovery_mode')}
             iconName="recovery"
-            disabled={isDisabled()}
+            ariaDisabled={isDisabled()}
             buttonType="alertStroke"
           />
         </Flex>

--- a/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
@@ -198,21 +198,19 @@ export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
           gridGap={SPACING.spacing16}
         >
           <LargeButton
+            css={SHARED_BUTTON_STYLE_ODD}
             onClick={onCancelClick}
             buttonText={t('cancel_run')}
-            css={
-              isDisabled() ? BTN_STYLE_DISABLED_ODD : SHARED_BUTTON_STYLE_ODD
-            }
-            iconName={'remove'}
+            iconName="remove"
+            disabled={isDisabled()}
             buttonType="alertAlt"
           />
           <LargeButton
+            css={SHARED_BUTTON_STYLE_ODD}
             onClick={onLaunchERClick}
             buttonText={t('launch_recovery_mode')}
-            css={
-              isDisabled() ? BTN_STYLE_DISABLED_ODD : SHARED_BUTTON_STYLE_ODD
-            }
-            iconName={'recovery'}
+            iconName="recovery"
+            disabled={isDisabled()}
             buttonType="alertStroke"
           />
         </Flex>
@@ -296,30 +294,6 @@ const SplashFrame = styled(Flex)`
 const SHARED_BUTTON_STYLE_ODD = css`
   width: 29rem;
   height: 13.5rem;
-`
-const BTN_STYLE_DISABLED_ODD = css`
-  ${SHARED_BUTTON_STYLE_ODD}
-
-  background-color: ${COLORS.grey35};
-  color: ${COLORS.grey50};
-  border: none;
-  box-shadow: none;
-
-  #btn-icon: {
-    color: ${COLORS.grey50};
-  }
-
-  &:active,
-  &:focus,
-  &:hover {
-    background-color: ${COLORS.grey35};
-    color: ${COLORS.grey50};
-  }
-  &:active,
-  &:focus,
-  &:hover #btn-icon {
-    color: ${COLORS.grey50};
-  }
 `
 
 const PRIMARY_BTN_STYLES_DESKTOP = css`

--- a/components/src/atoms/buttons/LargeButton.tsx
+++ b/components/src/atoms/buttons/LargeButton.tsx
@@ -292,23 +292,22 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
         {buttonText}
       </StyledText>
       {iconName ? (
-        <Box
-          css={css`
-            width: 1.5rem;
-            height: 1.5rem;
-            @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-              width: 5rem;
-              height: 5rem;
-            }
-          `}
-        >
-          <Icon
-            name={iconName}
-            aria-label={`${iconName} icon`}
-            color={appliedIconColor}
-          />
-        </Box>
+        <Icon
+          name={iconName}
+          aria-label={`${iconName} icon`}
+          color={appliedIconColor}
+          css={ICON_STYLE}
+        />
       ) : null}
     </Btn>
   )
 }
+
+const ICON_STYLE = css`
+  width: 1.5rem;
+  height: 1.5rem;
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    width: 5rem;
+    height: 5rem;
+  }
+`

--- a/components/src/atoms/buttons/LargeButton.tsx
+++ b/components/src/atoms/buttons/LargeButton.tsx
@@ -1,6 +1,6 @@
 import type * as React from 'react'
 import { css } from 'styled-components'
-import { Box, Btn } from '../../primitives'
+import { Btn } from '../../primitives'
 
 import { BORDERS, COLORS } from '../../helix-design-system'
 import { RESPONSIVENESS, SPACING, TYPOGRAPHY } from '../../ui-style-constants'
@@ -154,6 +154,26 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       ? `color: ${LARGE_BUTTON_PROPS_BY_TYPE[style].activeIconColor}`
       : ''
 
+  // In order to keep button sizes consistent and expected, all large button types need an outline.
+  // The outline color is always the same as the background color unless the background color is uniquely different
+  // from the outline.
+  const computedOutlineStyle = (): string => {
+    const outlineColor = (): string => {
+      if (disabled) {
+        return LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor
+      } else if (buttonType === 'alertStroke') {
+        return LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
+      } else {
+        return LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+      }
+    }
+
+    const calculatedBorderRadius =
+      buttonType === 'stroke' ? BORDERS.borderRadius2 : BORDERS.borderRadius4
+
+    return `${calculatedBorderRadius} solid ${outlineColor()}`
+  }
+
   const LARGE_BUTTON_STYLE = css`
     color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
     background-color: ${
@@ -164,7 +184,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     text-align: ${TYPOGRAPHY.textAlignLeft};
     border-radius: ${BORDERS.borderRadiusFull};
     align-items: ${ALIGN_CENTER};
-    border: ${buttonType === 'stroke' ? `2px solid ${COLORS.blue50}` : 'none'};
+    border: ${computedOutlineStyle()};
 
     &:active {
       background-color: ${
@@ -214,14 +234,6 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       padding: ${SPACING.spacing24};
       line-height: ${TYPOGRAPHY.lineHeight20};
       gap: ${SPACING.spacing60};
-      outline: ${BORDERS.borderRadius4} solid
-        ${
-          buttonType === 'alertStroke' && !disabled
-            ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
-            : 'none'
-        };
-
-      ${TYPOGRAPHY.pSemiBold}
 
       &:active {
         background-color: ${
@@ -297,6 +309,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
           aria-label={`${iconName} icon`}
           color={appliedIconColor}
           css={ICON_STYLE}
+          id="btn-icon"
         />
       ) : null}
     </Btn>

--- a/components/src/atoms/buttons/LargeButton.tsx
+++ b/components/src/atoms/buttons/LargeButton.tsx
@@ -4,8 +4,7 @@ import { Box, Btn } from '../../primitives'
 
 import { BORDERS, COLORS } from '../../helix-design-system'
 import { RESPONSIVENESS, SPACING, TYPOGRAPHY } from '../../ui-style-constants'
-import { LegacyStyledText } from '../../atoms/StyledText'
-import { fontSizeBodyLargeSemiBold } from '../../helix-design-system/product/typography'
+import { StyledText } from '../StyledText'
 import {
   ALIGN_CENTER,
   ALIGN_FLEX_START,
@@ -162,7 +161,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     };
     cursor: ${CURSOR_POINTER};
     padding: ${SPACING.spacing16} ${SPACING.spacing24};
-    text-align: ${TYPOGRAPHY.textAlignCenter};
+    text-align: ${TYPOGRAPHY.textAlignLeft};
     border-radius: ${BORDERS.borderRadiusFull};
     align-items: ${ALIGN_CENTER};
     border: ${buttonType === 'stroke' ? `2px solid ${COLORS.blue50}` : 'none'};
@@ -224,14 +223,6 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
       ${TYPOGRAPHY.pSemiBold}
 
-      #btn-icon: {
-        color: ${
-          disabled
-            ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
-            : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
-        };
-      }
-
       &:active {
         background-color: ${
           disabled
@@ -276,6 +267,11 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
         };
       }
   `
+
+  const appliedIconColor = disabled
+    ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
+    : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
+
   return (
     <Btn
       type={type}
@@ -286,17 +282,15 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       aria-disabled={ariaDisabled}
       {...buttonProps}
     >
-      <LegacyStyledText
+      <StyledText
+        oddStyle="level3HeaderSemiBold"
+        desktopStyle="bodyLargeSemiBold"
         css={css`
-          font-size: ${fontSizeBodyLargeSemiBold};
           padding-right: ${iconName != null ? SPACING.spacing8 : '0'};
-          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-            ${TYPOGRAPHY.level3HeaderSemiBold}
-          }
         `}
       >
         {buttonText}
-      </LegacyStyledText>
+      </StyledText>
       {iconName ? (
         <Box
           css={css`
@@ -308,7 +302,11 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
             }
           `}
         >
-          <Icon name={iconName} aria-label={`${iconName} icon`} id="btn-icon" />
+          <Icon
+            name={iconName}
+            aria-label={`${iconName} icon`}
+            color={appliedIconColor}
+          />
         </Box>
       ) : null}
     </Btn>

--- a/components/src/atoms/buttons/LargeButton.tsx
+++ b/components/src/atoms/buttons/LargeButton.tsx
@@ -48,6 +48,8 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     ...buttonProps
   } = props
 
+  const computedDisabled = disabled || ariaDisabled
+
   const LARGE_BUTTON_PROPS_BY_TYPE: Record<
     LargeButtonTypes,
     {
@@ -157,9 +159,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
   // In order to keep button sizes consistent and expected, all large button types need an outline.
   // The outline color is always the same as the background color unless the background color is uniquely different
   // from the outline.
-  const computedOutlineStyle = (): string => {
-    const outlineColor = (): string => {
-      if (disabled) {
+  const computedBorderStyle = (): string => {
+    const borderColor = (): string => {
+      if (computedDisabled) {
         return LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor
       } else if (buttonType === 'alertStroke') {
         return LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
@@ -171,7 +173,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     const calculatedBorderRadius =
       buttonType === 'stroke' ? BORDERS.borderRadius2 : BORDERS.borderRadius4
 
-    return `${calculatedBorderRadius} solid ${outlineColor()}`
+    return `${calculatedBorderRadius} solid ${borderColor()}`
   }
 
   const LARGE_BUTTON_STYLE = css`
@@ -184,7 +186,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     text-align: ${TYPOGRAPHY.textAlignLeft};
     border-radius: ${BORDERS.borderRadiusFull};
     align-items: ${ALIGN_CENTER};
-    border: ${computedOutlineStyle()};
+    border: ${computedBorderStyle()};
 
     &:active {
       background-color: ${
@@ -203,7 +205,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       };
 
       border: ${
-        buttonType === 'stroke' ? `2px solid ${COLORS.blue55}` : 'none'
+        buttonType === 'stroke'
+          ? `2px solid ${COLORS.blue55}`
+          : `${computedBorderStyle()}`
       };
     }
 
@@ -237,14 +241,14 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
       &:active {
         background-color: ${
-          disabled
+          computedDisabled
             ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
             : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
         };
-        ${!disabled && activeColorFor(buttonType)};
+        ${!computedDisabled && activeColorFor(buttonType)};
         outline: ${BORDERS.borderRadius4} solid
           ${
-            disabled
+            computedDisabled
               ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
               : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
           };
@@ -255,15 +259,15 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
       &:focus-visible {
         background-color: ${
-          disabled
+          computedDisabled
             ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
             : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleBackgroundColor
         };
-        ${!disabled && activeColorFor(buttonType)};
+        ${!computedDisabled && activeColorFor(buttonType)};
         padding: calc(${SPACING.spacing24} + ${SPACING.spacing2});
-        border: ${SPACING.spacing2} solid ${COLORS.transparent};
+        border: ${computedBorderStyle()};
         outline: ${
-          disabled
+          computedDisabled
             ? 'none'
             : `3px solid
     ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleOutlineColor}`
@@ -280,7 +284,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       }
   `
 
-  const appliedIconColor = disabled
+  const appliedIconColor = computedDisabled
     ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
     : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
 
@@ -309,7 +313,6 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
           aria-label={`${iconName} icon`}
           color={appliedIconColor}
           css={ICON_STYLE}
-          id="btn-icon"
         />
       ) : null}
     </Btn>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Recently we've migrated a few app atoms into the components directory, and a few nuanced things broke in the process. This PR fixes some of these identifiable issues.

**PLEASE NOTE FOR PD** - I noticed that we had `text-align: center` on the primary button text. My guess is this was added as some PD work-around, but this does break specific usages on the ODD. [Looking at designs](https://www.figma.com/design/OIdG64Q5cgvEw82ish5Eee/Design-System%3A-Flex?node-id=1500-82971&t=8WV9w7bqdaCip0DD-4), it seems reasonable that  the button should be `text-align: left` and probably not center. If `LargeButton` is broken on some spots in PD, I think we need to: 

- See if this is caused by some sort of different styling issue elsewhere and solve the problem there.
- If the above can't solve the problem, we'll need to talk to design about adding some sort of `textAlign` prop to the component itself.

Let me know if I can be of any help!

e7ca894b22f59262d6e18d33869f38a550257ad6 - This should have been two commits, whoops. The first is entirely my fault: during the mergeback of 8.0 into edge, I accidentally deleted the right margin offest for `ODDModal`. Secondly, the icon color is not correctly applied to `LargeButton` of `secondary` type. This likely has to do with some lower level Icon/SVG implementations, but a totally adequate solution is to apply the color directly to `Icon`, which is what we typically do, anyway. Note that the text alignment is incorrect here (and this commit fixes it), see the disclaimer above.

bf8dcf9c3f3a128d7aa61c6a4011554580daf5ac - Icon sizing doesn't work as expected. Creating a `Box` that wraps an SVG doesn't actually constrain the size of the SVG in practice. We have to apply the CSS styles directly.

098104823c58fd2949bc161e0184563c7e53ec75 - To get consistent button sizes, we need to always apply border consistently. Otherwise, two primary buttons can have different sizes depending on `buttonType`, which is something we want to avoid. Let's just use a simple helper function to determine the border style, including the new PD-specific `stroke` style.

36dd1241f5a1ab7766e158ab3c5eb4a58d8e31f9 - Before the `LargeButton` refactor into the components dir, there wasn't fully-supported disabled state for some styles. The refactor fixed that, so we can delete a little bit of cruft from the error recovery splash screen.


### Current Issues

<img width="896" alt="Screenshot 2024-10-03 at 9 52 39 AM" src="https://github.com/user-attachments/assets/674d2a61-e9c2-4a3f-bed0-c29ec5d2cabc">

<img width="1313" alt="Screenshot 2024-10-03 at 10 57 56 AM" src="https://github.com/user-attachments/assets/0ae40312-2224-4f40-8e7a-53a3c7e4eef8">

<img width="1192" alt="Screenshot 2024-10-03 at 11 05 07 AM" src="https://github.com/user-attachments/assets/e77259b4-68ef-4cdc-ba75-3a41688295c5">

### PR Fixes

<img width="898" alt="Screenshot 2024-10-03 at 9 56 23 AM" src="https://github.com/user-attachments/assets/728b9dce-b8c4-4087-a5f2-b8e3703f479a">

<img width="1193" alt="Screenshot 2024-10-03 at 10 48 24 AM" src="https://github.com/user-attachments/assets/d20d982e-2a94-4091-9c99-0aaa2da31cfd">

<img width="1259" alt="Screenshot 2024-10-03 at 2 37 13 PM" src="https://github.com/user-attachments/assets/16125264-0202-47c4-b519-93ae2f69baf0">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- These changes were ODD-specifc, so I smoke tested the ODD. HOWEVER, I do suspect this affects PD indirectly, see note above.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
