### PR TITLE
fix(shared-data): adjust the gripper pickup parameters for the plate reader lid.

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_flex_lid_absorbance_plate_reader_module/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_lid_absorbance_plate_reader_module/1.json
@@ -33,8 +33,8 @@
   "version": 1,
   "schemaVersion": 2,
   "allowedRoles": ["fixture"],
-  "gripForce": 20.0,
-  "gripHeightFromLabwareBottom": 53.0,
+  "gripForce": 21.0,
+  "gripHeightFromLabwareBottom": 48.0,
   "cornerOffsetFromSlot": {
     "x": 0,
     "y": 0,
@@ -43,12 +43,12 @@
   "gripperOffsets": {
     "default": {
       "pickUpOffset": {
-        "x": 14,
+        "x": 9,
         "y": 0,
         "z": 0
       },
       "dropOffset": {
-        "x": 14,
+        "x": 9,
         "y": 0,
         "z": 0
       }


### PR DESCRIPTION
# Overview

The plate reader lid sways quite a bit when moved between the plate reader and the dock, this happens primarily because the gripper does not grab the lid in its center of gravity. We have also changed the design of the plate reader lid grip edge which gives us more space to hold the device.

## Test Plan and Hands-on Testing

- [x] Make sure that we can move the plate reader lid with the gripper
- [x] Make sure the gripper paddles are centered on the plate reader lid when picking it up and there's less sway when moving.

## Changelog

- Increase the grip force to 21 when picking up the plate reader lid
- decrease the `pickUpOffset` and `dropOffset` to 9mm on the x-axis to center the gripper paddles
- decrease the height at which the gripper picks up the plate reader lid so its closer to the center of gravity.

## Review requests

- makes sense?

## Risk assessment

Low, unreleased.