### PR TITLE
chore(release): notes for Internal Release 2.2.0-alpha.0

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -2,6 +2,10 @@ For more details about this release, please see the full [technical change log][
 
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.2.0-alpha.0
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.2.0. It's for internal testing only.
+
 ## Internal Release 2.0.0-alpha.4
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. There are no changes to `buildroot`, `ot3-firmware`, or `oe-core` since the last internal release.

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,6 +1,10 @@
 For more details about this release, please see the full [technical changelog][].
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.2.0-alpha.0
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.2.0. It's for internal testing only.
+
 ## Internal Release 2.0.0-alpha.4
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. There are no changes to `buildroot`, `ot3-firmware`, or `oe-core` since the last internal release.


### PR DESCRIPTION
# Overview

Internal release notes for Internal Release 2.2.0-alpha.0.

Tagging edge in the monorepo and HEADs on "main" branches of dependency repositories if necessary.