### PR TITLE
feat(shared-data): Support nozzle layouts in well selection

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -7,6 +7,7 @@ import type {
   RunCommandError,
   RunTimeCommand,
   RunTimeParameter,
+  NozzleLayoutConfig,
 } from '@opentrons/shared-data'
 import type { ResourceLink, ErrorDetails } from '../types'
 export * from './commands/types'
@@ -200,4 +201,3 @@ export interface NozzleLayoutValues {
   activeNozzles: string[]
   config: NozzleLayoutConfig
 }
-export type NozzleLayoutConfig = 'column' | 'row' | 'full' | 'subrect'

--- a/app/src/organisms/WellSelection/index.tsx
+++ b/app/src/organisms/WellSelection/index.tsx
@@ -45,11 +45,11 @@ export function WellSelection(props: WellSelectionProps): JSX.Element {
       const primaryWells: WellGroup = reduce(
         selectedWells,
         (acc: WellGroup, _, wellName: string): WellGroup => {
-          const wellSet = getWellSetForMultichannel(
-            definition,
+          const wellSet = getWellSetForMultichannel({
+            labwareDef: definition,
             wellName,
-            channels
-          )
+            channels,
+          })
           if (!wellSet) return acc
           return { ...acc, [wellSet[0]]: null }
         },
@@ -74,7 +74,11 @@ export function WellSelection(props: WellSelectionProps): JSX.Element {
         selectedWells,
         (acc: WellGroup, _, wellName: string): WellGroup => {
           const wellSetForMulti =
-            getWellSetForMultichannel(definition, wellName, channels) || []
+            getWellSetForMultichannel({
+              labwareDef: definition,
+              wellName,
+              channels,
+            }) || []
           const channelWells = arrayToWellGroup(wellSetForMulti)
           return {
             ...acc,
@@ -102,11 +106,11 @@ export function WellSelection(props: WellSelectionProps): JSX.Element {
       ? reduce<WellGroup, WellGroup>(
           selectedPrimaryWells,
           (acc, _, wellName): WellGroup => {
-            const wellSet = getWellSetForMultichannel(
-              definition,
+            const wellSet = getWellSetForMultichannel({
+              labwareDef: definition,
               wellName,
-              channels
-            )
+              channels,
+            })
             if (!wellSet) return acc
             return { ...acc, ...arrayToWellGroup(wellSet) }
           },

--- a/protocol-designer/src/components/labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/labware/SelectableLabware.tsx
@@ -75,11 +75,11 @@ export const SelectableLabware = (props: Props): JSX.Element => {
       const primaryWells: WellGroup = reduce(
         selectedWells,
         (acc: WellGroup, _, wellName: string): WellGroup => {
-          const wellSet = getWellSetForMultichannel(
+          const wellSet = getWellSetForMultichannel({
             labwareDef,
             wellName,
-            channels
-          )
+            channels,
+          })
           if (!wellSet) return acc
           return { ...acc, [wellSet[0]]: null }
         },
@@ -109,7 +109,8 @@ export const SelectableLabware = (props: Props): JSX.Element => {
           selectedWells,
           (acc: WellGroup, _, wellName: string): WellGroup => {
             const wellSetForMulti =
-              getWellSetForMultichannel(labwareDef, wellName, channels) || []
+              getWellSetForMultichannel({ labwareDef, wellName, channels }) ||
+              []
             const channelWells = arrayToWellGroup(wellSetForMulti)
             return {
               ...acc,
@@ -144,11 +145,11 @@ export const SelectableLabware = (props: Props): JSX.Element => {
   const handleMouseEnterWell: (args: WellMouseEvent) => void = args => {
     if (nozzleType != null) {
       const channels = getChannelsFromNozleType(nozzleType)
-      const wellSet = getWellSetForMultichannel(
+      const wellSet = getWellSetForMultichannel({
         labwareDef,
-        args.wellName,
-        channels
-      )
+        wellName: args.wellName,
+        channels,
+      })
       const nextHighlightedWells = arrayToWellGroup(wellSet || [])
       nextHighlightedWells && updateHighlightedWells(nextHighlightedWells)
     } else {
@@ -163,11 +164,11 @@ export const SelectableLabware = (props: Props): JSX.Element => {
           selectedPrimaryWells,
           (acc, _, wellName): WellGroup => {
             const channels = getChannelsFromNozleType(nozzleType)
-            const wellSet = getWellSetForMultichannel(
+            const wellSet = getWellSetForMultichannel({
               labwareDef,
               wellName,
-              channels
-            )
+              channels,
+            })
             if (!wellSet) return acc
             return { ...acc, ...arrayToWellGroup(wellSet) }
           },

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -28,7 +28,11 @@ export function getAllWellsFromPrimaryWells(
   channels: 8 | 96
 ): string[] {
   const allWells = primaryWells.reduce((acc: string[], well: string) => {
-    const nextWellSet = getWellSetForMultichannel(labwareDef, well, channels)
+    const nextWellSet = getWellSetForMultichannel({
+      labwareDef,
+      wellName: well,
+      channels,
+    })
 
     // filter out any nulls (but you shouldn't get any)
     if (!nextWellSet) {

--- a/protocol-designer/src/top-selectors/substep-highlight.ts
+++ b/protocol-designer/src/top-selectors/substep-highlight.ts
@@ -130,11 +130,11 @@ function _getSelectedWellsForStep(
         wells.push(commandWellName)
       } else if (channels === 8 || channels === 96) {
         const wellSet =
-          getWellSetForMultichannel(
-            invariantContext.labwareEntities[labwareId].def,
-            commandWellName,
-            channels
-          ) || []
+          getWellSetForMultichannel({
+            labwareDef: invariantContext.labwareEntities[labwareId].def,
+            wellName: commandWellName,
+            channels,
+          }) || []
         wells.push(...wellSet)
       } else {
         console.error(
@@ -241,11 +241,11 @@ function _getSelectedWellsForSubstep(
           activeTips.labwareId === labwareId &&
           channels !== 1
         ) {
-          const multiTipWellSet = getWellSetForMultichannel(
-            invariantContext.labwareEntities[labwareId].def,
-            activeTips.wellName,
-            channels
-          )
+          const multiTipWellSet = getWellSetForMultichannel({
+            labwareDef: invariantContext.labwareEntities[labwareId].def,
+            wellName: activeTips.wellName,
+            channels,
+          })
           if (multiTipWellSet) tipWellSet = multiTipWellSet
         }
       } else {

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -226,53 +226,45 @@ describe('getWellSetForMultichannel (integration test)', () => {
   it('96-flat', () => {
     const labwareDef = fixture96Plate
 
-    expect(getWellSetForMultichannel(labwareDef, 'A1', EIGHT_CHANNEL)).toEqual([
-      'A1',
-      'B1',
-      'C1',
-      'D1',
-      'E1',
-      'F1',
-      'G1',
-      'H1',
-    ])
+    expect(
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'A1',
+        channels: EIGHT_CHANNEL,
+      })
+    ).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1'])
 
-    expect(getWellSetForMultichannel(labwareDef, 'B1', EIGHT_CHANNEL)).toEqual([
-      'A1',
-      'B1',
-      'C1',
-      'D1',
-      'E1',
-      'F1',
-      'G1',
-      'H1',
-    ])
+    expect(
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'B1',
+        channels: EIGHT_CHANNEL,
+      })
+    ).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1'])
 
-    expect(getWellSetForMultichannel(labwareDef, 'H1', EIGHT_CHANNEL)).toEqual([
-      'A1',
-      'B1',
-      'C1',
-      'D1',
-      'E1',
-      'F1',
-      'G1',
-      'H1',
-    ])
+    expect(
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'H1',
+        channels: EIGHT_CHANNEL,
+      })
+    ).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1'])
 
-    expect(getWellSetForMultichannel(labwareDef, 'A2', EIGHT_CHANNEL)).toEqual([
-      'A2',
-      'B2',
-      'C2',
-      'D2',
-      'E2',
-      'F2',
-      'G2',
-      'H2',
-    ])
+    expect(
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'A2',
+        channels: EIGHT_CHANNEL,
+      })
+    ).toEqual(['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2'])
 
     //  96-channel
     expect(
-      getWellSetForMultichannel(labwareDef, 'A1', NINETY_SIX_CHANNEL)
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'A1',
+        channels: NINETY_SIX_CHANNEL,
+      })
     ).toEqual(wellsFor96WellPlate)
   })
 
@@ -280,38 +272,40 @@ describe('getWellSetForMultichannel (integration test)', () => {
     const labwareDef = fixture96Plate
 
     expect(
-      getWellSetForMultichannel(labwareDef, 'A13', EIGHT_CHANNEL)
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'A13',
+        channels: EIGHT_CHANNEL,
+      })
     ).toBeFalsy()
   })
 
   it('trough-12row', () => {
     const labwareDef = fixture12Trough
 
-    expect(getWellSetForMultichannel(labwareDef, 'A1', EIGHT_CHANNEL)).toEqual([
-      'A1',
-      'A1',
-      'A1',
-      'A1',
-      'A1',
-      'A1',
-      'A1',
-      'A1',
-    ])
+    expect(
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'A1',
+        channels: EIGHT_CHANNEL,
+      })
+    ).toEqual(['A1', 'A1', 'A1', 'A1', 'A1', 'A1', 'A1', 'A1'])
 
-    expect(getWellSetForMultichannel(labwareDef, 'A2', EIGHT_CHANNEL)).toEqual([
-      'A2',
-      'A2',
-      'A2',
-      'A2',
-      'A2',
-      'A2',
-      'A2',
-      'A2',
-    ])
+    expect(
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'A2',
+        channels: EIGHT_CHANNEL,
+      })
+    ).toEqual(['A2', 'A2', 'A2', 'A2', 'A2', 'A2', 'A2', 'A2'])
 
     //  96-channel
     expect(
-      getWellSetForMultichannel(labwareDef, 'A1', NINETY_SIX_CHANNEL)
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'A1',
+        channels: NINETY_SIX_CHANNEL,
+      })
     ).toEqual(wellsForReservoir)
   })
 
@@ -324,31 +318,29 @@ describe('getWellSetForMultichannel (integration test)', () => {
       well96Channel
     )
 
-    expect(getWellSetForMultichannel(labwareDef, 'C1', EIGHT_CHANNEL)).toEqual([
-      'A1',
-      'C1',
-      'E1',
-      'G1',
-      'I1',
-      'K1',
-      'M1',
-      'O1',
-    ])
+    expect(
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'C1',
+        channels: EIGHT_CHANNEL,
+      })
+    ).toEqual(['A1', 'C1', 'E1', 'G1', 'I1', 'K1', 'M1', 'O1'])
 
-    expect(getWellSetForMultichannel(labwareDef, 'F2', EIGHT_CHANNEL)).toEqual([
-      'B2',
-      'D2',
-      'F2',
-      'H2',
-      'J2',
-      'L2',
-      'N2',
-      'P2',
-    ])
+    expect(
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: 'F2',
+        channels: EIGHT_CHANNEL,
+      })
+    ).toEqual(['B2', 'D2', 'F2', 'H2', 'J2', 'L2', 'N2', 'P2'])
 
     //  96-channel
     expect(
-      getWellSetForMultichannel(labwareDef, well96Channel, NINETY_SIX_CHANNEL)
+      getWellSetForMultichannel({
+        labwareDef,
+        wellName: well96Channel,
+        channels: NINETY_SIX_CHANNEL,
+      })
     ).toEqual(ninetySixChannelWells)
   })
 })

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -352,3 +352,142 @@ describe('getWellSetForMultichannel (integration test)', () => {
     ).toEqual(ninetySixChannelWells)
   })
 })
+
+describe('getWellSetForMultichannel with pipetteNozzleDetails', () => {
+  let getWellSetForMultichannel: ReturnType<
+    typeof makeWellSetHelpers
+  >['getWellSetForMultichannel']
+
+  const labwareDef = fixture96Plate
+
+  beforeEach(() => {
+    const helpers = makeWellSetHelpers()
+    getWellSetForMultichannel = helpers.getWellSetForMultichannel
+  })
+
+  it('returns full column for 8-channel pipette with no config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 8,
+    })
+    expect(result).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1'])
+  })
+
+  it('returns full column for 8-channel pipette with full config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 8,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'full',
+        activeNozzleCount: 8,
+      },
+    })
+    expect(result).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1'])
+  })
+
+  it('returns single well for 8-channel pipette with single nozzle config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 8,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'single',
+        activeNozzleCount: 1,
+      },
+    })
+    expect(result).toEqual(['C1'])
+  })
+
+  it('returns partial column for 8-channel pipette with partial column config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 8,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'column',
+        activeNozzleCount: 4,
+      },
+    })
+    expect(result).toEqual(['C1', 'D1', 'E1', 'F1'])
+  })
+
+  it('returns row for 8-channel pipette with row config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 8,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'row',
+        activeNozzleCount: 8,
+      },
+    })
+    expect(result).toEqual([
+      'C1',
+      'C2',
+      'C3',
+      'C4',
+      'C5',
+      'C6',
+      'C7',
+      'C8',
+      'C9',
+      'C10',
+      'C11',
+      'C12',
+    ])
+  })
+
+  it('handles edge cases for 8-channel partial column selection', () => {
+    const bottomEdgeResult = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'G1',
+      channels: 8,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'column',
+        activeNozzleCount: 4,
+      },
+    })
+    expect(bottomEdgeResult).toEqual(['E1', 'F1', 'G1', 'H1'])
+  })
+
+  it('returns full plate for 96-channel pipette with no config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'A1',
+      channels: 96,
+    })
+    expect(result?.length).toBe(96)
+    expect(result?.[0]).toBe('A1')
+    expect(result?.[95]).toBe('H12')
+  })
+
+  it('returns full plate for 96-channel pipette with full config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'A1',
+      channels: 96,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'full',
+        activeNozzleCount: 96,
+      },
+    })
+    expect(result?.length).toBe(96)
+    expect(result?.[0]).toBe('A1')
+    expect(result?.[95]).toBe('H12')
+  })
+
+  it('returns single column for 96-channel pipette with column config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 96,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'column',
+        activeNozzleCount: 8,
+      },
+    })
+    expect(result).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1'])
+  })
+})

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -392,6 +392,32 @@ describe('getWellSetForMultichannel with pipetteNozzleDetails', () => {
     expect(result).toEqual(['C1'])
   })
 
+  it('returns null for 8-channel pipette with row nozzle config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 8,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'row',
+        activeNozzleCount: 8,
+      },
+    })
+    expect(result).toEqual(null)
+  })
+
+  it('returns null for 8-channel pipette with subrect nozzle config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 8,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'subrect',
+        activeNozzleCount: 8,
+      },
+    })
+    expect(result).toEqual(null)
+  })
+
   it('returns partial column for 8-channel pipette with partial column config', () => {
     const result = getWellSetForMultichannel({
       labwareDef: labwareDef,
@@ -403,32 +429,6 @@ describe('getWellSetForMultichannel with pipetteNozzleDetails', () => {
       },
     })
     expect(result).toEqual(['C1', 'D1', 'E1', 'F1'])
-  })
-
-  it('returns row for 8-channel pipette with row config', () => {
-    const result = getWellSetForMultichannel({
-      labwareDef: labwareDef,
-      wellName: 'C1',
-      channels: 8,
-      pipetteNozzleDetails: {
-        nozzleConfig: 'row',
-        activeNozzleCount: 8,
-      },
-    })
-    expect(result).toEqual([
-      'C1',
-      'C2',
-      'C3',
-      'C4',
-      'C5',
-      'C6',
-      'C7',
-      'C8',
-      'C9',
-      'C10',
-      'C11',
-      'C12',
-    ])
   })
 
   it('handles edge cases for 8-channel partial column selection', () => {
@@ -481,5 +481,18 @@ describe('getWellSetForMultichannel with pipetteNozzleDetails', () => {
       },
     })
     expect(result).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1'])
+  })
+
+  it('returns null for 8-channel pipette with subrect nozzle config', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 96,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'subrect',
+        activeNozzleCount: 96,
+      },
+    })
+    expect(result).toEqual(null)
   })
 })

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -441,7 +441,7 @@ describe('getWellSetForMultichannel with pipetteNozzleDetails', () => {
         activeNozzleCount: 4,
       },
     })
-    expect(bottomEdgeResult).toEqual(['E1', 'F1', 'G1', 'H1'])
+    expect(bottomEdgeResult).toEqual(['G1', 'H1'])
   })
 
   it('returns full plate for 96-channel pipette with no config', () => {

--- a/shared-data/js/helpers/wellSets.ts
+++ b/shared-data/js/helpers/wellSets.ts
@@ -179,7 +179,6 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
         case 'single':
           return [wellName]
         case 'row':
-          return getActiveRowFromWell(allWellSetsFor8Channel)
         case 'subrect':
         default:
           console.error('Unhandled nozzleConfig case.')

--- a/shared-data/js/helpers/wellSets.ts
+++ b/shared-data/js/helpers/wellSets.ts
@@ -140,20 +140,9 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
       }
 
       const wellIndex = targetColumn.indexOf(wellName)
-      const totalWells = targetColumn.length
 
-      if (activeNozzleCount >= totalWells) {
-        return targetColumn
-      }
-
-      // Calculate how many wells we can include below the selected well, handling edge cases.
-      const wellsBelow = totalWells - wellIndex - 1
-      const wellsNeededAbove = Math.max(0, activeNozzleCount - wellsBelow - 1)
-
-      const startIndex = Math.max(0, wellIndex - wellsNeededAbove)
-      const endIndex = Math.min(totalWells, startIndex + activeNozzleCount)
-
-      return targetColumn.slice(startIndex, endIndex)
+      // If there are fewer wells than active nozzles, only select as many wells as there are nozzles.
+      return targetColumn.slice(wellIndex, wellIndex + activeNozzleCount)
     }
 
     if (channels === 8) {

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -846,3 +846,10 @@ export interface CutoutConfig {
 }
 
 export type DeckConfiguration = CutoutConfig[]
+
+export type NozzleLayoutConfig =
+  | 'single'
+  | 'column'
+  | 'row'
+  | 'full'
+  | 'subrect'


### PR DESCRIPTION
Works towards [RSQ-161](https://opentrons.atlassian.net/browse/RSQ-161)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When we want a well set relevant to a specific pipette's interaction with a specific labware, we use a helper, `getWellSetForMultichannel`. This works great, but it doesn't have the ability to return relevant wells given a nozzle layout. So for example, if the pipette has a nozzle layout of "column" on a 96 channel, and the well of interest is A2, all 96-wells are returned. 

This PR adds support for all current nozzle layouts, which are generally utilized in the context of partial tip configs.

In nozzle configurations which do not naturally incorporate the entire row/column (this is only the 8-channel column config with <8 nozzles, currently), return the`wellName` and the number of relevant wells "lower" than that well name. Ex, if B1 is the `wellName` and the active nozzle count is 4, return B1-E1.  

The only tricky thing here are the edge cases. For example, what happens if a labware has A-H rows, and the `wellName` is G1 while the 8-channel pipette is in a `column` config with 4 active nozzles? In these cases, return what we can "beneath" the well, and then backfill the remainder active nozzles using wells above the `wellName`. In this example, we'd return E1-H1. 

Note: It's easier to view this PR by commit, since there's a lot of noise due to a refactor.

480dfba7536cbba1f78d1502630928a0e1ecb52c - The actual PR.
eae73b5b4f173508adfe6c89f190c998de36fa7c - Just a refactor to use the "object as parameter" pattern.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Sufficiently covered by testing.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Well set helpers now support specific nozzle configurations.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RSQ-161]: https://opentrons.atlassian.net/browse/RSQ-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ