### PR TITLE
fix(abt): move to 3.13 stable

### DIFF
--- a/.github/workflows/analyses-snapshot-lint.yaml
+++ b/.github/workflows/analyses-snapshot-lint.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: 'actions/setup-python@v5'
         with:
-          python-version: '3.13.0-rc.3'
+          python-version: '3.13.0'
           cache: 'pipenv'
           cache-dependency-path: analyses-snapshot-testing/Pipfile.lock
       - name: Setup

--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13.0-rc.3'
+          python-version: '3.13.0'
           cache: 'pipenv'
           cache-dependency-path: analyses-snapshot-testing/Pipfile.lock
 

--- a/analyses-snapshot-testing/mypy.ini
+++ b/analyses-snapshot-testing/mypy.ini
@@ -7,7 +7,7 @@ disallow_any_generics = true
 check_untyped_defs = true
 no_implicit_reexport = true
 exclude = "__init__.py"
-python_version = 3.12
+python_version = 3.13
 plugins = pydantic.mypy
 
 [pydantic-mypy]


### PR DESCRIPTION
# Overview

Moved to `3.13.0-rc.3` yesterday, today the stable is available in the runners.

I speculate this will solve the issues with python not being mapped in 
https://github.com/Opentrons/opentrons/actions/runs/11243746409/job/31260344370?pr=16439
