### PR TITLE
docs(robot-server): Fix labware router response bodies

### DIFF
--- a/robot-server/robot_server/service/json_api/__init__.py
+++ b/robot-server/robot_server/service/json_api/__init__.py
@@ -14,7 +14,6 @@ from .response import (
     DeprecatedResponseDataModel,
     ResourceModel,
     PydanticResponse,
-    ResponseList,
     NotifyRefetchBody,
     NotifyUnsubscribeBody,
 )
@@ -44,7 +43,6 @@ __all__ = [
     "DeprecatedResponseDataModel",
     "DeprecatedResponseModel",
     "DeprecatedMultiResponseModel",
-    "ResponseList",
     # notify models
     "NotifyRefetchBody",
     "NotifyUnsubscribeBody",

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -278,12 +278,6 @@ class DeprecatedMultiResponseModel(
     )
 
 
-class ResponseList(BaseModel, Generic[ResponseDataT]):
-    """A response that returns a list resource."""
-
-    __root__: List[ResponseDataT]
-
-
 class NotifyRefetchBody(BaseResponseBody):
     """A notification response that returns a flag for refetching via HTTP."""
 

--- a/robot-server/tests/runs/router/test_labware_router.py
+++ b/robot-server/tests/runs/router/test_labware_router.py
@@ -169,7 +169,7 @@ async def test_get_run_labware_definition(
         runId="run-id", run_data_manager=mock_run_data_manager
     )
 
-    assert result.content.data.__root__ == [
+    assert result.content.data == [
         SD_LabwareDefinition.construct(namespace="test_1"),  # type: ignore[call-arg]
         SD_LabwareDefinition.construct(namespace="test_2"),  # type: ignore[call-arg]
     ]


### PR DESCRIPTION
## Overview

The `GET /runs/{id}/loaded_labware_definitions` and `POST /runs/{id}/labware_definitions` endpoints were accidentally documented in OpenAPI as returning the *run,* not the labware definition. This fixes that.

## Review requests

* Documented return types match actual return types?
* OK with the `SimpleBody[list[...]]` thing?

## Risk assessment

Low.
