### PR TITLE
fix(app): fix WellSelection over-render

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
@@ -72,7 +72,10 @@ export const mockRecoveryContentProps: RecoveryContentProps = {
   recoveryCommands: {} as any,
   tipStatusUtils: {} as any,
   currentRecoveryOptionUtils: {} as any,
-  failedLabwareUtils: { pickUpTipLabware: mockPickUpTipLabware } as any,
+  failedLabwareUtils: {
+    pickUpTipLabware: mockPickUpTipLabware,
+    selectedTipLocation: { A1: null },
+  } as any,
   failedPipetteInfo: {} as any,
   deckMapUtils: { setSelectedLocation: () => {} } as any,
   stepCounts: {} as any,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -27,7 +27,7 @@ describe('useRecoveryCommands', () => {
   } as any
   const mockRunId = '123'
   const mockFailedLabwareUtils = {
-    selectedTipLocations: { A1: null },
+    selectedTipLocation: { A1: null },
     pickUpTipLabware: { id: 'MOCK_LW_ID' },
   } as any
   const mockProceedToRouteAndStep = vi.fn()
@@ -223,7 +223,7 @@ describe('useRecoveryCommands', () => {
     } as any
 
     const buildPickUpTipsCmd = buildPickUpTips(
-      mockFailedLabwareUtils.selectedTipLocations,
+      mockFailedLabwareUtils.selectedTipLocation,
       mockFailedCmdWithPipetteId,
       mockFailedLabware
     )

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -170,7 +170,7 @@ function getRelevantPickUpTipCommand(
 
 interface UseTipSelectionUtilsResult {
   /* Always returns null if the relevant labware is not relevant to tip pick up. */
-  selectedTipLocations: WellGroup | null
+  selectedTipLocation: WellGroup | null
   tipSelectorDef: LabwareDefinition2
   selectTips: (tipGroup: WellGroup) => void
   deselectTips: (locations: string[]) => void
@@ -220,7 +220,7 @@ function useTipSelectionUtils(
     selectedLocs != null && Object.keys(selectedLocs).length > 0
 
   return {
-    selectedTipLocations: selectedLocs,
+    selectedTipLocation: selectedLocs,
     tipSelectorDef,
     selectTips,
     deselectTips,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -162,10 +162,10 @@ export function useRecoveryCommands({
 
   // Pick up the user-selected tips
   const pickUpTips = useCallback((): Promise<CommandData[]> => {
-    const { selectedTipLocations, failedLabware } = failedLabwareUtils
+    const { selectedTipLocation, failedLabware } = failedLabwareUtils
 
     const pickUpTipCmd = buildPickUpTips(
-      selectedTipLocations,
+      selectedTipLocation,
       failedCommandByRunRecord,
       failedLabware
     )

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TipSelection.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TipSelection.tsx
@@ -12,7 +12,7 @@ export function TipSelection(props: TipSelectionProps): JSX.Element {
 
   const {
     tipSelectorDef,
-    selectedTipLocations,
+    selectedTipLocation,
     selectTips,
     deselectTips,
   } = failedLabwareUtils
@@ -33,7 +33,7 @@ export function TipSelection(props: TipSelectionProps): JSX.Element {
     <WellSelection
       definition={tipSelectorDef}
       deselectWells={onDeselectTips}
-      selectedPrimaryWells={selectedTipLocations as WellGroup}
+      selectedPrimaryWell={Object.keys(selectedTipLocation as WellGroup)[0]}
       selectWells={onSelectTips}
       channels={failedPipetteInfo?.data.channels ?? 1}
     />

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TipSelection.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TipSelection.test.tsx
@@ -35,7 +35,7 @@ describe('TipSelection', () => {
     expect(vi.mocked(WellSelection)).toHaveBeenCalledWith(
       expect.objectContaining({
         definition: props.failedLabwareUtils.tipSelectorDef,
-        selectedPrimaryWells: props.failedLabwareUtils.selectedTipLocations,
+        selectedPrimaryWell: 'A1',
         channels: props.failedPipetteInfo?.data.channels ?? 1,
       }),
       {}

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectDestWells.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectDestWells.tsx
@@ -189,7 +189,7 @@ export function SelectDestWells(props: SelectDestWellsProps): JSX.Element {
                   )
                 )
               }}
-              selectedPrimaryWells={selectedWells}
+              selectedPrimaryWell={Object.keys(selectedWells)[0]}
               selectWells={wellGroup => {
                 if (Object.keys(wellGroup).length > 0) {
                   setIsNumberWellsSelectedError(false)

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectSourceWells.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectSourceWells.tsx
@@ -117,7 +117,7 @@ export function SelectSourceWells(props: SelectSourceWellsProps): JSX.Element {
                   )
                 )
               }}
-              selectedPrimaryWells={selectedWells}
+              selectedPrimaryWell={Object.keys(selectedWells)[0]}
               selectWells={wellGroup => {
                 setSelectedWells(prevWells => ({ ...prevWells, ...wellGroup }))
               }}

--- a/app/src/organisms/WellSelection/index.tsx
+++ b/app/src/organisms/WellSelection/index.tsx
@@ -20,7 +20,9 @@ import type { GenericRect } from './types'
 interface WellSelectionProps {
   definition: LabwareDefinition2
   deselectWells: (wells: string[]) => void
-  selectedPrimaryWells: WellGroup
+  /* A well from which to derive the well set.
+   * If utilizing this component specifically in the context of a command, this should be the 'wellName'. */
+  selectedPrimaryWell: string
   selectWells: (wellGroup: WellGroup) => unknown
   channels: PipetteChannels
 }
@@ -29,7 +31,7 @@ export function WellSelection(props: WellSelectionProps): JSX.Element {
   const {
     definition,
     deselectWells,
-    selectedPrimaryWells,
+    selectedPrimaryWell,
     selectWells,
     channels,
   } = props
@@ -50,7 +52,9 @@ export function WellSelection(props: WellSelectionProps): JSX.Element {
             wellName,
             channels,
           })
-          if (!wellSet) return acc
+          if (!wellSet) {
+            return acc
+          }
           return { ...acc, [wellSet[0]]: null }
         },
         {}
@@ -100,23 +104,22 @@ export function WellSelection(props: WellSelectionProps): JSX.Element {
     setHighlightedWells({})
   }
 
-  // For rendering, show all wells not just primary wells
-  const allSelectedWells =
-    channels === 8 || channels === 96
-      ? reduce<WellGroup, WellGroup>(
-          selectedPrimaryWells,
-          (acc, _, wellName): WellGroup => {
-            const wellSet = getWellSetForMultichannel({
-              labwareDef: definition,
-              wellName,
-              channels,
-            })
-            if (!wellSet) return acc
-            return { ...acc, ...arrayToWellGroup(wellSet) }
-          },
-          {}
-        )
-      : selectedPrimaryWells
+  // For rendering, show all valid wells, not just primary wells
+  const buildAllSelectedWells = (): WellGroup => {
+    if (channels === 8 || channels === 96) {
+      const wellSet = getWellSetForMultichannel({
+        labwareDef: definition,
+        wellName: selectedPrimaryWell,
+        channels,
+      })
+
+      return wellSet != null ? arrayToWellGroup(wellSet) : {}
+    } else {
+      return { [selectedPrimaryWell]: null }
+    }
+  }
+
+  const allSelectedWells = buildAllSelectedWells()
 
   const wellFill: WellFill = {}
   const wellStroke: WellStroke = {}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a rendering issue with `WellSelection`, in which `allSelectedWells` for multi-channel pipettes is computed by passing each key of `selectedTipLocations` into `getWellSetForMultichannel`. Although some of the internal logic for that util has changed recently, it's always been true that `getWellSetForMultichannel` returns all the relevant wells given just one well, so we don't need to iterate over all `selectedPrimaryWells` with a `reduce`. 

This over-render isn't an obvious problem until we introduced partial tip configs. Note this PR doesn't contain partial tip support, but we'll have to be more intentional about specifying just the well of interest when we do support partial tip configs (in the very very near future).

### Before

<img width="314" alt="Screenshot 2024-10-10 at 1 11 23 PM" src="https://github.com/user-attachments/assets/903efef1-f14e-4bf8-a8bc-ce449694626e">

_8-channel with 3 active nozzles. E1 is the active well and the `selectedPrimaryWells` are C12-E12._

### After

<img width="339" alt="Screenshot 2024-10-10 at 1 08 58 PM" src="https://github.com/user-attachments/assets/b08a0181-05a3-49d9-9cdd-d92bba759781">

_Same config as in the before image._
<!--


Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images.
- Verified this doesn't break the QT Source/Dest well component.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
