### PR TITLE
fix(shared-data): fix well util for partial-column 8-channel

### DIFF
--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -421,19 +421,6 @@ describe('getWellSetForMultichannel with pipetteNozzleDetails', () => {
   it('returns partial column for 8-channel pipette with partial column config', () => {
     const result = getWellSetForMultichannel({
       labwareDef: labwareDef,
-      wellName: 'C1',
-      channels: 8,
-      pipetteNozzleDetails: {
-        nozzleConfig: 'column',
-        activeNozzleCount: 4,
-      },
-    })
-    expect(result).toEqual(['C1', 'D1', 'E1', 'F1'])
-  })
-
-  it('handles edge cases for 8-channel partial column selection', () => {
-    const bottomEdgeResult = getWellSetForMultichannel({
-      labwareDef: labwareDef,
       wellName: 'G1',
       channels: 8,
       pipetteNozzleDetails: {
@@ -441,7 +428,20 @@ describe('getWellSetForMultichannel with pipetteNozzleDetails', () => {
         activeNozzleCount: 4,
       },
     })
-    expect(bottomEdgeResult).toEqual(['G1', 'H1'])
+    expect(result).toEqual(['D1', 'E1', 'F1', 'G1'])
+  })
+
+  it('handles edge cases for 8-channel partial column selection', () => {
+    const result = getWellSetForMultichannel({
+      labwareDef: labwareDef,
+      wellName: 'C1',
+      channels: 8,
+      pipetteNozzleDetails: {
+        nozzleConfig: 'column',
+        activeNozzleCount: 4,
+      },
+    })
+    expect(result).toEqual(['A1', 'B1', 'C1'])
   })
 
   it('returns full plate for 96-channel pipette with no config', () => {

--- a/shared-data/js/helpers/wellSets.ts
+++ b/shared-data/js/helpers/wellSets.ts
@@ -111,6 +111,8 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
     return wellSetByPrimaryWell
   }
 
+  // TODO(jh 10-10-24): The partial tip logic is strongly coupled to lower-level partial tip API changes.
+  //  Consider alternative methods for deriving well sets when in partial nozzle configurations.
   const getWellSetForMultichannel = ({
     labwareDef,
     wellName,

--- a/shared-data/js/helpers/wellSets.ts
+++ b/shared-data/js/helpers/wellSets.ts
@@ -142,7 +142,10 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
       const wellIndex = targetColumn.indexOf(wellName)
 
       // If there are fewer wells than active nozzles, only select as many wells as there are nozzles.
-      return targetColumn.slice(wellIndex, wellIndex + activeNozzleCount)
+      return targetColumn.slice(
+        Math.max(wellIndex - activeNozzleCount + 1, 0),
+        wellIndex + 1
+      )
     }
 
     if (channels === 8) {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

I made some incorrect assumptions about how partial-column 8-channel pick-up works. See [this slack thread](https://opentrons.slack.com/archives/C06M9F26YGH/p1728570134231709).

This PR effectively inverts the current behavior for partial-column 8-channel well rendering. Because the starting nozzle is always `H1` in this config, we always _end_ on `wellName` and render as many wells as we can before that, stopping at either the beginning of the tip rack or until we exhaust the number of active nozzles.

As an aside, exploring how to make this code more robust if any of the lower-level partial tip logic changes would be worth the time. I think it would be nice to explore the server returning more relevant tip state for a specific labware (or perhaps pipette state and exact pick up location intentions), and using that data for rendering wells.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Sufficiently covered by the testing changes.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
