### PR TITLE
feat(shared-data): add Pydantic models for liquid class schema

### DIFF
--- a/shared-data/liquid-class/fixtures/fixture_glycerol50.json
+++ b/shared-data/liquid-class/fixtures/fixture_glycerol50.json
@@ -152,7 +152,12 @@
               "10": 7,
               "20": 10
             },
-            "delay": 1
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.5
+              }
+            }
           },
           "multiDispense": {
             "submerge": {

--- a/shared-data/liquid-class/fixtures/fixture_glycerol50.json
+++ b/shared-data/liquid-class/fixtures/fixture_glycerol50.json
@@ -217,13 +217,6 @@
               "10": 40,
               "20": 30
             },
-            "mix": {
-              "enable": true,
-              "params": {
-                "repetitions": 3,
-                "volume": 15
-              }
-            },
             "conditioningByVolume": {
               "default": 10,
               "5": 5

--- a/shared-data/liquid-class/schemas/1.json
+++ b/shared-data/liquid-class/schemas/1.json
@@ -359,8 +359,7 @@
           "$ref": "#/definitions/pushOutByVolume"
         },
         "delay": {
-          "$ref": "#/definitions/positiveNumber",
-          "description": "Delay after dispense, in seconds."
+          "$ref": "#/definitions/delay"
         }
       },
       "required": [

--- a/shared-data/liquid-class/schemas/1.json
+++ b/shared-data/liquid-class/schemas/1.json
@@ -393,9 +393,6 @@
         "flowRateByVolume": {
           "$ref": "#/definitions/flowRateByVolume"
         },
-        "mix": {
-          "$ref": "#/definitions/mix"
-        },
         "conditioningByVolume": {
           "$ref": "#/definitions/conditioningByVolume"
         },

--- a/shared-data/python/opentrons_shared_data/liquid_classes/__init__.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/__init__.py
@@ -1,0 +1,1 @@
+"""opentrons_shared_data.liquid_classes: types and functions for accessing liquid class definitions."""

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -29,7 +29,7 @@ _NonNegativeNumber = Union[_StrictNonNegativeInt, _StrictNonNegativeFloat]
 """Non-negative JSON number type, written to preserve lack of decimal point."""
 
 LiquidHandlingPropertyByVolume = Dict[str, _NonNegativeNumber]
-"""Settings for liquid class settings keyed by target aspiration volume."""
+"""Settings for liquid class settings keyed by target aspiration/dispense volume."""
 
 
 class PositionReference(Enum):
@@ -209,7 +209,7 @@ class RetractAspirate(BaseModel):
 
 
 class RetractDispense(BaseModel):
-    """Shared properties for the retract function after aspiration."""
+    """Shared properties for the retract function after dispense."""
 
     positionReference: PositionReference = Field(
         ..., description="Position reference for retract after dispense."
@@ -247,10 +247,12 @@ class AspirateParams(BaseModel):
     offset: Coordinate = Field(..., description="Relative offset for aspiration.")
     flowRateByVolume: LiquidHandlingPropertyByVolume = Field(
         ...,
-        description="Settings for flow rate keyed by target aspiration/dispense volume.",
+        description="Settings for flow rate keyed by target aspiration volume.",
     )
     preWet: bool = Field(..., description="Whether to perform a pre-wet action.")
-    mix: MixProperties = Field(..., description="Mixing settings for after an aspirate")
+    mix: MixProperties = Field(
+        ..., description="Mixing settings for before an aspirate"
+    )
     delay: DelayProperties = Field(..., description="Delay settings after an aspirate")
 
 
@@ -269,11 +271,11 @@ class SingleDispenseParams(BaseModel):
     offset: Coordinate = Field(..., description="Relative offset for single dispense.")
     flowRateByVolume: LiquidHandlingPropertyByVolume = Field(
         ...,
-        description="Settings for flow rate keyed by target aspiration/dispense volume.",
+        description="Settings for flow rate keyed by target dispense volume.",
     )
-    mix: MixProperties = Field(..., description="Mixing settings for after an aspirate")
+    mix: MixProperties = Field(..., description="Mixing settings for after a dispense")
     pushOutByVolume: LiquidHandlingPropertyByVolume = Field(
-        ..., description="Settings for pushout keyed by target aspiration volume."
+        ..., description="Settings for pushout keyed by target dispense volume."
     )
     delay: DelayProperties = Field(..., description="Delay after dispense, in seconds.")
 
@@ -293,7 +295,7 @@ class MultiDispenseParams(BaseModel):
     )
     flowRateByVolume: LiquidHandlingPropertyByVolume = Field(
         ...,
-        description="Settings for flow rate keyed by target aspiration/dispense volume.",
+        description="Settings for flow rate keyed by target dispense volume.",
     )
     mix: MixProperties = Field(..., description="Mixing settings for after an aspirate")
     conditioningByVolume: LiquidHandlingPropertyByVolume = Field(
@@ -303,7 +305,9 @@ class MultiDispenseParams(BaseModel):
     disposalByVolume: LiquidHandlingPropertyByVolume = Field(
         ..., description="Settings for disposal volume keyed by target dispense volume."
     )
-    delay: DelayProperties = Field(..., description="Delay settings after an aspirate")
+    delay: DelayProperties = Field(
+        ..., description="Delay settings after each dispense"
+    )
 
 
 class ByTipTypeSetting(BaseModel):
@@ -325,7 +329,7 @@ class ByTipTypeSetting(BaseModel):
 
 
 class ByPipetteSetting(BaseModel):
-    """The settings for a specific kind of pipette when interacting with this liquid class."""
+    """The settings for this liquid class when used with a specific kind of pipette."""
 
     pipetteModel: str = Field(..., description="The pipette model this applies to.")
     byTipType: Sequence[ByTipTypeSetting] = Field(

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -273,9 +273,7 @@ class SingleDispenseParams(BaseModel):
     pushOutByVolume: LiquidHandlingPropertyByVolume = Field(
         ..., description="Settings for pushout keyed by target aspiration volume."
     )
-    delay: _NonNegativeNumber = Field(
-        ..., description="Delay after dispense, in seconds."
-    )
+    delay: DelayProperties = Field(..., description="Delay after dispense, in seconds.")
 
 
 class MultiDispenseParams(BaseModel):

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -57,8 +57,8 @@ class Coordinate(BaseModel):
     z: _Number
 
 
-class DelayArguments(BaseModel):
-    """Arguments for delay."""
+class DelayParams(BaseModel):
+    """Parameters for delay."""
 
     duration: _NonNegativeNumber = Field(
         ..., description="Duration of delay, in seconds."
@@ -69,21 +69,21 @@ class DelayProperties(BaseModel):
     """Shared properties for delay.."""
 
     enable: bool = Field(..., description="Whether delay is enabled.")
-    params: Optional[DelayArguments] = Field(
+    params: Optional[DelayParams] = Field(
         None, description="Parameters for the delay function."
     )
 
     @validator("params")
     def _validate_params(
-        cls, v: Optional[DelayArguments], values: Dict[str, Any]
-    ) -> Optional[DelayArguments]:
+        cls, v: Optional[DelayParams], values: Dict[str, Any]
+    ) -> Optional[DelayParams]:
         if v is None and values["enable"]:
             raise ValueError("If enable is true parameters for delay must be defined.")
         return v
 
 
-class TouchTipArguments(BaseModel):
-    """Arguments for touch-tip."""
+class TouchTipParams(BaseModel):
+    """Parameters for touch-tip."""
 
     zOffset: _Number = Field(
         ...,
@@ -101,14 +101,14 @@ class TouchTipProperties(BaseModel):
     """Shared properties for the touch-tip function."""
 
     enable: bool = Field(..., description="Whether touch-tip is enabled.")
-    params: Optional[TouchTipArguments] = Field(
+    params: Optional[TouchTipParams] = Field(
         None, description="Parameters for the touch-tip function."
     )
 
     @validator("params")
     def _validate_params(
-        cls, v: Optional[TouchTipArguments], values: Dict[str, Any]
-    ) -> Optional[TouchTipArguments]:
+        cls, v: Optional[TouchTipParams], values: Dict[str, Any]
+    ) -> Optional[TouchTipParams]:
         if v is None and values["enable"]:
             raise ValueError(
                 "If enable is true parameters for touch tip must be defined."
@@ -116,8 +116,8 @@ class TouchTipProperties(BaseModel):
         return v
 
 
-class MixArguments(BaseModel):
-    """Arguments for mix."""
+class MixParams(BaseModel):
+    """Parameters for mix."""
 
     repetitions: _StrictNonNegativeInt = Field(
         ..., description="Number of mixing repetitions."
@@ -129,21 +129,21 @@ class MixProperties(BaseModel):
     """Mixing properties."""
 
     enable: bool = Field(..., description="Whether mix is enabled.")
-    params: Optional[MixArguments] = Field(
+    params: Optional[MixParams] = Field(
         None, description="Parameters for the mix function."
     )
 
     @validator("params")
     def _validate_params(
-        cls, v: Optional[MixArguments], values: Dict[str, Any]
-    ) -> Optional[MixArguments]:
+        cls, v: Optional[MixParams], values: Dict[str, Any]
+    ) -> Optional[MixParams]:
         if v is None and values["enable"]:
             raise ValueError("If enable is true parameters for mix must be defined.")
         return v
 
 
-class BlowoutArguments(BaseModel):
-    """Arguments for blowout."""
+class BlowoutParams(BaseModel):
+    """Parameters for blowout."""
 
     location: BlowoutLocation = Field(
         ..., description="Location well or trash entity for blow out."
@@ -157,14 +157,14 @@ class BlowoutProperties(BaseModel):
     """Blowout properties."""
 
     enable: bool = Field(..., description="Whether blow-out is enabled.")
-    params: Optional[BlowoutArguments] = Field(
+    params: Optional[BlowoutParams] = Field(
         None, description="Parameters for the blowout function."
     )
 
     @validator("params")
     def _validate_params(
-        cls, v: Optional[BlowoutArguments], values: Dict[str, Any]
-    ) -> Optional[BlowoutArguments]:
+        cls, v: Optional[BlowoutParams], values: Dict[str, Any]
+    ) -> Optional[BlowoutParams]:
         if v is None and values["enable"]:
             raise ValueError(
                 "If enable is true parameters for blowout must be defined."
@@ -234,8 +234,8 @@ class RetractDispense(BaseModel):
     )
 
 
-class AspirateParams(BaseModel):
-    """Parameters specific to the aspirate function."""
+class AspirateProperties(BaseModel):
+    """Properties specific to the aspirate function."""
 
     submerge: Submerge = Field(..., description="Submerge settings for aspirate.")
     retract: RetractAspirate = Field(
@@ -256,8 +256,8 @@ class AspirateParams(BaseModel):
     delay: DelayProperties = Field(..., description="Delay settings after an aspirate")
 
 
-class SingleDispenseParams(BaseModel):
-    """Parameters specific to the single-dispense function."""
+class SingleDispenseProperties(BaseModel):
+    """Properties specific to the single-dispense function."""
 
     submerge: Submerge = Field(
         ..., description="Submerge settings for single dispense."
@@ -280,8 +280,8 @@ class SingleDispenseParams(BaseModel):
     delay: DelayProperties = Field(..., description="Delay after dispense, in seconds.")
 
 
-class MultiDispenseParams(BaseModel):
-    """Parameters specific to the multi-dispense function."""
+class MultiDispenseProperties(BaseModel):
+    """Properties specific to the multi-dispense function."""
 
     submerge: Submerge = Field(..., description="Submerge settings for multi-dispense.")
     retract: RetractDispense = Field(
@@ -316,13 +316,13 @@ class ByTipTypeSetting(BaseModel):
         ...,
         description="The tip type whose properties will be used when handling this specific liquid class with this pipette",
     )
-    aspirate: AspirateParams = Field(
+    aspirate: AspirateProperties = Field(
         ..., description="Aspirate parameters for this tip type."
     )
-    singleDispense: SingleDispenseParams = Field(
+    singleDispense: SingleDispenseProperties = Field(
         ..., description="Single dispense parameters for this tip type."
     )
-    multiDispense: Optional[MultiDispenseParams] = Field(
+    multiDispense: Optional[MultiDispenseProperties] = Field(
         None, description="Optional multi-dispense parameters for this tip type."
     )
 

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -1,0 +1,339 @@
+"""Python shared data models for liquid class definitions."""
+
+from enum import Enum
+from typing import TYPE_CHECKING, Literal, Union, Optional, Dict, Any, Sequence
+
+from pydantic import (
+    BaseModel,
+    validator,
+    Field,
+    conint,
+    confloat,
+    StrictInt,
+    StrictFloat,
+)
+
+
+if TYPE_CHECKING:
+    _StrictNonNegativeInt = int
+    _StrictNonNegativeFloat = float
+else:
+    _StrictNonNegativeInt = conint(strict=True, ge=0)
+    _StrictNonNegativeFloat = confloat(strict=True, ge=0.0)
+
+
+_Number = Union[StrictInt, StrictFloat]
+"""JSON number type, written to preserve lack of decimal point"""
+
+_NonNegativeNumber = Union[_StrictNonNegativeInt, _StrictNonNegativeFloat]
+"""Non-negative JSON number type, written to preserve lack of decimal point."""
+
+LiquidHandlingPropertyByVolume = Dict[str, _NonNegativeNumber]
+"""Settings for liquid class settings keyed by target aspiration volume."""
+
+
+class PositionReference(Enum):
+    """Positional reference for liquid handling operations."""
+
+    WELL_BOTTOM = "well-bottom"
+    WELL_TOP = "well-top"
+    WELL_CENTER = "well-center"
+    LIQUID_MENISCUS = "liquid-meniscus"
+
+
+class BlowoutLocation(Enum):
+    """Location for blowout during a transfer function."""
+
+    SOURCE = "source"
+    DESTINATION = "destination"
+    TRASH = "trash"
+
+
+class Coordinate(BaseModel):
+    """Three-dimensional coordinates."""
+
+    x: _Number
+    y: _Number
+    z: _Number
+
+
+class DelayArguments(BaseModel):
+    """Arguments for delay."""
+
+    duration: _NonNegativeNumber = Field(
+        ..., description="Duration of delay, in seconds."
+    )
+
+
+class DelayProperties(BaseModel):
+    """Shared properties for delay.."""
+
+    enable: bool = Field(..., description="Whether delay is enabled.")
+    params: Optional[DelayArguments] = Field(
+        None, description="Parameters for the delay function."
+    )
+
+    @validator("enable")
+    def _validate_enable(cls, v: bool, values: Dict[str, Any]) -> bool:
+        if v and values["params"] is None:
+            raise ValueError("If enable is true parameters for delay must be defined.")
+        return v
+
+
+class TouchTipArguments(BaseModel):
+    """Arguments for touch-tip."""
+
+    zOffset: _Number = Field(
+        ...,
+        description="Offset from the top of the well for touch-tip, in millimeters.",
+    )
+    mmToEdge: _Number = Field(
+        ..., description="Offset away from the the well edge, in millimeters."
+    )
+    speed: _NonNegativeNumber = Field(
+        ..., description="Touch-tip speed, in millimeters per second."
+    )
+
+
+class TouchTipProperties(BaseModel):
+    """Shared properties for the touch-tip function."""
+
+    enable: bool = Field(..., description="Whether touch-tip is enabled.")
+    params: Optional[TouchTipArguments] = Field(
+        None, description="Parameters for the touch-tip function."
+    )
+
+    @validator("enable")
+    def _validate_enable(cls, v: bool, values: Dict[str, Any]) -> bool:
+        if v and values["params"] is None:
+            raise ValueError(
+                "If enable is true parameters for touch tip must be defined."
+            )
+        return v
+
+
+class MixArguments(BaseModel):
+    """Arguments for mix."""
+
+    repetitions: int = Field(..., description="Number of mixing repetitions.", ge=0)
+    volume: _Number = Field(..., description="Volume used for mixing, in microliters.")
+
+
+class MixProperties(BaseModel):
+    """Mixing properties."""
+
+    enable: bool = Field(..., description="Whether mix is enabled.")
+    params: Optional[MixArguments] = Field(
+        None, description="Parameters for the mix function."
+    )
+
+    @validator("enable")
+    def _validate_enable(cls, v: bool, values: Dict[str, Any]) -> bool:
+        if v and values["params"] is None:
+            raise ValueError("If enable is true parameters for mix must be defined.")
+        return v
+
+
+class BlowoutArguments(BaseModel):
+    """Arguments for blowout."""
+
+    location: BlowoutLocation = Field(
+        ..., description="Location well or trash entity for blow out."
+    )
+    flowRate: _NonNegativeNumber = Field(
+        ..., description="Flow rate for blow out, in microliters per second."
+    )
+
+
+class BlowoutProperties(BaseModel):
+    """Blowout properties."""
+
+    enable: bool = Field(..., description="Whether blow-out is enabled.")
+    params: Optional[BlowoutArguments] = Field(
+        None, description="Parameters for the blowout function."
+    )
+
+    @validator("enable")
+    def _validate_enable(cls, v: bool, values: Dict[str, Any]) -> bool:
+        if v and values["params"] is None:
+            raise ValueError(
+                "If enable is true parameters for blowout must be defined."
+            )
+        return v
+
+
+class Submerge(BaseModel):
+    """Shared properties for the submerge function before aspiration or dispense."""
+
+    positionReference: PositionReference = Field(
+        ..., description="Position reference for submerge."
+    )
+    offset: Coordinate = Field(..., description="Relative offset for submerge.")
+    speed: _NonNegativeNumber = Field(
+        ..., description="Speed of submerging, in millimeters per second."
+    )
+    delay: DelayProperties = Field(..., description="Delay settings for submerge.")
+
+
+class RetractAspirate(BaseModel):
+    """Shared properties for the retract function after aspiration."""
+
+    positionReference: PositionReference = Field(
+        ..., description="Position reference for retract after aspirate."
+    )
+    offset: Coordinate = Field(
+        ..., description="Relative offset for retract after aspirate."
+    )
+    speed: _NonNegativeNumber = Field(
+        ..., description="Speed of retraction, in millimeters per second."
+    )
+    airGapByVolume: LiquidHandlingPropertyByVolume = Field(
+        ..., description="Settings for air gap keyed by target aspiration volume."
+    )
+    touchTip: TouchTipProperties = Field(
+        ..., description="Touch tip settings for retract after aspirate."
+    )
+    delay: DelayProperties = Field(
+        ..., description="Delay settings for retract after aspirate."
+    )
+
+
+class RetractDispense(BaseModel):
+    """Shared properties for the retract function after aspiration."""
+
+    positionReference: PositionReference = Field(
+        ..., description="Position reference for retract after dispense."
+    )
+    offset: Coordinate = Field(
+        ..., description="Relative offset for retract after dispense."
+    )
+    speed: _NonNegativeNumber = Field(
+        ..., description="Speed of retraction, in millimeters per second."
+    )
+    airGapByVolume: LiquidHandlingPropertyByVolume = Field(
+        ..., description="Settings for air gap keyed by target aspiration volume."
+    )
+    blowout: BlowoutProperties = Field(
+        ..., description="Blowout properties for retract after dispense."
+    )
+    touchTip: TouchTipProperties = Field(
+        ..., description="Touch tip settings for retract after dispense."
+    )
+    delay: DelayProperties = Field(
+        ..., description="Delay settings for retract after dispense."
+    )
+
+
+class AspirateParams(BaseModel):
+    """Parameters specific to the aspirate function."""
+
+    submerge: Submerge = Field(..., description="Submerge settings for aspirate.")
+    retract: RetractAspirate = Field(
+        ..., description="Pipette retract settings after an aspirate."
+    )
+    positionReference: PositionReference = Field(
+        ..., description="Position reference for aspiration."
+    )
+    offset: Coordinate = Field(..., description="Relative offset for aspiration.")
+    flowRateByVolume: LiquidHandlingPropertyByVolume = Field(
+        ...,
+        description="Settings for flow rate keyed by target aspiration/dispense volume.",
+    )
+    preWet: bool = Field(..., description="Whether to perform a pre-wet action.")
+    mix: MixProperties = Field(..., description="Mixing settings for after an aspirate")
+    delay: DelayProperties = Field(..., description="Delay settings after an aspirate")
+
+
+class SingleDispenseParams(BaseModel):
+    """Parameters specific to the single-dispense function."""
+
+    submerge: Submerge = Field(
+        ..., description="Submerge settings for single dispense."
+    )
+    retract: RetractDispense = Field(
+        ..., description="Pipette retract settings after a single dispense."
+    )
+    positionReference: PositionReference = Field(
+        ..., description="Position reference for single dispense."
+    )
+    offset: Coordinate = Field(..., description="Relative offset for single dispense.")
+    flowRateByVolume: LiquidHandlingPropertyByVolume = Field(
+        ...,
+        description="Settings for flow rate keyed by target aspiration/dispense volume.",
+    )
+    mix: MixProperties = Field(..., description="Mixing settings for after an aspirate")
+    pushOutByVolume: LiquidHandlingPropertyByVolume = Field(
+        ..., description="Settings for pushout keyed by target aspiration volume."
+    )
+    delay: DelayProperties = Field(..., description="Delay settings after an aspirate")
+
+
+class MultiDispenseParams(BaseModel):
+    """Parameters specific to the multi-dispense function."""
+
+    submerge: Submerge = Field(..., description="Submerge settings for multi-dispense.")
+    retract: RetractDispense = Field(
+        ..., description="Pipette retract settings after a multi-dispense."
+    )
+    positionReference: PositionReference = Field(
+        ..., description="Position reference for multi-dispense."
+    )
+    offset: Coordinate = Field(
+        ..., description="Relative offset for single multi-dispense."
+    )
+    flowRateByVolume: LiquidHandlingPropertyByVolume = Field(
+        ...,
+        description="Settings for flow rate keyed by target aspiration/dispense volume.",
+    )
+    mix: MixProperties = Field(..., description="Mixing settings for after an aspirate")
+    conditioningByVolume: LiquidHandlingPropertyByVolume = Field(
+        ...,
+        description="Settings for conditioning volume keyed by target dispense volume.",
+    )
+    disposalByVolume: LiquidHandlingPropertyByVolume = Field(
+        ..., description="Settings for disposal volume keyed by target dispense volume."
+    )
+    delay: DelayProperties = Field(..., description="Delay settings after an aspirate")
+
+
+class ByTipTypeSetting(BaseModel):
+    """Settings for each kind of tip this pipette can use."""
+
+    tipType: str = Field(
+        ...,
+        description="The tip type whose properties will be used when handling this specific liquid class with this pipette",
+    )
+    aspirate: AspirateParams = Field(
+        ..., description="Aspirate parameters for this tip type."
+    )
+    singleDispense: SingleDispenseParams = Field(
+        ..., description="Single dispense parameters for this tip type."
+    )
+    multiDispense: Optional[MultiDispenseParams] = Field(
+        None, description="Optional multi-dispense parameters for this tip type."
+    )
+
+
+class ByPipetteSetting(BaseModel):
+    """The settings for a specific kind of pipette when interacting with this liquid class."""
+
+    pipetteModel: str = Field(..., description="The pipette model this applies to.")
+    byTipType: Sequence[ByTipTypeSetting] = Field(
+        ..., description="Settings for each kind of tip this pipette can use"
+    )
+
+
+class LiquidClassSchemaV1(BaseModel):
+    """Defines a single liquid class's properties for liquid handling functions."""
+
+    liquidName: str = Field(
+        ..., description="The name of the liquid (e.g., water, ethanol, serum)."
+    )
+    schemaVersion: Literal[1] = Field(
+        ..., description="Which schema version a liquid class is using"
+    )
+    namespace: str = Field(...)
+    byPipette: Sequence[ByPipetteSetting] = Field(
+        ...,
+        description="Liquid class settings by each pipette compatible with this liquid class.",
+    )

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -73,9 +73,11 @@ class DelayProperties(BaseModel):
         None, description="Parameters for the delay function."
     )
 
-    @validator("enable")
-    def _validate_enable(cls, v: bool, values: Dict[str, Any]) -> bool:
-        if v and values["params"] is None:
+    @validator("params")
+    def _validate_params(
+        cls, v: Optional[DelayArguments], values: Dict[str, Any]
+    ) -> Optional[DelayArguments]:
+        if v is None and values["enable"]:
             raise ValueError("If enable is true parameters for delay must be defined.")
         return v
 
@@ -103,9 +105,11 @@ class TouchTipProperties(BaseModel):
         None, description="Parameters for the touch-tip function."
     )
 
-    @validator("enable")
-    def _validate_enable(cls, v: bool, values: Dict[str, Any]) -> bool:
-        if v and values["params"] is None:
+    @validator("params")
+    def _validate_params(
+        cls, v: Optional[TouchTipArguments], values: Dict[str, Any]
+    ) -> Optional[TouchTipArguments]:
+        if v is None and values["enable"]:
             raise ValueError(
                 "If enable is true parameters for touch tip must be defined."
             )
@@ -127,9 +131,11 @@ class MixProperties(BaseModel):
         None, description="Parameters for the mix function."
     )
 
-    @validator("enable")
-    def _validate_enable(cls, v: bool, values: Dict[str, Any]) -> bool:
-        if v and values["params"] is None:
+    @validator("params")
+    def _validate_params(
+        cls, v: Optional[MixArguments], values: Dict[str, Any]
+    ) -> Optional[MixArguments]:
+        if v is None and values["enable"]:
             raise ValueError("If enable is true parameters for mix must be defined.")
         return v
 
@@ -153,9 +159,11 @@ class BlowoutProperties(BaseModel):
         None, description="Parameters for the blowout function."
     )
 
-    @validator("enable")
-    def _validate_enable(cls, v: bool, values: Dict[str, Any]) -> bool:
-        if v and values["params"] is None:
+    @validator("params")
+    def _validate_params(
+        cls, v: Optional[BlowoutArguments], values: Dict[str, Any]
+    ) -> Optional[BlowoutArguments]:
+        if v is None and values["enable"]:
             raise ValueError(
                 "If enable is true parameters for blowout must be defined."
             )
@@ -265,7 +273,9 @@ class SingleDispenseParams(BaseModel):
     pushOutByVolume: LiquidHandlingPropertyByVolume = Field(
         ..., description="Settings for pushout keyed by target aspiration volume."
     )
-    delay: DelayProperties = Field(..., description="Delay settings after an aspirate")
+    delay: _NonNegativeNumber = Field(
+        ..., description="Delay after dispense, in seconds."
+    )
 
 
 class MultiDispenseParams(BaseModel):

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -297,7 +297,6 @@ class MultiDispenseParams(BaseModel):
         ...,
         description="Settings for flow rate keyed by target dispense volume.",
     )
-    mix: MixProperties = Field(..., description="Mixing settings for after an aspirate")
     conditioningByVolume: LiquidHandlingPropertyByVolume = Field(
         ...,
         description="Settings for conditioning volume keyed by target dispense volume.",

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -119,7 +119,9 @@ class TouchTipProperties(BaseModel):
 class MixArguments(BaseModel):
     """Arguments for mix."""
 
-    repetitions: int = Field(..., description="Number of mixing repetitions.", ge=0)
+    repetitions: _StrictNonNegativeInt = Field(
+        ..., description="Number of mixing repetitions."
+    )
     volume: _Number = Field(..., description="Volume used for mixing, in microliters.")
 
 

--- a/shared-data/python/tests/liquid_classes/test_load_schema.py
+++ b/shared-data/python/tests/liquid_classes/test_load_schema.py
@@ -1,0 +1,16 @@
+import json
+
+from opentrons_shared_data import load_shared_data
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    LiquidClassSchemaV1,
+)
+
+
+def test_load_liquid_class_schema_v1() -> None:
+    fixture_data = load_shared_data("liquid-class/fixtures/fixture_glycerol50.json")
+    liquid_class_model = LiquidClassSchemaV1.parse_raw(fixture_data)
+    liquid_class_def_from_model = json.loads(
+        liquid_class_model.json(exclude_unset=True)
+    )
+    expected_liquid_class_def = json.loads(fixture_data)
+    assert liquid_class_def_from_model == expected_liquid_class_def


### PR DESCRIPTION
# Overview

Closes AUTH-834.

This PR follows #16267 and implements the schema as shared data Pydantic models for usage in other parts of the codebase. The models follow the schema in a straightforward matter, the only extra parts that needed to be added were custom validators for the `params` portion of the different liquid handling properties. If the params are `None` but `enable` is set to True, it will raise a validation error.

## Test Plan and Hands on Testing

Testing is covered by the unit test added which is able to successfully load the example fixture as the Pydantic model.

## Changelog

- Added `liquid_class` folder to Python section of shared-data
- Added Pydantic representation of schema

## Review requests

Mostly suggestions for names of files, models, and definitely descriptions. Most of the descriptions written are pretty simple and more useful suggestions would be appreciated.

## Risk assessment

Low, new shared data code that doesn't touch anything else.