### PR TITLE
refactor(api): Ensure we handle state updates even for failed commands

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -30,6 +30,7 @@ from .actions import (
     SetPipetteMovementSpeedAction,
     AddAbsorbanceReaderLidAction,
 )
+from .get_state_update import get_state_update
 
 __all__ = [
     # action pipeline interface
@@ -61,4 +62,6 @@ __all__ = [
     # action payload values
     "PauseSource",
     "FinishErrorDetails",
+    # helper functions
+    "get_state_update",
 ]

--- a/api/src/opentrons/protocol_engine/actions/get_state_update.py
+++ b/api/src/opentrons/protocol_engine/actions/get_state_update.py
@@ -1,0 +1,18 @@
+# noqa: D100
+
+
+from .actions import Action, SucceedCommandAction, FailCommandAction
+from ..commands.command import DefinedErrorData
+from ..state.update_types import StateUpdate
+
+
+def get_state_update(action: Action) -> StateUpdate | None:
+    """Extract the StateUpdate from an action, if there is one."""
+    if isinstance(action, SucceedCommandAction):
+        return action.state_update
+    elif isinstance(action, FailCommandAction) and isinstance(
+        action.error, DefinedErrorData
+    ):
+        return action.error.state_update
+    else:
+        return None


### PR DESCRIPTION
## Overview

This goes towards EXEC-639 in general.

`LabwareStore`, and most parts of `PipetteStore`, are now handling Protocol Engine state updates according to EXEC-639. However, in some places, they are only doing that *when a command succeeds.* They ought to also do it when the command fails with a defined error.

I don't think that has caused any problems so far, but it seems like something that would trip us up as we continue adding more defined errors and as we continue with EXEC-639.

So this PR tries to set a pattern for consistently handling both the success and failure cases.

## Test Plan and Hands on Testing

Existing automated unit tests.

## Review requests

None.

## Risk assessment

Low.