### PR TITLE
fix(app): do not load pipette during error recovery

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
@@ -1,19 +1,15 @@
 // This is the main unifying function for maintenanceRun and fixit type flows.
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 
 import { useDropTipCommandErrors } from '.'
 import { useDropTipMaintenanceRun } from './useDropTipMaintenanceRun'
 import { useDropTipCreateCommands } from './useDropTipCreateCommands'
-import {
-  useDropTipCommands,
-  buildLoadPipetteCommand,
-} from './useDropTipCommands'
+import { useDropTipCommands } from './useDropTipCommands'
 
 import type { SetRobotErrorDetailsParams } from '.'
 import type { UseDropTipCommandsResult } from './useDropTipCommands'
 import type { ErrorDetails, IssuedCommandsType } from '../types'
 import type { DropTipWizardFlowsProps } from '..'
-import type { UseDropTipCreateCommandsResult } from './useDropTipCreateCommands'
 
 export type UseDTWithTypeParams = DropTipWizardFlowsProps & {
   issuedCommandsType: IssuedCommandsType
@@ -62,8 +58,6 @@ export function useDropTipWithType(
     fixitCommandTypeUtils,
   })
 
-  useRegisterPipetteFixitType({ ...params, ...dtCreateCommandUtils })
-
   return {
     activeMaintenanceRunId,
     errorDetails,
@@ -105,27 +99,4 @@ function useIsExitingDT(
   const isExitingIfNotFixit = issuedCommandsType === 'fixit' ? false : isExiting
 
   return { isExiting: isExitingIfNotFixit, toggleIsExiting }
-}
-
-type UseRegisterPipetteFixitType = UseDTWithTypeParams &
-  UseDropTipCreateCommandsResult
-
-// On mount, if fixit command type, load the managed pipette ID for use in DT Wiz.
-function useRegisterPipetteFixitType({
-  mount,
-  instrumentModelSpecs,
-  issuedCommandsType,
-  chainRunCommands,
-  fixitCommandTypeUtils,
-}: UseRegisterPipetteFixitType): void {
-  useEffect(() => {
-    if (issuedCommandsType === 'fixit') {
-      const command = buildLoadPipetteCommand(
-        instrumentModelSpecs.name,
-        mount,
-        fixitCommandTypeUtils?.pipetteId
-      )
-      void chainRunCommands([command], true)
-    }
-  }, [])
 }


### PR DESCRIPTION
Closes [EXEC-760](https://opentrons.atlassian.net/browse/EXEC-760)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The `loadPipette` command is important for executing commands associated with a specific pipette, but it also resets internal state, which can leads to bugs like the ones in the linked ticket. If the pipette has been loaded earlier (ie, during error recovery, synonymous with `fixit` command flows), we should not load the pipette. We still load the pipette during maintenance runs (drop tip wizard when not in error recovery).  

Thank you @SyntaxColoring for spending the time identifying the root cause of this issue!
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Followed the protocol attached in the ticket. The `AssertionError` is reproducible 100% of the time.
- Tested using this branch. The error no longer occurs.
- Confirmed that drop tip flows outside of error recovery aren't impacted.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed protocol runs sometimes failing after specific recovery flows involving blowout and tip dropping.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-760]: https://opentrons.atlassian.net/browse/EXEC-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ