### PR TITLE
refactor(api): Port tip consumption to StateUpdate

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -114,7 +114,9 @@ class DropTipImplementation(
 
         await self._tip_handler.drop_tip(pipette_id=pipette_id, home_after=home_after)
 
-        state_update.update_tip_state(pipette_id=params.pipetteId, tip_geometry=None)
+        state_update.update_pipette_tip_state(
+            pipette_id=params.pipetteId, tip_geometry=None
+        )
 
         return SuccessData(
             public=DropTipResult(position=deck_point),

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -57,7 +57,9 @@ class DropTipInPlaceImplementation(
 
         state_update = update_types.StateUpdate()
 
-        state_update.update_tip_state(pipette_id=params.pipetteId, tip_geometry=None)
+        state_update.update_pipette_tip_state(
+            pipette_id=params.pipetteId, tip_geometry=None
+        )
 
         return SuccessData(
             public=DropTipInPlaceResult(), private=None, state_update=state_update

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -130,7 +130,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 labware_id=labware_id,
                 well_name=well_name,
             )
-            state_update.update_tip_state(
+            state_update.update_pipette_tip_state(
                 pipette_id=pipette_id,
                 tip_geometry=tip_geometry,
             )

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -74,7 +74,9 @@ class UnsafeDropTipInPlaceImplementation(
         )
 
         state_update = StateUpdate()
-        state_update.update_tip_state(pipette_id=params.pipetteId, tip_geometry=None)
+        state_update.update_pipette_tip_state(
+            pipette_id=params.pipetteId, tip_geometry=None
+        )
 
         return SuccessData(
             public=UnsafeDropTipInPlaceResult(), private=None, state_update=state_update

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -216,7 +216,7 @@ class TipView(HasState[TipState]):
             critical_row: int,
             entry_well: str,
         ) -> Optional[List[str]]:
-            tip_cluster = []
+            tip_cluster: list[str] = []
             for i in range(active_columns):
                 if entry_well == "A1" or entry_well == "H1":
                     if critical_column - i >= 0:
@@ -267,12 +267,12 @@ class TipView(HasState[TipState]):
 
                 # In the case of a 96ch we can attempt to index in by singular rows and columns assuming that indexed direction is safe
                 # The tip cluster list is ordered: Each row from a column in order by columns
-                tip_cluster_final_column = []
+                tip_cluster_final_column: list[str] = []
                 for i in range(active_rows):
                     tip_cluster_final_column.append(
                         tip_cluster[((active_columns * active_rows) - 1) - i]
                     )
-                tip_cluster_final_row = []
+                tip_cluster_final_row: list[str] = []
                 for i in range(active_columns):
                     tip_cluster_final_row.append(
                         tip_cluster[(active_rows - 1) + (i * active_rows)]

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -35,6 +35,11 @@ class TipRackWellState(Enum):
 TipRackStateByWellName = Dict[str, TipRackWellState]
 
 
+# todo(mm, 2024-10-10): This info is duplicated between here and PipetteState because
+# TipStore is using it to compute which tips a PickUpTip removes from the tip rack,
+# given the pipette's current nozzle map. We could avoid this duplication by moving the
+# computation to TipView, calling it from PickUpTipImplementation, and passing the
+# precomputed list of wells to TipStore.
 @dataclass
 class _PipetteInfo:
     channels: int

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -15,9 +15,6 @@ from ..commands import (
     LoadLabwareResult,
     PickUpTip,
     PickUpTipResult,
-    DropTipResult,
-    DropTipInPlaceResult,
-    unsafe,
 )
 from ..commands.configuring_common import (
     PipetteConfigUpdateResultMixin,
@@ -123,12 +120,6 @@ class TipStore(HasState[TipState], HandlesActions):
             self._set_used_tips(
                 pipette_id=pipette_id, well_name=well_name, labware_id=labware_id
             )
-
-        elif isinstance(
-            command.result,
-            (DropTipResult, DropTipInPlaceResult, unsafe.UnsafeDropTipInPlaceResult),
-        ):
-            pipette_id = command.params.pipetteId
 
     def _handle_failed_command(
         self,

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -88,13 +88,8 @@ class TipStore(HasState[TipState], HandlesActions):
                 pipette_id = action.private_result.pipette_id
                 nozzle_map = action.private_result.nozzle_map
                 pipette_info = self._state.pipette_info_by_pipette_id[pipette_id]
-                if nozzle_map:
-                    pipette_info.active_channels = nozzle_map.tip_count
-                    pipette_info.nozzle_map = nozzle_map
-                else:
-                    # todo(mm, 2024-10-10): nozzle_map looks always truthy--can this
-                    # else-block actually run?
-                    pipette_info.active_channels = pipette_info.channels
+                pipette_info.active_channels = nozzle_map.tip_count
+                pipette_info.nozzle_map = nozzle_map
 
         elif isinstance(action, FailCommandAction):
             self._handle_failed_command(action)

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -274,7 +274,7 @@ class StateUpdate:
             pipette_id=pipette_id, nozzle_map=nozzle_map
         )
 
-    def update_tip_state(
+    def update_pipette_tip_state(
         self, pipette_id: str, tip_geometry: typing.Optional[TipGeometry]
     ) -> None:
         """Update tip state."""

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -137,6 +137,23 @@ class PipetteTipStateUpdate:
 
 
 @dataclasses.dataclass
+class TipsUsedUpdate:
+    """Represents an update that marks tips in a tip rack as used."""
+
+    pipette_id: str
+    """The pipette that did the tip pickup."""
+
+    labware_id: str
+
+    well_name: str
+    """The well that the pipette's primary nozzle targeted.
+
+    Wells in addition to this one will also be marked as used, depending on the
+    pipette's nozzle layout.
+    """
+
+
+@dataclasses.dataclass
 class StateUpdate:
     """Represents an update to perform on engine state."""
 
@@ -154,8 +171,10 @@ class StateUpdate:
 
     loaded_labware: LoadedLabwareUpdate | NoChangeType = NO_CHANGE
 
+    tips_used: TipsUsedUpdate | NoChangeType = NO_CHANGE
+
     # These convenience functions let the caller avoid the boilerplate of constructing a
-    # complicated dataclass tree, and they give us a
+    # complicated dataclass tree.
 
     @typing.overload
     def set_pipette_location(
@@ -280,4 +299,12 @@ class StateUpdate:
         """Update tip state."""
         self.pipette_tip_state = PipetteTipStateUpdate(
             pipette_id=pipette_id, tip_geometry=tip_geometry
+        )
+
+    def mark_tips_as_used(
+        self, pipette_id: str, labware_id: str, well_name: str
+    ) -> None:
+        """Mark tips in a tip rack as used. See `MarkTipsUsedState`."""
+        self.tips_used = TipsUsedUpdate(
+            pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
         )

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -207,6 +207,10 @@ class StateUpdate:
                 new_deck_point=new_deck_point,
             )
 
+    def clear_all_pipette_locations(self) -> None:
+        """Mark all pipettes as having an unknown location."""
+        self.pipette_location = CLEAR
+
     def set_labware_location(
         self,
         *,
@@ -237,10 +241,6 @@ class StateUpdate:
             new_location=location,
             display_name=display_name,
         )
-
-    def clear_all_pipette_locations(self) -> None:
-        """Mark all pipettes as having an unknown location."""
-        self.pipette_location = CLEAR
 
     def set_load_pipette(
         self,

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -83,6 +83,9 @@ async def test_success(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
             ),
+            tips_used=update_types.TipsUsedUpdate(
+                pipette_id="pipette-id", labware_id="labware-id", well_name="A3"
+            ),
         ),
     )
 
@@ -139,6 +142,9 @@ async def test_tip_physically_missing_error(
                     labware_id="labware-id", well_name="well-name"
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
-            )
+            ),
+            tips_used=update_types.TipsUsedUpdate(
+                pipette_id="pipette-id", labware_id="labware-id", well_name="well-name"
+            ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -76,41 +76,6 @@ def _dummy_command() -> commands.Command:
     return commands.Comment.construct()  # type: ignore[call-arg]
 
 
-@pytest.fixture
-def drop_tip_command() -> commands.DropTip:
-    """Get a drop tip command value object."""
-    return commands.DropTip.construct(  # type: ignore[call-arg]
-        params=commands.DropTipParams.construct(
-            pipetteId="pipette-id",
-            labwareId="cool-labware",
-            wellName="A1",
-        ),
-        result=commands.DropTipResult.construct(position=DeckPoint(x=0, y=0, z=0)),
-    )
-
-
-@pytest.fixture
-def drop_tip_in_place_command() -> commands.DropTipInPlace:
-    """Get a drop tip in place command object."""
-    return commands.DropTipInPlace.construct(  # type: ignore[call-arg]
-        params=commands.DropTipInPlaceParams.construct(
-            pipetteId="pipette-id",
-        ),
-        result=commands.DropTipInPlaceResult.construct(),
-    )
-
-
-@pytest.fixture
-def unsafe_drop_tip_in_place_command() -> commands.unsafe.UnsafeDropTipInPlace:
-    """Get an unsafe drop-tip-in-place command."""
-    return commands.unsafe.UnsafeDropTipInPlace.construct(  # type: ignore[call-arg]
-        params=commands.unsafe.UnsafeDropTipInPlaceParams.construct(
-            pipetteId="pipette-id"
-        ),
-        result=commands.unsafe.UnsafeDropTipInPlaceResult.construct(),
-    )
-
-
 @pytest.mark.parametrize(
     "labware_definition",
     [

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -14,8 +14,9 @@ from opentrons_shared_data.pipette.pipette_definition import ValidNozzleMaps
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_engine import actions, commands
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.tips import TipStore, TipView
-from opentrons.protocol_engine.types import FlowRates, DeckPoint
+from opentrons.protocol_engine.types import FlowRates
 from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
 )
@@ -70,19 +71,9 @@ def load_labware_command(labware_definition: LabwareDefinition) -> commands.Load
     )
 
 
-@pytest.fixture
-def pick_up_tip_command() -> commands.PickUpTip:
-    """Get a pick-up tip command value object."""
-    return commands.PickUpTip.construct(  # type: ignore[call-arg]
-        params=commands.PickUpTipParams.construct(
-            pipetteId="pipette-id",
-            labwareId="cool-labware",
-            wellName="A1",
-        ),
-        result=commands.PickUpTipResult.construct(
-            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
-        ),
-    )
+def _dummy_command() -> commands.Command:
+    """Return a placeholder command."""
+    return commands.Comment.construct()  # type: ignore[call-arg]
 
 
 @pytest.fixture
@@ -310,7 +301,6 @@ def test_get_next_tip_used_starting_tip(
 )
 def test_get_next_tip_skips_picked_up_tip(
     load_labware_command: commands.LoadLabware,
-    pick_up_tip_command: commands.PickUpTip,
     subject: TipStore,
     input_tip_amount: int,
     get_next_tip_tips: int,
@@ -322,6 +312,7 @@ def test_get_next_tip_skips_picked_up_tip(
     subject.handle_action(
         actions.SucceedCommandAction(private_result=None, command=load_labware_command)
     )
+
     load_pipette_command = commands.LoadPipette.construct(  # type: ignore[call-arg]
         result=commands.LoadPipetteResult(pipetteId="pipette-id")
     )
@@ -372,8 +363,20 @@ def test_get_next_tip_skips_picked_up_tip(
             private_result=load_pipette_private_result, command=load_pipette_command
         )
     )
+
+    pick_up_tip_state_update = update_types.StateUpdate(
+        tips_used=update_types.TipsUsedUpdate(
+            pipette_id="pipette-id",
+            labware_id="cool-labware",
+            well_name="A1",
+        )
+    )
     subject.handle_action(
-        actions.SucceedCommandAction(command=pick_up_tip_command, private_result=None)
+        actions.SucceedCommandAction(
+            command=_dummy_command(),
+            private_result=None,
+            state_update=pick_up_tip_state_update,
+        )
     )
 
     result = TipView(subject.state).get_next_tip(
@@ -436,19 +439,15 @@ def test_get_next_tip_with_starting_tip(
 
     assert result == "B2"
 
-    pick_up_tip = commands.PickUpTip.construct(  # type: ignore[call-arg]
-        params=commands.PickUpTipParams.construct(
-            pipetteId="pipette-id",
-            labwareId="cool-labware",
-            wellName="B2",
-        ),
-        result=commands.PickUpTipResult.construct(
-            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
-        ),
+    pick_up_tip_state_update = update_types.StateUpdate(
+        tips_used=update_types.TipsUsedUpdate("pipette-id", "cool-labware", "B2")
     )
-
     subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=pick_up_tip)
+        actions.SucceedCommandAction(
+            command=_dummy_command(),
+            private_result=None,
+            state_update=pick_up_tip_state_update,
+        )
     )
 
     result = TipView(subject.state).get_next_tip(
@@ -512,19 +511,17 @@ def test_get_next_tip_with_starting_tip_8_channel(
 
     assert result == "A2"
 
-    pick_up_tip = commands.PickUpTip.construct(  # type: ignore[call-arg]
-        params=commands.PickUpTipParams.construct(
-            pipetteId="pipette-id",
-            labwareId="cool-labware",
-            wellName="A2",
-        ),
-        result=commands.PickUpTipResult.construct(
-            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
-        ),
+    pick_up_tip_state_update = update_types.StateUpdate(
+        tips_used=update_types.TipsUsedUpdate(
+            pipette_id="pipette-id", labware_id="cool-labware", well_name="A2"
+        )
     )
-
     subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=pick_up_tip)
+        actions.SucceedCommandAction(
+            command=_dummy_command(),
+            private_result=None,
+            state_update=pick_up_tip_state_update,
+        )
     )
 
     result = TipView(subject.state).get_next_tip(
@@ -578,10 +575,10 @@ def test_get_next_tip_with_1_channel_followed_by_8_channel(
             private_result=load_pipette_private_result, command=load_pipette_command
         )
     )
-    load_pipette_command2 = commands.LoadPipette.construct(  # type: ignore[call-arg]
+    load_pipette_command_2 = commands.LoadPipette.construct(  # type: ignore[call-arg]
         result=commands.LoadPipetteResult(pipetteId="pipette-id2")
     )
-    load_pipette_private_result2 = commands.LoadPipettePrivateResult(
+    load_pipette_private_result_2 = commands.LoadPipettePrivateResult(
         pipette_id="pipette-id2",
         serial_number="pipette-serial2",
         config=LoadedStaticPipetteData(
@@ -607,7 +604,7 @@ def test_get_next_tip_with_1_channel_followed_by_8_channel(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=load_pipette_private_result2, command=load_pipette_command2
+            private_result=load_pipette_private_result_2, command=load_pipette_command_2
         )
     )
 
@@ -620,19 +617,17 @@ def test_get_next_tip_with_1_channel_followed_by_8_channel(
 
     assert result == "A1"
 
-    pick_up_tip2 = commands.PickUpTip.construct(  # type: ignore[call-arg]
-        params=commands.PickUpTipParams.construct(
-            pipetteId="pipette-id2",
-            labwareId="cool-labware",
-            wellName="A1",
-        ),
-        result=commands.PickUpTipResult.construct(
-            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
-        ),
+    pick_up_tip_2_state_update = update_types.StateUpdate(
+        tips_used=update_types.TipsUsedUpdate(
+            pipette_id="pipette-id2", labware_id="cool-labware", well_name="A1"
+        )
     )
-
     subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=pick_up_tip2)
+        actions.SucceedCommandAction(
+            command=_dummy_command(),
+            private_result=None,
+            state_update=pick_up_tip_2_state_update,
+        )
     )
 
     result = TipView(subject.state).get_next_tip(
@@ -696,19 +691,17 @@ def test_get_next_tip_with_starting_tip_out_of_tips(
 
     assert result == "H12"
 
-    pick_up_tip = commands.PickUpTip.construct(  # type: ignore[call-arg]
-        params=commands.PickUpTipParams.construct(
-            pipetteId="pipette-id",
-            labwareId="cool-labware",
-            wellName="H12",
-        ),
-        result=commands.PickUpTipResult.construct(
-            position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
-        ),
+    pick_up_tip_state_update = update_types.StateUpdate(
+        tips_used=update_types.TipsUsedUpdate(
+            pipette_id="pipette-id", labware_id="cool-labware", well_name="H12"
+        )
     )
-
     subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=pick_up_tip)
+        actions.SucceedCommandAction(
+            command=_dummy_command(),
+            private_result=None,
+            state_update=pick_up_tip_state_update,
+        )
     )
 
     result = TipView(subject.state).get_next_tip(
@@ -776,7 +769,6 @@ def test_get_next_tip_with_column_and_starting_tip(
 def test_reset_tips(
     subject: TipStore,
     load_labware_command: commands.LoadLabware,
-    pick_up_tip_command: commands.PickUpTip,
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
 ) -> None:
     """It should be able to reset tip tracking state."""
@@ -818,18 +810,30 @@ def test_reset_tips(
     )
 
     subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=pick_up_tip_command)
+        actions.SucceedCommandAction(
+            command=_dummy_command(),
+            private_result=None,
+            state_update=update_types.StateUpdate(
+                tips_used=update_types.TipsUsedUpdate(
+                    pipette_id="pipette-id",
+                    labware_id="cool-labware",
+                    well_name="A1",
+                )
+            ),
+        )
     )
+
+    def get_result() -> str | None:
+        return TipView(subject.state).get_next_tip(
+            labware_id="cool-labware",
+            num_tips=1,
+            starting_tip_name=None,
+            nozzle_map=None,
+        )
+
+    assert get_result() != "A1"
     subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
-
-    result = TipView(subject.state).get_next_tip(
-        labware_id="cool-labware",
-        num_tips=1,
-        starting_tip_name=None,
-        nozzle_map=None,
-    )
-
-    assert result == "A1"
+    assert get_result() == "A1"
 
 
 def test_handle_pipette_config_action(
@@ -1032,7 +1036,6 @@ def test_next_tip_uses_active_channels(
     subject: TipStore,
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
     load_labware_command: commands.LoadLabware,
-    pick_up_tip_command: commands.PickUpTip,
 ) -> None:
     """Test that tip tracking logic uses pipette's active channels."""
     # Load labware
@@ -1102,7 +1105,17 @@ def test_next_tip_uses_active_channels(
     )
     # Pick up partial tips
     subject.handle_action(
-        actions.SucceedCommandAction(command=pick_up_tip_command, private_result=None)
+        actions.SucceedCommandAction(
+            command=_dummy_command(),
+            private_result=None,
+            state_update=update_types.StateUpdate(
+                tips_used=update_types.TipsUsedUpdate(
+                    pipette_id="pipette-id",
+                    labware_id="cool-labware",
+                    well_name="A1",
+                )
+            ),
+        )
     )
 
     result = TipView(subject.state).get_next_tip(
@@ -1118,7 +1131,6 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
     subject: TipStore,
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
     load_labware_command: commands.LoadLabware,
-    pick_up_tip_command: commands.PickUpTip,
 ) -> None:
     """Test tip tracking logic using multiple pipette configurations."""
     # Load labware
@@ -1167,21 +1179,22 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
             starting_tip_name=None,
             nozzle_map=nozzle_map,
         )
-        assert result == well
+        assert result is not None and result == well
 
-        pick_up_tip = commands.PickUpTip.construct(  # type: ignore[call-arg]
-            params=commands.PickUpTipParams.construct(
-                pipetteId="pipette-id",
-                labwareId="cool-labware",
-                wellName=result,
-            ),
-            result=commands.PickUpTipResult.construct(
-                position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
-            ),
+        pick_up_tip_state_update = update_types.StateUpdate(
+            tips_used=update_types.TipsUsedUpdate(
+                pipette_id="pipette-id",
+                labware_id="cool-labware",
+                well_name=result,
+            )
         )
 
         subject.handle_action(
-            actions.SucceedCommandAction(private_result=None, command=pick_up_tip)
+            actions.SucceedCommandAction(
+                command=_dummy_command(),
+                private_result=None,
+                state_update=pick_up_tip_state_update,
+            )
         )
 
     # Configure nozzle for partial configurations
@@ -1277,7 +1290,6 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
     subject: TipStore,
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
     load_labware_command: commands.LoadLabware,
-    pick_up_tip_command: commands.PickUpTip,
 ) -> None:
     """Test tip tracking logic to ensure once a tiprack is consumed it returns None when consuming tips using multiple pipette configurations."""
     # Load labware
@@ -1327,19 +1339,18 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
             nozzle_map=nozzle_map,
         )
         if result is not None:
-            pick_up_tip = commands.PickUpTip.construct(  # type: ignore[call-arg]
-                params=commands.PickUpTipParams.construct(
-                    pipetteId="pipette-id",
-                    labwareId="cool-labware",
-                    wellName=result,
-                ),
-                result=commands.PickUpTipResult.construct(
-                    position=DeckPoint(x=0, y=0, z=0), tipLength=1.23
-                ),
+            pick_up_tip_state_update = update_types.StateUpdate(
+                tips_used=update_types.TipsUsedUpdate(
+                    pipette_id="pipette-id", labware_id="cool-labware", well_name=result
+                )
             )
 
             subject.handle_action(
-                actions.SucceedCommandAction(private_result=None, command=pick_up_tip)
+                actions.SucceedCommandAction(
+                    command=_dummy_command(),
+                    private_result=None,
+                    state_update=pick_up_tip_state_update,
+                )
             )
 
         return result


### PR DESCRIPTION
## Overview

A refactor towards EXEC-758 and EXEC-764.

## Test Plan and Hands on Testing

* [x] Make sure analysis snapshot tests continue to pass, indicating that tip tracking has not changed.

## Changelog

* `TipStore` was looking for `PickUpTipResult`s to track tips being consumed from tip racks. Convert this to use the newer `StateUpdate` mechanism.
* Various other small refactors. See the commit messages for details.

## Review requests

None in particular.

## Risk assessment

Low if tests pass.
