### PR TITLE
fix(components): fix logic for whether TC is selected in DeckConfigurator

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -14,6 +14,7 @@ import {
   MAGNETIC_BLOCK_V1_FIXTURE,
   ABSORBANCE_READER_V1_FIXTURE,
   STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE,
+  THERMOCYCLER_MODULE_CUTOUTS,
 } from '@opentrons/shared-data'
 
 import { COLORS } from '../../helix-design-system'
@@ -228,18 +229,26 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
           }
         />
       ))}
-      {thermocyclerFixtures.map(({ cutoutId, cutoutFixtureId }) => (
-        <ThermocyclerFixture
-          key={cutoutId}
-          deckDefinition={deckDef}
-          handleClickRemove={
-            editableCutoutIds.includes(cutoutId) ? handleClickRemove : undefined
-          }
-          fixtureLocation={cutoutId}
-          cutoutFixtureId={cutoutFixtureId}
-          selected={cutoutId === selectedCutoutId}
-        />
-      ))}
+      {thermocyclerFixtures.map(({ cutoutId, cutoutFixtureId }) => {
+        return (
+          <ThermocyclerFixture
+            key={cutoutId}
+            deckDefinition={deckDef}
+            handleClickRemove={
+              editableCutoutIds.includes(cutoutId)
+                ? handleClickRemove
+                : undefined
+            }
+            fixtureLocation={cutoutId}
+            cutoutFixtureId={cutoutFixtureId}
+            selected={
+              selectedCutoutId != null &&
+              THERMOCYCLER_MODULE_CUTOUTS.includes(selectedCutoutId) &&
+              THERMOCYCLER_MODULE_CUTOUTS.includes(cutoutId)
+            }
+          />
+        )
+      })}
       {absorbanceReaderFixtures.map(({ cutoutId, cutoutFixtureId }) => (
         <AbsorbanceReaderFixture
           key={cutoutId}


### PR DESCRIPTION
# Overview

In our `DeckConfigurator` component, there is a leaky equality check for selected cutout ID with configured thermocycler cutout. The situation arises when a thermocycler is configured in cutout A1 and the selected cutout ID is B1, or vice versa. These point to the thermocycler being configured in the same physical location, so we should check whether both selected and configured cutout IDs are included in thermocycler cutouts ([cutoutA1, cutoutB1]).

<img width="783" alt="Screenshot 2024-10-14 at 10 23 13 AM" src="https://github.com/user-attachments/assets/a6f87dbe-44b2-4120-949d-fe08095dfe26">

Closes RQA-3237

## Test Plan and Hands on Testing

- On desktop app, launch module calibration for thermocycler
- If the thermocycler has not yet been configured on the robot's deck configuration, follow the prompt in the modal to do so
- Confirm that the fixture style for the thermocycler is selected style (blue)

## Changelog

- expand selected check in `DeckConfigurator` for thermocycler module cutouts

## Review requests

see test plan

## Risk assessment

low