### PR TITLE
refactor(api): Port `TipState`'s nozzle layout to `StateUpdate`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -306,7 +306,6 @@ from .configure_nozzle_layout import (
     ConfigureNozzleLayoutCreate,
     ConfigureNozzleLayoutParams,
     ConfigureNozzleLayoutResult,
-    ConfigureNozzleLayoutPrivateResult,
     ConfigureNozzleLayoutCommandType,
 )
 
@@ -569,7 +568,6 @@ __all__ = [
     "ConfigureNozzleLayoutParams",
     "ConfigureNozzleLayoutResult",
     "ConfigureNozzleLayoutCommandType",
-    "ConfigureNozzleLayoutPrivateResult",
     # get pipette tip presence bundle
     "GetTipPresence",
     "GetTipPresenceCreate",

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -288,7 +288,6 @@ from .configure_nozzle_layout import (
     ConfigureNozzleLayoutParams,
     ConfigureNozzleLayoutResult,
     ConfigureNozzleLayoutCommandType,
-    ConfigureNozzleLayoutPrivateResult,
 )
 
 from .verify_tip_presence import (
@@ -709,7 +708,6 @@ CommandPrivateResult = Union[
     None,
     LoadPipettePrivateResult,
     ConfigureForVolumePrivateResult,
-    ConfigureNozzleLayoutPrivateResult,
 ]
 
 # All `DefinedErrorData`s that implementations will actually return in practice.

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -10,9 +10,6 @@ from .pipetting_common import (
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors.error_occurrence import ErrorOccurrence
-from .configuring_common import (
-    PipetteNozzleLayoutResultMixin,
-)
 from ..types import (
     AllNozzleLayoutConfiguration,
     SingleNozzleLayoutConfiguration,
@@ -40,12 +37,6 @@ class ConfigureNozzleLayoutParams(PipetteIdMixin):
     ]
 
 
-class ConfigureNozzleLayoutPrivateResult(PipetteNozzleLayoutResultMixin):
-    """Result sent to the store but not serialized."""
-
-    pass
-
-
 class ConfigureNozzleLayoutResult(BaseModel):
     """Result data from execution of an configureNozzleLayout command."""
 
@@ -55,7 +46,7 @@ class ConfigureNozzleLayoutResult(BaseModel):
 class ConfigureNozzleLayoutImplementation(
     AbstractCommandImpl[
         ConfigureNozzleLayoutParams,
-        SuccessData[ConfigureNozzleLayoutResult, ConfigureNozzleLayoutPrivateResult],
+        SuccessData[ConfigureNozzleLayoutResult, None],
     ]
 ):
     """Configure nozzle layout command implementation."""
@@ -68,7 +59,7 @@ class ConfigureNozzleLayoutImplementation(
 
     async def execute(
         self, params: ConfigureNozzleLayoutParams
-    ) -> SuccessData[ConfigureNozzleLayoutResult, ConfigureNozzleLayoutPrivateResult]:
+    ) -> SuccessData[ConfigureNozzleLayoutResult, None]:
         """Check that requested pipette can support the requested nozzle layout."""
         primary_nozzle = params.configurationParams.dict().get("primaryNozzle")
         front_right_nozzle = params.configurationParams.dict().get("frontRightNozzle")
@@ -93,10 +84,7 @@ class ConfigureNozzleLayoutImplementation(
 
         return SuccessData(
             public=ConfigureNozzleLayoutResult(),
-            private=ConfigureNozzleLayoutPrivateResult(
-                pipette_id=params.pipetteId,
-                nozzle_map=nozzle_map,
-            ),
+            private=None,
             state_update=update_state,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/configuring_common.py
+++ b/api/src/opentrons/protocol_engine/commands/configuring_common.py
@@ -1,9 +1,6 @@
 """Common configuration command base models."""
 
 from dataclasses import dataclass
-from opentrons.hardware_control.nozzle_manager import (
-    NozzleMap,
-)
 from ..resources import pipette_data_provider
 
 
@@ -14,13 +11,3 @@ class PipetteConfigUpdateResultMixin:
     pipette_id: str
     serial_number: str
     config: pipette_data_provider.LoadedStaticPipetteData
-
-
-@dataclass
-class PipetteNozzleLayoutResultMixin:
-    """A nozzle layout result for updating the pipette state."""
-
-    pipette_id: str
-
-    nozzle_map: NozzleMap
-    """A dataclass object holding information about the current nozzle configuration."""

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
@@ -19,7 +19,6 @@ from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.configure_nozzle_layout import (
     ConfigureNozzleLayoutParams,
     ConfigureNozzleLayoutResult,
-    ConfigureNozzleLayoutPrivateResult,
     ConfigureNozzleLayoutImplementation,
 )
 
@@ -146,10 +145,7 @@ async def test_configure_nozzle_layout_implementation(
 
     assert result == SuccessData(
         public=ConfigureNozzleLayoutResult(),
-        private=ConfigureNozzleLayoutPrivateResult(
-            pipette_id="pipette-id",
-            nozzle_map=expected_nozzlemap,
-        ),
+        private=None,
         state_update=StateUpdate(
             pipette_nozzle_map=PipetteNozzleMapUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -978,17 +978,17 @@ def test_active_channels(
     )
 
     # Configure nozzle for partial configuration
-    configure_nozzle_layout_cmd = commands.ConfigureNozzleLayout.construct(  # type: ignore[call-arg]
-        result=commands.ConfigureNozzleLayoutResult()
-    )
-    configure_nozzle_private_result = commands.ConfigureNozzleLayoutPrivateResult(
-        pipette_id="pipette-id",
-        nozzle_map=nozzle_map,
+    state_update = update_types.StateUpdate(
+        pipette_nozzle_map=update_types.PipetteNozzleMapUpdate(
+            pipette_id="pipette-id",
+            nozzle_map=nozzle_map,
+        )
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=configure_nozzle_private_result,
-            command=configure_nozzle_layout_cmd,
+            command=_dummy_command(),
+            private_result=None,
+            state_update=state_update,
         )
     )
     assert (
@@ -1043,29 +1043,38 @@ def test_next_tip_uses_active_channels(
     )
 
     # Configure nozzle for partial configuration
-    configure_nozzle_layout_cmd = commands.ConfigureNozzleLayout.construct(  # type: ignore[call-arg]
-        result=commands.ConfigureNozzleLayoutResult()
-    )
-    configure_nozzle_private_result = commands.ConfigureNozzleLayoutPrivateResult(
-        pipette_id="pipette-id",
-        nozzle_map=NozzleMap.build(
-            physical_nozzles=NINETY_SIX_MAP,
-            physical_rows=NINETY_SIX_ROWS,
-            physical_columns=NINETY_SIX_COLS,
-            starting_nozzle="A12",
-            back_left_nozzle="A12",
-            front_right_nozzle="H12",
-            valid_nozzle_maps=ValidNozzleMaps(
-                maps={
-                    "A12_H12": ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
-                }
+    state_update = update_types.StateUpdate(
+        pipette_nozzle_map=update_types.PipetteNozzleMapUpdate(
+            pipette_id="pipette-id",
+            nozzle_map=NozzleMap.build(
+                physical_nozzles=NINETY_SIX_MAP,
+                physical_rows=NINETY_SIX_ROWS,
+                physical_columns=NINETY_SIX_COLS,
+                starting_nozzle="A12",
+                back_left_nozzle="A12",
+                front_right_nozzle="H12",
+                valid_nozzle_maps=ValidNozzleMaps(
+                    maps={
+                        "A12_H12": [
+                            "A12",
+                            "B12",
+                            "C12",
+                            "D12",
+                            "E12",
+                            "F12",
+                            "G12",
+                            "H12",
+                        ]
+                    }
+                ),
             ),
-        ),
+        )
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=configure_nozzle_private_result,
-            command=configure_nozzle_layout_cmd,
+            command=_dummy_command(),
+            private_result=None,
+            state_update=state_update,
         )
     )
     # Pick up partial tips
@@ -1162,78 +1171,77 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
             )
         )
 
-    # Configure nozzle for partial configurations
-    configure_nozzle_layout_cmd = commands.ConfigureNozzleLayout.construct(  # type: ignore[call-arg]
-        result=commands.ConfigureNozzleLayoutResult()
-    )
-
     def _reconfigure_nozzle_layout(start: str, back_l: str, front_r: str) -> NozzleMap:
-        configure_nozzle_private_result = commands.ConfigureNozzleLayoutPrivateResult(
-            pipette_id="pipette-id",
-            nozzle_map=NozzleMap.build(
-                physical_nozzles=NINETY_SIX_MAP,
-                physical_rows=NINETY_SIX_ROWS,
-                physical_columns=NINETY_SIX_COLS,
-                starting_nozzle=start,
-                back_left_nozzle=back_l,
-                front_right_nozzle=front_r,
-                valid_nozzle_maps=ValidNozzleMaps(
-                    maps={
-                        "A1": ["A1"],
-                        "H1": ["H1"],
-                        "A12": ["A12"],
-                        "H12": ["H12"],
-                        "A1_H3": [
-                            "A1",
-                            "A2",
-                            "A3",
-                            "B1",
-                            "B2",
-                            "B3",
-                            "C1",
-                            "C2",
-                            "C3",
-                            "D1",
-                            "D2",
-                            "D3",
-                            "E1",
-                            "E2",
-                            "E3",
-                            "F1",
-                            "F2",
-                            "F3",
-                            "G1",
-                            "G2",
-                            "G3",
-                            "H1",
-                            "H2",
-                            "H3",
-                        ],
-                        "A1_F2": [
-                            "A1",
-                            "A2",
-                            "B1",
-                            "B2",
-                            "C1",
-                            "C2",
-                            "D1",
-                            "D2",
-                            "E1",
-                            "E2",
-                            "F1",
-                            "F2",
-                        ],
-                    }
-                ),
+        nozzle_map = NozzleMap.build(
+            physical_nozzles=NINETY_SIX_MAP,
+            physical_rows=NINETY_SIX_ROWS,
+            physical_columns=NINETY_SIX_COLS,
+            starting_nozzle=start,
+            back_left_nozzle=back_l,
+            front_right_nozzle=front_r,
+            valid_nozzle_maps=ValidNozzleMaps(
+                maps={
+                    "A1": ["A1"],
+                    "H1": ["H1"],
+                    "A12": ["A12"],
+                    "H12": ["H12"],
+                    "A1_H3": [
+                        "A1",
+                        "A2",
+                        "A3",
+                        "B1",
+                        "B2",
+                        "B3",
+                        "C1",
+                        "C2",
+                        "C3",
+                        "D1",
+                        "D2",
+                        "D3",
+                        "E1",
+                        "E2",
+                        "E3",
+                        "F1",
+                        "F2",
+                        "F3",
+                        "G1",
+                        "G2",
+                        "G3",
+                        "H1",
+                        "H2",
+                        "H3",
+                    ],
+                    "A1_F2": [
+                        "A1",
+                        "A2",
+                        "B1",
+                        "B2",
+                        "C1",
+                        "C2",
+                        "D1",
+                        "D2",
+                        "E1",
+                        "E2",
+                        "F1",
+                        "F2",
+                    ],
+                }
             ),
+        )
+        state_update = update_types.StateUpdate(
+            pipette_nozzle_map=update_types.PipetteNozzleMapUpdate(
+                pipette_id="pipette-id",
+                nozzle_map=nozzle_map,
+            )
         )
         subject.handle_action(
             actions.SucceedCommandAction(
-                private_result=configure_nozzle_private_result,
-                command=configure_nozzle_layout_cmd,
+                command=_dummy_command(),
+                private_result=None,
+                state_update=state_update,
             )
         )
-        return configure_nozzle_private_result.nozzle_map
+        return nozzle_map
 
     map = _reconfigure_nozzle_layout("A1", "A1", "H3")
     _assert_and_pickup("A10", map)
@@ -1320,51 +1328,47 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
 
         return result
 
-    # Configure nozzle for partial configurations
-    configure_nozzle_layout_cmd = commands.ConfigureNozzleLayout.construct(  # type: ignore[call-arg]
-        result=commands.ConfigureNozzleLayoutResult()
-    )
-
     def _reconfigure_nozzle_layout(start: str, back_l: str, front_r: str) -> NozzleMap:
-        configure_nozzle_private_result = commands.ConfigureNozzleLayoutPrivateResult(
-            pipette_id="pipette-id",
-            nozzle_map=NozzleMap.build(
-                physical_nozzles=NINETY_SIX_MAP,
-                physical_rows=NINETY_SIX_ROWS,
-                physical_columns=NINETY_SIX_COLS,
-                starting_nozzle=start,
-                back_left_nozzle=back_l,
-                front_right_nozzle=front_r,
-                valid_nozzle_maps=ValidNozzleMaps(
-                    maps={
-                        "A1": ["A1"],
-                        "H1": ["H1"],
-                        "A12": ["A12"],
-                        "H12": ["H12"],
-                        "Full": sum(
-                            [
-                                NINETY_SIX_ROWS["A"],
-                                NINETY_SIX_ROWS["B"],
-                                NINETY_SIX_ROWS["C"],
-                                NINETY_SIX_ROWS["D"],
-                                NINETY_SIX_ROWS["E"],
-                                NINETY_SIX_ROWS["F"],
-                                NINETY_SIX_ROWS["G"],
-                                NINETY_SIX_ROWS["H"],
-                            ],
-                            [],
-                        ),
-                    }
-                ),
+        nozzle_map = NozzleMap.build(
+            physical_nozzles=NINETY_SIX_MAP,
+            physical_rows=NINETY_SIX_ROWS,
+            physical_columns=NINETY_SIX_COLS,
+            starting_nozzle=start,
+            back_left_nozzle=back_l,
+            front_right_nozzle=front_r,
+            valid_nozzle_maps=ValidNozzleMaps(
+                maps={
+                    "A1": ["A1"],
+                    "H1": ["H1"],
+                    "A12": ["A12"],
+                    "H12": ["H12"],
+                    "Full": sum(
+                        [
+                            NINETY_SIX_ROWS["A"],
+                            NINETY_SIX_ROWS["B"],
+                            NINETY_SIX_ROWS["C"],
+                            NINETY_SIX_ROWS["D"],
+                            NINETY_SIX_ROWS["E"],
+                            NINETY_SIX_ROWS["F"],
+                            NINETY_SIX_ROWS["G"],
+                            NINETY_SIX_ROWS["H"],
+                        ],
+                        [],
+                    ),
+                }
             ),
+        )
+        state_update = update_types.StateUpdate(
+            pipette_nozzle_map=update_types.PipetteNozzleMapUpdate(
+                pipette_id="pipette-id", nozzle_map=nozzle_map
+            )
         )
         subject.handle_action(
             actions.SucceedCommandAction(
-                private_result=configure_nozzle_private_result,
-                command=configure_nozzle_layout_cmd,
+                command=_dummy_command(), private_result=None, state_update=state_update
             )
         )
-        return configure_nozzle_private_result.nozzle_map
+        return nozzle_map
 
     map = _reconfigure_nozzle_layout("A1", "A1", "A1")
     for x in range(96):


### PR DESCRIPTION
## Overview

Another step towards EXEC-758.

## Test Plan and Hands on Testing

* [ ] Make sure analysis snapshot tests keep passing, indicating that tip tracking has not changed. 

## Changelog

When a `ConfigureNozzleLayout` command runs, instead of updating `TipStore` via `ConfigureNozzleLayoutPrivateResult`, update it via `StateUpdate`.

## Review requests

* Double-check that the code I'm removing, based on `ConfigureNozzleLayoutPrivateResult`, is exactly replaced by the code I'm adding, based on `StateUpdate`.

## Risk assessment

I think low, as long as we keep reviewing these diffs carefully.