### PR TITLE
refactor(api): Delete dead PipetteStore code and type nozzle maps as non-Optional

### DIFF
--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -96,7 +96,7 @@ class StaticPipetteConfig:
     nozzle_offset_z: float
     pipette_bounding_box_offsets: PipetteBoundingBoxOffsets
     bounding_nozzle_offsets: BoundingNozzlesOffsets
-    default_nozzle_map: NozzleMap
+    default_nozzle_map: NozzleMap  # todo(mm, 2024-10-14): unused, remove?
     lld_settings: Optional[Dict[str, Dict[str, float]]]
 
 
@@ -170,15 +170,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.aspirated_volume_by_id[pipette_id] = None
             self._state.movement_speed_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None
-            # TODO(mm, 2024-10-11): This seems wrong--because of the order in which
-            # we process the individual attributes of StateUpdate, when we process a
-            # loadPipette command, won't we always reach here before static_config is
-            # populated?
-            static_config = self._state.static_config_by_id.get(pipette_id)
-            if static_config:
-                self._state.nozzle_configuration_by_id[
-                    pipette_id
-                ] = static_config.default_nozzle_map
 
     def _update_tip_state(self, state_update: update_types.StateUpdate) -> None:
         if state_update.pipette_tip_state != update_types.NO_CHANGE:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -167,6 +167,10 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.aspirated_volume_by_id[pipette_id] = None
             self._state.movement_speed_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None
+            # TODO(mm, 2024-10-11): This seems wrong--because of the order in which
+            # we process the individual attributes of StateUpdate, when we process a
+            # loadPipette command, won't we always reach here before static_config is
+            # populated?
             static_config = self._state.static_config_by_id.get(pipette_id)
             if static_config:
                 self._state.nozzle_configuration_by_id[

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -632,31 +632,23 @@ class PipetteView(HasState[PipetteState]):
 
     def get_nozzle_layout_type(self, pipette_id: str) -> NozzleConfigurationType:
         """Get the current set nozzle layout configuration."""
-        nozzle_map_for_pipette = self._state.nozzle_configuration_by_id.get(pipette_id)
-        if nozzle_map_for_pipette:
-            return nozzle_map_for_pipette.configuration
-        else:
-            return NozzleConfigurationType.FULL
+        nozzle_map_for_pipette = self._state.nozzle_configuration_by_id[pipette_id]
+        return nozzle_map_for_pipette.configuration
 
     def get_is_partially_configured(self, pipette_id: str) -> bool:
         """Determine if the provided pipette is partially configured."""
         return self.get_nozzle_layout_type(pipette_id) != NozzleConfigurationType.FULL
 
-    def get_primary_nozzle(self, pipette_id: str) -> Optional[str]:
+    def get_primary_nozzle(self, pipette_id: str) -> str:
         """Get the primary nozzle, if any, related to the given pipette's nozzle configuration."""
-        nozzle_map = self._state.nozzle_configuration_by_id.get(pipette_id)
-        return nozzle_map.starting_nozzle if nozzle_map else None
+        nozzle_map = self._state.nozzle_configuration_by_id[pipette_id]
+        return nozzle_map.starting_nozzle
 
     def _get_critical_point_offset_without_tip(
         self, pipette_id: str, critical_point: Optional[CriticalPoint]
     ) -> Point:
         """Get the offset of the specified critical point from pipette's mount position."""
-        nozzle_map = self._state.nozzle_configuration_by_id.get(pipette_id)
-        # Nozzle map is unavailable only when there's no pipette loaded
-        # so this is merely for satisfying the type checker
-        assert (
-            nozzle_map is not None
-        ), "Error getting critical point offset. Nozzle map not found."
+        nozzle_map = self._state.nozzle_configuration_by_id[pipette_id]
         match critical_point:
             case CriticalPoint.INSTRUMENT_XY_CENTER:
                 return nozzle_map.instrument_xy_center_offset

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -104,6 +104,9 @@ class StaticPipetteConfig:
 class PipetteState:
     """Basic pipette data state and getter methods."""
 
+    # todo(mm, 2024-10-14): It's getting difficult to ensure that all of these
+    # attributes are populated at the appropriate times. Refactor to a
+    # single dict-of-many-things instead of many dicts-of-single-things.
     pipettes_by_id: Dict[str, LoadedPipette]
     aspirated_volume_by_id: Dict[str, Optional[float]]
     current_location: Optional[CurrentPipetteLocation]

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -143,8 +143,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         """Modify state in reaction to an action."""
         state_update = get_state_update(action)
         if state_update is not None:
-            self._load_pipette_or_update_config(state_update)
+            self._set_load_pipette(state_update)
             self._update_current_location(state_update)
+            self._update_pipette_config(state_update)
             self._update_pipette_nozzle_map(state_update)
             self._update_tip_state(state_update)
 
@@ -154,52 +155,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif isinstance(action, SetPipetteMovementSpeedAction):
             self._state.movement_speed_by_id[action.pipette_id] = action.speed
 
-    def _load_pipette_or_update_config(
-        self, state_update: update_types.StateUpdate
-    ) -> None:
-        if state_update.pipette_config != update_types.NO_CHANGE:
-            config = state_update.pipette_config.config
-            self._state.static_config_by_id[
-                state_update.pipette_config.pipette_id
-            ] = StaticPipetteConfig(
-                serial_number=state_update.pipette_config.serial_number,
-                model=config.model,
-                display_name=config.display_name,
-                min_volume=config.min_volume,
-                max_volume=config.max_volume,
-                channels=config.channels,
-                tip_configuration_lookup_table=config.tip_configuration_lookup_table,
-                nominal_tip_overlap=config.nominal_tip_overlap,
-                home_position=config.home_position,
-                nozzle_offset_z=config.nozzle_offset_z,
-                pipette_bounding_box_offsets=PipetteBoundingBoxOffsets(
-                    back_left_corner=config.back_left_corner_offset,
-                    front_right_corner=config.front_right_corner_offset,
-                    back_right_corner=Point(
-                        config.front_right_corner_offset.x,
-                        config.back_left_corner_offset.y,
-                        config.back_left_corner_offset.z,
-                    ),
-                    front_left_corner=Point(
-                        config.back_left_corner_offset.x,
-                        config.front_right_corner_offset.y,
-                        config.back_left_corner_offset.z,
-                    ),
-                ),
-                bounding_nozzle_offsets=BoundingNozzlesOffsets(
-                    back_left_offset=config.nozzle_map.back_left_nozzle_offset,
-                    front_right_offset=config.nozzle_map.front_right_nozzle_offset,
-                ),
-                default_nozzle_map=config.nozzle_map,
-                lld_settings=config.pipette_lld_settings,
-            )
-            self._state.flow_rates_by_id[
-                state_update.pipette_config.pipette_id
-            ] = config.flow_rates
-            self._state.nozzle_configuration_by_id[
-                state_update.pipette_config.pipette_id
-            ] = config.nozzle_map
-
+    def _set_load_pipette(self, state_update: update_types.StateUpdate) -> None:
         if state_update.loaded_pipette != update_types.NO_CHANGE:
             pipette_id = state_update.loaded_pipette.pipette_id
 
@@ -214,15 +170,10 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.aspirated_volume_by_id[pipette_id] = None
             self._state.movement_speed_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None
-
-            # This should always be truthy because LoadPipetteImplementation always
-            # supplies state_update.pipette_config, which we process above,
-            # populating self._state.static_config_by_id[pipette_id].
-            #
-            # todo(mm, 2024-10-14): Formalize this expectation by having
-            # state_update.loaded_pipette incorporate all the stuff in
-            # state_update.pipette_config, so LoadPipetteImplementation only has to
-            # supply state_update.loaded_pipette.
+            # TODO(mm, 2024-10-11): This seems wrong--because of the order in which
+            # we process the individual attributes of StateUpdate, when we process a
+            # loadPipette command, won't we always reach here before static_config is
+            # populated?
             static_config = self._state.static_config_by_id.get(pipette_id)
             if static_config:
                 self._state.nozzle_configuration_by_id[
@@ -314,6 +265,50 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 self._state.current_deck_point = CurrentDeckPoint(
                     mount=loaded_pipette.mount, deck_point=new_deck_point
                 )
+
+    def _update_pipette_config(self, state_update: update_types.StateUpdate) -> None:
+        if state_update.pipette_config != update_types.NO_CHANGE:
+            config = state_update.pipette_config.config
+            self._state.static_config_by_id[
+                state_update.pipette_config.pipette_id
+            ] = StaticPipetteConfig(
+                serial_number=state_update.pipette_config.serial_number,
+                model=config.model,
+                display_name=config.display_name,
+                min_volume=config.min_volume,
+                max_volume=config.max_volume,
+                channels=config.channels,
+                tip_configuration_lookup_table=config.tip_configuration_lookup_table,
+                nominal_tip_overlap=config.nominal_tip_overlap,
+                home_position=config.home_position,
+                nozzle_offset_z=config.nozzle_offset_z,
+                pipette_bounding_box_offsets=PipetteBoundingBoxOffsets(
+                    back_left_corner=config.back_left_corner_offset,
+                    front_right_corner=config.front_right_corner_offset,
+                    back_right_corner=Point(
+                        config.front_right_corner_offset.x,
+                        config.back_left_corner_offset.y,
+                        config.back_left_corner_offset.z,
+                    ),
+                    front_left_corner=Point(
+                        config.back_left_corner_offset.x,
+                        config.front_right_corner_offset.y,
+                        config.back_left_corner_offset.z,
+                    ),
+                ),
+                bounding_nozzle_offsets=BoundingNozzlesOffsets(
+                    back_left_offset=config.nozzle_map.back_left_nozzle_offset,
+                    front_right_offset=config.nozzle_map.front_right_nozzle_offset,
+                ),
+                default_nozzle_map=config.nozzle_map,
+                lld_settings=config.pipette_lld_settings,
+            )
+            self._state.flow_rates_by_id[
+                state_update.pipette_config.pipette_id
+            ] = config.flow_rates
+            self._state.nozzle_configuration_by_id[
+                state_update.pipette_config.pipette_id
+            ] = config.nozzle_map
 
     def _update_pipette_nozzle_map(
         self, state_update: update_types.StateUpdate

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -112,7 +112,7 @@ class PipetteState:
     movement_speed_by_id: Dict[str, Optional[float]]
     static_config_by_id: Dict[str, StaticPipetteConfig]
     flow_rates_by_id: Dict[str, FlowRates]
-    nozzle_configuration_by_id: Dict[str, Optional[NozzleMap]]
+    nozzle_configuration_by_id: Dict[str, NozzleMap]
     liquid_presence_detection_by_id: Dict[str, bool]
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -1,5 +1,5 @@
 """Test for the ProtocolEngine-based instrument API core."""
-from typing import cast, Optional, Union
+from typing import cast, Optional
 
 from opentrons_shared_data.errors.exceptions import PipetteLiquidNotFoundError
 import pytest
@@ -1227,17 +1227,14 @@ def test_configure_nozzle_layout(
     argnames=["pipette_channels", "nozzle_layout", "primary_nozzle", "expected_result"],
     argvalues=[
         (96, NozzleConfigurationType.FULL, "A1", True),
-        (96, NozzleConfigurationType.FULL, None, True),
         (96, NozzleConfigurationType.ROW, "A1", True),
         (96, NozzleConfigurationType.COLUMN, "A1", True),
         (96, NozzleConfigurationType.COLUMN, "A12", True),
         (96, NozzleConfigurationType.SINGLE, "H12", True),
         (96, NozzleConfigurationType.SINGLE, "A1", True),
         (8, NozzleConfigurationType.FULL, "A1", True),
-        (8, NozzleConfigurationType.FULL, None, True),
         (8, NozzleConfigurationType.SINGLE, "H1", True),
         (8, NozzleConfigurationType.SINGLE, "A1", True),
-        (1, NozzleConfigurationType.FULL, None, True),
     ],
 )
 def test_is_tip_tracking_available(
@@ -1246,7 +1243,7 @@ def test_is_tip_tracking_available(
     subject: InstrumentCore,
     pipette_channels: int,
     nozzle_layout: NozzleConfigurationType,
-    primary_nozzle: Union[str, None],
+    primary_nozzle: str,
     expected_result: bool,
 ) -> None:
     """It should return whether tip tracking is available based on nozzle configuration."""

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -191,25 +191,52 @@ def test_location_state_update(subject: PipetteStore) -> None:
     )
 
 
-def test_handles_load_pipette(subject: PipetteStore) -> None:
+def test_handles_load_pipette(
+    subject: PipetteStore,
+    supported_tip_fixture: pipette_definition.SupportedTipsDefinition,
+) -> None:
     """It should add the pipette data to the state."""
-    command = create_load_pipette_command(
+    dummy_command = create_succeeded_command()
+
+    load_pipette_update = update_types.LoadPipetteUpdate(
         pipette_id="pipette-id",
         pipette_name=PipetteNameType.P300_SINGLE,
         mount=MountType.LEFT,
+        liquid_presence_detection=None,
+    )
+
+    config = LoadedStaticPipetteData(
+        model="pipette-model",
+        display_name="pipette name",
+        min_volume=1.23,
+        max_volume=4.56,
+        channels=7,
+        flow_rates=FlowRates(
+            default_aspirate={"a": 1},
+            default_dispense={"b": 2},
+            default_blow_out={"c": 3},
+        ),
+        tip_configuration_lookup_table={4: supported_tip_fixture},
+        nominal_tip_overlap={"default": 5},
+        home_position=8.9,
+        nozzle_offset_z=10.11,
+        nozzle_map=get_default_nozzle_map(PipetteNameType.P300_SINGLE),
+        back_left_corner_offset=Point(x=1, y=2, z=3),
+        front_right_corner_offset=Point(x=4, y=5, z=6),
+        pipette_lld_settings={},
+    )
+    config_update = update_types.PipetteConfigUpdate(
+        pipette_id="pipette-id",
+        config=config,
+        serial_number="pipette-serial",
     )
 
     subject.handle_action(
         SucceedCommandAction(
             private_result=None,
-            command=command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
-                loaded_pipette=update_types.LoadPipetteUpdate(
-                    pipette_id="pipette-id",
-                    pipette_name=PipetteNameType.P300_SINGLE,
-                    mount=MountType.LEFT,
-                    liquid_presence_detection=None,
-                )
+                loaded_pipette=load_pipette_update, pipette_config=config_update
             ),
         )
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -65,7 +65,7 @@ def get_pipette_view(
     movement_speed_by_id: Optional[Dict[str, Optional[float]]] = None,
     static_config_by_id: Optional[Dict[str, StaticPipetteConfig]] = None,
     flow_rates_by_id: Optional[Dict[str, FlowRates]] = None,
-    nozzle_layout_by_id: Optional[Dict[str, Optional[NozzleMap]]] = None,
+    nozzle_layout_by_id: Optional[Dict[str, NozzleMap]] = None,
     liquid_presence_detection_by_id: Optional[Dict[str, bool]] = None,
 ) -> PipetteView:
     """Get a pipette view test subject with the specified state."""

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -1367,24 +1367,24 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
         return configure_nozzle_private_result.nozzle_map
 
     map = _reconfigure_nozzle_layout("A1", "A1", "A1")
-    for x in range(96):
+    for _ in range(96):
         _get_next_and_pickup(map)
     assert _get_next_and_pickup(map) is None
 
     subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
     map = _reconfigure_nozzle_layout("A12", "A12", "A12")
-    for x in range(96):
+    for _ in range(96):
         _get_next_and_pickup(map)
     assert _get_next_and_pickup(map) is None
 
     subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
     map = _reconfigure_nozzle_layout("H1", "H1", "H1")
-    for x in range(96):
+    for _ in range(96):
         _get_next_and_pickup(map)
     assert _get_next_and_pickup(map) is None
 
     subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
     map = _reconfigure_nozzle_layout("H12", "H12", "H12")
-    for x in range(96):
+    for _ in range(96):
         _get_next_and_pickup(map)
     assert _get_next_and_pickup(map) is None


### PR DESCRIPTION
## Overview

Minor refactors to `PipetteStore` to follow up on https://github.com/Opentrons/opentrons/pull/16469#discussion_r1797314114 and close EXEC-768.

## Test Plan and Hands on Testing

* [x] Run something with and without partial tip configuration and make sure it doesn't raise a `KeyError` or anything.

## Changelog

* `PipetteState` was typed to allow a nozzle map of `None`. Since [#14529](https://github.com/Opentrons/opentrons/pull/14529), this never occurs in practice—a properly-loaded pipette always has a nozzle map. So, remove the `None` possibility and simplify the consumers accordingly.
* As described in EXEC-768, there was a chunk of code that looked like we recently broke it. It turns out we did not break it, we made it redundant. So just delete it. See my comment below for details.
* Update `PipetteStore` tests to more closely reflect how `LoadPipetteImplementation` uses it.

## Review requests

Does my comment below seem right?

## Risk assessment

Low if I do the manual testing described above.