### PR TITLE
fix(robot-server): fix robot-server blinker task startup causing hw init failure on the Flex.

### DIFF
--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -154,14 +154,18 @@ class FrontButtonLightBlinker:
         `mark_persistence_init_complete()` have both been called.
         """
         if should_use_ot3():
-            # Dont run this task on the Flex
+            # Dont run this task on the Flex because,
+            # 1. There is no front button blinker on the Flex
+            # 2. The Flex raises an error when attempting to turn on the lights
+            #    while there is a system firmware update in progress. This causes
+            #    the hardware controller to fail initialization, leaving the
+            #    robot server in a bad state.
             return
 
         assert self._hardware_and_task is None, "hardware should only be set once."
 
         async def blink_forever() -> None:
             while True:
-                # This should no-op on a Flex.
                 await hardware.set_lights(button=True)
                 await asyncio.sleep(0.5)
                 await hardware.set_lights(button=False)

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -153,6 +153,10 @@ class FrontButtonLightBlinker:
         Blinking will continue until `mark_hardware_init_complete()` and
         `mark_persistence_init_complete()` have both been called.
         """
+        if should_use_ot3():
+            # Dont run this task on the Flex
+            return
+
         assert self._hardware_and_task is None, "hardware should only be set once."
 
         async def blink_forever() -> None:


### PR DESCRIPTION
# Overview

The robot server crashes during initialization after doing firmware updates, this happens because we attempt to use the `FrontButtonBlinker.start_blinker` task in the Flex. The [Opentrons/opentrons#6286](https://github.com/Opentrons/opentrons/pull/16286) introduced this issue, it added the modern `lifetime` concept to the FastAPI robot-server startup routine to perform better setup and teardowns. However, it also removed `fbl_init` which checked if the robot was a Flex before instantiating the `FrontButtonBlinkerLight` class. This pull request fixes this issue by adding a conditional that checks if we are on a Flex when instantiating the `FrontButtonBlinkerLight` task.

Closes: [RQA-3302](https://opentrons.atlassian.net/browse/RQA-3302)

## Test Plan and Hands on Testing

- [x] Make sure the robot server starts up after doing firmware updates on the Flex
- [x] Make sure the blinker LED on the OT-2 still works 

## Changelog

- Dont run the FrontButtonBlinkerLight task on the Flex

## Review requests

- Makes sense?

## Risk assessment

low

[RQA-3302]: https://opentrons.atlassian.net/browse/RQA-3302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ