### PR TITLE
feat(api): Return `tipPhysicallyAttachedError` from `dropTip` and `dropTipInPlace` commands

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -84,6 +84,7 @@ from .drop_tip import (
     DropTipCreate,
     DropTipResult,
     DropTipCommandType,
+    TipPhysicallyAttachedError,
 )
 
 from .drop_tip_in_place import (
@@ -713,6 +714,7 @@ CommandPrivateResult = Union[
 # All `DefinedErrorData`s that implementations will actually return in practice.
 CommandDefinedErrorData = Union[
     DefinedErrorData[TipPhysicallyMissingError],
+    DefinedErrorData[TipPhysicallyAttachedError],
     DefinedErrorData[OverpressureError],
     DefinedErrorData[LiquidNotFoundError],
     DefinedErrorData[GripperMovementError],

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -11,6 +11,7 @@ from .command import DefinedErrorData
 from .pipetting_common import (
     OverpressureError,
     LiquidNotFoundError,
+    TipPhysicallyAttachedError,
 )
 
 from . import absorbance_reader
@@ -84,7 +85,6 @@ from .drop_tip import (
     DropTipCreate,
     DropTipResult,
     DropTipCommandType,
-    TipPhysicallyAttachedError,
 )
 
 from .drop_tip_in_place import (

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -1,7 +1,6 @@
 """Drop tip command request, result, and implementation models."""
 from __future__ import annotations
 
-from opentrons_shared_data.errors import ErrorCodes
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
@@ -11,7 +10,11 @@ from opentrons.protocol_engine.resources.model_utils import ModelUtils
 
 from ..state import update_types
 from ..types import DropTipWellLocation, DeckPoint
-from .pipetting_common import PipetteIdMixin, DestinationPositionResult
+from .pipetting_common import (
+    PipetteIdMixin,
+    DestinationPositionResult,
+    TipPhysicallyAttachedError,
+)
 from .command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -62,20 +65,6 @@ class DropTipResult(DestinationPositionResult):
     """Result data from the execution of a DropTip command."""
 
     pass
-
-
-class TipPhysicallyAttachedError(ErrorOccurrence):
-    """Returned when sensors determine that a tip remains on the pipette after a drop attempt.
-
-    The pipette will act as if the tip was not dropped. So, you won't be able to pick
-    up a new tip without dropping the current one, and movement commands will assume
-    there is a tip hanging off the bottom of the pipette.
-    """
-
-    isDefined: bool = True
-    errorType: Literal["tipPhysicallyAttached"] = "tipPhysicallyAttached"
-    errorCode: str = ErrorCodes.TIP_DROP_FAILED.value.code
-    detail: str = "Tip still detected after trying to drop it."
 
 
 _ExecuteReturn = (

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -1,13 +1,21 @@
 """Drop tip in place command request, result, and implementation models."""
 from __future__ import annotations
-from opentrons.protocol_engine.state import update_types
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from .pipetting_common import PipetteIdMixin
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    DefinedErrorData,
+    SuccessData,
+)
+from .pipetting_common import PipetteIdMixin, TipPhysicallyAttachedError
+from ..errors.exceptions import TipAttachedError
 from ..errors.error_occurrence import ErrorOccurrence
+from ..resources.model_utils import ModelUtils
+from ..state import update_types
 
 if TYPE_CHECKING:
     from ..execution import TipHandler
@@ -35,35 +43,54 @@ class DropTipInPlaceResult(BaseModel):
     pass
 
 
+_ExecuteReturn = (
+    SuccessData[DropTipInPlaceResult, None]
+    | DefinedErrorData[TipPhysicallyAttachedError]
+)
+
+
 class DropTipInPlaceImplementation(
-    AbstractCommandImpl[DropTipInPlaceParams, SuccessData[DropTipInPlaceResult, None]]
+    AbstractCommandImpl[DropTipInPlaceParams, _ExecuteReturn]
 ):
     """Drop tip in place command implementation."""
 
     def __init__(
         self,
         tip_handler: TipHandler,
+        model_utils: ModelUtils,
         **kwargs: object,
     ) -> None:
         self._tip_handler = tip_handler
+        self._model_utils = model_utils
 
-    async def execute(
-        self, params: DropTipInPlaceParams
-    ) -> SuccessData[DropTipInPlaceResult, None]:
+    async def execute(self, params: DropTipInPlaceParams) -> _ExecuteReturn:
         """Drop a tip using the requested pipette."""
-        await self._tip_handler.drop_tip(
-            pipette_id=params.pipetteId, home_after=params.homeAfter
-        )
-
         state_update = update_types.StateUpdate()
 
-        state_update.update_pipette_tip_state(
-            pipette_id=params.pipetteId, tip_geometry=None
-        )
-
-        return SuccessData(
-            public=DropTipInPlaceResult(), private=None, state_update=state_update
-        )
+        try:
+            await self._tip_handler.drop_tip(
+                pipette_id=params.pipetteId, home_after=params.homeAfter
+            )
+        except TipAttachedError as exception:
+            error = TipPhysicallyAttachedError(
+                id=self._model_utils.generate_id(),
+                createdAt=self._model_utils.get_timestamp(),
+                wrappedErrors=[
+                    ErrorOccurrence.from_failed(
+                        id=self._model_utils.generate_id(),
+                        createdAt=self._model_utils.get_timestamp(),
+                        error=exception,
+                    )
+                ],
+            )
+            return DefinedErrorData(public=error, state_update=state_update)
+        else:
+            state_update.update_pipette_tip_state(
+                pipette_id=params.pipetteId, tip_geometry=None
+            )
+            return SuccessData(
+                public=DropTipInPlaceResult(), private=None, state_update=state_update
+            )
 
 
 class DropTipInPlace(

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -168,3 +168,19 @@ class LiquidNotFoundError(ErrorOccurrence):
 
     errorCode: str = ErrorCodes.PIPETTE_LIQUID_NOT_FOUND.value.code
     detail: str = ErrorCodes.PIPETTE_LIQUID_NOT_FOUND.value.detail
+
+
+class TipPhysicallyAttachedError(ErrorOccurrence):
+    """Returned when sensors determine that a tip remains on the pipette after a drop attempt.
+
+    The pipette will act as if the tip was not dropped. So, you won't be able to pick
+    up a new tip without dropping the current one, and movement commands will assume
+    there is a tip hanging off the bottom of the pipette.
+    """
+
+    isDefined: bool = True
+
+    errorType: Literal["tipPhysicallyAttached"] = "tipPhysicallyAttached"
+
+    errorCode: str = ErrorCodes.TIP_DROP_FAILED.value.code
+    detail: str = ErrorCodes.TIP_DROP_FAILED.value.detail

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -1,6 +1,8 @@
 """Test drop tip commands."""
+from datetime import datetime
+
 import pytest
-from decoy import Decoy
+from decoy import Decoy, matchers
 
 from opentrons.protocol_engine import (
     DropTipWellLocation,
@@ -9,17 +11,22 @@ from opentrons.protocol_engine import (
     WellOffset,
     DeckPoint,
 )
-from opentrons.protocol_engine.state import update_types
-from opentrons.protocol_engine.state.state import StateView
-from opentrons.protocol_engine.execution import MovementHandler, TipHandler
-from opentrons.types import Point
-
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
 from opentrons.protocol_engine.commands.drop_tip import (
     DropTipParams,
     DropTipResult,
     DropTipImplementation,
 )
+from opentrons.protocol_engine.commands.pipetting_common import (
+    TipPhysicallyAttachedError,
+)
+from opentrons.protocol_engine.errors.exceptions import TipAttachedError
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
+from opentrons.protocol_engine.state import update_types
+from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.execution import MovementHandler, TipHandler
+
+from opentrons.types import Point
 
 
 @pytest.fixture
@@ -38,6 +45,12 @@ def mock_movement_handler(decoy: Decoy) -> MovementHandler:
 def mock_tip_handler(decoy: Decoy) -> TipHandler:
     """Get a mock TipHandler."""
     return decoy.mock(cls=TipHandler)
+
+
+@pytest.fixture
+def mock_model_utils(decoy: Decoy) -> ModelUtils:
+    """Get a mock ModelUtils."""
+    return decoy.mock(cls=ModelUtils)
 
 
 def test_drop_tip_params_defaults() -> None:
@@ -72,12 +85,14 @@ async def test_drop_tip_implementation(
     mock_state_view: StateView,
     mock_movement_handler: MovementHandler,
     mock_tip_handler: TipHandler,
+    mock_model_utils: ModelUtils,
 ) -> None:
     """A DropTip command should have an execution implementation."""
     subject = DropTipImplementation(
         state_view=mock_state_view,
         movement=mock_movement_handler,
         tip_handler=mock_tip_handler,
+        model_utils=mock_model_utils,
     )
 
     params = DropTipParams(
@@ -141,12 +156,14 @@ async def test_drop_tip_with_alternating_locations(
     mock_state_view: StateView,
     mock_movement_handler: MovementHandler,
     mock_tip_handler: TipHandler,
+    mock_model_utils: ModelUtils,
 ) -> None:
     """It should drop tip at random location within the labware every time."""
     subject = DropTipImplementation(
         state_view=mock_state_view,
         movement=mock_movement_handler,
         tip_handler=mock_tip_handler,
+        model_utils=mock_model_utils,
     )
     params = DropTipParams(
         pipetteId="abc",
@@ -202,6 +219,79 @@ async def test_drop_tip_with_alternating_locations(
             ),
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc", tip_geometry=None
+            ),
+        ),
+    )
+
+
+async def test_tip_attached_error(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    mock_movement_handler: MovementHandler,
+    mock_tip_handler: TipHandler,
+    mock_model_utils: ModelUtils,
+) -> None:
+    """A DropTip command should have an execution implementation."""
+    subject = DropTipImplementation(
+        state_view=mock_state_view,
+        movement=mock_movement_handler,
+        tip_handler=mock_tip_handler,
+        model_utils=mock_model_utils,
+    )
+
+    params = DropTipParams(
+        pipetteId="abc",
+        labwareId="123",
+        wellName="A3",
+        wellLocation=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
+    )
+
+    decoy.when(
+        mock_state_view.pipettes.get_is_partially_configured(pipette_id="abc")
+    ).then_return(False)
+
+    decoy.when(
+        mock_state_view.geometry.get_checked_tip_drop_location(
+            pipette_id="abc",
+            labware_id="123",
+            well_location=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
+            partially_configured=False,
+        )
+    ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
+
+    decoy.when(
+        await mock_movement_handler.move_to_well(
+            pipette_id="abc",
+            labware_id="123",
+            well_name="A3",
+            well_location=WellLocation(offset=WellOffset(x=4, y=5, z=6)),
+        )
+    ).then_return(Point(x=111, y=222, z=333))
+    decoy.when(
+        await mock_tip_handler.drop_tip(pipette_id="abc", home_after=None)
+    ).then_raise(TipAttachedError("Egads!"))
+
+    decoy.when(mock_model_utils.generate_id()).then_return("error-id")
+    decoy.when(mock_model_utils.get_timestamp()).then_return(
+        datetime(year=1, month=2, day=3)
+    )
+
+    result = await subject.execute(params)
+
+    assert result == DefinedErrorData(
+        public=TipPhysicallyAttachedError.construct(
+            id="error-id",
+            createdAt=datetime(year=1, month=2, day=3),
+            wrappedErrors=[matchers.Anything()],
+        ),
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="abc",
+                new_location=update_types.Well(
+                    labware_id="123",
+                    well_name="A3",
+                ),
+                new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -1,18 +1,24 @@
 """Test drop tip in place commands."""
-from opentrons.protocol_engine.state.update_types import (
-    PipetteTipStateUpdate,
-    StateUpdate,
-)
+from datetime import datetime
+
 import pytest
-from decoy import Decoy
+from decoy import Decoy, matchers
 
-from opentrons.protocol_engine.execution import TipHandler
-
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.pipetting_common import (
+    TipPhysicallyAttachedError,
+)
+from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
 from opentrons.protocol_engine.commands.drop_tip_in_place import (
     DropTipInPlaceParams,
     DropTipInPlaceResult,
     DropTipInPlaceImplementation,
+)
+from opentrons.protocol_engine.errors.exceptions import TipAttachedError
+from opentrons.protocol_engine.execution import TipHandler
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
+from opentrons.protocol_engine.state.update_types import (
+    PipetteTipStateUpdate,
+    StateUpdate,
 )
 
 
@@ -22,13 +28,21 @@ def mock_tip_handler(decoy: Decoy) -> TipHandler:
     return decoy.mock(cls=TipHandler)
 
 
-async def test_drop_tip_implementation(
+@pytest.fixture
+def mock_model_utils(decoy: Decoy) -> ModelUtils:
+    """Get a mock ModelUtils."""
+    return decoy.mock(cls=ModelUtils)
+
+
+async def test_success(
     decoy: Decoy,
     mock_tip_handler: TipHandler,
+    mock_model_utils: ModelUtils,
 ) -> None:
     """A DropTip command should have an execution implementation."""
-    subject = DropTipInPlaceImplementation(tip_handler=mock_tip_handler)
-
+    subject = DropTipInPlaceImplementation(
+        tip_handler=mock_tip_handler, model_utils=mock_model_utils
+    )
     params = DropTipInPlaceParams(pipetteId="abc", homeAfter=False)
 
     result = await subject.execute(params)
@@ -44,4 +58,37 @@ async def test_drop_tip_implementation(
     decoy.verify(
         await mock_tip_handler.drop_tip(pipette_id="abc", home_after=False),
         times=1,
+    )
+
+
+async def test_tip_attached_error(
+    decoy: Decoy,
+    mock_tip_handler: TipHandler,
+    mock_model_utils: ModelUtils,
+) -> None:
+    """A DropTip command should have an execution implementation."""
+    subject = DropTipInPlaceImplementation(
+        tip_handler=mock_tip_handler, model_utils=mock_model_utils
+    )
+
+    params = DropTipInPlaceParams(pipetteId="abc", homeAfter=False)
+
+    decoy.when(
+        await mock_tip_handler.drop_tip(pipette_id="abc", home_after=False)
+    ).then_raise(TipAttachedError("Egads!"))
+
+    decoy.when(mock_model_utils.generate_id()).then_return("error-id")
+    decoy.when(mock_model_utils.get_timestamp()).then_return(
+        datetime(year=1, month=2, day=3)
+    )
+
+    result = await subject.execute(params)
+
+    assert result == DefinedErrorData(
+        public=TipPhysicallyAttachedError.construct(
+            id="error-id",
+            createdAt=datetime(year=1, month=2, day=3),
+            wrappedErrors=[matchers.Anything()],
+        ),
+        state_update=StateUpdate(),
     )


### PR DESCRIPTION
## Overview

Half of EXEC-764.

## Test Plan and Hands on Testing

I've done this:

1. Run a `dropTip` command on a robot. Immediately after the pipette drops the tip, physically hold the tip sensor up, to induce a `tipPhysicallyAttachedError`.
2. Confirm that the robot enters error recovery mode. Confirm with manual HTTP requests that the error shape looks correct.

## Changelog

This is the main part of EXEC-764. It adds `try`/`except` blocks in the implementations of `dropTip` and `dropTipInPlace` commands to turn it into a *recoverable, defined* error when the sensor detects that the tip is still attached.

This unfortunately does not totally close EXEC-764 because there is a problem with `opentrons.hardware`'s tip tracking getting out of sync with `opentrons.protocol_engine`'s tip tracking. If you retry the command, the robot will incorrectly act as if there is *not* a tip on the pipette, and slam the tip into the bottom of the tip rack. This is the same problem that we had with `pickUpTip`'s `tipPhysicallyMissingError`, and we solved it there by adding new hardware API methods that put tip tracking more in control of the caller. I'll do the same thing for these commands in a separate PR.

## Review requests

* Does the plan above to fix tip tracking sound good?
* I am *not* catching stalls or collisions here because that smells like something that we'll want to keep a distinct `errorType`, but I haven't really thought it through. Any thoughts?

## Risk assessment

Low.