### PR TITLE
fix(app): Fix intermittent drop tip failing

### DIFF
--- a/app/src/organisms/Desktop/Devices/PipetteCard/FlexPipetteCard.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/FlexPipetteCard.tsx
@@ -94,7 +94,7 @@ export function FlexPipetteCard({
     setSelectedPipette(SINGLE_MOUNT_PIPETTES)
   }
 
-  const { showDTWiz, toggleDTWiz } = useDropTipWizardFlows()
+  const { showDTWiz, enableDTWiz, disableDTWiz } = useDropTipWizardFlows()
 
   const handleLaunchPipetteWizardFlows = (
     flowType: PipetteWizardFlow
@@ -186,7 +186,7 @@ export function FlexPipetteCard({
             label: i18n.format(t('drop_tips'), 'capitalize'),
             disabled: attachedPipette == null || isRunActive,
             onClick: () => {
-              toggleDTWiz()
+              enableDTWiz()
             },
           },
         ]
@@ -270,7 +270,7 @@ export function FlexPipetteCard({
           robotType={FLEX_ROBOT_TYPE}
           mount={mount}
           instrumentModelSpecs={pipetteModelSpecs}
-          closeFlow={toggleDTWiz}
+          closeFlow={disableDTWiz}
           modalStyle="simple"
         />
       ) : null}

--- a/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
@@ -62,9 +62,9 @@ describe('FlexPipetteCard', () => {
       data: undefined,
     } as any)
     vi.mocked(useDropTipWizardFlows).mockReturnValue({
-      toggleDTWiz: mockDTWizToggle,
+      enableDTWiz: mockDTWizToggle,
       showDTWiz: false,
-    })
+    } as any)
   })
   afterEach(() => {
     vi.resetAllMocks()

--- a/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -55,7 +55,8 @@ describe('PipetteCard', () => {
     ])
     vi.mocked(useDropTipWizardFlows).mockReturnValue({
       showDTWiz: false,
-      toggleDTWiz: vi.fn(),
+      enableDTWiz: vi.fn(),
+      disableDTWiz: vi.fn(),
     })
     when(usePipetteSettingsQuery)
       .calledWith({ refetchInterval: 5000, enabled: true })

--- a/app/src/organisms/Desktop/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/index.tsx
@@ -72,7 +72,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const [showSlideout, setShowSlideout] = useState(false)
   const [showAboutSlideout, setShowAboutSlideout] = useState(false)
 
-  const { showDTWiz, toggleDTWiz } = useDropTipWizardFlows()
+  const { showDTWiz, disableDTWiz, enableDTWiz } = useDropTipWizardFlows()
 
   const settings =
     usePipetteSettingsQuery({
@@ -110,7 +110,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
           robotType={OT2_ROBOT_TYPE}
           mount={mount}
           instrumentModelSpecs={pipetteModelSpecs}
-          closeFlow={toggleDTWiz}
+          closeFlow={disableDTWiz}
           modalStyle="simple"
         />
       ) : null}
@@ -207,7 +207,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               pipetteSpecs={pipetteModelSpecs}
               mount={mount}
               handleChangePipette={handleChangePipette}
-              handleDropTip={toggleDTWiz}
+              handleDropTip={enableDTWiz}
               handleSettingsSlideout={handleSettingsSlideout}
               handleAboutSlideout={handleAboutSlideout}
               pipetteSettings={settings}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
@@ -49,7 +49,7 @@ export function useRunHeaderDropTip({
   const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
 
   const { closeCurrentRun } = useCloseCurrentRun()
-  const { showDTWiz, toggleDTWiz } = useDropTipWizardFlows()
+  const { showDTWiz, disableDTWiz, enableDTWiz } = useDropTipWizardFlows()
 
   const {
     areTipsAttached,
@@ -66,7 +66,7 @@ export function useRunHeaderDropTip({
 
   const dropTipModalUtils = useProtocolDropTipModal({
     areTipsAttached,
-    toggleDTWiz,
+    enableDTWiz,
     isRunCurrent,
     currentRunId: runId,
     pipetteInfo: buildPipetteDetails(aPipetteWithTip),
@@ -78,12 +78,12 @@ export function useRunHeaderDropTip({
   // The onCloseFlow for Drop Tip Wizard
   const onCloseFlow = (isTakeover?: boolean): void => {
     if (isTakeover) {
-      toggleDTWiz()
+      disableDTWiz()
     } else {
       void setTipStatusResolved(() => {
-        toggleDTWiz()
+        disableDTWiz()
         closeCurrentRun()
-      }, toggleDTWiz)
+      }, disableDTWiz)
     }
   }
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
@@ -30,7 +30,7 @@ type UseProtocolDropTipModalProps = Pick<
   'pipetteInfo'
 > & {
   areTipsAttached: TipAttachmentStatusResult['areTipsAttached']
-  toggleDTWiz: () => void
+  enableDTWiz: () => void
   currentRunId: string
   onSkipAndHome: () => void
   /* True if the most recent run is the current run */
@@ -47,7 +47,7 @@ export type UseProtocolDropTipModalResult =
 // Wraps functionality required for rendering the related modal.
 export function useProtocolDropTipModal({
   areTipsAttached,
-  toggleDTWiz,
+  enableDTWiz,
   isRunCurrent,
   onSkipAndHome,
   pipetteInfo,
@@ -75,7 +75,7 @@ export function useProtocolDropTipModal({
   }
 
   const onBeginRemoval = (): void => {
-    toggleDTWiz()
+    enableDTWiz()
     setShowModal(false)
   }
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/__tests__/ProtocolDropTipModal.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/__tests__/ProtocolDropTipModal.test.tsx
@@ -21,7 +21,7 @@ describe('useProtocolDropTipModal', () => {
   beforeEach(() => {
     props = {
       areTipsAttached: true,
-      toggleDTWiz: vi.fn(),
+      enableDTWiz: vi.fn(),
       isRunCurrent: true,
       onSkipAndHome: vi.fn(),
       currentRunId: 'MOCK_ID',
@@ -89,7 +89,7 @@ describe('useProtocolDropTipModal', () => {
       result.current.modalProps?.onBeginRemoval()
     })
 
-    expect(props.toggleDTWiz).toHaveBeenCalled()
+    expect(props.enableDTWiz).toHaveBeenCalled()
   })
 
   it('should set isDisabled to true when isHomingPipettes is true', () => {

--- a/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
@@ -22,15 +22,20 @@ import type {
  */
 export function useDropTipWizardFlows(): {
   showDTWiz: boolean
-  toggleDTWiz: () => void
+  enableDTWiz: () => void
+  disableDTWiz: () => void
 } {
   const [showDTWiz, setShowDTWiz] = useState(false)
 
-  const toggleDTWiz = (): void => {
-    setShowDTWiz(!showDTWiz)
+  return {
+    showDTWiz,
+    enableDTWiz: () => {
+      setShowDTWiz(true)
+    },
+    disableDTWiz: () => {
+      setShowDTWiz(false)
+    },
   }
-
-  return { showDTWiz, toggleDTWiz }
 }
 
 export interface DropTipWizardFlowsProps {

--- a/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
+++ b/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
@@ -47,7 +47,7 @@ const TipsAttachedModal = NiceModal.create(
     const modal = useModal()
 
     const { mount, specs } = aPipetteWithTip
-    const { showDTWiz, toggleDTWiz } = useDropTipWizardFlows()
+    const { showDTWiz, disableDTWiz, enableDTWiz } = useDropTipWizardFlows()
     const { homePipettes, isHoming } = useHomePipettes({
       ...homePipetteProps,
       pipetteInfo: buildPipetteDetails(aPipetteWithTip),
@@ -68,7 +68,7 @@ const TipsAttachedModal = NiceModal.create(
     }
 
     const cleanUpAndClose = (isTakeover?: boolean): void => {
-      toggleDTWiz()
+      disableDTWiz()
 
       if (!isTakeover) {
         modal.remove()
@@ -106,7 +106,7 @@ const TipsAttachedModal = NiceModal.create(
               <SmallButton
                 flex="1"
                 buttonText={t('begin_removal')}
-                onClick={toggleDTWiz}
+                onClick={enableDTWiz}
                 disabled={isHoming}
               />
             </Flex>

--- a/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardFlows.test.ts
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardFlows.test.ts
@@ -13,9 +13,15 @@ describe('useDropTipWizardFlows', () => {
     expect(result.current.showDTWiz).toBe(false)
 
     act(() => {
-      result.current.toggleDTWiz()
+      result.current.enableDTWiz()
     })
 
     expect(result.current.showDTWiz).toBe(true)
+
+    act(() => {
+      result.current.disableDTWiz()
+    })
+
+    expect(result.current.showDTWiz).toBe(false)
   })
 })

--- a/app/src/organisms/DropTipWizardFlows/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/TipsAttachedModal.test.tsx
@@ -74,7 +74,8 @@ describe('TipsAttachedModal', () => {
     } as any)
     vi.mocked(useDropTipWizardFlows).mockReturnValue({
       showDTWiz: false,
-      toggleDTWiz: mockToggleDTWiz,
+      enableDTWiz: mockToggleDTWiz,
+      disableDTWiz: vi.fn(),
     })
   })
 

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -88,8 +88,11 @@ export function useDropTipCommands({
                 console.error(error.message)
               })
               .finally(() => {
-                closeFlow()
-                deleteMaintenanceRun(activeMaintenanceRunId)
+                deleteMaintenanceRun(activeMaintenanceRunId, {
+                  onSettled: () => {
+                    closeFlow()
+                  },
+                })
               })
           }
         }

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipMaintenanceRun.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipMaintenanceRun.tsx
@@ -17,7 +17,7 @@ export type UseDropTipMaintenanceRunParams = Omit<
   UseDTWithTypeParams,
   'instrumentModelSpecs' | 'mount'
 > & {
-  setErrorDetails?: (errorDetails: SetRobotErrorDetailsParams) => void
+  setErrorDetails: (errorDetails: SetRobotErrorDetailsParams) => void
   instrumentModelSpecs?: PipetteModelSpecs
   mount?: PipetteData['mount']
 }
@@ -95,9 +95,7 @@ function useCreateDropTipMaintenanceRun({
         .catch((error: Error) => error)
     },
     onError: (error: Error) => {
-      if (setErrorDetails != null) {
-        setErrorDetails({ message: error.message })
-      }
+      setErrorDetails({ message: error.message })
     },
   })
 
@@ -108,11 +106,9 @@ function useCreateDropTipMaintenanceRun({
       instrumentModelName != null
     ) {
       createTargetedMaintenanceRun({}).catch((e: Error) => {
-        if (setErrorDetails != null) {
-          setErrorDetails({
-            message: `Error creating maintenance run: ${e.message}`,
-          })
-        }
+        setErrorDetails({
+          message: `Error creating maintenance run: ${e.message}`,
+        })
       })
     } else {
       console.warn(

--- a/app/src/pages/ODD/InstrumentDetail/InstrumentDetailOverflowMenu.tsx
+++ b/app/src/pages/ODD/InstrumentDetail/InstrumentDetailOverflowMenu.tsx
@@ -35,7 +35,7 @@ import type {
 interface InstrumentDetailsOverflowMenuProps {
   instrument: PipetteData | GripperData
   host: HostConfig | null
-  toggleDTWiz: () => void
+  enableDTWiz: () => void
 }
 
 export const handleInstrumentDetailOverflowMenu = (
@@ -46,13 +46,13 @@ export const handleInstrumentDetailOverflowMenu = (
   NiceModal.show(InstrumentDetailsOverflowMenu, {
     instrument,
     host,
-    toggleDTWiz,
+    enableDTWiz: toggleDTWiz,
   })
 }
 
 const InstrumentDetailsOverflowMenu = NiceModal.create(
   (props: InstrumentDetailsOverflowMenuProps): JSX.Element => {
-    const { instrument, host, toggleDTWiz } = props
+    const { instrument, host, enableDTWiz } = props
     const { t } = useTranslation('robot_controls')
     const modal = useModal()
     const [wizardProps, setWizardProps] = React.useState<
@@ -98,7 +98,7 @@ const InstrumentDetailsOverflowMenu = NiceModal.create(
     }
 
     const handleDropTip = (): void => {
-      toggleDTWiz()
+      enableDTWiz()
       modal.remove()
     }
 

--- a/app/src/pages/ODD/InstrumentDetail/__tests__/InstrumentDetail.test.tsx
+++ b/app/src/pages/ODD/InstrumentDetail/__tests__/InstrumentDetail.test.tsx
@@ -111,8 +111,9 @@ describe('InstrumentDetail', () => {
     vi.mocked(useParams).mockReturnValue({ mount: 'left' })
     vi.mocked(useIsOEMMode).mockReturnValue(false)
     vi.mocked(useDropTipWizardFlows).mockReturnValue({
-      toggleDTWiz: () => null,
+      enableDTWiz: vi.fn(),
       showDTWiz: false,
+      disableDTWiz: vi.fn(),
     })
     vi.mocked(DropTipWizardFlows).mockReturnValue(<div>MOCK_DROP_TIP_WIZ</div>)
   })

--- a/app/src/pages/ODD/InstrumentDetail/index.tsx
+++ b/app/src/pages/ODD/InstrumentDetail/index.tsx
@@ -48,7 +48,7 @@ export const InstrumentDetail = (): JSX.Element => {
   const gripperDisplayName = useGripperDisplayName(
     instrument?.instrumentModel as GripperModel
   )
-  const { showDTWiz, toggleDTWiz } = useDropTipWizardFlows()
+  const { showDTWiz, disableDTWiz, enableDTWiz } = useDropTipWizardFlows()
   const pipetteModelSpecs =
     instrument != null
       ? getPipetteModelSpecs((instrument as PipetteData).instrumentModel) ??
@@ -69,7 +69,7 @@ export const InstrumentDetail = (): JSX.Element => {
               robotType={FLEX_ROBOT_TYPE}
               mount={instrument.mount}
               instrumentModelSpecs={pipetteModelSpecs}
-              closeFlow={toggleDTWiz}
+              closeFlow={disableDTWiz}
               modalStyle="simple"
             />,
             getTopPortalEl()
@@ -93,7 +93,7 @@ export const InstrumentDetail = (): JSX.Element => {
                   handleInstrumentDetailOverflowMenu(
                     instrument,
                     host,
-                    toggleDTWiz
+                    enableDTWiz
                   )
                 }}
               >


### PR DESCRIPTION
Closes [RQA-3287](https://opentrons.atlassian.net/browse/RQA-3287)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

After the semi-recent drop tip wizard cleanup, in which the `fixit` DT flows were more decoupled from the `setup` DT flow logic, we (the royal we, aka me) eagerly closed the wizard before ensuring the maintenance run was actually deleted. This can put drop tip wizard in a weird state if launched too quickly after exiting, as seen in the ticket with the 500 POST request to the `maintenance_runs` endpoint. To fix this, let's just ensure we don't close the wizard until the request settles.

410eccc4f1b353b137e28e815797c5ca95551dc7 prevents a weird bug. If you access drop tip wizard from the Device Details page and a pipette unrenders during drop tip wizard, it sometimes toggles a lot because we pass a generic drop tip `toggle`, and several different things within DT wiz call this toggle. By specifying `enableDTWiz` and `disableDTWiz`, this problem no longer occurs.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Tested all drop tip wizard entry points, ensuring nothing breaks.
- Repro'd the ticket linked above and validated the fix works.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed drop tip wizard sometimes getting stuck on "getting ready" indefinitely or randomly failing when starting.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3287]: https://opentrons.atlassian.net/browse/RQA-3287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ