### PR TITLE
refactor(app): do not show fallback tooltip on run action button

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionBtnDisabledUtils.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionBtnDisabledUtils.ts
@@ -23,7 +23,7 @@ interface UseActionButtonDisabledUtilsProps extends BaseActionButtonProps {
 }
 
 type UseActionButtonDisabledUtilsResult =
-  | { isDisabled: true; disabledReason: string }
+  | { isDisabled: true; disabledReason: string | null }
   | { isDisabled: false; disabledReason: null }
 
 // Manages the various reasons the ActionButton may be disabled, returning the disabled state and user-facing disabled
@@ -45,7 +45,6 @@ export function useActionBtnDisabledUtils(
     isClosingCurrentRun,
   } = props
 
-  const { t } = useTranslation('shared')
   const {
     isPlayRunActionLoading,
     isPauseRunActionLoading,
@@ -77,7 +76,7 @@ export function useActionBtnDisabledUtils(
   })
 
   return isDisabled
-    ? { isDisabled: true, disabledReason: disabledReason ?? t('robot_is_busy') }
+    ? { isDisabled: true, disabledReason }
     : { isDisabled: false, disabledReason: null }
 }
 


### PR DESCRIPTION
Closes [RQA-3311](https://opentrons.atlassian.net/browse/RQA-3311)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

During the protocol run header refactor, I thought it would be neat to have a fallback tooltip if the run button was disabled, but the user was never prompted with a specific reason. I was wrong. See the linked ticket for some of the confusing tooltip behavior.

To fix, let's just use the same behavior we had back in 8.0.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Confirmed no more weird tooltips.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the tooltip showing when clicking pause/resume.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3311]: https://opentrons.atlassian.net/browse/RQA-3311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ