### PR TITLE
fix(shared-data): fix broken RTP choice range formatter util

### DIFF
--- a/shared-data/js/helpers/orderRuntimeParameterRangeOptions.ts
+++ b/shared-data/js/helpers/orderRuntimeParameterRangeOptions.ts
@@ -21,12 +21,14 @@ export const isNumeric = (str: string): boolean => {
 export const orderRuntimeParameterRangeOptions = (
   choices: Choice[]
 ): string => {
-  // when this function is called, the array length is always 2
+  // when this function is called, the array length is always in [1,2]
   if (choices.length > 2) {
-    console.error(`expected to have length 2 but has length ${choices.length}`)
+    console.error(
+      `expected to have length [1,2] but has length ${choices.length}`
+    )
     return ''
   }
-  const displayNames = [choices[0].displayName, choices[1].displayName]
+  const displayNames = choices.map(({ displayName }) => displayName)
   if (isNumeric(displayNames[0])) {
     return displayNames
       .sort((a, b) => {


### PR DESCRIPTION
# Overview

We developed a utility function `orderRuntimeParameterRangeOptions` to order choice-type parameters in the `ParametersTable` and `ProtocolDetails` components. However, the util incorrectly assumed that the RTP choice array passed to the utility was of length 2 when it could also be of length 1. This PR filters the array of any length rather than explicitly indexing its second element to fix the bug.

Closes AUTH-929

## Test Plan and Hands on Testing

- upload a CSV protocol with a single-choice runtime parameter
[example](https://github.com/user-attachments/files/17385310/csv_end_to_end_ot2.py.zip)

- verify that you can proceed with protocol setup 

## Changelog

- fix logic in filtering choices

## Review requests

see test plan

## Risk assessment

low