### PR TITLE
feat(api): add liquid class in PAPI

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -222,6 +222,17 @@ settings = [
         robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
         internal_only=True,
     ),
+    SettingDefinition(
+        _id="allowLiquidClasses",
+        title="Allow the use of liquid classes",
+        description=(
+            "Do not enable."
+            " This is an Opentrons internal setting to allow using in-development"
+            " liquid classes."
+        ),
+        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
+        internal_only=True,
+    ),
 ]
 
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -726,6 +726,16 @@ def _migrate34to35(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate35to36(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 36 of the feature flags file.
+
+    - Adds the allowLiquidClasses config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["allowLiquidClasses"] = None
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -762,6 +772,7 @@ _MIGRATIONS = [
     _migrate32to33,
     _migrate33to34,
     _migrate34to35,
+    _migrate35to36,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -78,3 +78,7 @@ def enable_performance_metrics(robot_type: RobotTypeEnum) -> bool:
 
 def oem_mode_enabled() -> bool:
     return advs.get_setting_with_env_overload("enableOEMMode", RobotTypeEnum.FLEX)
+
+
+def allow_liquid_classes(robot_type: RobotTypeEnum) -> bool:
+    return advs.get_setting_with_env_overload("allowLiquidClasses", robot_type)

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -29,7 +29,7 @@ from .module_contexts import (
     AbsorbanceReaderContext,
 )
 from .disposal_locations import TrashBin, WasteChute
-from ._liquid import Liquid
+from ._liquid import Liquid, LiquidClass
 from ._types import OFF_DECK
 from ._nozzle_layout import (
     COLUMN,
@@ -67,6 +67,7 @@ __all__ = [
     "WasteChute",
     "Well",
     "Liquid",
+    "LiquidClass",
     "Parameters",
     "COLUMN",
     "PARTIAL_COLUMN",

--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -65,7 +65,7 @@ class LiquidClass:
     def create(cls, liquid_class_definition: LiquidClassSchemaV1) -> "LiquidClass":
         """Liquid class factory method."""
 
-        return LiquidClass(
+        return cls(
             _name=liquid_class_definition.liquidClassName,
             _display_name=liquid_class_definition.displayName,
             _by_pipette_setting=liquid_class_definition.byPipette,

--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -29,6 +29,8 @@ class Liquid:
     display_color: Optional[str]
 
 
+# TODO (spp, 2024-10-17): create PAPI-equivalent types for all the properties
+#  and have validation on value updates with user-facing error messages
 @dataclass
 class TransferProperties:
     _aspirate: AspirateProperties
@@ -64,7 +66,7 @@ class LiquidClass:
 
         return LiquidClass(
             name=liquid_class_definition.liquidName,
-            _by_pipette_setting=liquid_class_definition.byPipette,  # make sure this is a copy and not a reference
+            _by_pipette_setting=liquid_class_definition.byPipette,
         )
 
     def get_for(self, pipette: str, tiprack: str) -> TransferProperties:
@@ -76,7 +78,7 @@ class LiquidClass:
             )
         )
         if len(settings_for_pipette) == 0:
-            raise KeyError(
+            raise ValueError(
                 f"No properties found for {pipette} in {self.name} liquid class"
             )
         settings_for_tip: Sequence[ByTipTypeSetting] = list(
@@ -86,7 +88,7 @@ class LiquidClass:
             )
         )
         if len(settings_for_tip) == 0:
-            raise KeyError(
+            raise ValueError(
                 f"No properties found for {tiprack} in {self.name} liquid class"
             )
         return TransferProperties(

--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -81,22 +81,20 @@ class LiquidClass:
 
     def get_for(self, pipette: str, tiprack: str) -> TransferProperties:
         """Get liquid class transfer properties for the specified pipette and tip."""
-        settings_for_pipette: Sequence[ByPipetteSetting] = list(
-            filter(
-                lambda pip_setting: pip_setting.pipetteModel == pipette,
-                self._by_pipette_setting,
-            )
-        )
+        settings_for_pipette: Sequence[ByPipetteSetting] = [
+            pip_setting
+            for pip_setting in self._by_pipette_setting
+            if pip_setting.pipetteModel == pipette
+        ]
         if len(settings_for_pipette) == 0:
             raise ValueError(
                 f"No properties found for {pipette} in {self._name} liquid class"
             )
-        settings_for_tip: Sequence[ByTipTypeSetting] = list(
-            filter(
-                lambda tip_setting: tip_setting.tiprack == tiprack,
-                settings_for_pipette[0].byTipType,
-            )
-        )
+        settings_for_tip: Sequence[ByTipTypeSetting] = [
+            tip_setting
+            for tip_setting in settings_for_pipette[0].byTipType
+            if tip_setting.tiprack == tiprack
+        ]
         if len(settings_for_tip) == 0:
             raise ValueError(
                 f"No properties found for {tiprack} in {self._name} liquid class"

--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -1,5 +1,14 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
+
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    LiquidClassSchemaV1,
+    AspirateProperties,
+    SingleDispenseProperties,
+    MultiDispenseProperties,
+    ByPipetteSetting,
+    ByTipTypeSetting,
+)
 
 
 @dataclass(frozen=True)
@@ -18,3 +27,70 @@ class Liquid:
     name: str
     description: Optional[str]
     display_color: Optional[str]
+
+
+@dataclass
+class TransferProperties:
+    _aspirate: AspirateProperties
+    _dispense: SingleDispenseProperties
+    _multi_dispense: Optional[MultiDispenseProperties]
+
+    @property
+    def aspirate(self) -> AspirateProperties:
+        """Aspirate properties."""
+        return self._aspirate
+
+    @property
+    def dispense(self) -> SingleDispenseProperties:
+        """Single dispense properties."""
+        return self._dispense
+
+    @property
+    def multi_dispense(self) -> Optional[MultiDispenseProperties]:
+        """Multi dispense properties."""
+        return self._multi_dispense
+
+
+@dataclass
+class LiquidClass:
+    """A data class that contains properties of a specific class of liquids."""
+
+    name: str
+    _by_pipette_setting: Sequence[ByPipetteSetting]
+
+    @classmethod
+    def create(cls, liquid_class_definition: LiquidClassSchemaV1) -> "LiquidClass":
+        """Liquid class factory method."""
+
+        return LiquidClass(
+            name=liquid_class_definition.liquidName,
+            _by_pipette_setting=liquid_class_definition.byPipette,  # make sure this is a copy and not a reference
+        )
+
+    def get_for(self, pipette: str, tiprack: str) -> TransferProperties:
+        """Get liquid class transfer properties for the specified pipette and tip."""
+        settings_for_pipette: Sequence[ByPipetteSetting] = list(
+            filter(
+                lambda pip_setting: pip_setting.pipetteModel == pipette,
+                self._by_pipette_setting,
+            )
+        )
+        if len(settings_for_pipette) == 0:
+            raise KeyError(
+                f"No properties found for {pipette} in {self.name} liquid class"
+            )
+        settings_for_tip: Sequence[ByTipTypeSetting] = list(
+            filter(
+                lambda tip_setting: tip_setting.tiprack == tiprack,
+                settings_for_pipette[0].byTipType,
+            )
+        )
+        if len(settings_for_tip) == 0:
+            raise KeyError(
+                f"No properties found for {tiprack} in {self.name} liquid class"
+            )
+        return TransferProperties(
+            _aspirate=settings_for_tip[0].aspirate,
+            _dispense=settings_for_tip[0].singleDispense,
+            _multi_dispense=settings_for_tip[0].multiDispense,
+        )

--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -57,7 +57,8 @@ class TransferProperties:
 class LiquidClass:
     """A data class that contains properties of a specific class of liquids."""
 
-    name: str
+    _name: str
+    _display_name: str
     _by_pipette_setting: Sequence[ByPipetteSetting]
 
     @classmethod
@@ -65,9 +66,18 @@ class LiquidClass:
         """Liquid class factory method."""
 
         return LiquidClass(
-            name=liquid_class_definition.liquidName,
+            _name=liquid_class_definition.liquidClassName,
+            _display_name=liquid_class_definition.displayName,
             _by_pipette_setting=liquid_class_definition.byPipette,
         )
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def display_name(self) -> str:
+        return self._display_name
 
     def get_for(self, pipette: str, tiprack: str) -> TransferProperties:
         """Get liquid class transfer properties for the specified pipette and tip."""
@@ -79,7 +89,7 @@ class LiquidClass:
         )
         if len(settings_for_pipette) == 0:
             raise ValueError(
-                f"No properties found for {pipette} in {self.name} liquid class"
+                f"No properties found for {pipette} in {self._name} liquid class"
             )
         settings_for_tip: Sequence[ByTipTypeSetting] = list(
             filter(
@@ -89,7 +99,7 @@ class LiquidClass:
         )
         if len(settings_for_tip) == 0:
             raise ValueError(
-                f"No properties found for {tiprack} in {self.name} liquid class"
+                f"No properties found for {tiprack} in {self._name} liquid class"
             )
         return TransferProperties(
             _aspirate=settings_for_tip[0].aspirate,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 from typing import Dict, Optional, Type, Union, List, Tuple, TYPE_CHECKING
 
+from opentrons_shared_data.liquid_classes import LiquidClassDefinitionDoesNotExist
+
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine.commands import LoadModuleResult
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
@@ -764,8 +766,8 @@ class ProtocolCore(
                 # Calling this often will degrade protocol execution performance.
                 liquid_class_def = liquid_classes.load_definition(name)
                 self._defined_liquid_class_defs_by_name[name] = liquid_class_def
-            except KeyError:
-                raise ValueError("Liquid class definition not found")
+            except LiquidClassDefinitionDoesNotExist:
+                raise ValueError(f"Liquid class definition not found for '{name}'.")
 
         return LiquidClass.create(liquid_class_def)
 

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -7,6 +7,10 @@ from opentrons.protocol_engine.commands import LoadModuleResult
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data import liquid_classes
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    LiquidClassSchemaV1,
+)
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.robot.types import RobotType
 
@@ -51,7 +55,7 @@ from opentrons.protocol_engine.errors import (
 
 from ... import validation
 from ..._types import OffDeckType
-from ..._liquid import Liquid
+from ..._liquid import Liquid, LiquidClass
 from ...disposal_locations import TrashBin, WasteChute
 from ..protocol import AbstractProtocol
 from ..labware import LabwareLoadParams
@@ -103,6 +107,7 @@ class ProtocolCore(
             str, Union[ModuleCore, NonConnectedModuleCore]
         ] = {}
         self._disposal_locations: List[Union[Labware, TrashBin, WasteChute]] = []
+        self._defined_liquid_class_defs_by_name: Dict[str, LiquidClassSchemaV1] = {}
         self._load_fixed_trash()
 
     @property
@@ -746,6 +751,23 @@ class ProtocolCore(
                 liquid.displayColor.__root__ if liquid.displayColor else None
             ),
         )
+
+    def define_liquid_class(self, name: str) -> LiquidClass:
+        """Define a liquid class for use in transfer functions."""
+        try:
+            # Check if we have already loaded this liquid class' definition
+            liquid_class_def = self._defined_liquid_class_defs_by_name[name]
+        except KeyError:
+            try:
+                # Fetching the liquid class data from file and parsing it
+                # is an expensive operation and should be avoided.
+                # Calling this often will degrade protocol execution performance.
+                liquid_class_def = liquid_classes.load_definition(name)
+                self._defined_liquid_class_defs_by_name[name] = liquid_class_def
+            except KeyError:
+                raise ValueError("Liquid class definition not found")
+
+        return LiquidClass.create(liquid_class_def)
 
     def get_labware_location(
         self, labware_core: LabwareCore

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -17,7 +17,7 @@ from opentrons.protocols import labware as labware_definition
 
 from ...labware import Labware
 from ...disposal_locations import TrashBin, WasteChute
-from ..._liquid import Liquid
+from ..._liquid import Liquid, LiquidClass
 from ..._types import OffDeckType
 from ..protocol import AbstractProtocol
 from ..labware import LabwareLoadParams
@@ -530,6 +530,10 @@ class LegacyProtocolCore(
     ) -> Liquid:
         """Define a liquid to load into a well."""
         assert False, "define_liquid only supported on engine core"
+
+    def define_liquid_class(self, name: str) -> LiquidClass:
+        """Define a liquid class."""
+        assert False, "define_liquid_class is only supported on engine core"
 
     def get_labware_location(
         self, labware_core: LegacyLabwareCore

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -18,7 +18,7 @@ from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from .instrument import InstrumentCoreType
 from .labware import LabwareCoreType, LabwareLoadParams
 from .module import ModuleCoreType
-from .._liquid import Liquid
+from .._liquid import Liquid, LiquidClass
 from .._types import OffDeckType
 from ..disposal_locations import TrashBin, WasteChute
 
@@ -246,6 +246,10 @@ class AbstractProtocol(
         self, name: str, description: Optional[str], display_color: Optional[str]
     ) -> Liquid:
         """Define a liquid to load into a well."""
+
+    @abstractmethod
+    def define_liquid_class(self, name: str) -> LiquidClass:
+        """Define a liquid class for use in transfer functions."""
 
     @abstractmethod
     def get_labware_location(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -61,7 +61,7 @@ from .core.engine import ENGINE_CORE_API_VERSION
 from .core.legacy.legacy_protocol_core import LegacyProtocolCore
 
 from . import validation
-from ._liquid import Liquid
+from ._liquid import Liquid, LiquidClass
 from .disposal_locations import TrashBin, WasteChute
 from .deck import Deck
 from .instrument_context import InstrumentContext
@@ -1283,6 +1283,14 @@ class ProtocolContext(CommandPublisher):
             description=description,
             display_color=display_color,
         )
+
+    # TODO: add feature flag
+    def define_liquid_class(
+        self,
+        name: str,
+    ) -> LiquidClass:
+        """Define a liquid class for use in the protocol."""
+        return self._core.define_liquid_class(name=name)
 
     @property
     @requires_version(2, 5)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -14,8 +14,10 @@ from typing import (
 
 from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from opentrons.types import Mount, Location, DeckLocation, DeckSlotName, StagingSlotName
+from opentrons.config import feature_flags
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.hardware_control.modules.types import (
     MagneticBlockModel,
@@ -1284,13 +1286,17 @@ class ProtocolContext(CommandPublisher):
             display_color=display_color,
         )
 
-    # TODO: add feature flag
     def define_liquid_class(
         self,
         name: str,
     ) -> LiquidClass:
         """Define a liquid class for use in the protocol."""
-        return self._core.define_liquid_class(name=name)
+        if feature_flags.allow_liquid_classes(
+            robot_type=RobotTypeEnum.robot_literal_to_enum(self._core.robot_type)
+        ):
+            return self._core.define_liquid_class(name=name)
+        else:
+            raise NotImplementedError("This method is not implemented.")
 
     @property
     @requires_version(2, 5)

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -8,7 +8,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 35
+    return 36
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -30,6 +30,7 @@ def default_file_settings() -> Dict[str, Any]:
         "enableErrorRecoveryExperiments": None,
         "enableOEMMode": None,
         "enablePerformanceMetrics": None,
+        "allowLiquidClasses": None,
     }
 
 
@@ -68,6 +69,7 @@ def v2_config(v1_config: Dict[str, Any]) -> Dict[str, Any]:
     r.update(
         {
             "_version": 2,
+            "disableLogAggregation": None,
         }
     )
     return r
@@ -410,6 +412,26 @@ def v34_config(v33_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v35_config(v34_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v34_config.copy()
+    r.pop("disableLogAggregation")
+    r["_version"] = 35
+    return r
+
+
+@pytest.fixture
+def v36_config(v35_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v35_config.copy()
+    r.update(
+        {
+            "_version": 36,
+            "allowLiquidClasses": None,
+        }
+    )
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -449,6 +471,8 @@ def v34_config(v33_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v32_config"),
         lazy_fixture("v33_config"),
         lazy_fixture("v34_config"),
+        lazy_fixture("v35_config"),
+        lazy_fixture("v36_config"),
     ],
 )
 def old_settings(request: SubRequest) -> Dict[str, Any]:
@@ -539,4 +563,5 @@ def test_ensures_config() -> None:
         "enableErrorRecoveryExperiments": None,
         "enableOEMMode": None,
         "enablePerformanceMetrics": None,
+        "allowLiquidClasses": None,
     }

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -786,14 +786,19 @@ def minimal_module_def() -> ModuleDefinitionV3:
 @pytest.fixture
 def minimal_liquid_class_def1() -> LiquidClassSchemaV1:
     return LiquidClassSchemaV1(
-        liquidName="water1", schemaVersion=1, namespace="test-fixture-1", byPipette=[]
+        liquidClassName="water1",
+        displayName="water 1",
+        schemaVersion=1,
+        namespace="test-fixture-1",
+        byPipette=[],
     )
 
 
 @pytest.fixture
 def minimal_liquid_class_def2() -> LiquidClassSchemaV1:
     return LiquidClassSchemaV1(
-        liquidName="water2",
+        liquidClassName="water2",
+        displayName="water 2",
         schemaVersion=1,
         namespace="test-fixture-2",
         byPipette=[

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -20,6 +20,7 @@ from typing import (
     Union,
     cast,
 )
+
 from typing_extensions import TypedDict
 
 import pytest
@@ -37,6 +38,9 @@ from opentrons_shared_data.robot.types import RobotTypeEnum
 from opentrons_shared_data.protocol.types import JsonProtocol
 from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons_shared_data.module.types import ModuleDefinitionV3
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    LiquidClassSchemaV1,
+)
 from opentrons_shared_data.deck.types import (
     RobotModel,
     DeckDefinitionV3,
@@ -763,3 +767,17 @@ def minimal_module_def() -> ModuleDefinitionV3:
         "cornerOffsetFromSlot": {"x": 0.1, "y": 0.1, "z": 0.0},
         "twoDimensionalRendering": {},
     }
+
+
+@pytest.fixture
+def minimal_liquid_class_def1() -> LiquidClassSchemaV1:
+    return LiquidClassSchemaV1(
+        liquidName="water1", schemaVersion=1, namespace="test-fixture-1", byPipette=[]
+    )
+
+
+@pytest.fixture
+def minimal_liquid_class_def2() -> LiquidClassSchemaV1:
+    return LiquidClassSchemaV1(
+        liquidName="water2", schemaVersion=1, namespace="test-fixture-2", byPipette=[]
+    )

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -40,6 +40,20 @@ from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons_shared_data.module.types import ModuleDefinitionV3
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
+    ByPipetteSetting,
+    ByTipTypeSetting,
+    AspirateProperties,
+    Submerge,
+    PositionReference,
+    DelayProperties,
+    DelayParams,
+    RetractAspirate,
+    SingleDispenseProperties,
+    RetractDispense,
+    Coordinate,
+    MixProperties,
+    TouchTipProperties,
+    BlowoutProperties,
 )
 from opentrons_shared_data.deck.types import (
     RobotModel,
@@ -779,5 +793,67 @@ def minimal_liquid_class_def1() -> LiquidClassSchemaV1:
 @pytest.fixture
 def minimal_liquid_class_def2() -> LiquidClassSchemaV1:
     return LiquidClassSchemaV1(
-        liquidName="water2", schemaVersion=1, namespace="test-fixture-2", byPipette=[]
+        liquidName="water2",
+        schemaVersion=1,
+        namespace="test-fixture-2",
+        byPipette=[
+            ByPipetteSetting(
+                pipetteModel="p20_single_gen2",
+                byTipType=[
+                    ByTipTypeSetting(
+                        tiprack="opentrons_96_tiprack_20ul",
+                        aspirate=AspirateProperties(
+                            submerge=Submerge(
+                                positionReference=PositionReference.LIQUID_MENISCUS,
+                                offset=Coordinate(x=0, y=0, z=-5),
+                                speed=100,
+                                delay=DelayProperties(
+                                    enable=True, params=DelayParams(duration=1.5)
+                                ),
+                            ),
+                            retract=RetractAspirate(
+                                positionReference=PositionReference.WELL_TOP,
+                                offset=Coordinate(x=0, y=0, z=5),
+                                speed=100,
+                                airGapByVolume={"default": 2, "5": 3, "10": 4},
+                                touchTip=TouchTipProperties(enable=False),
+                                delay=DelayProperties(enable=False),
+                            ),
+                            positionReference=PositionReference.WELL_BOTTOM,
+                            offset=Coordinate(x=0, y=0, z=-5),
+                            flowRateByVolume={"default": 50, "10": 40, "20": 30},
+                            preWet=True,
+                            mix=MixProperties(enable=False),
+                            delay=DelayProperties(
+                                enable=True, params=DelayParams(duration=2)
+                            ),
+                        ),
+                        singleDispense=SingleDispenseProperties(
+                            submerge=Submerge(
+                                positionReference=PositionReference.LIQUID_MENISCUS,
+                                offset=Coordinate(x=0, y=0, z=-5),
+                                speed=100,
+                                delay=DelayProperties(enable=False),
+                            ),
+                            retract=RetractDispense(
+                                positionReference=PositionReference.WELL_TOP,
+                                offset=Coordinate(x=0, y=0, z=5),
+                                speed=100,
+                                airGapByVolume={"default": 2, "5": 3, "10": 4},
+                                blowout=BlowoutProperties(enable=False),
+                                touchTip=TouchTipProperties(enable=False),
+                                delay=DelayProperties(enable=False),
+                            ),
+                            positionReference=PositionReference.WELL_BOTTOM,
+                            offset=Coordinate(x=0, y=0, z=-5),
+                            flowRateByVolume={"default": 50, "10": 40, "20": 30},
+                            mix=MixProperties(enable=False),
+                            pushOutByVolume={"default": 5, "10": 7, "20": 10},
+                            delay=DelayProperties(enable=False),
+                        ),
+                        multiDispense=None,
+                    )
+                ],
+            )
+        ],
     )

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -1762,7 +1762,9 @@ def test_define_liquid_class(
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
     """It should create a LiquidClass and cache the definition."""
-    expected_liquid_class = LiquidClass(name="water1", _by_pipette_setting=[])
+    expected_liquid_class = LiquidClass(
+        _name="water1", _display_name="water 1", _by_pipette_setting=[]
+    )
     decoy.when(liquid_classes.load_definition("water")).then_return(
         minimal_liquid_class_def1
     )

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -3,6 +3,10 @@ import inspect
 from typing import Optional, Type, cast, Tuple
 
 import pytest
+from opentrons_shared_data import liquid_classes
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    LiquidClassSchemaV1,
+)
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from decoy import Decoy
 
@@ -69,7 +73,7 @@ from opentrons.protocol_api.core.engine import (
     ModuleCore,
     load_labware_params,
 )
-from opentrons.protocol_api._liquid import Liquid
+from opentrons.protocol_api._liquid import Liquid, LiquidClass
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
 from opentrons.protocol_api.core.engine.exceptions import InvalidModuleLocationError
 from opentrons.protocol_api.core.engine.module_core import (
@@ -109,6 +113,15 @@ def patch_mock_load_labware_params(
     """Mock out load_labware_params.py functions."""
     for name, func in inspect.getmembers(load_labware_params, inspect.isfunction):
         monkeypatch.setattr(load_labware_params, name, decoy.mock(func=func))
+
+
+@pytest.fixture(autouse=True)
+def patch_mock_load_liquid_class_def(
+    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mock out liquid_classes.load_definition() function."""
+    mock_load = decoy.mock(func=liquid_classes.load_definition)
+    monkeypatch.setattr(liquid_classes, "load_definition", mock_load)
 
 
 @pytest.fixture(autouse=True)
@@ -1740,6 +1753,25 @@ def test_add_liquid(
     )
 
     assert result == expected_result
+
+
+def test_define_liquid_class(
+    decoy: Decoy,
+    subject: ProtocolCore,
+    minimal_liquid_class_def1: LiquidClassSchemaV1,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should create a LiquidClass and cache the definition."""
+    expected_liquid_class = LiquidClass(name="water1", _by_pipette_setting=[])
+    decoy.when(liquid_classes.load_definition("water")).then_return(
+        minimal_liquid_class_def1
+    )
+    assert subject.define_liquid_class("water") == expected_liquid_class
+
+    decoy.when(liquid_classes.load_definition("water")).then_return(
+        minimal_liquid_class_def2
+    )
+    assert subject.define_liquid_class("water") == expected_liquid_class
 
 
 def test_get_labware_location_deck_slot(

--- a/api/tests/opentrons/protocol_api/test_liquid_class.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class.py
@@ -1,0 +1,38 @@
+"""Tests for LiquidClass methods."""
+import pytest
+
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    LiquidClassSchemaV1,
+)
+from opentrons.protocol_api import LiquidClass
+
+
+def test_create_liquid_class(
+    minimal_liquid_class_def1: LiquidClassSchemaV1,
+) -> None:
+    """It should create a LiquidClass from provided definition."""
+    assert LiquidClass.create(minimal_liquid_class_def1) == LiquidClass(
+        name="water1", _by_pipette_setting=[]
+    )
+
+
+def test_get_for_pipette_and_tip(
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should get the properties for the specified pipette and tip."""
+    liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    result = liq_class.get_for("p20_single_gen2", "opentrons_96_tiprack_20ul")
+    assert result.aspirate.flowRateByVolume == {"default": 50, "10": 40, "20": 30}
+
+
+def test_get_for_raises_for_incorrect_pipette_or_tip(
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should raise an error when accessing non-existent properties."""
+    liq_class = LiquidClass.create(minimal_liquid_class_def2)
+
+    with pytest.raises(ValueError):
+        liq_class.get_for("p20_single_gen2", "no_such_tiprack")
+
+    with pytest.raises(ValueError):
+        liq_class.get_for("p300_single", "opentrons_96_tiprack_20ul")

--- a/api/tests/opentrons/protocol_api/test_liquid_class.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class.py
@@ -12,7 +12,7 @@ def test_create_liquid_class(
 ) -> None:
     """It should create a LiquidClass from provided definition."""
     assert LiquidClass.create(minimal_liquid_class_def1) == LiquidClass(
-        name="water1", _by_pipette_setting=[]
+        _name="water1", _display_name="water 1", _by_pipette_setting=[]
     )
 
 

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -8,6 +8,7 @@ from decoy import Decoy, matchers
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 
+from opentrons.protocol_api._liquid import LiquidClass
 from opentrons.types import Mount, DeckSlotName, StagingSlotName
 from opentrons.protocol_api import OFF_DECK
 from opentrons.legacy_broker import LegacyBroker
@@ -1212,6 +1213,17 @@ def test_define_liquid_arg_defaulting(
                 name="water"
                 # description and display_color omitted.
             )
+
+
+def test_define_liquid_class(
+    decoy: Decoy, mock_core: ProtocolCore, subject: ProtocolContext
+) -> None:
+    """It should create the liquid class definition."""
+    expected_liquid_class = LiquidClass(name="volatile_100", _by_pipette_setting=[])
+    decoy.when(mock_core.define_liquid_class("volatile_90")).then_return(
+        expected_liquid_class
+    )
+    assert subject.define_liquid_class("volatile_90") == expected_liquid_class
 
 
 def test_bundled_data(

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1219,7 +1219,9 @@ def test_define_liquid_class(
     decoy: Decoy, mock_core: ProtocolCore, subject: ProtocolContext
 ) -> None:
     """It should create the liquid class definition."""
-    expected_liquid_class = LiquidClass(name="volatile_100", _by_pipette_setting=[])
+    expected_liquid_class = LiquidClass(
+        _name="volatile_100", _display_name="volatile 100%", _by_pipette_setting=[]
+    )
     decoy.when(mock_core.define_liquid_class("volatile_90")).then_return(
         expected_liquid_class
     )

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -1,0 +1,38 @@
+"""Tests for the APIs around liquid classes."""
+import pytest
+from opentrons import simulate
+
+
+@pytest.mark.ot2_only
+def test_liquid_class_creation_and_property_fetching() -> None:
+    """It should create the liquid class and provide access to its properties."""
+    protocol_context = simulate.get_protocol_api(version="2.20", robot_type="OT-2")
+    pipette_left = protocol_context.load_instrument("p20_single_gen2", mount="left")
+    pipette_right = protocol_context.load_instrument("p300_multi", mount="right")
+    tiprack = protocol_context.load_labware("opentrons_96_tiprack_20ul", "1")
+
+    glycerol_50 = protocol_context.define_liquid_class("fixture_glycerol50")
+
+    assert glycerol_50.name == "fixture_glycerol50"
+    assert glycerol_50.display_name == "Glycerol 50%"
+    assert (
+        glycerol_50.get_for(
+            pipette_left.name, tiprack.load_name
+        ).dispense.flowRateByVolume["default"]
+        == 50
+    )
+    assert (
+        glycerol_50.get_for(
+            pipette_left.name, tiprack.load_name
+        ).aspirate.submerge.speed
+        == 100
+    )
+
+    with pytest.raises(ValueError):
+        glycerol_50.get_for(pipette_right.name, tiprack.load_name)
+
+    with pytest.raises(AttributeError):
+        glycerol_50.name = "foo"  # type: ignore
+
+    with pytest.raises(AttributeError):
+        glycerol_50.display_name = "bar"  # type: ignore

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -37,7 +37,10 @@ def test_liquid_class_creation_and_property_fetching(
         == 100
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="No properties found for p300_multi in fixture_glycerol50 liquid class",
+    ):
         glycerol_50.get_for(pipette_right.name, tiprack.load_name)
 
     with pytest.raises(AttributeError):
@@ -45,6 +48,9 @@ def test_liquid_class_creation_and_property_fetching(
 
     with pytest.raises(AttributeError):
         glycerol_50.display_name = "bar"  # type: ignore
+
+    with pytest.raises(ValueError, match="Liquid class definition not found"):
+        protocol_context.define_liquid_class("non-existent-liquid")
 
 
 def test_liquid_class_feature_flag() -> None:

--- a/shared-data/liquid-class/fixtures/fixture_glycerol50.json
+++ b/shared-data/liquid-class/fixtures/fixture_glycerol50.json
@@ -1,5 +1,6 @@
 {
-  "liquidName": "Glycerol 50%",
+  "liquidClassName": "fixture_glycerol50",
+  "displayName": "Glycerol 50%",
   "schemaVersion": 1,
   "namespace": "opentrons",
   "byPipette": [

--- a/shared-data/liquid-class/fixtures/fixture_glycerol50.json
+++ b/shared-data/liquid-class/fixtures/fixture_glycerol50.json
@@ -7,7 +7,7 @@
       "pipetteModel": "p20_single_gen2",
       "byTipType": [
         {
-          "tipType": "p20_tip",
+          "tiprack": "opentrons_96_tiprack_20ul",
           "aspirate": {
             "submerge": {
               "positionReference": "liquid-meniscus",

--- a/shared-data/liquid-class/schemas/1.json
+++ b/shared-data/liquid-class/schemas/1.json
@@ -465,7 +465,7 @@
                   "$ref": "#/definitions/multiDispenseParams"
                 }
               },
-              "required": ["tipType", "aspirate", "singleDispense"],
+              "required": ["tiprack", "aspirate", "singleDispense"],
               "additionalProperties": false
             }
           }

--- a/shared-data/liquid-class/schemas/1.json
+++ b/shared-data/liquid-class/schemas/1.json
@@ -447,9 +447,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "tipType": {
+                "tiprack": {
                   "type": "string",
-                  "description": "The tip type whose properties will be used when handling this specific liquid class with this pipette"
+                  "description": "The tiprack name whose tip will be used when handling this specific liquid class with this pipette"
                 },
                 "aspirate": {
                   "$ref": "#/definitions/aspirateParams"

--- a/shared-data/liquid-class/schemas/1.json
+++ b/shared-data/liquid-class/schemas/1.json
@@ -418,9 +418,13 @@
     }
   },
   "properties": {
-    "liquidName": {
+    "liquidClassName": {
+      "$ref": "#/definitions/safeString",
+      "description": "The name of the liquid class specified when loading into protocol (e.g., water, ethanol, serum). Should be the same as file name."
+    },
+    "displayName": {
       "type": "string",
-      "description": "The name of the liquid (e.g., water, ethanol, serum)."
+      "description": "User-readable name of the liquid class."
     },
     "schemaVersion": {
       "description": "Which schema version a liquid class is using",
@@ -471,6 +475,6 @@
       }
     }
   },
-  "required": ["liquidName", "schemaVersion", "namespace", "byPipette"],
+  "required": ["liquidClassName", "displayName","schemaVersion", "namespace", "byPipette"],
   "additionalProperties": false
 }

--- a/shared-data/liquid-class/schemas/1.json
+++ b/shared-data/liquid-class/schemas/1.json
@@ -475,6 +475,12 @@
       }
     }
   },
-  "required": ["liquidClassName", "displayName","schemaVersion", "namespace", "byPipette"],
+  "required": [
+    "liquidClassName",
+    "displayName",
+    "schemaVersion",
+    "namespace",
+    "byPipette"
+  ],
   "additionalProperties": false
 }

--- a/shared-data/python/opentrons_shared_data/liquid_classes/__init__.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/__init__.py
@@ -6,7 +6,7 @@ from .liquid_class_definition import LiquidClassSchemaV1
 
 
 class LiquidClassDefinitionDoesNotExist(Exception):
-    """Specified liquid class' definition does not exist."""
+    """Specified liquid class definition does not exist."""
 
 
 # TODO (spp, 2024-10-16): update the path once definitions are added

--- a/shared-data/python/opentrons_shared_data/liquid_classes/__init__.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/__init__.py
@@ -1,1 +1,14 @@
 """opentrons_shared_data.liquid_classes: types and functions for accessing liquid class definitions."""
+
+import json
+from typing import cast
+from .liquid_class_definition import LiquidClassSchemaV1
+from .. import load_shared_data
+
+
+# TODO (spp, 2024-10-16): update the path once definitions are added
+def load_definition(name: str) -> LiquidClassSchemaV1:
+    return cast(
+        LiquidClassSchemaV1,
+        json.loads(load_shared_data(f"liquid-class/fixtures/{name}.json")),
+    )

--- a/shared-data/python/opentrons_shared_data/liquid_classes/__init__.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/__init__.py
@@ -1,14 +1,25 @@
-"""opentrons_shared_data.liquid_classes: types and functions for accessing liquid class definitions."""
-
+"""Types and functions for accessing liquid class definitions."""
 import json
-from typing import cast
-from .liquid_class_definition import LiquidClassSchemaV1
+
 from .. import load_shared_data
+from .liquid_class_definition import LiquidClassSchemaV1
+
+
+class LiquidClassDefinitionDoesNotExist(Exception):
+    """Specified liquid class' definition does not exist."""
 
 
 # TODO (spp, 2024-10-16): update the path once definitions are added
 def load_definition(name: str) -> LiquidClassSchemaV1:
-    return cast(
-        LiquidClassSchemaV1,
-        json.loads(load_shared_data(f"liquid-class/fixtures/{name}.json")),
-    )
+    """Load the specified liquid class' definition as a LiquidClassSchemaV1 object.
+
+    Note: this is an expensive operation and should be called sparingly.
+    """
+    try:
+        return LiquidClassSchemaV1.parse_obj(
+            json.loads(load_shared_data(f"liquid-class/fixtures/{name}.json"))
+        )
+    except FileNotFoundError:
+        raise LiquidClassDefinitionDoesNotExist(
+            f"No definition found for liquid class '{name}'"
+        )

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -312,9 +312,9 @@ class MultiDispenseProperties(BaseModel):
 class ByTipTypeSetting(BaseModel):
     """Settings for each kind of tip this pipette can use."""
 
-    tipType: str = Field(
+    tiprack: str = Field(
         ...,
-        description="The tip type whose properties will be used when handling this specific liquid class with this pipette",
+        description="The name of tiprack whose tip will be used when handling this specific liquid class with this pipette",
     )
     aspirate: AspirateProperties = Field(
         ..., description="Aspirate parameters for this tip type."

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -339,9 +339,10 @@ class ByPipetteSetting(BaseModel):
 class LiquidClassSchemaV1(BaseModel):
     """Defines a single liquid class's properties for liquid handling functions."""
 
-    liquidName: str = Field(
+    liquidClassName: str = Field(
         ..., description="The name of the liquid (e.g., water, ethanol, serum)."
     )
+    displayName: str = Field(..., description="User-readable name of the liquid class.")
     schemaVersion: Literal[1] = Field(
         ..., description="Which schema version a liquid class is using"
     )

--- a/shared-data/python/tests/gripper/test_load.py
+++ b/shared-data/python/tests/gripper/test_load.py
@@ -2,6 +2,7 @@ import json
 from opentrons_shared_data.gripper import load_definition, load_schema
 from opentrons_shared_data.gripper.gripper_definition import (
     GripperModel,
+    GripperDefinition,
 )
 from opentrons_shared_data import load_shared_data
 
@@ -11,6 +12,8 @@ def test_load_schema() -> None:
 
 
 def test_load_definition() -> None:
-    load_definition(GripperModel.v1, 1) == json.loads(
-        load_shared_data("gripper/definitions/1/gripperV1.json")
-    )
+    gripper_def = load_definition(GripperModel.v1, 1)
+    assert type(gripper_def) is GripperDefinition
+    assert gripper_def.model == GripperModel.v1
+    assert gripper_def.grip_force_profile.default_grip_force == 15
+    assert gripper_def.geometry.base_offset_from_mount == (19.5, -74.325, -94.825)

--- a/shared-data/python/tests/liquid_classes/test_load.py
+++ b/shared-data/python/tests/liquid_classes/test_load.py
@@ -4,6 +4,11 @@ from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.liquid_classes import load_definition
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
+    PositionReference,
+    Coordinate,
+    Submerge,
+    DelayParams,
+    DelayProperties,
 )
 
 
@@ -18,6 +23,12 @@ def test_load_liquid_class_schema_v1() -> None:
 
 
 def test_load_definition() -> None:
-    assert load_definition("fixture_glycerol50") == json.loads(
-        load_shared_data("liquid-class/fixtures/fixture_glycerol50.json")
+    glycerol_definition = load_definition("fixture_glycerol50")
+    assert type(glycerol_definition) is LiquidClassSchemaV1
+    assert glycerol_definition.byPipette[0].pipetteModel == "p20_single_gen2"
+    assert glycerol_definition.byPipette[0].byTipType[0].aspirate.submerge == Submerge(
+        positionReference=PositionReference.LIQUID_MENISCUS,
+        offset=Coordinate(x=0, y=0, z=-5),
+        speed=100,
+        delay=DelayProperties(enable=True, params=DelayParams(duration=1.5)),
     )

--- a/shared-data/python/tests/liquid_classes/test_load.py
+++ b/shared-data/python/tests/liquid_classes/test_load.py
@@ -1,6 +1,7 @@
 import json
 
 from opentrons_shared_data import load_shared_data
+from opentrons_shared_data.liquid_classes import load_definition
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
 )
@@ -14,3 +15,9 @@ def test_load_liquid_class_schema_v1() -> None:
     )
     expected_liquid_class_def = json.loads(fixture_data)
     assert liquid_class_def_from_model == expected_liquid_class_def
+
+
+def test_load_definition() -> None:
+    assert load_definition("fixture_glycerol50") == json.loads(
+        load_shared_data("liquid-class/fixtures/fixture_glycerol50.json")
+    )

--- a/shared-data/python/tests/liquid_classes/test_validations.py
+++ b/shared-data/python/tests/liquid_classes/test_validations.py
@@ -1,0 +1,32 @@
+"""Tests that validate the built-in liquid class definitions."""
+import pytest
+from typing import List
+
+from opentrons_shared_data import get_shared_data_root
+from opentrons_shared_data.liquid_classes import load_definition
+
+
+def _get_all_liquid_classes() -> List[str]:
+    # TODO (spp, 2024-10-16): update the path once definitions are added
+    return [
+        deffile.stem
+        for deffile in (get_shared_data_root() / "liquid-class" / "fixtures").iterdir()
+    ]
+
+
+@pytest.mark.parametrize("liquid_class_name", list(_get_all_liquid_classes()))
+def test_validate_unique_pipette_keys(liquid_class_name: str) -> None:
+    """A liquid class definition should contain only one set of properties per pipette model."""
+    definition_dict = load_definition(liquid_class_name)
+    pipette_models = [prop.pipetteModel for prop in definition_dict.byPipette]
+    assert len(pipette_models) == len(set(pipette_models))
+
+
+@pytest.mark.parametrize("liquid_class_name", list(_get_all_liquid_classes()))
+def test_validate_unique_tip_keys(liquid_class_name: str) -> None:
+    """A liquid class definition should contain only one set of properties per tip type."""
+    definition_dict = load_definition(liquid_class_name)
+
+    for by_pip_prop in definition_dict.byPipette:
+        tipracks = [tip_prop.tiprack for tip_prop in by_pip_prop.byTipType]
+        assert len(tipracks) == len(set(tipracks))


### PR DESCRIPTION
AUTH-835, AUTH-836

# Overview

Adds `LiquidClass` class and `ProtocolContext.define_liquid_class()` to PAPI. Also adds an `allowLiquidClasses` feature flag that will need to be set to True in order to use the new API method.

## Test Plan and Hands on Testing

I think the integration and unit tests in the PR are good enough for this work. This PR doesn't add the ability to actually use the liquid class in any way other than fetching values of the class so there isn't anything to be tested on a robot.

## Changelog

- added `LiquidClass` dataclass to PAPI
- added `ProtocolContext.define_liquid_class` to define a liquid class in the protocol
- added `allowLiquidClasses` internal feature flag

Some small schema changes:
- changed `liquidName` -> `liquidClassName` and made it a `safestring`
- added a `displayName`
- changed `tipType` -> tiprack

Misc shared data changes:
- added `liquid_classes.load_definition()`
- added validation tests for liquid class definitions

## Review requests

- does the `LiquidClass` structure make sense? 
  - background on the structure- keeping all dataclass attributes private and defining properties and setters explicitly allows us to restrict access to attributes that shouldn't change, while giving us a way to validate the properties before they are set/updated by the user.
- any naming improvements? I am not fully satisfied with the 'tiprack' property in the liquid class schema name when the parent classification says `byTipType`. But `byTiprackType` also didn't feel correct. So looking for suggestions for improvement or reassurance that it's fine the way it is.

## Risk assessment

Low. Doesn't affect anything existing, and is behind a feature flag.
