### PR TITLE
fix(api): ER support for in place commands and blow out

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -92,6 +92,7 @@ class AspirateInPlaceImplementation(
                 " so the plunger can be reset in a known safe position."
             )
         try:
+            current_position = await self._gantry_mover.get_position(params.pipetteId)
             volume = await self._pipetting.aspirate_in_place(
                 pipette_id=params.pipetteId,
                 volume=params.volume,
@@ -99,7 +100,6 @@ class AspirateInPlaceImplementation(
                 command_note_adder=self._command_note_adder,
             )
         except PipetteOverpressureError as e:
-            current_position = await self._gantry_mover.get_position(params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -1,23 +1,32 @@
 """Blow-out in place command request, result, and implementation models."""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type, Union
+from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
 from typing_extensions import Literal
 from pydantic import BaseModel
 
 from .pipetting_common import (
+    OverpressureError,
     PipetteIdMixin,
     FlowRateMixin,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    DefinedErrorData,
+    SuccessData,
+)
 from ..errors.error_occurrence import ErrorOccurrence
 
 from opentrons.hardware_control import HardwareControlAPI
 
 
 if TYPE_CHECKING:
-    from ..execution import PipettingHandler
+    from ..execution import PipettingHandler, GantryMover
     from ..state.state import StateView
+    from ..resources import ModelUtils
 
 
 BlowOutInPlaceCommandType = Literal["blowOutInPlace"]
@@ -35,8 +44,14 @@ class BlowOutInPlaceResult(BaseModel):
     pass
 
 
+_ExecuteReturn = Union[
+    SuccessData[BlowOutInPlaceResult, None],
+    DefinedErrorData[OverpressureError],
+]
+
+
 class BlowOutInPlaceImplementation(
-    AbstractCommandImpl[BlowOutInPlaceParams, SuccessData[BlowOutInPlaceResult, None]]
+    AbstractCommandImpl[BlowOutInPlaceParams, _ExecuteReturn]
 ):
     """BlowOutInPlace command implementation."""
 
@@ -45,21 +60,46 @@ class BlowOutInPlaceImplementation(
         pipetting: PipettingHandler,
         state_view: StateView,
         hardware_api: HardwareControlAPI,
+        model_utils: ModelUtils,
+        gantry_mover: GantryMover,
         **kwargs: object,
     ) -> None:
         self._pipetting = pipetting
         self._state_view = state_view
         self._hardware_api = hardware_api
+        self._model_utils = model_utils
+        self._gantry_mover = gantry_mover
 
-    async def execute(
-        self, params: BlowOutInPlaceParams
-    ) -> SuccessData[BlowOutInPlaceResult, None]:
+    async def execute(self, params: BlowOutInPlaceParams) -> _ExecuteReturn:
         """Blow-out without moving the pipette."""
-        await self._pipetting.blow_out_in_place(
-            pipette_id=params.pipetteId, flow_rate=params.flowRate
-        )
-
-        return SuccessData(public=BlowOutInPlaceResult(), private=None)
+        try:
+            await self._pipetting.blow_out_in_place(
+                pipette_id=params.pipetteId, flow_rate=params.flowRate
+            )
+        except PipetteOverpressureError as e:
+            current_position = await self._gantry_mover.get_position(params.pipetteId)
+            return DefinedErrorData(
+                public=OverpressureError(
+                    id=self._model_utils.generate_id(),
+                    createdAt=self._model_utils.get_timestamp(),
+                    wrappedErrors=[
+                        ErrorOccurrence.from_failed(
+                            id=self._model_utils.generate_id(),
+                            createdAt=self._model_utils.get_timestamp(),
+                            error=e,
+                        )
+                    ],
+                    errorInfo={
+                        "retryLocation": (
+                            current_position.x,
+                            current_position.y,
+                            current_position.z,
+                        )
+                    },
+                ),
+            )
+        else:
+            return SuccessData(public=BlowOutInPlaceResult(), private=None)
 
 
 class BlowOutInPlace(

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -73,11 +73,11 @@ class BlowOutInPlaceImplementation(
     async def execute(self, params: BlowOutInPlaceParams) -> _ExecuteReturn:
         """Blow-out without moving the pipette."""
         try:
+            current_position = await self._gantry_mover.get_position(params.pipetteId)
             await self._pipetting.blow_out_in_place(
                 pipette_id=params.pipetteId, flow_rate=params.flowRate
             )
         except PipetteOverpressureError as e:
-            current_position = await self._gantry_mover.get_position(params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -70,6 +70,7 @@ class DispenseInPlaceImplementation(
     async def execute(self, params: DispenseInPlaceParams) -> _ExecuteReturn:
         """Dispense without moving the pipette."""
         try:
+            current_position = await self._gantry_mover.get_position(params.pipetteId)
             volume = await self._pipetting.dispense_in_place(
                 pipette_id=params.pipetteId,
                 volume=params.volume,
@@ -77,7 +78,6 @@ class DispenseInPlaceImplementation(
                 push_out=params.pushOut,
             )
         except PipetteOverpressureError as e:
-            current_position = await self._gantry_mover.get_position(params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -1,6 +1,9 @@
 """Test blow-out command."""
-from decoy import Decoy
+from datetime import datetime
+from decoy import Decoy, matchers
 
+from opentrons.protocol_engine.commands.pipetting_common import OverpressureError
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.types import Point
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset, DeckPoint
 from opentrons.protocol_engine.state import update_types
@@ -10,28 +13,40 @@ from opentrons.protocol_engine.commands import (
     BlowOutImplementation,
     BlowOutParams,
 )
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
 from opentrons.protocol_engine.execution import (
     MovementHandler,
     PipettingHandler,
 )
 from opentrons.hardware_control import HardwareControlAPI
+from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
+import pytest
 
 
-async def test_blow_out_implementation(
-    decoy: Decoy,
+@pytest.fixture
+def subject(
     state_view: StateView,
     hardware_api: HardwareControlAPI,
     movement: MovementHandler,
+    model_utils: ModelUtils,
     pipetting: PipettingHandler,
-) -> None:
-    """Test BlowOut command execution."""
-    subject = BlowOutImplementation(
+) -> BlowOutImplementation:
+    return BlowOutImplementation(
         state_view=state_view,
         movement=movement,
         hardware_api=hardware_api,
         pipetting=pipetting,
+        model_utils=model_utils,
     )
+
+
+async def test_blow_out_implementation(
+    decoy: Decoy,
+    movement: MovementHandler,
+    pipetting: PipettingHandler,
+    subject: BlowOutImplementation,
+) -> None:
+    """Test BlowOut command execution."""
 
     location = WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1))
 
@@ -72,4 +87,58 @@ async def test_blow_out_implementation(
     decoy.verify(
         await pipetting.blow_out_in_place(pipette_id="pipette-id", flow_rate=1.234),
         times=1,
+    )
+
+
+async def test_overpressure_error(
+    decoy: Decoy,
+    pipetting: PipettingHandler,
+    subject: BlowOutImplementation,
+    model_utils: ModelUtils,
+    movement: MovementHandler,
+) -> None:
+    """It should return an overpressure error if the hardware API indicates that."""
+    pipette_id = "pipette-id"
+
+    error_id = "error-id"
+    error_timestamp = datetime(year=2020, month=1, day=2)
+
+    location = WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1))
+
+    data = BlowOutParams(
+        pipetteId="pipette-id",
+        labwareId="labware-id",
+        wellName="C6",
+        wellLocation=location,
+        flowRate=1.234,
+    )
+
+    decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
+        True
+    )
+
+    decoy.when(
+        await pipetting.blow_out_in_place(pipette_id="pipette-id", flow_rate=1.234)
+    ).then_raise(PipetteOverpressureError())
+
+    decoy.when(model_utils.generate_id()).then_return(error_id)
+    decoy.when(model_utils.get_timestamp()).then_return(error_timestamp)
+    decoy.when(
+        await movement.move_to_well(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="C6",
+            well_location=location,
+        )
+    ).then_return(Point(x=1, y=2, z=3))
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=OverpressureError.construct(
+            id=error_id,
+            createdAt=error_timestamp,
+            wrappedErrors=[matchers.Anything()],
+            errorInfo={"retryLocation": (1, 2, 3)},
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -31,6 +31,7 @@ def subject(
     model_utils: ModelUtils,
     pipetting: PipettingHandler,
 ) -> BlowOutImplementation:
+    """Get the impelementation subject."""
     return BlowOutImplementation(
         state_view=state_view,
         movement=movement,
@@ -47,7 +48,6 @@ async def test_blow_out_implementation(
     subject: BlowOutImplementation,
 ) -> None:
     """Test BlowOut command execution."""
-
     location = WellLocation(origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1))
 
     data = BlowOutParams(

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
@@ -45,7 +45,6 @@ async def test_blow_out_in_place_implementation(
     pipetting: PipettingHandler,
 ) -> None:
     """Test BlowOut command execution."""
-
     data = BlowOutInPlaceParams(
         pipetteId="pipette-id",
         flowRate=1.234,

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
@@ -1,33 +1,51 @@
 """Test blow-out-in-place commands."""
-from decoy import Decoy
+from datetime import datetime
+from decoy import Decoy, matchers
 
+from opentrons.protocol_engine.commands.pipetting_common import OverpressureError
+from opentrons.protocol_engine.execution.gantry_mover import GantryMover
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.commands.blow_out_in_place import (
     BlowOutInPlaceParams,
     BlowOutInPlaceResult,
     BlowOutInPlaceImplementation,
 )
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
 from opentrons.protocol_engine.execution import (
     MovementHandler,
     PipettingHandler,
 )
 from opentrons.hardware_control import HardwareControlAPI
+from opentrons.types import Point
+from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
+import pytest
+
+
+@pytest.fixture
+def subject(
+    pipetting: PipettingHandler,
+    state_view: StateView,
+    hardware_api: HardwareControlAPI,
+    model_utils: ModelUtils,
+    gantry_mover: GantryMover,
+) -> BlowOutInPlaceImplementation:
+    """Get the impelementation subject."""
+    return BlowOutInPlaceImplementation(
+        pipetting=pipetting,
+        hardware_api=hardware_api,
+        state_view=state_view,
+        model_utils=model_utils,
+        gantry_mover=gantry_mover,
+    )
 
 
 async def test_blow_out_in_place_implementation(
     decoy: Decoy,
-    state_view: StateView,
-    hardware_api: HardwareControlAPI,
-    movement: MovementHandler,
+    subject: BlowOutInPlaceImplementation,
     pipetting: PipettingHandler,
 ) -> None:
     """Test BlowOut command execution."""
-    subject = BlowOutInPlaceImplementation(
-        state_view=state_view,
-        hardware_api=hardware_api,
-        pipetting=pipetting,
-    )
 
     data = BlowOutInPlaceParams(
         pipetteId="pipette-id",
@@ -40,4 +58,48 @@ async def test_blow_out_in_place_implementation(
 
     decoy.verify(
         await pipetting.blow_out_in_place(pipette_id="pipette-id", flow_rate=1.234)
+    )
+
+
+async def test_overpressure_error(
+    decoy: Decoy,
+    gantry_mover: GantryMover,
+    pipetting: PipettingHandler,
+    subject: BlowOutInPlaceImplementation,
+    model_utils: ModelUtils,
+) -> None:
+    """It should return an overpressure error if the hardware API indicates that."""
+    pipette_id = "pipette-id"
+
+    position = Point(x=1, y=2, z=3)
+
+    error_id = "error-id"
+    error_timestamp = datetime(year=2020, month=1, day=2)
+
+    data = BlowOutInPlaceParams(
+        pipetteId=pipette_id,
+        flowRate=1.234,
+    )
+
+    decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
+        True
+    )
+
+    decoy.when(
+        await pipetting.blow_out_in_place(pipette_id="pipette-id", flow_rate=1.234)
+    ).then_raise(PipetteOverpressureError())
+
+    decoy.when(model_utils.generate_id()).then_return(error_id)
+    decoy.when(model_utils.get_timestamp()).then_return(error_timestamp)
+    decoy.when(await gantry_mover.get_position(pipette_id)).then_return(position)
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=OverpressureError.construct(
+            id=error_id,
+            createdAt=error_timestamp,
+            wrappedErrors=[matchers.Anything()],
+            errorInfo={"retryLocation": (position.x, position.y, position.z)},
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
@@ -13,7 +13,6 @@ from opentrons.protocol_engine.commands.blow_out_in_place import (
 )
 from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
 from opentrons.protocol_engine.execution import (
-    MovementHandler,
     PipettingHandler,
 )
 from opentrons.hardware_control import HardwareControlAPI


### PR DESCRIPTION
# Overview

fixed bug causing in place commands to fail the run [EXEC-707 ](https://opentrons.atlassian.net/browse/EXEC-707)
added defined errors for `BlowOutInPlace` and `BlowOut`.

## Test Plan and Hands on Testing

Tested on the FLEX.
upload the protocol from the ticket (its too long to post it here)
while dispensing in place trigger an over pressure error.
make sure the run is entering ER. 

## Changelog

moved logic to get pipette current position above the method that raises the over pressure error.
added defined errors for BlowOut and BlowOutInPlace.

## Review requests

changes make sense? 

## Risk assessment

low. bug fix and defined errors.