### PR TITLE
feat(protocol-designer): update StepSummary render logic and copy

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -36,7 +36,7 @@
     "engage": "<semiBoldText>{{module}}</semiBoldText><text>engaged to</text><tag/>"
   },
   "mix": "Mix",
-  "mix_step": "<text>Mixing</text><tag/><text>{{times}} times in</text><semiBoldText>{{labware}}</semiBoldText>",
+  "mix_step": "<text>Mixing</text><tag/><text>{{times}} times in</text><semiBoldText>{{wells}} of {{labware}}</semiBoldText>",
   "mix_repetitions": "Mix repetitions",
   "module": "Module",
   "move_labware": {
@@ -44,9 +44,9 @@
     "no_gripper": "<text>Move</text><semiBoldText>{{labware}}</semiBoldText><text>to</text><tag/>"
   },
   "move_liquid": {
-    "consolidate": "<text>Consolidating</text><tag/><text>from</text><semiBoldText>{{source}}</semiBoldText><text>to</text><semiBoldText>{{destination}}</semiBoldText>",
-    "distribute": "<text>Distributing</text><tag/><text>from</text><semiBoldText>{{source}}</semiBoldText><text>to</text><semiBoldText>{{destination}}</semiBoldText>",
-    "transfer": "<text>Transferring</text><tag/><text>from</text><semiBoldText>{{source}}</semiBoldText><text>to</text><semiBoldText>{{destination}}</semiBoldText>"
+    "consolidate": "<text>Consolidating</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destinationWells}} of {{destination}}</semiBoldText>",
+    "distribute": "<text>Distributing</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destinationWells}} of {{destination}}</semiBoldText>",
+    "transfer": "<text>Transferring</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destinationWells}} of {{destination}}</semiBoldText>"
   },
   "multiAspirate": "Consolidate path",
   "multiDispense": "Distribute path",

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -17,6 +17,7 @@
   "from": "from",
   "heater_shaker": {
     "active": {
+      "ambient": "ambient",
       "latch": "<text>Latch</text><tag/>",
       "shake": "<text>Shaking at</text><tag/>",
       "temperature": "<semiBoldText>{{module}}</semiBoldText><text>set to</text><tag/>",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -1,6 +1,8 @@
 import { useSelector } from 'react-redux'
 import { Trans, useTranslation } from 'react-i18next'
-import { first, flatten, last } from 'lodash'
+import first from 'lodash/first'
+import flatten from 'lodash/flatten'
+import last from 'lodash/last'
 import {
   ALIGN_CENTER,
   BORDERS,
@@ -381,15 +383,17 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       gridGap={SPACING.spacing4}
       width="100%"
     >
-      <Flex
-        backgroundColor={COLORS.grey30}
-        padding={SPACING.spacing12}
-        borderRadius={BORDERS.borderRadius4}
-        width={FLEX_MAX_CONTENT}
-        minWidth="100%"
-      >
-        {stepSummaryContent}
-      </Flex>
+      {stepSummaryContent != null ? (
+        <Flex
+          backgroundColor={COLORS.grey30}
+          padding={SPACING.spacing12}
+          borderRadius={BORDERS.borderRadius4}
+          width={FLEX_MAX_CONTENT}
+          minWidth="100%"
+        >
+          {stepSummaryContent}
+        </Flex>
+      ) : null}
       {stepDetails != null && stepDetails !== '' ? (
         <StyledText
           backgroundColor={COLORS.grey30}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -342,9 +342,13 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
             <StyledTrans
               i18nKey="protocol_steps:heater_shaker.active.temperature"
               values={{ module: moduleDisplayName }}
-              tagText={`${targetHeaterShakerTemperature ?? '-'}${t(
-                'application:units.degrees'
-              )}`}
+              tagText={
+                targetHeaterShakerTemperature != null
+                  ? `${targetHeaterShakerTemperature}${t(
+                      'application:units.degrees'
+                    )}`
+                  : t('protocol_steps:heater_shaker.active.ambient')
+              }
             />
             {targetSpeed != null ? (
               <StyledTrans

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -63,10 +63,10 @@ export function ProtocolSteps(): JSX.Element {
       ? savedStepForms[currentstepIdForStepSummary]
       : null
 
+  const stepDetails = currentStep?.stepDetails ?? null
   return (
     <Flex
       backgroundColor={COLORS.grey10}
-      // alignItems={ALIGN_CENTER}
       width="100%"
       gridGap={SPACING.spacing16}
       height="calc(100vh - 4rem)"
@@ -99,14 +99,21 @@ export function ProtocolSteps(): JSX.Element {
               />
             </Flex>
           ) : null}
-          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            gridGap={SPACING.spacing16}
+            maxWidth="46.9375rem"
+          >
             {deckView === leftString ? (
               <DeckSetupContainer tab="protocolSteps" />
             ) : (
               <OffDeck tab="protocolSteps" />
             )}
             {formData == null ? (
-              <StepSummary currentStep={currentStep} />
+              <StepSummary
+                currentStep={currentStep}
+                stepDetails={stepDetails}
+              />
             ) : null}
           </Flex>
         </Flex>

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -41,6 +41,8 @@ export function getDefaultsForStepType(
         pickUpTip_location: undefined,
         pickUpTip_wellNames: undefined,
         pipette: null,
+        stepDetails: null,
+        stepName: null,
         times: null,
         tipRack: null,
         volume: undefined,
@@ -101,6 +103,8 @@ export function getDefaultsForStepType(
         pickUpTip_wellNames: undefined,
         pipette: null,
         preWetTip: false,
+        stepDetails: null,
+        stepName: null,
         tipRack: null,
         volume: null,
       }
@@ -108,11 +112,15 @@ export function getDefaultsForStepType(
     case 'comment':
       return {
         message: null,
+        stepDetails: null,
+        stepName: null,
       }
     case 'moveLabware':
       return {
         labware: null,
         newLocation: null,
+        stepDetails: null,
+        stepName: null,
         useGripper: false,
       }
 
@@ -126,6 +134,8 @@ export function getDefaultsForStepType(
         pauseSecond: null,
         pauseTemperature: null,
         pauseTime: null,
+        stepDetails: null,
+        stepName: null,
       }
 
     case 'manualIntervention':
@@ -133,6 +143,8 @@ export function getDefaultsForStepType(
         labwareLocationUpdate: {},
         moduleLocationUpdate: {},
         pipetteLocationUpdate: {},
+        stepDetails: null,
+        stepName: null,
       }
 
     case 'magnet':
@@ -140,6 +152,8 @@ export function getDefaultsForStepType(
         engageHeight: null,
         magnetAction: null,
         moduleId: null,
+        stepDetails: null,
+        stepName: null,
       }
 
     case 'temperature':
@@ -147,6 +161,8 @@ export function getDefaultsForStepType(
         moduleId: null,
         setTemperature: null,
         targetTemperature: null,
+        stepDetails: null,
+        stepName: null,
       }
     case 'heaterShaker':
       return {
@@ -159,6 +175,8 @@ export function getDefaultsForStepType(
         setShake: null,
         targetHeaterShakerTemperature: null,
         targetSpeed: null,
+        stepDetails: null,
+        stepName: null,
       }
     case 'thermocycler':
       return {
@@ -177,6 +195,8 @@ export function getDefaultsForStepType(
         profileItemsById: {},
         profileTargetLidTemp: null,
         profileVolume: null,
+        stepDetails: null,
+        stepName: null,
         thermocyclerFormType: null,
       }
 

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -41,8 +41,6 @@ export function getDefaultsForStepType(
         pickUpTip_location: undefined,
         pickUpTip_wellNames: undefined,
         pipette: null,
-        stepDetails: null,
-        stepName: null,
         times: null,
         tipRack: null,
         volume: undefined,
@@ -103,8 +101,6 @@ export function getDefaultsForStepType(
         pickUpTip_wellNames: undefined,
         pipette: null,
         preWetTip: false,
-        stepDetails: null,
-        stepName: null,
         tipRack: null,
         volume: null,
       }
@@ -112,15 +108,11 @@ export function getDefaultsForStepType(
     case 'comment':
       return {
         message: null,
-        stepDetails: null,
-        stepName: null,
       }
     case 'moveLabware':
       return {
         labware: null,
         newLocation: null,
-        stepDetails: null,
-        stepName: null,
         useGripper: false,
       }
 
@@ -134,8 +126,6 @@ export function getDefaultsForStepType(
         pauseSecond: null,
         pauseTemperature: null,
         pauseTime: null,
-        stepDetails: null,
-        stepName: null,
       }
 
     case 'manualIntervention':
@@ -143,8 +133,6 @@ export function getDefaultsForStepType(
         labwareLocationUpdate: {},
         moduleLocationUpdate: {},
         pipetteLocationUpdate: {},
-        stepDetails: null,
-        stepName: null,
       }
 
     case 'magnet':
@@ -152,8 +140,6 @@ export function getDefaultsForStepType(
         engageHeight: null,
         magnetAction: null,
         moduleId: null,
-        stepDetails: null,
-        stepName: null,
       }
 
     case 'temperature':
@@ -161,8 +147,6 @@ export function getDefaultsForStepType(
         moduleId: null,
         setTemperature: null,
         targetTemperature: null,
-        stepDetails: null,
-        stepName: null,
       }
     case 'heaterShaker':
       return {
@@ -175,8 +159,6 @@ export function getDefaultsForStepType(
         setShake: null,
         targetHeaterShakerTemperature: null,
         targetSpeed: null,
-        stepDetails: null,
-        stepName: null,
       }
     case 'thermocycler':
       return {
@@ -195,8 +177,6 @@ export function getDefaultsForStepType(
         profileItemsById: {},
         profileTargetLidTemp: null,
         profileVolume: null,
-        stepDetails: null,
-        stepName: null,
         thermocyclerFormType: null,
       }
 


### PR DESCRIPTION
# Overview

This PR updates when StepSummaries show and updates copy to reflect final decisions. The intended behavior is to only show StepSummary when a step is hovered or selected, but not when the step form is open. Hovered StepSummaries take precedence over those of selected steps. I also add an optional second element to StepSummary that will display the step's notes if they exists.

Closes AUTH-886

## Test Plan and Hands on Testing

- Select a step without opening step form edit toolbox and move cursor off the timeline toolbox. Verify that the step summary under the deck map describes the selected step
- With step still selected, hover over a different step in the timeline and verify that the step summary describes the hovered step
- Add a description to a step by opening step form edit toolbox and clicking rename to open rename modal
- Save the step form, produce the step's summary by hovering the step, and verify that the step description shows

https://github.com/user-attachments/assets/1cb8a0c2-3f36-4a7b-9973-3ac13d9036c5

## Changelog

- fix logic for which step summary if any shows
- add step description to step summary

## Review requests

see test plan

## Risk assessment

low