### PR TITLE
fix(protocol-designer): fix create button clickable area issue

### DIFF
--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -80,7 +80,6 @@ export function Landing(): JSX.Element {
       <StyledNavLink to={'/createNew'}>
         <LargeButton
           onClick={() => {
-            console.log('clicked')
             dispatch(toggleNewProtocolModal(true))
           }}
           buttonText={<ButtonText>{t('create_a_protocol')}</ButtonText>}

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -77,16 +77,15 @@ export function Landing(): JSX.Element {
           </StyledText>
         </Flex>
       </Flex>
-      <LargeButton
-        onClick={() => {
-          dispatch(toggleNewProtocolModal(true))
-        }}
-        buttonText={
-          <StyledNavLink to={'/createNew'}>
-            <ButtonText>{t('create_a_protocol')}</ButtonText>
-          </StyledNavLink>
-        }
-      />
+      <StyledNavLink to={'/createNew'}>
+        <LargeButton
+          onClick={() => {
+            console.log('clicked')
+            dispatch(toggleNewProtocolModal(true))
+          }}
+          buttonText={<ButtonText>{t('create_a_protocol')}</ButtonText>}
+        />
+      </StyledNavLink>
       <StyledLabel>
         <Flex css={BUTTON_LINK_STYLE}>
           <StyledText desktopStyle="bodyLargeRegular">


### PR DESCRIPTION

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix create button clickable area issue
the issue is that `StyledNavLink` wraps only text. now it wraps the button.

close RQA-3359
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
go to https://sandbox.designer.opentrons.com/fix_RQA-3359/
1. click the blue part of create a protocol button
check PD moves to the create page
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
