### PR TITLE
test(abt): fix Makefile variable

### DIFF
--- a/analyses-snapshot-testing/Makefile
+++ b/analyses-snapshot-testing/Makefile
@@ -84,7 +84,7 @@ build-opentrons-analysis:
 	@echo "The image will be named opentrons-analysis:$(ANALYSIS_REF)"
 	@echo "If you want to build a different version, run 'make build-opentrons-analysis ANALYSIS_REF=<version>'"
 	@echo "Cache is always busted to ensure latest version of the code is used"
-	docker build --build-arg OPENTRONS_VERSION=$(ANALYSIS_REF) --build-arg CACHEBUST=$(CACHEBUST) -t opentrons-analysis:$(ANALYSIS_REF) citools/.
+	docker build --build-arg ANALYSIS_REF=$(ANALYSIS_REF) --build-arg CACHEBUST=$(CACHEBUST) -t opentrons-analysis:$(ANALYSIS_REF) citools/.
 
 .PHONY: generate-protocols
 generate-protocols:


### PR DESCRIPTION
# Overview

Thank you @SyntaxColoring !

> OPENTRONS_VERSION was shifted to a different set of tools in the Makefile and I missed this rename.

[PR 16518](https://github.com/Opentrons/opentrons/pull/16518) changed an error message. The branch was based on a recent edge (~2 hours ago). The analyses snapshot tests [ran on it and reported no mismatches](https://github.com/Opentrons/opentrons/actions/runs/11392247090/job/31697875735).
Now that that commit has hit edge, [the tests ARE reporting a mismatch](https://github.com/Opentrons/opentrons/actions/runs/11393719961/job/31702596080).
There have been no changes to the analysis-snapshot-testing/ directory in the past week.

## Test Plan and Hands on Testing

- [x] locally the right branch is cloned
- [x] In CI the right branch is cloned

[See the right branch referenced in this PR](https://github.com/Opentrons/opentrons/actions/runs/11394418067/job/31704702684?pr=16525#step:4:308)  
