### PR TITLE
refactor(app): update desktop RecoveryOptions

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -14,14 +14,8 @@ import {
   RECOVERY_MAP,
   ERROR_KINDS,
   ODD_SECTION_TITLE_STYLE,
-  ODD_ONLY,
-  DESKTOP_ONLY,
 } from '../constants'
-import {
-  RecoveryODDOneDesktopTwoColumnContentWrapper,
-  RecoveryRadioGroup,
-  FailedStepNextStep,
-} from '../shared'
+import { RecoverySingleColumnContentWrapper } from '../shared'
 
 import type { ErrorKind, RecoveryContentProps, RecoveryRoute } from '../types'
 import type { PipetteWithTip } from '/app/organisms/DropTipWizardFlows'
@@ -52,7 +46,7 @@ export function SelectRecoveryOptionHome({
   currentRecoveryOptionUtils,
   getRecoveryOptionCopy,
   analytics,
-  ...rest
+  isOnDevice,
 }: RecoveryContentProps): JSX.Element | null {
   const { t } = useTranslation('error_recovery')
   const { proceedToRouteAndStep } = routeUpdateActions
@@ -66,7 +60,7 @@ export function SelectRecoveryOptionHome({
   useCurrentTipStatus(determineTipStatus)
 
   return (
-    <RecoveryODDOneDesktopTwoColumnContentWrapper
+    <RecoverySingleColumnContentWrapper
       footerDetails={{
         primaryBtnOnClick: () => {
           analytics.reportActionSelectedEvent(selectedRoute)
@@ -83,27 +77,16 @@ export function SelectRecoveryOptionHome({
         >
           {t('choose_a_recovery_action')}
         </StyledText>
-        <Flex css={ODD_ONLY}>
-          <ODDRecoveryOptions
-            validRecoveryOptions={validRecoveryOptions}
-            setSelectedRoute={setSelectedRoute}
-            selectedRoute={selectedRoute}
-            getRecoveryOptionCopy={getRecoveryOptionCopy}
-            errorKind={errorKind}
-          />
-        </Flex>
-        <Flex css={DESKTOP_ONLY}>
-          <DesktopRecoveryOptions
-            validRecoveryOptions={validRecoveryOptions}
-            setSelectedRoute={setSelectedRoute}
-            selectedRoute={selectedRoute}
-            getRecoveryOptionCopy={getRecoveryOptionCopy}
-            errorKind={errorKind}
-          />
-        </Flex>
+        <RecoveryOptions
+          validRecoveryOptions={validRecoveryOptions}
+          setSelectedRoute={setSelectedRoute}
+          selectedRoute={selectedRoute}
+          getRecoveryOptionCopy={getRecoveryOptionCopy}
+          errorKind={errorKind}
+          isOnDevice={isOnDevice}
+        />
       </Flex>
-      <FailedStepNextStep {...rest} />
-    </RecoveryODDOneDesktopTwoColumnContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }
 
@@ -111,16 +94,18 @@ interface RecoveryOptionsProps {
   validRecoveryOptions: RecoveryRoute[]
   setSelectedRoute: (route: RecoveryRoute) => void
   getRecoveryOptionCopy: RecoveryContentProps['getRecoveryOptionCopy']
-  errorKind: ErrorKind
+  errorKind: RecoveryContentProps['errorKind']
+  isOnDevice: RecoveryContentProps['isOnDevice']
   selectedRoute?: RecoveryRoute
 }
-// For ODD use only.
-export function ODDRecoveryOptions({
+
+export function RecoveryOptions({
   errorKind,
   validRecoveryOptions,
   selectedRoute,
   setSelectedRoute,
   getRecoveryOptionCopy,
+  isOnDevice,
 }: RecoveryOptionsProps): JSX.Element {
   return (
     <Flex
@@ -140,6 +125,7 @@ export function ODDRecoveryOptions({
             }}
             isSelected={recoveryOption === selectedRoute}
             radioButtonType="large"
+            largeDesktopBorderRadius={!isOnDevice}
           />
         )
       })}
@@ -147,38 +133,6 @@ export function ODDRecoveryOptions({
   )
 }
 
-export function DesktopRecoveryOptions({
-  errorKind,
-  validRecoveryOptions,
-  selectedRoute,
-  setSelectedRoute,
-  getRecoveryOptionCopy,
-}: RecoveryOptionsProps): JSX.Element {
-  return (
-    <RecoveryRadioGroup
-      css={RADIO_GAP}
-      onChange={e => {
-        setSelectedRoute(e.currentTarget.value)
-      }}
-      value={selectedRoute}
-      options={validRecoveryOptions.map(
-        (option: RecoveryRoute) =>
-          ({
-            value: option,
-            children: (
-              <StyledText
-                desktopStyle="bodyDefaultRegular"
-                role="label"
-                htmlFor={option}
-              >
-                {getRecoveryOptionCopy(option, errorKind)}
-              </StyledText>
-            ),
-          } as const)
-      )}
-    />
-  )
-}
 // Pre-fetch tip attachment status. Users are not blocked from proceeding at this step.
 export function useCurrentTipStatus(
   determineTipStatus: () => Promise<PipetteWithTip[]>
@@ -254,7 +208,3 @@ export const GENERAL_ERROR_OPTIONS: RecoveryRoute[] = [
   RECOVERY_MAP.RETRY_STEP.ROUTE,
   RECOVERY_MAP.CANCEL_RUN.ROUTE,
 ]
-
-const RADIO_GAP = `
-  gap: ${SPACING.spacing4};
-`

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SelectRecoveryOptions.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SelectRecoveryOptions.test.tsx
@@ -8,8 +8,7 @@ import { i18n } from '/app/i18n'
 import { mockRecoveryContentProps } from '../../__fixtures__'
 import {
   SelectRecoveryOption,
-  ODDRecoveryOptions,
-  DesktopRecoveryOptions,
+  RecoveryOptions,
   getRecoveryOptions,
   GENERAL_ERROR_OPTIONS,
   OVERPRESSURE_WHILE_ASPIRATING_OPTIONS,
@@ -36,21 +35,13 @@ const renderSelectRecoveryOption = (
   )[0]
 }
 
-const renderODDRecoveryOptions = (
-  props: React.ComponentProps<typeof ODDRecoveryOptions>
+const renderRecoveryOptions = (
+  props: React.ComponentProps<typeof RecoveryOptions>
 ) => {
-  return renderWithProviders(<ODDRecoveryOptions {...props} />, {
+  return renderWithProviders(<RecoveryOptions {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
-const renderDesktopRecoveryOptions = (
-  props: React.ComponentProps<typeof DesktopRecoveryOptions>
-) => {
-  return renderWithProviders(<DesktopRecoveryOptions {...props} />, {
-    i18nInstance: i18n,
-  })[0]
-}
-
 describe('SelectRecoveryOption', () => {
   const { RETRY_STEP, RETRY_NEW_TIPS } = RECOVERY_MAP
   let props: React.ComponentProps<typeof SelectRecoveryOption>
@@ -241,194 +232,188 @@ describe('SelectRecoveryOption', () => {
     )
   })
 })
-;([
-  ['desktop', renderDesktopRecoveryOptions] as const,
-  ['odd', renderODDRecoveryOptions] as const,
-] as const).forEach(([target, renderer]) => {
-  describe(`RecoveryOptions on ${target}`, () => {
-    let props: React.ComponentProps<typeof DesktopRecoveryOptions>
-    let mockSetSelectedRoute: Mock
-    let mockGetRecoveryOptionCopy: Mock
+describe('RecoveryOptions', () => {
+  let props: React.ComponentProps<typeof RecoveryOptions>
+  let mockSetSelectedRoute: Mock
+  let mockGetRecoveryOptionCopy: Mock
 
-    beforeEach(() => {
-      mockSetSelectedRoute = vi.fn()
-      mockGetRecoveryOptionCopy = vi.fn()
-      const generalRecoveryOptions = getRecoveryOptions(
-        ERROR_KINDS.GENERAL_ERROR
+  beforeEach(() => {
+    mockSetSelectedRoute = vi.fn()
+    mockGetRecoveryOptionCopy = vi.fn()
+    const generalRecoveryOptions = getRecoveryOptions(ERROR_KINDS.GENERAL_ERROR)
+
+    props = {
+      errorKind: ERROR_KINDS.GENERAL_ERROR,
+      validRecoveryOptions: generalRecoveryOptions,
+      setSelectedRoute: mockSetSelectedRoute,
+      getRecoveryOptionCopy: mockGetRecoveryOptionCopy,
+      isOnDevice: true,
+    }
+
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(RECOVERY_MAP.RETRY_STEP.ROUTE, expect.any(String))
+      .thenReturn('Retry step')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(RECOVERY_MAP.RETRY_STEP.ROUTE, ERROR_KINDS.TIP_DROP_FAILED)
+      .thenReturn('Retry dropping tip')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(RECOVERY_MAP.CANCEL_RUN.ROUTE, expect.any(String))
+      .thenReturn('Cancel run')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE, expect.any(String))
+      .thenReturn('Retry with new tips')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(RECOVERY_MAP.MANUAL_FILL_AND_SKIP.ROUTE, expect.any(String))
+      .thenReturn('Manually fill well and skip to next step')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE, expect.any(String))
+      .thenReturn('Retry with same tips')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(
+        RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE,
+        expect.any(String)
       )
-
-      props = {
-        errorKind: ERROR_KINDS.GENERAL_ERROR,
-        validRecoveryOptions: generalRecoveryOptions,
-        setSelectedRoute: mockSetSelectedRoute,
-        getRecoveryOptionCopy: mockGetRecoveryOptionCopy,
-      }
-
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(RECOVERY_MAP.RETRY_STEP.ROUTE, expect.any(String))
-        .thenReturn('Retry step')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(RECOVERY_MAP.RETRY_STEP.ROUTE, ERROR_KINDS.TIP_DROP_FAILED)
-        .thenReturn('Retry dropping tip')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(RECOVERY_MAP.CANCEL_RUN.ROUTE, expect.any(String))
-        .thenReturn('Cancel run')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE, expect.any(String))
-        .thenReturn('Retry with new tips')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(RECOVERY_MAP.MANUAL_FILL_AND_SKIP.ROUTE, expect.any(String))
-        .thenReturn('Manually fill well and skip to next step')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE, expect.any(String))
-        .thenReturn('Retry with same tips')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(
-          RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE,
-          expect.any(String)
-        )
-        .thenReturn('Skip to next step with same tips')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(
-          RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE,
-          expect.any(String)
-        )
-        .thenReturn('Skip to next step with new tips')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(RECOVERY_MAP.IGNORE_AND_SKIP.ROUTE, expect.any(String))
-        .thenReturn('Ignore error and skip to next step')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE, expect.any(String))
-        .thenReturn('Manually move labware and skip to next step')
-      when(mockGetRecoveryOptionCopy)
-        .calledWith(
-          RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.ROUTE,
-          expect.any(String)
-        )
-        .thenReturn('Manually replace labware on deck and retry step')
-    })
-
-    it('renders valid recovery options for a general error errorKind', () => {
-      renderer(props)
-
-      screen.getByRole('label', { name: 'Retry step' })
-      screen.getByRole('label', { name: 'Cancel run' })
-    })
-
-    it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING} errorKind`, () => {
-      props = {
-        ...props,
-        validRecoveryOptions: OVERPRESSURE_WHILE_ASPIRATING_OPTIONS,
-      }
-
-      renderer(props)
-
-      screen.getByRole('label', { name: 'Retry with new tips' })
-      screen.getByRole('label', { name: 'Cancel run' })
-    })
-
-    it('updates the selectedRoute when a new option is selected', () => {
-      renderer(props)
-
-      fireEvent.click(screen.getByRole('label', { name: 'Cancel run' }))
-
-      expect(mockSetSelectedRoute).toHaveBeenCalledWith(
-        RECOVERY_MAP.CANCEL_RUN.ROUTE
+      .thenReturn('Skip to next step with same tips')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(
+        RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE,
+        expect.any(String)
       )
+      .thenReturn('Skip to next step with new tips')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(RECOVERY_MAP.IGNORE_AND_SKIP.ROUTE, expect.any(String))
+      .thenReturn('Ignore error and skip to next step')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE, expect.any(String))
+      .thenReturn('Manually move labware and skip to next step')
+    when(mockGetRecoveryOptionCopy)
+      .calledWith(
+        RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.ROUTE,
+        expect.any(String)
+      )
+      .thenReturn('Manually replace labware on deck and retry step')
+  })
+
+  it('renders valid recovery options for a general error errorKind', () => {
+    renderRecoveryOptions(props)
+
+    screen.getByRole('label', { name: 'Retry step' })
+    screen.getByRole('label', { name: 'Cancel run' })
+  })
+
+  it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING} errorKind`, () => {
+    props = {
+      ...props,
+      validRecoveryOptions: OVERPRESSURE_WHILE_ASPIRATING_OPTIONS,
+    }
+
+    renderRecoveryOptions(props)
+
+    screen.getByRole('label', { name: 'Retry with new tips' })
+    screen.getByRole('label', { name: 'Cancel run' })
+  })
+
+  it('updates the selectedRoute when a new option is selected', () => {
+    renderRecoveryOptions(props)
+
+    fireEvent.click(screen.getByRole('label', { name: 'Cancel run' }))
+
+    expect(mockSetSelectedRoute).toHaveBeenCalledWith(
+      RECOVERY_MAP.CANCEL_RUN.ROUTE
+    )
+  })
+
+  it(`renders valid recovery options for a ${ERROR_KINDS.NO_LIQUID_DETECTED} errorKind`, () => {
+    props = {
+      ...props,
+      validRecoveryOptions: NO_LIQUID_DETECTED_OPTIONS,
+    }
+
+    renderRecoveryOptions(props)
+
+    screen.getByRole('label', {
+      name: 'Manually fill well and skip to next step',
     })
+    screen.getByRole('label', { name: 'Ignore error and skip to next step' })
+    screen.getByRole('label', { name: 'Cancel run' })
+  })
 
-    it(`renders valid recovery options for a ${ERROR_KINDS.NO_LIQUID_DETECTED} errorKind`, () => {
-      props = {
-        ...props,
-        validRecoveryOptions: NO_LIQUID_DETECTED_OPTIONS,
-      }
+  it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE} errorKind`, () => {
+    props = {
+      ...props,
+      validRecoveryOptions: OVERPRESSURE_PREPARE_TO_ASPIRATE,
+    }
 
-      renderer(props)
+    renderRecoveryOptions(props)
 
-      screen.getByRole('label', {
-        name: 'Manually fill well and skip to next step',
-      })
-      screen.getByRole('label', { name: 'Ignore error and skip to next step' })
-      screen.getByRole('label', { name: 'Cancel run' })
+    screen.getByRole('label', { name: 'Retry with new tips' })
+    screen.getByRole('label', { name: 'Retry with same tips' })
+    screen.getByRole('label', { name: 'Cancel run' })
+  })
+
+  it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING} errorKind`, () => {
+    props = {
+      ...props,
+      validRecoveryOptions: OVERPRESSURE_WHILE_DISPENSING_OPTIONS,
+    }
+
+    renderRecoveryOptions(props)
+
+    screen.getByRole('label', { name: 'Skip to next step with same tips' })
+    screen.getByRole('label', { name: 'Skip to next step with new tips' })
+    screen.getByRole('label', { name: 'Cancel run' })
+  })
+
+  it(`renders valid recovery options for a ${ERROR_KINDS.TIP_NOT_DETECTED} errorKind`, () => {
+    props = {
+      ...props,
+      validRecoveryOptions: TIP_NOT_DETECTED_OPTIONS,
+    }
+
+    renderRecoveryOptions(props)
+
+    screen.getByRole('label', {
+      name: 'Retry step',
     })
-
-    it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE} errorKind`, () => {
-      props = {
-        ...props,
-        validRecoveryOptions: OVERPRESSURE_PREPARE_TO_ASPIRATE,
-      }
-
-      renderer(props)
-
-      screen.getByRole('label', { name: 'Retry with new tips' })
-      screen.getByRole('label', { name: 'Retry with same tips' })
-      screen.getByRole('label', { name: 'Cancel run' })
+    screen.getByRole('label', {
+      name: 'Ignore error and skip to next step',
     })
+    screen.getByRole('label', { name: 'Cancel run' })
+  })
 
-    it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING} errorKind`, () => {
-      props = {
-        ...props,
-        validRecoveryOptions: OVERPRESSURE_WHILE_DISPENSING_OPTIONS,
-      }
+  it(`renders valid recovery options for a ${ERROR_KINDS.TIP_DROP_FAILED} errorKind`, () => {
+    props = {
+      ...props,
+      errorKind: ERROR_KINDS.TIP_DROP_FAILED,
+      validRecoveryOptions: TIP_DROP_FAILED_OPTIONS,
+    }
 
-      renderer(props)
+    renderRecoveryOptions(props)
 
-      screen.getByRole('label', { name: 'Skip to next step with same tips' })
-      screen.getByRole('label', { name: 'Skip to next step with new tips' })
-      screen.getByRole('label', { name: 'Cancel run' })
+    screen.getByRole('label', {
+      name: 'Retry dropping tip',
     })
-
-    it(`renders valid recovery options for a ${ERROR_KINDS.TIP_NOT_DETECTED} errorKind`, () => {
-      props = {
-        ...props,
-        validRecoveryOptions: TIP_NOT_DETECTED_OPTIONS,
-      }
-
-      renderer(props)
-
-      screen.getByRole('label', {
-        name: 'Retry step',
-      })
-      screen.getByRole('label', {
-        name: 'Ignore error and skip to next step',
-      })
-      screen.getByRole('label', { name: 'Cancel run' })
+    screen.getByRole('label', {
+      name: 'Ignore error and skip to next step',
     })
+    screen.getByRole('label', { name: 'Cancel run' })
+  })
 
-    it(`renders valid recovery options for a ${ERROR_KINDS.TIP_DROP_FAILED} errorKind`, () => {
-      props = {
-        ...props,
-        errorKind: ERROR_KINDS.TIP_DROP_FAILED,
-        validRecoveryOptions: TIP_DROP_FAILED_OPTIONS,
-      }
+  it(`renders valid recovery options for a ${ERROR_KINDS.GRIPPER_ERROR} errorKind`, () => {
+    props = {
+      ...props,
+      validRecoveryOptions: GRIPPER_ERROR_OPTIONS,
+    }
 
-      renderer(props)
+    renderRecoveryOptions(props)
 
-      screen.getByRole('label', {
-        name: 'Retry dropping tip',
-      })
-      screen.getByRole('label', {
-        name: 'Ignore error and skip to next step',
-      })
-      screen.getByRole('label', { name: 'Cancel run' })
+    screen.getByRole('label', {
+      name: 'Manually move labware and skip to next step',
     })
-
-    it(`renders valid recovery options for a ${ERROR_KINDS.GRIPPER_ERROR} errorKind`, () => {
-      props = {
-        ...props,
-        validRecoveryOptions: GRIPPER_ERROR_OPTIONS,
-      }
-
-      renderer(props)
-
-      screen.getByRole('label', {
-        name: 'Manually move labware and skip to next step',
-      })
-      screen.getByRole('label', {
-        name: 'Manually replace labware on deck and retry step',
-      })
-      screen.getByRole('label', { name: 'Cancel run' })
+    screen.getByRole('label', {
+      name: 'Manually replace labware on deck and retry step',
     })
+    screen.getByRole('label', { name: 'Cancel run' })
   })
 })
 


### PR DESCRIPTION
Closes [EXEC-739](https://opentrons.atlassian.net/browse/EXEC-739)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Part of the design unification work has entailed adding desktop support for `RadioButton`. Per design, we'd like to use the new look in the [SelectRecoveryOption view](https://www.figma.com/design/OGssKRmCOvuXSqUpK2qXrV/Feature%3A-Error-Recovery-November-Release?node-id=9769-70828&t=iHLzx4tjJpLvYhqd-4). 

Unfortunately, there's still some special casing logic that has to occur, because we need the 'desktop' border radius (PD uses both the ODD and desktop border radius styles, so we can't make a hard and fast style rule for the component). It might be worth extending `RadioGroup` to some sort of app molecule `RadioGroup` and enforce the border radius styling there, but it's probably worth talking to design before doing that.

<img width="1017" alt="Screenshot 2024-10-18 at 9 34 21 AM" src="https://github.com/user-attachments/assets/121afd63-9def-4e87-be62-24d62e663ea3">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-739]: https://opentrons.atlassian.net/browse/EXEC-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ