### PR TITLE
refactor(api): Allow adding/removing tips on HW API without `await`

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1285,7 +1285,7 @@ class API(
         instrument.set_current_volume(0)
 
         self.set_current_tiprack_diameter(mount, 0.0)
-        await self.remove_tip(mount)
+        self.remove_tip(mount)
 
     async def create_simulating_module(
         self,

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -415,7 +415,7 @@ class PipetteHandlerProvider(Generic[MountType]):
         if instr:
             instr.reset_nozzle_configuration()
 
-    async def add_tip(self, mount: MountType, tip_length: float) -> None:
+    def add_tip(self, mount: MountType, tip_length: float) -> None:
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments
         instr_dict = attached[mount]
@@ -430,7 +430,7 @@ class PipetteHandlerProvider(Generic[MountType]):
                 f"attach tip called while tip already attached to {instr}"
             )
 
-    async def remove_tip(self, mount: MountType) -> None:
+    def remove_tip(self, mount: MountType) -> None:
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments
         instr_dict = attached[mount]

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -425,7 +425,7 @@ class OT3PipetteHandler:
         if instr:
             instr.reset_nozzle_configuration()
 
-    async def add_tip(self, mount: OT3Mount, tip_length: float) -> None:
+    def add_tip(self, mount: OT3Mount, tip_length: float) -> None:
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments
         instr_dict = attached[mount]
@@ -440,7 +440,7 @@ class OT3PipetteHandler:
                 "attach tip called while tip already attached to {instr}"
             )
 
-    async def remove_tip(self, mount: OT3Mount) -> None:
+    def remove_tip(self, mount: OT3Mount) -> None:
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments
         instr_dict = attached[mount]

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -819,13 +819,13 @@ async def find_pipette_offset(
     try:
         if reset_instrument_offset:
             await hcapi.reset_instrument_offset(mount)
-        await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
+        hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
         offset = await _calibrate_mount(
             hcapi, mount, slot, method, raise_verify_error, probe=probe
         )
         return offset
     finally:
-        await hcapi.remove_tip(mount)
+        hcapi.remove_tip(mount)
 
 
 async def calibrate_pipette(
@@ -877,7 +877,7 @@ async def calibrate_module(
         if mount == OT3Mount.GRIPPER:
             hcapi.add_gripper_probe(GripperProbe.FRONT)
         else:
-            await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
+            hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
 
         LOG.info(
             f"Starting module calibration for {module_id} at {nominal_position} using {mount}"
@@ -903,7 +903,7 @@ async def calibrate_module(
             hcapi.remove_gripper_probe()
             await hcapi.ungrip()
         else:
-            await hcapi.remove_tip(mount)
+            hcapi.remove_tip(mount)
 
 
 async def calibrate_belts(
@@ -927,7 +927,7 @@ async def calibrate_belts(
         raise RuntimeError("Must use pipette mount, not gripper")
     try:
         hcapi.reset_deck_calibration()
-        await hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
+        hcapi.add_tip(mount, hcapi.config.calibration.probe_length)
         belt_attitude, alignment_details = await _determine_transform_matrix(
             hcapi, mount
         )
@@ -935,7 +935,7 @@ async def calibrate_belts(
         return belt_attitude, alignment_details
     finally:
         hcapi.load_deck_calibration()
-        await hcapi.remove_tip(mount)
+        hcapi.remove_tip(mount)
 
 
 def apply_machine_transform(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2607,13 +2607,13 @@ class OT3API(
                 starting_nozzle,
             )
 
-    async def add_tip(
+    def add_tip(
         self, mount: Union[top_types.Mount, OT3Mount], tip_length: float
     ) -> None:
-        await self._pipette_handler.add_tip(OT3Mount.from_mount(mount), tip_length)
+        self._pipette_handler.add_tip(OT3Mount.from_mount(mount), tip_length)
 
-    async def remove_tip(self, mount: Union[top_types.Mount, OT3Mount]) -> None:
-        await self._pipette_handler.remove_tip(OT3Mount.from_mount(mount))
+    def remove_tip(self, mount: Union[top_types.Mount, OT3Mount]) -> None:
+        self._pipette_handler.remove_tip(OT3Mount.from_mount(mount))
 
     def add_gripper_probe(self, probe: GripperProbe) -> None:
         self._gripper_handler.add_probe(probe)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2338,7 +2338,7 @@ class OT3API(
         instrument.set_current_volume(0)
 
         self.set_current_tiprack_diameter(mount, 0.0)
-        await self.remove_tip(mount)
+        self.remove_tip(mount)
 
     async def clean_up(self) -> None:
         """Get the API ready to stop cleanly."""

--- a/api/src/opentrons/hardware_control/protocols/__init__.py
+++ b/api/src/opentrons/hardware_control/protocols/__init__.py
@@ -86,7 +86,7 @@ class FlexHardwareControlInterface(
 
 
 __all__ = [
-    "HardwareControlAPI",
+    "HardwareControlInterface",
     "FlexHardwareControlInterface",
     "Simulatable",
     "Stoppable",

--- a/api/src/opentrons/hardware_control/protocols/__init__.py
+++ b/api/src/opentrons/hardware_control/protocols/__init__.py
@@ -58,11 +58,6 @@ class HardwareControlInterface(
     def get_robot_type(self) -> Type[OT2RobotType]:
         return OT2RobotType
 
-    # todo(mm, 2024-10-17): This probably belongs in InstrumentConfigurer, alongside
-    # add_tip() and remove_tip().
-    def cache_tip(self, mount: MountArgType, tip_length: float) -> None:
-        ...
-
 
 class FlexHardwareControlInterface(
     PositionEstimator,
@@ -88,11 +83,6 @@ class FlexHardwareControlInterface(
 
     def get_robot_type(self) -> Type[FlexRobotType]:
         return FlexRobotType
-
-    # todo(mm, 2024-10-17): This probably belongs in InstrumentConfigurer, alongside
-    # add_tip() and remove_tip().
-    def cache_tip(self, mount: MountArgType, tip_length: float) -> None:
-        ...
 
 
 __all__ = [

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -152,6 +152,9 @@ class InstrumentConfigurer(Protocol[MountArgType]):
         """
         ...
 
+    def cache_tip(self, mount: MountArgType, tip_length: float) -> None:
+        ...
+
     def remove_tip(self, mount: MountArgType) -> None:
         """Inform the hardware that a tip is no longer attached to a pipette.
 

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -142,10 +142,9 @@ class InstrumentConfigurer(Protocol[MountArgType]):
         """
         ...
 
-    # todo(mm, 2024-10-17): Can this be made non-async?
     # todo(mm, 2024-10-17): Consider deleting this in favor of cache_tip(), which is
     # the same except for `assert`s, if we can do so without breaking anything.
-    async def add_tip(self, mount: MountArgType, tip_length: float) -> None:
+    def add_tip(self, mount: MountArgType, tip_length: float) -> None:
         """Inform the hardware that a tip is now attached to a pipette.
 
         This changes the critical point of the pipette to make sure that
@@ -153,8 +152,7 @@ class InstrumentConfigurer(Protocol[MountArgType]):
         """
         ...
 
-    # todo(mm, 2024-10-17): Can this be made non-async?
-    async def remove_tip(self, mount: MountArgType) -> None:
+    def remove_tip(self, mount: MountArgType) -> None:
         """Inform the hardware that a tip is no longer attached to a pipette.
 
         This changes the critical point of the system to the end of the

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -276,14 +276,14 @@ class HardwareTipHandler(TipHandler):
         # Allow TipNotAttachedError to propagate.
         await self.verify_tip_presence(pipette_id, TipPresenceStatus.ABSENT)
 
-        await self._hardware_api.remove_tip(hw_mount)
+        self._hardware_api.remove_tip(hw_mount)
         self._hardware_api.set_current_tiprack_diameter(hw_mount, 0)
 
     async def add_tip(self, pipette_id: str, tip: TipGeometry) -> None:
         """See documentation on abstract base class."""
         hw_mount = self._state_view.pipettes.get_mount(pipette_id).to_hw_mount()
 
-        await self._hardware_api.add_tip(mount=hw_mount, tip_length=tip.length)
+        self._hardware_api.add_tip(mount=hw_mount, tip_length=tip.length)
 
         self._hardware_api.set_current_tiprack_diameter(
             mount=hw_mount,

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -491,7 +491,7 @@ async def test_shake_during_drop(
         },
     }
     await hardware_api.cache_instruments()
-    await hardware_api.add_tip(types.Mount.RIGHT, 50.0)
+    hardware_api.add_tip(types.Mount.RIGHT, 50.0)
     hardware_api.set_current_tiprack_diameter(types.Mount.RIGHT, 2.0 * 4)
 
     shake_tips_drop = mock.Mock(side_effect=hardware_api._shake_off_tips_drop)
@@ -515,7 +515,7 @@ async def test_shake_during_drop(
 
     # Test drop tip shake with 25% of tiprack well diameter
     # over upper (2.25 mm) limit
-    await hardware_api.add_tip(types.Mount.RIGHT, 20)
+    hardware_api.add_tip(types.Mount.RIGHT, 20)
     hardware_api.set_current_tiprack_diameter(types.Mount.RIGHT, 2.3 * 4)
     shake_tips_drop.reset_mock()
     move_rel.reset_move()
@@ -530,7 +530,7 @@ async def test_shake_during_drop(
 
     # Test drop tip shake with 25% of tiprack well diameter
     # below lower (1.0 mm) limit
-    await hardware_api.add_tip(types.Mount.RIGHT, 50)
+    hardware_api.add_tip(types.Mount.RIGHT, 50)
     hardware_api.set_current_tiprack_diameter(types.Mount.RIGHT, 0.9 * 4)
     shake_tips_drop.reset_mock()
     move_rel.reset_mock()

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -812,7 +812,7 @@ async def test_liquid_probe(
     pipette = ot3_hardware.hardware_pipettes[mount.to_mount()]
 
     assert pipette
-    await ot3_hardware.add_tip(mount, 100)
+    ot3_hardware.add_tip(mount, 100)
     await ot3_hardware.home()
     mock_move_to.return_value = None
 
@@ -905,7 +905,7 @@ async def test_liquid_probe_plunger_moves(
     pipette = ot3_hardware.hardware_pipettes[mount.to_mount()]
 
     assert pipette
-    await ot3_hardware.add_tip(mount, 100)
+    ot3_hardware.add_tip(mount, 100)
     await ot3_hardware.home()
     mock_move_to.return_value = None
 
@@ -1012,7 +1012,7 @@ async def test_liquid_probe_mount_moves(
     pipette = ot3_hardware.hardware_pipettes[mount.to_mount()]
 
     assert pipette
-    await ot3_hardware.add_tip(mount, 100)
+    ot3_hardware.add_tip(mount, 100)
     await ot3_hardware.home()
     mock_move_to.return_value = None
 
@@ -1073,7 +1073,7 @@ async def test_multi_liquid_probe(
     await ot3_hardware.cache_pipette(OT3Mount.LEFT, instr_data, None)
     pipette = ot3_hardware.hardware_pipettes[OT3Mount.LEFT.to_mount()]
     assert pipette
-    await ot3_hardware.add_tip(OT3Mount.LEFT, 100)
+    ot3_hardware.add_tip(OT3Mount.LEFT, 100)
     await ot3_hardware.home()
     mock_move_to.return_value = None
 
@@ -1142,7 +1142,7 @@ async def test_liquid_not_found(
     await ot3_hardware.cache_pipette(OT3Mount.LEFT, instr_data, None)
     pipette = ot3_hardware.hardware_pipettes[OT3Mount.LEFT.to_mount()]
     assert pipette
-    await ot3_hardware.add_tip(OT3Mount.LEFT, 100)
+    ot3_hardware.add_tip(OT3Mount.LEFT, 100)
     await ot3_hardware.home()
     await ot3_hardware.move_to(OT3Mount.LEFT, Point(10, 10, 10))
 
@@ -1633,7 +1633,7 @@ async def test_prepare_for_aspirate(
     await ot3_hardware.cache_pipette(mount, instr_data, None)
     assert ot3_hardware.hardware_pipettes[mount.to_mount()]
 
-    await ot3_hardware.add_tip(mount, 100)
+    ot3_hardware.add_tip(mount, 100)
     await ot3_hardware.prepare_for_aspirate(OT3Mount.LEFT)
     mock_move_to_plunger_bottom.assert_called_once_with(OT3Mount.LEFT, 1.0)
 
@@ -1668,7 +1668,7 @@ async def test_plunger_ready_to_aspirate_after_dispense(
     await ot3_hardware.cache_pipette(mount, instr_data, None)
     assert ot3_hardware.hardware_pipettes[mount.to_mount()]
 
-    await ot3_hardware.add_tip(mount, 100)
+    ot3_hardware.add_tip(mount, 100)
     await ot3_hardware.prepare_for_aspirate(OT3Mount.LEFT)
     assert ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate
 
@@ -1729,7 +1729,7 @@ async def test_move_to_plunger_bottom(
 
     # tip attached, moving DOWN towards "bottom" position
     await ot3_hardware.home()
-    await ot3_hardware.add_tip(mount, 100)
+    ot3_hardware.add_tip(mount, 100)
     mock_move.reset_mock()
     await ot3_hardware.prepare_for_aspirate(mount)
     # make sure we've done the backlash compensation

--- a/api/tests/opentrons/protocol_engine/execution/test_tip_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_tip_handler.py
@@ -258,7 +258,7 @@ async def test_drop_tip(
     decoy.verify(
         await mock_hardware_api.tip_drop_moves(mount=Mount.RIGHT, home_after=True)
     )
-    decoy.verify(await mock_hardware_api.remove_tip(mount=Mount.RIGHT))
+    decoy.verify(mock_hardware_api.remove_tip(mount=Mount.RIGHT))
     decoy.verify(
         mock_hardware_api.set_current_tiprack_diameter(
             mount=Mount.RIGHT, tiprack_diameter=0
@@ -292,7 +292,7 @@ async def test_add_tip(
     await subject.add_tip(pipette_id="pipette-id", tip=tip)
 
     decoy.verify(
-        await mock_hardware_api.add_tip(mount=Mount.LEFT, tip_length=50),
+        mock_hardware_api.add_tip(mount=Mount.LEFT, tip_length=50),
         mock_hardware_api.set_current_tiprack_diameter(
             mount=Mount.LEFT,
             tiprack_diameter=5,

--- a/hardware-testing/hardware_testing/examples/capacitive_probe_ot3.py
+++ b/hardware-testing/hardware_testing/examples/capacitive_probe_ot3.py
@@ -143,7 +143,7 @@ async def _main(is_simulating: bool, cycles: int, stable: bool) -> None:
         raise RuntimeError("No pipette attached")
 
     # add length to the pipette, to account for the attached probe
-    await api.add_tip(mount, PROBE_LENGTH)
+    api.add_tip(mount, PROBE_LENGTH)
 
     await helpers_ot3.home_ot3(api)
     for c in range(cycles):
@@ -154,7 +154,7 @@ async def _main(is_simulating: bool, cycles: int, stable: bool) -> None:
     z_ax = types.Axis.by_mount(mount)
     top_z = helpers_ot3.get_endstop_position_ot3(api, mount)[z_ax]
     await api.move_to(mount, ASSUMED_XY_LOCATION._replace(z=top_z))
-    await api.remove_tip(mount)
+    api.remove_tip(mount)
     await api.disengage_axes([types.Axis.X, types.Axis.Y])
 
 

--- a/hardware-testing/hardware_testing/examples/capacitive_probe_ot3_tunable.py
+++ b/hardware-testing/hardware_testing/examples/capacitive_probe_ot3_tunable.py
@@ -85,7 +85,7 @@ async def _main(is_simulating: bool, cycles: int, stable: bool) -> None:
         raise RuntimeError("No pipette attached")
 
     # add length to the pipette, to account for the attached probe
-    await api.add_tip(mount, PROBE_LENGTH)
+    api.add_tip(mount, PROBE_LENGTH)
 
     await helpers_ot3.home_ot3(api)
     for c in range(cycles):
@@ -96,7 +96,7 @@ async def _main(is_simulating: bool, cycles: int, stable: bool) -> None:
     z_ax = types.Axis.by_mount(mount)
     top_z = helpers_ot3.get_endstop_position_ot3(api, mount)[z_ax]
     await api.move_to(mount, ASSUMED_XY_LOCATION._replace(z=top_z))
-    await api.remove_tip(mount)
+    api.remove_tip(mount)
     await api.disengage_axes([types.Axis.X, types.Axis.Y])
 
 

--- a/hardware-testing/hardware_testing/examples/plunger_ot3.py
+++ b/hardware-testing/hardware_testing/examples/plunger_ot3.py
@@ -19,14 +19,14 @@ async def _main(is_simulating: bool) -> None:
     await api.home_plunger(mount)
 
     # move the plunger based on volume (aspirate/dispense)
-    await api.add_tip(mount, tip_length=10)
+    api.add_tip(mount, tip_length=10)
     await api.prepare_for_aspirate(mount)
     max_vol = pipette.working_volume
     for vol in [max_vol, max_vol / 2, max_vol / 10]:
         await api.aspirate(mount, volume=vol)
         await api.dispense(mount, volume=vol)
         await api.prepare_for_aspirate(mount)
-    await api.remove_tip(mount)
+    api.remove_tip(mount)
 
     # move the plunger based on position (millimeters)
     plunger_poses = helpers_ot3.get_plunger_positions_ot3(api, mount)

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -36,11 +36,7 @@ from hardware_testing.opentrons_api.helpers_ot3 import clear_pipette_ul_per_mm
 import opentrons.protocol_engine.execution.pipetting as PE_pipetting
 from opentrons.protocol_engine.notes import CommandNoteAdder
 
-from opentrons.protocol_engine import (
-    StateView,
-    WellLocation,
-    DropTipWellLocation,
-)
+from opentrons.protocol_engine import StateView
 from opentrons.protocol_api.core.engine import pipette_movement_conflict
 
 
@@ -267,7 +263,7 @@ def _override_check_safe_for_pipette_movement(
     pipette_id: str,
     labware_id: str,
     well_name: str,
-    well_location: Union[WellLocation, DropTipWellLocation],
+    well_location: object,
 ) -> None:
     pass
 

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_capacitance.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_capacitance.py
@@ -145,7 +145,7 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
         # ATTACHED-pF
         if not api.is_simulator:
             ui.get_user_ready(f"ATTACH probe to {probe.name} channel")
-        await api.add_tip(OT3Mount.LEFT, api.config.calibration.probe_length)
+        api.add_tip(OT3Mount.LEFT, api.config.calibration.probe_length)
         attached_pf = await _read_from_sensor(api, sensor_id, 10)
         if not attached_pf:
             ui.print_error(f"{probe} cap sensor not working, skipping")
@@ -229,4 +229,4 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
         await api.home_z(OT3Mount.LEFT)
         if not api.is_simulator:
             ui.get_user_ready("REMOVE probe")
-        await api.remove_tip(OT3Mount.LEFT)
+        api.remove_tip(OT3Mount.LEFT)

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
@@ -144,7 +144,7 @@ async def _drop_tip(api: OT3API, trash: Point) -> None:
     # NOTE: a FW bug (as of v14) will sometimes not fully drop tips.
     #       so here we ask if the operator needs to try again
     while not api.is_simulator and ui.get_user_answer("try dropping again"):
-        await api.add_tip(OT3Mount.LEFT, helpers_ot3.get_default_tip_length(TIP_VOLUME))
+        api.add_tip(OT3Mount.LEFT, helpers_ot3.get_default_tip_length(TIP_VOLUME))
         await api.drop_tip(OT3Mount.LEFT)
     await api.home_z(OT3Mount.LEFT)
 
@@ -172,7 +172,7 @@ async def _partial_pick_up(api: OT3API, position: Point, current: float) -> None
         safe_height=position.z + 10,
     )
     await _partial_pick_up_z_motion(api, current=current, distance=13, speed=5)
-    await api.add_tip(OT3Mount.LEFT, helpers_ot3.get_default_tip_length(TIP_VOLUME))
+    api.add_tip(OT3Mount.LEFT, helpers_ot3.get_default_tip_length(TIP_VOLUME))
     await api.prepare_for_aspirate(OT3Mount.LEFT)
     await api.home_z(OT3Mount.LEFT)
 

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_pressure.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_pressure.py
@@ -119,7 +119,7 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
 
         # SEALED-Pa
         sealed_pa = 0.0
-        await api.add_tip(OT3Mount.LEFT, helpers_ot3.get_default_tip_length(TIP_VOLUME))
+        api.add_tip(OT3Mount.LEFT, helpers_ot3.get_default_tip_length(TIP_VOLUME))
         await api.prepare_for_aspirate(OT3Mount.LEFT)
         if not api.is_simulator:
             ui.get_user_ready(f"attach {TIP_VOLUME} uL TIP to {probe.name} sensor")
@@ -171,4 +171,4 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
 
         if not api.is_simulator:
             ui.get_user_ready("REMOVE tip")
-        await api.remove_tip(OT3Mount.LEFT)
+        api.remove_tip(OT3Mount.LEFT)

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -981,7 +981,7 @@ async def _test_diagnostics_capacitive(  # noqa: C901
             probe_pos += Point(13, 13, 0)
             if sensor_id == SensorId.S1:
                 probe_pos += Point(x=0, y=9 * 7, z=0)
-            await api.add_tip(mount, api.config.calibration.probe_length)
+            api.add_tip(mount, api.config.calibration.probe_length)
             print(f"Moving to: {probe_pos}")
             # start probe 5mm above deck
             _probe_start_mm = probe_pos.z + 5
@@ -1013,7 +1013,7 @@ async def _test_diagnostics_capacitive(  # noqa: C901
         await api.home_z(mount)
         if not api.is_simulator:
             _get_operator_answer_to_question('REMOVE the probe, enter "y" when removed')
-        await api.remove_tip(mount)
+        api.remove_tip(mount)
 
     return all(results)
 
@@ -1029,9 +1029,9 @@ async def _test_diagnostics_pressure(
     sensor_ids = [SensorId.S0]
     if pip.channels == 8:
         sensor_ids.append(SensorId.S1)
-    await api.add_tip(mount, 0.1)
+    api.add_tip(mount, 0.1)
     await api.prepare_for_aspirate(mount)
-    await api.remove_tip(mount)
+    api.remove_tip(mount)
 
     async def _read_pressure(_sensor_id: SensorId) -> float:
         return await _read_pipette_sensor_repeatedly_and_average(

--- a/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_instruments.py
+++ b/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_instruments.py
@@ -101,7 +101,7 @@ async def _probe_mount_and_record_result(
             ui.get_user_ready(f"attach {probe.name} calibration probe")
         api.add_gripper_probe(probe)
     else:
-        await api.add_tip(mount, 0.1)
+        api.add_tip(mount, 0.1)
 
     # probe downwards
     pos = await api.gantry_position(mount)
@@ -131,7 +131,7 @@ async def _probe_mount_and_record_result(
         api.remove_gripper_probe()
         await api.ungrip()
     else:
-        await api.remove_tip(mount)
+        api.remove_tip(mount)
 
 
 async def _test_pipette(

--- a/hardware-testing/hardware_testing/scripts/gripper_ot3.py
+++ b/hardware-testing/hardware_testing/scripts/gripper_ot3.py
@@ -287,7 +287,7 @@ async def _probe_labware_corners(
 ) -> List[float]:
     nominal_corners = _calculate_probe_positions(slot, labware_key, deck_item)
     await api.home([types.Axis.by_mount(PROBE_MOUNT)])
-    await api.add_tip(PROBE_MOUNT, api.config.calibration.probe_length)
+    api.add_tip(PROBE_MOUNT, api.config.calibration.probe_length)
     found_heights: List[float] = list()
     for corner in nominal_corners:
         current_pos = await api.gantry_position(PROBE_MOUNT)
@@ -300,7 +300,7 @@ async def _probe_labware_corners(
         )
         found_heights.append(found_z)
     await api.home([types.Axis.by_mount(PROBE_MOUNT)])
-    await api.remove_tip(PROBE_MOUNT)
+    api.remove_tip(PROBE_MOUNT)
     print(f'\tLabware Corners ("{deck_item}" at slot {slot})')
     print(f"\t\tTop-Left = {found_heights[0]}")
     print(f"\t\tTop-Right = {found_heights[1]}")

--- a/hardware-testing/hardware_testing/scripts/manual_calibration_ot3.py
+++ b/hardware-testing/hardware_testing/scripts/manual_calibration_ot3.py
@@ -374,9 +374,9 @@ async def _init_deck_and_pipette_coordinates(
     if mount != OT3Mount.GRIPPER:
         # do this early on, so that all coordinates are using the probe's length
         if short_probe:
-            await api.add_tip(mount, helpers_ot3.CALIBRATION_PROBE_EVT.length - 10)
+            api.add_tip(mount, helpers_ot3.CALIBRATION_PROBE_EVT.length - 10)
         else:
-            await api.add_tip(mount, helpers_ot3.CALIBRATION_PROBE_EVT.length)
+            api.add_tip(mount, helpers_ot3.CALIBRATION_PROBE_EVT.length)
     return calibration_square_pos
 
 


### PR DESCRIPTION
## Changelog

* Turn `API.remove_tip()` and `OT3API.remove_tip()` non-async. This will help with EXEC-779 by letting us keep the whole auto-fixup process non-async.
* Same for `.add_tip()`. This isn't directly helpful to us because we use `.cache_tip()` anyway, but it's nice for consistency.
* A couple other minor cleanups.

## Test Plan and Hands on Testing

* [x] Make sure all CI keeps passing.

## Review requests

* Is there any reason we *would* want these methods to be `async`?
* Is it sufficient to ensure that all of CI keeps passing, or are there hidden things that this might break?

## Risk assessment

Low *if CI covers everything that calls this.*
