### PR TITLE
fix(app): change image/video path to relative path

### DIFF
--- a/app/src/organisms/Desktop/Devices/ChangePipette/InstructionStep.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/InstructionStep.tsx
@@ -29,18 +29,12 @@ export function InstructionStep(props: Props): JSX.Element {
 
   const display =
     displayCategory === 'GEN2'
-      ? new URL(
-          `/app/assets/images/change-pip/${direction}-${String(
-            mount
-          )}-${channelsKey}-GEN2-${diagram}@3x.png`,
-          import.meta.url
-        ).href
-      : new URL(
-          `/app/assets/images/change-pip/${direction}-${String(
-            mount
-          )}-${channelsKey}-${diagram}@3x.png`,
-          import.meta.url
-        ).href
+      ? `../app/assets/images/change-pip/${direction}-${String(
+          mount
+        )}-${channelsKey}-GEN2-${diagram}@3x.png`
+      : `../app/assets/images/change-pip/${direction}-${String(
+          mount
+        )}-${channelsKey}-${diagram}@3x.png`
 
   return (
     <Flex justifyContent={JUSTIFY_SPACE_EVENLY}>

--- a/app/src/organisms/Desktop/Devices/ChangePipette/InstructionStep.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/InstructionStep.tsx
@@ -29,12 +29,18 @@ export function InstructionStep(props: Props): JSX.Element {
 
   const display =
     displayCategory === 'GEN2'
-      ? `../app/assets/images/change-pip/${direction}-${String(
-          mount
-        )}-${channelsKey}-GEN2-${diagram}@3x.png`
-      : `../app/assets/images/change-pip/${direction}-${String(
-          mount
-        )}-${channelsKey}-${diagram}@3x.png`
+    ? new URL(
+      `../../../../assets/images/change-pip/${direction}-${String(
+        mount
+      )}-${channelsKey}-GEN2-${diagram}@3x.png`,
+      import.meta.url
+    ).href
+  : new URL(
+      `../../../../assets/images/change-pip/${direction}-${String(
+        mount
+      )}-${channelsKey}-${diagram}@3x.png`,
+      import.meta.url
+    ).href
 
   return (
     <Flex justifyContent={JUSTIFY_SPACE_EVENLY}>

--- a/app/src/organisms/Desktop/Devices/ChangePipette/InstructionStep.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/InstructionStep.tsx
@@ -29,18 +29,18 @@ export function InstructionStep(props: Props): JSX.Element {
 
   const display =
     displayCategory === 'GEN2'
-    ? new URL(
-      `../../../../assets/images/change-pip/${direction}-${String(
-        mount
-      )}-${channelsKey}-GEN2-${diagram}@3x.png`,
-      import.meta.url
-    ).href
-  : new URL(
-      `../../../../assets/images/change-pip/${direction}-${String(
-        mount
-      )}-${channelsKey}-${diagram}@3x.png`,
-      import.meta.url
-    ).href
+      ? new URL(
+          `../../../../assets/images/change-pip/${direction}-${String(
+            mount
+          )}-${channelsKey}-GEN2-${diagram}@3x.png`,
+          import.meta.url
+        ).href
+      : new URL(
+          `../../../../assets/images/change-pip/${direction}-${String(
+            mount
+          )}-${channelsKey}-${diagram}@3x.png`,
+          import.meta.url
+        ).href
 
   return (
     <Flex justifyContent={JUSTIFY_SPACE_EVENLY}>

--- a/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
@@ -43,9 +43,7 @@ export function LevelingVideo(props: {
       loop={true}
       controls={true}
     >
-      <source
-        src={video}
-      />
+      <source src={video} />
     </video>
   )
 }

--- a/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
@@ -26,6 +26,11 @@ export function LevelingVideo(props: {
   mount: Mount
 }): JSX.Element {
   const { pipetteName, mount } = props
+  const video = new URL(
+    `../../../../app/assets/videos/pip-leveling/${pipetteName}-${mount}.webm`,
+    import.meta.url
+  ).href
+
   return (
     <video
       css={css`
@@ -39,7 +44,7 @@ export function LevelingVideo(props: {
       controls={true}
     >
       <source
-        src={`../app/assets/videos/pip-leveling/${pipetteName}-${mount}.webm`}
+        src={video}
       />
     </video>
   )

--- a/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
@@ -39,12 +39,7 @@ export function LevelingVideo(props: {
       controls={true}
     >
       <source
-        src={
-          new URL(
-            `/app/assets/videos/pip-leveling/${pipetteName}-${mount}.webm`,
-            import.meta.url
-          ).href
-        }
+        src={`../app/assets/videos/pip-leveling/${pipetteName}-${mount}.webm`}
       />
     </video>
   )

--- a/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
@@ -27,7 +27,7 @@ export function LevelingVideo(props: {
 }): JSX.Element {
   const { pipetteName, mount } = props
   const video = new URL(
-    `../../../../app/assets/videos/pip-leveling/${pipetteName}-${mount}.webm`,
+    `../../../../assets/videos/pip-leveling/${pipetteName}-${mount}.webm`,
     import.meta.url
   ).href
 


### PR DESCRIPTION
# Overview

closes [RQA-3297](https://opentrons.atlassian.net/browse/RQA-3297).
change URL to relative path.

## Test Plan and Hands on Testing

attach/detach a pipette and make sure that all images and videos appear. 

## Risk assessment

low.


[RQA-3297]: https://opentrons.atlassian.net/browse/RQA-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ