### PR TITLE
fix(protocol-designer): update privacy settings copy

### DIFF
--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -125,7 +125,7 @@
   "warning": "WARNING:",
   "wasteChute": "Waste chute",
   "wasteChuteAndStagingArea": "Waste chute and staging area slot",
-  "we_are_improving": "We’re working to improve Protocol Designer. Part of the process involves watching real user sessions to understand which parts of the interface are working and which could use improvement. We never share sessions outside of Opentrons.",
+  "we_are_improving": "In order to improve our products, Opentrons would like to collect data related to your use of Protocol Designer. With your consent, Opentrons will collect and store analytics and session data, including through the use of cookies and similar technologies, solely for the purpose enhancing our products. Find detailed information in our <link1>privacy policy</link1>. By using Protocol Designer, you consent to the Opentrons <link2>EULA</link2>.",
   "welcome": "Welcome to Protocol Designer!",
   "yes": "Yes"
 }

--- a/protocol-designer/src/pages/Settings/__tests__/Settings.test.tsx
+++ b/protocol-designer/src/pages/Settings/__tests__/Settings.test.tsx
@@ -53,9 +53,9 @@ describe('Settings', () => {
     screen.getByText('Reset hints')
     screen.getByText('Privacy')
     screen.getByText('Share sessions with Opentrons')
-    screen.getByText(
-      'We’re working to improve Protocol Designer. Part of the process involves watching real user sessions to understand which parts of the interface are working and which could use improvement. We never share sessions outside of Opentrons.'
-    )
+    screen.debug()
+    screen.getByRole('link', { name: 'privacy policy' })
+    screen.getByRole('link', { name: 'EULA' })
   })
   it('renders the announcement modal when view release notes button is clicked', () => {
     vi.mocked(AnnouncementModal).mockReturnValue(

--- a/protocol-designer/src/pages/Settings/index.tsx
+++ b/protocol-designer/src/pages/Settings/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from 'styled-components'
 import {
@@ -11,6 +11,7 @@ import {
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
+  Link as LinkComponent,
   SPACING,
   StyledText,
   TYPOGRAPHY,
@@ -31,6 +32,8 @@ import { getFeatureFlagData } from '../../feature-flags/selectors'
 import type { FlagTypes } from '../../feature-flags'
 
 const HOT_KEY_FLAG = 'OT_PD_ENABLE_HOT_KEYS_DISPLAY'
+const PRIVACY_POLICY_URL = 'https://opentrons.com/privacy-policy'
+const EULA_URL = 'https://opentrons.com/eula'
 
 export function Settings(): JSX.Element {
   const dispatch = useDispatch()
@@ -235,11 +238,28 @@ export function Settings(): JSX.Element {
                   <StyledText desktopStyle="bodyDefaultSemiBold">
                     {t('shared:shared_sessions')}
                   </StyledText>
-                  <Flex color={COLORS.grey60}>
-                    <StyledText desktopStyle="bodyDefaultRegular">
-                      {t('shared:we_are_improving')}
-                    </StyledText>
-                  </Flex>
+                  <StyledText desktopStyle="bodyDefaultRegular">
+                    <Trans
+                      t={t}
+                      i18nKey="shared:we_are_improving"
+                      components={{
+                        link1: (
+                          <LinkComponent
+                            external
+                            href={PRIVACY_POLICY_URL}
+                            color={COLORS.blue50}
+                          />
+                        ),
+                        link2: (
+                          <LinkComponent
+                            external
+                            href={EULA_URL}
+                            color={COLORS.blue50}
+                          />
+                        ),
+                      }}
+                    />
+                  </StyledText>
                 </Flex>
                 <Btn
                   role="switch"


### PR DESCRIPTION
# Overview

Updates PD privacy settings copy according to latest legal recommendations. Adds links within copy to direct to privacy policy and opentrons EULA.

Closes AUTH-902

## Test Plan and Hands on Testing

- Launch PD with redesign and inspect settings page
- Verify that privacy settings copy matches that in attached ticket, and links direct to correct URLs

## Changelog

- update copy for privacy settings
- update tests

## Review requests

see test plan

## Risk assessment

medium. need to be extra sure copy is correct 