### PR TITLE
fix(app): don't re-open drop tip wizard flows if unrendered

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
   useDropTipLocations,
@@ -63,6 +63,14 @@ export function DropTipWizardFlows(
   })
   const dropTipRoutingUtils = useDropTipRouting(fixitCommandTypeUtils)
   const dropTipCommandLocations = useDropTipLocations(props.robotType) // Prefetch to reduce client latency
+
+  // If the flow unrenders for any reason (ex, the pipette card managing the flow unrenders), don't re-render the flow
+  // after it closes.
+  useEffect(() => {
+    return () => {
+      dropTipWithTypeUtils.dropTipCommands.handleCleanUpAndClose()
+    }
+  }, [])
 
   return (
     <DropTipWizard


### PR DESCRIPTION
Closes [RQA-3287](https://opentrons.atlassian.net/browse/RQA-3287)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In #16490, I made the disable/enable drop tip wizard states more explicit. However, I also removed the logic to `toggle()` the wizard if it abruptly closes, which sometimes happens if the pipette card unrenders. This just adds the unrender logic back and makes it more explicit: if the flow does close abruptly, it's important we do clean up the maintenance run, too.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Unrendered the pipette card on the OT-2 by disconnecting the pipette. Ensured the maintenance run cleaned up successfully.

- Tested DT wiz through all entrypoints on the OT-2:

- [x] Post run
- [x] Pipette cards

- And on the flex:
- [x] Error recovery
- [x] Pipette cards
- [x] ODD instrument page

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed drop tip wizard sometimes re-opening after clicking exit.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3287]: https://opentrons.atlassian.net/browse/RQA-3287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ