### PR TITLE
feat(opentrons-ai-client): inject mixpanel tokens into build

### DIFF
--- a/.github/workflows/opentrons-ai-client-staging-continuous-deploy.yaml
+++ b/.github/workflows/opentrons-ai-client-staging-continuous-deploy.yaml
@@ -53,8 +53,8 @@ jobs:
           make setup-js
       - name: 'build'
         env:
-            OT_AI_CLIENT_MIXPANEL_ID: ${{ secrets.OT_AI_CLIENT_MIXPANEL_ID }}
-            OT_AI_CLIENT_MIXPANEL_DEV_ID: ${{ secrets.OT_AI_CLIENT_MIXPANEL_DEV_ID }}
+            # inject dev id since this is for staging
+            OT_AI_CLIENT_MIXPANEL_ID: ${{ secrets.OT_AI_CLIENT_MIXPANEL_DEV_ID }}
         run: |
           make -C opentrons-ai-client build-staging
       - name: Configure AWS Credentials

--- a/.github/workflows/opentrons-ai-client-staging-continuous-deploy.yaml
+++ b/.github/workflows/opentrons-ai-client-staging-continuous-deploy.yaml
@@ -52,6 +52,9 @@ jobs:
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
       - name: 'build'
+        env:
+            OT_AI_CLIENT_MIXPANEL_ID: ${{ secrets.OT_AI_CLIENT_MIXPANEL_ID }}
+            OT_AI_CLIENT_MIXPANEL_DEV_ID: ${{ secrets.OT_AI_CLIENT_MIXPANEL_DEV_ID }}
         run: |
           make -C opentrons-ai-client build-staging
       - name: Configure AWS Credentials

--- a/.github/workflows/opentrons-ai-client-test.yaml
+++ b/.github/workflows/opentrons-ai-client-test.yaml
@@ -9,12 +9,9 @@ on:
     paths:
       - 'Makefile'
       - 'opentrons-ai-client/**/*'
-      - 'components/**/*'
-      - '*.js'
-      - '*.json'
-      - 'yarn.lock'
-      - '.github/workflows/app-test-build-deploy.yaml'
-      - '.github/workflows/utils.js'
+      - 'components/**'
+      - 'shared-data/**'
+      - '.github/workflows/opentrons-ai-client-test.yml'
     branches:
       - '**'
     tags:
@@ -24,10 +21,9 @@ on:
     paths:
       - 'Makefile'
       - 'opentrons-ai-client/**/*'
-      - 'components/**/*'
-      - '*.js'
-      - '*.json'
-      - 'yarn.lock'
+      - 'components/**'
+      - 'shared-data/**'
+      - '.github/workflows/opentrons-ai-client-test.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/opentrons-ai-production-deploy.yaml
+++ b/.github/workflows/opentrons-ai-production-deploy.yaml
@@ -52,6 +52,8 @@ jobs:
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
       - name: 'build'
+        env:
+              OT_AI_CLIENT_MIXPANEL_ID: ${{ secrets.OT_AI_CLIENT_MIXPANEL_ID }}
         run: |
           make -C opentrons-ai-client build-production
       - name: Configure AWS Credentials


### PR DESCRIPTION
# Overview

This PR injects mixpanel dev and prod project tokens into the ai client (we do the same thing for the app, PD, and LL). Devs can now initialize mixpanel in the ai client and start registering events. We can verify these events once deploys make it to staging/prod environments.


## Review requests

Nothing for now other than reading the code. I don't think we can verify anything until this makes it into edge and we start pushing mixpanel events.

## Risk assessment

Low
