### PR TITLE
refactor(app): Support slot-only display names

### DIFF
--- a/app/src/local-resources/labware/utils/__tests__/getLabwareDisplayLocation.test.tsx
+++ b/app/src/local-resources/labware/utils/__tests__/getLabwareDisplayLocation.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  FLEX_ROBOT_TYPE,
+  getModuleDisplayName,
+  getModuleType,
+  getOccludedSlotCountForModule,
+  getLabwareDefURI,
+  getLabwareDisplayName,
+} from '@opentrons/shared-data'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+import { getLabwareDisplayLocation } from '/app/local-resources/labware'
+import {
+  getModuleModel,
+  getModuleDisplayLocation,
+} from '/app/local-resources/modules'
+
+import type { ComponentProps } from 'react'
+import type { LabwareLocation } from '@opentrons/shared-data'
+
+vi.mock('@opentrons/shared-data', async () => {
+  const actual = await vi.importActual('@opentrons/shared-data')
+  return {
+    ...actual,
+    getModuleDisplayName: vi.fn(),
+    getModuleType: vi.fn(),
+    getOccludedSlotCountForModule: vi.fn(),
+    getLabwareDefURI: vi.fn(),
+    getLabwareDisplayName: vi.fn(),
+  }
+})
+
+vi.mock('/app/local-resources/modules', () => ({
+  getModuleModel: vi.fn(),
+  getModuleDisplayLocation: vi.fn(),
+}))
+
+const TestWrapper = ({
+  location,
+  params,
+}: {
+  location: LabwareLocation | null
+  params: any
+}) => {
+  const { t } = useTranslation('protocol_command_text')
+  const displayLocation = getLabwareDisplayLocation({ ...params, location, t })
+  return <div>{displayLocation}</div>
+}
+
+const render = (props: ComponentProps<typeof TestWrapper>) => {
+  return renderWithProviders(<TestWrapper {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('getLabwareDisplayLocation with translations', () => {
+  const defaultParams = {
+    loadedLabwares: [],
+    loadedModules: [],
+    robotType: FLEX_ROBOT_TYPE,
+    allRunDefs: [],
+  }
+
+  it('should return an empty string for null location', () => {
+    render({ location: null, params: defaultParams })
+    expect(screen.queryByText(/.+/)).toBeNull()
+  })
+
+  it('should return "off deck" for offDeck location', () => {
+    render({ location: 'offDeck', params: defaultParams })
+
+    screen.getByText('off deck')
+  })
+
+  it('should return a slot name for slot location', () => {
+    render({ location: { slotName: 'A1' }, params: defaultParams })
+
+    screen.getByText('Slot A1')
+  })
+
+  it('should return an addressable area name for an addressable area location', () => {
+    render({ location: { addressableAreaName: 'B2' }, params: defaultParams })
+
+    screen.getByText('Slot B2')
+  })
+
+  it('should return a module location for a module location', () => {
+    const mockModuleModel = 'temperatureModuleV2'
+    vi.mocked(getModuleModel).mockReturnValue(mockModuleModel)
+    vi.mocked(getModuleDisplayLocation).mockReturnValue('3')
+    vi.mocked(getModuleDisplayName).mockReturnValue('Temperature Module')
+    vi.mocked(getModuleType).mockReturnValue('temperatureModuleType')
+    vi.mocked(getOccludedSlotCountForModule).mockReturnValue(1)
+
+    render({ location: { moduleId: 'temp123' }, params: defaultParams })
+
+    screen.getByText('Temperature Module in Slot 3')
+  })
+
+  it('should return an adapter location for an adapter location', () => {
+    const mockLoadedLabwares = [
+      {
+        id: 'adapter123',
+        definitionUri: 'adapter-uri',
+        location: { slotName: 'D1' },
+      },
+    ]
+    const mockAllRunDefs = [
+      { uri: 'adapter-uri', metadata: { displayName: 'Mock Adapter' } },
+    ]
+    vi.mocked(getLabwareDefURI).mockReturnValue('adapter-uri')
+    vi.mocked(getLabwareDisplayName).mockReturnValue('Mock Adapter')
+
+    render({
+      location: { labwareId: 'adapter123' },
+      params: {
+        ...defaultParams,
+        loadedLabwares: mockLoadedLabwares,
+        allRunDefs: mockAllRunDefs,
+        detailLevel: 'full',
+      },
+    })
+
+    screen.getByText('Mock Adapter in D1')
+  })
+
+  it('should return a slot-only location when detailLevel is "slot-only"', () => {
+    render({
+      location: { slotName: 'C1' },
+      params: { ...defaultParams, detailLevel: 'slot-only' },
+    })
+
+    screen.getByText('Slot C1')
+  })
+
+  it('should handle an adapter on module location when the detail level is full', () => {
+    const mockLoadedLabwares = [
+      {
+        id: 'adapter123',
+        definitionUri: 'adapter-uri',
+        location: { moduleId: 'temp123' },
+      },
+    ]
+    const mockLoadedModules = [{ id: 'temp123', model: 'temperatureModuleV2' }]
+    const mockAllRunDefs = [
+      { uri: 'adapter-uri', metadata: { displayName: 'Mock Adapter' } },
+    ]
+
+    vi.mocked(getLabwareDefURI).mockReturnValue('adapter-uri')
+    vi.mocked(getLabwareDisplayName).mockReturnValue('Mock Adapter')
+    vi.mocked(getModuleDisplayLocation).mockReturnValue('2')
+    vi.mocked(getModuleDisplayName).mockReturnValue('Temperature Module')
+    vi.mocked(getModuleType).mockReturnValue('temperatureModuleType')
+    vi.mocked(getOccludedSlotCountForModule).mockReturnValue(1)
+
+    render({
+      location: { labwareId: 'adapter123' },
+      params: {
+        ...defaultParams,
+        loadedLabwares: mockLoadedLabwares,
+        loadedModules: mockLoadedModules,
+        allRunDefs: mockAllRunDefs,
+        detailLevel: 'full',
+      },
+    })
+
+    screen.getByText('Mock Adapter on Temperature Module in 2')
+  })
+})

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -151,7 +151,6 @@ export function useERUtils({
     failedPipetteInfo,
     runRecord,
     runCommands,
-    allRunDefs,
   })
 
   const recoveryCommands = useRecoveryCommands({


### PR DESCRIPTION
Closes [EXEC-786](https://opentrons.atlassian.net/browse/EXEC-786)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR extends `getLabwareDisplayLocation` functionality, providing a new `detailLevel` parameter, which we utilize in [Error Recovery](https://www.figma.com/design/OGssKRmCOvuXSqUpK2qXrV/Feature%3A-Error-Recovery-November-Release?node-id=9752-53429&t=bvyIMW8P5367NUmK-4). When we want copy for a labware location, sometimes we don't want the copy to include too much detail (ex., 'labware in module/adapter XYZ in slot C1') but just want the actual slot name without the extra info (ex, 'labware in slot C1').

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Changes are sufficiently covered by testing now, but I did confirm correct copy in Error Recovery and checked various protocol runs around the office, too.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->


<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-786]: https://opentrons.atlassian.net/browse/EXEC-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-3391]: https://opentrons.atlassian.net/browse/RQA-3391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ