### PR TITLE
refactor(robot-server): Use last run command for `/runs/:runId/currentState` links

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -98,7 +98,7 @@ export interface RunsLinks {
 }
 
 export interface RunCommandLink {
-  last: CommandLinkNoMeta
+  lastCompleted: CommandLinkNoMeta
 }
 
 export interface CommandLinkNoMeta {

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -98,7 +98,7 @@ export interface RunsLinks {
 }
 
 export interface RunCommandLink {
-  current: CommandLinkNoMeta
+  last: CommandLinkNoMeta
 }
 
 export interface CommandLinkNoMeta {

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -257,6 +257,22 @@ class RunOrchestrator:
         """Get the "current" command, if any."""
         return self._protocol_engine.state_view.commands.get_current()
 
+    def get_most_recently_finalized_command(self) -> Optional[CommandPointer]:
+        """Get the most recently finalized command, if any."""
+        most_recently_finalized_command = (
+            self._protocol_engine.state_view.commands.get_most_recently_finalized_command()
+        )
+        return (
+            CommandPointer(
+                command_id=most_recently_finalized_command.command.id,
+                command_key=most_recently_finalized_command.command.key,
+                created_at=most_recently_finalized_command.command.createdAt,
+                index=most_recently_finalized_command.index,
+            )
+            if most_recently_finalized_command
+            else None
+        )
+
     def get_command_slice(
         self, cursor: Optional[int], length: int, include_fixit_commands: bool
     ) -> CommandSlice:

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -132,7 +132,7 @@ class AllRunsLinks(BaseModel):
 class CurrentStateLinks(BaseModel):
     """Links returned with the current state of a run."""
 
-    last: Optional[CommandLinkNoMeta] = Field(
+    lastCompleted: Optional[CommandLinkNoMeta] = Field(
         None,
         description="Path to the last completed command when current state was reported, if any.",
     )
@@ -597,7 +597,7 @@ async def get_current_state(
         raise RunStopped(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
 
     links = CurrentStateLinks.construct(
-        last=CommandLinkNoMeta.construct(
+        lastCompleted=CommandLinkNoMeta.construct(
             id=last_completed_command.command_id,
             href=f"/runs/{runId}/commands/{last_completed_command.command_id}",
         )

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -461,6 +461,19 @@ class RunDataManager:
             # this should be the most recently completed command, not `None`.
             return None
 
+    def get_last_completed_command(self, run_id: str) -> Optional[CommandPointer]:
+        """Get the "last" command, if any.
+
+        See `ProtocolEngine.state_view.commands.get_most_recently_finalized_command()` for the definition of "last."
+
+        Args:
+            run_id: ID of the run.
+        """
+        if self._run_orchestrator_store.current_run_id == run_id:
+            return self._run_orchestrator_store.get_most_recently_finalized_command()
+        else:
+            return self._get_historical_run_last_command(run_id=run_id)
+
     def get_recovery_target_command(self, run_id: str) -> Optional[CommandPointer]:
         """Get the current error recovery target.
 
@@ -554,3 +567,20 @@ class RunDataManager:
             return self._run_orchestrator_store.get_run_time_parameters()
         else:
             return self._run_store.get_run_time_parameters(run_id=run_id)
+
+    def _get_historical_run_last_command(self, run_id: str) -> Optional[CommandPointer]:
+        command_slice = self._run_store.get_commands_slice(
+            run_id=run_id, cursor=None, length=1, include_fixit_commands=True
+        )
+        command = command_slice.commands[-1]
+
+        return (
+            CommandPointer(
+                command_id=command.id,
+                command_key=command.key,
+                created_at=command.createdAt,
+                index=command_slice.total_length - 1,
+            )
+            if command
+            else None
+        )

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -578,7 +578,7 @@ class RunDataManager:
                 command_id=command.id,
                 command_key=command.key,
                 created_at=command.createdAt,
-                index=command_slice.total_length - 1,
+                index=command_slice.cursor,
             )
             if command
             else None

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -569,6 +569,8 @@ class RunDataManager:
         command_slice = self._run_store.get_commands_slice(
             run_id=run_id, cursor=None, length=1, include_fixit_commands=True
         )
+        if not command_slice.commands:
+            return None
         command = command_slice.commands[-1]
 
         return (

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -456,10 +456,7 @@ class RunDataManager:
         if self._run_orchestrator_store.current_run_id == run_id:
             return self._run_orchestrator_store.get_current_command()
         else:
-            # todo(mm, 2024-05-20):
-            # For historical runs to behave consistently with the current run,
-            # this should be the most recently completed command, not `None`.
-            return None
+            return self._get_historical_run_last_command(run_id=run_id)
 
     def get_last_completed_command(self, run_id: str) -> Optional[CommandPointer]:
         """Get the "last" command, if any.

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -335,8 +335,12 @@ class RunOrchestratorStore:
         return self.run_orchestrator.get_run_time_parameters()
 
     def get_current_command(self) -> Optional[CommandPointer]:
-        """Get the current running command."""
+        """Get the current running command, if any."""
         return self.run_orchestrator.get_current_command()
+
+    def get_most_recently_finalized_command(self) -> Optional[CommandPointer]:
+        """Get the most recently finalized command, if any."""
+        return self.run_orchestrator.get_most_recently_finalized_command()
 
     def get_command_slice(
         self, cursor: Optional[int], length: int, include_fixit_commands: bool

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -876,10 +876,12 @@ async def test_get_current_state_success(
     decoy.when(mock_run_data_manager.get_nozzle_maps(run_id=run_id)).then_return(
         mock_nozzle_maps
     )
-    decoy.when(mock_run_data_manager.get_current_command(run_id=run_id)).then_return(
+    decoy.when(
+        mock_run_data_manager.get_last_completed_command(run_id=run_id)
+    ).then_return(
         CommandPointer(
-            command_id="current-command-id",
-            command_key="current-command-key",
+            command_id="last-command-id",
+            command_key="last-command-key",
             created_at=datetime(year=2024, month=4, day=4),
             index=101,
         )
@@ -901,9 +903,9 @@ async def test_get_current_state_success(
         }
     )
     assert result.content.links == CurrentStateLinks(
-        current=CommandLinkNoMeta(
-            href="/runs/test-run-id/commands/current-command-id",
-            id="current-command-id",
+        last=CommandLinkNoMeta(
+            href="/runs/test-run-id/commands/last-command-id",
+            id="last-command-id",
         )
     )
 

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -903,7 +903,7 @@ async def test_get_current_state_success(
         }
     )
     assert result.content.links == CurrentStateLinks(
-        last=CommandLinkNoMeta(
+        lastCompleted=CommandLinkNoMeta(
             href="/runs/test-run-id/commands/last-command-id",
             id="last-command-id",
         )

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -1023,7 +1023,7 @@ def test_get_current_command_not_current_run(
     )
 
     command_slice = CommandSlice(
-        commands=[last_command_slice], cursor=1, total_length=1
+        commands=[last_command_slice], cursor=0, total_length=1
     )
 
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("not-run-id")
@@ -1049,7 +1049,7 @@ def test_get_last_completed_command_current_run(
         command_id=run_command.id,
         command_key=run_command.key,
         created_at=run_command.createdAt,
-        index=5,
+        index=1,
     )
 
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
@@ -1084,7 +1084,7 @@ def test_get_last_completed_command_not_current_run(
         command_id="command-id-1",
         command_key="command-key",
         created_at=datetime(year=2021, month=1, day=1),
-        index=0,
+        index=1,
     )
 
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -1012,6 +1012,74 @@ def test_get_current_command_not_current_run(
     assert result is None
 
 
+def test_get_last_completed_command_current_run(
+    decoy: Decoy,
+    subject: RunDataManager,
+    mock_run_orchestrator_store: RunOrchestratorStore,
+    run_command: commands.Command,
+) -> None:
+    """Should get the last command from the engine store for the current run."""
+    run_id = "current-run-id"
+    expected_last_command = CommandPointer(
+        command_id=run_command.id,
+        command_key=run_command.key,
+        created_at=run_command.createdAt,
+        index=5,
+    )
+
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
+    decoy.when(
+        mock_run_orchestrator_store.get_most_recently_finalized_command()
+    ).then_return(expected_last_command)
+
+    result = subject.get_last_completed_command(run_id)
+
+    assert result == expected_last_command
+
+
+def test_get_last_completed_command_not_current_run(
+    decoy: Decoy,
+    subject: RunDataManager,
+    mock_run_orchestrator_store: RunOrchestratorStore,
+    mock_run_store: RunStore,
+    run_command: commands.Command,
+) -> None:
+    """Should get the last command from the run store for a historical run."""
+    run_id = "historical-run-id"
+
+    last_command_slice = commands.WaitForResume(
+        id="command-id-1",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=commands.CommandStatus.SUCCEEDED,
+        params=commands.WaitForResumeParams(message="Hello"),
+    )
+
+    expected_last_command = CommandPointer(
+        command_id="command-id-1",
+        command_key="command-key",
+        created_at=datetime(year=2021, month=1, day=1),
+        index=0,
+    )
+
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(
+        "different-run-id"
+    )
+
+    command_slice = CommandSlice(
+        commands=[last_command_slice], cursor=1, total_length=1
+    )
+    decoy.when(
+        mock_run_store.get_commands_slice(
+            run_id=run_id, cursor=None, length=1, include_fixit_commands=True
+        )
+    ).then_return(command_slice)
+
+    result = subject.get_last_completed_command(run_id)
+
+    assert result == expected_last_command
+
+
 def test_get_command_from_engine(
     decoy: Decoy,
     subject: RunDataManager,

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -1004,12 +1004,37 @@ def test_get_current_command_not_current_run(
     subject: RunDataManager,
     mock_run_store: RunStore,
     mock_run_orchestrator_store: RunOrchestratorStore,
+    run_command: commands.Command,
 ) -> None:
-    """Should return None because the run is not current."""
+    """Should get the last command from the run store for a historical run."""
+    last_command_slice = commands.WaitForResume(
+        id="command-id-1",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=commands.CommandStatus.SUCCEEDED,
+        params=commands.WaitForResumeParams(message="Hello"),
+    )
+
+    expected_last_command = CommandPointer(
+        command_id="command-id-1",
+        command_key="command-key",
+        created_at=datetime(year=2021, month=1, day=1),
+        index=0,
+    )
+
+    command_slice = CommandSlice(
+        commands=[last_command_slice], cursor=1, total_length=1
+    )
+
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("not-run-id")
+    decoy.when(
+        mock_run_store.get_commands_slice(
+            run_id="run-id", cursor=None, length=1, include_fixit_commands=True
+        )
+    ).then_return(command_slice)
     result = subject.get_current_command("run-id")
 
-    assert result is None
+    assert result == expected_last_command
 
 
 def test_get_last_completed_command_current_run(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In https://github.com/Opentrons/opentrons/pull/16417, it was noted that `links` should include a reference to the last completed command as opposed to the "current" command in order to prevent torn state. This PR updates the link to do just that.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran some protocols, noted that the command was in fact the last command at the time of query.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Updated the `links` property within the `runs/runId/currentState` response.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
c8dce6043734f4e619179c432c6bdc324366da63 - Updates the behavior for `get_current_command` for historical runs with the behavior that I _think_ we want given the comment, but is this actually the case? CC: @SyntaxColoring 
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
