### PR TITLE
refactor(app): permit scrolling during ER & drop tip on desktop app

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/DropTipWizard.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizard.tsx
@@ -17,6 +17,7 @@ import {
   ModalShell,
   DISPLAY_FLEX,
   OVERFLOW_HIDDEN,
+  OVERFLOW_AUTO,
 } from '@opentrons/components'
 
 import { getTopPortalEl } from '/app/App/portal'
@@ -307,7 +308,11 @@ function useInitiateExit(): {
 const SHARED_STYLE = `
   display: ${DISPLAY_FLEX};
   flex-direction: ${DIRECTION_COLUMN};
-  overflow: ${OVERFLOW_HIDDEN};
+  overflow-y: ${OVERFLOW_AUTO};
+  
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    overflow: ${OVERFLOW_HIDDEN};
+  }
 `
 
 const INTERVENTION_CONTAINER_STYLE = css`

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryInterventionModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryInterventionModal.tsx
@@ -4,6 +4,7 @@ import { css } from 'styled-components'
 
 import {
   Flex,
+  OVERFLOW_AUTO,
   OVERFLOW_HIDDEN,
   RESPONSIVENESS,
   SPACING,
@@ -56,19 +57,21 @@ const SMALL_MODAL_STYLE = css`
   height: 22rem;
   padding: ${SPACING.spacing32};
   width: 100%;
-  overflow: ${OVERFLOW_HIDDEN};
+  overflow-y: ${OVERFLOW_AUTO};
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     padding: ${SPACING.spacing32};
     height: 100%;
+    overflow: ${OVERFLOW_HIDDEN};
   }
 `
 const LARGE_MODAL_STYLE = css`
   height: 26.75rem;
   width: 100%;
-  overflow: ${OVERFLOW_HIDDEN};
+  overflow-y: ${OVERFLOW_AUTO};
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     height: 100%;
+    overflow: ${OVERFLOW_HIDDEN};
   }
 `


### PR DESCRIPTION
Closes [RQA-3391](https://opentrons.atlassian.net/browse/RQA-3391)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In cropped views of the desktop app, it's currently not possible to scroll. We should allow that. After some post-8.0 refactoring, I accidentally added this to ER/drop tip wiz in order to prevent wonky looking scrolling bars on the ODD, but we can just not show the bars on the ODD (since the ODD is always the same screen size).

https://github.com/user-attachments/assets/ca525505-cf66-4ed4-9145-1285ab7a1458


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video. Also ran through some DT flows on the desktop app/ODD and didn't see any issues.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- It's possible to scroll error recovery and drop tip wizard on the desktop app.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3391]: https://opentrons.atlassian.net/browse/RQA-3391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ