### PR TITLE
refactor(app): Add move animations to manual gripper move during Error Recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/ErrorRecoveryFlows.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/ErrorRecoveryFlows.test.tsx
@@ -8,7 +8,7 @@ import {
   RUN_STATUS_RUNNING,
   RUN_STATUS_STOP_REQUESTED,
 } from '@opentrons/api-client'
-import { getLabwareDefinitionsFromCommands } from '/app/local-resources/labware'
+import { getLoadedLabwareDefinitionsByUri } from '@opentrons/shared-data'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -33,7 +33,13 @@ vi.mock('/app/redux/config')
 vi.mock('../RecoverySplash')
 vi.mock('/app/redux-resources/analytics')
 vi.mock('@opentrons/react-api-client')
-vi.mock('/app/local-resources/labware')
+vi.mock('@opentrons/shared-data', async () => {
+  const actual = await vi.importActual('@opentrons/shared-data')
+  return {
+    ...actual,
+    getLoadedLabwareDefinitionsByUri: vi.fn(),
+  }
+})
 vi.mock('react-redux', async () => {
   const actual = await vi.importActual('react-redux')
   return {
@@ -45,7 +51,6 @@ vi.mock('react-redux', async () => {
 describe('useErrorRecoveryFlows', () => {
   beforeEach(() => {
     vi.mocked(useCurrentlyRecoveringFrom).mockReturnValue('mockCommand' as any)
-    vi.mocked(getLabwareDefinitionsFromCommands).mockReturnValue([])
   })
 
   it('should have initial state of isERActive as false', () => {
@@ -143,7 +148,7 @@ describe('ErrorRecoveryFlows', () => {
       runStatus: RUN_STATUS_AWAITING_RECOVERY,
       failedCommandByRunRecord: mockFailedCommand,
       runId: 'MOCK_RUN_ID',
-      protocolAnalysis: {} as any,
+      protocolAnalysis: null,
     }
     vi.mocked(ErrorRecoveryWizard).mockReturnValue(<div>MOCK WIZARD</div>)
     vi.mocked(RecoverySplash).mockReturnValue(<div>MOCK RUN PAUSED SPLASH</div>)
@@ -168,6 +173,7 @@ describe('ErrorRecoveryFlows', () => {
       intent: 'recovering',
       showTakeover: false,
     })
+    vi.mocked(getLoadedLabwareDefinitionsByUri).mockReturnValue({})
   })
 
   it('renders the wizard when showERWizard is true', () => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -168,8 +168,8 @@ const TestWrapper = (props: GetRelevantLwLocationsParams) => {
   const displayLocation = useRelevantFailedLwLocations(props)
   return (
     <>
-      <div>{`Current Loc: ${displayLocation.currentLoc}`}</div>
-      <div>{`New Loc: ${displayLocation.newLoc}`}</div>
+      <div>{`Current Loc: ${displayLocation.displayNameCurrentLoc}`}</div>
+      <div>{`New Loc: ${displayLocation.displayNameNewLoc}`}</div>
     </>
   )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, renderHook } from '@testing-library/react'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -181,7 +181,7 @@ const render = (props: ComponentProps<typeof TestWrapper>) => {
 }
 
 describe('useRelevantFailedLwLocations', () => {
-  const mockProtocolAnalysis = {} as any
+  const mockRunRecord = { data: { modules: [], labware: [] } } as any
   const mockFailedLabware = {
     location: { slotName: 'D1' },
   } as any
@@ -194,14 +194,25 @@ describe('useRelevantFailedLwLocations', () => {
     render({
       failedLabware: mockFailedLabware,
       failedCommandByRunRecord: mockFailedCommand,
-      protocolAnalysis: mockProtocolAnalysis,
+      runRecord: mockRunRecord,
     })
 
     screen.getByText('Current Loc: Slot D1')
     screen.getByText('New Loc: null')
+
+    const { result } = renderHook(() =>
+      useRelevantFailedLwLocations({
+        failedLabware: mockFailedLabware,
+        failedCommandByRunRecord: mockFailedCommand,
+        runRecord: mockRunRecord,
+      })
+    )
+
+    expect(result.current.currentLoc).toStrictEqual({ slotName: 'D1' })
+    expect(result.current.newLoc).toBeNull()
   })
 
-  it('should return current and new location for moveLabware commands', () => {
+  it('should return current and new locations for moveLabware commands', () => {
     const mockFailedCommand = {
       commandType: 'moveLabware',
       params: {
@@ -212,10 +223,21 @@ describe('useRelevantFailedLwLocations', () => {
     render({
       failedLabware: mockFailedLabware,
       failedCommandByRunRecord: mockFailedCommand,
-      protocolAnalysis: mockProtocolAnalysis,
+      runRecord: mockRunRecord,
     })
 
     screen.getByText('Current Loc: Slot D1')
     screen.getByText('New Loc: Slot C2')
+
+    const { result } = renderHook(() =>
+      useRelevantFailedLwLocations({
+        failedLabware: mockFailedLabware,
+        failedCommandByRunRecord: mockFailedCommand,
+        runRecord: mockRunRecord,
+      })
+    )
+
+    expect(result.current.currentLoc).toStrictEqual({ slotName: 'D1' })
+    expect(result.current.newLoc).toStrictEqual({ slotName: 'C2' })
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -10,6 +10,11 @@ import {
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 
+import {
+  getRunLabwareRenderInfo,
+  getRunModuleRenderInfo,
+} from '/app/organisms/InterventionModal/utils'
+
 import type { Run } from '@opentrons/api-client'
 import type {
   DeckDefinition,
@@ -25,6 +30,10 @@ import type {
 } from '@opentrons/shared-data'
 import type { ErrorRecoveryFlowsProps } from '..'
 import type { UseFailedLabwareUtilsResult } from './useFailedLabwareUtils'
+import type {
+  RunLabwareInfo,
+  RunModuleInfo,
+} from '/app/organisms/InterventionModal/utils'
 import type { ERUtilsProps } from './useERUtils'
 
 interface UseDeckMapUtilsProps {
@@ -42,6 +51,8 @@ export interface UseDeckMapUtilsResult {
   loadedLabware: LoadedLabware[]
   loadedModules: LoadedModule[]
   movedLabwareDef: LabwareDefinition2 | null
+  moduleRenderInfo: RunModuleInfo[]
+  labwareRenderInfo: RunLabwareInfo[]
   highlightLabwareEventuallyIn: string[]
   kind: 'intervention'
   robotType: RobotType
@@ -96,6 +107,30 @@ export function useDeckMapUtils({
       ? labwareDefinitionsByUri[failedLabwareUtils.failedLabware.definitionUri]
       : null
 
+  const moduleRenderInfo = useMemo(
+    () =>
+      runRecord != null && labwareDefinitionsByUri != null
+        ? getRunModuleRenderInfo(
+            runRecord.data,
+            deckDef,
+            labwareDefinitionsByUri
+          )
+        : [],
+    [deckDef, labwareDefinitionsByUri, runRecord]
+  )
+
+  const labwareRenderInfo = useMemo(
+    () =>
+      runRecord != null && labwareDefinitionsByUri != null
+        ? getRunLabwareRenderInfo(
+            runRecord.data,
+            labwareDefinitionsByUri,
+            deckDef
+          )
+        : [],
+    [deckDef, labwareDefinitionsByUri, runRecord]
+  )
+
   return {
     deckConfig,
     modulesOnDeck: runCurrentModules.map(
@@ -118,6 +153,8 @@ export function useDeckMapUtils({
     loadedModules: runRecord?.data.modules ?? [],
     loadedLabware: runRecord?.data.labware ?? [],
     movedLabwareDef,
+    moduleRenderInfo,
+    labwareRenderInfo,
   }
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -20,7 +20,11 @@ import { useShowDoorInfo } from './useShowDoorInfo'
 import { useCleanupRecoveryState } from './useCleanupRecoveryState'
 import { useFailedPipetteUtils } from './useFailedPipetteUtils'
 
-import type { LabwareDefinition2, RobotType } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition2,
+  LabwareDefinitionsByUri,
+  RobotType,
+} from '@opentrons/shared-data'
 import type { IRecoveryMap, RouteStep, RecoveryRoute } from '../types'
 import type { ErrorRecoveryFlowsProps } from '..'
 import type { UseRouteUpdateActionsResult } from './useRouteUpdateActions'
@@ -48,6 +52,7 @@ export type ERUtilsProps = Omit<ErrorRecoveryFlowsProps, 'failedCommand'> & {
   failedCommand: ReturnType<typeof useRetainedFailedCommandBySource>
   showTakeover: boolean
   allRunDefs: LabwareDefinition2[]
+  labwareDefinitionsByUri: LabwareDefinitionsByUri | null
 }
 
 export interface ERUtilsResults {
@@ -82,6 +87,7 @@ export function useERUtils({
   runStatus,
   showTakeover,
   allRunDefs,
+  labwareDefinitionsByUri,
 }: ERUtilsProps): ERUtilsResults {
   const { data: attachedInstruments } = useInstrumentsQuery()
   const { data: runRecord } = useNotifyRunQuery(runId)
@@ -168,6 +174,7 @@ export function useERUtils({
     runRecord,
     protocolAnalysis,
     failedLabwareUtils,
+    labwareDefinitionsByUri,
   })
 
   const recoveryActionMutationUtils = useRecoveryActionMutation(

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -107,7 +107,7 @@ export function useFailedLabwareUtils({
   const failedLabwareLocations = useRelevantFailedLwLocations({
     failedLabware,
     failedCommandByRunRecord,
-    protocolAnalysis,
+    runRecord,
   })
 
   return {
@@ -340,7 +340,7 @@ export function getRelevantWellName(
 
 export type GetRelevantLwLocationsParams = Pick<
   UseFailedLabwareUtilsProps,
-  'protocolAnalysis' | 'failedCommandByRunRecord'
+  'runRecord' | 'failedCommandByRunRecord'
 > & {
   failedLabware: UseFailedLabwareUtilsResult['failedLabware']
 }
@@ -348,7 +348,7 @@ export type GetRelevantLwLocationsParams = Pick<
 export function useRelevantFailedLwLocations({
   failedLabware,
   failedCommandByRunRecord,
-  protocolAnalysis,
+  runRecord,
 }: GetRelevantLwLocationsParams): RelevantFailedLabwareLocations {
   const { t } = useTranslation('protocol_command_text')
 
@@ -356,8 +356,8 @@ export function useRelevantFailedLwLocations({
     LabwareDisplayLocationSlotOnly,
     'location'
   > = {
-    loadedLabwares: protocolAnalysis?.labware ?? [],
-    loadedModules: protocolAnalysis?.modules ?? [],
+    loadedLabwares: runRecord?.data?.labware ?? [],
+    loadedModules: runRecord?.data?.modules ?? [],
     robotType: FLEX_ROBOT_TYPE,
     t,
     detailLevel: 'slot-only',

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -13,11 +13,13 @@ import {
   RUN_STATUS_STOP_REQUESTED,
   RUN_STATUS_SUCCEEDED,
 } from '@opentrons/api-client'
-import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import {
+  getLoadedLabwareDefinitionsByUri,
+  OT2_ROBOT_TYPE,
+} from '@opentrons/shared-data'
 import { useHost } from '@opentrons/react-api-client'
 
 import { getIsOnDevice } from '/app/redux/config'
-import { getLabwareDefinitionsFromCommands } from '/app/local-resources/labware'
 import { ErrorRecoveryWizard, useERWizard } from './ErrorRecoveryWizard'
 import { RecoverySplash, useRecoverySplash } from './RecoverySplash'
 import { RecoveryTakeover } from './RecoveryTakeover'
@@ -127,13 +129,19 @@ export function ErrorRecoveryFlows(
   const robotName = useHost()?.robotName ?? 'robot'
 
   const isValidRobotSideAnalysis = protocolAnalysis != null
-  const allRunDefs = useMemo(
+
+  // TODO(jh, 10-22-24): EXEC-769.
+  const labwareDefinitionsByUri = useMemo(
     () =>
       protocolAnalysis != null
-        ? getLabwareDefinitionsFromCommands(protocolAnalysis.commands)
-        : [],
+        ? getLoadedLabwareDefinitionsByUri(protocolAnalysis?.commands)
+        : null,
     [isValidRobotSideAnalysis]
   )
+  const allRunDefs =
+    labwareDefinitionsByUri != null
+      ? Object.values(labwareDefinitionsByUri)
+      : []
 
   const {
     showTakeover,
@@ -151,6 +159,7 @@ export function ErrorRecoveryFlows(
     showTakeover,
     failedCommand: failedCommandBySource,
     allRunDefs,
+    labwareDefinitionsByUri,
   })
 
   const renderWizard =

--- a/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
@@ -22,12 +22,14 @@ export function LeftColumnLabwareInfo({
     failedLabwareNickname,
     failedLabwareLocations,
   } = failedLabwareUtils
-  const { newLoc, currentLoc } = failedLabwareLocations
+  const { displayNameNewLoc, displayNameCurrentLoc } = failedLabwareLocations
 
   const buildNewLocation = (): React.ComponentProps<
     typeof InterventionContent
   >['infoProps']['newLocationProps'] =>
-    newLoc != null ? { deckLabel: newLoc.toUpperCase() } : undefined
+    displayNameNewLoc != null
+      ? { deckLabel: displayNameNewLoc.toUpperCase() }
+      : undefined
 
   return (
     <InterventionContent
@@ -36,7 +38,9 @@ export function LeftColumnLabwareInfo({
         type,
         labwareName: failedLabwareName ?? '',
         labwareNickname: failedLabwareNickname ?? '',
-        currentLocationProps: { deckLabel: currentLoc.toUpperCase() },
+        currentLocationProps: {
+          deckLabel: displayNameCurrentLoc.toUpperCase(),
+        },
         newLocationProps: buildNewLocation(),
       }}
       notificationProps={

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
@@ -1,4 +1,11 @@
-import { Flex } from '@opentrons/components'
+import {
+  Flex,
+  MoveLabwareOnDeck,
+  COLORS,
+  Module,
+  LabwareRender,
+} from '@opentrons/components'
+import { inferModuleOrientationFromXCoordinate } from '@opentrons/shared-data'
 
 import { useTranslation } from 'react-i18next'
 import { RecoverySingleColumnContentWrapper } from './RecoveryContentWrapper'
@@ -8,8 +15,8 @@ import { LeftColumnLabwareInfo } from './LeftColumnLabwareInfo'
 import { getSlotNameAndLwLocFrom } from '../hooks/useDeckMapUtils'
 import { RECOVERY_MAP } from '../constants'
 
-import type { RecoveryContentProps } from '../types'
 import type * as React from 'react'
+import type { RecoveryContentProps } from '../types'
 import type { InterventionContent } from '/app/molecules/InterventionModal/InterventionContent'
 
 export function TwoColLwInfoAndDeck(
@@ -21,6 +28,7 @@ export function TwoColLwInfoAndDeck(
     failedLabwareUtils,
     deckMapUtils,
     currentRecoveryOptionUtils,
+    isOnDevice,
   } = props
   const {
     RETRY_NEW_TIPS,
@@ -100,6 +108,76 @@ export function TwoColLwInfoAndDeck(
     }
   }
 
+  // TODO(jh, 10-22-24): Componentize an app-only abstraction above MoveLabwareOnDeck. EXEC-788.
+  const buildDeckView = (): JSX.Element => {
+    switch (selectedRecoveryOption) {
+      case MANUAL_MOVE_AND_SKIP.ROUTE: {
+        const { newLoc, currentLoc } = failedLabwareUtils.failedLabwareLocations
+        const {
+          movedLabwareDef,
+          moduleRenderInfo,
+          labwareRenderInfo,
+          ...restUtils
+        } = deckMapUtils
+
+        const failedLwId = failedLabware?.id ?? ''
+
+        const isValidDeck =
+          currentLoc != null && newLoc != null && movedLabwareDef != null
+
+        return isValidDeck ? (
+          <MoveLabwareOnDeck
+            deckFill={isOnDevice ? COLORS.grey35 : '#e6e6e6'}
+            initialLabwareLocation={currentLoc}
+            finalLabwareLocation={newLoc}
+            movedLabwareDef={movedLabwareDef}
+            {...restUtils}
+            backgroundItems={
+              <>
+                {moduleRenderInfo.map(
+                  ({
+                    x,
+                    y,
+                    moduleId,
+                    moduleDef,
+                    nestedLabwareDef,
+                    nestedLabwareId,
+                  }) => (
+                    <Module
+                      key={moduleId}
+                      def={moduleDef}
+                      x={x}
+                      y={y}
+                      orientation={inferModuleOrientationFromXCoordinate(x)}
+                    >
+                      {nestedLabwareDef != null &&
+                      nestedLabwareId !== failedLwId ? (
+                        <LabwareRender definition={nestedLabwareDef} />
+                      ) : null}
+                    </Module>
+                  )
+                )}
+                {labwareRenderInfo
+                  .filter(l => l.labwareId !== failedLwId)
+                  .map(({ x, y, labwareDef, labwareId }) => (
+                    <g key={labwareId} transform={`translate(${x},${y})`}>
+                      {labwareDef != null && labwareId !== failedLwId ? (
+                        <LabwareRender definition={labwareDef} />
+                      ) : null}
+                    </g>
+                  ))}
+              </>
+            }
+          />
+        ) : (
+          <Flex />
+        )
+      }
+      default:
+        return <DeckMapContent {...deckMapUtils} />
+    }
+  }
+
   return (
     <RecoverySingleColumnContentWrapper>
       <TwoColumn>
@@ -109,9 +187,7 @@ export function TwoColLwInfoAndDeck(
           type={buildType()}
           bannerText={buildBannerText()}
         />
-        <Flex marginTop="0.7rem">
-          <DeckMapContent {...deckMapUtils} />
-        </Flex>
+        <Flex marginTop="0.7rem">{buildDeckView()}</Flex>
       </TwoColumn>
       <RecoveryFooterButtons primaryBtnOnClick={primaryOnClick} />
     </RecoverySingleColumnContentWrapper>

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
@@ -27,8 +27,8 @@ describe('LeftColumnLabwareInfo', () => {
         failedLabwareName: 'MOCK_LW_NAME',
         failedLabwareNickname: 'MOCK_LW_NICKNAME',
         failedLabwareLocations: {
-          currentLoc: 'slot A1',
-          newLoc: 'slot B2',
+          displayNameCurrentLoc: 'slot A1',
+          displayNameNewLoc: 'slot B2',
         },
       } as any,
       type: 'location',
@@ -93,7 +93,10 @@ describe('LeftColumnLabwareInfo', () => {
     props.failedLabwareUtils.failedLabwareLocations = {
       displayNameCurrentLoc: 'slot A1',
       displayNameNewLoc: 'slot B2',
+      newLoc: {} as any,
+      currentLoc: {} as any,
     }
+
     render(props)
 
     expect(vi.mocked(InterventionContent)).toHaveBeenCalledWith(

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
@@ -76,7 +76,7 @@ describe('LeftColumnLabwareInfo', () => {
   })
 
   it('does not include newLocationProps when newLoc is not provided', () => {
-    props.failedLabwareUtils.failedLabwareLocations.newLoc = null
+    props.failedLabwareUtils.failedLabwareLocations.displayNameNewLoc = null
     render(props)
 
     expect(vi.mocked(InterventionContent)).toHaveBeenCalledWith(
@@ -91,8 +91,8 @@ describe('LeftColumnLabwareInfo', () => {
 
   it('converts location labels to uppercase', () => {
     props.failedLabwareUtils.failedLabwareLocations = {
-      currentLoc: 'slot A1',
-      newLoc: 'slot B2',
+      displayNameCurrentLoc: 'slot A1',
+      displayNameNewLoc: 'slot B2',
     }
     render(props)
 

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SelectTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SelectTips.test.tsx
@@ -53,7 +53,10 @@ describe('SelectTips', () => {
       failedLabwareUtils: {
         selectedTipLocations: { A1: null },
         areTipsSelected: true,
-        failedLabwareLocations: { newLoc: null, currentLoc: 'A1' },
+        failedLabwareLocations: {
+          displayNameNewLoc: null,
+          displayNameCurrentLoc: 'A1',
+        },
       } as any,
     }
 
@@ -161,7 +164,10 @@ describe('SelectTips', () => {
       failedLabwareUtils: {
         selectedTipLocations: null,
         areTipsSelected: false,
-        failedLabwareLocations: { newLoc: null, currentLoc: '' },
+        failedLabwareLocations: {
+          displayNameNewLoc: null,
+          displayNameCurrentLoc: '',
+        },
       } as any,
     }
 


### PR DESCRIPTION
Closes [RQA-3392](https://opentrons.atlassian.net/browse/RQA-3392)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Per design, when manually moving labware during a gripper error recovery flow, we should show the labware moving instead of stationary in the initial slot . While there exists a move labware deck view, it does require some legwork to wire up the props necessary to render the component, `MoveLabwareOnDeck`. There's room to make `MoveLabwareOnDeck` better and not make use of utils internal to the component, see [EXEC-788](https://opentrons.atlassian.net/browse/EXEC-788). 

e55194864d075fb38a37f882838166c614fe5287 - We need actual labware locations for `MoveLabwareOnDeck`, since we're doing more than just rendering their display equivalent now.

f8ed1070b7152e84f956050cb7dd442522c2540d - Turns out we have another O(n) util that does almost the same thing as `getLabwareDefinitionsFromCommands`, and it turns out we are also misusing it in the app. I've corrected the one misuse of this in Error Recovery. There's already a sustaining ticket for auditing our usage of these utils.

19ad1d6b227d637d0808f42776bf94ec56e15d46 - Fixes a bug that's obvious when nesting labware on top of a module.

d6110fa5e84dddb7bd0c9ca64e477f26da803a18 - Wires up the new props to an appropriate deck map.

48ff3a02d05335f2b2c3b2d46eea240bc9a45e9e - Tests, etc.


https://github.com/user-attachments/assets/64d9ebec-8d33-49d9-bcde-d2deaa9515d7

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
- Smoke tested some other ER runs. Behavior is as expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Manually moving labware during a failed gripper recovery shows the "move labware" animation on the deck view.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3392]: https://opentrons.atlassian.net/browse/RQA-3392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-788]: https://opentrons.atlassian.net/browse/EXEC-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ