### PR TITLE
fix(app): store run step completion in redux

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 import {
   RUN_STATUS_IDLE,
@@ -14,6 +15,7 @@ import {
   useTrackEvent,
 } from '/app/redux/analytics'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
+import { getMissingSetupSteps } from '/app/redux/protocol-runs'
 import { useIsHeaterShakerInProtocol } from '/app/organisms/ModuleCard/hooks'
 import { isAnyHeaterShakerShaking } from '../../../RunHeaderModalContainer/modals'
 import {
@@ -24,6 +26,8 @@ import {
 
 import type { IconName } from '@opentrons/components'
 import type { BaseActionButtonProps } from '..'
+import type { State } from '/app/redux/types'
+import type { StepKey } from '/app/redux/protocol-runs'
 
 interface UseButtonPropertiesProps extends BaseActionButtonProps {
   isProtocolNotReady: boolean
@@ -42,7 +46,6 @@ interface UseButtonPropertiesProps extends BaseActionButtonProps {
 export function useActionButtonProperties({
   isProtocolNotReady,
   runStatus,
-  missingSetupSteps,
   robotName,
   runId,
   confirmAttachment,
@@ -66,6 +69,9 @@ export function useActionButtonProperties({
   const isHeaterShakerInProtocol = useIsHeaterShakerInProtocol()
   const isHeaterShakerShaking = isAnyHeaterShakerShaking(attachedModules)
   const trackEvent = useTrackEvent()
+  const missingSetupSteps = useSelector<State, StepKey[]>((state: State) =>
+    getMissingSetupSteps(state, runId)
+  )
 
   let buttonText = ''
   let handleButtonClick = (): void => {}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useMissingStepsModal.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useMissingStepsModal.ts
@@ -1,17 +1,21 @@
+import { useSelector } from 'react-redux'
 import { RUN_STATUS_IDLE, RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import { useConditionalConfirm } from '@opentrons/components'
 
 import { useIsHeaterShakerInProtocol } from '/app/organisms/ModuleCard/hooks'
 import { isAnyHeaterShakerShaking } from '../modals'
+import { getMissingSetupSteps } from '/app/redux/protocol-runs'
 
 import type { UseConditionalConfirmResult } from '@opentrons/components'
 import type { RunStatus, AttachedModule } from '@opentrons/api-client'
 import type { ConfirmMissingStepsModalProps } from '../modals'
+import type { State } from '/app/redux/types'
+import type { StepKey } from '/app/redux/protocol-runs'
 
 interface UseMissingStepsModalProps {
   runStatus: RunStatus | null
   attachedModules: AttachedModule[]
-  missingSetupSteps: string[]
+  runId: string
   handleProceedToRunClick: () => void
 }
 
@@ -30,12 +34,14 @@ export type UseMissingStepsModalResult =
 export function useMissingStepsModal({
   attachedModules,
   runStatus,
-  missingSetupSteps,
+  runId,
   handleProceedToRunClick,
 }: UseMissingStepsModalProps): UseMissingStepsModalResult {
   const isHeaterShakerInProtocol = useIsHeaterShakerInProtocol()
   const isHeaterShakerShaking = isAnyHeaterShakerShaking(attachedModules)
-
+  const missingSetupSteps = useSelector<State, StepKey[]>((state: State) =>
+    getMissingSetupSteps(state, runId)
+  )
   const shouldShowHSConfirm =
     isHeaterShakerInProtocol &&
     !isHeaterShakerShaking &&

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmMissingStepsModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmMissingStepsModal.tsx
@@ -12,11 +12,27 @@ import {
   TYPOGRAPHY,
   Modal,
 } from '@opentrons/components'
+import {
+  LPC_STEP_KEY,
+  LABWARE_SETUP_STEP_KEY,
+  LIQUID_SETUP_STEP_KEY,
+  MODULE_SETUP_STEP_KEY,
+  ROBOT_CALIBRATION_STEP_KEY,
+} from '/app/redux/protocol-runs'
+import type { StepKey } from '/app/redux/protocol-runs'
+
+const STEP_KEY_TO_I18N_KEY = {
+  [LPC_STEP_KEY]: 'applied_labware_offsets',
+  [LABWARE_SETUP_STEP_KEY]: 'labware_placement',
+  [LIQUID_SETUP_STEP_KEY]: 'liquids',
+  [MODULE_SETUP_STEP_KEY]: 'module_setup',
+  [ROBOT_CALIBRATION_STEP_KEY]: 'robot_calibration',
+}
 
 export interface ConfirmMissingStepsModalProps {
   onCloseClick: () => void
   onConfirmClick: () => void
-  missingSteps: string[]
+  missingSteps: StepKey[]
 }
 export const ConfirmMissingStepsModal = (
   props: ConfirmMissingStepsModalProps
@@ -41,7 +57,7 @@ export const ConfirmMissingStepsModal = (
             missingSteps: new Intl.ListFormat('en', {
               style: 'short',
               type: 'conjunction',
-            }).format(missingSteps.map(step => t(step))),
+            }).format(missingSteps.map(step => t(STEP_KEY_TO_I18N_KEY[step]))),
           })}
         </LegacyStyledText>
       </Flex>

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/useRunHeaderModalContainer.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/useRunHeaderModalContainer.ts
@@ -62,7 +62,6 @@ export function useRunHeaderModalContainer({
   runStatus,
   runRecord,
   attachedModules,
-  missingSetupSteps,
   protocolRunControls,
   runErrors,
 }: UseRunHeaderModalContainerProps): UseRunHeaderModalContainerResult {
@@ -102,7 +101,7 @@ export function useRunHeaderModalContainer({
   const missingStepsModalUtils = useMissingStepsModal({
     attachedModules,
     runStatus,
-    missingSetupSteps,
+    runId,
     handleProceedToRunClick,
   })
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
@@ -30,6 +30,7 @@ vi.mock('react-router-dom')
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/redux-resources/robots')
 vi.mock('/app/resources/runs')
+vi.mock('/app/redux/protocol-runs')
 vi.mock('../RunHeaderModalContainer')
 vi.mock('../RunHeaderBannerContainer')
 vi.mock('../RunHeaderContent')
@@ -51,7 +52,6 @@ describe('ProtocolRunHeader', () => {
       robotName: MOCK_ROBOT,
       runId: MOCK_RUN_ID,
       makeHandleJumpToStep: vi.fn(),
-      missingSetupSteps: [],
     }
 
     vi.mocked(useNavigate).mockReturnValue(mockNavigate)

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
@@ -35,7 +35,6 @@ export interface ProtocolRunHeaderProps {
   robotName: string
   runId: string
   makeHandleJumpToStep: (index: number) => () => void
-  missingSetupSteps: string[]
 }
 
 export function ProtocolRunHeader(

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -40,6 +40,13 @@ import {
   useModuleCalibrationStatus,
   useProtocolAnalysisErrors,
 } from '/app/resources/runs'
+import {
+  ROBOT_CALIBRATION_STEP_KEY,
+  MODULE_SETUP_STEP_KEY,
+  LPC_STEP_KEY,
+  LABWARE_SETUP_STEP_KEY,
+  LIQUID_SETUP_STEP_KEY,
+} from '/app/redux/protocol-runs'
 import { SetupLabware } from './SetupLabware'
 import { SetupLabwarePositionCheck } from './SetupLabwarePositionCheck'
 import { SetupRobotCalibration } from './SetupRobotCalibration'
@@ -49,18 +56,7 @@ import { SetupLiquids } from './SetupLiquids'
 import { EmptySetupStep } from './EmptySetupStep'
 import { HowLPCWorksModal } from './SetupLabwarePositionCheck/HowLPCWorksModal'
 
-const ROBOT_CALIBRATION_STEP_KEY = 'robot_calibration_step' as const
-const MODULE_SETUP_KEY = 'module_setup_step' as const
-const LPC_KEY = 'labware_position_check_step' as const
-const LABWARE_SETUP_KEY = 'labware_setup_step' as const
-const LIQUID_SETUP_KEY = 'liquid_setup_step' as const
-
-export type StepKey =
-  | typeof ROBOT_CALIBRATION_STEP_KEY
-  | typeof MODULE_SETUP_KEY
-  | typeof LPC_KEY
-  | typeof LABWARE_SETUP_KEY
-  | typeof LIQUID_SETUP_KEY
+import type { StepKey } from '/app/redux/protocol-runs'
 
 export type MissingStep =
   | 'applied_labware_offsets'
@@ -134,31 +130,35 @@ export function ProtocolRunSetup({
     protocolAnalysis != null
       ? [
           ROBOT_CALIBRATION_STEP_KEY,
-          MODULE_SETUP_KEY,
-          LPC_KEY,
-          LABWARE_SETUP_KEY,
-          LIQUID_SETUP_KEY,
+          MODULE_SETUP_STEP_KEY,
+          LPC_STEP_KEY,
+          LABWARE_SETUP_STEP_KEY,
+          LIQUID_SETUP_STEP_KEY,
         ]
-      : [ROBOT_CALIBRATION_STEP_KEY, LPC_KEY, LABWARE_SETUP_KEY]
+      : [ROBOT_CALIBRATION_STEP_KEY, LPC_STEP_KEY, LABWARE_SETUP_STEP_KEY]
 
   const targetStepKeyInOrder = stepsKeysInOrder.filter((stepKey: StepKey) => {
     if (protocolAnalysis == null) {
-      return stepKey !== MODULE_SETUP_KEY && stepKey !== LIQUID_SETUP_KEY
+      return (
+        stepKey !== MODULE_SETUP_STEP_KEY && stepKey !== LIQUID_SETUP_STEP_KEY
+      )
     }
 
     if (
       protocolAnalysis.modules.length === 0 &&
       protocolAnalysis.liquids.length === 0
     ) {
-      return stepKey !== MODULE_SETUP_KEY && stepKey !== LIQUID_SETUP_KEY
+      return (
+        stepKey !== MODULE_SETUP_STEP_KEY && stepKey !== LIQUID_SETUP_STEP_KEY
+      )
     }
 
     if (protocolAnalysis.modules.length === 0) {
-      return stepKey !== MODULE_SETUP_KEY
+      return stepKey !== MODULE_SETUP_STEP_KEY
     }
 
     if (protocolAnalysis.liquids.length === 0) {
-      return stepKey !== LIQUID_SETUP_KEY
+      return stepKey !== LIQUID_SETUP_STEP_KEY
     }
     return true
   })
@@ -240,11 +240,11 @@ export function ProtocolRunSetup({
         incompleteElement: null,
       },
     },
-    [MODULE_SETUP_KEY]: {
+    [MODULE_SETUP_STEP_KEY]: {
       stepInternals: (
         <SetupModuleAndDeck
           expandLabwarePositionCheckStep={() => {
-            setExpandedStepKey(LPC_KEY)
+            setExpandedStepKey(LPC_STEP_KEY)
           }}
           robotName={robotName}
           runId={runId}
@@ -256,7 +256,7 @@ export function ProtocolRunSetup({
         ? flexDeckHardwareDescription
         : ot2DeckHardwareDescription,
       rightElProps: {
-        stepKey: MODULE_SETUP_KEY,
+        stepKey: MODULE_SETUP_STEP_KEY,
         complete:
           calibrationStatusModules.complete &&
           !isMissingModule &&
@@ -272,14 +272,14 @@ export function ProtocolRunSetup({
         incompleteElement: null,
       },
     },
-    [LPC_KEY]: {
+    [LPC_STEP_KEY]: {
       stepInternals: (
         <SetupLabwarePositionCheck
           {...{ runId, robotName }}
           setOffsetsConfirmed={confirmed => {
             setLpcComplete(confirmed)
             if (confirmed) {
-              setExpandedStepKey(LABWARE_SETUP_KEY)
+              setExpandedStepKey(LABWARE_SETUP_STEP_KEY)
               setMissingSteps(
                 missingSteps.filter(step => step !== 'applied_labware_offsets')
               )
@@ -290,14 +290,14 @@ export function ProtocolRunSetup({
       ),
       description: t('labware_position_check_step_description'),
       rightElProps: {
-        stepKey: LPC_KEY,
+        stepKey: LPC_STEP_KEY,
         complete: lpcComplete,
         completeText: t('offsets_ready'),
         incompleteText: null,
         incompleteElement: <LearnAboutLPC />,
       },
     },
-    [LABWARE_SETUP_KEY]: {
+    [LABWARE_SETUP_STEP_KEY]: {
       stepInternals: (
         <SetupLabware
           robotName={robotName}
@@ -310,25 +310,27 @@ export function ProtocolRunSetup({
                 missingSteps.filter(step => step !== 'labware_placement')
               )
               const nextStep =
-                targetStepKeyInOrder.findIndex(v => v === LABWARE_SETUP_KEY) ===
+                targetStepKeyInOrder.findIndex(
+                  v => v === LABWARE_SETUP_STEP_KEY
+                ) ===
                 targetStepKeyInOrder.length - 1
                   ? null
-                  : LIQUID_SETUP_KEY
+                  : LIQUID_SETUP_STEP_KEY
               setExpandedStepKey(nextStep)
             }
           }}
         />
       ),
-      description: t(`${LABWARE_SETUP_KEY}_description`),
+      description: t(`${LABWARE_SETUP_STEP_KEY}_description`),
       rightElProps: {
-        stepKey: LABWARE_SETUP_KEY,
+        stepKey: LABWARE_SETUP_STEP_KEY,
         complete: labwareSetupComplete,
         completeText: t('placements_ready'),
         incompleteText: null,
         incompleteElement: null,
       },
     },
-    [LIQUID_SETUP_KEY]: {
+    [LIQUID_SETUP_STEP_KEY]: {
       stepInternals: (
         <SetupLiquids
           robotName={robotName}
@@ -345,10 +347,10 @@ export function ProtocolRunSetup({
         />
       ),
       description: hasLiquids
-        ? t(`${LIQUID_SETUP_KEY}_description`)
+        ? t(`${LIQUID_SETUP_STEP_KEY}_description`)
         : i18n.format(t('liquids_not_in_the_protocol'), 'capitalize'),
       rightElProps: {
-        stepKey: LIQUID_SETUP_KEY,
+        stepKey: LIQUID_SETUP_STEP_KEY,
         complete: liquidSetupComplete,
         completeText: t('liquids_ready'),
         incompleteText: null,
@@ -431,7 +433,7 @@ export function ProtocolRunSetup({
 interface NoHardwareRequiredStepCompletion {
   stepKey: Exclude<
     StepKey,
-    typeof ROBOT_CALIBRATION_STEP_KEY | typeof MODULE_SETUP_KEY
+    typeof ROBOT_CALIBRATION_STEP_KEY | typeof MODULE_SETUP_STEP_KEY
   >
   complete: boolean
   incompleteText: string | null
@@ -440,7 +442,7 @@ interface NoHardwareRequiredStepCompletion {
 }
 
 interface HardwareRequiredStepCompletion {
-  stepKey: typeof ROBOT_CALIBRATION_STEP_KEY | typeof MODULE_SETUP_KEY
+  stepKey: typeof ROBOT_CALIBRATION_STEP_KEY | typeof MODULE_SETUP_STEP_KEY
   complete: boolean
   missingHardware: boolean
   incompleteText: string | null
@@ -457,7 +459,7 @@ const stepRequiresHW = (
   props: StepRightElementProps
 ): props is HardwareRequiredStepCompletion =>
   props.stepKey === ROBOT_CALIBRATION_STEP_KEY ||
-  props.stepKey === MODULE_SETUP_KEY
+  props.stepKey === MODULE_SETUP_STEP_KEY
 
 function StepRightElement(props: StepRightElementProps): JSX.Element | null {
   if (props.complete) {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -63,14 +63,6 @@ import { HowLPCWorksModal } from './SetupLabwarePositionCheck/HowLPCWorksModal'
 import type { Dispatch, State } from '/app/redux/types'
 import type { StepKey } from '/app/redux/protocol-runs'
 
-const STEP_KEY_TO_I18N_KEY = {
-  LPC_STEP_KEY: 'applied_labware_offsets',
-  LABWARE_SETUP_STEP_KEY: 'labware_placement',
-  LIQUID_SETUP_STEP_KEY: 'liquids',
-  MODULE_SETUP_STEP_KEY: 'module_setup',
-  ROBOT_CALIBRATION_STEP_KEY: 'robot_calibrtion',
-}
-
 interface ProtocolRunSetupProps {
   protocolRunHeaderRef: React.RefObject<HTMLDivElement> | null
   robotName: string

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupRobotCalibration.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupRobotCalibration.tsx
@@ -23,7 +23,7 @@ import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import { useIsFlex } from '/app/redux-resources/robots'
 
 import type { ProtocolCalibrationStatus } from '/app/redux/calibration/types'
-import type { StepKey } from './ProtocolRunSetup'
+import type { StepKey } from '/app/redux/protocol-runs'
 
 interface SetupRobotCalibrationProps {
   robotName: string

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -32,10 +32,7 @@ import { useDeckConfigurationCompatibility } from '/app/resources/deck_configura
 import { useRobot, useIsFlex } from '/app/redux-resources/robots'
 import { useRequiredSetupStepsInOrder } from '/app/redux-resources/runs'
 import { useStoredProtocolAnalysis } from '/app/resources/analysis'
-import {
-  updateRunSetupStepsComplete,
-  getMissingSetupSteps,
-} from '/app/redux/protocol-runs'
+import { getMissingSetupSteps } from '/app/redux/protocol-runs'
 
 import { SetupLabware } from '../SetupLabware'
 import { SetupRobotCalibration } from '../SetupRobotCalibration'
@@ -46,8 +43,6 @@ import { ProtocolRunSetup } from '../ProtocolRunSetup'
 import * as ReduxRuns from '/app/redux/protocol-runs'
 
 import type { State } from '/app/redux/types'
-
-import type { StepKey } from '/app/redux/protocol-runs'
 
 import type * as SharedData from '@opentrons/shared-data'
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -94,7 +94,7 @@ const render = () => {
       runId={RUN_ID}
     />,
     {
-      initialState: {},
+      initialState: {} as State,
       i18nInstance: i18n,
     }
   )[0]

--- a/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
@@ -25,10 +25,7 @@ import { ApiHostProvider } from '@opentrons/react-api-client'
 import { useSyncRobotClock } from '/app/organisms/Desktop/Devices/hooks'
 import { ProtocolRunHeader } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader'
 import { RunPreview } from '/app/organisms/Desktop/Devices/RunPreview'
-import {
-  ProtocolRunSetup,
-  initialMissingSteps,
-} from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup'
+import { ProtocolRunSetup } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup'
 import { BackToTopButton } from '/app/organisms/Desktop/Devices/ProtocolRun/BackToTopButton'
 import { ProtocolRunModuleControls } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunModuleControls'
 import { ProtocolRunRuntimeParameters } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunRunTimeParameters'
@@ -187,10 +184,6 @@ function PageContents(props: PageContentsProps): JSX.Element {
     }
   }, [jumpedIndex])
 
-  const [missingSteps, setMissingSteps] = useState<
-    ReturnType<typeof initialMissingSteps>
-  >(initialMissingSteps())
-
   const makeHandleScrollToStep = (i: number) => () => {
     listRef.current?.scrollToIndex(i, true, -1 * JUMP_OFFSET_FROM_TOP_PX)
   }
@@ -210,8 +203,6 @@ function PageContents(props: PageContentsProps): JSX.Element {
           protocolRunHeaderRef={protocolRunHeaderRef}
           robotName={robotName}
           runId={runId}
-          setMissingSteps={setMissingSteps}
-          missingSteps={missingSteps}
         />
       ),
       backToTop: (
@@ -269,7 +260,6 @@ function PageContents(props: PageContentsProps): JSX.Element {
         robotName={robotName}
         runId={runId}
         makeHandleJumpToStep={makeHandleJumpToStep}
-        missingSetupSteps={missingSteps}
       />
       <Flex gridGap={SPACING.spacing8} marginBottom={SPACING.spacing12}>
         <SetupTab

--- a/app/src/redux-resources/runs/hooks/index.ts
+++ b/app/src/redux-resources/runs/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useRequiredSetupStepsInOrder'

--- a/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
+++ b/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
@@ -28,8 +28,8 @@ export interface UseRequiredSetupStepsInOrderProps {
 }
 
 export interface UseRequiredSetupStepsInOrderReturn {
-  orderedSteps: StepKey[]
-  orderedApplicableSteps: StepKey[]
+  orderedSteps: readonly StepKey[]
+  orderedApplicableSteps: readonly StepKey[]
 }
 
 const ALL_STEPS_IN_ORDER = [
@@ -76,7 +76,7 @@ const keyFor = (
 export function useRequiredSetupStepsInOrder({
   runId,
   protocolAnalysis,
-}: UseRequiredSetupStepsInOrderProps) {
+}: UseRequiredSetupStepsInOrderProps): UseRequiredSetupStepsInOrderReturn {
   const dispatch = useDispatch<Dispatch>()
   const requiredSteps = useSelector<State>(state =>
     getSetupStepsRequired(state, runId)

--- a/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
+++ b/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
@@ -1,0 +1,107 @@
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import {
+  updateRunSetupStepsRequired,
+  getSetupStepsRequired,
+  ROBOT_CALIBRATION_STEP_KEY,
+  MODULE_SETUP_STEP_KEY,
+  LPC_STEP_KEY,
+  LABWARE_SETUP_STEP_KEY,
+  LIQUID_SETUP_STEP_KEY,
+} from '/app/redux/protocol-runs'
+
+import type {
+  StepKey,
+  StepMap,
+  UpdateRunSetupStepsRequiredAction,
+} from '/app/redux/protocol-runs'
+import type { Dispatch, State } from '/app/redux/types'
+import type {
+  CompletedProtocolAnalysis,
+  ProtocolAnalysisOutput,
+} from '@opentrons/shared-data'
+
+export interface UseRequiredSetupStepsInOrderProps {
+  runId: string
+  protocolAnalysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput | null
+}
+
+export interface UseRequiredSetupStepsInOrderReturn {
+  orderedSteps: StepKey[]
+  orderedApplicableSteps: StepKey[]
+}
+
+const ALL_STEPS_IN_ORDER = [
+  ROBOT_CALIBRATION_STEP_KEY,
+  MODULE_SETUP_STEP_KEY,
+  LPC_STEP_KEY,
+  LABWARE_SETUP_STEP_KEY,
+  LIQUID_SETUP_STEP_KEY,
+] as const
+
+const NO_ANALYSIS_STEPS_IN_ORDER = [
+  ROBOT_CALIBRATION_STEP_KEY,
+  LPC_STEP_KEY,
+  LABWARE_SETUP_STEP_KEY,
+]
+
+const keysInOrder = (
+  protocolAnalysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput | null
+): UseRequiredSetupStepsInOrderReturn => {
+  const orderedSteps =
+    protocolAnalysis == null ? NO_ANALYSIS_STEPS_IN_ORDER : ALL_STEPS_IN_ORDER
+
+  const orderedApplicableSteps =
+    protocolAnalysis == null
+      ? NO_ANALYSIS_STEPS_IN_ORDER
+      : ALL_STEPS_IN_ORDER.filter((stepKey: StepKey) => {
+          if (protocolAnalysis.modules.length === 0) {
+            return stepKey !== MODULE_SETUP_STEP_KEY
+          }
+
+          if (protocolAnalysis.liquids.length === 0) {
+            return stepKey !== LIQUID_SETUP_STEP_KEY
+          }
+          return true
+        })
+  return { orderedSteps: orderedSteps as StepKey[], orderedApplicableSteps }
+}
+
+export function useRequiredSetupStepsInOrder({
+  runId,
+  protocolAnalysis,
+}: UseRequiredSetupStepsInOrderProps) {
+  const dispatch = useDispatch<Dispatch>()
+  const requiredSteps = useSelector<State>(state =>
+    getSetupStepsRequired(state, runId)
+  )
+
+  useEffect(() => {
+    const applicable = keysInOrder(protocolAnalysis)
+    dispatch(
+      updateRunSetupStepsRequired(runId, {
+        ...ALL_STEPS_IN_ORDER.reduce<
+          UpdateRunSetupStepsRequiredAction['payload']['required']
+        >(
+          (acc, thiskey) => ({
+            ...acc,
+            [thiskey]: applicable.orderedApplicableSteps.includes(thiskey),
+          }),
+          {}
+        ),
+      })
+    )
+  }, [runId, protocolAnalysis, dispatch])
+  return protocolAnalysis == null
+    ? {
+        orderedSteps: NO_ANALYSIS_STEPS_IN_ORDER,
+        orderedApplicableSteps: NO_ANALYSIS_STEPS_IN_ORDER,
+      }
+    : {
+        orderedSteps: ALL_STEPS_IN_ORDER,
+        orderedApplicableSteps: ALL_STEPS_IN_ORDER.filter(
+          step => (requiredSteps as Required<StepMap<boolean>> | null)?.[step]
+        ),
+      }
+}

--- a/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
+++ b/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
@@ -68,6 +68,11 @@ const keysInOrder = (
   return { orderedSteps: orderedSteps as StepKey[], orderedApplicableSteps }
 }
 
+const keyFor = (
+  analysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput | null
+  // @ts-expect-error(sf, 2024-10-23): purposeful weak object typing
+): string | null => analysis?.id ?? analysis?.metadata?.id ?? null
+
 export function useRequiredSetupStepsInOrder({
   runId,
   protocolAnalysis,
@@ -92,7 +97,7 @@ export function useRequiredSetupStepsInOrder({
         ),
       })
     )
-  }, [runId, protocolAnalysis, dispatch])
+  }, [runId, keyFor(protocolAnalysis), dispatch])
   return protocolAnalysis == null
     ? {
         orderedSteps: NO_ANALYSIS_STEPS_IN_ORDER,

--- a/app/src/redux-resources/runs/index.ts
+++ b/app/src/redux-resources/runs/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks'

--- a/app/src/redux/protocol-runs/__tests__/reducer.test.ts
+++ b/app/src/redux/protocol-runs/__tests__/reducer.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+
+import { protocolRunReducer } from '../reducer'
+import {
+    updateRunSetupStepsComplete,
+    updateRunSetupStepsRequired,
+} from '../actions'
+import * as Constants from '../constants'
+
+describe('protocol runs reducer', () => {
+    const INITIAL = {
+        [Constants.ROBOT_CALIBRATION_STEP_KEY]: {
+            required: true,
+            complete: false,
+        },
+        [Constants.MODULE_SETUP_STEP_KEY]: { required: true, complete: false },
+        [Constants.LPC_STEP_KEY]: { required: true, complete: false },
+        [Constants.LABWARE_SETUP_STEP_KEY]: {
+            required: true,
+            complete: false,
+        },
+        [Constants.LIQUID_SETUP_STEP_KEY]: { required: true, complete: false },
+    }
+    it('establishes an empty state if you tell it one', () => {
+        const nextState = protocolRunReducer(
+            undefined,
+            updateRunSetupStepsComplete('some-run-id', {})
+        )
+        expect(nextState['some-run-id']?.setup).toEqual(INITIAL)
+    })
+    it('updates complete based on an action', () => {
+        const nextState = protocolRunReducer(
+            {
+                ['some-run-id']: {
+                    setup: {
+                        ...INITIAL,
+                        [Constants.LIQUID_SETUP_STEP_KEY]: {
+                            complete: true,
+                            required: true,
+                        },
+                    },
+                },
+            },
+            updateRunSetupStepsComplete('some-run-id', {
+                [Constants.LPC_STEP_KEY]: true,
+            })
+        )
+        expect(nextState['some-run-id']?.setup).toEqual({
+            ...INITIAL,
+            [Constants.LIQUID_SETUP_STEP_KEY]: {
+                required: true,
+                complete: true,
+            },
+            [Constants.LPC_STEP_KEY]: { required: true, complete: true },
+        })
+    })
+    it('updates required based on an action', () => {
+        const nextState = protocolRunReducer(
+            {
+                ['some-run-id']: {
+                    setup: INITIAL,
+                },
+            },
+            updateRunSetupStepsRequired('some-run-id', {
+                [Constants.LIQUID_SETUP_STEP_KEY]: false,
+            })
+        )
+        expect(nextState['some-run-id']?.setup).toEqual({
+            ...INITIAL,
+            [Constants.LIQUID_SETUP_STEP_KEY]: {
+                required: false,
+                complete: false,
+            },
+        })
+    })
+})

--- a/app/src/redux/protocol-runs/__tests__/reducer.test.ts
+++ b/app/src/redux/protocol-runs/__tests__/reducer.test.ts
@@ -2,75 +2,75 @@ import { describe, it, expect } from 'vitest'
 
 import { protocolRunReducer } from '../reducer'
 import {
-    updateRunSetupStepsComplete,
-    updateRunSetupStepsRequired,
+  updateRunSetupStepsComplete,
+  updateRunSetupStepsRequired,
 } from '../actions'
 import * as Constants from '../constants'
 
 describe('protocol runs reducer', () => {
-    const INITIAL = {
-        [Constants.ROBOT_CALIBRATION_STEP_KEY]: {
-            required: true,
-            complete: false,
-        },
-        [Constants.MODULE_SETUP_STEP_KEY]: { required: true, complete: false },
-        [Constants.LPC_STEP_KEY]: { required: true, complete: false },
-        [Constants.LABWARE_SETUP_STEP_KEY]: {
-            required: true,
-            complete: false,
-        },
-        [Constants.LIQUID_SETUP_STEP_KEY]: { required: true, complete: false },
-    }
-    it('establishes an empty state if you tell it one', () => {
-        const nextState = protocolRunReducer(
-            undefined,
-            updateRunSetupStepsComplete('some-run-id', {})
-        )
-        expect(nextState['some-run-id']?.setup).toEqual(INITIAL)
-    })
-    it('updates complete based on an action', () => {
-        const nextState = protocolRunReducer(
-            {
-                ['some-run-id']: {
-                    setup: {
-                        ...INITIAL,
-                        [Constants.LIQUID_SETUP_STEP_KEY]: {
-                            complete: true,
-                            required: true,
-                        },
-                    },
-                },
-            },
-            updateRunSetupStepsComplete('some-run-id', {
-                [Constants.LPC_STEP_KEY]: true,
-            })
-        )
-        expect(nextState['some-run-id']?.setup).toEqual({
+  const INITIAL = {
+    [Constants.ROBOT_CALIBRATION_STEP_KEY]: {
+      required: true,
+      complete: false,
+    },
+    [Constants.MODULE_SETUP_STEP_KEY]: { required: true, complete: false },
+    [Constants.LPC_STEP_KEY]: { required: true, complete: false },
+    [Constants.LABWARE_SETUP_STEP_KEY]: {
+      required: true,
+      complete: false,
+    },
+    [Constants.LIQUID_SETUP_STEP_KEY]: { required: true, complete: false },
+  }
+  it('establishes an empty state if you tell it one', () => {
+    const nextState = protocolRunReducer(
+      undefined,
+      updateRunSetupStepsComplete('some-run-id', {})
+    )
+    expect(nextState['some-run-id']?.setup).toEqual(INITIAL)
+  })
+  it('updates complete based on an action', () => {
+    const nextState = protocolRunReducer(
+      {
+        ['some-run-id']: {
+          setup: {
             ...INITIAL,
             [Constants.LIQUID_SETUP_STEP_KEY]: {
-                required: true,
-                complete: true,
+              complete: true,
+              required: true,
             },
-            [Constants.LPC_STEP_KEY]: { required: true, complete: true },
-        })
+          },
+        },
+      },
+      updateRunSetupStepsComplete('some-run-id', {
+        [Constants.LPC_STEP_KEY]: true,
+      })
+    )
+    expect(nextState['some-run-id']?.setup).toEqual({
+      ...INITIAL,
+      [Constants.LIQUID_SETUP_STEP_KEY]: {
+        required: true,
+        complete: true,
+      },
+      [Constants.LPC_STEP_KEY]: { required: true, complete: true },
     })
-    it('updates required based on an action', () => {
-        const nextState = protocolRunReducer(
-            {
-                ['some-run-id']: {
-                    setup: INITIAL,
-                },
-            },
-            updateRunSetupStepsRequired('some-run-id', {
-                [Constants.LIQUID_SETUP_STEP_KEY]: false,
-            })
-        )
-        expect(nextState['some-run-id']?.setup).toEqual({
-            ...INITIAL,
-            [Constants.LIQUID_SETUP_STEP_KEY]: {
-                required: false,
-                complete: false,
-            },
-        })
+  })
+  it('updates required based on an action', () => {
+    const nextState = protocolRunReducer(
+      {
+        ['some-run-id']: {
+          setup: INITIAL,
+        },
+      },
+      updateRunSetupStepsRequired('some-run-id', {
+        [Constants.LIQUID_SETUP_STEP_KEY]: false,
+      })
+    )
+    expect(nextState['some-run-id']?.setup).toEqual({
+      ...INITIAL,
+      [Constants.LIQUID_SETUP_STEP_KEY]: {
+        required: false,
+        complete: false,
+      },
     })
+  })
 })

--- a/app/src/redux/protocol-runs/__tests__/reducer.test.ts
+++ b/app/src/redux/protocol-runs/__tests__/reducer.test.ts
@@ -31,7 +31,7 @@ describe('protocol runs reducer', () => {
   it('updates complete based on an action', () => {
     const nextState = protocolRunReducer(
       {
-        ['some-run-id']: {
+        'some-run-id': {
           setup: {
             ...INITIAL,
             [Constants.LIQUID_SETUP_STEP_KEY]: {
@@ -57,7 +57,7 @@ describe('protocol runs reducer', () => {
   it('updates required based on an action', () => {
     const nextState = protocolRunReducer(
       {
-        ['some-run-id']: {
+        'some-run-id': {
           setup: INITIAL,
         },
       },

--- a/app/src/redux/protocol-runs/actions.ts
+++ b/app/src/redux/protocol-runs/actions.ts
@@ -2,17 +2,17 @@ import * as Constants from './constants'
 import type * as Types from './types'
 
 export const updateRunSetupStepsComplete = (
-    runId: string,
-    complete: Types.UpdateRunSetupStepsCompleteAction['payload']['complete']
+  runId: string,
+  complete: Types.UpdateRunSetupStepsCompleteAction['payload']['complete']
 ): Types.UpdateRunSetupStepsCompleteAction => ({
-    type: Constants.UPDATE_RUN_SETUP_STEPS_COMPLETE,
-    payload: { runId, complete },
+  type: Constants.UPDATE_RUN_SETUP_STEPS_COMPLETE,
+  payload: { runId, complete },
 })
 
 export const updateRunSetupStepsRequired = (
-    runId: string,
-    required: Types.UpdateRunSetupStepsRequiredAction['payload']['required']
+  runId: string,
+  required: Types.UpdateRunSetupStepsRequiredAction['payload']['required']
 ): Types.UpdateRunSetupStepsRequiredAction => ({
-    type: Constants.UPDATE_RUN_SETUP_STEPS_REQUIRED,
-    payload: { runId, required },
+  type: Constants.UPDATE_RUN_SETUP_STEPS_REQUIRED,
+  payload: { runId, required },
 })

--- a/app/src/redux/protocol-runs/actions.ts
+++ b/app/src/redux/protocol-runs/actions.ts
@@ -1,0 +1,18 @@
+import * as Constants from './constants'
+import type * as Types from './types'
+
+export const updateRunSetupStepsComplete = (
+    runId: string,
+    complete: Types.UpdateRunSetupStepsCompleteAction['payload']['complete']
+): Types.UpdateRunSetupStepsCompleteAction => ({
+    type: Constants.UPDATE_RUN_SETUP_STEPS_COMPLETE,
+    payload: { runId, complete },
+})
+
+export const updateRunSetupStepsRequired = (
+    runId: string,
+    required: Types.UpdateRunSetupStepsRequiredAction['payload']['required']
+): Types.UpdateRunSetupStepsRequiredAction => ({
+    type: Constants.UPDATE_RUN_SETUP_STEPS_REQUIRED,
+    payload: { runId, required },
+})

--- a/app/src/redux/protocol-runs/constants.ts
+++ b/app/src/redux/protocol-runs/constants.ts
@@ -1,17 +1,17 @@
 export const ROBOT_CALIBRATION_STEP_KEY: 'robot_calibration_step' =
-    'robot_calibration_step'
+  'robot_calibration_step'
 export const MODULE_SETUP_STEP_KEY: 'module_setup_step' = 'module_setup_step'
 export const LPC_STEP_KEY: 'labware_position_check_step' =
-    'labware_position_check_step'
+  'labware_position_check_step'
 export const LABWARE_SETUP_STEP_KEY: 'labware_setup_step' = 'labware_setup_step'
 export const LIQUID_SETUP_STEP_KEY: 'liquid_setup_step' = 'liquid_setup_step'
 
 export const SETUP_STEP_KEYS = [
-    ROBOT_CALIBRATION_STEP_KEY,
-    MODULE_SETUP_STEP_KEY,
-    LPC_STEP_KEY,
-    LABWARE_SETUP_STEP_KEY,
-    LIQUID_SETUP_STEP_KEY,
+  ROBOT_CALIBRATION_STEP_KEY,
+  MODULE_SETUP_STEP_KEY,
+  LPC_STEP_KEY,
+  LABWARE_SETUP_STEP_KEY,
+  LIQUID_SETUP_STEP_KEY,
 ] as const
 
 export const UPDATE_RUN_SETUP_STEPS_COMPLETE = 'protocolRuns:UPDATE_RUN_SETUP_STEPS_COMPLETE' as const

--- a/app/src/redux/protocol-runs/constants.ts
+++ b/app/src/redux/protocol-runs/constants.ts
@@ -1,0 +1,18 @@
+export const ROBOT_CALIBRATION_STEP_KEY: 'robot_calibration_step' =
+    'robot_calibration_step'
+export const MODULE_SETUP_STEP_KEY: 'module_setup_step' = 'module_setup_step'
+export const LPC_STEP_KEY: 'labware_position_check_step' =
+    'labware_position_check_step'
+export const LABWARE_SETUP_STEP_KEY: 'labware_setup_step' = 'labware_setup_step'
+export const LIQUID_SETUP_STEP_KEY: 'liquid_setup_step' = 'liquid_setup_step'
+
+export const SETUP_STEP_KEYS = [
+    ROBOT_CALIBRATION_STEP_KEY,
+    MODULE_SETUP_STEP_KEY,
+    LPC_STEP_KEY,
+    LABWARE_SETUP_STEP_KEY,
+    LIQUID_SETUP_STEP_KEY,
+] as const
+
+export const UPDATE_RUN_SETUP_STEPS_COMPLETE = 'protocolRuns:UPDATE_RUN_SETUP_STEPS_COMPLETE' as const
+export const UPDATE_RUN_SETUP_STEPS_REQUIRED = 'protocolRuns:UPDATE_RUN_SETUP_STEPS_REQUIRED' as const

--- a/app/src/redux/protocol-runs/index.ts
+++ b/app/src/redux/protocol-runs/index.ts
@@ -1,0 +1,7 @@
+// runs constants, actions, selectors, and types
+
+export * from './actions'
+export * from './constants'
+export * from './selectors'
+
+export type * from './types'

--- a/app/src/redux/protocol-runs/reducer.ts
+++ b/app/src/redux/protocol-runs/reducer.ts
@@ -4,10 +4,10 @@ import type { Reducer } from 'redux'
 import type { Action } from '../types'
 
 import type {
-    ProtocolRunState,
-    RunSetupStatus,
-    StepKey,
-    StepState,
+  ProtocolRunState,
+  RunSetupStatus,
+  StepKey,
+  StepState,
 } from './types'
 
 const INITIAL_STATE: ProtocolRunState = {}
@@ -15,58 +15,54 @@ const INITIAL_STATE: ProtocolRunState = {}
 const INITIAL_SETUP_STEP_STATE = { complete: false, required: true }
 
 const INITIAL_RUN_SETUP_STATE: RunSetupStatus = {
-    [Constants.ROBOT_CALIBRATION_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
-    [Constants.MODULE_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
-    [Constants.LPC_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
-    [Constants.LABWARE_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
-    [Constants.LIQUID_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+  [Constants.ROBOT_CALIBRATION_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+  [Constants.MODULE_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+  [Constants.LPC_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+  [Constants.LABWARE_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+  [Constants.LIQUID_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
 }
 
 export const protocolRunReducer: Reducer<ProtocolRunState, Action> = (
-    state = INITIAL_STATE,
-    action
+  state = INITIAL_STATE,
+  action
 ) => {
-    switch (action.type) {
-        case Constants.UPDATE_RUN_SETUP_STEPS_COMPLETE: {
-            return {
-                ...state,
-                [action.payload.runId]: {
-                    setup: Constants.SETUP_STEP_KEYS.reduce(
-                        (currentState, step) => ({
-                            ...currentState,
-                            [step]: {
-                                complete:
-                                    action.payload.complete[step] ??
-                                    currentState[step].complete,
-                                required: currentState[step].required,
-                            },
-                        }),
-                        state[action.payload.runId]?.setup ??
-                            INITIAL_RUN_SETUP_STATE
-                    ),
-                },
-            }
-        }
-        case Constants.UPDATE_RUN_SETUP_STEPS_REQUIRED: {
-            return {
-                ...state,
-                [action.payload.runId]: {
-                    setup: Constants.SETUP_STEP_KEYS.reduce(
-                        (currentState, step) => ({
-                            ...currentState,
-                            [step]: {
-                                required:
-                                    action.payload.required[step] ??
-                                    currentState[step].required,
-                                complete: currentState[step].complete,
-                            },
-                        }),
-                        state[action.payload.runId]?.setup ??
-                            INITIAL_RUN_SETUP_STATE
-                    ),
-                },
-            }
-        }
+  switch (action.type) {
+    case Constants.UPDATE_RUN_SETUP_STEPS_COMPLETE: {
+      return {
+        ...state,
+        [action.payload.runId]: {
+          setup: Constants.SETUP_STEP_KEYS.reduce(
+            (currentState, step) => ({
+              ...currentState,
+              [step]: {
+                complete:
+                  action.payload.complete[step] ?? currentState[step].complete,
+                required: currentState[step].required,
+              },
+            }),
+            state[action.payload.runId]?.setup ?? INITIAL_RUN_SETUP_STATE
+          ),
+        },
+      }
     }
-    return state
+    case Constants.UPDATE_RUN_SETUP_STEPS_REQUIRED: {
+      return {
+        ...state,
+        [action.payload.runId]: {
+          setup: Constants.SETUP_STEP_KEYS.reduce(
+            (currentState, step) => ({
+              ...currentState,
+              [step]: {
+                required:
+                  action.payload.required[step] ?? currentState[step].required,
+                complete: currentState[step].complete,
+              },
+            }),
+            state[action.payload.runId]?.setup ?? INITIAL_RUN_SETUP_STATE
+          ),
+        },
+      }
+    }
+  }
+  return state
 }

--- a/app/src/redux/protocol-runs/reducer.ts
+++ b/app/src/redux/protocol-runs/reducer.ts
@@ -3,12 +3,7 @@ import * as Constants from './constants'
 import type { Reducer } from 'redux'
 import type { Action } from '../types'
 
-import type {
-  ProtocolRunState,
-  RunSetupStatus,
-  StepKey,
-  StepState,
-} from './types'
+import type { ProtocolRunState, RunSetupStatus } from './types'
 
 const INITIAL_STATE: ProtocolRunState = {}
 

--- a/app/src/redux/protocol-runs/reducer.ts
+++ b/app/src/redux/protocol-runs/reducer.ts
@@ -1,0 +1,72 @@
+import * as Constants from './constants'
+
+import type { Reducer } from 'redux'
+import type { Action } from '../types'
+
+import type {
+    ProtocolRunState,
+    RunSetupStatus,
+    StepKey,
+    StepState,
+} from './types'
+
+const INITIAL_STATE: ProtocolRunState = {}
+
+const INITIAL_SETUP_STEP_STATE = { complete: false, required: true }
+
+const INITIAL_RUN_SETUP_STATE: RunSetupStatus = {
+    [Constants.ROBOT_CALIBRATION_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+    [Constants.MODULE_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+    [Constants.LPC_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+    [Constants.LABWARE_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+    [Constants.LIQUID_SETUP_STEP_KEY]: INITIAL_SETUP_STEP_STATE,
+}
+
+export const protocolRunReducer: Reducer<ProtocolRunState, Action> = (
+    state = INITIAL_STATE,
+    action
+) => {
+    switch (action.type) {
+        case Constants.UPDATE_RUN_SETUP_STEPS_COMPLETE: {
+            return {
+                ...state,
+                [action.payload.runId]: {
+                    setup: Constants.SETUP_STEP_KEYS.reduce(
+                        (currentState, step) => ({
+                            ...currentState,
+                            [step]: {
+                                complete:
+                                    action.payload.complete[step] ??
+                                    currentState[step].complete,
+                                required: currentState[step].required,
+                            },
+                        }),
+                        state[action.payload.runId]?.setup ??
+                            INITIAL_RUN_SETUP_STATE
+                    ),
+                },
+            }
+        }
+        case Constants.UPDATE_RUN_SETUP_STEPS_REQUIRED: {
+            return {
+                ...state,
+                [action.payload.runId]: {
+                    setup: Constants.SETUP_STEP_KEYS.reduce(
+                        (currentState, step) => ({
+                            ...currentState,
+                            [step]: {
+                                required:
+                                    action.payload.required[step] ??
+                                    currentState[step].required,
+                                complete: currentState[step].complete,
+                            },
+                        }),
+                        state[action.payload.runId]?.setup ??
+                            INITIAL_RUN_SETUP_STATE
+                    ),
+                },
+            }
+        }
+    }
+    return state
+}

--- a/app/src/redux/protocol-runs/selectors.ts
+++ b/app/src/redux/protocol-runs/selectors.ts
@@ -1,0 +1,91 @@
+import type { State } from '../types'
+import type * as Types from './types'
+
+export const getSetupStepComplete: (
+    state: State,
+    runId: string,
+    step: Types.StepKey
+) => boolean | null = (state, runId, step) =>
+    getSetupStepsComplete(state, runId)?.[step] ?? null
+
+export const getSetupStepsComplete: (
+    state: State,
+    runId: string
+) => Types.StepMap<boolean> | null = (state, runId) => {
+    const setup = state.protocolRuns[runId]?.setup
+    if (setup == null) {
+        return null
+    }
+    return (Object.entries(setup) as Array<
+        [Types.StepKey, Types.StepState]
+    >).reduce<Types.StepMap<boolean>>(
+        (acc, [step, state]) => ({
+            ...acc,
+            [step]: state.complete,
+        }),
+        {} as Types.StepMap<boolean>
+    )
+}
+
+export const getSetupStepRequired: (
+    state: State,
+    runId: string,
+    step: Types.StepKey
+) => boolean | null = (state, runId, step) =>
+    getSetupStepsRequired(state, runId)?.[step] ?? null
+
+export const getSetupStepsRequired: (
+    state: State,
+    runId: string
+) => Types.StepMap<boolean> | null = (state, runId) => {
+    const setup = state.protocolRuns[runId]?.setup
+    if (setup == null) {
+        return null
+    }
+    return (Object.entries(setup) as Array<
+        [Types.StepKey, Types.StepState]
+    >).reduce<Types.StepMap<boolean>>(
+        (acc, [step, state]) => ({ ...acc, [step]: state.required }),
+        {} as Types.StepMap<boolean>
+    )
+}
+
+export const getSetupStepMissing: (
+    state: State,
+    runId: string,
+    step: Types.StepKey
+) => boolean | null = (state, runId, step) =>
+    getSetupStepsMissing(state, runId)?.[step] || null
+
+export const getSetupStepsMissing: (
+    state: State,
+    runId: string
+) => Types.StepMap<boolean> | null = (state, runId) => {
+    const setup = state.protocolRuns[runId]?.setup
+    if (setup == null) {
+        return null
+    }
+    return (Object.entries(setup) as Array<
+        [Types.StepKey, Types.StepState]
+    >).reduce<Types.StepMap<boolean>>(
+        (acc, [step, state]) => ({
+            ...acc,
+            [step]: state.required && !state.complete,
+        }),
+        {} as Types.StepMap<boolean>
+    )
+}
+
+export const getMissingSetupSteps: (
+    state: State,
+    runId: string
+) => Types.StepKey[] = (state, runId) => {
+    const missingStepMap = getSetupStepsMissing(state, runId)
+    if (missingStepMap == null) return []
+    const missingStepList = (Object.entries(missingStepMap) as Array<
+        [Types.StepKey, boolean]
+    >)
+        .map(([step, missing]) => (missing ? step : null))
+        .filter(stepName => stepName != null)
+    return missingStepList as Types.StepKey[]
+}

--- a/app/src/redux/protocol-runs/selectors.ts
+++ b/app/src/redux/protocol-runs/selectors.ts
@@ -18,13 +18,13 @@ export const getSetupStepsComplete: (
   }
   return (Object.entries(setup) as Array<
     [Types.StepKey, Types.StepState]
-  >).reduce<Types.StepMap<boolean>>(
+  >).reduce<Partial<Types.StepMap<boolean>>>(
     (acc, [step, state]) => ({
       ...acc,
       [step]: state.complete,
     }),
-    {} as Types.StepMap<boolean>
-  )
+    {}
+  ) as Types.StepMap<boolean>
 }
 
 export const getSetupStepRequired: (
@@ -44,10 +44,10 @@ export const getSetupStepsRequired: (
   }
   return (Object.entries(setup) as Array<
     [Types.StepKey, Types.StepState]
-  >).reduce<Types.StepMap<boolean>>(
+  >).reduce<Partial<Types.StepMap<boolean>>>(
     (acc, [step, state]) => ({ ...acc, [step]: state.required }),
-    {} as Types.StepMap<boolean>
-  )
+    {}
+  ) as Types.StepMap<boolean>
 }
 
 export const getSetupStepMissing: (
@@ -67,13 +67,13 @@ export const getSetupStepsMissing: (
   }
   return (Object.entries(setup) as Array<
     [Types.StepKey, Types.StepState]
-  >).reduce<Types.StepMap<boolean>>(
+  >).reduce<Partial<Types.StepMap<boolean>>>(
     (acc, [step, state]) => ({
       ...acc,
       [step]: state.required && !state.complete,
     }),
-    {} as Types.StepMap<boolean>
-  )
+    {}
+  ) as Types.StepMap<boolean>
 }
 
 export const getMissingSetupSteps: (

--- a/app/src/redux/protocol-runs/selectors.ts
+++ b/app/src/redux/protocol-runs/selectors.ts
@@ -2,90 +2,90 @@ import type { State } from '../types'
 import type * as Types from './types'
 
 export const getSetupStepComplete: (
-    state: State,
-    runId: string,
-    step: Types.StepKey
+  state: State,
+  runId: string,
+  step: Types.StepKey
 ) => boolean | null = (state, runId, step) =>
-    getSetupStepsComplete(state, runId)?.[step] ?? null
+  getSetupStepsComplete(state, runId)?.[step] ?? null
 
 export const getSetupStepsComplete: (
-    state: State,
-    runId: string
+  state: State,
+  runId: string
 ) => Types.StepMap<boolean> | null = (state, runId) => {
-    const setup = state.protocolRuns[runId]?.setup
-    if (setup == null) {
-        return null
-    }
-    return (Object.entries(setup) as Array<
-        [Types.StepKey, Types.StepState]
-    >).reduce<Types.StepMap<boolean>>(
-        (acc, [step, state]) => ({
-            ...acc,
-            [step]: state.complete,
-        }),
-        {} as Types.StepMap<boolean>
-    )
+  const setup = state.protocolRuns[runId]?.setup
+  if (setup == null) {
+    return null
+  }
+  return (Object.entries(setup) as Array<
+    [Types.StepKey, Types.StepState]
+  >).reduce<Types.StepMap<boolean>>(
+    (acc, [step, state]) => ({
+      ...acc,
+      [step]: state.complete,
+    }),
+    {} as Types.StepMap<boolean>
+  )
 }
 
 export const getSetupStepRequired: (
-    state: State,
-    runId: string,
-    step: Types.StepKey
+  state: State,
+  runId: string,
+  step: Types.StepKey
 ) => boolean | null = (state, runId, step) =>
-    getSetupStepsRequired(state, runId)?.[step] ?? null
+  getSetupStepsRequired(state, runId)?.[step] ?? null
 
 export const getSetupStepsRequired: (
-    state: State,
-    runId: string
+  state: State,
+  runId: string
 ) => Types.StepMap<boolean> | null = (state, runId) => {
-    const setup = state.protocolRuns[runId]?.setup
-    if (setup == null) {
-        return null
-    }
-    return (Object.entries(setup) as Array<
-        [Types.StepKey, Types.StepState]
-    >).reduce<Types.StepMap<boolean>>(
-        (acc, [step, state]) => ({ ...acc, [step]: state.required }),
-        {} as Types.StepMap<boolean>
-    )
+  const setup = state.protocolRuns[runId]?.setup
+  if (setup == null) {
+    return null
+  }
+  return (Object.entries(setup) as Array<
+    [Types.StepKey, Types.StepState]
+  >).reduce<Types.StepMap<boolean>>(
+    (acc, [step, state]) => ({ ...acc, [step]: state.required }),
+    {} as Types.StepMap<boolean>
+  )
 }
 
 export const getSetupStepMissing: (
-    state: State,
-    runId: string,
-    step: Types.StepKey
+  state: State,
+  runId: string,
+  step: Types.StepKey
 ) => boolean | null = (state, runId, step) =>
-    getSetupStepsMissing(state, runId)?.[step] || null
+  getSetupStepsMissing(state, runId)?.[step] || null
 
 export const getSetupStepsMissing: (
-    state: State,
-    runId: string
+  state: State,
+  runId: string
 ) => Types.StepMap<boolean> | null = (state, runId) => {
-    const setup = state.protocolRuns[runId]?.setup
-    if (setup == null) {
-        return null
-    }
-    return (Object.entries(setup) as Array<
-        [Types.StepKey, Types.StepState]
-    >).reduce<Types.StepMap<boolean>>(
-        (acc, [step, state]) => ({
-            ...acc,
-            [step]: state.required && !state.complete,
-        }),
-        {} as Types.StepMap<boolean>
-    )
+  const setup = state.protocolRuns[runId]?.setup
+  if (setup == null) {
+    return null
+  }
+  return (Object.entries(setup) as Array<
+    [Types.StepKey, Types.StepState]
+  >).reduce<Types.StepMap<boolean>>(
+    (acc, [step, state]) => ({
+      ...acc,
+      [step]: state.required && !state.complete,
+    }),
+    {} as Types.StepMap<boolean>
+  )
 }
 
 export const getMissingSetupSteps: (
-    state: State,
-    runId: string
+  state: State,
+  runId: string
 ) => Types.StepKey[] = (state, runId) => {
-    const missingStepMap = getSetupStepsMissing(state, runId)
-    if (missingStepMap == null) return []
-    const missingStepList = (Object.entries(missingStepMap) as Array<
-        [Types.StepKey, boolean]
-    >)
-        .map(([step, missing]) => (missing ? step : null))
-        .filter(stepName => stepName != null)
-    return missingStepList as Types.StepKey[]
+  const missingStepMap = getSetupStepsMissing(state, runId)
+  if (missingStepMap == null) return []
+  const missingStepList = (Object.entries(missingStepMap) as Array<
+    [Types.StepKey, boolean]
+  >)
+    .map(([step, missing]) => (missing ? step : null))
+    .filter(stepName => stepName != null)
+  return missingStepList as Types.StepKey[]
 }

--- a/app/src/redux/protocol-runs/types.ts
+++ b/app/src/redux/protocol-runs/types.ts
@@ -1,11 +1,11 @@
 import {
-    ROBOT_CALIBRATION_STEP_KEY,
-    MODULE_SETUP_STEP_KEY,
-    LPC_STEP_KEY,
-    LABWARE_SETUP_STEP_KEY,
-    LIQUID_SETUP_STEP_KEY,
-    UPDATE_RUN_SETUP_STEPS_COMPLETE,
-    UPDATE_RUN_SETUP_STEPS_REQUIRED,
+  ROBOT_CALIBRATION_STEP_KEY,
+  MODULE_SETUP_STEP_KEY,
+  LPC_STEP_KEY,
+  LABWARE_SETUP_STEP_KEY,
+  LIQUID_SETUP_STEP_KEY,
+  UPDATE_RUN_SETUP_STEPS_COMPLETE,
+  UPDATE_RUN_SETUP_STEPS_REQUIRED,
 } from './constants'
 
 export type RobotCalibrationStepKey = typeof ROBOT_CALIBRATION_STEP_KEY
@@ -15,47 +15,47 @@ export type LabwareSetupStepKey = typeof LABWARE_SETUP_STEP_KEY
 export type LiquidSetupStepKey = typeof LIQUID_SETUP_STEP_KEY
 
 export type StepKey =
-    | RobotCalibrationStepKey
-    | ModuleSetupStepKey
-    | LPCStepKey
-    | LabwareSetupStepKey
-    | LiquidSetupStepKey
+  | RobotCalibrationStepKey
+  | ModuleSetupStepKey
+  | LPCStepKey
+  | LabwareSetupStepKey
+  | LiquidSetupStepKey
 
 export interface StepState {
-    required: boolean
-    complete: boolean
+  required: boolean
+  complete: boolean
 }
 
 export type StepMap<V> = { [Step in StepKey]: V }
 
 export type RunSetupStatus = {
-    [Step in StepKey]: StepState
+  [Step in StepKey]: StepState
 }
 
 export interface PerRunUIState {
-    setup: RunSetupStatus
+  setup: RunSetupStatus
 }
 
 export type ProtocolRunState = Partial<{
-    readonly [runId: string]: PerRunUIState
+  readonly [runId: string]: PerRunUIState
 }>
 
 export interface UpdateRunSetupStepsCompleteAction {
-    type: typeof UPDATE_RUN_SETUP_STEPS_COMPLETE
-    payload: {
-        runId: string
-        complete: Partial<{ [Step in StepKey]: boolean }>
-    }
+  type: typeof UPDATE_RUN_SETUP_STEPS_COMPLETE
+  payload: {
+    runId: string
+    complete: Partial<{ [Step in StepKey]: boolean }>
+  }
 }
 
 export interface UpdateRunSetupStepsRequiredAction {
-    type: typeof UPDATE_RUN_SETUP_STEPS_REQUIRED
-    payload: {
-        runId: string
-        required: Partial<{ [Step in StepKey]: boolean }>
-    }
+  type: typeof UPDATE_RUN_SETUP_STEPS_REQUIRED
+  payload: {
+    runId: string
+    required: Partial<{ [Step in StepKey]: boolean }>
+  }
 }
 
 export type ProtocolRunAction =
-    | UpdateRunSetupStepsCompleteAction
-    | UpdateRunSetupStepsRequiredAction
+  | UpdateRunSetupStepsCompleteAction
+  | UpdateRunSetupStepsRequiredAction

--- a/app/src/redux/protocol-runs/types.ts
+++ b/app/src/redux/protocol-runs/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ROBOT_CALIBRATION_STEP_KEY,
   MODULE_SETUP_STEP_KEY,
   LPC_STEP_KEY,

--- a/app/src/redux/protocol-runs/types.ts
+++ b/app/src/redux/protocol-runs/types.ts
@@ -1,0 +1,61 @@
+import {
+    ROBOT_CALIBRATION_STEP_KEY,
+    MODULE_SETUP_STEP_KEY,
+    LPC_STEP_KEY,
+    LABWARE_SETUP_STEP_KEY,
+    LIQUID_SETUP_STEP_KEY,
+    UPDATE_RUN_SETUP_STEPS_COMPLETE,
+    UPDATE_RUN_SETUP_STEPS_REQUIRED,
+} from './constants'
+
+export type RobotCalibrationStepKey = typeof ROBOT_CALIBRATION_STEP_KEY
+export type ModuleSetupStepKey = typeof MODULE_SETUP_STEP_KEY
+export type LPCStepKey = typeof LPC_STEP_KEY
+export type LabwareSetupStepKey = typeof LABWARE_SETUP_STEP_KEY
+export type LiquidSetupStepKey = typeof LIQUID_SETUP_STEP_KEY
+
+export type StepKey =
+    | RobotCalibrationStepKey
+    | ModuleSetupStepKey
+    | LPCStepKey
+    | LabwareSetupStepKey
+    | LiquidSetupStepKey
+
+export interface StepState {
+    required: boolean
+    complete: boolean
+}
+
+export type StepMap<V> = { [Step in StepKey]: V }
+
+export type RunSetupStatus = {
+    [Step in StepKey]: StepState
+}
+
+export interface PerRunUIState {
+    setup: RunSetupStatus
+}
+
+export type ProtocolRunState = Partial<{
+    readonly [runId: string]: PerRunUIState
+}>
+
+export interface UpdateRunSetupStepsCompleteAction {
+    type: typeof UPDATE_RUN_SETUP_STEPS_COMPLETE
+    payload: {
+        runId: string
+        complete: Partial<{ [Step in StepKey]: boolean }>
+    }
+}
+
+export interface UpdateRunSetupStepsRequiredAction {
+    type: typeof UPDATE_RUN_SETUP_STEPS_REQUIRED
+    payload: {
+        runId: string
+        required: Partial<{ [Step in StepKey]: boolean }>
+    }
+}
+
+export type ProtocolRunAction =
+    | UpdateRunSetupStepsCompleteAction
+    | UpdateRunSetupStepsRequiredAction

--- a/app/src/redux/reducer.ts
+++ b/app/src/redux/reducer.ts
@@ -48,6 +48,9 @@ import { calibrationReducer } from './calibration/reducer'
 // local protocol storage from file system state
 import { protocolStorageReducer } from './protocol-storage/reducer'
 
+// local protocol run state
+import { protocolRunReducer } from './protocol-runs/reducer'
+
 import type { Reducer } from 'redux'
 import type { State, Action } from './types'
 
@@ -68,4 +71,5 @@ export const rootReducer: Reducer<State, Action> = combineReducers({
   sessions: sessionReducer,
   calibration: calibrationReducer,
   protocolStorage: protocolStorageReducer,
+  protocolRuns: protocolRunReducer,
 })

--- a/app/src/redux/types.ts
+++ b/app/src/redux/types.ts
@@ -37,6 +37,8 @@ import type { AlertsState, AlertsAction } from './alerts/types'
 import type { SessionState, SessionsAction } from './sessions/types'
 import type { AnalyticsTriggerAction } from './analytics/types'
 
+import type { ProtocolRunState, ProtocolRunAction } from './protocol-runs/types'
+
 export interface State {
   readonly robotApi: RobotApiState
   readonly robotAdmin: RobotAdminState
@@ -54,6 +56,7 @@ export interface State {
   readonly sessions: SessionState
   readonly calibration: CalibrationState
   readonly protocolStorage: ProtocolStorageState
+  readonly protocolRuns: ProtocolRunState
 }
 
 export type Action =
@@ -78,6 +81,7 @@ export type Action =
   | CalibrationAction
   | AnalyticsTriggerAction
   | AddCustomLabwareFromCreatorAction
+  | ProtocolRunAction
 
 export type GetState = () => State
 


### PR DESCRIPTION
[It turns out that since we implemented the green checks displayed for completed steps as react component state, if you navigate away from the component it loses the state.

To fix this we can throw it in redux. This PR does that, in the app anyway. 

## testing
- [x] the green checks on the desktop should still work, including when you nav away and back

## reviews
- i have not done redux stuff in a while! does this look right?


Closes RQA-3304