### PR TITLE
chore(release): internal release notes ot3@v2.2.0-alpha.1

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -2,6 +2,10 @@ For more details about this release, please see the full [technical change log][
 
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.2.0-alpha.1
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.2.0. It's for internal testing only.
+
 ## Internal Release 2.2.0-alpha.0
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.2.0. It's for internal testing only.

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,6 +1,10 @@
 For more details about this release, please see the full [technical changelog][].
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.2.0-alpha.1
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.2.0. It's for internal testing only.
+
 ## Internal Release 2.2.0-alpha.0
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.2.0. It's for internal testing only.


### PR DESCRIPTION
# Overview

For internal release builds, I occasionally miss adding placeholder release notes before the builds. The audience testing these internal releases can use the repository and compare tags to see the changes.

When we perform an internal build for a specific audience or isolated code, the release notes will be more meaningful and should not be omitted.