### PR TITLE
fix(step-generation): add wait for temperature timeline warning

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -219,6 +219,10 @@
       "TIPRACK_IN_WASTE_CHUTE_HAS_TIPS": {
         "title": "Disposing unused tips",
         "body": "This step moves a tip rack that contains unused tips to the waste chute. There is no way to retrieve the tips after disposal."
+      },
+      "TEMPERATURE_IS_POTENTIALLY_UNREACHABLE": {
+        "title": "The pause temperature is potentially unreachable",
+        "body": "This step tries to set the module temperature but it can possibly not be reached, resulting in your protocol running forever."
       }
     }
   },

--- a/step-generation/src/__tests__/moveLabware.test.ts
+++ b/step-generation/src/__tests__/moveLabware.test.ts
@@ -372,7 +372,7 @@ describe('moveLabware', () => {
     )
     expect(result.warnings).toEqual([
       {
-        message: 'Disposing of a tiprack with tips',
+        message: 'Disposing unused tips',
         type: 'TIPRACK_IN_WASTE_CHUTE_HAS_TIPS',
       },
     ])

--- a/step-generation/src/__tests__/waitForTemperature.test.ts
+++ b/step-generation/src/__tests__/waitForTemperature.test.ts
@@ -46,7 +46,7 @@ describe('waitForTemperature', () => {
     invariantContext = stateAndContext.invariantContext
     robotState = stateAndContext.robotState
   })
-  it('temperature module id exists and temp status is approaching temp', () => {
+  it('temperature module id exists and temp status is approaching temp with a warning that the temp might not be hit', () => {
     const temperature = 20
     const args: WaitForTemperatureArgs = {
       module: temperatureModuleId,
@@ -68,6 +68,12 @@ describe('waitForTemperature', () => {
             moduleId: temperatureModuleId,
             celsius: 20,
           },
+        },
+      ],
+      warnings: [
+        {
+          type: 'TEMPERATURE_IS_POTENTIALLY_UNREACHABLE',
+          message: expect.any(String),
         },
       ],
     }

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -575,6 +575,7 @@ export type WarningType =
   | 'ASPIRATE_FROM_PRISTINE_WELL'
   | 'LABWARE_IN_WASTE_CHUTE_HAS_LIQUID'
   | 'TIPRACK_IN_WASTE_CHUTE_HAS_TIPS'
+  | 'TEMPERATURE_IS_POTENTIALLY_UNREACHABLE'
 
 export interface CommandCreatorWarning {
   message: string

--- a/step-generation/src/warningCreators.ts
+++ b/step-generation/src/warningCreators.ts
@@ -27,7 +27,6 @@ export function tiprackInWasteChuteHasTips(): CommandCreatorWarning {
 export function potentiallyUnreachableTemp(): CommandCreatorWarning {
   return {
     type: 'TEMPERATURE_IS_POTENTIALLY_UNREACHABLE',
-    message:
-      'The module set temperature is potentially unreachable.',
+    message: 'The module set temperature is potentially unreachable.',
   }
 }

--- a/step-generation/src/warningCreators.ts
+++ b/step-generation/src/warningCreators.ts
@@ -2,14 +2,13 @@ import type { CommandCreatorWarning } from './types'
 export function aspirateMoreThanWellContents(): CommandCreatorWarning {
   return {
     type: 'ASPIRATE_MORE_THAN_WELL_CONTENTS',
-    message: 'Not enough liquid in well(s)',
+    message: 'Not enough liquid',
   }
 }
 export function aspirateFromPristineWell(): CommandCreatorWarning {
   return {
     type: 'ASPIRATE_FROM_PRISTINE_WELL',
-    message:
-      'Aspirating from a pristine well. No liquids were ever added to this well',
+    message: 'This step tries to aspirate from an empty well.',
   }
 }
 export function labwareInWasteChuteHasLiquid(): CommandCreatorWarning {
@@ -21,6 +20,14 @@ export function labwareInWasteChuteHasLiquid(): CommandCreatorWarning {
 export function tiprackInWasteChuteHasTips(): CommandCreatorWarning {
   return {
     type: 'TIPRACK_IN_WASTE_CHUTE_HAS_TIPS',
-    message: 'Disposing of a tiprack with tips',
+    message: 'Disposing unused tips',
+  }
+}
+
+export function potentiallyUnreachableTemp(): CommandCreatorWarning {
+  return {
+    type: 'TEMPERATURE_IS_POTENTIALLY_UNREACHABLE',
+    message:
+      'The module set temperature is potentially unreachable.',
   }
 }


### PR DESCRIPTION
closes RESC-329 AUTH-891

# Overview

Adds in a warning to let the user know that the temperature might not be reached. The reason why its a warning and not an error is because sometimes, it will arise when the module is slowly changing between or before commands but sometimes it is actually blocking. there is no way to decipher if it is actually blocking.

This addresses an escalation ticket RESC-329 that we want fixed for the redesign release

<img width="1376" alt="Screenshot 2024-10-23 at 16 03 30" src="https://github.com/user-attachments/assets/7d09652b-1ba3-4ae7-80b3-729ed2bbf098">

## Test Plan and Hands on Testing

Upload the attached protocol and see that there are 2 warnings in the timeline from 2 pause steps. if you open them up, you should see the warning at the top of the form

[Protocol Script_05-Sep-2024 (2) (1).json](https://github.com/user-attachments/files/17497708/Protocol.Script_05-Sep-2024.2.1.json)

## Changelog

- adds the new warning creator to the waitToTemperature atomic command
- adds on to the test case

## Risk assessment

low
