### PR TITLE
fix(app): Fix "carraige" typo to "carriage"

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -49,7 +49,7 @@
   "install_probe": "Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the <bold>{{location}}</bold> pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.",
   "loose_detach": "Loosen screws and detach ",
   "move_gantry_to_front": "Move gantry to front",
-  "must_detach_mounting_plate": "You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.",
+  "must_detach_mounting_plate": "You must detach the mounting plate and reattach the z-axis carriage before using other pipettes. We do not recommend exiting this process before completion.",
   "name_and_volume_detected": "{{name}} Pipette Detected",
   "next": "next",
   "ninety_six_channel": "{{ninetySix}} pipette",

--- a/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
@@ -24,7 +24,7 @@ describe('UnskippableModal', () => {
     render(props)
     screen.getByText('This is a critical step that should not be skipped')
     screen.getByText(
-      'You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.'
+      'You must detach the mounting plate and reattach the z-axis carriage before using other pipettes. We do not recommend exiting this process before completion.'
     )
     fireEvent.click(screen.getByRole('button', { name: 'Go back' }))
     expect(props.goBack).toHaveBeenCalled()
@@ -39,7 +39,7 @@ describe('UnskippableModal', () => {
     render(props)
     screen.getByText('This is a critical step that should not be skipped')
     screen.getByText(
-      'You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.'
+      'You must detach the mounting plate and reattach the z-axis carriage before using other pipettes. We do not recommend exiting this process before completion.'
     )
     screen.getByText('Exit')
     screen.getByText('Go back')


### PR DESCRIPTION
## Overview

Fix a typo in the copy.

## Test Plan and Hands on Testing

None needed.

## Changelog

"carraige" -> "carriage"

## Review requests

None.

## Risk assessment

Very low.