### PR TITLE
refactor(api): Allow cache_tip() to overwrite the current tip

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1189,11 +1189,6 @@ class API(
 
         await self.retract(mount, spec.retract_target)
 
-    def cache_tip(self, mount: top_types.Mount, tip_length: float) -> None:
-        instrument = self.get_pipette(mount)
-        instrument.add_tip(tip_length=tip_length)
-        instrument.set_current_volume(0)
-
     async def pick_up_tip(
         self,
         mount: top_types.Mount,

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -430,6 +430,11 @@ class PipetteHandlerProvider(Generic[MountType]):
                 f"attach tip called while tip already attached to {instr}"
             )
 
+    def cache_tip(self, mount: MountType, tip_length: float) -> None:
+        instrument = self.get_pipette(mount)
+        instrument.add_tip(tip_length=tip_length)
+        instrument.set_current_volume(0)
+
     def remove_tip(self, mount: MountType) -> None:
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -432,6 +432,9 @@ class PipetteHandlerProvider(Generic[MountType]):
 
     def cache_tip(self, mount: MountType, tip_length: float) -> None:
         instrument = self.get_pipette(mount)
+        if instrument.has_tip:
+            # instrument.add_tip() would raise an AssertionError if we tried to overwrite an existing tip.
+            instrument.remove_tip()
         instrument.add_tip(tip_length=tip_length)
         instrument.set_current_volume(0)
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -442,7 +442,9 @@ class OT3PipetteHandler:
 
     def cache_tip(self, mount: OT3Mount, tip_length: float) -> None:
         instrument = self.get_pipette(mount)
-
+        if instrument.has_tip:
+            # instrument.add_tip() would raise an AssertionError if we tried to overwrite an existing tip.
+            instrument.remove_tip()
         instrument.add_tip(tip_length=tip_length)
         instrument.set_current_volume(0)
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -440,6 +440,12 @@ class OT3PipetteHandler:
                 "attach tip called while tip already attached to {instr}"
             )
 
+    def cache_tip(self, mount: OT3Mount, tip_length: float) -> None:
+        instrument = self.get_pipette(mount)
+
+        instrument.add_tip(tip_length=tip_length)
+        instrument.set_current_volume(0)
+
     def remove_tip(self, mount: OT3Mount) -> None:
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2236,15 +2236,6 @@ class OT3API(
             )
             await self.home_gear_motors()
 
-    def cache_tip(
-        self, mount: Union[top_types.Mount, OT3Mount], tip_length: float
-    ) -> None:
-        realmount = OT3Mount.from_mount(mount)
-        instrument = self._pipette_handler.get_pipette(realmount)
-
-        instrument.add_tip(tip_length=tip_length)
-        instrument.set_current_volume(0)
-
     async def pick_up_tip(
         self,
         mount: Union[top_types.Mount, OT3Mount],
@@ -2612,6 +2603,11 @@ class OT3API(
         self, mount: Union[top_types.Mount, OT3Mount], tip_length: float
     ) -> None:
         self._pipette_handler.add_tip(OT3Mount.from_mount(mount), tip_length)
+
+    def cache_tip(
+        self, mount: Union[top_types.Mount, OT3Mount], tip_length: float
+    ) -> None:
+        self._pipette_handler.cache_tip(OT3Mount.from_mount(mount), tip_length)
 
     def remove_tip(self, mount: Union[top_types.Mount, OT3Mount]) -> None:
         self._pipette_handler.remove_tip(OT3Mount.from_mount(mount))

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -142,10 +142,12 @@ class InstrumentConfigurer(Protocol[MountArgType]):
         """
         ...
 
-    # todo(mm, 2024-10-17): Consider deleting this in favor of cache_tip(), which is
-    # the same except for `assert`s, if we can do so without breaking anything.
+    # todo(mm, 2024-10-17): Consider deleting this in favor of cache_tip()
+    # if we can do so without breaking anything.
     def add_tip(self, mount: MountArgType, tip_length: float) -> None:
         """Inform the hardware that a tip is now attached to a pipette.
+
+        If a tip is already attached, this no-ops.
 
         This changes the critical point of the pipette to make sure that
         the end of the tip is what moves around, and allows liquid handling.
@@ -153,6 +155,11 @@ class InstrumentConfigurer(Protocol[MountArgType]):
         ...
 
     def cache_tip(self, mount: MountArgType, tip_length: float) -> None:
+        """Inform the hardware that a tip is now attached to a pipette.
+
+        This is like `add_tip()`, except that if a tip is already attached,
+        this replaces it instead of no-opping.
+        """
         ...
 
     def remove_tip(self, mount: MountArgType) -> None:

--- a/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
+++ b/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
@@ -78,7 +78,9 @@ class HardwareStopper:
                 try:
                     if self._state_store.labware.get_fixed_trash_id() == FIXED_TRASH_ID:
                         # OT-2 and Flex 2.15 protocols will default to the Fixed Trash Labware
-                        await self._tip_handler.add_tip(pipette_id=pipette_id, tip=tip)
+                        await self._tip_handler.cache_tip(
+                            pipette_id=pipette_id, tip=tip
+                        )
                         await self._movement_handler.move_to_well(
                             pipette_id=pipette_id,
                             labware_id=FIXED_TRASH_ID,
@@ -90,7 +92,9 @@ class HardwareStopper:
                         )
                     elif self._state_store.config.robot_type == "OT-2 Standard":
                         # API 2.16 and above OT2 protocols use addressable areas
-                        await self._tip_handler.add_tip(pipette_id=pipette_id, tip=tip)
+                        await self._tip_handler.cache_tip(
+                            pipette_id=pipette_id, tip=tip
+                        )
                         await self._movement_handler.move_to_addressable_area(
                             pipette_id=pipette_id,
                             addressable_area_name="fixedTrash",

--- a/api/tests/opentrons/protocol_engine/execution/test_hardware_stopper.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_hardware_stopper.py
@@ -158,7 +158,7 @@ async def test_hardware_stopping_sequence_no_tip_drop(
     decoy.verify(await hardware_api.stop(home_after=False), times=1)
 
     decoy.verify(
-        await mock_tip_handler.add_tip(
+        await mock_tip_handler.cache_tip(
             pipette_id="pipette-id",
             tip=TipGeometry(length=1.0, volume=2.0, diameter=3.0),
         ),
@@ -181,7 +181,7 @@ async def test_hardware_stopping_sequence_no_pipette(
     )
 
     decoy.when(
-        await mock_tip_handler.add_tip(
+        await mock_tip_handler.cache_tip(
             pipette_id="pipette-id",
             tip=TipGeometry(length=1.0, volume=2.0, diameter=3.0),
         ),
@@ -271,7 +271,7 @@ async def test_hardware_stopping_sequence_with_fixed_trash(
         await movement.home(
             axes=[MotorAxis.X, MotorAxis.Y, MotorAxis.LEFT_Z, MotorAxis.RIGHT_Z]
         ),
-        await mock_tip_handler.add_tip(
+        await mock_tip_handler.cache_tip(
             pipette_id="pipette-id",
             tip=TipGeometry(length=1.0, volume=2.0, diameter=3.0),
         ),
@@ -320,7 +320,7 @@ async def test_hardware_stopping_sequence_with_OT2_addressable_area(
         await movement.home(
             axes=[MotorAxis.X, MotorAxis.Y, MotorAxis.LEFT_Z, MotorAxis.RIGHT_Z]
         ),
-        await mock_tip_handler.add_tip(
+        await mock_tip_handler.cache_tip(
             pipette_id="pipette-id",
             tip=TipGeometry(length=1.0, volume=2.0, diameter=3.0),
         ),

--- a/api/tests/opentrons/protocol_engine/execution/test_tip_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_tip_handler.py
@@ -289,10 +289,10 @@ async def test_add_tip(
         MountType.LEFT
     )
 
-    await subject.add_tip(pipette_id="pipette-id", tip=tip)
+    await subject.cache_tip(pipette_id="pipette-id", tip=tip)
 
     decoy.verify(
-        mock_hardware_api.add_tip(mount=Mount.LEFT, tip_length=50),
+        mock_hardware_api.cache_tip(mount=Mount.LEFT, tip_length=50),
         mock_hardware_api.set_current_tiprack_diameter(
             mount=Mount.LEFT,
             tiprack_diameter=5,


### PR DESCRIPTION
## Overview

The hardware API has two similar methods, `add_tip()` and `cache_tip()`. One of their differences is that if there's already a tip, `add_tip()` no-ops, whereas `cache_tip()` raises an `AssertionError`. 

Neither behavior is really appropriate for error recovery. We mostly want Protocol Engine's state to be the single source of truth, and we want to synchronize the hardware API's state to it (if the hardware API must have its own state at all). It's difficult to do that reliably if the hardware API's state-setting methods are context-sensitive like this.

So this changes `cache_tip()` to idempotently overwrite the hardware API's current tip instead of raising an `AssertionError`.

Goes towards EXEC-778.

## Test Plan and Hands on Testing

* [x] Run a protocol and make sure tip pickups, tip drops, aspirates, etc. keep working as normal.
    * [ ] OT-2
        * Can't easily test this right now because of unrelated errors on `edge`
    * [x] Flex
* [x] Induce a `tipPhysicallyMissing` error and make sure the "retry failed step" error recovery flow still works.

## Changelog

* 1f9bbffd390f15c6ecefeb9c6cef3055172ee453: Move `cache_tip()` next to `add_tip()`. As long as we have to maintain them both in parallel, this makes that easier. No behavioral change. This highlights some additional subtle differences between the two methods (like `set_current_volume()`), which I'm not addressing in this PR.
* 0cb1605ef133fd29f02af5d1699f6d9bd0c4f646: The actual behavioral change described in the overview.
* 1bfc52955d79526f6cccd6e333d38156906a49b6: Get Protocol Engine to uniformly use `cache_tip()` instead of `add_tip()`.

  This is theoretically a behavioral change, but it should be safe, given the two call sites. `HardwareStopper` was basically setting the tip to...the current tip, so it's just another flavor of no-op. `pick_up_tip()` should only ever get to this point after it's validated that there is no tip on the pipette, so the behavioral difference doesn't come into play.

## Review requests

Does this seem like a not-wrong hardware API direction?

## Risk assessment

Low.
