### PR TITLE
fix(protocol-designer): fix ListItemDescriptor content and description alignment issue

### DIFF
--- a/components/src/atoms/ListItem/ListItemChildren/ListItemDescriptor.tsx
+++ b/components/src/atoms/ListItem/ListItemChildren/ListItemDescriptor.tsx
@@ -8,8 +8,8 @@ import { SPACING } from '../../../ui-style-constants'
 
 interface ListItemDescriptorProps {
   type: 'default' | 'large'
-  description: JSX.Element | string
-  content: JSX.Element | string
+  description: JSX.Element
+  content: JSX.Element
 }
 
 export const ListItemDescriptor = (

--- a/components/src/atoms/ListItem/ListItemChildren/ListItemDescriptor.tsx
+++ b/components/src/atoms/ListItem/ListItemChildren/ListItemDescriptor.tsx
@@ -10,13 +10,12 @@ interface ListItemDescriptorProps {
   type: 'default' | 'large'
   description: JSX.Element | string
   content: JSX.Element | string
-  isInSlideout?: boolean
 }
 
 export const ListItemDescriptor = (
   props: ListItemDescriptorProps
 ): JSX.Element => {
-  const { description, content, type, isInSlideout = false } = props
+  const { description, content, type } = props
   return (
     <Flex
       flexDirection={DIRECTION_ROW}
@@ -26,10 +25,8 @@ export const ListItemDescriptor = (
       justifyContent={type === 'default' ? JUSTIFY_SPACE_BETWEEN : 'none'}
       padding={type === 'default' ? SPACING.spacing4 : SPACING.spacing12}
     >
-      <Flex minWidth={isInSlideout ? undefined : '13.75rem'}>
-        {description}
-      </Flex>
-      <Flex width="100%">{content}</Flex>
+      {description}
+      {content}
     </Flex>
   )
 }

--- a/protocol-designer/src/organisms/MaterialsListModal/index.tsx
+++ b/protocol-designer/src/organisms/MaterialsListModal/index.tsx
@@ -96,13 +96,18 @@ export function MaterialsListModal({
                       <ListItemDescriptor
                         type="large"
                         description={
-                          fixture.location != null ? (
-                            <DeckInfoLabel
-                              deckLabel={fixture.location.replace('cutout', '')}
-                            />
-                          ) : (
-                            ''
-                          )
+                          <Flex minWidth="13.75rem">
+                            {fixture.location != null ? (
+                              <DeckInfoLabel
+                                deckLabel={fixture.location.replace(
+                                  'cutout',
+                                  ''
+                                )}
+                              />
+                            ) : (
+                              ''
+                            )}
+                          </Flex>
                         }
                         content={
                           <Flex

--- a/protocol-designer/src/organisms/MaterialsListModal/index.tsx
+++ b/protocol-designer/src/organisms/MaterialsListModal/index.tsx
@@ -11,7 +11,6 @@ import {
   DIRECTION_ROW,
   Flex,
   InfoScreen,
-  JUSTIFY_SPACE_BETWEEN,
   LiquidIcon,
   ListItem,
   ListItemDescriptor,
@@ -32,13 +31,14 @@ import { getInitialDeckSetup } from '../../step-forms/selectors'
 import { getTopPortalEl } from '../../components/portals/TopPortal'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import { HandleEnter } from '../../atoms/HandleEnter'
+import { LINE_CLAMP_TEXT_STYLE } from '../../atoms'
 
 import type { AdditionalEquipmentName } from '@opentrons/step-generation'
 import type { LabwareOnDeck, ModuleOnDeck } from '../../step-forms'
 import type { OrderedLiquids } from '../../labware-ingred/types'
 
 // ToDo (kk:09/04/2024) this should be removed when break-point is set up
-const MODAL_MIN_WIDTH = '36.1875rem'
+const MODAL_MIN_WIDTH = '37.125rem'
 
 export interface FixtureInList {
   name: AdditionalEquipmentName
@@ -82,6 +82,7 @@ export function MaterialsListModal({
         title={t('materials_list')}
         marginLeft="0rem"
         minWidth={MODAL_MIN_WIDTH}
+        childrenPadding={SPACING.spacing24}
       >
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
@@ -130,7 +131,11 @@ export function MaterialsListModal({
                       <ListItemDescriptor
                         type="large"
                         description={
-                          <DeckInfoLabel deckLabel={formatLocation(hw.slot)} />
+                          <Flex minWidth="13.75rem">
+                            <DeckInfoLabel
+                              deckLabel={formatLocation(hw.slot)}
+                            />
+                          </Flex>
                         }
                         content={
                           <Flex
@@ -189,9 +194,15 @@ export function MaterialsListModal({
                       <ListItemDescriptor
                         type="large"
                         description={
-                          <DeckInfoLabel deckLabel={deckLabelSlot} />
+                          <Flex minWidth="13.75rem">
+                            <DeckInfoLabel deckLabel={deckLabelSlot} />
+                          </Flex>
                         }
-                        content={lw.def.metadata.displayName}
+                        content={
+                          <StyledText desktopStyle="bodyDefaultRegular">
+                            {lw.def.metadata.displayName}
+                          </StyledText>
+                        }
                       />
                     </ListItem>
                   )
@@ -246,29 +257,31 @@ export function MaterialsListModal({
                     } else {
                       return (
                         <ListItem type="noActive" key={`liquid_${id}`}>
-                          <Flex
-                            justifyContent={JUSTIFY_SPACE_BETWEEN}
-                            width="100%"
-                            padding={SPACING.spacing12}
-                          >
-                            <Flex
-                              alignItems={ALIGN_CENTER}
-                              gridGap={SPACING.spacing8}
-                              flex="1"
-                            >
-                              <LiquidIcon color={liquid.displayColor ?? ''} />
-                              <StyledText desktopStyle="bodyDefaultRegular">
-                                {liquid.name ?? t('n/a')}
-                              </StyledText>
-                            </Flex>
-
-                            <Flex flex="1.27">
+                          <ListItemDescriptor
+                            type="large"
+                            description={
+                              <Flex
+                                minWidth="13.75rem"
+                                alignItems={ALIGN_CENTER}
+                                gridGap={SPACING.spacing8}
+                                width="13.75rem"
+                              >
+                                <LiquidIcon color={liquid.displayColor ?? ''} />
+                                <StyledText
+                                  desktopStyle="bodyDefaultRegular"
+                                  css={LINE_CLAMP_TEXT_STYLE(3)}
+                                >
+                                  {liquid.name ?? t('n/a')}
+                                </StyledText>
+                              </Flex>
+                            }
+                            content={
                               <Tag
                                 text={`${totalVolume.toString()} uL`}
                                 type="default"
                               />
-                            </Flex>
-                          </Flex>
+                            }
+                          />
                         </ListItem>
                       )
                     }

--- a/protocol-designer/src/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/organisms/SlotInformation/index.tsx
@@ -1,4 +1,3 @@
-import type * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 import {
@@ -12,6 +11,7 @@ import {
   StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import type { FC } from 'react'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import type { RobotType } from '@opentrons/shared-data'
 
@@ -25,7 +25,7 @@ interface SlotInformationProps {
   fixtures?: string[]
 }
 
-export const SlotInformation: React.FC<SlotInformationProps> = ({
+export const SlotInformation: FC<SlotInformationProps> = ({
   location,
   robotType,
   liquids = [],
@@ -50,10 +50,10 @@ export const SlotInformation: React.FC<SlotInformationProps> = ({
       </Flex>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         {liquids.length > 1 ? (
-          <ListItem type="noActive">
+          <ListItem type="noActive" width="max-content">
             <ListItemDescriptor
               type="default"
-              content={liquids.join(', ')}
+              content={<StyledText>liquids.join(', ')</StyledText>}
               description={t('liquid')}
             />
           </ListItem>
@@ -115,18 +115,14 @@ function StackInfo({ title, stackInformation }: StackInfoProps): JSX.Element {
       <ListItemDescriptor
         type="default"
         content={
-          stackInformation != null ? (
-            <StyledText
-              desktopStyle="bodyDefaultRegular"
-              textAlign={TYPOGRAPHY.textAlignRight}
-            >
-              {stackInformation}
-            </StyledText>
-          ) : (
-            t('none')
-          )
+          <StyledText
+            desktopStyle="bodyDefaultRegular"
+            textAlign={TYPOGRAPHY.textAlignRight}
+          >
+            {stackInformation ?? t('none')}
+          </StyledText>
         }
-        description={title}
+        description={<Flex width="7.40625rem">{title}</Flex>}
       />
     </ListItem>
   )

--- a/protocol-designer/src/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/organisms/SlotInformation/index.tsx
@@ -53,7 +53,7 @@ export const SlotInformation: FC<SlotInformationProps> = ({
           <ListItem type="noActive" width="max-content">
             <ListItemDescriptor
               type="default"
-              content={<StyledText>liquids.join(', ')</StyledText>}
+              content={<StyledText>{liquids.join(', ')}</StyledText>}
               description={t('liquid')}
             />
           </ListItem>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MagnetTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MagnetTools/index.tsx
@@ -83,7 +83,6 @@ export function MagnetTools(props: StepFormProps): JSX.Element {
         <ListItem type="noActive">
           <ListItemDescriptor
             type="large"
-            isInSlideout
             content={
               <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
                 <StyledText

--- a/protocol-designer/src/pages/ProtocolOverview/InstrumentsInfo.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/InstrumentsInfo.tsx
@@ -1,15 +1,16 @@
 import { useTranslation } from 'react-i18next'
 
 import {
-  Flex,
-  StyledText,
   Btn,
+  COLORS,
   DIRECTION_COLUMN,
-  SPACING,
+  Flex,
   JUSTIFY_SPACE_BETWEEN,
-  TYPOGRAPHY,
   ListItem,
   ListItemDescriptor,
+  SPACING,
+  StyledText,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { getPipetteSpecsV2, FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
@@ -93,34 +94,88 @@ export function InstrumentsInfo({
         <ListItem type="noActive" key={`ProtocolOverview_robotType`}>
           <ListItemDescriptor
             type="large"
-            description={t('robotType')}
+            description={
+              <Flex minWidth="13.75rem">
+                {' '}
+                <StyledText
+                  desktopStyle="bodyDefaultRegular"
+                  color={COLORS.grey60}
+                >
+                  {t('robotType')}
+                </StyledText>
+              </Flex>
+            }
             content={
-              robotType === FLEX_ROBOT_TYPE
-                ? t('shared:opentrons_flex')
-                : t('shared:ot2')
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {robotType === FLEX_ROBOT_TYPE
+                  ? t('shared:opentrons_flex')
+                  : t('shared:ot2')}
+              </StyledText>
             }
           />
         </ListItem>
         <ListItem type="noActive" key={`ProtocolOverview_left`}>
           <ListItemDescriptor
             type="large"
-            description={t('left_pip')}
-            content={pipetteInfo(leftPipette)}
+            description={
+              <Flex minWidth="13.75rem">
+                {' '}
+                <StyledText
+                  desktopStyle="bodyDefaultRegular"
+                  color={COLORS.grey60}
+                >
+                  {t('left_pip')}
+                </StyledText>
+              </Flex>
+            }
+            content={
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {pipetteInfo(leftPipette)}
+              </StyledText>
+            }
           />
         </ListItem>
         <ListItem type="noActive" key={`ProtocolOverview_right`}>
           <ListItemDescriptor
             type="large"
-            description={t('right_pip')}
-            content={pipetteInfo(rightPipette)}
+            description={
+              <Flex minWidth="13.75rem">
+                {' '}
+                <StyledText
+                  desktopStyle="bodyDefaultRegular"
+                  color={COLORS.grey60}
+                >
+                  {t('right_pip')}
+                </StyledText>
+              </Flex>
+            }
+            content={
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {pipetteInfo(rightPipette)}
+              </StyledText>
+            }
           />
         </ListItem>
         {robotType === FLEX_ROBOT_TYPE ? (
           <ListItem type="noActive" key={`ProtocolOverview_gripper`}>
             <ListItemDescriptor
               type="large"
-              description={t('extension')}
-              content={isGripperAttached ? t('gripper') : t('na')}
+              description={
+                <Flex minWidth="13.75rem">
+                  {' '}
+                  <StyledText
+                    desktopStyle="bodyDefaultRegular"
+                    color={COLORS.grey60}
+                  >
+                    {t('extension')}
+                  </StyledText>
+                </Flex>
+              }
+              content={
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {isGripperAttached ? t('gripper') : t('na')}
+                </StyledText>
+              }
             />
           </ListItem>
         ) : null}

--- a/protocol-designer/src/pages/ProtocolOverview/LiquidDefinitions.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/LiquidDefinitions.tsx
@@ -37,11 +37,15 @@ export function LiquidDefinitions({
               <ListItemDescriptor
                 type="large"
                 description={
-                  <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
+                  <Flex
+                    alignItems={ALIGN_CENTER}
+                    gridGap={SPACING.spacing8}
+                    minWidth="13.75rem"
+                    width="13.75rem"
+                  >
                     <LiquidIcon color={liquid.displayColor} />
                     <StyledText
                       desktopStyle="bodyDefaultRegular"
-                      overflowWrap="anywhere"
                       id="liquid-name"
                       css={LINE_CLAMP_TEXT_STYLE(3)}
                     >
@@ -49,7 +53,14 @@ export function LiquidDefinitions({
                     </StyledText>
                   </Flex>
                 }
-                content={liquid.description ?? t('na')}
+                content={
+                  <StyledText
+                    desktopStyle="bodyDefaultRegular"
+                    css={LINE_CLAMP_TEXT_STYLE(10)}
+                  >
+                    {liquid.description ?? t('na')}
+                  </StyledText>
+                }
               />
             </ListItem>
           ))

--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -1,14 +1,15 @@
 import { useTranslation } from 'react-i18next'
 import {
-  Flex,
+  Btn,
+  COLORS,
   DIRECTION_COLUMN,
-  SPACING,
+  Flex,
   JUSTIFY_SPACE_BETWEEN,
-  TYPOGRAPHY,
-  StyledText,
   ListItem,
   ListItemDescriptor,
-  Btn,
+  SPACING,
+  StyledText,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 
 import { BUTTON_LINK_STYLE } from '../../atoms'
@@ -62,8 +63,21 @@ export function ProtocolMetadata({
             <ListItem type="noActive" key={`ProtocolOverview_${title}`}>
               <ListItemDescriptor
                 type="large"
-                description={t(`${title}`)}
-                content={value ?? t('na')}
+                description={
+                  <Flex minWidth="13.75rem">
+                    <StyledText
+                      desktopStyle="bodyDefaultRegular"
+                      color={COLORS.grey60}
+                    >
+                      {t(`${title}`)}
+                    </StyledText>
+                  </Flex>
+                }
+                content={
+                  <StyledText desktopStyle="bodyDefaultRegular">
+                    {value ?? t('na')}
+                  </StyledText>
+                }
               />
             </ListItem>
           )
@@ -71,10 +85,23 @@ export function ProtocolMetadata({
         <ListItem type="noActive" key="ProtocolOverview_robotVersion">
           <ListItemDescriptor
             type="large"
-            description={t('required_app_version')}
-            content={t('app_version', {
-              version: REQUIRED_APP_VERSION,
-            })}
+            description={
+              <Flex minWidth="13.75rem">
+                <StyledText
+                  desktopStyle="bodyDefaultRegular"
+                  color={COLORS.grey60}
+                >
+                  {t('required_app_version')}
+                </StyledText>
+              </Flex>
+            }
+            content={
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {t('app_version', {
+                  version: REQUIRED_APP_VERSION,
+                })}
+              </StyledText>
+            }
           />
         </ListItem>
       </Flex>

--- a/protocol-designer/src/pages/ProtocolOverview/StepsInfo.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/StepsInfo.tsx
@@ -35,12 +35,14 @@ export function StepsInfo({ savedStepForms }: StepsInfoProps): JSX.Element {
             <ListItemDescriptor
               type="large"
               description={
-                <StyledText
-                  desktopStyle="bodyDefaultRegular"
-                  color={COLORS.grey60}
-                >
-                  {t('number_of_steps')}
-                </StyledText>
+                <Flex minWidth="13.75rem">
+                  <StyledText
+                    desktopStyle="bodyDefaultRegular"
+                    color={COLORS.grey60}
+                  >
+                    {t('number_of_steps')}
+                  </StyledText>
+                </Flex>
               }
               content={
                 <StyledText desktopStyle="bodyDefaultRegular">


### PR DESCRIPTION


<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix ListItemDescriptor content and description alignment issue

remove `string` type from `description` and `content`.
There are 2 types in the design, but actually we need to use ListDescriptor in SlotInfo that has 118.5px as width.
Technically we can add a condition to switch 3 types but at this moment we don't know how Desktop app and other web application use it. For this change, we might need to write a little bit more lines, but it makes things easy since we can pass `JSX.Element` that we style or layout separately.

design
https://www.figma.com/design/WbkiUyU8VhtKz0JSuIFA45/Feature%3A-Protocol-Designer-Phase-1?node-id=10092-334055&m=dev


SlotDetails
### before
![Screenshot 2024-10-23 at 6 20 23 PM](https://github.com/user-attachments/assets/764a621f-994e-45b1-a4b4-00c2e8c01ec1)

### after
![Screenshot 2024-10-23 at 7 07 54 PM](https://github.com/user-attachments/assets/4aee497e-1d90-4618-bf2d-c27cae830181)


## Protocol Overview
### Protocol Metadata
### Instruments
### Liquid Definitions
### Protocol Steps
### Materials List
![Screenshot 2024-10-23 at 8 06 59 PM](https://github.com/user-attachments/assets/7d528500-543e-4885-9970-a1266cfb9100)


![Screenshot 2024-10-23 at 8 07 12 PM](https://github.com/user-attachments/assets/a782ba69-6440-474a-8099-ca13ee5aa30a)



close RQA-3424

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
