### PR TITLE
fix(app): remove some dangerous reverse()s

### DIFF
--- a/app/src/local-resources/commands/hooks/useCommandTextString/utils/getFinalLabwareLocation.ts
+++ b/app/src/local-resources/commands/hooks/useCommandTextString/utils/getFinalLabwareLocation.ts
@@ -1,4 +1,25 @@
-import type { LabwareLocation, RunTimeCommand } from '@opentrons/shared-data'
+import type {
+  LabwareLocation,
+  RunTimeCommand,
+  LoadLabwareRunTimeCommand,
+  MoveLabwareRunTimeCommand,
+} from '@opentrons/shared-data'
+
+const findLastAt = <T, U extends T = T>(
+  arr: readonly T[],
+  pred: ((el: T) => boolean) | ((el: T) => el is U)
+): [U, number] | [undefined, -1] => {
+  let arrayLoc = -1
+  const lastEl = arr.findLast((el: T, idx: number): el is U => {
+    arrayLoc = idx
+    return pred(el)
+  })
+  if (lastEl === undefined) {
+    return [undefined, -1]
+  } else {
+    return [lastEl, arrayLoc]
+  }
+}
 
 /**
  * given a list of commands and a labwareId, calculate the resulting location
@@ -11,15 +32,22 @@ export function getFinalLabwareLocation(
   labwareId: string,
   commands: RunTimeCommand[]
 ): LabwareLocation | null {
-  for (const c of commands.reverse()) {
-    if (c.commandType === 'loadLabware' && c.result?.labwareId === labwareId) {
-      return c.params.location
-    } else if (
-      c.commandType === 'moveLabware' &&
-      c.params.labwareId === labwareId
-    ) {
-      return c.params.newLocation
-    }
+  const [lastMove, lastMoveIndex] = findLastAt(
+    commands,
+    (c: RunTimeCommand): c is MoveLabwareRunTimeCommand =>
+      c.commandType === 'moveLabware' && c.params.labwareId === labwareId
+  )
+
+  const [lastLoad, lastLoadIndex] = findLastAt(
+    commands,
+    (c: RunTimeCommand): c is LoadLabwareRunTimeCommand =>
+      c.commandType === 'loadLabware' && c.result?.labwareId === labwareId
+  )
+  if (lastMoveIndex > lastLoadIndex) {
+    return lastMove?.params?.newLocation ?? null
+  } else if (lastLoadIndex > lastMoveIndex) {
+    return lastLoad?.params?.location ?? null
+  } else {
+    return null
   }
-  return null
 }


### PR DESCRIPTION
There weer a couple command texts that were doing a `.reverse()` of the commands array. This is O(N) which is gross and also might be cached which would cause bugs, so replace it with some uses of findLast() that definitely weren't inspired by wanting to do some fun typing exercises.

## testing
- [x] tests pass, really