### PR TITLE
chore: fix github workflow and failing tests

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -148,7 +148,7 @@ jobs:
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
       - name: 'test native(er) packages'
-        run: make test-js-internal tests="${{}matrix.shell}/src" cov_opts="--coverage=true"
+        run: make test-js-internal tests="${{matrix.shell}}/src" cov_opts="--coverage=true"
       - name: 'Upload coverage report'
         uses: 'codecov/codecov-action@v3'
         with:

--- a/app/src/organisms/ApplyHistoricOffsets/hooks/useHistoricRunDetails.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/useHistoricRunDetails.ts
@@ -6,11 +6,13 @@ export function useHistoricRunDetails(
   hostOverride?: HostConfig | null
 ): RunData[] {
   const { data: allHistoricRuns } = useNotifyAllRunsQuery({}, {}, hostOverride)
-
   return allHistoricRuns == null
     ? []
-    : allHistoricRuns.data.toSorted(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      )
+    : // TODO(sf): figure out why .toSorted() doesn't work in vitest
+      allHistoricRuns.data
+        .map(t => t)
+        .sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        )
 }

--- a/app/src/pages/ODD/RobotDashboard/index.tsx
+++ b/app/src/pages/ODD/RobotDashboard/index.tsx
@@ -41,8 +41,7 @@ export function RobotDashboard(): JSX.Element {
   )
 
   const recentRunsOfUniqueProtocols = (allRunsQueryData?.data ?? [])
-    .toReversed() // newest runs first
-    .reduce<RunData[]>((acc, run) => {
+    .reduceRight<RunData[]>((acc, run) => {
       if (
         acc.some(collectedRun => collectedRun.protocolId === run.protocolId)
       ) {

--- a/app/src/redux/config/__tests__/config.test.ts
+++ b/app/src/redux/config/__tests__/config.test.ts
@@ -28,6 +28,7 @@ describe('config', () => {
       expect(Cfg.configInitialized(state.config as any)).toEqual({
         type: 'config:INITIALIZED',
         payload: { config: state.config },
+        meta: { shell: true },
       })
     })
 
@@ -35,6 +36,7 @@ describe('config', () => {
       expect(Cfg.configValueUpdated('foo.bar', false)).toEqual({
         type: 'config:VALUE_UPDATED',
         payload: { path: 'foo.bar', value: false },
+        meta: { shell: true },
       })
     })
 


### PR DESCRIPTION
Messed up the app test workflow so it wasn't running and therefore we didn't notice some tests were failing. Fix the workflow, fix the tests.

Only changes of note are that vitest doesn't support baseline 2023 copying array reorder functions for some reason so replace them with equivalents.

- [x] test: protocols should still not bounce around on the odd dashboard