### PR TITLE
fix(protocol-designer): temporarily filter out TC auto-sealer lid

### DIFF
--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -57,6 +57,8 @@ export const PD_DO_NOT_LIST = [
   'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat',
   'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
   'opentrons_96_pcr_adapter_armadillo_wellplate_200ul',
+  //  temporarily blocking TC lid adapter until it is supported in PD
+  'opentrons_tough_pcr_auto_sealing_lid',
 ]
 
 export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {


### PR DESCRIPTION
closes RQA-3428 AUTH-988

# Overview

Temporarily filter out the TC auto-sealer  lid

## Test Plan and Hands on Testing

Create a flex protocol with a thermocycler. go to add the labware to it and select the tough plate. see that there is no TC lid available after selecting it

## Changelog

- add loadname to PD_DO_NOT_LIST

## Risk assessment

low
