### PR TITLE
fix(scripts): set correct aws bucket region when deploying

### DIFF
--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -65,7 +65,8 @@ async function runPromoteToProduction() {
     }
     const s3Client = new S3Client({
       apiVersion: '2006-03-01',
-      region: 'us-east-1',
+      region:
+        projectDomain === PROTOCOL_DESIGNER_DOMAIN ? 'us-east-1' : 'us-east-2',
       credentials: productionCredentials,
     })
 

--- a/scripts/deploy/promote-to-staging.js
+++ b/scripts/deploy/promote-to-staging.js
@@ -76,7 +76,8 @@ async function runPromoteToStaging() {
 
     const s3WithCreds = new S3Client({
       apiVersion: '2006-03-01',
-      region: 'us-east-1',
+      region:
+        projectDomain === PROTOCOL_DESIGNER_DOMAIN ? 'us-east-1' : 'us-east-2',
       credentials: stagingCredentials,
     })
     console.log(`Promoting ${projectDomain} from sandbox to staging\n`)

--- a/scripts/deploy/rollback.js
+++ b/scripts/deploy/rollback.js
@@ -97,7 +97,8 @@ async function runRollback() {
 
     const s3Client = new S3Client({
       apiVersion: '2006-03-01',
-      region: 'us-east-1',
+      region:
+        projectDomain === PROTOCOL_DESIGNER_DOMAIN ? 'us-east-1' : 'us-east-2',
       credentials: rollBackCredentials,
     })
 


### PR DESCRIPTION
# Overview

For whatever reason when all of our aws buckets were moved around to different accounts the regions they live in changed. PD lives in `'us-east-1`, and all of the others live in `'us-east-2`

You must correctly specify the regions to successfully send aws commands. 

# Test Plan

I verified I could promote to staging for docs, PD, and LL