### PR TITLE
feat(app, app-shell-odd): add Flex resource monitor

### DIFF
--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -24,6 +24,7 @@ import {
   closeBrokerConnection,
 } from './notifications'
 import { setUserDataPath } from './early'
+import { registerResourceMonitor } from './monitor'
 
 import type { OTLogger } from './log'
 import type { BrowserWindow } from 'electron'
@@ -135,6 +136,7 @@ function startUp(): void {
     registerConfig(dispatch),
     registerDiscovery(dispatch),
     registerRobotSystemUpdate(dispatch),
+    registerResourceMonitor(dispatch),
     registerAppRestart(),
     registerUpdateBrightness(),
     registerNotify(dispatch, mainWindow),

--- a/app-shell-odd/src/monitor/ResourceMonitor.ts
+++ b/app-shell-odd/src/monitor/ResourceMonitor.ts
@@ -1,0 +1,291 @@
+import { exec } from 'child_process'
+import { promises as fs } from 'fs'
+
+import { createLogger } from '../log'
+import { UI_INITIALIZED } from '../constants'
+
+import type { Action, Dispatch } from '../types'
+
+const PARENT_PROCESSES = [
+  'opentrons-robot-server.service',
+  'opentrons-robot-app.service',
+] as const
+const REPORTING_INTERVAL_MS = 3600000 // 1 hour
+const MAX_CMD_STR_LENGTH = 100
+const MAX_REPORTED_PROCESSES = 15
+
+interface ProcessTreeNode {
+  pid: number
+  cmd: string
+  children: ProcessTreeNode[]
+}
+
+interface ProcessDetails {
+  name: string
+  memRssMb: string
+}
+
+interface ResourceMonitorDetails {
+  systemAvailMemMb: string
+  systemUptimeHrs: string
+  processesDetails: ProcessDetails[]
+}
+
+// TODO(jh 10-24-24): Add testing, making proper affordances for mocking fs.readFile.
+
+// Scrapes system and select process resource metrics, reporting those metrics to the browser layer.
+// Note that only MAX_REPORTED_PROCESSES are actually dispatched.
+export class ResourceMonitor {
+  private readonly monitoredProcesses: Set<string>
+  private readonly log: ReturnType<typeof createLogger>
+  private intervalId: NodeJS.Timeout | null
+
+  constructor() {
+    this.monitoredProcesses = new Set(PARENT_PROCESSES)
+    this.log = createLogger('monitor')
+    this.intervalId = null
+  }
+
+  start(dispatch: Dispatch): Dispatch {
+    // Scrape and report metrics on an interval.
+    const beginMonitor = (): void => {
+      if (this.intervalId == null) {
+        this.intervalId = setInterval(() => {
+          this.getResourceDetails()
+            .then(resourceDetails => {
+              this.log.debug('resource monitor report', {
+                resourceDetails,
+              })
+              this.dispatchResourceDetails(resourceDetails, dispatch)
+            })
+            .catch(error => {
+              this.log.error('Error monitoring process: ', error)
+            })
+        }, REPORTING_INTERVAL_MS)
+      } else {
+        this.log.warn(
+          'Attempted to start an already started instance of ResourceMonitor.'
+        )
+      }
+    }
+
+    return function handleAction(action: Action) {
+      switch (action.type) {
+        case UI_INITIALIZED:
+          beginMonitor()
+      }
+    }
+  }
+
+  private dispatchResourceDetails(
+    details: ResourceMonitorDetails,
+    dispatch: Dispatch
+  ): void {
+    const { processesDetails, systemUptimeHrs, systemAvailMemMb } = details
+    dispatch({
+      type: 'analytics:RESOURCE_MONITOR_REPORT',
+      payload: {
+        systemUptimeHrs,
+        systemAvailMemMb,
+        processesDetails: processesDetails.slice(0, MAX_REPORTED_PROCESSES), // don't accidentally send too many items to mixpanel.
+      },
+    })
+  }
+
+  private getResourceDetails(): Promise<ResourceMonitorDetails> {
+    return Promise.all([
+      this.getSystemAvailableMemory(),
+      this.getSystemUptimeHrs(),
+      this.getProcessDetails(),
+    ]).then(([systemAvailMemMb, systemUptimeHrs, processesDetails]) => ({
+      systemAvailMemMb,
+      systemUptimeHrs,
+      processesDetails,
+    }))
+  }
+
+  // Scrape system uptime from /proc/uptime.
+  private getSystemUptimeHrs(): Promise<string> {
+    return fs
+      .readFile('/proc/uptime', 'utf8')
+      .then(uptime => {
+        // First value is uptime in seconds, second is idle time
+        const uptimeSeconds = Math.floor(parseFloat(uptime.split(' ')[0]))
+        return (uptimeSeconds / 3600).toFixed(2)
+      })
+      .catch(error => {
+        throw new Error(
+          `Failed to read system uptime: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      })
+  }
+
+  // Scrape system available memory from /proc/meminfo.
+  private getSystemAvailableMemory(): Promise<string> {
+    return fs
+      .readFile('/proc/meminfo', 'utf8')
+      .then(meminfo => {
+        const match = meminfo.match(/MemAvailable:\s+(\d+)\s+kB/)
+        if (match == null) {
+          throw new Error('Could not find MemAvailable in meminfo file')
+        } else {
+          const memInKb = parseInt(match[1], 10)
+          return (memInKb / 1024).toFixed(2)
+        }
+      })
+      .catch(error => {
+        throw new Error(
+          `Failed to read available memory info: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      })
+  }
+
+  // Given parent process names, get metrics for parent and all spawned processes.
+  private getProcessDetails(): Promise<ProcessDetails[]> {
+    return Promise.all(
+      Array.from(this.monitoredProcesses).map(parentProcess =>
+        this.getProcessTree(parentProcess)
+          .then(processTree => {
+            if (processTree == null) {
+              return []
+            } else {
+              return this.getProcessDetailsFlattened(processTree)
+            }
+          })
+          .catch(error => {
+            this.log.error('Failed to get process tree', {
+              parentProcess,
+              error,
+            })
+            return []
+          })
+      )
+    ).then(detailsArrays => detailsArrays.flat())
+  }
+
+  private getProcessTree(
+    parentProcess: string
+  ): Promise<ProcessTreeNode | null> {
+    return this.getProcessPid(parentProcess).then(parentPid => {
+      if (parentPid == null) {
+        return null
+      } else {
+        return this.buildProcessTree(parentPid)
+      }
+    })
+  }
+
+  private getProcessPid(serviceName: string): Promise<number | null> {
+    return new Promise((resolve, reject) => {
+      exec(`systemctl show ${serviceName} -p MainPID`, (error, stdout) => {
+        if (error != null) {
+          reject(
+            new Error(`Failed to get PID for ${serviceName}: ${error.message}`)
+          )
+        } else {
+          const match = stdout.match(/MainPID=(\d+)/)
+
+          if (match == null) {
+            resolve(null)
+          } else {
+            const pid = parseInt(match[1], 10)
+            resolve(pid > 1 ? pid : null)
+          }
+        }
+      })
+    })
+  }
+
+  // Recursively build the process tree, scraping the cmdline string for each pid.
+  private buildProcessTree(pid: number): Promise<ProcessTreeNode> {
+    return Promise.all([
+      this.getProcessCmdline(pid),
+      this.getChildProcessesFrom(pid),
+    ]).then(([cmd, childPids]) => {
+      return Promise.all(
+        childPids.map(childPid => this.buildProcessTree(childPid))
+      ).then(children => ({
+        pid,
+        cmd,
+        children,
+      }))
+    })
+  }
+
+  // Get the exact cmdline string for the given pid, truncating if necessary.
+  private getProcessCmdline(pid: number): Promise<string> {
+    return fs
+      .readFile(`/proc/${pid}/cmdline`, 'utf8')
+      .then(cmdline => {
+        const cmd = cmdline.replace(/\0/g, ' ').trim()
+        return cmd.length > MAX_CMD_STR_LENGTH
+          ? `${cmd.substring(0, MAX_CMD_STR_LENGTH)}...`
+          : cmd
+      })
+      .catch(error => {
+        this.log.error(`Failed to read cmdline for PID ${pid}`, error)
+        return `PID ${pid}`
+      })
+  }
+
+  private getChildProcessesFrom(parentPid: number): Promise<number[]> {
+    return new Promise((resolve, reject) => {
+      exec(`pgrep -P ${parentPid}`, (error, stdout) => {
+        // code 1 means no children found
+        if (error != null && error.code !== 1) {
+          reject(error)
+        } else {
+          const children = stdout
+            .trim()
+            .split('\n')
+            .filter(line => line.length > 0)
+            .map(pid => parseInt(pid, 10))
+
+          resolve(children)
+        }
+      })
+    })
+  }
+
+  // Get the actual metric(s) for a given node and recursively get metric(s) for all child nodes.
+  private getProcessDetailsFlattened(
+    node: ProcessTreeNode
+  ): Promise<ProcessDetails[]> {
+    return this.getProcessMemory(node.pid).then(memRssMb => {
+      const currentNodeDetails: ProcessDetails = {
+        name: node.cmd,
+        memRssMb,
+      }
+
+      return Promise.all(
+        node.children.map(child => this.getProcessDetailsFlattened(child))
+      ).then(childDetailsArrays => {
+        return [currentNodeDetails, ...childDetailsArrays.flat()]
+      })
+    })
+  }
+
+  // Scrape VmRSS from /proc/pid/status for a given pid.
+  private getProcessMemory(pid: number): Promise<string> {
+    return fs
+      .readFile(`/proc/${pid}/status`, 'utf8')
+      .then(status => {
+        const match = status.match(/VmRSS:\s+(\d+)\s+kB/)
+        if (match == null) {
+          throw new Error('Could not find VmRSS in status file')
+        } else {
+          const memInKb = parseInt(match[1], 10)
+          return (memInKb / 1024).toFixed(2)
+        }
+      })
+      .catch(error => {
+        throw new Error(
+          `Failed to read memory info for PID ${pid}: ${error.message}`
+        )
+      })
+  }
+}

--- a/app-shell-odd/src/monitor/__tests__/ResourceMonitor.test.ts
+++ b/app-shell-odd/src/monitor/__tests__/ResourceMonitor.test.ts
@@ -1,0 +1,162 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck -- Get around private method access warnings.
+
+import path from 'path'
+import fs from 'fs-extra'
+import tempy from 'tempy'
+import {
+  vi,
+  describe,
+  beforeEach,
+  afterEach,
+  afterAll,
+  it,
+  expect,
+} from 'vitest'
+import { exec } from 'child_process'
+
+import { ResourceMonitor, PARENT_PROCESSES } from '../ResourceMonitor'
+import { UI_INITIALIZED } from '../../constants'
+
+vi.mock('child_process')
+vi.mock('../../log', async importOriginal => {
+  const actual = await importOriginal<typeof createLogger>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      error: vi.fn(),
+    }),
+  }
+})
+
+describe('ResourceMonitor', () => {
+  let procDir: string
+  let monitor: ResourceMonitor
+  const tempDirs: string[] = []
+
+  beforeEach(async () => {
+    procDir = tempy.directory()
+    tempDirs.push(procDir)
+
+    vi.mocked(exec).mockImplementation((cmd, callback) => {
+      if (cmd.startsWith('systemctl')) {
+        callback(null, 'MainPID=1234\n')
+      } else if (cmd.startsWith('pgrep')) {
+        callback({ code: 1 } as any, '')
+      }
+      return {} as any
+    })
+
+    // Populate mock files with some mock data.
+    await fs.writeFile(path.join(procDir, 'uptime'), '3600.00 7200.00\n')
+    await fs.writeFile(
+      path.join(procDir, 'meminfo'),
+      'MemTotal:        8192000 kB\nMemAvailable:    4096000 kB\n'
+    )
+
+    const parentPidDir = path.join(procDir, '1234')
+    await fs.ensureDir(parentPidDir)
+    await fs.writeFile(
+      path.join(parentPidDir, 'cmdline'),
+      'process1234\0arg1\0arg2'
+    )
+    await fs.writeFile(
+      path.join(parentPidDir, 'status'),
+      'Name:\tprocess\nVmRSS:\t2048 kB\n'
+    )
+
+    monitor = new ResourceMonitor({ procPath: procDir })
+  })
+
+  afterEach(() => {
+    monitor.stop()
+  })
+
+  afterAll(() => {
+    vi.resetAllMocks()
+    return Promise.all(tempDirs.map(d => fs.remove(d)))
+  })
+
+  describe('getSystemUptimeHrs', () => {
+    it('reads and parses system uptime', () => {
+      return monitor.getResourceDetails().then(details => {
+        expect(details.systemUptimeHrs).toBe('1.00')
+      })
+    })
+
+    it('handles error reading uptime file', async () => {
+      await fs.remove(path.join(procDir, 'uptime'))
+      await expect(monitor.getResourceDetails()).rejects.toThrow(
+        'Failed to read system uptime'
+      )
+    })
+  })
+
+  describe('getSystemAvailableMemory', () => {
+    it('reads and parses available memory', () => {
+      return monitor.getResourceDetails().then(details => {
+        expect(details.systemAvailMemMb).toBe('4000.00')
+      })
+    })
+
+    it('handles missing MemAvailable in meminfo', async () => {
+      await fs.writeFile(
+        path.join(procDir, 'meminfo'),
+        'MemTotal:        8192000 kB\n'
+      )
+
+      await expect(monitor.getResourceDetails()).rejects.toThrow(
+        'Could not find MemAvailable in meminfo file'
+      )
+    })
+  })
+
+  describe('getProcessDetails', () => {
+    it('collects process details for parent process', () => {
+      return monitor.getResourceDetails().then(details => {
+        expect(details.processesDetails).toHaveLength(PARENT_PROCESSES.length)
+        expect(details.processesDetails[0]).toEqual({
+          name: 'process1234 arg1 arg2',
+          memRssMb: '2.00',
+        })
+      })
+    })
+
+    it('handles missing process', () => {
+      // Mock exec to return non-existent PID
+      vi.mocked(exec).mockImplementation((cmd, callback) => {
+        if (cmd.startsWith('systemctl')) {
+          callback(null, 'MainPID=9999\n')
+        } else {
+          callback({ code: 1 } as any, '')
+        }
+        return {} as any
+      })
+
+      return monitor.getResourceDetails().then(details => {
+        expect(details.processesDetails).toHaveLength(0)
+      })
+    })
+
+    it('handles errors reading process details', async () => {
+      await fs.remove(path.join(procDir, '1234', 'status'))
+      await monitor.getResourceDetails().then(details => {
+        expect(details.processesDetails).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('start', () => {
+    it(`handler correctly updates internal state when ${UI_INITIALIZED} is dispatched`, () => {
+      const dispatch = vi.fn()
+      const handler = monitor.start(dispatch)
+
+      expect(typeof handler).toBe('function')
+
+      handler({ type: UI_INITIALIZED })
+
+      expect(monitor.intervalId).not.toBeNull()
+    })
+  })
+})

--- a/app-shell-odd/src/monitor/index.ts
+++ b/app-shell-odd/src/monitor/index.ts
@@ -1,0 +1,8 @@
+import { ResourceMonitor } from './ResourceMonitor'
+
+import type { Dispatch } from '../types'
+
+export function registerResourceMonitor(dispatch: Dispatch): Dispatch {
+  const resourceMonitor = new ResourceMonitor()
+  return resourceMonitor.start(dispatch)
+}

--- a/app/src/redux/analytics/__tests__/make-event.test.ts
+++ b/app/src/redux/analytics/__tests__/make-event.test.ts
@@ -121,4 +121,23 @@ describe('analytics events map', () => {
       })
     })
   })
+
+  describe('events with calibration data', () => {
+    it('analytics:RESOURCE_MONITOR_REPORT -> resourceMonitorReport event', () => {
+      const state = {} as any
+      const action = {
+        type: 'analytics:RESOURCE_MONITOR_REPORT',
+        payload: {
+          systemAvailMemMb: '500',
+          systemUptimeHrs: '111',
+          processesDetails: [],
+        },
+      } as any
+
+      return expect(makeEvent(action, state)).resolves.toEqual({
+        name: 'resourceMonitorReport',
+        properties: { ...action.payload },
+      })
+    })
+  })
 })

--- a/app/src/redux/analytics/constants.ts
+++ b/app/src/redux/analytics/constants.ts
@@ -97,3 +97,9 @@ export const ANALYTICS_QUICK_TRANSFER_DETAILS_PAGE = 'quickTransferDetailsPage'
 export const ANALYTICS_QUICK_TRANSFER_RUN_FROM_DETAILS =
   'quickTransferRunFromDetails'
 export const ANALYTICS_QUICK_TRANSFER_RERUN = 'quickTransferReRunFromSummary'
+
+/**
+ * Resource Monitor Analytics
+ */
+export const ANALYTICS_RESOURCE_MONITOR_REPORT: 'analytics:RESOURCE_MONITOR_REPORT' =
+  'analytics:RESOURCE_MONITOR_REPORT'

--- a/app/src/redux/analytics/make-event.ts
+++ b/app/src/redux/analytics/make-event.ts
@@ -247,6 +247,15 @@ export function makeEvent(
       })
     }
 
+    case Constants.ANALYTICS_RESOURCE_MONITOR_REPORT: {
+      return Promise.resolve({
+        name: 'resourceMonitorReport',
+        properties: {
+          ...action.payload,
+        },
+      })
+    }
+
     case RobotAdmin.RESET_CONFIG: {
       const { resets } = action.payload
       return Promise.resolve({

--- a/app/src/redux/analytics/mixpanel.ts
+++ b/app/src/redux/analytics/mixpanel.ts
@@ -43,9 +43,12 @@ export function trackEvent(
 
   log.debug('Trackable event', { event, optedIn })
   if (MIXPANEL_ID != null && optedIn) {
-    if (event.superProperties != null) mixpanel.register(event.superProperties)
-    if ('name' in event && event.name != null)
+    if (event.superProperties != null) {
+      mixpanel.register(event.superProperties)
+    }
+    if ('name' in event && event.name != null) {
       mixpanel.track(event.name, event.properties)
+    }
   }
 }
 

--- a/app/src/redux/analytics/types.ts
+++ b/app/src/redux/analytics/types.ts
@@ -5,6 +5,7 @@ import type { Config } from '../config/types'
 import type {
   ANALYTICS_PIPETTE_OFFSET_STARTED,
   ANALYTICS_TIP_LENGTH_STARTED,
+  ANALYTICS_RESOURCE_MONITOR_REPORT,
 } from './constants'
 
 export type AnalyticsConfig = Config['analytics']
@@ -118,9 +119,19 @@ export interface TipLengthStartedAnalyticsAction {
   }
 }
 
+export interface ResourceMonitorAnalyticsAction {
+  type: typeof ANALYTICS_RESOURCE_MONITOR_REPORT
+  payload: {
+    systemAvailMemMb: string
+    systemUptimeHrs: string
+    processesDetails: Array<Record<string, any>>
+  }
+}
+
 export type AnalyticsTriggerAction =
   | PipetteOffsetStartedAnalyticsAction
   | TipLengthStartedAnalyticsAction
+  | ResourceMonitorAnalyticsAction
 
 export interface SessionInstrumentAnalyticsData {
   sessionType: string


### PR DESCRIPTION
Closes [EXEC-789](https://opentrons.atlassian.net/browse/EXEC-789)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds a resource monitor to the ODD for select processes and general system metrics, dispatched hourly to Mixpanel if the user has opted-in.  The shape of the data reported is the `ResourceMonitorDetails` interface. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that the expected shape of data is dispatched hourly to Mixpanel. Although I can't yet play around with the data in Mixpanel without an ODD build that contains a mixpanel ID, the [docs](https://mixpanel.com/blog/tapping-into-advanced-data-types/) make it seem that more complex filters involving list data are possible, so I think we're good on that front. We can always tweak the shape of the analytics in a future QA alpha.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added a resource monitor on the ODD for tracking memory usage of the system and select processes.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-789]: https://opentrons.atlassian.net/browse/EXEC-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ