### PR TITLE
fix(api): prevent moving a labware onto itself

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -186,6 +186,10 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
                 top_labware_definition=current_labware_definition,
                 bottom_labware_id=available_new_location.labwareId,
             )
+            if params.labwareId == available_new_location.labwareId:
+                raise LabwareMovementNotAllowedError(
+                    "Cannot move a labware onto itself."
+                )
 
         # Allow propagation of ModuleNotLoadedError.
         new_offset_id = self._equipment.find_applicable_labware_offset_id(


### PR DESCRIPTION
# Overview

Fixes PLAT-572.

This PR fixes a bug found where you were able to move a labware that could be stacked upon the same labware type (for example, the thermocycler lid) onto the same instance of the labware, ie.e stacking it on itself. Not only does this make no logical or physical sense, it would cause a `RecursionError` the next time any gantry movement happened, since during the course of finding the highest Z we would recursively find the height of any stacked labware. If a labware's parent happens to be itself (which should never happen), it will keep recursively trying to find a deck slot or module until the max recursion error occurs.

Now, when moving to an `OnLabwareLocation`, we check to make sure that the labware ID of the labware being moved does not match the labware ID of the new location. If it does, we will raise an error informing that the labware is trying to be moved on itself.

For more information on this recursive error, see PR #16600.

## Test Plan and Hands on Testing

The following protocol now fails with a `LabwareMovementNotAllowedError` on the `move_labware` line, not with a `RecursionError` on the `pick_up_tip` line.

```
metadata = {
    'protocolName': 'Impossible Geometry Stacking Test',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.20"
}


def run(context):
    trash_bin = context.load_trash_bin('A3')
    tip_rack = context.load_labware('opentrons_flex_96_tiprack_50ul', 'D2')
    pipette = context.load_instrument('flex_1channel_50', mount="left", tip_racks=[tip_rack])

    lid1 = context.load_labware("opentrons_tough_pcr_auto_sealing_lid", "C3")
    lid2 = lid1.load_labware("opentrons_tough_pcr_auto_sealing_lid")

    context.move_labware(lid2, lid2, use_gripper=True)

    pipette.pick_up_tip()
``` 

## Changelog

- Prevent moving a labware onto the same instance of labware

## Risk assessment

Low.