### PR TITLE
RFC: prototyping papi transfer + engine core + pe load liquid class

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -338,6 +338,14 @@ from .liquid_probe import (
     TryLiquidProbeCommandType,
 )
 
+from .load_liquid_class import (
+    LoadLiquidClass,
+    LoadLiquidClassParams,
+    LoadLiquidClassResult,
+    LoadLiquidClassCreate,
+    LoadLiquidClassCommandType,
+)
+
 __all__ = [
     # command type unions
     "Command",
@@ -591,4 +599,10 @@ __all__ = [
     "TryLiquidProbeCreate",
     "TryLiquidProbeResult",
     "TryLiquidProbeCommandType",
+    # Load liquid class command bundle
+    "LoadLiquidClass",
+    "LoadLiquidClassParams",
+    "LoadLiquidClassResult",
+    "LoadLiquidClassCreate",
+    "LoadLiquidClassCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -320,6 +320,14 @@ from .liquid_probe import (
     TryLiquidProbeCommandType,
 )
 
+from .load_liquid_class import (
+    LoadLiquidClass,
+    LoadLiquidClassParams,
+    LoadLiquidClassResult,
+    LoadLiquidClassCreate,
+    LoadLiquidClassCommandType,
+)
+
 Command = Annotated[
     Union[
         Aspirate,
@@ -339,6 +347,7 @@ Command = Annotated[
         LoadLabware,
         ReloadLabware,
         LoadLiquid,
+        LoadLiquidClass,
         LoadModule,
         LoadPipette,
         MoveLabware,
@@ -416,6 +425,7 @@ CommandParams = Union[
     LoadLabwareParams,
     ReloadLabwareParams,
     LoadLiquidParams,
+    LoadLiquidClassParams,
     LoadModuleParams,
     LoadPipetteParams,
     MoveLabwareParams,
@@ -491,6 +501,7 @@ CommandType = Union[
     LoadLabwareCommandType,
     ReloadLabwareCommandType,
     LoadLiquidCommandType,
+    LoadLiquidClassCommandType,
     LoadModuleCommandType,
     LoadPipetteCommandType,
     MoveLabwareCommandType,
@@ -644,6 +655,7 @@ CommandResult = Union[
     LoadLabwareResult,
     ReloadLabwareResult,
     LoadLiquidResult,
+    LoadLiquidClassResult,
     LoadModuleResult,
     LoadPipetteResult,
     MoveLabwareResult,

--- a/api/src/opentrons/protocol_engine/commands/load_liquid_class.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid_class.py
@@ -1,0 +1,111 @@
+"""Load liquid class command request, result, and implementation models."""
+from __future__ import annotations
+
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    AspirateProperties,
+    SingleDispenseProperties,
+    MultiDispenseProperties,
+)
+from pydantic import BaseModel, Field
+from typing import Optional, Type, Dict, TYPE_CHECKING
+from typing_extensions import Literal
+
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
+from ..types import ImmutableLiquidClass
+
+if TYPE_CHECKING:
+    from ..state.state import StateView
+
+LoadLiquidClassCommandType = Literal["loadLiquidClass"]
+
+
+class LoadLiquidClassParams(BaseModel):
+    """Payload required to load a liquid into a well."""
+
+    pipetteId: str = Field(
+        ...,
+        description="Unique identifier of pipette to use with liquid class.",
+    )
+    tiprackId: str = Field(
+        ...,
+        description="Unique identifier of tip rack to use with liquid class.",
+    )
+    aspirateProperties: AspirateProperties
+    singleDispenseProperties: SingleDispenseProperties
+    multiDispenseProperties: Optional[MultiDispenseProperties]
+    liquidClassId: Optional[str] = Field(
+        None,
+        description="An optional ID to assign to this liquid class. If None, an ID "
+        "will be generated.",
+    )
+
+
+class LoadLiquidClassResult(BaseModel):
+    """Result data from the execution of a LoadLiquidClass command."""
+
+    loadedLiquidClass: ImmutableLiquidClass = Field(
+        ..., description="An immutable liquid class created from the load params."
+    )
+
+
+class LoadLiquidClassImplementation(
+    AbstractCommandImpl[LoadLiquidClassParams, SuccessData[LoadLiquidClassResult, None]]
+):
+    """Load liquid command implementation."""
+
+    def __init__(self, state_view: StateView, **kwargs: object) -> None:
+        self._state_view = state_view
+
+    async def execute(
+        self, params: LoadLiquidClassParams
+    ) -> SuccessData[LoadLiquidClassResult, None]:
+        """Load data necessary for a liquid class."""
+
+        liq_class_hash = "create-a-hash"
+        existing_liq_class = self._state_view.liquid.get_liq_class_by_hash(
+            liq_class_hash
+        )
+        if existing_liq_class:
+            liq_class = existing_liq_class
+        else:
+            liq_class = ImmutableLiquidClass(
+                id="get-a-uuid",
+                hash="create-a-hash",
+                pipetteId=params.pipetteId,
+                tiprackId=params.tiprackId,
+                aspirateProperties=params.aspirateProperties,
+                singleDispenseProperties=params.singleDispenseProperties,
+                multiDispenseProperties=params.multiDispenseProperties,
+            )
+        # **** TODO: save liquid class to state *****
+
+        return SuccessData(
+            public=LoadLiquidClassResult(
+                loadedLiquidClass=liq_class,
+            ),
+            private=None,
+        )
+
+
+class LoadLiquidClass(
+    BaseCommand[LoadLiquidClassParams, LoadLiquidClassResult, ErrorOccurrence]
+):
+    """Load liquid command resource model."""
+
+    commandType: LoadLiquidClassCommandType = "loadLiquidClass"
+    params: LoadLiquidClassParams
+    result: Optional[LoadLiquidClassResult]
+
+    _ImplementationCls: Type[
+        LoadLiquidClassImplementation
+    ] = LoadLiquidClassImplementation
+
+
+class LoadLiquidClassCreate(BaseCommandCreate[LoadLiquidClassParams]):
+    """Load liquid command creation request."""
+
+    commandType: LoadLiquidClassCommandType = "loadLiquidClass"
+    params: LoadLiquidClassParams
+
+    _CommandCls: Type[LoadLiquidClass] = LoadLiquidClass

--- a/api/src/opentrons/protocol_engine/state/liquids.py
+++ b/api/src/opentrons/protocol_engine/state/liquids.py
@@ -1,7 +1,7 @@
 """Basic liquid data state and store."""
 from dataclasses import dataclass
 from typing import Dict, List
-from opentrons.protocol_engine.types import Liquid
+from opentrons.protocol_engine.types import Liquid, ImmutableLiquidClass
 
 from ._abstract_store import HasState, HandlesActions
 from ..actions import Action, AddLiquidAction
@@ -13,6 +13,7 @@ class LiquidState:
     """State of all loaded liquids."""
 
     liquids_by_id: Dict[str, Liquid]
+    liquid_classes_by_id: Dict[str, ImmutableLiquidClass]
 
 
 class LiquidStore(HasState[LiquidState], HandlesActions):
@@ -22,7 +23,10 @@ class LiquidStore(HasState[LiquidState], HandlesActions):
 
     def __init__(self) -> None:
         """Initialize a liquid store and its state."""
-        self._state = LiquidState(liquids_by_id={})
+        self._state = LiquidState(
+            liquids_by_id={},
+            liquid_classes_by_id={},
+        )
 
     def handle_action(self, action: Action) -> None:
         """Modify state in reaction to an action."""

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -42,7 +42,11 @@ from opentrons_shared_data.pipette.types import (  # noqa: F401
     LabwareUri as LabwareUri,
 )
 from opentrons_shared_data.module.types import ModuleType as SharedDataModuleType
-
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    AspirateProperties,
+    SingleDispenseProperties,
+    MultiDispenseProperties,
+)
 
 # todo(mm, 2024-06-24): This monolithic status field is getting to be a bit much.
 # We should consider splitting this up into multiple fields.
@@ -1135,3 +1139,17 @@ CSVRuntimeParamPaths = Dict[str, Path]
 
 
 ABSMeasureMode = Literal["single", "multi"]
+
+
+# TODO: add frozen dataclass of all properties
+#  These properties can skip the 'enable' prop and just have params as optional.
+#  If the params exist, the action is performed, if not, it's not performed.
+@dataclass(frozen=True)
+class ImmutableLiquidClass:
+    id: str
+    hash: str
+    pipetteId: str
+    tiprackId: str
+    aspirateProperties: AspirateProperties
+    singleDispenseProperties: SingleDispenseProperties
+    multiDispenseProperties: MultiDispenseProperties


### PR DESCRIPTION
RFC for AUTH-865

This is a prototype of what PAPI & PE implementation of liquid class handling will roughly look like. It shows the flow of control between PAPI & PE when executing the transfer function that uses a liquid class. The code is a mix of pseudo-code and true code. 

There are quite a few lines that build on top of assumed future changes, for example, `TouchTip` command is used here assuming that it'll have an `mmToEdge` param. The most visible such assumption is that each of the liquid handling PE commands is assumed to have a `liquidClassId` param. This is one of the main things I'm looking for comments on whether it's a good thing or not.

Summary of changes:

1. Adds a protocol engine `LoadLiquidClass` command that will take in a liquid class's properties and save it in state. It will provide a liquid class ID that can be used in liquid handling functions.
2. Adds an `InstrumentContext.transfer()` (overloaded) method that takes in a liquid class
3. Assumes that there will be some sort of minimal 'transfer plan builder' that will build each 1-to-1 transfer's locations, including tip pick up location (if any), source well, dest well, and tip drop well.
4. Adds an implementation of the engine core's transfer function that calls engine commands for executing each 1-to-1 transfer from above, while using the liquid class properties.

Request for comments:
1. Opinion on this approach
2. Is point 3 above the correct way to go? It is slightly similar to the transfer planner we currently have without going into absolutely all details of each transfer. It keeps the planning to a minimal so that we can use the tip tracking provision of the protocol api and convert the location types to what's expected by the engine core.
3. This approach will require all the liquid handling (and maybe WaitForDuration) commands to include a new optional `liquidClassId` param. Any problems with that?
