### PR TITLE
feat(api): Attach error recovery debug notes to commands

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[057de2035d][OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[057de2035d][OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -9383,7 +9383,14 @@
       },
       "id": "UUID",
       "key": "08e16a2cac011d4bef561f8b0854d19e",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "displayName": "4 custom tubes",
         "loadName": "cpx_4_tuberack_100ul",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0cbde10c37][OT2_S_v2_18_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0cbde10c37][OT2_S_v2_18_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -9383,7 +9383,14 @@
       },
       "id": "UUID",
       "key": "08e16a2cac011d4bef561f8b0854d19e",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "displayName": "4 custom tubes",
         "loadName": "cpx_4_tuberack_100ul",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[134037b2aa][OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[134037b2aa][OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods].json
@@ -7895,7 +7895,14 @@
       },
       "id": "UUID",
       "key": "675eb8be-6c85-4204-9c87-d7fdd522f580",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "moduleId": "UUID"
       },

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13ec753045][Flex_S_v2_18_Illumina_Stranded_total_RNA_Ribo_Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13ec753045][Flex_S_v2_18_Illumina_Stranded_total_RNA_Ribo_Zero].json
@@ -4341,7 +4341,14 @@
       },
       "id": "UUID",
       "key": "bccdb28e967f574dfbe472004101d7f9",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "displayName": "Index Anchors",
         "loadName": "eppendorf_96_wellplate_150ul",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19c783e363][Flex_X_v8_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19c783e363][Flex_X_v8_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips].json
@@ -12587,7 +12587,14 @@
       },
       "id": "UUID",
       "key": "702caca4-12c8-4f26-a68e-138134723f09",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "labwareId": "UUID",
         "newLocation": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4389e3ab18][OT2_X_v6_P20S_None_SimpleTransfer].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4389e3ab18][OT2_X_v6_P20S_None_SimpleTransfer].json
@@ -1772,7 +1772,14 @@
       },
       "id": "UUID",
       "key": "c2e4fa67-3c04-4d22-b3fa-5d61e956c488",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "flowRate": 3.78,
         "labwareId": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4b17883f74][OT2_S_v2_17_P300M_P20S_HS_TC_TM_dispense_changes].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4b17883f74][OT2_S_v2_17_P300M_P20S_HS_TC_TM_dispense_changes].json
@@ -3035,7 +3035,14 @@
       },
       "id": "UUID",
       "key": "0bd3f36a944ee534e422ee69360a9501",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "flowRate": 7.56,
         "labwareId": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4cb705bdbf][Flex_X_v2_16_NO_PIPETTES_MM_MagneticModuleInFlexProtocol].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4cb705bdbf][Flex_X_v2_16_NO_PIPETTES_MM_MagneticModuleInFlexProtocol].json
@@ -32,7 +32,14 @@
       },
       "id": "UUID",
       "key": "8511b05ba5565bf0e6dcccd800e2ee23",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "location": {
           "slotName": "C1"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[53db9bf516][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_left].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[53db9bf516][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_left].json
@@ -1205,7 +1205,14 @@
       },
       "id": "UUID",
       "key": "2c37ad797da7df791b57a7843a203e88",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "configurationParams": {
           "backLeftNozzle": "A1",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5e958b7c98][Flex_X_v2_16_P300MGen2_None_OT2PipetteInFlexProtocol].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5e958b7c98][Flex_X_v2_16_P300MGen2_None_OT2PipetteInFlexProtocol].json
@@ -1181,7 +1181,14 @@
       },
       "id": "UUID",
       "key": "bd403a1c851a75b4b68ce34796d713fa",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "liquidPresenceDetection": false,
         "mount": "left",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[604023f7f1][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[604023f7f1][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol3].json
@@ -121,7 +121,14 @@
       },
       "id": "UUID",
       "key": "a3a7eed460d8d94a91747f23820a180d",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "location": {
           "slotName": "C3"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[93b724671e][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_right].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[93b724671e][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_right].json
@@ -2366,7 +2366,14 @@
       },
       "id": "UUID",
       "key": "4b1d27a6f17f312dd76668f0c48ed406",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "configurationParams": {
           "backLeftNozzle": "G12",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9e56ee92f6][Flex_X_v2_16_P1000_96_GRIP_DropLabwareIntoTrashBin].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9e56ee92f6][Flex_X_v2_16_P1000_96_GRIP_DropLabwareIntoTrashBin].json
@@ -1350,7 +1350,14 @@
       },
       "id": "UUID",
       "key": "4cca9753dc59d176eee1522349363a75",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "labwareId": "UUID",
         "newLocation": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ac886d7768][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IDTXgen96Part1to3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ac886d7768][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IDTXgen96Part1to3].json
@@ -15103,7 +15103,14 @@
       },
       "id": "UUID",
       "key": "c3eacf39e9a35058cac9f69100549344",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "forceDirect": false,
         "labwareId": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[acefe91275][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_left].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[acefe91275][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_left].json
@@ -2351,7 +2351,14 @@
       },
       "id": "UUID",
       "key": "4b1d27a6f17f312dd76668f0c48ed406",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "configurationParams": {
           "backLeftNozzle": "A1",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b777168ac1][Flex_S_v2_19_Illumina_Stranded_total_RNA_Ribo_Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b777168ac1][Flex_S_v2_19_Illumina_Stranded_total_RNA_Ribo_Zero].json
@@ -4341,7 +4341,14 @@
       },
       "id": "UUID",
       "key": "bccdb28e967f574dfbe472004101d7f9",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "displayName": "Index Anchors",
         "loadName": "eppendorf_96_wellplate_150ul",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d0154b1493][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_right].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d0154b1493][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_right].json
@@ -1220,7 +1220,14 @@
       },
       "id": "UUID",
       "key": "2c37ad797da7df791b57a7843a203e88",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "configurationParams": {
           "backLeftNozzle": "G12",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e0b0133ffb][pl_Illumina_Stranded_total_RNA_Ribo_Zero_protocol].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e0b0133ffb][pl_Illumina_Stranded_total_RNA_Ribo_Zero_protocol].json
@@ -39047,7 +39047,14 @@
       },
       "id": "UUID",
       "key": "f524340032354f66bf69110d530e98ad",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "labwareId": "UUID",
         "newLocation": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed1e64c539][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInCol2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed1e64c539][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInCol2].json
@@ -32,7 +32,14 @@
       },
       "id": "UUID",
       "key": "8511b05ba5565bf0e6dcccd800e2ee23",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "location": {
           "slotName": "C2"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f24bb0b4d9][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IlluminaDNAPrep96PART3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f24bb0b4d9][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IlluminaDNAPrep96PART3].json
@@ -17824,7 +17824,14 @@
       },
       "id": "UUID",
       "key": "7e96139ed2163fa7f870805d0b3d14b6",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "forceDirect": false,
         "labwareId": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f5f3b9c5bb][Flex_X_v2_16_P1000_96_TM_ModuleAndWasteChuteConflict].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f5f3b9c5bb][Flex_X_v2_16_P1000_96_TM_ModuleAndWasteChuteConflict].json
@@ -1255,7 +1255,14 @@
       },
       "id": "UUID",
       "key": "c55807b45b6b1d4ea04e12b0ee553f78",
-      "notes": [],
+      "notes": [
+        {
+          "longMessage": "Handling this command failure with FAIL_RUN.",
+          "noteKind": "debugErrorRecovery",
+          "shortMessage": "Handling this command failure with FAIL_RUN.",
+          "source": "execution"
+        }
+      ],
       "params": {
         "location": {
           "slotName": "D3"

--- a/api/src/opentrons/protocol_engine/notes/__init__.py
+++ b/api/src/opentrons/protocol_engine/notes/__init__.py
@@ -1,5 +1,17 @@
 """Protocol engine notes module."""
 
-from .notes import NoteKind, CommandNote, CommandNoteAdder, CommandNoteTracker
+from .notes import (
+    NoteKind,
+    CommandNote,
+    CommandNoteAdder,
+    CommandNoteTracker,
+    make_error_recovery_debug_note,
+)
 
-__all__ = ["NoteKind", "CommandNote", "CommandNoteAdder", "CommandNoteTracker"]
+__all__ = [
+    "NoteKind",
+    "CommandNote",
+    "CommandNoteAdder",
+    "CommandNoteTracker",
+    "make_error_recovery_debug_note",
+]

--- a/api/src/opentrons/protocol_engine/notes/notes.py
+++ b/api/src/opentrons/protocol_engine/notes/notes.py
@@ -1,6 +1,9 @@
 """Definitions of data and interface shapes for notes."""
-from typing import Union, Literal, Protocol, List
+from typing import Union, Literal, Protocol, List, TYPE_CHECKING
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 
 NoteKind = Union[Literal["warning", "information"], str]
 
@@ -23,6 +26,20 @@ class CommandNote(BaseModel):
     )
     source: str = Field(
         ..., description="An identifier for the party that created the note"
+    )
+
+
+def make_error_recovery_debug_note(type: "ErrorRecoveryType") -> CommandNote:
+    """Return a note for debugging error recovery.
+
+    This is intended to be read by developers and support people, not computers.
+    """
+    message = f"Handling this command failure with {type.name}."
+    return CommandNote.construct(
+        noteKind="debugErrorRecovery",
+        shortMessage=message,
+        longMessage=message,
+        source="execution",
     )
 
 

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_run_failure.tavern.yaml
@@ -101,7 +101,7 @@ stages:
             startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
             completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
             status: failed
-            notes: []
+            notes: !anylist
             error:
               id: !anystr
               errorType: TipNotAttachedError


### PR DESCRIPTION
## Overview

User interactions for error recovery are already "logged", as the run's `actions`. However, stuff that the robot does automatically is not. This closes that gap in a basic way. When a command fails, we'll append a human-readable `note` to it that mentions how Protocol Engine is basically treating it. (`FAIL_RUN`, `WAIT_FOR_RECOVERY`, `CONTINUE_WITH_ERROR`, or `ASSUME_FALSE_POSITIVE_AND_CONTINUE`.)

In particular, this means that when a user selects **Ignore all errors of this type,** the run log can show us all the commands that the robot auto-handled in that way.

Closes EXEC-780.

## Test Plan and Hands on Testing

* [x] Run a protocol with some command errors. Download the run log and make sure these notes show up on any commands that failed.

## Review requests

The existing `CommandNote` shape is just human-readable. So for simplicity, I'm matching that and just providing a human-readable string.

Would it be a good idea to also expand `CommandNote` with a `Mapping[str, Any]` field, like we have for errors? Then we could put stuff like `StateUpdate`s in there without it being a gross monolithic string.

## Risk assessment

Low.
