### PR TITLE
refactor(api): Delete dead `private_result` supporting code

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -18,7 +18,6 @@ from ..commands import (
     Command,
     CommandCreate,
     CommandDefinedErrorData,
-    CommandPrivateResult,
 )
 from ..error_recovery_policy import ErrorRecoveryPolicy, ErrorRecoveryType
 from ..notes.notes import CommandNote
@@ -145,10 +144,6 @@ class SucceedCommandAction:
 
     command: Command
     """The command in its new succeeded state."""
-
-    # todo(mm, 2024-08-26): Remove when no state stores use this anymore.
-    # https://opentrons.atlassian.net/browse/EXEC-639
-    private_result: CommandPrivateResult
 
     state_update: StateUpdate = dataclasses.field(
         # todo(mm, 2024-08-26): This has a default only to make it easier to transition

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -38,7 +38,6 @@ from .command_unions import (
     CommandCreate,
     CommandResult,
     CommandType,
-    CommandPrivateResult,
     CommandDefinedErrorData,
 )
 

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
@@ -142,7 +142,6 @@ class CloseLidImpl(
 
         return SuccessData(
             public=CloseLidResult(),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
@@ -37,9 +37,7 @@ class CloseLidResult(BaseModel):
     """Result data from closing the lid on an aborbance reading."""
 
 
-class CloseLidImpl(
-    AbstractCommandImpl[CloseLidParams, SuccessData[CloseLidResult, None]]
-):
+class CloseLidImpl(AbstractCommandImpl[CloseLidParams, SuccessData[CloseLidResult]]):
     """Execution implementation of closing the lid on an Absorbance Reader."""
 
     def __init__(
@@ -53,9 +51,7 @@ class CloseLidImpl(
         self._equipment = equipment
         self._labware_movement = labware_movement
 
-    async def execute(
-        self, params: CloseLidParams
-    ) -> SuccessData[CloseLidResult, None]:
+    async def execute(self, params: CloseLidParams) -> SuccessData[CloseLidResult]:
         """Execute the close lid command."""
         mod_substate = self._state_view.modules.get_absorbance_reader_substate(
             module_id=params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/initialize.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/initialize.py
@@ -105,7 +105,6 @@ class InitializeImpl(
 
         return SuccessData(
             public=InitializeResult(),
-            private=None,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/initialize.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/initialize.py
@@ -37,7 +37,7 @@ class InitializeResult(BaseModel):
 
 
 class InitializeImpl(
-    AbstractCommandImpl[InitializeParams, SuccessData[InitializeResult, None]]
+    AbstractCommandImpl[InitializeParams, SuccessData[InitializeResult]]
 ):
     """Execution implementation of initializing an Absorbance Reader."""
 
@@ -50,9 +50,7 @@ class InitializeImpl(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(
-        self, params: InitializeParams
-    ) -> SuccessData[InitializeResult, None]:
+    async def execute(self, params: InitializeParams) -> SuccessData[InitializeResult]:
         """Initiate a single absorbance measurement."""
         abs_reader_substate = self._state_view.modules.get_absorbance_reader_substate(
             module_id=params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
@@ -38,7 +38,7 @@ class OpenLidResult(BaseModel):
     """Result data from opening the lid on an aborbance reading."""
 
 
-class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, None]]):
+class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult]]):
     """Execution implementation of opening the lid on an Absorbance Reader."""
 
     def __init__(
@@ -52,7 +52,7 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, 
         self._equipment = equipment
         self._labware_movement = labware_movement
 
-    async def execute(self, params: OpenLidParams) -> SuccessData[OpenLidResult, None]:
+    async def execute(self, params: OpenLidParams) -> SuccessData[OpenLidResult]:
         """Move the absorbance reader lid from the module to the lid dock."""
         mod_substate = self._state_view.modules.get_absorbance_reader_substate(
             module_id=params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
@@ -137,7 +137,6 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, 
 
         return SuccessData(
             public=OpenLidResult(),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -168,12 +168,10 @@ class ReadAbsorbanceImpl(
                     public=ReadAbsorbanceResult(
                         data=asbsorbance_result, fileIds=file_ids
                     ),
-                    private=None,
                 )
 
         return SuccessData(
             public=ReadAbsorbanceResult(data=asbsorbance_result, fileIds=file_ids),
-            private=None,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -48,7 +48,7 @@ class ReadAbsorbanceResult(BaseModel):
 
 
 class ReadAbsorbanceImpl(
-    AbstractCommandImpl[ReadAbsorbanceParams, SuccessData[ReadAbsorbanceResult, None]]
+    AbstractCommandImpl[ReadAbsorbanceParams, SuccessData[ReadAbsorbanceResult]]
 ):
     """Execution implementation of an Absorbance Reader measurement."""
 
@@ -65,7 +65,7 @@ class ReadAbsorbanceImpl(
 
     async def execute(  # noqa: C901
         self, params: ReadAbsorbanceParams
-    ) -> SuccessData[ReadAbsorbanceResult, None]:
+    ) -> SuccessData[ReadAbsorbanceResult]:
         """Initiate an absorbance measurement."""
         abs_reader_substate = self._state_view.modules.get_absorbance_reader_substate(
             module_id=params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -167,7 +167,6 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
                     volume=volume_aspirated,
                     position=deck_point,
                 ),
-                private=None,
                 state_update=state_update,
             )
 

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -52,7 +52,7 @@ class AspirateResult(BaseLiquidHandlingResult, DestinationPositionResult):
 
 
 _ExecuteReturn = Union[
-    SuccessData[AspirateResult, None],
+    SuccessData[AspirateResult],
     DefinedErrorData[OverpressureError],
 ]
 

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -150,7 +150,6 @@ class AspirateInPlaceImplementation(
                 )
             return SuccessData(
                 public=AspirateInPlaceResult(volume=volume),
-                private=None,
                 state_update=state_update,
             )
 

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -49,7 +49,7 @@ class AspirateInPlaceResult(BaseLiquidHandlingResult):
 
 
 _ExecuteReturn = Union[
-    SuccessData[AspirateInPlaceResult, None],
+    SuccessData[AspirateInPlaceResult],
     DefinedErrorData[OverpressureError],
 ]
 

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -48,7 +48,7 @@ class BlowOutResult(DestinationPositionResult):
 
 
 _ExecuteReturn = Union[
-    SuccessData[BlowOutResult, None],
+    SuccessData[BlowOutResult],
     DefinedErrorData[OverpressureError],
 ]
 

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -116,7 +116,6 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, _ExecuteReturn]):
         else:
             return SuccessData(
                 public=BlowOutResult(position=deck_point),
-                private=None,
                 state_update=state_update,
             )
 

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -99,7 +99,9 @@ class BlowOutInPlaceImplementation(
                 ),
             )
         else:
-            return SuccessData(public=BlowOutInPlaceResult(), private=None)
+            return SuccessData(
+                public=BlowOutInPlaceResult(),
+            )
 
 
 class BlowOutInPlace(

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -45,7 +45,7 @@ class BlowOutInPlaceResult(BaseModel):
 
 
 _ExecuteReturn = Union[
-    SuccessData[BlowOutInPlaceResult, None],
+    SuccessData[BlowOutInPlaceResult],
     DefinedErrorData[OverpressureError],
 ]
 

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_gripper.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_gripper.py
@@ -71,9 +71,7 @@ class CalibrateGripperResult(BaseModel):
 
 
 class CalibrateGripperImplementation(
-    AbstractCommandImpl[
-        CalibrateGripperParams, SuccessData[CalibrateGripperResult, None]
-    ]
+    AbstractCommandImpl[CalibrateGripperParams, SuccessData[CalibrateGripperResult]]
 ):
     """The implementation of a `calibrateGripper` command."""
 
@@ -87,7 +85,7 @@ class CalibrateGripperImplementation(
 
     async def execute(
         self, params: CalibrateGripperParams
-    ) -> SuccessData[CalibrateGripperResult, None]:
+    ) -> SuccessData[CalibrateGripperResult]:
         """Execute a `calibrateGripper` command.
 
         1. Move from the current location to the calibration area on the deck.

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_gripper.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_gripper.py
@@ -126,7 +126,6 @@ class CalibrateGripperImplementation(
                 ),
                 savedCalibration=calibration_data,
             ),
-            private=None,
         )
 
     @staticmethod

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
@@ -49,7 +49,7 @@ class CalibrateModuleResult(BaseModel):
 
 
 class CalibrateModuleImplementation(
-    AbstractCommandImpl[CalibrateModuleParams, SuccessData[CalibrateModuleResult, None]]
+    AbstractCommandImpl[CalibrateModuleParams, SuccessData[CalibrateModuleResult]]
 ):
     """CalibrateModule command implementation."""
 
@@ -64,7 +64,7 @@ class CalibrateModuleImplementation(
 
     async def execute(
         self, params: CalibrateModuleParams
-    ) -> SuccessData[CalibrateModuleResult, None]:
+    ) -> SuccessData[CalibrateModuleResult]:
         """Execute calibrate-module command."""
         ot3_api = ensure_ot3_hardware(
             self._hardware_api,

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
@@ -91,7 +91,6 @@ class CalibrateModuleImplementation(
                 ),
                 location=slot,
             ),
-            private=None,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
@@ -72,7 +72,6 @@ class CalibratePipetteImplementation(
                     x=pipette_offset.x, y=pipette_offset.y, z=pipette_offset.z
                 )
             ),
-            private=None,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
@@ -34,9 +34,7 @@ class CalibratePipetteResult(BaseModel):
 
 
 class CalibratePipetteImplementation(
-    AbstractCommandImpl[
-        CalibratePipetteParams, SuccessData[CalibratePipetteResult, None]
-    ]
+    AbstractCommandImpl[CalibratePipetteParams, SuccessData[CalibratePipetteResult]]
 ):
     """CalibratePipette command implementation."""
 
@@ -49,7 +47,7 @@ class CalibratePipetteImplementation(
 
     async def execute(
         self, params: CalibratePipetteParams
-    ) -> SuccessData[CalibratePipetteResult, None]:
+    ) -> SuccessData[CalibratePipetteResult]:
         """Execute calibrate-pipette command."""
         # TODO (tz, 20-9-22): Add a better solution to determine if a command can be executed on an OT-3/OT-2
         ot3_api = ensure_ot3_hardware(

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -57,7 +57,7 @@ class MoveToMaintenancePositionResult(BaseModel):
 class MoveToMaintenancePositionImplementation(
     AbstractCommandImpl[
         MoveToMaintenancePositionParams,
-        SuccessData[MoveToMaintenancePositionResult, None],
+        SuccessData[MoveToMaintenancePositionResult],
     ]
 ):
     """Calibration set up position command implementation."""
@@ -73,7 +73,7 @@ class MoveToMaintenancePositionImplementation(
 
     async def execute(
         self, params: MoveToMaintenancePositionParams
-    ) -> SuccessData[MoveToMaintenancePositionResult, None]:
+    ) -> SuccessData[MoveToMaintenancePositionResult]:
         """Move the requested mount to a maintenance deck slot."""
         ot3_api = ensure_ot3_hardware(
             self._hardware_api,

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -118,7 +118,9 @@ class MoveToMaintenancePositionImplementation(
                 )
                 await ot3_api.disengage_axes([Axis.Z_R])
 
-        return SuccessData(public=MoveToMaintenancePositionResult(), private=None)
+        return SuccessData(
+            public=MoveToMaintenancePositionResult(),
+        )
 
 
 class MoveToMaintenancePosition(

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -231,8 +231,6 @@ class BaseCommand(
                     # Our _ImplementationCls must return public result data that can fit
                     # in our `result` field:
                     _ResultT,
-                    # But we don't care (here) what kind of private result data it returns:
-                    object,
                 ],
                 DefinedErrorData[
                     # Our _ImplementationCls must return public error data that can fit
@@ -247,7 +245,7 @@ class BaseCommand(
 _ExecuteReturnT_co = TypeVar(
     "_ExecuteReturnT_co",
     bound=Union[
-        SuccessData[BaseModel, object],
+        SuccessData[BaseModel],
         DefinedErrorData[ErrorOccurrence],
     ],
     covariant=True,

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -39,7 +39,6 @@ _ResultT = TypeVar("_ResultT", bound=BaseModel)
 _ResultT_co = TypeVar("_ResultT_co", bound=BaseModel, covariant=True)
 _ErrorT = TypeVar("_ErrorT", bound=ErrorOccurrence)
 _ErrorT_co = TypeVar("_ErrorT_co", bound=ErrorOccurrence, covariant=True)
-_PrivateResultT_co = TypeVar("_PrivateResultT_co", covariant=True)
 
 
 class CommandStatus(str, Enum):
@@ -108,18 +107,11 @@ class BaseCommandCreate(
 
 
 @dataclasses.dataclass(frozen=True)
-class SuccessData(Generic[_ResultT_co, _PrivateResultT_co]):
+class SuccessData(Generic[_ResultT_co]):
     """Data from the successful completion of a command."""
 
     public: _ResultT_co
     """Public result data. Exposed over HTTP and stored in databases."""
-
-    private: _PrivateResultT_co
-    """Additional result data, only given to `opentrons.protocol_engine` internals.
-
-    Deprecated:
-        Use `state_update` instead.
-    """
 
     state_update: StateUpdate = dataclasses.field(
         # todo(mm, 2024-08-22): Remove the default once all command implementations

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -1,7 +1,7 @@
 """Union types of concrete command definitions."""
 
 from collections.abc import Collection
-from typing import Annotated, Literal, Type, Union, get_type_hints
+from typing import Annotated, Type, Union, get_type_hints
 
 from pydantic import Field
 
@@ -699,9 +699,6 @@ CommandResult = Union[
     unsafe.UnsafeUngripLabwareResult,
 ]
 
-# todo(mm, 2024-10-28): This has been obsoleted by StateUpdate. Delete this.
-# https://opentrons.atlassian.net/browse/EXEC-639
-CommandPrivateResult = Literal[None]
 
 # All `DefinedErrorData`s that implementations will actually return in practice.
 CommandDefinedErrorData = Union[

--- a/api/src/opentrons/protocol_engine/commands/comment.py
+++ b/api/src/opentrons/protocol_engine/commands/comment.py
@@ -24,14 +24,14 @@ class CommentResult(BaseModel):
 
 
 class CommentImplementation(
-    AbstractCommandImpl[CommentParams, SuccessData[CommentResult, None]]
+    AbstractCommandImpl[CommentParams, SuccessData[CommentResult]]
 ):
     """Comment command implementation."""
 
     def __init__(self, **kwargs: object) -> None:
         pass
 
-    async def execute(self, params: CommentParams) -> SuccessData[CommentResult, None]:
+    async def execute(self, params: CommentParams) -> SuccessData[CommentResult]:
         """No operation taken other than capturing message in command."""
         return SuccessData(
             public=CommentResult(),

--- a/api/src/opentrons/protocol_engine/commands/comment.py
+++ b/api/src/opentrons/protocol_engine/commands/comment.py
@@ -33,7 +33,9 @@ class CommentImplementation(
 
     async def execute(self, params: CommentParams) -> SuccessData[CommentResult, None]:
         """No operation taken other than capturing message in command."""
-        return SuccessData(public=CommentResult(), private=None)
+        return SuccessData(
+            public=CommentResult(),
+        )
 
 
 class Comment(BaseCommand[CommentParams, CommentResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -70,7 +70,6 @@ class ConfigureForVolumeImplementation(
 
         return SuccessData(
             public=ConfigureForVolumeResult(),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -43,7 +43,7 @@ class ConfigureForVolumeResult(BaseModel):
 class ConfigureForVolumeImplementation(
     AbstractCommandImpl[
         ConfigureForVolumeParams,
-        SuccessData[ConfigureForVolumeResult, None],
+        SuccessData[ConfigureForVolumeResult],
     ]
 ):
     """Configure for volume command implementation."""
@@ -53,7 +53,7 @@ class ConfigureForVolumeImplementation(
 
     async def execute(
         self, params: ConfigureForVolumeParams
-    ) -> SuccessData[ConfigureForVolumeResult, None]:
+    ) -> SuccessData[ConfigureForVolumeResult]:
         """Check that requested pipette can be configured for the given volume."""
         pipette_result = await self._equipment.configure_for_volume(
             pipette_id=params.pipetteId,

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -84,7 +84,6 @@ class ConfigureNozzleLayoutImplementation(
 
         return SuccessData(
             public=ConfigureNozzleLayoutResult(),
-            private=None,
             state_update=update_state,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -46,7 +46,7 @@ class ConfigureNozzleLayoutResult(BaseModel):
 class ConfigureNozzleLayoutImplementation(
     AbstractCommandImpl[
         ConfigureNozzleLayoutParams,
-        SuccessData[ConfigureNozzleLayoutResult, None],
+        SuccessData[ConfigureNozzleLayoutResult],
     ]
 ):
     """Configure nozzle layout command implementation."""
@@ -59,7 +59,7 @@ class ConfigureNozzleLayoutImplementation(
 
     async def execute(
         self, params: ConfigureNozzleLayoutParams
-    ) -> SuccessData[ConfigureNozzleLayoutResult, None]:
+    ) -> SuccessData[ConfigureNozzleLayoutResult]:
         """Check that requested pipette can support the requested nozzle layout."""
         primary_nozzle = params.configurationParams.dict().get("primaryNozzle")
         front_right_nozzle = params.configurationParams.dict().get("frontRightNozzle")

--- a/api/src/opentrons/protocol_engine/commands/custom.py
+++ b/api/src/opentrons/protocol_engine/commands/custom.py
@@ -49,7 +49,9 @@ class CustomImplementation(
     # for legacy RPC (pre-ProtocolEngine) payloads.
     async def execute(self, params: CustomParams) -> SuccessData[CustomResult, None]:
         """A custom command does nothing when executed directly."""
-        return SuccessData(public=CustomResult.construct(), private=None)
+        return SuccessData(
+            public=CustomResult.construct(),
+        )
 
 
 class Custom(BaseCommand[CustomParams, CustomResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/custom.py
+++ b/api/src/opentrons/protocol_engine/commands/custom.py
@@ -40,14 +40,14 @@ class CustomResult(BaseModel):
 
 
 class CustomImplementation(
-    AbstractCommandImpl[CustomParams, SuccessData[CustomResult, None]]
+    AbstractCommandImpl[CustomParams, SuccessData[CustomResult]]
 ):
     """Custom command implementation."""
 
     # TODO(mm, 2022-11-09): figure out how a plugin can specify a custom command
     # implementation. For now, always no-op, so we can use custom commands as containers
     # for legacy RPC (pre-ProtocolEngine) payloads.
-    async def execute(self, params: CustomParams) -> SuccessData[CustomResult, None]:
+    async def execute(self, params: CustomParams) -> SuccessData[CustomResult]:
         """A custom command does nothing when executed directly."""
         return SuccessData(
             public=CustomResult.construct(),

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -54,7 +54,7 @@ class DispenseResult(BaseLiquidHandlingResult, DestinationPositionResult):
 
 
 _ExecuteReturn = Union[
-    SuccessData[DispenseResult, None],
+    SuccessData[DispenseResult],
     DefinedErrorData[OverpressureError],
 ]
 

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -135,7 +135,6 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
             )
             return SuccessData(
                 public=DispenseResult(volume=volume, position=deck_point),
-                private=None,
                 state_update=state_update,
             )
 

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -129,7 +129,6 @@ class DispenseInPlaceImplementation(
                 )
             return SuccessData(
                 public=DispenseInPlaceResult(volume=volume),
-                private=None,
                 state_update=state_update,
             )
 

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -49,7 +49,7 @@ class DispenseInPlaceResult(BaseLiquidHandlingResult):
 
 
 _ExecuteReturn = Union[
-    SuccessData[DispenseInPlaceResult, None],
+    SuccessData[DispenseInPlaceResult],
     DefinedErrorData[OverpressureError],
 ]
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -161,7 +161,6 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
             )
             return SuccessData(
                 public=DropTipResult(position=deck_point),
-                private=None,
                 state_update=state_update,
             )
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -68,7 +68,7 @@ class DropTipResult(DestinationPositionResult):
 
 
 _ExecuteReturn = (
-    SuccessData[DropTipResult, None] | DefinedErrorData[TipPhysicallyAttachedError]
+    SuccessData[DropTipResult] | DefinedErrorData[TipPhysicallyAttachedError]
 )
 
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -44,8 +44,7 @@ class DropTipInPlaceResult(BaseModel):
 
 
 _ExecuteReturn = (
-    SuccessData[DropTipInPlaceResult, None]
-    | DefinedErrorData[TipPhysicallyAttachedError]
+    SuccessData[DropTipInPlaceResult] | DefinedErrorData[TipPhysicallyAttachedError]
 )
 
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -96,9 +96,7 @@ class DropTipInPlaceImplementation(
             state_update.update_pipette_tip_state(
                 pipette_id=params.pipetteId, tip_geometry=None
             )
-            return SuccessData(
-                public=DropTipInPlaceResult(), private=None, state_update=state_update
-            )
+            return SuccessData(public=DropTipInPlaceResult(), state_update=state_update)
 
 
 class DropTipInPlace(

--- a/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
@@ -59,7 +59,9 @@ class GetTipPresenceImplementation(
             pipette_id=pipette_id,
         )
 
-        return SuccessData(public=GetTipPresenceResult(status=result), private=None)
+        return SuccessData(
+            public=GetTipPresenceResult(status=result),
+        )
 
 
 class GetTipPresence(

--- a/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
@@ -38,7 +38,7 @@ class GetTipPresenceResult(BaseModel):
 
 
 class GetTipPresenceImplementation(
-    AbstractCommandImpl[GetTipPresenceParams, SuccessData[GetTipPresenceResult, None]]
+    AbstractCommandImpl[GetTipPresenceParams, SuccessData[GetTipPresenceResult]]
 ):
     """GetTipPresence command implementation."""
 
@@ -51,7 +51,7 @@ class GetTipPresenceImplementation(
 
     async def execute(
         self, params: GetTipPresenceParams
-    ) -> SuccessData[GetTipPresenceResult, None]:
+    ) -> SuccessData[GetTipPresenceResult]:
         """Verify if tip presence is as expected for the requested pipette."""
         pipette_id = params.pipetteId
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
@@ -27,9 +27,7 @@ class CloseLabwareLatchResult(BaseModel):
 
 
 class CloseLabwareLatchImpl(
-    AbstractCommandImpl[
-        CloseLabwareLatchParams, SuccessData[CloseLabwareLatchResult, None]
-    ]
+    AbstractCommandImpl[CloseLabwareLatchParams, SuccessData[CloseLabwareLatchResult]]
 ):
     """Execution implementation of a Heater-Shaker's close labware latch command."""
 
@@ -44,7 +42,7 @@ class CloseLabwareLatchImpl(
 
     async def execute(
         self, params: CloseLabwareLatchParams
-    ) -> SuccessData[CloseLabwareLatchResult, None]:
+    ) -> SuccessData[CloseLabwareLatchResult]:
         """Close a Heater-Shaker's labware latch."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
@@ -59,7 +59,9 @@ class CloseLabwareLatchImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.close_labware_latch()
 
-        return SuccessData(public=CloseLabwareLatchResult(), private=None)
+        return SuccessData(
+            public=CloseLabwareLatchResult(),
+        )
 
 
 class CloseLabwareLatch(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -58,7 +58,9 @@ class DeactivateHeaterImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.deactivate_heater()
 
-        return SuccessData(public=DeactivateHeaterResult(), private=None)
+        return SuccessData(
+            public=DeactivateHeaterResult(),
+        )
 
 
 class DeactivateHeater(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -27,9 +27,7 @@ class DeactivateHeaterResult(BaseModel):
 
 
 class DeactivateHeaterImpl(
-    AbstractCommandImpl[
-        DeactivateHeaterParams, SuccessData[DeactivateHeaterResult, None]
-    ]
+    AbstractCommandImpl[DeactivateHeaterParams, SuccessData[DeactivateHeaterResult]]
 ):
     """Execution implementation of a Heater-Shaker's deactivate heater command."""
 
@@ -44,7 +42,7 @@ class DeactivateHeaterImpl(
 
     async def execute(
         self, params: DeactivateHeaterParams
-    ) -> SuccessData[DeactivateHeaterResult, None]:
+    ) -> SuccessData[DeactivateHeaterResult]:
         """Unset a Heater-Shaker's target temperature."""
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
@@ -60,7 +60,9 @@ class DeactivateShakerImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.deactivate_shaker()
 
-        return SuccessData(public=DeactivateShakerResult(), private=None)
+        return SuccessData(
+            public=DeactivateShakerResult(),
+        )
 
 
 class DeactivateShaker(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
@@ -26,9 +26,7 @@ class DeactivateShakerResult(BaseModel):
 
 
 class DeactivateShakerImpl(
-    AbstractCommandImpl[
-        DeactivateShakerParams, SuccessData[DeactivateShakerResult, None]
-    ]
+    AbstractCommandImpl[DeactivateShakerParams, SuccessData[DeactivateShakerResult]]
 ):
     """Execution implementation of a Heater-Shaker's deactivate shaker command."""
 
@@ -43,7 +41,7 @@ class DeactivateShakerImpl(
 
     async def execute(
         self, params: DeactivateShakerParams
-    ) -> SuccessData[DeactivateShakerResult, None]:
+    ) -> SuccessData[DeactivateShakerResult]:
         """Deactivate shaker for a Heater-Shaker."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
@@ -87,7 +87,6 @@ class OpenLabwareLatchImpl(
 
         return SuccessData(
             public=OpenLabwareLatchResult(pipetteRetracted=pipette_should_retract),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
@@ -34,9 +34,7 @@ class OpenLabwareLatchResult(BaseModel):
 
 
 class OpenLabwareLatchImpl(
-    AbstractCommandImpl[
-        OpenLabwareLatchParams, SuccessData[OpenLabwareLatchResult, None]
-    ]
+    AbstractCommandImpl[OpenLabwareLatchParams, SuccessData[OpenLabwareLatchResult]]
 ):
     """Execution implementation of a Heater-Shaker's open latch labware command."""
 
@@ -53,7 +51,7 @@ class OpenLabwareLatchImpl(
 
     async def execute(
         self, params: OpenLabwareLatchParams
-    ) -> SuccessData[OpenLabwareLatchResult, None]:
+    ) -> SuccessData[OpenLabwareLatchResult]:
         """Open a Heater-Shaker's labware latch."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
@@ -94,7 +94,6 @@ class SetAndWaitForShakeSpeedImpl(
             public=SetAndWaitForShakeSpeedResult(
                 pipetteRetracted=pipette_should_retract
             ),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
@@ -36,7 +36,7 @@ class SetAndWaitForShakeSpeedResult(BaseModel):
 
 class SetAndWaitForShakeSpeedImpl(
     AbstractCommandImpl[
-        SetAndWaitForShakeSpeedParams, SuccessData[SetAndWaitForShakeSpeedResult, None]
+        SetAndWaitForShakeSpeedParams, SuccessData[SetAndWaitForShakeSpeedResult]
     ]
 ):
     """Execution implementation of Heater-Shaker's set and wait shake speed command."""
@@ -55,7 +55,7 @@ class SetAndWaitForShakeSpeedImpl(
     async def execute(
         self,
         params: SetAndWaitForShakeSpeedParams,
-    ) -> SuccessData[SetAndWaitForShakeSpeedResult, None]:
+    ) -> SuccessData[SetAndWaitForShakeSpeedResult]:
         """Set and wait for a Heater-Shaker's target shake speed."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -64,7 +64,9 @@ class SetTargetTemperatureImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.start_set_temperature(validated_temp)
 
-        return SuccessData(public=SetTargetTemperatureResult(), private=None)
+        return SuccessData(
+            public=SetTargetTemperatureResult(),
+        )
 
 
 class SetTargetTemperature(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -29,7 +29,7 @@ class SetTargetTemperatureResult(BaseModel):
 
 class SetTargetTemperatureImpl(
     AbstractCommandImpl[
-        SetTargetTemperatureParams, SuccessData[SetTargetTemperatureResult, None]
+        SetTargetTemperatureParams, SuccessData[SetTargetTemperatureResult]
     ]
 ):
     """Execution implementation of a Heater-Shaker's set temperature command."""
@@ -46,7 +46,7 @@ class SetTargetTemperatureImpl(
     async def execute(
         self,
         params: SetTargetTemperatureParams,
-    ) -> SuccessData[SetTargetTemperatureResult, None]:
+    ) -> SuccessData[SetTargetTemperatureResult]:
         """Set a Heater-Shaker's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
@@ -72,7 +72,9 @@ class WaitForTemperatureImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.await_temperature(awaiting_temperature=target_temp)
 
-        return SuccessData(public=WaitForTemperatureResult(), private=None)
+        return SuccessData(
+            public=WaitForTemperatureResult(),
+        )
 
 
 class WaitForTemperature(

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
@@ -36,9 +36,7 @@ class WaitForTemperatureResult(BaseModel):
 
 
 class WaitForTemperatureImpl(
-    AbstractCommandImpl[
-        WaitForTemperatureParams, SuccessData[WaitForTemperatureResult, None]
-    ]
+    AbstractCommandImpl[WaitForTemperatureParams, SuccessData[WaitForTemperatureResult]]
 ):
     """Execution implementation of a Heater-Shaker's wait for temperature command."""
 
@@ -53,7 +51,7 @@ class WaitForTemperatureImpl(
 
     async def execute(
         self, params: WaitForTemperatureParams
-    ) -> SuccessData[WaitForTemperatureResult, None]:
+    ) -> SuccessData[WaitForTemperatureResult]:
         """Wait for a Heater-Shaker's target temperature to be reached."""
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/home.py
+++ b/api/src/opentrons/protocol_engine/commands/home.py
@@ -42,15 +42,13 @@ class HomeResult(BaseModel):
     """Result data from the execution of a Home command."""
 
 
-class HomeImplementation(
-    AbstractCommandImpl[HomeParams, SuccessData[HomeResult, None]]
-):
+class HomeImplementation(AbstractCommandImpl[HomeParams, SuccessData[HomeResult]]):
     """Home command implementation."""
 
     def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
         self._movement = movement
 
-    async def execute(self, params: HomeParams) -> SuccessData[HomeResult, None]:
+    async def execute(self, params: HomeParams) -> SuccessData[HomeResult]:
         """Home some or all motors to establish positional accuracy."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/home.py
+++ b/api/src/opentrons/protocol_engine/commands/home.py
@@ -66,7 +66,7 @@ class HomeImplementation(
         # preserve prior behavior, but we might only want to do this if we actually home.
         state_update.clear_all_pipette_locations()
 
-        return SuccessData(public=HomeResult(), private=None, state_update=state_update)
+        return SuccessData(public=HomeResult(), state_update=state_update)
 
 
 class Home(BaseCommand[HomeParams, HomeResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -249,7 +249,6 @@ class LiquidProbeImplementation(
                 public=LiquidProbeResult(
                     z_position=z_pos_or_error, position=deck_point
                 ),
-                private=None,
                 state_update=state_update,
             )
 
@@ -308,7 +307,6 @@ class TryLiquidProbeImplementation(
                 z_position=z_pos,
                 position=deck_point,
             ),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -86,10 +86,10 @@ class TryLiquidProbeResult(DestinationPositionResult):
 
 
 _LiquidProbeExecuteReturn = Union[
-    SuccessData[LiquidProbeResult, None],
+    SuccessData[LiquidProbeResult],
     DefinedErrorData[LiquidNotFoundError],
 ]
-_TryLiquidProbeExecuteReturn = SuccessData[TryLiquidProbeResult, None]
+_TryLiquidProbeExecuteReturn = SuccessData[TryLiquidProbeResult]
 
 
 class _ExecuteCommonResult(NamedTuple):

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -167,7 +167,6 @@ class LoadLabwareImplementation(
                 definition=loaded_labware.definition,
                 offsetId=loaded_labware.offsetId,
             ),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -88,7 +88,7 @@ class LoadLabwareResult(BaseModel):
 
 
 class LoadLabwareImplementation(
-    AbstractCommandImpl[LoadLabwareParams, SuccessData[LoadLabwareResult, None]]
+    AbstractCommandImpl[LoadLabwareParams, SuccessData[LoadLabwareResult]]
 ):
     """Load labware command implementation."""
 
@@ -100,7 +100,7 @@ class LoadLabwareImplementation(
 
     async def execute(
         self, params: LoadLabwareParams
-    ) -> SuccessData[LoadLabwareResult, None]:
+    ) -> SuccessData[LoadLabwareResult]:
         """Load definition and calibration data necessary for a labware."""
         # TODO (tz, 8-15-2023): extend column validation to column 1 when working
         # on https://opentrons.atlassian.net/browse/RSS-258 and completing

--- a/api/src/opentrons/protocol_engine/commands/load_liquid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid.py
@@ -40,7 +40,7 @@ class LoadLiquidResult(BaseModel):
 
 
 class LoadLiquidImplementation(
-    AbstractCommandImpl[LoadLiquidParams, SuccessData[LoadLiquidResult, None]]
+    AbstractCommandImpl[LoadLiquidParams, SuccessData[LoadLiquidResult]]
 ):
     """Load liquid command implementation."""
 
@@ -50,9 +50,7 @@ class LoadLiquidImplementation(
         self._state_view = state_view
         self._model_utils = model_utils
 
-    async def execute(
-        self, params: LoadLiquidParams
-    ) -> SuccessData[LoadLiquidResult, None]:
+    async def execute(self, params: LoadLiquidParams) -> SuccessData[LoadLiquidResult]:
         """Load data necessary for a liquid."""
         self._state_view.liquid.validate_liquid_id(params.liquidId)
 

--- a/api/src/opentrons/protocol_engine/commands/load_liquid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid.py
@@ -67,9 +67,7 @@ class LoadLiquidImplementation(
             last_loaded=self._model_utils.get_timestamp(),
         )
 
-        return SuccessData(
-            public=LoadLiquidResult(), private=None, state_update=state_update
-        )
+        return SuccessData(public=LoadLiquidResult(), state_update=state_update)
 
 
 class LoadLiquid(BaseCommand[LoadLiquidParams, LoadLiquidResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -106,7 +106,7 @@ class LoadModuleResult(BaseModel):
 
 
 class LoadModuleImplementation(
-    AbstractCommandImpl[LoadModuleParams, SuccessData[LoadModuleResult, None]]
+    AbstractCommandImpl[LoadModuleParams, SuccessData[LoadModuleResult]]
 ):
     """The implementation of the load module command."""
 
@@ -116,9 +116,7 @@ class LoadModuleImplementation(
         self._equipment = equipment
         self._state_view = state_view
 
-    async def execute(
-        self, params: LoadModuleParams
-    ) -> SuccessData[LoadModuleResult, None]:
+    async def execute(self, params: LoadModuleParams) -> SuccessData[LoadModuleResult]:
         """Check that the requested module is attached and assign its identifier."""
         module_type = params.model.as_type()
         self._ensure_module_location(params.location.slotName, module_type)

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -198,7 +198,6 @@ class LoadModuleImplementation(
                 model=loaded_module.definition.model,
                 definition=loaded_module.definition,
             ),
-            private=None,
         )
 
     def _ensure_module_location(

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -130,7 +130,6 @@ class LoadPipetteImplementation(
 
         return SuccessData(
             public=LoadPipetteResult(pipetteId=loaded_pipette.pipette_id),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -66,7 +66,7 @@ class LoadPipetteResult(BaseModel):
 
 
 class LoadPipetteImplementation(
-    AbstractCommandImpl[LoadPipetteParams, SuccessData[LoadPipetteResult, None]]
+    AbstractCommandImpl[LoadPipetteParams, SuccessData[LoadPipetteResult]]
 ):
     """Load pipette command implementation."""
 
@@ -78,7 +78,7 @@ class LoadPipetteImplementation(
 
     async def execute(
         self, params: LoadPipetteParams
-    ) -> SuccessData[LoadPipetteResult, None]:
+    ) -> SuccessData[LoadPipetteResult]:
         """Check that requested pipette is attached and assign its identifier."""
         pipette_generation = convert_to_pipette_name_type(
             params.pipetteName.value

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -38,7 +38,7 @@ class DisengageResult(BaseModel):
 
 
 class DisengageImplementation(
-    AbstractCommandImpl[DisengageParams, SuccessData[DisengageResult, None]]
+    AbstractCommandImpl[DisengageParams, SuccessData[DisengageResult]]
 ):
     """The implementation of a Magnetic Module disengage command."""
 
@@ -51,9 +51,7 @@ class DisengageImplementation(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(
-        self, params: DisengageParams
-    ) -> SuccessData[DisengageResult, None]:
+    async def execute(self, params: DisengageParams) -> SuccessData[DisengageResult]:
         """Execute a Magnetic Module disengage command.
 
         Raises:

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -75,7 +75,9 @@ class DisengageImplementation(
         if hardware_module is not None:  # Not virtualizing modules.
             await hardware_module.deactivate()
 
-        return SuccessData(public=DisengageResult(), private=None)
+        return SuccessData(
+            public=DisengageResult(),
+        )
 
 
 class Disengage(BaseCommand[DisengageParams, DisengageResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -54,7 +54,7 @@ class EngageResult(BaseModel):
 
 
 class EngageImplementation(
-    AbstractCommandImpl[EngageParams, SuccessData[EngageResult, None]]
+    AbstractCommandImpl[EngageParams, SuccessData[EngageResult]]
 ):
     """The implementation of a Magnetic Module engage command."""
 
@@ -67,7 +67,7 @@ class EngageImplementation(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: EngageParams) -> SuccessData[EngageResult, None]:
+    async def execute(self, params: EngageParams) -> SuccessData[EngageResult]:
         """Execute a Magnetic Module engage command.
 
         Raises:

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -95,7 +95,9 @@ class EngageImplementation(
         if hardware_module is not None:  # Not virtualizing modules.
             await hardware_module.engage(height=hardware_height)
 
-        return SuccessData(public=EngageResult(), private=None)
+        return SuccessData(
+            public=EngageResult(),
+        )
 
 
 class Engage(BaseCommand[EngageParams, EngageResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -301,7 +301,6 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
 
         return SuccessData(
             public=MoveLabwareResult(offsetId=new_offset_id),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -98,9 +98,7 @@ class GripperMovementError(ErrorOccurrence):
     errorType: Literal["gripperMovement"] = "gripperMovement"
 
 
-_ExecuteReturn = (
-    SuccessData[MoveLabwareResult, None] | DefinedErrorData[GripperMovementError]
-)
+_ExecuteReturn = SuccessData[MoveLabwareResult] | DefinedErrorData[GripperMovementError]
 
 
 class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteReturn]):

--- a/api/src/opentrons/protocol_engine/commands/move_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/move_relative.py
@@ -67,7 +67,6 @@ class MoveRelativeImplementation(
 
         return SuccessData(
             public=MoveRelativeResult(position=deck_point),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/move_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/move_relative.py
@@ -39,7 +39,7 @@ class MoveRelativeResult(DestinationPositionResult):
 
 
 class MoveRelativeImplementation(
-    AbstractCommandImpl[MoveRelativeParams, SuccessData[MoveRelativeResult, None]]
+    AbstractCommandImpl[MoveRelativeParams, SuccessData[MoveRelativeResult]]
 ):
     """Move relative command implementation."""
 
@@ -48,7 +48,7 @@ class MoveRelativeImplementation(
 
     async def execute(
         self, params: MoveRelativeParams
-    ) -> SuccessData[MoveRelativeResult, None]:
+    ) -> SuccessData[MoveRelativeResult]:
         """Move (jog) a given pipette a relative distance."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
@@ -134,7 +134,6 @@ class MoveToAddressableAreaImplementation(
 
         return SuccessData(
             public=MoveToAddressableAreaResult(position=DeckPoint(x=x, y=y, z=z)),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
@@ -76,7 +76,7 @@ class MoveToAddressableAreaResult(DestinationPositionResult):
 
 class MoveToAddressableAreaImplementation(
     AbstractCommandImpl[
-        MoveToAddressableAreaParams, SuccessData[MoveToAddressableAreaResult, None]
+        MoveToAddressableAreaParams, SuccessData[MoveToAddressableAreaResult]
     ]
 ):
     """Move to addressable area command implementation."""
@@ -89,7 +89,7 @@ class MoveToAddressableAreaImplementation(
 
     async def execute(
         self, params: MoveToAddressableAreaParams
-    ) -> SuccessData[MoveToAddressableAreaResult, None]:
+    ) -> SuccessData[MoveToAddressableAreaResult]:
         """Move the requested pipette to the requested addressable area."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
@@ -140,7 +140,6 @@ class MoveToAddressableAreaForDropTipImplementation(
             public=MoveToAddressableAreaForDropTipResult(
                 position=DeckPoint(x=x, y=y, z=z)
             ),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
@@ -86,7 +86,7 @@ class MoveToAddressableAreaForDropTipResult(DestinationPositionResult):
 class MoveToAddressableAreaForDropTipImplementation(
     AbstractCommandImpl[
         MoveToAddressableAreaForDropTipParams,
-        SuccessData[MoveToAddressableAreaForDropTipResult, None],
+        SuccessData[MoveToAddressableAreaForDropTipResult],
     ]
 ):
     """Move to addressable area for drop tip command implementation."""
@@ -99,7 +99,7 @@ class MoveToAddressableAreaForDropTipImplementation(
 
     async def execute(
         self, params: MoveToAddressableAreaForDropTipParams
-    ) -> SuccessData[MoveToAddressableAreaForDropTipResult, None]:
+    ) -> SuccessData[MoveToAddressableAreaForDropTipResult]:
         """Move the requested pipette to the requested addressable area in preperation of a drop tip."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -35,9 +35,7 @@ class MoveToCoordinatesResult(DestinationPositionResult):
 
 
 class MoveToCoordinatesImplementation(
-    AbstractCommandImpl[
-        MoveToCoordinatesParams, SuccessData[MoveToCoordinatesResult, None]
-    ]
+    AbstractCommandImpl[MoveToCoordinatesParams, SuccessData[MoveToCoordinatesResult]]
 ):
     """Move to coordinates command implementation."""
 
@@ -50,7 +48,7 @@ class MoveToCoordinatesImplementation(
 
     async def execute(
         self, params: MoveToCoordinatesParams
-    ) -> SuccessData[MoveToCoordinatesResult, None]:
+    ) -> SuccessData[MoveToCoordinatesResult]:
         """Move the requested pipette to the requested coordinates."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -68,7 +68,6 @@ class MoveToCoordinatesImplementation(
 
         return SuccessData(
             public=MoveToCoordinatesResult(position=DeckPoint(x=x, y=y, z=z)),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -83,7 +83,6 @@ class MoveToWellImplementation(
 
         return SuccessData(
             public=MoveToWellResult(position=deck_point),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -35,7 +35,7 @@ class MoveToWellResult(DestinationPositionResult):
 
 
 class MoveToWellImplementation(
-    AbstractCommandImpl[MoveToWellParams, SuccessData[MoveToWellResult, None]]
+    AbstractCommandImpl[MoveToWellParams, SuccessData[MoveToWellResult]]
 ):
     """Move to well command implementation."""
 
@@ -45,9 +45,7 @@ class MoveToWellImplementation(
         self._state_view = state_view
         self._movement = movement
 
-    async def execute(
-        self, params: MoveToWellParams
-    ) -> SuccessData[MoveToWellResult, None]:
+    async def execute(self, params: MoveToWellParams) -> SuccessData[MoveToWellResult]:
         """Move the requested pipette to the requested well."""
         pipette_id = params.pipetteId
         labware_id = params.labwareId

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -179,7 +179,6 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                     tipDiameter=tip_geometry.diameter,
                     position=deck_point,
                 ),
-                private=None,
                 state_update=state_update,
             )
 

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -86,7 +86,7 @@ class TipPhysicallyMissingError(ErrorOccurrence):
 
 
 _ExecuteReturn = Union[
-    SuccessData[PickUpTipResult, None],
+    SuccessData[PickUpTipResult],
     DefinedErrorData[TipPhysicallyMissingError],
 ]
 
@@ -109,7 +109,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
 
     async def execute(
         self, params: PickUpTipParams
-    ) -> Union[SuccessData[PickUpTipResult, None], _ExecuteReturn]:
+    ) -> Union[SuccessData[PickUpTipResult], _ExecuteReturn]:
         """Move to and pick up a tip using the requested pipette."""
         pipette_id = params.pipetteId
         labware_id = params.labwareId

--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -92,7 +92,9 @@ class PrepareToAspirateImplementation(
                 ),
             )
         else:
-            return SuccessData(public=PrepareToAspirateResult(), private=None)
+            return SuccessData(
+                public=PrepareToAspirateResult(),
+            )
 
 
 class PrepareToAspirate(

--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -40,7 +40,7 @@ class PrepareToAspirateResult(BaseModel):
 
 
 _ExecuteReturn = Union[
-    SuccessData[PrepareToAspirateResult, None],
+    SuccessData[PrepareToAspirateResult],
     DefinedErrorData[OverpressureError],
 ]
 

--- a/api/src/opentrons/protocol_engine/commands/reload_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/reload_labware.py
@@ -78,7 +78,6 @@ class ReloadLabwareImplementation(
                 labwareId=params.labwareId,
                 offsetId=reloaded_labware.offsetId,
             ),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/reload_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/reload_labware.py
@@ -47,7 +47,7 @@ class ReloadLabwareResult(BaseModel):
 
 
 class ReloadLabwareImplementation(
-    AbstractCommandImpl[ReloadLabwareParams, SuccessData[ReloadLabwareResult, None]]
+    AbstractCommandImpl[ReloadLabwareParams, SuccessData[ReloadLabwareResult]]
 ):
     """Reload labware command implementation."""
 
@@ -59,7 +59,7 @@ class ReloadLabwareImplementation(
 
     async def execute(
         self, params: ReloadLabwareParams
-    ) -> SuccessData[ReloadLabwareResult, None]:
+    ) -> SuccessData[ReloadLabwareResult]:
         """Reload the definition and calibration data for a specific labware."""
         reloaded_labware = await self._equipment.reload_labware(
             labware_id=params.labwareId,

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -39,7 +39,7 @@ class RetractAxisResult(BaseModel):
 
 
 class RetractAxisImplementation(
-    AbstractCommandImpl[RetractAxisParams, SuccessData[RetractAxisResult, None]]
+    AbstractCommandImpl[RetractAxisParams, SuccessData[RetractAxisResult]]
 ):
     """Retract Axis command implementation."""
 
@@ -48,7 +48,7 @@ class RetractAxisImplementation(
 
     async def execute(
         self, params: RetractAxisParams
-    ) -> SuccessData[RetractAxisResult, None]:
+    ) -> SuccessData[RetractAxisResult]:
         """Retract the specified axis."""
         state_update = update_types.StateUpdate()
         await self._movement.retract_axis(axis=params.axis)

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -53,9 +53,7 @@ class RetractAxisImplementation(
         state_update = update_types.StateUpdate()
         await self._movement.retract_axis(axis=params.axis)
         state_update.clear_all_pipette_locations()
-        return SuccessData(
-            public=RetractAxisResult(), private=None, state_update=state_update
-        )
+        return SuccessData(public=RetractAxisResult(), state_update=state_update)
 
 
 class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/save_position.py
+++ b/api/src/opentrons/protocol_engine/commands/save_position.py
@@ -76,7 +76,6 @@ class SavePositionImplementation(
                 positionId=position_id,
                 position=DeckPoint(x=x, y=y, z=z),
             ),
-            private=None,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/save_position.py
+++ b/api/src/opentrons/protocol_engine/commands/save_position.py
@@ -46,7 +46,7 @@ class SavePositionResult(BaseModel):
 
 
 class SavePositionImplementation(
-    AbstractCommandImpl[SavePositionParams, SuccessData[SavePositionResult, None]]
+    AbstractCommandImpl[SavePositionParams, SuccessData[SavePositionResult]]
 ):
     """Save position command implementation."""
 
@@ -61,7 +61,7 @@ class SavePositionImplementation(
 
     async def execute(
         self, params: SavePositionParams
-    ) -> SuccessData[SavePositionResult, None]:
+    ) -> SuccessData[SavePositionResult]:
         """Check the requested pipette's current position."""
         position_id = self._model_utils.ensure_id(params.positionId)
         fail_on_not_homed = (

--- a/api/src/opentrons/protocol_engine/commands/set_rail_lights.py
+++ b/api/src/opentrons/protocol_engine/commands/set_rail_lights.py
@@ -41,7 +41,9 @@ class SetRailLightsImplementation(
     ) -> SuccessData[SetRailLightsResult, None]:
         """Dispatch a set lights command setting the state of the rail lights."""
         await self._rail_lights.set_rail_lights(params.on)
-        return SuccessData(public=SetRailLightsResult(), private=None)
+        return SuccessData(
+            public=SetRailLightsResult(),
+        )
 
 
 class SetRailLights(

--- a/api/src/opentrons/protocol_engine/commands/set_rail_lights.py
+++ b/api/src/opentrons/protocol_engine/commands/set_rail_lights.py
@@ -29,7 +29,7 @@ class SetRailLightsResult(BaseModel):
 
 
 class SetRailLightsImplementation(
-    AbstractCommandImpl[SetRailLightsParams, SuccessData[SetRailLightsResult, None]]
+    AbstractCommandImpl[SetRailLightsParams, SuccessData[SetRailLightsResult]]
 ):
     """setRailLights command implementation."""
 
@@ -38,7 +38,7 @@ class SetRailLightsImplementation(
 
     async def execute(
         self, params: SetRailLightsParams
-    ) -> SuccessData[SetRailLightsResult, None]:
+    ) -> SuccessData[SetRailLightsResult]:
         """Dispatch a set lights command setting the state of the rail lights."""
         await self._rail_lights.set_rail_lights(params.on)
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/set_status_bar.py
+++ b/api/src/opentrons/protocol_engine/commands/set_status_bar.py
@@ -49,7 +49,7 @@ class SetStatusBarResult(BaseModel):
 
 
 class SetStatusBarImplementation(
-    AbstractCommandImpl[SetStatusBarParams, SuccessData[SetStatusBarResult, None]]
+    AbstractCommandImpl[SetStatusBarParams, SuccessData[SetStatusBarResult]]
 ):
     """setStatusBar command implementation."""
 
@@ -58,7 +58,7 @@ class SetStatusBarImplementation(
 
     async def execute(
         self, params: SetStatusBarParams
-    ) -> SuccessData[SetStatusBarResult, None]:
+    ) -> SuccessData[SetStatusBarResult]:
         """Execute the setStatusBar command."""
         if not self._status_bar.status_bar_should_not_be_changed():
             state = _animation_to_status_bar_state(params.animation)

--- a/api/src/opentrons/protocol_engine/commands/set_status_bar.py
+++ b/api/src/opentrons/protocol_engine/commands/set_status_bar.py
@@ -63,7 +63,9 @@ class SetStatusBarImplementation(
         if not self._status_bar.status_bar_should_not_be_changed():
             state = _animation_to_status_bar_state(params.animation)
             await self._status_bar.set_status_bar(state)
-        return SuccessData(public=SetStatusBarResult(), private=None)
+        return SuccessData(
+            public=SetStatusBarResult(),
+        )
 
 
 class SetStatusBar(

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
@@ -57,7 +57,9 @@ class DeactivateTemperatureImpl(
 
         if temp_hardware_module is not None:
             await temp_hardware_module.deactivate()
-        return SuccessData(public=DeactivateTemperatureResult(), private=None)
+        return SuccessData(
+            public=DeactivateTemperatureResult(),
+        )
 
 
 class DeactivateTemperature(

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
@@ -27,7 +27,7 @@ class DeactivateTemperatureResult(BaseModel):
 
 class DeactivateTemperatureImpl(
     AbstractCommandImpl[
-        DeactivateTemperatureParams, SuccessData[DeactivateTemperatureResult, None]
+        DeactivateTemperatureParams, SuccessData[DeactivateTemperatureResult]
     ]
 ):
     """Execution implementation of a Temperature Module's deactivate command."""
@@ -43,7 +43,7 @@ class DeactivateTemperatureImpl(
 
     async def execute(
         self, params: DeactivateTemperatureParams
-    ) -> SuccessData[DeactivateTemperatureResult, None]:
+    ) -> SuccessData[DeactivateTemperatureResult]:
         """Deactivate a Temperature Module."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         module_substate = self._state_view.modules.get_temperature_module_substate(

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -34,7 +34,7 @@ class SetTargetTemperatureResult(BaseModel):
 
 class SetTargetTemperatureImpl(
     AbstractCommandImpl[
-        SetTargetTemperatureParams, SuccessData[SetTargetTemperatureResult, None]
+        SetTargetTemperatureParams, SuccessData[SetTargetTemperatureResult]
     ]
 ):
     """Execution implementation of a Temperature Module's set temperature command."""
@@ -50,7 +50,7 @@ class SetTargetTemperatureImpl(
 
     async def execute(
         self, params: SetTargetTemperatureParams
-    ) -> SuccessData[SetTargetTemperatureResult, None]:
+    ) -> SuccessData[SetTargetTemperatureResult]:
         """Set a Temperature Module's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         module_substate = self._state_view.modules.get_temperature_module_substate(

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -69,7 +69,6 @@ class SetTargetTemperatureImpl(
             await temp_hardware_module.start_set_temperature(celsius=validated_temp)
         return SuccessData(
             public=SetTargetTemperatureResult(targetTemperature=validated_temp),
-            private=None,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/wait_for_temperature.py
@@ -74,7 +74,9 @@ class WaitForTemperatureImpl(
             await temp_hardware_module.await_temperature(
                 awaiting_temperature=target_temp
             )
-        return SuccessData(public=WaitForTemperatureResult(), private=None)
+        return SuccessData(
+            public=WaitForTemperatureResult(),
+        )
 
 
 class WaitForTemperature(

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/wait_for_temperature.py
@@ -35,9 +35,7 @@ class WaitForTemperatureResult(BaseModel):
 
 
 class WaitForTemperatureImpl(
-    AbstractCommandImpl[
-        WaitForTemperatureParams, SuccessData[WaitForTemperatureResult, None]
-    ]
+    AbstractCommandImpl[WaitForTemperatureParams, SuccessData[WaitForTemperatureResult]]
 ):
     """Execution implementation of Temperature Module's wait for temperature command."""
 
@@ -52,7 +50,7 @@ class WaitForTemperatureImpl(
 
     async def execute(
         self, params: WaitForTemperatureParams
-    ) -> SuccessData[WaitForTemperatureResult, None]:
+    ) -> SuccessData[WaitForTemperatureResult]:
         """Wait for a Temperature Module's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         module_substate = self._state_view.modules.get_temperature_module_substate(

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
@@ -69,9 +69,7 @@ class CloseLidImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.close()
 
-        return SuccessData(
-            public=CloseLidResult(), private=None, state_update=state_update
-        )
+        return SuccessData(public=CloseLidResult(), state_update=state_update)
 
 
 class CloseLid(BaseCommand[CloseLidParams, CloseLidResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
@@ -28,9 +28,7 @@ class CloseLidResult(BaseModel):
     """Result data from closing a Thermocycler's lid."""
 
 
-class CloseLidImpl(
-    AbstractCommandImpl[CloseLidParams, SuccessData[CloseLidResult, None]]
-):
+class CloseLidImpl(AbstractCommandImpl[CloseLidParams, SuccessData[CloseLidResult]]):
     """Execution implementation of a Thermocycler's close lid command."""
 
     def __init__(
@@ -44,9 +42,7 @@ class CloseLidImpl(
         self._equipment = equipment
         self._movement = movement
 
-    async def execute(
-        self, params: CloseLidParams
-    ) -> SuccessData[CloseLidResult, None]:
+    async def execute(self, params: CloseLidParams) -> SuccessData[CloseLidResult]:
         """Close a Thermocycler's lid."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
@@ -27,7 +27,7 @@ class DeactivateBlockResult(BaseModel):
 
 
 class DeactivateBlockImpl(
-    AbstractCommandImpl[DeactivateBlockParams, SuccessData[DeactivateBlockResult, None]]
+    AbstractCommandImpl[DeactivateBlockParams, SuccessData[DeactivateBlockResult]]
 ):
     """Execution implementation of a Thermocycler's deactivate block command."""
 
@@ -42,7 +42,7 @@ class DeactivateBlockImpl(
 
     async def execute(
         self, params: DeactivateBlockParams
-    ) -> SuccessData[DeactivateBlockResult, None]:
+    ) -> SuccessData[DeactivateBlockResult]:
         """Unset a Thermocycler's target block temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
@@ -54,7 +54,9 @@ class DeactivateBlockImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.deactivate_block()
 
-        return SuccessData(public=DeactivateBlockResult(), private=None)
+        return SuccessData(
+            public=DeactivateBlockResult(),
+        )
 
 
 class DeactivateBlock(

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
@@ -27,7 +27,7 @@ class DeactivateLidResult(BaseModel):
 
 
 class DeactivateLidImpl(
-    AbstractCommandImpl[DeactivateLidParams, SuccessData[DeactivateLidResult, None]]
+    AbstractCommandImpl[DeactivateLidParams, SuccessData[DeactivateLidResult]]
 ):
     """Execution implementation of a Thermocycler's deactivate lid command."""
 
@@ -42,7 +42,7 @@ class DeactivateLidImpl(
 
     async def execute(
         self, params: DeactivateLidParams
-    ) -> SuccessData[DeactivateLidResult, None]:
+    ) -> SuccessData[DeactivateLidResult]:
         """Unset a Thermocycler's target lid temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
@@ -54,7 +54,9 @@ class DeactivateLidImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.deactivate_lid()
 
-        return SuccessData(public=DeactivateLidResult(), private=None)
+        return SuccessData(
+            public=DeactivateLidResult(),
+        )
 
 
 class DeactivateLid(

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
@@ -65,9 +65,7 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, 
         if thermocycler_hardware is not None:
             await thermocycler_hardware.open()
 
-        return SuccessData(
-            public=OpenLidResult(), private=None, state_update=state_update
-        )
+        return SuccessData(public=OpenLidResult(), state_update=state_update)
 
 
 class OpenLid(BaseCommand[OpenLidParams, OpenLidResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
@@ -28,7 +28,7 @@ class OpenLidResult(BaseModel):
     """Result data from opening a Thermocycler's lid."""
 
 
-class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, None]]):
+class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult]]):
     """Execution implementation of a Thermocycler's open lid command."""
 
     def __init__(
@@ -42,7 +42,7 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, 
         self._equipment = equipment
         self._movement = movement
 
-    async def execute(self, params: OpenLidParams) -> SuccessData[OpenLidResult, None]:
+    async def execute(self, params: OpenLidParams) -> SuccessData[OpenLidResult]:
         """Open a Thermocycler's lid."""
         state_update = update_types.StateUpdate()
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_extended_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_extended_profile.py
@@ -59,7 +59,6 @@ class RunExtendedProfileResult(BaseModel):
 def _transform_profile_step(
     step: ProfileStep, thermocycler_state: ThermocyclerModuleSubState
 ) -> ThermocyclerStep:
-
     return ThermocyclerStep(
         temperature=thermocycler_state.validate_target_block_temperature(step.celsius),
         hold_time_seconds=step.holdSeconds,
@@ -97,9 +96,7 @@ def _transform_profile_element(
 
 
 class RunExtendedProfileImpl(
-    AbstractCommandImpl[
-        RunExtendedProfileParams, SuccessData[RunExtendedProfileResult, None]
-    ]
+    AbstractCommandImpl[RunExtendedProfileParams, SuccessData[RunExtendedProfileResult]]
 ):
     """Execution implementation of a Thermocycler's run profile command."""
 
@@ -114,7 +111,7 @@ class RunExtendedProfileImpl(
 
     async def execute(
         self, params: RunExtendedProfileParams
-    ) -> SuccessData[RunExtendedProfileResult, None]:
+    ) -> SuccessData[RunExtendedProfileResult]:
         """Run a Thermocycler profile."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_extended_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_extended_profile.py
@@ -142,7 +142,9 @@ class RunExtendedProfileImpl(
                 profile=profile, volume=target_volume
             )
 
-        return SuccessData(public=RunExtendedProfileResult(), private=None)
+        return SuccessData(
+            public=RunExtendedProfileResult(),
+        )
 
 
 class RunExtendedProfile(

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
@@ -47,7 +47,7 @@ class RunProfileResult(BaseModel):
 
 
 class RunProfileImpl(
-    AbstractCommandImpl[RunProfileParams, SuccessData[RunProfileResult, None]]
+    AbstractCommandImpl[RunProfileParams, SuccessData[RunProfileResult]]
 ):
     """Execution implementation of a Thermocycler's run profile command."""
 
@@ -60,9 +60,7 @@ class RunProfileImpl(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(
-        self, params: RunProfileParams
-    ) -> SuccessData[RunProfileResult, None]:
+    async def execute(self, params: RunProfileParams) -> SuccessData[RunProfileResult]:
         """Run a Thermocycler profile."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
@@ -96,7 +96,9 @@ class RunProfileImpl(
                 steps=steps, repetitions=1, volume=target_volume
             )
 
-        return SuccessData(public=RunProfileResult(), private=None)
+        return SuccessData(
+            public=RunProfileResult(),
+        )
 
 
 class RunProfile(BaseCommand[RunProfileParams, RunProfileResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
@@ -46,7 +46,7 @@ class SetTargetBlockTemperatureResult(BaseModel):
 class SetTargetBlockTemperatureImpl(
     AbstractCommandImpl[
         SetTargetBlockTemperatureParams,
-        SuccessData[SetTargetBlockTemperatureResult, None],
+        SuccessData[SetTargetBlockTemperatureResult],
     ]
 ):
     """Execution implementation of a Thermocycler's set block temperature command."""
@@ -63,7 +63,7 @@ class SetTargetBlockTemperatureImpl(
     async def execute(
         self,
         params: SetTargetBlockTemperatureParams,
-    ) -> SuccessData[SetTargetBlockTemperatureResult, None]:
+    ) -> SuccessData[SetTargetBlockTemperatureResult]:
         """Set a Thermocycler's target block temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
@@ -97,7 +97,6 @@ class SetTargetBlockTemperatureImpl(
             public=SetTargetBlockTemperatureResult(
                 targetBlockTemperature=target_temperature
             ),
-            private=None,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
@@ -70,7 +70,6 @@ class SetTargetLidTemperatureImpl(
             public=SetTargetLidTemperatureResult(
                 targetLidTemperature=target_temperature
             ),
-            private=None,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
@@ -34,7 +34,7 @@ class SetTargetLidTemperatureResult(BaseModel):
 
 class SetTargetLidTemperatureImpl(
     AbstractCommandImpl[
-        SetTargetLidTemperatureParams, SuccessData[SetTargetLidTemperatureResult, None]
+        SetTargetLidTemperatureParams, SuccessData[SetTargetLidTemperatureResult]
     ]
 ):
     """Execution implementation of a Thermocycler's set lid temperature command."""
@@ -51,7 +51,7 @@ class SetTargetLidTemperatureImpl(
     async def execute(
         self,
         params: SetTargetLidTemperatureParams,
-    ) -> SuccessData[SetTargetLidTemperatureResult, None]:
+    ) -> SuccessData[SetTargetLidTemperatureResult]:
         """Set a Thermocycler's target lid temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
@@ -28,7 +28,7 @@ class WaitForBlockTemperatureResult(BaseModel):
 
 class WaitForBlockTemperatureImpl(
     AbstractCommandImpl[
-        WaitForBlockTemperatureParams, SuccessData[WaitForBlockTemperatureResult, None]
+        WaitForBlockTemperatureParams, SuccessData[WaitForBlockTemperatureResult]
     ]
 ):
     """Execution implementation of Thermocycler's wait for block temperature command."""
@@ -45,7 +45,7 @@ class WaitForBlockTemperatureImpl(
     async def execute(
         self,
         params: WaitForBlockTemperatureParams,
-    ) -> SuccessData[WaitForBlockTemperatureResult, None]:
+    ) -> SuccessData[WaitForBlockTemperatureResult]:
         """Wait for a Thermocycler's target block temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
@@ -61,7 +61,9 @@ class WaitForBlockTemperatureImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.wait_for_block_target()
 
-        return SuccessData(public=WaitForBlockTemperatureResult(), private=None)
+        return SuccessData(
+            public=WaitForBlockTemperatureResult(),
+        )
 
 
 class WaitForBlockTemperature(

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
@@ -28,7 +28,7 @@ class WaitForLidTemperatureResult(BaseModel):
 
 class WaitForLidTemperatureImpl(
     AbstractCommandImpl[
-        WaitForLidTemperatureParams, SuccessData[WaitForLidTemperatureResult, None]
+        WaitForLidTemperatureParams, SuccessData[WaitForLidTemperatureResult]
     ]
 ):
     """Execution implementation of Thermocycler's wait for lid temperature command."""
@@ -45,7 +45,7 @@ class WaitForLidTemperatureImpl(
     async def execute(
         self,
         params: WaitForLidTemperatureParams,
-    ) -> SuccessData[WaitForLidTemperatureResult, None]:
+    ) -> SuccessData[WaitForLidTemperatureResult]:
         """Wait for a Thermocycler's lid temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
@@ -61,7 +61,9 @@ class WaitForLidTemperatureImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.wait_for_lid_target()
 
-        return SuccessData(public=WaitForLidTemperatureResult(), private=None)
+        return SuccessData(
+            public=WaitForLidTemperatureResult(),
+        )
 
 
 class WaitForLidTemperature(

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -119,7 +119,6 @@ class TouchTipImplementation(
 
         return SuccessData(
             public=TouchTipResult(position=final_deck_point),
-            private=None,
             state_update=state_update,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -50,7 +50,7 @@ class TouchTipResult(DestinationPositionResult):
 
 
 class TouchTipImplementation(
-    AbstractCommandImpl[TouchTipParams, SuccessData[TouchTipResult, None]]
+    AbstractCommandImpl[TouchTipParams, SuccessData[TouchTipResult]]
 ):
     """Touch tip command implementation."""
 
@@ -65,9 +65,7 @@ class TouchTipImplementation(
         self._movement = movement
         self._gantry_mover = gantry_mover
 
-    async def execute(
-        self, params: TouchTipParams
-    ) -> SuccessData[TouchTipResult, None]:
+    async def execute(self, params: TouchTipParams) -> SuccessData[TouchTipResult]:
         """Touch tip to sides of a well using the requested pipette."""
         pipette_id = params.pipetteId
         labware_id = params.labwareId

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
@@ -67,7 +67,9 @@ class UnsafeBlowOutInPlaceImplementation(
             pipette_id=params.pipetteId, flow_rate=params.flowRate
         )
 
-        return SuccessData(public=UnsafeBlowOutInPlaceResult(), private=None)
+        return SuccessData(
+            public=UnsafeBlowOutInPlaceResult(),
+        )
 
 
 class UnsafeBlowOutInPlace(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
@@ -36,7 +36,7 @@ class UnsafeBlowOutInPlaceResult(BaseModel):
 
 class UnsafeBlowOutInPlaceImplementation(
     AbstractCommandImpl[
-        UnsafeBlowOutInPlaceParams, SuccessData[UnsafeBlowOutInPlaceResult, None]
+        UnsafeBlowOutInPlaceParams, SuccessData[UnsafeBlowOutInPlaceResult]
     ]
 ):
     """UnsafeBlowOutInPlace command implementation."""
@@ -54,7 +54,7 @@ class UnsafeBlowOutInPlaceImplementation(
 
     async def execute(
         self, params: UnsafeBlowOutInPlaceParams
-    ) -> SuccessData[UnsafeBlowOutInPlaceResult, None]:
+    ) -> SuccessData[UnsafeBlowOutInPlaceResult]:
         """Blow-out without moving the pipette even when position is unknown."""
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         pipette_location = self._state_view.motion.get_pipette_location(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -79,7 +79,7 @@ class UnsafeDropTipInPlaceImplementation(
         )
 
         return SuccessData(
-            public=UnsafeDropTipInPlaceResult(), private=None, state_update=state_update
+            public=UnsafeDropTipInPlaceResult(), state_update=state_update
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -42,7 +42,7 @@ class UnsafeDropTipInPlaceResult(BaseModel):
 
 class UnsafeDropTipInPlaceImplementation(
     AbstractCommandImpl[
-        UnsafeDropTipInPlaceParams, SuccessData[UnsafeDropTipInPlaceResult, None]
+        UnsafeDropTipInPlaceParams, SuccessData[UnsafeDropTipInPlaceResult]
     ]
 ):
     """Unsafe drop tip in place command implementation."""
@@ -60,7 +60,7 @@ class UnsafeDropTipInPlaceImplementation(
 
     async def execute(
         self, params: UnsafeDropTipInPlaceParams
-    ) -> SuccessData[UnsafeDropTipInPlaceResult, None]:
+    ) -> SuccessData[UnsafeDropTipInPlaceResult]:
         """Drop a tip using the requested pipette, even if the plunger position is not known."""
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         pipette_location = self._state_view.motion.get_pipette_location(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_engage_axes.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_engage_axes.py
@@ -32,7 +32,7 @@ class UnsafeEngageAxesResult(BaseModel):
 class UnsafeEngageAxesImplementation(
     AbstractCommandImpl[
         UnsafeEngageAxesParams,
-        SuccessData[UnsafeEngageAxesResult, None],
+        SuccessData[UnsafeEngageAxesResult],
     ]
 ):
     """Enable axes command implementation."""
@@ -48,7 +48,7 @@ class UnsafeEngageAxesImplementation(
 
     async def execute(
         self, params: UnsafeEngageAxesParams
-    ) -> SuccessData[UnsafeEngageAxesResult, None]:
+    ) -> SuccessData[UnsafeEngageAxesResult]:
         """Enable exes."""
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         await ot3_hardware_api.engage_axes(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_engage_axes.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_engage_axes.py
@@ -57,7 +57,9 @@ class UnsafeEngageAxesImplementation(
                 for axis in params.axes
             ]
         )
-        return SuccessData(public=UnsafeEngageAxesResult(), private=None)
+        return SuccessData(
+            public=UnsafeEngageAxesResult(),
+        )
 
 
 class UnsafeEngageAxes(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_ungrip_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_ungrip_labware.py
@@ -47,7 +47,9 @@ class UnsafeUngripLabwareImplementation(
         if not ot3_hardware_api.has_gripper():
             raise GripperNotAttachedError("No gripper found to perform ungrip.")
         await ot3_hardware_api.ungrip()
-        return SuccessData(public=UnsafeUngripLabwareResult(), private=None)
+        return SuccessData(
+            public=UnsafeUngripLabwareResult(),
+        )
 
 
 class UnsafeUngripLabware(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_ungrip_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_ungrip_labware.py
@@ -27,7 +27,7 @@ class UnsafeUngripLabwareResult(BaseModel):
 class UnsafeUngripLabwareImplementation(
     AbstractCommandImpl[
         UnsafeUngripLabwareParams,
-        SuccessData[UnsafeUngripLabwareResult, None],
+        SuccessData[UnsafeUngripLabwareResult],
     ]
 ):
     """Ungrip labware command implementation."""
@@ -41,7 +41,7 @@ class UnsafeUngripLabwareImplementation(
 
     async def execute(
         self, params: UnsafeUngripLabwareParams
-    ) -> SuccessData[UnsafeUngripLabwareResult, None]:
+    ) -> SuccessData[UnsafeUngripLabwareResult]:
         """Ungrip Labware."""
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         if not ot3_hardware_api.has_gripper():

--- a/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
@@ -59,7 +59,9 @@ class UpdatePositionEstimatorsImplementation(
                 for axis in params.axes
             ]
         )
-        return SuccessData(public=UpdatePositionEstimatorsResult(), private=None)
+        return SuccessData(
+            public=UpdatePositionEstimatorsResult(),
+        )
 
 
 class UpdatePositionEstimators(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
@@ -34,7 +34,7 @@ class UpdatePositionEstimatorsResult(BaseModel):
 class UpdatePositionEstimatorsImplementation(
     AbstractCommandImpl[
         UpdatePositionEstimatorsParams,
-        SuccessData[UpdatePositionEstimatorsResult, None],
+        SuccessData[UpdatePositionEstimatorsResult],
     ]
 ):
     """Update position estimators command implementation."""
@@ -50,7 +50,7 @@ class UpdatePositionEstimatorsImplementation(
 
     async def execute(
         self, params: UpdatePositionEstimatorsParams
-    ) -> SuccessData[UpdatePositionEstimatorsResult, None]:
+    ) -> SuccessData[UpdatePositionEstimatorsResult]:
         """Update axis position estimators from their encoders."""
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         await ot3_hardware_api.update_axis_position_estimations(

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -67,7 +67,9 @@ class VerifyTipPresenceImplementation(
             follow_singular_sensor=follow_singular_sensor,
         )
 
-        return SuccessData(public=VerifyTipPresenceResult(), private=None)
+        return SuccessData(
+            public=VerifyTipPresenceResult(),
+        )
 
 
 class VerifyTipPresence(

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -36,9 +36,7 @@ class VerifyTipPresenceResult(BaseModel):
 
 
 class VerifyTipPresenceImplementation(
-    AbstractCommandImpl[
-        VerifyTipPresenceParams, SuccessData[VerifyTipPresenceResult, None]
-    ]
+    AbstractCommandImpl[VerifyTipPresenceParams, SuccessData[VerifyTipPresenceResult]]
 ):
     """VerifyTipPresence command implementation."""
 
@@ -51,7 +49,7 @@ class VerifyTipPresenceImplementation(
 
     async def execute(
         self, params: VerifyTipPresenceParams
-    ) -> SuccessData[VerifyTipPresenceResult, None]:
+    ) -> SuccessData[VerifyTipPresenceResult]:
         """Verify if tip presence is as expected for the requested pipette."""
         pipette_id = params.pipetteId
         expected_state = params.expectedState

--- a/api/src/opentrons/protocol_engine/commands/wait_for_duration.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_duration.py
@@ -29,7 +29,7 @@ class WaitForDurationResult(BaseModel):
 
 
 class WaitForDurationImplementation(
-    AbstractCommandImpl[WaitForDurationParams, SuccessData[WaitForDurationResult, None]]
+    AbstractCommandImpl[WaitForDurationParams, SuccessData[WaitForDurationResult]]
 ):
     """Wait for duration command implementation."""
 
@@ -38,7 +38,7 @@ class WaitForDurationImplementation(
 
     async def execute(
         self, params: WaitForDurationParams
-    ) -> SuccessData[WaitForDurationResult, None]:
+    ) -> SuccessData[WaitForDurationResult]:
         """Wait for a duration of time."""
         await self._run_control.wait_for_duration(params.seconds)
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/wait_for_duration.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_duration.py
@@ -41,7 +41,9 @@ class WaitForDurationImplementation(
     ) -> SuccessData[WaitForDurationResult, None]:
         """Wait for a duration of time."""
         await self._run_control.wait_for_duration(params.seconds)
-        return SuccessData(public=WaitForDurationResult(), private=None)
+        return SuccessData(
+            public=WaitForDurationResult(),
+        )
 
 
 class WaitForDuration(

--- a/api/src/opentrons/protocol_engine/commands/wait_for_resume.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_resume.py
@@ -42,7 +42,9 @@ class WaitForResumeImplementation(
     ) -> SuccessData[WaitForResumeResult, None]:
         """Dispatch a PauseAction to the store to pause the protocol."""
         await self._run_control.wait_for_resume()
-        return SuccessData(public=WaitForResumeResult(), private=None)
+        return SuccessData(
+            public=WaitForResumeResult(),
+        )
 
 
 class WaitForResume(

--- a/api/src/opentrons/protocol_engine/commands/wait_for_resume.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_resume.py
@@ -30,7 +30,7 @@ class WaitForResumeResult(BaseModel):
 
 
 class WaitForResumeImplementation(
-    AbstractCommandImpl[WaitForResumeParams, SuccessData[WaitForResumeResult, None]]
+    AbstractCommandImpl[WaitForResumeParams, SuccessData[WaitForResumeResult]]
 ):
     """Wait for resume command implementation."""
 
@@ -39,7 +39,7 @@ class WaitForResumeImplementation(
 
     async def execute(
         self, params: WaitForResumeParams
-    ) -> SuccessData[WaitForResumeResult, None]:
+    ) -> SuccessData[WaitForResumeResult]:
         """Dispatch a PauseAction to the store to pause the protocol."""
         await self._run_control.wait_for_resume()
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -192,7 +192,6 @@ class CommandExecutor:
                 self._action_dispatcher.dispatch(
                     SucceedCommandAction(
                         command=succeeded_command,
-                        private_result=result.private,
                         state_update=result.state_update,
                     ),
                 )

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -271,7 +271,6 @@ class LegacyCommandMapper:
                 results.append(
                     pe_actions.SucceedCommandAction(
                         completed_command,
-                        private_result=None,
                         state_update=StateUpdate(),
                     )
                 )
@@ -689,7 +688,6 @@ class LegacyCommandMapper:
 
         succeed_action = pe_actions.SucceedCommandAction(
             command=succeeded_command,
-            private_result=None,
             state_update=state_update,
         )
 
@@ -764,7 +762,6 @@ class LegacyCommandMapper:
 
         succeed_action = pe_actions.SucceedCommandAction(
             command=succeeded_command,
-            private_result=None,
             state_update=state_update,
         )
 
@@ -830,7 +827,7 @@ class LegacyCommandMapper:
             started_at=succeeded_command.startedAt,  # type: ignore[arg-type]
         )
         succeed_action = pe_actions.SucceedCommandAction(
-            command=succeeded_command, private_result=None, state_update=StateUpdate()
+            command=succeeded_command, state_update=StateUpdate()
         )
 
         self._command_count["LOAD_MODULE"] = count + 1

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_gripper.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_gripper.py
@@ -72,7 +72,6 @@ async def test_calibrate_gripper(
     result = await subject.execute(params)
     assert result == SuccessData(
         public=CalibrateGripperResult(jawOffset=Vec3f(x=1.1, y=2.2, z=3.3)),
-        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
@@ -95,7 +95,6 @@ async def test_calibrate_module_implementation(
             ),
             location=location,
         ),
-        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_pipette.py
@@ -64,7 +64,6 @@ async def test_calibrate_pipette_implementation(
         public=CalibratePipetteResult(
             pipetteOffset=InstrumentOffsetVector(x=3, y=4, z=6)
         ),
-        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -56,7 +56,9 @@ async def test_calibration_move_to_location_implementation_for_attach_instrument
     decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
 
     result = await subject.execute(params=params)
-    assert result == SuccessData(public=MoveToMaintenancePositionResult(), private=None)
+    assert result == SuccessData(
+        public=MoveToMaintenancePositionResult(),
+    )
 
     hw_mount = mount_type.to_hw_mount()
     decoy.verify(
@@ -100,7 +102,9 @@ async def test_calibration_move_to_location_implementation_for_attach_plate(
     decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
 
     result = await subject.execute(params=params)
-    assert result == SuccessData(public=MoveToMaintenancePositionResult(), private=None)
+    assert result == SuccessData(
+        public=MoveToMaintenancePositionResult(),
+    )
 
     decoy.verify(
         await ot3_hardware_api.prepare_for_mount_movement(Mount.LEFT),
@@ -150,7 +154,9 @@ async def test_calibration_move_to_location_implementation_for_gripper(
     decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
 
     result = await subject.execute(params=params)
-    assert result == SuccessData(public=MoveToMaintenancePositionResult(), private=None)
+    assert result == SuccessData(
+        public=MoveToMaintenancePositionResult(),
+    )
 
     decoy.verify(
         await ot3_hardware_api.prepare_for_mount_movement(Mount.LEFT),

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_labware_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_labware_latch.py
@@ -45,7 +45,7 @@ async def test_close_labware_latch(
     result = await subject.execute(data)
     decoy.verify(await heater_shaker_hardware.close_labware_latch(), times=1)
     assert result == SuccessData(
-        public=heater_shaker.CloseLabwareLatchResult(), private=None
+        public=heater_shaker.CloseLabwareLatchResult(),
     )
 
 
@@ -77,5 +77,5 @@ async def test_close_labware_latch_virtual(
     result = await subject.execute(data)
 
     assert result == SuccessData(
-        public=heater_shaker.CloseLabwareLatchResult(), private=None
+        public=heater_shaker.CloseLabwareLatchResult(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
@@ -46,5 +46,5 @@ async def test_deactivate_heater(
     result = await subject.execute(data)
     decoy.verify(await hs_hardware.deactivate_heater(), times=1)
     assert result == SuccessData(
-        public=heater_shaker.DeactivateHeaterResult(), private=None
+        public=heater_shaker.DeactivateHeaterResult(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_shaker.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_shaker.py
@@ -46,7 +46,7 @@ async def test_deactivate_shaker(
     result = await subject.execute(data)
     decoy.verify(await hs_hardware.deactivate_shaker(), times=1)
     assert result == SuccessData(
-        public=heater_shaker.DeactivateShakerResult(), private=None
+        public=heater_shaker.DeactivateShakerResult(),
     )
 
 
@@ -78,5 +78,5 @@ async def test_deactivate_shaker_virtual(
 
     result = await subject.execute(data)
     assert result == SuccessData(
-        public=heater_shaker.DeactivateShakerResult(), private=None
+        public=heater_shaker.DeactivateShakerResult(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_labware_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_labware_latch.py
@@ -81,7 +81,6 @@ async def test_open_labware_latch(
         public=heater_shaker.OpenLabwareLatchResult(
             pipetteRetracted=expect_pipette_retracted
         ),
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR)
         if expect_pipette_retracted
         else update_types.StateUpdate(),

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_and_wait_for_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_and_wait_for_shake_speed.py
@@ -84,7 +84,6 @@ async def test_set_and_wait_for_shake_speed(
         public=heater_shaker.SetAndWaitForShakeSpeedResult(
             pipetteRetracted=expect_pipette_retracted
         ),
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR)
         if expect_pipette_retracted
         else update_types.StateUpdate(),

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_temperature.py
@@ -55,5 +55,5 @@ async def test_set_target_temperature(
     result = await subject.execute(data)
     decoy.verify(await hs_hardware.start_set_temperature(celsius=45.6), times=1)
     assert result == SuccessData(
-        public=heater_shaker.SetTargetTemperatureResult(), private=None
+        public=heater_shaker.SetTargetTemperatureResult(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_wait_for_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_wait_for_temperature.py
@@ -50,5 +50,5 @@ async def test_wait_for_temperature(
         await hs_hardware.await_temperature(awaiting_temperature=123.45), times=1
     )
     assert result == SuccessData(
-        public=heater_shaker.WaitForTemperatureResult(), private=None
+        public=heater_shaker.WaitForTemperatureResult(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -46,4 +46,4 @@ async def test_magnetic_module_disengage_implementation(
     result = await subject.execute(params=params)
 
     decoy.verify(await magnetic_module_hw.deactivate(), times=1)
-    assert result == SuccessData(public=DisengageResult(), private=None)
+    assert result == SuccessData(public=DisengageResult())

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -51,4 +51,4 @@ async def test_magnetic_module_engage_implementation(
     result = await subject.execute(params=params)
 
     decoy.verify(await magnetic_module_hw.engage(9001), times=1)
-    assert result == SuccessData(public=EngageResult(), private=None)
+    assert result == SuccessData(public=EngageResult())

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
@@ -45,5 +45,5 @@ async def test_await_temperature(
     result = await subject.execute(data)
     decoy.verify(await tempdeck_hardware.deactivate(), times=1)
     assert result == SuccessData(
-        public=temperature_module.DeactivateTemperatureResult(), private=None
+        public=temperature_module.DeactivateTemperatureResult(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
@@ -52,5 +52,4 @@ async def test_set_target_temperature(
     decoy.verify(await tempdeck_hardware.start_set_temperature(celsius=1), times=1)
     assert result == SuccessData(
         public=temperature_module.SetTargetTemperatureResult(targetTemperature=1),
-        private=None,
     )

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_wait_for_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_wait_for_temperature.py
@@ -48,7 +48,7 @@ async def test_wait_for_temperature(
         await tempdeck_hardware.await_temperature(awaiting_temperature=123), times=1
     )
     assert result == SuccessData(
-        public=temperature_module.WaitForTemperatureResult(), private=None
+        public=temperature_module.WaitForTemperatureResult(),
     )
 
 
@@ -90,5 +90,5 @@ async def test_wait_for_temperature_requested_celsius(
         await tempdeck_hardware.await_temperature(awaiting_temperature=12), times=1
     )
     assert result == SuccessData(
-        public=temperature_module.WaitForTemperatureResult(), private=None
+        public=temperature_module.WaitForTemperatureResult(),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -103,7 +103,6 @@ async def test_aspirate_implementation_no_prep(
 
     assert result == SuccessData(
         public=AspirateResult(volume=50, position=DeckPoint(x=1, y=2, z=3)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
@@ -177,7 +176,6 @@ async def test_aspirate_implementation_with_prep(
 
     assert result == SuccessData(
         public=AspirateResult(volume=50, position=DeckPoint(x=1, y=2, z=3)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
@@ -383,7 +381,6 @@ async def test_aspirate_implementation_meniscus(
 
     assert result == SuccessData(
         public=AspirateResult(volume=50, position=DeckPoint(x=1, y=2, z=3)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
@@ -123,7 +123,6 @@ async def test_aspirate_in_place_implementation(
     if isinstance(location, CurrentWell):
         assert result == SuccessData(
             public=AspirateInPlaceResult(volume=123),
-            private=None,
             state_update=update_types.StateUpdate(
                 liquid_operated=update_types.LiquidOperatedUpdate(
                     labware_id=stateupdateLabware,
@@ -135,7 +134,6 @@ async def test_aspirate_in_place_implementation(
     else:
         assert result == SuccessData(
             public=AspirateInPlaceResult(volume=123),
-            private=None,
         )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -76,7 +76,6 @@ async def test_blow_out_implementation(
 
     assert result == SuccessData(
         public=BlowOutResult(position=DeckPoint(x=1, y=2, z=3)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
@@ -52,7 +52,7 @@ async def test_blow_out_in_place_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=BlowOutInPlaceResult(), private=None)
+    assert result == SuccessData(public=BlowOutInPlaceResult())
 
     decoy.verify(
         await pipetting.blow_out_in_place(pipette_id="pipette-id", flow_rate=1.234)

--- a/api/tests/opentrons/protocol_engine/commands/test_comment.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_comment.py
@@ -15,4 +15,4 @@ async def test_comment_implementation() -> None:
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=CommentResult(), private=None)
+    assert result == SuccessData(public=CommentResult())

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -84,7 +84,6 @@ async def test_configure_for_volume_implementation(
 
     assert result == SuccessData(
         public=ConfigureForVolumeResult(),
-        private=None,
         state_update=StateUpdate(
             pipette_config=PipetteConfigUpdate(
                 pipette_id="pipette-id", serial_number="some number", config=config

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
@@ -145,7 +145,6 @@ async def test_configure_nozzle_layout_implementation(
 
     assert result == SuccessData(
         public=ConfigureNozzleLayoutResult(),
-        private=None,
         state_update=StateUpdate(
             pipette_nozzle_map=PipetteNozzleMapUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -82,7 +82,6 @@ async def test_dispense_implementation(
 
     assert result == SuccessData(
         public=DispenseResult(volume=42, position=DeckPoint(x=1, y=2, z=3)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id-abc123",

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
@@ -85,7 +85,6 @@ async def test_dispense_in_place_implementation(
     if isinstance(location, CurrentWell):
         assert result == SuccessData(
             public=DispenseInPlaceResult(volume=42),
-            private=None,
             state_update=update_types.StateUpdate(
                 liquid_operated=update_types.LiquidOperatedUpdate(
                     labware_id=stateupdateLabware,
@@ -97,7 +96,6 @@ async def test_dispense_in_place_implementation(
     else:
         assert result == SuccessData(
             public=DispenseInPlaceResult(volume=42),
-            private=None,
         )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -129,7 +129,6 @@ async def test_drop_tip_implementation(
 
     assert result == SuccessData(
         public=DropTipResult(position=DeckPoint(x=111, y=222, z=333)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
@@ -207,7 +206,6 @@ async def test_drop_tip_with_alternating_locations(
     result = await subject.execute(params)
     assert result == SuccessData(
         public=DropTipResult(position=DeckPoint(x=111, y=222, z=333)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -49,7 +49,6 @@ async def test_success(
 
     assert result == SuccessData(
         public=DropTipInPlaceResult(),
-        private=None,
         state_update=StateUpdate(
             pipette_tip_state=PipetteTipStateUpdate(pipette_id="abc", tip_geometry=None)
         ),

--- a/api/tests/opentrons/protocol_engine/commands/test_get_tip_presence.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_get_tip_presence.py
@@ -41,5 +41,5 @@ async def test_get_tip_presence_implementation(
     result = await subject.execute(data)
 
     assert result == SuccessData(
-        public=GetTipPresenceResult(status=status), private=None
+        public=GetTipPresenceResult(status=status),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_home.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_home.py
@@ -24,7 +24,6 @@ async def test_home_implementation(decoy: Decoy, movement: MovementHandler) -> N
 
     assert result == SuccessData(
         public=HomeResult(),
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )
     decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]))
@@ -40,7 +39,6 @@ async def test_home_all_implementation(decoy: Decoy, movement: MovementHandler) 
 
     assert result == SuccessData(
         public=HomeResult(),
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )
     decoy.verify(await movement.home(axes=None))
@@ -63,7 +61,6 @@ async def test_home_with_invalid_position(
     result = await subject.execute(data)
     assert result == SuccessData(
         public=HomeResult(),
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )
 
@@ -76,7 +73,6 @@ async def test_home_with_invalid_position(
     result = await subject.execute(data)
     assert result == SuccessData(
         public=HomeResult(),
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -154,7 +154,6 @@ async def test_liquid_probe_implementation(
     assert type(result.public) is result_type  # Pydantic v1 only compares the fields.
     assert result == SuccessData(
         public=result_type(z_position=15.0, position=DeckPoint(x=1, y=2, z=3)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
@@ -255,7 +254,6 @@ async def test_liquid_not_found_error(
                 z_position=None,
                 position=DeckPoint(x=position.x, y=position.y, z=position.z),
             ),
-            private=None,
             state_update=expected_state_update,
         )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -94,7 +94,6 @@ async def test_load_labware_implementation(
             definition=well_plate_def,
             offsetId="labware-offset-id",
         ),
-        private=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id",
@@ -178,7 +177,6 @@ async def test_load_labware_on_labware(
             definition=well_plate_def,
             offsetId="labware-offset-id",
         ),
-        private=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
@@ -48,7 +48,6 @@ async def test_load_liquid_implementation(
 
     assert result == SuccessData(
         public=LoadLiquidResult(),
-        private=None,
         state_update=update_types.StateUpdate(
             liquid_loaded=update_types.LiquidLoadedUpdate(
                 labware_id="labware-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -92,7 +92,6 @@ async def test_load_module_implementation(
             model=ModuleModel.TEMPERATURE_MODULE_V2,
             definition=tempdeck_v2_def,
         ),
-        private=None,
     )
 
 
@@ -148,7 +147,6 @@ async def test_load_module_implementation_mag_block(
             model=ModuleModel.MAGNETIC_BLOCK_V1,
             definition=mag_block_v1_def,
         ),
-        private=None,
     )
 
 
@@ -204,7 +202,6 @@ async def test_load_module_implementation_abs_reader(
             model=ModuleModel.ABSORBANCE_READER_V1,
             definition=abs_reader_v1_def,
         ),
-        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -89,7 +89,6 @@ async def test_load_pipette_implementation(
 
     assert result == SuccessData(
         public=LoadPipetteResult(pipetteId="some id"),
-        private=None,
         state_update=StateUpdate(
             loaded_pipette=LoadPipetteUpdate(
                 pipette_name=PipetteNameType.P300_SINGLE,
@@ -155,7 +154,6 @@ async def test_load_pipette_implementation_96_channel(
 
     assert result == SuccessData(
         public=LoadPipetteResult(pipetteId="pipette-id"),
-        private=None,
         state_update=StateUpdate(
             loaded_pipette=LoadPipetteUpdate(
                 pipette_name=PipetteNameType.P1000_96,

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -126,7 +126,6 @@ async def test_manual_move_labware_implementation(
         public=MoveLabwareResult(
             offsetId="wowzers-a-new-offset-id",
         ),
-        private=None,
         state_update=update_types.StateUpdate(
             labware_location=update_types.LabwareLocationUpdate(
                 labware_id="my-cool-labware-id",
@@ -192,7 +191,6 @@ async def test_move_labware_implementation_on_labware(
         public=MoveLabwareResult(
             offsetId="wowzers-a-new-offset-id",
         ),
-        private=None,
         state_update=update_types.StateUpdate(
             labware_location=update_types.LabwareLocationUpdate(
                 labware_id="my-cool-labware-id",
@@ -280,7 +278,6 @@ async def test_gripper_move_labware_implementation(
         public=MoveLabwareResult(
             offsetId="wowzers-a-new-offset-id",
         ),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.CLEAR,
             labware_location=update_types.LabwareLocationUpdate(
@@ -516,7 +513,6 @@ async def test_gripper_move_to_waste_chute_implementation(
         public=MoveLabwareResult(
             offsetId="wowzers-a-new-offset-id",
         ),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.CLEAR,
             labware_location=update_types.LabwareLocationUpdate(

--- a/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
@@ -38,7 +38,6 @@ async def test_move_relative_implementation(
 
     assert result == SuccessData(
         public=MoveRelativeResult(position=DeckPoint(x=1, y=2, z=3)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
@@ -75,7 +75,6 @@ async def test_move_to_addressable_area_implementation_non_gen1(
 
     assert result == SuccessData(
         public=MoveToAddressableAreaResult(position=DeckPoint(x=9, y=8, z=7)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
@@ -139,7 +138,6 @@ async def test_move_to_addressable_area_implementation_with_gen1(
 
     assert result == SuccessData(
         public=MoveToAddressableAreaResult(position=DeckPoint(x=9, y=8, z=7)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
@@ -58,7 +58,6 @@ async def test_move_to_addressable_area_for_drop_tip_implementation(
 
     assert result == SuccessData(
         public=MoveToAddressableAreaForDropTipResult(position=DeckPoint(x=9, y=8, z=7)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
@@ -58,7 +58,6 @@ async def test_move_to_coordinates_implementation(
 
     assert result == SuccessData(
         public=MoveToCoordinatesResult(position=DeckPoint(x=4.44, y=5.55, z=6.66)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -61,7 +61,6 @@ async def test_move_to_well_implementation(
 
     assert result == SuccessData(
         public=MoveToWellResult(position=DeckPoint(x=9, y=8, z=7)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -84,7 +84,6 @@ async def test_success(
             tipDiameter=5,
             position=DeckPoint(x=111, y=222, z=333),
         ),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_prepare_to_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_prepare_to_aspirate.py
@@ -43,7 +43,7 @@ async def test_prepare_to_aspirate_implmenetation(
     )
 
     result = await subject.execute(data)
-    assert result == SuccessData(public=PrepareToAspirateResult(), private=None)
+    assert result == SuccessData(public=PrepareToAspirateResult())
 
 
 async def test_overpressure_error(

--- a/api/tests/opentrons/protocol_engine/commands/test_reload_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_reload_labware.py
@@ -66,7 +66,6 @@ async def test_reload_labware_implementation(
             labwareId="my-labware-id",
             offsetId="labware-offset-id",
         ),
-        private=None,
         state_update=StateUpdate(
             labware_location=LabwareLocationUpdate(
                 labware_id="my-labware-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_retract_axis.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_retract_axis.py
@@ -25,7 +25,6 @@ async def test_retract_axis_implementation(
 
     assert result == SuccessData(
         public=RetractAxisResult(),
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )
     decoy.verify(await movement.retract_axis(axis=MotorAxis.Y))

--- a/api/tests/opentrons/protocol_engine/commands/test_save_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_save_position.py
@@ -51,5 +51,4 @@ async def test_save_position_implementation(
             positionId="456",
             position=DeckPoint(x=1, y=2, z=3),
         ),
-        private=None,
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_set_rail_lights.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_set_rail_lights.py
@@ -26,6 +26,6 @@ async def test_set_rail_lights_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=SetRailLightsResult(), private=None)
+    assert result == SuccessData(public=SetRailLightsResult())
 
     decoy.verify(await rail_lights.set_rail_lights(True), times=1)

--- a/api/tests/opentrons/protocol_engine/commands/test_set_status_bar.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_set_status_bar.py
@@ -35,7 +35,7 @@ async def test_status_bar_busy(
 
     result = await subject.execute(params=data)
 
-    assert result == SuccessData(public=SetStatusBarResult(), private=None)
+    assert result == SuccessData(public=SetStatusBarResult())
 
     decoy.verify(await status_bar.set_status_bar(status=StatusBarState.OFF), times=0)
 
@@ -63,6 +63,6 @@ async def test_set_status_bar_animation(
     data = SetStatusBarParams(animation=animation)
 
     result = await subject.execute(params=data)
-    assert result == SuccessData(public=SetStatusBarResult(), private=None)
+    assert result == SuccessData(public=SetStatusBarResult())
 
     decoy.verify(await status_bar.set_status_bar(status=expected_state), times=1)

--- a/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
@@ -124,7 +124,6 @@ async def test_touch_tip_implementation(
 
     assert result == SuccessData(
         public=TouchTipResult(position=DeckPoint(x=4, y=5, z=6)),
-        private=None,
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_verify_tip_presence.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_verify_tip_presence.py
@@ -32,4 +32,4 @@ async def test_verify_tip_presence_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=VerifyTipPresenceResult(), private=None)
+    assert result == SuccessData(public=VerifyTipPresenceResult())

--- a/api/tests/opentrons/protocol_engine/commands/test_wait_for_duration.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_wait_for_duration.py
@@ -22,5 +22,5 @@ async def test_pause_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=WaitForDurationResult(), private=None)
+    assert result == SuccessData(public=WaitForDurationResult())
     decoy.verify(await run_control.wait_for_duration(42.0), times=1)

--- a/api/tests/opentrons/protocol_engine/commands/test_wait_for_resume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_wait_for_resume.py
@@ -23,7 +23,7 @@ async def test_wait_for_resume_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=WaitForResumeResult(), private=None)
+    assert result == SuccessData(public=WaitForResumeResult())
     decoy.verify(await run_control.wait_for_resume(), times=1)
 
 

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_close_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_close_lid.py
@@ -58,6 +58,5 @@ async def test_close_lid(
     )
     assert result == SuccessData(
         public=expected_result,
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_block.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_block.py
@@ -45,4 +45,4 @@ async def test_deactivate_block(
     result = await subject.execute(data)
 
     decoy.verify(await tc_hardware.deactivate_block(), times=1)
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(public=expected_result)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_lid.py
@@ -45,4 +45,4 @@ async def test_deactivate_lid(
     result = await subject.execute(data)
 
     decoy.verify(await tc_hardware.deactivate_lid(), times=1)
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(public=expected_result)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_open_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_open_lid.py
@@ -56,6 +56,5 @@ async def test_open_lid(
     )
     assert result == SuccessData(
         public=expected_result,
-        private=None,
         state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_run_extended_profile.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_run_extended_profile.py
@@ -112,4 +112,4 @@ async def test_run_extended_profile(
         ),
         times=1,
     )
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(public=expected_result)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_run_profile.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_run_profile.py
@@ -75,4 +75,4 @@ async def test_run_profile(
         ),
         times=1,
     )
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(public=expected_result)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_block_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_block_temperature.py
@@ -67,4 +67,4 @@ async def test_set_target_block_temperature(
         ),
         times=1,
     )
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(public=expected_result)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_lid_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_lid_temperature.py
@@ -56,4 +56,4 @@ async def test_set_target_lid_temperature(
     result = await subject.execute(data)
 
     decoy.verify(await tc_hardware.set_target_lid_temperature(celsius=45.6), times=1)
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(public=expected_result)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_block_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_block_temperature.py
@@ -51,4 +51,4 @@ async def test_set_target_block_temperature(
         tc_module_substate.get_target_block_temperature(),
         await tc_hardware.wait_for_block_target(),
     )
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(public=expected_result)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_lid_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_lid_temperature.py
@@ -51,4 +51,4 @@ async def test_set_target_block_temperature(
         tc_module_substate.get_target_lid_temperature(),
         await tc_hardware.wait_for_lid_target(),
     )
-    assert result == SuccessData(public=expected_result, private=None)
+    assert result == SuccessData(public=expected_result)

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_engage_axes.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_engage_axes.py
@@ -45,7 +45,7 @@ async def test_engage_axes_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=UnsafeEngageAxesResult(), private=None)
+    assert result == SuccessData(public=UnsafeEngageAxesResult())
 
     decoy.verify(
         await ot3_hardware_api.engage_axes([Axis.Z_L, Axis.P_L, Axis.X, Axis.Y]),

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_ungrip_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_ungrip_labware.py
@@ -22,7 +22,7 @@ async def test_ungrip_labware_implementation(
 
     result = await subject.execute(params=UnsafeUngripLabwareParams())
 
-    assert result == SuccessData(public=UnsafeUngripLabwareResult(), private=None)
+    assert result == SuccessData(public=UnsafeUngripLabwareResult())
 
     decoy.verify(
         await ot3_hardware_api.ungrip(),

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_blow_out_in_place.py
@@ -41,7 +41,7 @@ async def test_blow_out_in_place_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=UnsafeBlowOutInPlaceResult(), private=None)
+    assert result == SuccessData(public=UnsafeBlowOutInPlaceResult())
 
     decoy.verify(
         await ot3_hardware_api.update_axis_position_estimations([Axis.P_L]),

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -50,7 +50,6 @@ async def test_drop_tip_implementation(
 
     assert result == SuccessData(
         public=UnsafeDropTipInPlaceResult(),
-        private=None,
         state_update=StateUpdate(
             pipette_tip_state=PipetteTipStateUpdate(pipette_id="abc", tip_geometry=None)
         ),

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_update_position_estimators.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_update_position_estimators.py
@@ -45,7 +45,7 @@ async def test_update_position_estimators_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=UpdatePositionEstimatorsResult(), private=None)
+    assert result == SuccessData(public=UpdatePositionEstimatorsResult())
 
     decoy.verify(
         await ot3_hardware_api.update_axis_position_estimations(

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -220,7 +220,7 @@ class _TestCommandDefinedError(ErrorOccurrence):
 
 
 _TestCommandReturn = Union[
-    SuccessData[_TestCommandResult, None],
+    SuccessData[_TestCommandResult],
     DefinedErrorData[_TestCommandDefinedError],
 ]
 

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -263,7 +263,7 @@ async def test_execute(
         _ImplementationCls: Type[_TestCommandImpl] = TestCommandImplCls
 
     command_params = _TestCommandParams()
-    command_result = SuccessData(public=_TestCommandResult(), private=None)
+    command_result = SuccessData(public=_TestCommandResult())
 
     queued_command = cast(
         Command,
@@ -362,9 +362,7 @@ async def test_execute(
 
     decoy.verify(
         action_dispatcher.dispatch(
-            SucceedCommandAction(
-                private_result=None, command=expected_completed_command
-            )
+            SucceedCommandAction(command=expected_completed_command)
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store.py
@@ -234,9 +234,7 @@ def test_addressable_area_referencing_commands_load_on_simulated_deck(
     simulated_subject: AddressableAreaStore,
 ) -> None:
     """It should check and store the addressable area when referenced in a command."""
-    simulated_subject.handle_action(
-        SucceedCommandAction(private_result=None, command=command)
-    )
+    simulated_subject.handle_action(SucceedCommandAction(command=command))
     assert expected_area in simulated_subject.state.loaded_addressable_areas_by_name
 
 
@@ -301,7 +299,7 @@ def test_addressable_area_referencing_commands_load(
     subject: AddressableAreaStore,
 ) -> None:
     """It should check that the addressable area is in the deck config."""
-    subject.handle_action(SucceedCommandAction(private_result=None, command=command))
+    subject.handle_action(SucceedCommandAction(command=command))
     assert expected_area in subject.state.loaded_addressable_areas_by_name
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
@@ -84,7 +84,6 @@ def test_command_queue_and_unqueue() -> None:
         started_at=datetime(year=2022, month=2, day=2),
     )
     succeed_2 = SucceedCommandAction(
-        private_result=None,
         command=create_succeeded_command(command_id="command-id-2"),
     )
 
@@ -137,7 +136,6 @@ def test_setup_command_queue_and_unqueue() -> None:
         command_id="command-id-2", started_at=datetime(year=2022, month=2, day=2)
     )
     succeed_2 = SucceedCommandAction(
-        private_result=None,
         command=create_succeeded_command(command_id="command-id-2"),
     )
 
@@ -214,7 +212,6 @@ def test_running_command_id() -> None:
         started_at=datetime(year=2021, month=1, day=1),
     )
     succeed = SucceedCommandAction(
-        private_result=None,
         command=create_succeeded_command(command_id="command-id-1"),
     )
 
@@ -303,7 +300,6 @@ def test_command_store_keeps_commands_in_queue_order() -> None:
             command=create_succeeded_command(
                 command_id="command-id-2",
             ),
-            private_result=None,
         )
     )
     assert subject.state.command_history.get_all_ids() == [

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2937,7 +2937,6 @@ def test_get_offset_location_deck_slot(
                 version=nice_labware_definition.version,
             ),
         ),
-        private_result=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -2982,7 +2981,6 @@ def test_get_offset_location_module(
                 model=tempdeck_v2_def.model,
             ),
         ),
-        private_result=None,
     )
     load_labware = SucceedCommandAction(
         command=LoadLabware(
@@ -3002,7 +3000,6 @@ def test_get_offset_location_module(
                 version=nice_labware_definition.version,
             ),
         ),
-        private_result=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -3051,7 +3048,6 @@ def test_get_offset_location_module_with_adapter(
                 model=tempdeck_v2_def.model,
             ),
         ),
-        private_result=None,
     )
     load_adapter = SucceedCommandAction(
         command=LoadLabware(
@@ -3071,7 +3067,6 @@ def test_get_offset_location_module_with_adapter(
                 version=nice_adapter_definition.version,
             ),
         ),
-        private_result=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="adapter-id-1",
@@ -3100,7 +3095,6 @@ def test_get_offset_location_module_with_adapter(
                 version=nice_labware_definition.version,
             ),
         ),
-        private_result=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -3149,7 +3143,6 @@ def test_get_offset_fails_with_off_deck_labware(
                 version=nice_labware_definition.version,
             ),
         ),
-        private_result=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",

--- a/api/tests/opentrons/protocol_engine/state/test_labware_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_store.py
@@ -126,7 +126,6 @@ def test_handles_load_labware(
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=command,
             state_update=update_types.StateUpdate(
                 loaded_labware=update_types.LoadedLabwareUpdate(
@@ -154,7 +153,6 @@ def test_handles_reload_labware(
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=command,
             state_update=update_types.StateUpdate(
                 loaded_labware=update_types.LoadedLabwareUpdate(
@@ -194,7 +192,6 @@ def test_handles_reload_labware(
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=comment_command_2,
             state_update=update_types.StateUpdate(
                 labware_location=update_types.LabwareLocationUpdate(
@@ -254,7 +251,6 @@ def test_handles_move_labware(
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=comment_command,
             state_update=update_types.StateUpdate(
                 loaded_labware=update_types.LoadedLabwareUpdate(
@@ -273,7 +269,6 @@ def test_handles_move_labware(
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=comment_2,
             state_update=update_types.StateUpdate(
                 labware_location=update_types.LabwareLocationUpdate(
@@ -311,7 +306,6 @@ def test_handles_move_labware_off_deck(
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=comment_command,
             state_update=update_types.StateUpdate(
                 loaded_labware=update_types.LoadedLabwareUpdate(
@@ -330,7 +324,6 @@ def test_handles_move_labware_off_deck(
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=comment_2,
             state_update=update_types.StateUpdate(
                 labware_location=update_types.LabwareLocationUpdate(

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -197,7 +197,6 @@ def test_load_module(
 ) -> None:
     """It should handle a successful LoadModule command."""
     action = actions.SucceedCommandAction(
-        private_result=None,
         command=commands.LoadModule.construct(  # type: ignore[call-arg]
             params=commands.LoadModuleParams(
                 model=params_model,
@@ -261,7 +260,6 @@ def test_load_thermocycler_in_thermocycler_slot(
 ) -> None:
     """It should update additional slots for thermocycler module."""
     action = actions.SucceedCommandAction(
-        private_result=None,
         command=commands.LoadModule.construct(  # type: ignore[call-arg]
             params=commands.LoadModuleParams(
                 model=ModuleModel.THERMOCYCLER_MODULE_V2,
@@ -411,12 +409,8 @@ def test_handle_hs_temperature_commands(heater_shaker_v1_def: ModuleDefinition) 
         deck_fixed_labware=[],
     )
 
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=load_module_cmd)
-    )
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=set_temp_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=load_module_cmd))
+    subject.handle_action(actions.SucceedCommandAction(command=set_temp_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -425,9 +419,7 @@ def test_handle_hs_temperature_commands(heater_shaker_v1_def: ModuleDefinition) 
             plate_target_temperature=42,
         )
     }
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=deactivate_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=deactivate_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -465,12 +457,8 @@ def test_handle_hs_shake_commands(heater_shaker_v1_def: ModuleDefinition) -> Non
         deck_fixed_labware=[],
     )
 
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=load_module_cmd)
-    )
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=set_shake_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=load_module_cmd))
+    subject.handle_action(actions.SucceedCommandAction(command=set_shake_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -479,9 +467,7 @@ def test_handle_hs_shake_commands(heater_shaker_v1_def: ModuleDefinition) -> Non
             plate_target_temperature=None,
         )
     }
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=deactivate_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=deactivate_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -521,9 +507,7 @@ def test_handle_hs_labware_latch_commands(
         deck_fixed_labware=[],
     )
 
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=load_module_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=load_module_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -533,9 +517,7 @@ def test_handle_hs_labware_latch_commands(
         )
     }
 
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=close_latch_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=close_latch_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -544,9 +526,7 @@ def test_handle_hs_labware_latch_commands(
             plate_target_temperature=None,
         )
     }
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=open_latch_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=open_latch_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),
@@ -588,20 +568,14 @@ def test_handle_tempdeck_temperature_commands(
         deck_fixed_labware=[],
     )
 
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=load_module_cmd)
-    )
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=set_temp_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=load_module_cmd))
+    subject.handle_action(actions.SucceedCommandAction(command=set_temp_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": TemperatureModuleSubState(
             module_id=TemperatureModuleId("module-id"), plate_target_temperature=42
         )
     }
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=deactivate_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=deactivate_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": TemperatureModuleSubState(
             module_id=TemperatureModuleId("module-id"), plate_target_temperature=None
@@ -650,12 +624,8 @@ def test_handle_thermocycler_temperature_commands(
         deck_fixed_labware=[],
     )
 
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=load_module_cmd)
-    )
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=set_block_temp_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=load_module_cmd))
+    subject.handle_action(actions.SucceedCommandAction(command=set_block_temp_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -664,9 +634,7 @@ def test_handle_thermocycler_temperature_commands(
             target_lid_temperature=None,
         )
     }
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=set_lid_temp_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=set_lid_temp_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -675,9 +643,7 @@ def test_handle_thermocycler_temperature_commands(
             target_lid_temperature=35.3,
         )
     }
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=deactivate_lid_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=deactivate_lid_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -686,9 +652,7 @@ def test_handle_thermocycler_temperature_commands(
             target_lid_temperature=None,
         )
     }
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=deactivate_block_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=deactivate_block_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -734,12 +698,8 @@ def test_handle_thermocycler_lid_commands(
         deck_fixed_labware=[],
     )
 
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=load_module_cmd)
-    )
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=open_lid_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=load_module_cmd))
+    subject.handle_action(actions.SucceedCommandAction(command=open_lid_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),
@@ -749,9 +709,7 @@ def test_handle_thermocycler_lid_commands(
         )
     }
 
-    subject.handle_action(
-        actions.SucceedCommandAction(private_result=None, command=close_lid_cmd)
-    )
+    subject.handle_action(actions.SucceedCommandAction(command=close_lid_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": ThermocyclerModuleSubState(
             module_id=ThermocyclerModuleId("module-id"),

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -81,16 +81,13 @@ def test_location_state_update(subject: PipetteStore) -> None:
         pipette_name=PipetteNameType.P300_SINGLE,
         mount=MountType.RIGHT,
     )
-    subject.handle_action(
-        SucceedCommandAction(command=load_command, private_result=None)
-    )
+    subject.handle_action(SucceedCommandAction(command=load_command))
 
     # Update the location to a well:
     dummy_command = create_succeeded_command()
     subject.handle_action(
         SucceedCommandAction(
             command=dummy_command,
-            private_result=None,
             state_update=update_types.StateUpdate(
                 pipette_location=update_types.PipetteLocationUpdate(
                     pipette_id="pipette-id",
@@ -120,7 +117,6 @@ def test_location_state_update(subject: PipetteStore) -> None:
     subject.handle_action(
         SucceedCommandAction(
             command=dummy_command,
-            private_result=None,
             state_update=update_types.StateUpdate(
                 pipette_location=update_types.PipetteLocationUpdate(
                     pipette_id="pipette-id",
@@ -143,7 +139,6 @@ def test_location_state_update(subject: PipetteStore) -> None:
     subject.handle_action(
         SucceedCommandAction(
             command=dummy_command,
-            private_result=None,
             state_update=update_types.StateUpdate(
                 pipette_location=update_types.PipetteLocationUpdate(
                     pipette_id="pipette-id",
@@ -162,7 +157,6 @@ def test_location_state_update(subject: PipetteStore) -> None:
     subject.handle_action(
         SucceedCommandAction(
             command=dummy_command,
-            private_result=None,
             state_update=update_types.StateUpdate(
                 pipette_location=update_types.PipetteLocationUpdate(
                     pipette_id="pipette-id",
@@ -181,7 +175,6 @@ def test_location_state_update(subject: PipetteStore) -> None:
     subject.handle_action(
         SucceedCommandAction(
             command=dummy_command,
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
         )
     )
@@ -233,7 +226,6 @@ def test_handles_load_pipette(
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=dummy_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=load_pipette_update, pipette_config=config_update
@@ -271,7 +263,6 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_pipette_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
@@ -286,7 +277,6 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=pick_up_tip_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
@@ -303,7 +293,6 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=drop_tip_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
@@ -334,7 +323,6 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_pipette_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
@@ -348,7 +336,6 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=pick_up_tip_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
@@ -365,7 +352,6 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=drop_tip_in_place_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
@@ -396,7 +382,6 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_pipette_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
@@ -410,7 +395,6 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=pick_up_tip_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
@@ -427,7 +411,6 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=unsafe_drop_tip_in_place_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
@@ -461,7 +444,6 @@ def test_aspirate_adds_volume(
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
@@ -473,15 +455,11 @@ def test_aspirate_adds_volume(
             ),
         )
     )
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=aspirate_command)
-    )
+    subject.handle_action(SucceedCommandAction(command=aspirate_command))
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 42
 
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=aspirate_command)
-    )
+    subject.handle_action(SucceedCommandAction(command=aspirate_command))
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 84
 
@@ -514,7 +492,6 @@ def test_dispense_subtracts_volume(
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
@@ -526,18 +503,12 @@ def test_dispense_subtracts_volume(
             ),
         )
     )
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=aspirate_command)
-    )
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=dispense_command)
-    )
+    subject.handle_action(SucceedCommandAction(command=aspirate_command))
+    subject.handle_action(SucceedCommandAction(command=dispense_command))
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 21
 
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=dispense_command)
-    )
+    subject.handle_action(SucceedCommandAction(command=dispense_command))
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 0
 
@@ -567,7 +538,6 @@ def test_blow_out_clears_volume(
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
@@ -579,12 +549,8 @@ def test_blow_out_clears_volume(
             ),
         )
     )
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=aspirate_command)
-    )
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=blow_out_command)
-    )
+    subject.handle_action(SucceedCommandAction(command=aspirate_command))
+    subject.handle_action(SucceedCommandAction(command=blow_out_command))
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] is None
 
@@ -597,9 +563,7 @@ def test_set_movement_speed(subject: PipetteStore) -> None:
         pipette_name=PipetteNameType.P300_SINGLE,
         mount=MountType.LEFT,
     )
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=load_pipette_command)
-    )
+    subject.handle_action(SucceedCommandAction(command=load_pipette_command))
     subject.handle_action(
         SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=123.456)
     )
@@ -641,7 +605,6 @@ def test_add_pipette_config(
     subject.handle_action(
         SucceedCommandAction(
             command=command,
-            private_result=None,
             state_update=update_types.StateUpdate(
                 pipette_config=update_types.PipetteConfigUpdate(
                     pipette_id="pipette-id",
@@ -702,7 +665,6 @@ def test_prepare_to_aspirate_marks_pipette_ready(
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_pipette_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
@@ -716,7 +678,6 @@ def test_prepare_to_aspirate_marks_pipette_ready(
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=pick_up_tip_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
@@ -729,7 +690,6 @@ def test_prepare_to_aspirate_marks_pipette_ready(
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=previous,
         )
     )
@@ -737,7 +697,5 @@ def test_prepare_to_aspirate_marks_pipette_ready(
     prepare_to_aspirate_command = create_prepare_to_aspirate_command(
         pipette_id="pipette-id"
     )
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=prepare_to_aspirate_command)
-    )
+    subject.handle_action(SucceedCommandAction(command=prepare_to_aspirate_command))
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 0.0

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -66,7 +66,6 @@ def load_labware_action(
 ) -> actions.SucceedCommandAction:
     """Get a load labware command value object."""
     return actions.SucceedCommandAction(
-        private_result=None,
         command=_dummy_command(),
         state_update=update_types.StateUpdate(
             loaded_labware=update_types.LoadedLabwareUpdate(
@@ -124,7 +123,6 @@ def test_get_next_tip_returns_none(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -183,7 +181,6 @@ def test_get_next_tip_returns_first_tip(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -236,7 +233,6 @@ def test_get_next_tip_used_starting_tip(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -322,7 +318,6 @@ def test_get_next_tip_skips_picked_up_tip(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -338,7 +333,6 @@ def test_get_next_tip_skips_picked_up_tip(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=pick_up_tip_state_update,
         )
     )
@@ -387,7 +381,6 @@ def test_get_next_tip_with_starting_tip(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -407,7 +400,6 @@ def test_get_next_tip_with_starting_tip(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=pick_up_tip_state_update,
         )
     )
@@ -456,7 +448,6 @@ def test_get_next_tip_with_starting_tip_8_channel(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -479,7 +470,6 @@ def test_get_next_tip_with_starting_tip_8_channel(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=pick_up_tip_state_update,
         )
     )
@@ -528,7 +518,6 @@ def test_get_next_tip_with_1_channel_followed_by_8_channel(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -560,7 +549,6 @@ def test_get_next_tip_with_1_channel_followed_by_8_channel(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update_2),
             command=_dummy_command(),
         )
@@ -583,7 +571,6 @@ def test_get_next_tip_with_1_channel_followed_by_8_channel(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=pick_up_tip_2_state_update,
         )
     )
@@ -632,7 +619,6 @@ def test_get_next_tip_with_starting_tip_out_of_tips(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -655,7 +641,6 @@ def test_get_next_tip_with_starting_tip_out_of_tips(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=pick_up_tip_state_update,
         )
     )
@@ -704,7 +689,6 @@ def test_get_next_tip_with_column_and_starting_tip(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -755,7 +739,6 @@ def test_reset_tips(
 
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -764,7 +747,6 @@ def test_reset_tips(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=update_types.StateUpdate(
                 tips_used=update_types.TipsUsedUpdate(
                     pipette_id="pipette-id",
@@ -818,7 +800,6 @@ def test_handle_pipette_config_action(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -952,7 +933,6 @@ def test_active_channels(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -968,7 +948,6 @@ def test_active_channels(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=state_update,
         )
     )
@@ -1014,7 +993,6 @@ def test_next_tip_uses_active_channels(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -1051,7 +1029,6 @@ def test_next_tip_uses_active_channels(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=state_update,
         )
     )
@@ -1059,7 +1036,6 @@ def test_next_tip_uses_active_channels(
     subject.handle_action(
         actions.SucceedCommandAction(
             command=_dummy_command(),
-            private_result=None,
             state_update=update_types.StateUpdate(
                 tips_used=update_types.TipsUsedUpdate(
                     pipette_id="pipette-id",
@@ -1115,7 +1091,6 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -1141,7 +1116,6 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
         subject.handle_action(
             actions.SucceedCommandAction(
                 command=_dummy_command(),
-                private_result=None,
                 state_update=pick_up_tip_state_update,
             )
         )
@@ -1212,7 +1186,6 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
         subject.handle_action(
             actions.SucceedCommandAction(
                 command=_dummy_command(),
-                private_result=None,
                 state_update=state_update,
             )
         )
@@ -1270,7 +1243,6 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
     )
     subject.handle_action(
         actions.SucceedCommandAction(
-            private_result=None,
             state_update=update_types.StateUpdate(pipette_config=config_update),
             command=_dummy_command(),
         )
@@ -1293,7 +1265,6 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
             subject.handle_action(
                 actions.SucceedCommandAction(
                     command=_dummy_command(),
-                    private_result=None,
                     state_update=pick_up_tip_state_update,
                 )
             )
@@ -1337,7 +1308,7 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
         )
         subject.handle_action(
             actions.SucceedCommandAction(
-                command=_dummy_command(), private_result=None, state_update=state_update
+                command=_dummy_command(), state_update=state_update
             )
         )
         return nozzle_map

--- a/api/tests/opentrons/protocol_engine/state/test_well_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_well_store.py
@@ -27,7 +27,6 @@ def test_handles_liquid_probe_success(subject: WellStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=liquid_probe,
             state_update=update_types.StateUpdate(
                 liquid_probed=update_types.LiquidProbedUpdate(
@@ -65,7 +64,6 @@ def test_handles_load_liquid_success(subject: WellStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_liquid,
             state_update=update_types.StateUpdate(
                 liquid_loaded=update_types.LiquidLoadedUpdate(
@@ -124,7 +122,6 @@ def test_handles_load_liquid_and_aspirate(subject: WellStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=load_liquid,
             state_update=update_types.StateUpdate(
                 liquid_loaded=update_types.LiquidLoadedUpdate(
@@ -137,7 +134,6 @@ def test_handles_load_liquid_and_aspirate(subject: WellStore) -> None:
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=aspirate_1,
             state_update=update_types.StateUpdate(
                 liquid_operated=update_types.LiquidOperatedUpdate(
@@ -150,7 +146,6 @@ def test_handles_load_liquid_and_aspirate(subject: WellStore) -> None:
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=aspirate_2,
             state_update=update_types.StateUpdate(
                 liquid_operated=update_types.LiquidOperatedUpdate(
@@ -199,7 +194,6 @@ def test_handles_liquid_probe_and_aspirate(subject: WellStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=liquid_probe,
             state_update=update_types.StateUpdate(
                 liquid_probed=update_types.LiquidProbedUpdate(
@@ -214,7 +208,6 @@ def test_handles_liquid_probe_and_aspirate(subject: WellStore) -> None:
     )
     subject.handle_action(
         SucceedCommandAction(
-            private_result=None,
             command=aspirate,
             state_update=update_types.StateUpdate(
                 liquid_operated=update_types.LiquidOperatedUpdate(

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -117,7 +117,6 @@ def test_map_after_command() -> None:
 
     assert result == [
         pe_actions.SucceedCommandAction(
-            private_result=None,
             command=pe_commands.Comment.construct(
                 id="command.COMMENT-0",
                 key="command.COMMENT-0",
@@ -241,7 +240,6 @@ def test_command_stack() -> None:
             command_id="command.COMMENT-1", started_at=matchers.IsA(datetime)
         ),
         pe_actions.SucceedCommandAction(
-            private_result=None,
             command=pe_commands.Comment.construct(
                 id="command.COMMENT-0",
                 key="command.COMMENT-0",
@@ -321,7 +319,6 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
             ),
             notes=[],
         ),
-        private_result=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-0",
@@ -381,7 +378,6 @@ def test_map_instrument_load(decoy: Decoy) -> None:
             result=pe_commands.LoadPipetteResult(pipetteId="pipette-0"),
             notes=[],
         ),
-        private_result=None,
         state_update=StateUpdate(
             loaded_pipette=LoadPipetteUpdate(
                 pipette_id="pipette-0",
@@ -460,7 +456,6 @@ def test_map_module_load(
             ),
             notes=[],
         ),
-        private_result=None,
     )
 
     [result_queue, result_run, result_succeed] = LegacyCommandMapper(
@@ -525,7 +520,6 @@ def test_map_module_labware_load(minimal_labware_def: LabwareDefinition) -> None
             ),
             notes=[],
         ),
-        private_result=None,
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-0",
@@ -584,7 +578,6 @@ def test_map_pause() -> None:
             started_at=matchers.IsA(datetime),
         ),
         pe_actions.SucceedCommandAction(
-            private_result=None,
             command=pe_commands.WaitForResume.construct(
                 id="command.PAUSE-0",
                 key="command.PAUSE-0",

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -163,18 +163,14 @@ async def test_command_broker_messages(
 
     decoy.when(
         mock_legacy_command_mapper.map_command(command=legacy_command)
-    ).then_return(
-        [pe_actions.SucceedCommandAction(engine_command, private_result=None)]
-    )
+    ).then_return([pe_actions.SucceedCommandAction(engine_command)])
 
     await to_thread.run_sync(handler, legacy_command)
 
     await subject.teardown()
 
     decoy.verify(
-        mock_action_dispatcher.dispatch(
-            pe_actions.SucceedCommandAction(engine_command, private_result=None)
-        )
+        mock_action_dispatcher.dispatch(pe_actions.SucceedCommandAction(engine_command))
     )
 
 
@@ -222,9 +218,7 @@ async def test_equipment_broker_messages(
 
     decoy.when(
         mock_legacy_command_mapper.map_equipment_load(load_info=load_info)
-    ).then_return(
-        [pe_actions.SucceedCommandAction(command=engine_command, private_result=None)]
-    )
+    ).then_return([pe_actions.SucceedCommandAction(command=engine_command)])
 
     await to_thread.run_sync(handler, load_info)
 
@@ -232,6 +226,6 @@ async def test_equipment_broker_messages(
 
     decoy.verify(
         mock_action_dispatcher.dispatch(
-            pe_actions.SucceedCommandAction(command=engine_command, private_result=None)
+            pe_actions.SucceedCommandAction(command=engine_command)
         ),
     )


### PR DESCRIPTION
## Overview

#16620 deletes the last uses of `SucceedCommandAction.private_result`. (It is replaced by `SucceedCommandAction.state_update`.)

This PR deletes the attribute and the remaining code that was using it.

## Test Plan and Hands on Testing

Just CI.

## Review requests

This is basically just a few global find+replace operations. I've gone through the diff to make sure there was no collateral damage, but maybe you want to skim it too to double-check me.

## Risk assessment

Low.
