### PR TITLE
fix(shared-data): add cornerOffsetFromSlot to deck riser

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_flex_deck_riser/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_deck_riser/1.json
@@ -34,8 +34,8 @@
   "schemaVersion": 2,
   "allowedRoles": ["adapter"],
   "cornerOffsetFromSlot": {
-    "x": 0,
-    "y": 0,
+    "x": -6.125,
+    "y": -6.125,
     "z": 0
   }
 }


### PR DESCRIPTION
# Overview

The client was not able to render the deck riser correctly because it was offset by -6.125mm, this is because the `cornerOffsetFromSlot` was missing from the definition. This pull request adds this offset as measured by the hardware team. The value is negative because the deck riser top lip is larger than the slot it sits on.

## Test Plan and Hands on Testing

- [x] Make sure we can move TC lids with the gripper
- [x] Make sure we can pipette into TC lids
- [x] Make sure the deck riser is visually aligned on the deck map view.

## Changelog

- add -6.125mm x and y `cornerOffsetFromSlot` to the deck riser adaptor definition.

## Review requests

## Risk assessment
low