### PR TITLE
feat(app): add lid category to labware tab display

### DIFF
--- a/app/src/local-resources/labware/types.ts
+++ b/app/src/local-resources/labware/types.ts
@@ -21,6 +21,7 @@ export type LabwareFilter =
   | 'aluminumBlock'
   | 'customLabware'
   | 'adapter'
+  | 'lid'
 
 export type LabwareSort = 'alphabetical' | 'reverse'
 

--- a/app/src/pages/Desktop/Labware/__tests__/Labware.test.tsx
+++ b/app/src/pages/Desktop/Labware/__tests__/Labware.test.tsx
@@ -121,6 +121,9 @@ describe('Labware', () => {
     screen.getByRole('button', { name: 'Tube Rack' })
     screen.getByRole('button', { name: 'Reservoir' })
     screen.getByRole('button', { name: 'Aluminum Block' })
+    screen.getByRole('button', { name: 'Adapter' })
+    screen.getByRole('button', { name: 'Lid' })
+    screen.getByRole('button', { name: 'Custom Labware' })
   })
   it('renders changes filter menu button when an option is selected', () => {
     render()

--- a/app/src/pages/Desktop/Labware/index.tsx
+++ b/app/src/pages/Desktop/Labware/index.tsx
@@ -56,6 +56,7 @@ const labwareDisplayCategoryFilters: LabwareFilter[] = [
   'adapter',
   'aluminumBlock',
   'customLabware',
+  'lid',
   'reservoir',
   'tipRack',
   'tubeRack',


### PR DESCRIPTION
fix PLAT-516

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We need to add a "Lid" filter item to the Labware tab of the app so that labware with `displayCategory` lid will show up. Right now, this is only TC lids
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Look at labware tab, see that when you filter by lids
1. TC lid does show up
2. Plate reader lid does not show up

<img width="918" alt="Screen Shot 2024-10-29 at 10 34 42 AM" src="https://github.com/user-attachments/assets/982e634c-1314-4e78-8e69-da621acfa1ed">
<img width="247" alt="Screen Shot 2024-10-29 at 10 34 38 AM" src="https://github.com/user-attachments/assets/f5acc0fe-d884-4c85-a939-2c40e74a6801">
<img width="314" alt="Screen Shot 2024-10-29 at 10 42 01 AM" src="https://github.com/user-attachments/assets/31f309c8-e1f5-4e3f-bdc7-f126b9acb4b9">

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Add lid display category type and add it to filter dropdown list
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick check, this is a tiny pr
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
