### PR TITLE
fix(protocol-designer): custom labware should be uploadable

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/HoveredItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HoveredItems.tsx
@@ -58,6 +58,10 @@ export const HoveredItems = (
     hoveredLabware != null
       ? defs[hoveredLabware] ?? customLabwareDefs[hoveredLabware] ?? null
       : null
+  const selectedLabwareDef =
+    selectedLabwareDefUri != null
+      ? defs[selectedLabwareDefUri] ?? customLabwareDefs[selectedLabwareDefUri]
+      : null
 
   const orientation =
     hoveredSlotPosition != null
@@ -65,11 +69,11 @@ export const HoveredItems = (
       : null
 
   const nestedInfo: DeckLabelProps[] =
-    selectedLabwareDefUri != null &&
+    selectedLabwareDef != null &&
     (hoveredLabware == null || hoveredLabware !== selectedLabwareDefUri)
       ? [
           {
-            text: defs[selectedLabwareDefUri].metadata.displayName,
+            text: selectedLabwareDef.metadata.displayName,
             isLast: false,
             isSelected: true,
           },

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedHoveredItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedHoveredItems.tsx
@@ -53,6 +53,16 @@ export const SelectedHoveredItems = (
     hoveredLabware != null
       ? defs[hoveredLabware] ?? customLabwareDefs[hoveredLabware] ?? null
       : null
+  const selectedLabwareDef =
+    selectedLabwareDefUri != null
+      ? defs[selectedLabwareDefUri] ?? customLabwareDefs[selectedLabwareDefUri]
+      : null
+  const selectedNestedLabwareDef =
+    selectedNestedLabwareDefUri != null
+      ? defs[selectedNestedLabwareDefUri] ??
+        customLabwareDefs[selectedNestedLabwareDefUri]
+      : null
+
   const orientation =
     slotPosition != null
       ? inferModuleOrientationFromXCoordinate(slotPosition[0])
@@ -64,7 +74,8 @@ export const SelectedHoveredItems = (
     selectedLabwareDefUri != null &&
     (hoveredLabware == null || hoveredLabware !== selectedLabwareDefUri)
   ) {
-    const def = defs[selectedLabwareDefUri]
+    const def =
+      defs[selectedLabwareDefUri] ?? customLabwareDefs[selectedLabwareDefUri]
     const selectedLabwareLabel = {
       text: def.metadata.displayName,
       isSelected: true,
@@ -72,10 +83,9 @@ export const SelectedHoveredItems = (
     }
     labwareInfos.push(selectedLabwareLabel)
   }
-  if (selectedNestedLabwareDefUri != null && hoveredLabware == null) {
-    const def = defs[selectedNestedLabwareDefUri]
+  if (selectedNestedLabwareDef != null && hoveredLabware == null) {
     const selectedNestedLabwareLabel = {
-      text: def.metadata.displayName,
+      text: selectedNestedLabwareDef.metadata.displayName,
       isSelected: true,
       isLast: hoveredLabware == null,
     }
@@ -122,20 +132,18 @@ export const SelectedHoveredItems = (
             orientation={orientation}
           >
             <>
-              {selectedLabwareDefUri != null &&
+              {selectedLabwareDef != null &&
               selectedModuleModel != null &&
               hoveredLabware == null ? (
                 <g transform={`translate(0, 0)`}>
-                  <LabwareRender definition={defs[selectedLabwareDefUri]} />
+                  <LabwareRender definition={selectedLabwareDef} />
                 </g>
               ) : null}
-              {selectedNestedLabwareDefUri != null &&
+              {selectedNestedLabwareDef != null &&
               selectedModuleModel != null &&
               hoveredLabware == null ? (
                 <g transform={`translate(0, 0)`}>
-                  <LabwareRender
-                    definition={defs[selectedNestedLabwareDefUri]}
-                  />
+                  <LabwareRender definition={selectedNestedLabwareDef} />
                 </g>
               ) : null}
               {hoveredLabwareDef != null && selectedModuleModel != null ? (
@@ -157,41 +165,41 @@ export const SelectedHoveredItems = (
           ) : null}
         </>
       ) : null}
-      {selectedLabwareDefUri != null &&
+      {selectedLabwareDef != null &&
       slotPosition != null &&
       selectedModuleModel == null &&
       hoveredLabware == null ? (
         <>
           <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>
-            <LabwareRender definition={defs[selectedLabwareDefUri]} />
+            <LabwareRender definition={selectedLabwareDef} />
           </g>
           {selectedNestedLabwareDefUri == null ? (
             <LabwareLabel
               isLast={true}
               isSelected={true}
-              labwareDef={defs[selectedLabwareDefUri]}
+              labwareDef={selectedLabwareDef}
               position={slotPosition}
             />
           ) : null}
         </>
       ) : null}
-      {selectedNestedLabwareDefUri != null &&
+      {selectedNestedLabwareDef != null &&
       slotPosition != null &&
       selectedModuleModel == null &&
       hoveredLabware == null ? (
         <>
           <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>
-            <LabwareRender definition={defs[selectedNestedLabwareDefUri]} />
+            <LabwareRender definition={selectedNestedLabwareDef} />
           </g>
-          {selectedLabwareDefUri != null ? (
+          {selectedLabwareDef != null ? (
             <LabwareLabel
               isLast={false}
               isSelected={true}
-              labwareDef={defs[selectedLabwareDefUri]}
+              labwareDef={selectedLabwareDef}
               position={slotPosition}
               nestedLabwareInfo={[
                 {
-                  text: defs[selectedNestedLabwareDefUri].metadata.displayName,
+                  text: selectedNestedLabwareDef.metadata.displayName,
                   isSelected: true,
                   isLast: true,
                 },


### PR DESCRIPTION
closes RQA-3427

# Overview

Fix the custom labware experience when uploading it to deck setup

## Test Plan and Hands on Testing

Upload the attached custom labware def to PD during deck setup. You should be able to add it to the deck map and should work as expected (you can move it around, select it when transferring liquid, add liquid to it, rename it, etc)

[opentrons_24_tuberack_421ul.json](https://github.com/user-attachments/files/17559799/opentrons_24_tuberack_421ul.json)


## Changelog

- include a check for if the custom labware def is a custom labware or a regular labware

## Risk assessment

low