### PR TITLE
fix(protocol-designer): hide flex deck riser from PD for now

### DIFF
--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -57,8 +57,9 @@ export const PD_DO_NOT_LIST = [
   'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat',
   'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
   'opentrons_96_pcr_adapter_armadillo_wellplate_200ul',
-  //  temporarily blocking TC lid adapter until it is supported in PD
+  //  temporarily blocking TC lid adapter and deck riser until it is supported in PD
   'opentrons_tough_pcr_auto_sealing_lid',
+  'opentrons_flex_deck_riser',
 ]
 
 export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {


### PR DESCRIPTION
closes RQA-3444

# Overview

hide the flex deck riser from PD since adapters get automatically selectable in PD unless specifically blocked

## Test Plan and Hands on Testing

go to deck setup and click on the deck map and add an adapter to the slot. the deck riser should not be selectable

## Changelog

- add the loadname to the PD_DO_NOT_LIST

## Risk assessment

low
