### PR TITLE
fix(protocol-designer): deck thumbnail reflects liquids at starting d…

### DIFF
--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -181,6 +181,7 @@ export function Designer(): JSX.Element {
               onClick={() => {
                 if (hasTrashEntity) {
                   navigate('/overview')
+                  dispatch(selectTerminalItem('__initial_setup__'))
                 } else {
                   makeSnackbar(t('trash_required') as string)
                 }


### PR DESCRIPTION
…eck state

closes AUTH-816


# Overview

the deck thumbnail should always reflect the deck state at the starting deck state. this fixes an issue where the liquids would get updated to a different state

## Test Plan and Hands on Testing

Upload the attached protocol and go to protocol steps and click on the final deck state. see that the liquids and labware move on the deck map

then click "done" and go back to overview and see that the deckmap thumbnail shows everything, including liquids, at the starting deck state.

[1.0 testing.json](https://github.com/user-attachments/files/17559820/1.0.testing.json)


## Changelog

- set terminal item to the initial setup when pressing done from the designer tab

## Risk assessment

low