### PR TITLE
fix(app): fix stale well location in Error Recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -7,6 +7,7 @@ import {
   getRelevantWellName,
   getRelevantFailedLabwareCmdFrom,
   useRelevantFailedLwLocations,
+  useInitialSelectedLocationsFrom,
 } from '../useFailedLabwareUtils'
 import { DEFINED_ERROR_TYPES } from '../../constants'
 
@@ -239,5 +240,24 @@ describe('useRelevantFailedLwLocations', () => {
 
     expect(result.current.currentLoc).toStrictEqual({ slotName: 'D1' })
     expect(result.current.newLoc).toStrictEqual({ slotName: 'C2' })
+  })
+})
+
+describe('useInitialSelectedLocationsFrom', () => {
+  it('updates result if the relevant command changes', () => {
+    const cmd = { commandType: 'pickUpTip', params: { wellName: 'A1' } } as any
+    const cmd2 = { commandType: 'pickUpTip', params: { wellName: 'A2' } } as any
+
+    const { result, rerender } = renderHook((cmd: any) =>
+      useInitialSelectedLocationsFrom(cmd)
+    )
+
+    rerender(cmd)
+
+    expect(result.current).toStrictEqual({ A1: null })
+
+    rerender(cmd2)
+
+    expect(result.current).toStrictEqual({ A2: null })
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -214,8 +214,9 @@ function useTipSelectionUtils(
   const initialLocs = useInitialSelectedLocationsFrom(
     recentRelevantFailedLabwareCmd
   )
-  // Set the initial locs when they first become available.
-  if (selectedLocs == null && initialLocs != null) {
+
+  // Set the initial locs when they first become available or update.
+  if (selectedLocs !== initialLocs) {
     setSelectedLocs(initialLocs)
   }
 
@@ -253,17 +254,20 @@ function useTipSelectionUtils(
 }
 
 // Set the initial well selection to be the last pickup tip location for the pipette used in the failed command.
-function useInitialSelectedLocationsFrom(
+export function useInitialSelectedLocationsFrom(
   recentRelevantFailedLabwareCmd: FailedCommandRelevantLabware
 ): WellGroup | null {
   const [initialWells, setInitialWells] = useState<WellGroup | null>(null)
 
   // Note that while other commands may have a wellName associated with them,
   // we are only interested in wells for the purposes of tip picking up.
+  // Support state updates if the underlying data changes, since this data is lazily loaded and may change shortly
+  // after Error Recovery launches.
   if (
     recentRelevantFailedLabwareCmd != null &&
     recentRelevantFailedLabwareCmd.commandType === 'pickUpTip' &&
-    initialWells == null
+    (initialWells == null ||
+      !(recentRelevantFailedLabwareCmd.params.wellName in initialWells))
   ) {
     setInitialWells({ [recentRelevantFailedLabwareCmd.params.wellName]: null })
   }


### PR DESCRIPTION
Closes [RQA-3438](https://opentrons.atlassian.net/browse/RQA-3438)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The logic for determining the default well used during tip selection is calculated as soon as Error Recovery renders. After the initial well is determined, this state is set and then never updated for the remainder of Error Recovery. The current logic works well if there never has been a `recentRelevantFailedLabwareCmd`, however, if this is the 2nd+ instance of error recovery in the run, the `recentRelevantFailedLabwareCmd` is stale until the fetch for the new`recentRelevantFailedLabwareCmd` completes. 

Instead of gating the state setting behavior by whether or not there is a `recentRelevantFailedLabwareCmd`, we should gate it by whether the relevant data within `recentRelevantFailedLabwareCmd` has changed.

### Current Behavior

<img width="753" alt="Screenshot 2024-10-29 at 12 07 24 PM" src="https://github.com/user-attachments/assets/97eac14b-e655-4cf7-9b05-585973305172">

_Client entered Error Recovery utilizing tips in column 12 and successfully recovered. This is the second instance of Error Recovery, and we expect to see column 11 highlighted._

### Fixed Behavior

<img width="751" alt="Screenshot 2024-10-29 at 12 03 35 PM" src="https://github.com/user-attachments/assets/1f47acd0-c6c6-4f10-974f-770511fa98ae">


_Same scenario as above, but with corrected behavior._
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images. [Here's a protocol](https://github.com/user-attachments/files/17560227/multi-overpressure.py.zip) if you'd like to test it manually.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed incorrect initial well highlighting during "select tips" during Error Recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3438]: https://opentrons.atlassian.net/browse/RQA-3438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ