### PR TITLE
fix(api): Fix certain failed runs showing a stale recovery target

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -450,8 +450,8 @@ class CommandStore(HasState[CommandState], HandlesActions):
     def _handle_stop_action(self, action: StopAction) -> None:
         if not self._state.run_result:
             self._state.recovery_target = None
-
             self._state.queue_status = QueueStatus.PAUSED
+
             if action.from_estop:
                 self._state.stopped_by_estop = True
                 self._state.run_result = RunResult.FAILED
@@ -460,7 +460,9 @@ class CommandStore(HasState[CommandState], HandlesActions):
 
     def _handle_finish_action(self, action: FinishAction) -> None:
         if not self._state.run_result:
+            self._state.recovery_target = None
             self._state.queue_status = QueueStatus.PAUSED
+
             if action.set_run_status:
                 self._state.run_result = (
                     RunResult.SUCCEEDED


### PR DESCRIPTION
# Overview

Closes EXEC-503.

## Test Plan and Hands on Testing

I think unit tests are sufficient here.

As far as I know, this bug no longer has any user-visible effect that we can test against. This is because the PAPI layer handles error recovery much more comprehensively now, so this part of EXEC-503's steps to reproduce can't happen in practice:

> 2. The Python API naively lets the exception propagate, not taking advantage of the error’s recoverability

## Changelog

The bug was that I added code to do the right thing in `StopAction`, but I neglected to add the same code in `FinishAction`.

When a run ends:

* It sometimes, but not always, goes through an `opentrons.protocol_engine` `StopAction`, depending on the circumstances.
* It's always goes through an `opentrons.protocol_engine` `FinishAction`.

## Review requests

None in particular.

## Risk assessment

Low.