### PR TITLE
fix(protocol-designer): timeline warnings appear when reopening form

### DIFF
--- a/protocol-designer/src/organisms/Alerts/FormAlerts.tsx
+++ b/protocol-designer/src/organisms/Alerts/FormAlerts.tsx
@@ -28,12 +28,14 @@ import type { ProfileFormError } from '../../steplist/formLevel/profileErrors'
 import type { MakeAlert } from './types'
 
 interface FormAlertsProps {
+  showFormErrorsAndWarnings: boolean
   focusedField?: StepFieldName | null
   dirtyFields?: StepFieldName[]
 }
 
 function FormAlertsComponent(props: FormAlertsProps): JSX.Element | null {
-  const { focusedField, dirtyFields } = props
+  const { showFormErrorsAndWarnings, focusedField, dirtyFields } = props
+
   const { t } = useTranslation('alert')
   const dispatch = useDispatch()
   const formLevelErrorsForUnsavedForm = useSelector(
@@ -161,14 +163,26 @@ function FormAlertsComponent(props: FormAlertsProps): JSX.Element | null {
       )
     }
   }
-  return [...formErrors, ...formWarnings, ...timelineWarnings].length > 0 ? (
+
+  if (showFormErrorsAndWarnings) {
+    return [...formErrors, ...formWarnings].length > 0 ? (
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing4}
+        padding={`${SPACING.spacing16} ${SPACING.spacing16} 0`}
+      >
+        {formErrors.map((error, key) => makeAlert('error', error, key))}
+        {formWarnings.map((warning, key) => makeAlert('warning', warning, key))}
+      </Flex>
+    ) : null
+  }
+
+  return timelineWarnings.length > 0 ? (
     <Flex
       flexDirection={DIRECTION_COLUMN}
       gridGap={SPACING.spacing4}
       padding={`${SPACING.spacing16} ${SPACING.spacing16} 0`}
     >
-      {formErrors.map((error, key) => makeAlert('error', error, key))}
-      {formWarnings.map((warning, key) => makeAlert('warning', warning, key))}
       {timelineWarnings.map((warning, key) =>
         makeAlert('warning', warning, key)
       )}

--- a/protocol-designer/src/organisms/Alerts/FormAlerts.tsx
+++ b/protocol-designer/src/organisms/Alerts/FormAlerts.tsx
@@ -122,17 +122,13 @@ function FormAlertsComponent(props: FormAlertsProps): JSX.Element | null {
       </Banner>
     </Flex>
   )
+
   const formErrors = [
-    ...visibleFormErrors.reduce((acc, error) => {
-      return error.showAtForm ?? true
-        ? {
-            ...acc,
-            title: error.title,
-            description: error.body || null,
-            showAtForm: error.showAtForm ?? true,
-          }
-        : acc
-    }, []),
+    ...visibleFormErrors.map(error => ({
+      title: error.title,
+      description: error.body ?? null,
+      showAtForm: error.showAtForm ?? true,
+    })),
     ...visibleDynamicFieldFormErrors.map(error => ({
       title: error.title,
       description: error.body || null,

--- a/protocol-designer/src/organisms/Alerts/__tests__/FormAlerts.test.tsx
+++ b/protocol-designer/src/organisms/Alerts/__tests__/FormAlerts.test.tsx
@@ -37,6 +37,7 @@ describe('FormAlerts', () => {
     props = {
       focusedField: null,
       dirtyFields: [],
+      showFormErrorsAndWarnings: false,
     }
     vi.mocked(getFormLevelErrorsForUnsavedForm).mockReturnValue([])
     vi.mocked(getFormWarningsForSelectedStep).mockReturnValue([])
@@ -62,6 +63,7 @@ describe('FormAlerts', () => {
     expect(vi.mocked(dismissTimelineWarning)).toHaveBeenCalled()
   })
   it('renders a form level warning that is dismissible', () => {
+    props.showFormErrorsAndWarnings = true
     vi.mocked(getFormWarningsForSelectedStep).mockReturnValue([
       {
         type: 'TIP_POSITIONED_LOW_IN_TUBE',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -244,9 +244,11 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
           </Flex>
         }
       >
-        {showFormErrorsAndWarnings ? (
-          <FormAlerts focusedField={focusedField} dirtyFields={dirtyFields} />
-        ) : null}
+        <FormAlerts
+          focusedField={focusedField}
+          dirtyFields={dirtyFields}
+          showFormErrorsAndWarnings={showFormErrorsAndWarnings}
+        />
         <ToolsComponent
           {...{
             formData,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -128,7 +128,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
         nozzles={String(propsForFields.nozzles.value) ?? null}
         hasFormError={
           visibleFormErrors?.some(error =>
-            error.dependentFields.includes('aspirate_labware')
+            error.dependentFields.includes('aspirate_wells')
           ) ?? false
         }
       />


### PR DESCRIPTION
closes RQA-3450

# Overview

Fix how the timeline warnings appear when reopening a form

## Test Plan and Hands on Testing

Create a transfer step with no liquids defined. after you make it, you should see a warning icon on the step. reopen the step and see the warning at the top of the form

## Changelog

- branching logic for the timeline warnings vs form errors/warnings

## Risk assessment

low
