### PR TITLE
fix(protocol-designer): timer fields to allow : again

### DIFF
--- a/protocol-designer/src/molecules/InputStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/InputStepFormField/index.tsx
@@ -5,6 +5,7 @@ import type { FieldProps } from '../../components/StepEditForm/types'
 
 interface InputStepFormFieldProps extends FieldProps {
   title: string
+  type?: 'number' | 'text' | 'password'
   setIsPristine?: Dispatch<SetStateAction<boolean>>
   units?: string
   padding?: string
@@ -31,6 +32,7 @@ export function InputStepFormField(
     caption,
     formLevelError,
     setIsPristine,
+    type,
     ...otherProps
   } = props
   const { t } = useTranslation('tooltip')
@@ -42,7 +44,7 @@ export function InputStepFormField(
         tooltipText={
           showTooltip ? t(`${tooltipContent}`) ?? undefined : undefined
         }
-        type="number"
+        type={type}
         title={title}
         caption={caption}
         name={name}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -80,6 +80,7 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
     <InputStepFormField
       {...passThruProps}
       padding="0"
+      type="number"
       setIsPristine={setIsPristine}
       errorToShow={errorMessage}
       key={`${flowRateType}_FlowRateInput`}


### PR DESCRIPTION
# Overview

fixes a bug i introduced where the timer fields wouldn't allow you to add a `:`

## Test Plan and Hands on Testing

Test out a pause or heater-shaker timer field and make sure you can type a `:`

then, test a flow rate field in transfer/mix and see that you can add a `.`

## Changelog

- allow input field type to be optional instead of fixed with "number"

## Risk assessment

low
