### PR TITLE
fix(app): fix dropping tips in predefined waste chute location during Error Recovery

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -102,7 +102,7 @@ export function useDropTipCommands({
 
   const moveToAddressableArea = (
     addressableArea: AddressableAreaName,
-    stayAtHighestPossibleZ = true // Generally false when moving to a waste chute or trash bin.
+    stayAtHighestPossibleZ = true // Generally false when moving to a waste chute or trash bin or during "fixit" flows.
   ): Promise<void> => {
     return new Promise((resolve, reject) => {
       const addressableAreaFromConfig = getAddressableAreaFromConfig(
@@ -127,7 +127,7 @@ export function useDropTipCommands({
                 moveToAACommand,
               ]
             : [Z_HOME, moveToAACommand],
-          true
+          false
         )
           .then((commandData: CommandData[]) => {
             const error = commandData[0].data.error
@@ -222,7 +222,7 @@ export function useDropTipCommands({
         currentRoute === DT_ROUTES.BLOWOUT
           ? buildBlowoutCommands(instrumentModelSpecs, isFlex, pipetteId)
           : buildDropTipInPlaceCommand(isFlex, pipetteId),
-        true
+        false
       )
         .then((commandData: CommandData[]) => {
           const error = commandData[0].data.error

--- a/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
@@ -32,6 +32,7 @@ interface ChooseLocationProps extends DropTipWizardContainerProps {
 }
 
 export function ChooseLocation({
+  issuedCommandsType,
   dropTipCommandLocations,
   dropTipCommands,
   goBackRunValid,
@@ -97,7 +98,7 @@ export function ChooseLocation({
     toggleIsRobotPipetteMoving()
     void moveToAddressableArea(
       selectedLocation?.slotName as AddressableAreaName,
-      false
+      issuedCommandsType === 'fixit' // Because PE has tip state during fixit flows, do not specify a manual offset.
     ).then(() => {
       void blowoutOrDropTip(currentRoute, () => {
         const successStep =


### PR DESCRIPTION
Closes [EXEC-794](https://opentrons.atlassian.net/browse/EXEC-794)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

[8.2.0 adds predefined drop tip locations,](https://www.figma.com/design/OGssKRmCOvuXSqUpK2qXrV/Feature%3A-Error-Recovery-November-Release?node-id=9752-49391&t=xc6oiRgheGgsCwXk-4) and during drop tip wizard, the flow does not always have context concerning tip attachment status (ie, during maintenance runs). During a maintenance run, to automatically jog the pipette down somewhat before dropping the tip, we `moveToAddressableArea` with a predefined offset. 

While this works well for maintenance run type drop tip flows, it does not always play nicely during fixit type drop flows (ie, during Error Recovery). When attempting to move to an addressable area with the predefined z-offset, the command may fail with an error pointing to the z-offset being invalid given the attached tip.

There are several potential ways to work around this including:

1. Never specify an offset, always dropping into the waste chute (and trash bin) at maximum height. This works, but could be unideal in a real world scenario.
2. Use the predefined z-offset during maintenance run type drop tip flows only (no offset during Error Recovery/fixit type flows). This works, however, the z-offset moved traversed during fixit type flows is less than during a maintenance run type flow.
3. During a fixit type flow, get some information about currently attached tip length and use that. 

To keep complexity down and reduce the bug surface, this PR implements option 2.

Additionally, it's probably not a good idea to drop tips or blowout if the `moveToAddressableArea` command fails, so let's change that!

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran all permutations of moving to the predefined waste chute/trash bin locations in drop tip during Error Recovery and drop tip standalone, verifying expected behavior. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed dropping tips or blowing out in the waste chute during Error Recovery not always working.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-794]: https://opentrons.atlassian.net/browse/EXEC-794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ