### PR TITLE
fix(api): Fix Yocto check preventing OT-2s from booting

### DIFF
--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 from opentrons.config import CONFIG, ARCHITECTURE, SystemArchitecture
 
-if ARCHITECTURE is SystemArchitecture.BUILDROOT:
+if ARCHITECTURE is SystemArchitecture.YOCTO:
     from opentrons_hardware.sensors import SENSOR_LOG_NAME
 else:
     # we don't use the sensor log on ot2 or host


### PR DESCRIPTION
## Overview

This is a follow-up to #16590. That fix was fundamentally right, but its logic was accidentally flipped, so it didn't work. Neither of us noticed in code review, oops.

## Test Plan and Hands on Testing

* [x] Try it on an OT-2 and make sure the OT-2 boots.
* [x] Try it on a Flex and make sure the Flex boots.

## Review requests

Is this right?

## Risk assessment

Low.