### PR TITLE
fix(api): Fix Yocto check preventing OT-2s from booting

### DIFF
--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 from opentrons.config import CONFIG, ARCHITECTURE, SystemArchitecture
 
-if ARCHITECTURE is SystemArchitecture.BUILDROOT:
+if ARCHITECTURE is SystemArchitecture.YOCTO:
     from opentrons_hardware.sensors import SENSOR_LOG_NAME
 else:
     # we don't use the sensor log on ot2 or host


### PR DESCRIPTION
Same as https://github.com/Opentrons/opentrons/pull/16637, but into the release branch.

(cherry picked from commit d140271f4e318e3f2470a4d8c446156825bc9492)