### PR TITLE
fix(abr-testing): Resolves missing coordinate data issue during upload.

### DIFF
--- a/abr-testing/abr_testing/data_collection/abr_calibration_logs.py
+++ b/abr-testing/abr_testing/data_collection/abr_calibration_logs.py
@@ -82,7 +82,7 @@ def module_helper(
                 y = one_module["moduleOffset"]["offset"].get("y", "")
                 z = one_module["moduleOffset"]["offset"].get("z", "")
             except KeyError:
-                pass
+                continue
             if mod_serial in module_sheet_serials and modified in module_modify_dates:
                 continue
             module_row = (


### PR DESCRIPTION
Fix to prevent make abr-setup from failing due to no x, y, or z data in calibration log