### PR TITLE
fix(app): fix errant GET /run/:runId requests

### DIFF
--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -20,7 +20,7 @@ export function useNotifyRunQuery<TError = Error>(
 
   const httpQueryResult = useRunQuery(runId, queryOptionsNotify, hostOverride)
 
-  if (shouldRefetch) {
+  if (shouldRefetch && runId != null) {
     void httpQueryResult.refetch()
   }
 

--- a/app/src/resources/runs/useRunStatus.ts
+++ b/app/src/resources/runs/useRunStatus.ts
@@ -1,9 +1,7 @@
-import { useRef } from 'react'
 import {
   RUN_ACTION_TYPE_PLAY,
   RUN_STATUS_IDLE,
   RUN_STATUS_RUNNING,
-  RUN_STATUSES_TERMINAL,
 } from '@opentrons/api-client'
 import { useNotifyRunQuery } from './useNotifyRunQuery'
 import { DEFAULT_STATUS_REFETCH_INTERVAL } from './constants'
@@ -15,14 +13,8 @@ export function useRunStatus(
   runId: string | null,
   options?: UseQueryOptions<Run>
 ): RunStatus | null {
-  const lastRunStatus = useRef<RunStatus | null>(null)
-
   const { data } = useNotifyRunQuery(runId ?? null, {
     refetchInterval: DEFAULT_STATUS_REFETCH_INTERVAL,
-    enabled:
-      lastRunStatus.current == null ||
-      !(RUN_STATUSES_TERMINAL as RunStatus[]).includes(lastRunStatus.current),
-    onSuccess: data => (lastRunStatus.current = data?.data?.status ?? null),
     ...options,
   })
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When viewing the Devices tab on the desktop app, there are a lot of `GET` requests to `/runs/null`. These errant requests are generated by two places:

### `useRunStatuses`

The complex enabled logic has bit us in the past here - in this case, the custom `enabled` condition overrides the default condition not to fetch if there is no `runId`, creating the errant fetch. Prior to notifications, it was important to selectively enable this hook to prevent polling unnecessarily. However, telemetry indicates that pretty much everyone uses notifications, and this hook uses notifications, so for the sake of keeping things simple, let's just remove this logic. Worst case scenario, it's not terrible to poll here if MQTT is blocked.

### `useNotifyRunQuery`

A manual `refetch()` does not use the underlying `enabled` conditional logic of `useRunQuery`. There are two ways to solve it, either the way in this PR, or do extend `useRunQuery` to return a manual refetch function that wraps the custom, lower-level `enabled` logic.

For simplicity, I've chosen path 1, but I do think it would be worth revisiting this if we add more notification hooks with "always fetch only in specific circumstances" type logic.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- On the desktop app, navigated to the Devices tab and noted that healthy reachable robots without active runs no longer make requests to `runs/:runId`. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- There are no longer errant network requests to `/runs/runId` when there is no active run.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low - this doesn't touch networking in any potentially strange way.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
