### PR TITLE
fix(api): allow labware def schema v3

### DIFF
--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -593,7 +593,7 @@ class InnerWellGeometry(BaseModel):
 
 
 class LabwareDefinition(BaseModel):
-    schemaVersion: Literal[1, 2] = Field(
+    schemaVersion: Literal[1, 2, 3] = Field(
         ..., description="Which schema version a labware is using"
     )
     version: int = Field(


### PR DESCRIPTION
## Overview
Forgot to allow labware schema v3 from `labware_definitions.py`. Here's a fix for that 