### PR TITLE
fix(api): restrict the labware that can be moved to the plate reader + validate wavelengths.

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -581,7 +581,34 @@ class AbsorbanceReaderCore(ModuleCore, AbstractAbsorbanceReaderCore):
                 "Cannot perform Initialize action on Absorbance Reader without calling `.close_lid()` first."
             )
 
-        # TODO: check that the wavelengths are within the supported wavelengths
+        wavelength_len = len(wavelengths)
+        if mode == "single" and wavelength_len != 1:
+            raise ValueError(
+                f"Single mode can only be initialized with 1 wavelength"
+                f" {wavelength_len} wavelengths provided instead."
+            )
+
+        if mode == "multi" and (wavelength_len < 1 or wavelength_len > 6):
+            raise ValueError(
+                f"Multi mode can only be initialized with 1 - 6 wavelengths."
+                f" {wavelength_len} wavelengths provided instead."
+            )
+
+        if reference_wavelength is not None and (
+            reference_wavelength < 350 or reference_wavelength > 1000
+        ):
+            raise ValueError(
+                f"Unsupported reference wavelength: ({reference_wavelength}) needs"
+                f" to between 350 and 1000 nm."
+            )
+
+        for wavelength in wavelengths:
+            if not isinstance(wavelength, int) or wavelength < 350 or wavelength > 1000:
+                raise ValueError(
+                    f"Unsupported sample wavelength: ({wavelength}) needs"
+                    f" to between 350 and 1000 nm."
+                )
+
         self._engine_client.execute_command(
             cmd.absorbance_reader.InitializeParams(
                 moduleId=self.module_id,

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -41,6 +41,11 @@ from ..module import (
 from .exceptions import InvalidMagnetEngageHeightError
 
 
+# Valid wavelength range for absorbance reader
+ABS_WAVELENGTH_MIN = 350
+ABS_WAVELENGTH_MAX = 1000
+
+
 class ModuleCore(AbstractModuleCore):
     """Module core logic implementation for Python protocols.
     Args:
@@ -595,18 +600,23 @@ class AbsorbanceReaderCore(ModuleCore, AbstractAbsorbanceReaderCore):
             )
 
         if reference_wavelength is not None and (
-            reference_wavelength < 350 or reference_wavelength > 1000
+            reference_wavelength < ABS_WAVELENGTH_MIN
+            or reference_wavelength > ABS_WAVELENGTH_MAX
         ):
             raise ValueError(
                 f"Unsupported reference wavelength: ({reference_wavelength}) needs"
-                f" to between 350 and 1000 nm."
+                f" to between {ABS_WAVELENGTH_MIN} and {ABS_WAVELENGTH_MAX} nm."
             )
 
         for wavelength in wavelengths:
-            if not isinstance(wavelength, int) or wavelength < 350 or wavelength > 1000:
+            if (
+                not isinstance(wavelength, int)
+                or wavelength < ABS_WAVELENGTH_MIN
+                or wavelength > ABS_WAVELENGTH_MAX
+            ):
                 raise ValueError(
                     f"Unsupported sample wavelength: ({wavelength}) needs"
-                    f" to between 350 and 1000 nm."
+                    f" to between {ABS_WAVELENGTH_MIN} and {ABS_WAVELENGTH_MAX} nm."
                 )
 
         self._engine_client.execute_command(

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -162,12 +162,12 @@ class LoadLabwareImplementation(
                 top_labware_definition=loaded_labware.definition,
                 bottom_labware_id=verified_location.labwareId,
             )
-        # Labware needs to be 15mm or less to fit into the absorbance reader
+        # Validate labware for the absorbance reader
         elif isinstance(params.location, ModuleLocation):
             module = self._state_view.modules.get(params.location.moduleId)
             if module is not None and module.model == ModuleModel.ABSORBANCE_READER_V1:
                 self._state_view.labware.raise_if_labware_incompatible_with_plate_reader(
-                    loaded_labware.labware_id
+                    loaded_labware.definition
                 )
 
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -10,6 +10,8 @@ from ..errors import LabwareIsNotAllowedInLocationError
 from ..resources import labware_validation, fixture_validation
 from ..types import (
     LabwareLocation,
+    ModuleLocation,
+    ModuleModel,
     OnLabwareLocation,
     DeckSlotLocation,
     AddressableAreaLocation,
@@ -160,6 +162,13 @@ class LoadLabwareImplementation(
                 top_labware_definition=loaded_labware.definition,
                 bottom_labware_id=verified_location.labwareId,
             )
+        # Labware needs to be 15mm or less to fit into the absorbance reader
+        elif isinstance(params.location, ModuleLocation):
+            module = self._state_view.modules.get(params.location.moduleId)
+            if module is not None and module.model == ModuleModel.ABSORBANCE_READER_V1:
+                self._state_view.labware.raise_if_labware_incompatible_with_plate_reader(
+                    loaded_labware.labware_id
+                )
 
         return SuccessData(
             public=LoadLabwareResult(

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -223,12 +223,12 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
                 raise LabwareMovementNotAllowedError(
                     "Cannot move a labware onto itself."
                 )
-        # Labware needs to be 15mm or less to fit into the absorbance reader
+        # Validate labware for the absorbance reader
         elif isinstance(available_new_location, ModuleLocation):
             module = self._state_view.modules.get(available_new_location.moduleId)
             if module is not None and module.model == ModuleModel.ABSORBANCE_READER_V1:
                 self._state_view.labware.raise_if_labware_incompatible_with_plate_reader(
-                    params.labwareId
+                    current_labware_definition
                 )
 
         # Allow propagation of ModuleNotLoadedError.

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -13,9 +13,11 @@ from typing_extensions import Literal
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.types import Point
 from ..types import (
+    ModuleModel,
     CurrentWell,
     LabwareLocation,
     DeckSlotLocation,
+    ModuleLocation,
     OnLabwareLocation,
     AddressableAreaLocation,
     LabwareMovementStrategy,
@@ -187,6 +189,13 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
             if params.labwareId == available_new_location.labwareId:
                 raise LabwareMovementNotAllowedError(
                     "Cannot move a labware onto itself."
+                )
+        # Labware needs to be 15mm or less to fit into the absorbance reader
+        elif isinstance(available_new_location, ModuleLocation):
+            module = self._state_view.modules.get(available_new_location.moduleId)
+            if module is not None and module.model == ModuleModel.ABSORBANCE_READER_V1:
+                self._state_view.labware.raise_if_labware_incompatible_with_plate_reader(
+                    params.labwareId
                 )
 
         # Allow propagation of ModuleNotLoadedError.

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -13,9 +13,11 @@ from typing_extensions import Literal
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.types import Point
 from ..types import (
+    ModuleModel,
     CurrentWell,
     LabwareLocation,
     DeckSlotLocation,
+    ModuleLocation,
     OnLabwareLocation,
     AddressableAreaLocation,
     LabwareMovementStrategy,
@@ -220,6 +222,13 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
             if params.labwareId == available_new_location.labwareId:
                 raise LabwareMovementNotAllowedError(
                     "Cannot move a labware onto itself."
+                )
+        # Labware needs to be 15mm or less to fit into the absorbance reader
+        elif isinstance(available_new_location, ModuleLocation):
+            module = self._state_view.modules.get(available_new_location.moduleId)
+            if module is not None and module.model == ModuleModel.ABSORBANCE_READER_V1:
+                self._state_view.labware.raise_if_labware_incompatible_with_plate_reader(
+                    params.labwareId
                 )
 
         # Allow propagation of ModuleNotLoadedError.

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -82,7 +82,7 @@ _RIGHT_SIDE_SLOTS = {
 
 
 # The max height of the labware that can fit in a plate reader
-_PLATE_READER_MAX_LABWARE_Z_MM = 15
+_PLATE_READER_MAX_LABWARE_Z_MM = 16
 
 
 class LabwareLoadParams(NamedTuple):
@@ -824,26 +824,25 @@ class LabwareView(HasState[LabwareState]):
 
     def raise_if_labware_incompatible_with_plate_reader(
         self,
-        labware_id: str,
+        labware_definition: LabwareDefinition,
     ) -> None:
         """Raise an error if the labware is not compatible with the plate reader."""
-        labware_definition = self.get_definition(labware_id)
-        if labware_definition is not None:
+        # TODO: (ba, 2024-11-1): the plate reader lid should not be a labware.
+        load_name = labware_definition.parameters.loadName
+        if load_name != "opentrons_flex_lid_absorbance_plate_reader_module":
             number_of_wells = len(labware_definition.wells)
             if number_of_wells != 96:
                 raise errors.LabwareMovementNotAllowedError(
-                    f"Cannot move '{labware_definition.parameters.loadName}'"
-                    f" into plate reader because the labware contains {number_of_wells}"
-                    f" wells where 96 wells is expected."
+                    f"Cannot move '{load_name}' into plate reader because the"
+                    f" labware contains {number_of_wells} wells where 96 wells is expected."
                 )
             elif (
                 labware_definition.dimensions.zDimension
                 > _PLATE_READER_MAX_LABWARE_Z_MM
             ):
                 raise errors.LabwareMovementNotAllowedError(
-                    f"Cannot move '{labware_definition.parameters.loadName}'"
-                    f" into plate reader because the maximum allowed labware height"
-                    f" is {_PLATE_READER_MAX_LABWARE_Z_MM}mm."
+                    f"Cannot move '{load_name}' into plate reader because the"
+                    f" maximum allowed labware height is {_PLATE_READER_MAX_LABWARE_Z_MM}mm."
                 )
 
     def raise_if_labware_cannot_be_stacked(  # noqa: C901

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -81,6 +81,10 @@ _RIGHT_SIDE_SLOTS = {
 }
 
 
+# The max height of the labware that can fit in a plate reader
+_PLATE_READER_MAX_LABWARE_Z_MM = 15
+
+
 class LabwareLoadParams(NamedTuple):
     """Parameters required to load a labware in Protocol Engine."""
 
@@ -815,6 +819,30 @@ class LabwareView(HasState[LabwareState]):
             if labware.location == location:
                 raise errors.LocationIsOccupiedError(
                     f"Labware {labware.loadName} is already present at {location}."
+                )
+
+    def raise_if_labware_incompatible_with_plate_reader(
+        self,
+        labware_id: str,
+    ) -> None:
+        """Raise an error if the labware is not compatible with the plate reader."""
+        labware_definition = self.get_definition(labware_id)
+        if labware_definition is not None:
+            number_of_wells = len(labware_definition.wells)
+            if number_of_wells != 96:
+                raise errors.LabwareMovementNotAllowedError(
+                    f"Cannot move '{labware_definition.parameters.loadName}'"
+                    f" into plate reader because the labware contains {number_of_wells}"
+                    f" wells where 96 wells is expected."
+                )
+            elif (
+                labware_definition.dimensions.zDimension
+                > _PLATE_READER_MAX_LABWARE_Z_MM
+            ):
+                raise errors.LabwareMovementNotAllowedError(
+                    f"Cannot move '{labware_definition.parameters.loadName}'"
+                    f" into plate reader because the maximum allowed labware height"
+                    f" is {_PLATE_READER_MAX_LABWARE_Z_MM}mm."
                 )
 
     def raise_if_labware_cannot_be_stacked(  # noqa: C901

--- a/api/tests/opentrons/protocol_api/core/engine/test_absorbance_reader_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_absorbance_reader_core.py
@@ -69,59 +69,67 @@ def test_initialize(
 ) -> None:
     """It should set the sample wavelength with the engine client."""
     subject._ready_to_initialize = True
-    subject.initialize("single", [123])
+    subject.initialize("single", [350])
 
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.absorbance_reader.InitializeParams(
                 moduleId="1234",
                 measureMode="single",
-                sampleWavelengths=[123],
+                sampleWavelengths=[350],
                 referenceWavelength=None,
             ),
         ),
         times=1,
     )
-    assert subject._initialized_value == [123]
+    assert subject._initialized_value == [350]
 
     # Test reference wavelength
-    subject.initialize("single", [124], 450)
+    subject.initialize("single", [350], 450)
 
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.absorbance_reader.InitializeParams(
                 moduleId="1234",
                 measureMode="single",
-                sampleWavelengths=[124],
+                sampleWavelengths=[350],
                 referenceWavelength=450,
             ),
         ),
         times=1,
     )
-    assert subject._initialized_value == [124]
+    assert subject._initialized_value == [350]
 
     # Test initialize multi
-    subject.initialize("multi", [124, 125, 126])
+    subject.initialize("multi", [350, 400, 450])
 
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.absorbance_reader.InitializeParams(
                 moduleId="1234",
                 measureMode="multi",
-                sampleWavelengths=[124, 125, 126],
+                sampleWavelengths=[350, 400, 450],
                 referenceWavelength=None,
             ),
         ),
         times=1,
     )
-    assert subject._initialized_value == [124, 125, 126]
+    assert subject._initialized_value == [350, 400, 450]
 
 
 def test_initialize_not_ready(subject: AbsorbanceReaderCore) -> None:
     """It should raise CannotPerformModuleAction if you dont call .close_lid() command."""
     subject._ready_to_initialize = False
     with pytest.raises(CannotPerformModuleAction):
-        subject.initialize("single", [123])
+        subject.initialize("single", [350])
+
+
+@pytest.mark.parametrize("wavelength", [-350, 0, 1200, "wda"])
+def test_invalid_wavelengths(wavelength: int, subject: AbsorbanceReaderCore) -> None:
+    """It should raise ValueError if you provide an invalid wavelengthi."""
+    subject._ready_to_initialize = True
+    with pytest.raises(ValueError):
+        subject.initialize("single", [wavelength])
 
 
 def test_read(
@@ -129,7 +137,7 @@ def test_read(
 ) -> None:
     """It should call absorbance reader to read with the engine client."""
     subject._ready_to_initialize = True
-    subject._initialized_value = [123]
+    subject._initialized_value = [350]
     substate = AbsorbanceReaderSubState(
         module_id=AbsorbanceReaderId(subject.module_id),
         configured=True,
@@ -152,6 +160,7 @@ def test_read(
         mock_engine_client.execute_command(
             cmd.absorbance_reader.ReadAbsorbanceParams(
                 moduleId="1234",
+                fileName=None,
             ),
         ),
         times=1,


### PR DESCRIPTION
# Overview

This pull request restricts labware that can be loaded or moved onto a plate reader slot
* Contains 96 wells exactly
* Is below a certain height restriction (16 mm)

This also restricts the wavelengths that can be used

Closes: [PLAT-541](https://opentrons.atlassian.net/browse/PLAT-541) [PLAT-581](https://opentrons.atlassian.net/browse/PLAT-581)

## Test Plan and Hands on Testing

- [x] Load and move labware on a plate reader with a height 15mm or less
- [x] Make sure we raise `LabwareMovementNotAllowedError` if the labware is not 96 wells or the height is > 15mm
- [x] Make sure we only accept wavelengths in the range of 350 - 1000 nm or throw analysis error otherwise
- [x] Make sure we only accept 1 wavelength in single mode and 1-6 wavelengths in multi-mode or throw analysis error otherwise.

## Changelog

- add `raise_if_labware_incompatible_with_plate_reader` that checks labware compatibility with the plate reader
- use `raise_if_labware_incompatible_with_plate_reader` in `LoadModule` and `MoveLabware` commands.
- Add checks to absorbance reader PAPI commands so we fail during analysis if we have invalid wavelengths

## Review requests

- is the labware.py module the correct location for `raise_if_labware_incompatible_with_plate_reader`

## Risk assessment
low

[PLAT-541]: https://opentrons.atlassian.net/browse/PLAT-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PLAT-581]: https://opentrons.atlassian.net/browse/PLAT-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ