### PR TITLE
fix(api): update the plate reader serial number parser to include BYO and OPT delims.

### DIFF
--- a/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
+++ b/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
@@ -24,7 +24,7 @@ from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnect
 
 SN_PARSER = re.compile(r'ATTRS{serial}=="(?P<serial>.+?)"')
 VERSION_PARSER = re.compile(r"Absorbance (?P<version>V\d+\.\d+\.\d+)")
-SERIAL_PARSER = re.compile(r"(?P<serial>BYO[A-Z]{3}[0-9]{5})")
+SERIAL_PARSER = re.compile(r"(?P<serial>(OPT|BYO)[A-Z]{3}[0-9]{5})")
 
 
 class AsyncByonoy:
@@ -158,7 +158,7 @@ class AsyncByonoy:
         self._raise_if_error(err.name, f"Error getting device information: {err}")
         serial_match = SERIAL_PARSER.match(device_info.sn)
         version_match = VERSION_PARSER.match(device_info.version)
-        serial = serial_match["serial"] if serial_match else "BYOMAA00000"
+        serial = serial_match["serial"] if serial_match else "OPTMAA00000"
         version = version_match["version"].lower() if version_match else "v0.0.0"
         info = {
             "serial": serial,

--- a/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
+++ b/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
@@ -24,7 +24,7 @@ from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnect
 
 SN_PARSER = re.compile(r'ATTRS{serial}=="(?P<serial>.+?)"')
 VERSION_PARSER = re.compile(r"Absorbance (?P<version>V\d+\.\d+\.\d+)")
-SERIAL_PARSER = re.compile(r"(?P<serial>(OPT|BYO)[A-Z]{3}[0-9]{5})")
+SERIAL_PARSER = re.compile(r"(?P<serial>(OPT|BYO)[A-Z]{3}[0-9]+)")
 
 
 class AsyncByonoy:
@@ -156,9 +156,9 @@ class AsyncByonoy:
             func=partial(self._interface.get_device_information, handle),
         )
         self._raise_if_error(err.name, f"Error getting device information: {err}")
-        serial_match = SERIAL_PARSER.match(device_info.sn)
+        serial_match = SERIAL_PARSER.fullmatch(device_info.sn)
         version_match = VERSION_PARSER.match(device_info.version)
-        serial = serial_match["serial"] if serial_match else "OPTMAA00000"
+        serial = serial_match["serial"].strip() if serial_match else "OPTMAA00000"
         version = version_match["version"].lower() if version_match else "v0.0.0"
         info = {
             "serial": serial,

--- a/api/tests/opentrons/drivers/absorbance_reader/test_driver.py
+++ b/api/tests/opentrons/drivers/absorbance_reader/test_driver.py
@@ -90,8 +90,39 @@ async def test_driver_get_device_info(
 
     info = await connected_driver.get_device_info()
 
-    mock_interface.get_device_information.assert_called_once()
     assert info == {"serial": "BYOMAA00013", "model": "ABS96", "version": "v1.0.2"}
+    mock_interface.get_device_information.assert_called_once()
+    mock_interface.reset_mock()
+
+    # Test Device info with updated serial format
+    DEVICE_INFO.sn = "OPTMAA00034"
+    DEVICE_INFO.version = "Absorbance V1.0.2 2024-04-18"
+
+    mock_interface.get_device_information.return_value = (
+        MockErrorCode.NO_ERROR,
+        DEVICE_INFO,
+    )
+
+    info = await connected_driver.get_device_info()
+
+    assert info == {"serial": "OPTMAA00034", "model": "ABS96", "version": "v1.0.2"}
+    mock_interface.get_device_information.assert_called_once()
+    mock_interface.reset_mock()
+
+    # Test Device info with invalid serial format
+    DEVICE_INFO.sn = "YRFGHVMAA00034"
+    DEVICE_INFO.version = "Absorbance V1.0.2 2024-04-18"
+
+    mock_interface.get_device_information.return_value = (
+        MockErrorCode.NO_ERROR,
+        DEVICE_INFO,
+    )
+
+    info = await connected_driver.get_device_info()
+
+    assert info == {"serial": "OPTMAA00000", "model": "ABS96", "version": "v1.0.2"}
+    mock_interface.get_device_information.assert_called_once()
+    mock_interface.reset_mock()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

The serial number format was updated to OPT instead of BYO, so let's update the parser to include both.

## Test Plan and Hands on Testing

- [x] Plate reader with `BYO` in serial number is shown on the desktop app with full serial number
- [ ] Plate reader with `OPT` in serial number is shown on the desktop app with full serial number

## Changelog

- Update the serial number parser for the plate reader to include both OPT and BYO delimiters.

## Review requests
## Risk assessment

low