### PR TITLE
feat(protocol-designer): define liquids banner to assign liquids toolbox

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -67,6 +67,8 @@ export interface DropdownMenuProps {
   onFocus?: React.FocusEventHandler<HTMLButtonElement>
   /** blur handler */
   onBlur?: React.FocusEventHandler<HTMLButtonElement>
+  /** optional disabled */
+  disabled?: boolean
 }
 
 // TODO: (smb: 4/15/22) refactor this to use html select for accessibility
@@ -83,6 +85,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
     tooltipText,
     tabIndex = 0,
     error,
+    disabled = false,
     onFocus,
     onBlur,
   } = props
@@ -165,10 +168,12 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
 
   const DROPDOWN_STYLE = css`
     flex-direction: ${DIRECTION_ROW};
+    color: ${disabled ? COLORS.grey40 : COLORS.black90};
     background-color: ${COLORS.white};
     cursor: ${isDisabled ? CURSOR_DEFAULT : CURSOR_POINTER};
     padding: ${SPACING.spacing8} ${SPACING.spacing12};
-    border: 1px ${BORDERS.styleSolid} ${defaultBorderColor};
+    border: 1px ${BORDERS.styleSolid}
+      ${disabled ? COLORS.grey35 : defaultBorderColor};
     border-radius: ${dropdownType === 'rounded'
       ? BORDERS.borderRadiusFull
       : BORDERS.borderRadius4};
@@ -178,7 +183,8 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
     height: 2.25rem;
 
     &:hover {
-      border: 1px ${BORDERS.styleSolid} ${hoverBorderColor};
+      border: 1px ${BORDERS.styleSolid}
+        ${disabled ? COLORS.grey35 : hoverBorderColor};
     }
 
     &:active {
@@ -190,11 +196,6 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
       outline: 2px ${BORDERS.styleSolid} ${COLORS.blue50};
       outline-offset: 2px;
     }
-
-    &:disabled {
-      background-color: ${COLORS.transparent};
-      color: ${COLORS.grey40};
-    }
   `
   return (
     <Flex
@@ -204,7 +205,10 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
     >
       {title !== null ? (
         <Flex gridGap={SPACING.spacing8} paddingBottom={SPACING.spacing8}>
-          <StyledText desktopStyle="captionRegular" color={COLORS.grey60}>
+          <StyledText
+            desktopStyle="captionRegular"
+            color={disabled ? COLORS.grey35 : COLORS.grey60}
+          >
             {title}
           </StyledText>
           {tooltipText != null ? (
@@ -272,7 +276,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
             {filterOptions.map((option, index) => (
               <React.Fragment key={`${option.name}-${index}`}>
                 <MenuItem
-                  disabled={option.disabled}
+                  disabled={disabled ?? option.disabled}
                   zIndex={3}
                   key={`${option.name}-${index}`}
                   onClick={() => {

--- a/protocol-designer/src/assets/localization/en/liquids.json
+++ b/protocol-designer/src/assets/localization/en/liquids.json
@@ -3,6 +3,7 @@
   "add": "Add",
   "clear_wells": "Clear wells",
   "click_and_drag": "Click and drag to select wells",
+  "define_liq": "Define liquid",
   "define_liquid": "Define a liquid",
   "delete_liquid": "Delete liquid",
   "description": "Description",
@@ -13,6 +14,7 @@
   "liquids": "Liquids",
   "microliters": "µL",
   "name": "Name",
+  "no_liquids_defined": "No liquids defined",
   "save": "Save",
   "well": "Well"
 }

--- a/protocol-designer/src/assets/localization/en/liquids.json
+++ b/protocol-designer/src/assets/localization/en/liquids.json
@@ -3,7 +3,6 @@
   "add": "Add",
   "clear_wells": "Clear wells",
   "click_and_drag": "Click and drag to select wells",
-  "define_liq": "Define liquid",
   "define_liquid": "Define a liquid",
   "delete_liquid": "Delete liquid",
   "description": "Description",

--- a/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -257,7 +257,7 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
                   {t('add_liquid')}
                 </StyledText>
                 {liquidSelectionOptions.length === 0 ? (
-                  <Banner type="warning">
+                  <Banner type="warning" iconMarginLeft={SPACING.spacing4}>
                     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
                       <StyledText desktopStyle="captionRegular">
                         {t('no_liquids_defined')}

--- a/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -14,8 +14,8 @@ import {
   PrimaryButton,
   SPACING,
   StyledText,
-  TYPOGRAPHY,
   Toolbox,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import * as wellContentsSelectors from '../../top-selectors/well-contents'
@@ -30,7 +30,6 @@ import {
 import { deselectAllWells } from '../../well-selection/actions'
 import { DefineLiquidsModal } from '../DefineLiquidsModal'
 import { LiquidCard } from './LiquidCard'
-import type * as React from 'react'
 import type { DropdownOption } from '@opentrons/components'
 import type { ContentsByWell } from '../../labware-ingred/types'
 
@@ -271,7 +270,7 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
                         }}
                       >
                         <StyledText desktopStyle="captionRegular">
-                          {t('define_liq')}
+                          {t('define_liquid')}
                         </StyledText>
                       </Btn>
                     </Flex>

--- a/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -1,9 +1,11 @@
-import type * as React from 'react'
+import { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Controller, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import {
+  Banner,
   Btn,
+  COLORS,
   DIRECTION_COLUMN,
   DropdownMenu,
   Flex,
@@ -16,9 +18,10 @@ import {
   TYPOGRAPHY,
   Toolbox,
 } from '@opentrons/components'
+import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import * as wellContentsSelectors from '../../top-selectors/well-contents'
 import * as fieldProcessors from '../../steplist/fieldLevel/processing'
-import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
+import * as labwareIngredActions from '../../labware-ingred/actions'
 import { getSelectedWells } from '../../well-selection/selectors'
 import { getLabwareNicknamesById } from '../../ui/labware/selectors'
 import {
@@ -26,8 +29,9 @@ import {
   setWellContents,
 } from '../../labware-ingred/actions'
 import { deselectAllWells } from '../../well-selection/actions'
+import { DefineLiquidsModal } from '../DefineLiquidsModal'
 import { LiquidCard } from './LiquidCard'
-
+import type * as React from 'react'
 import type { DropdownOption } from '@opentrons/components'
 import type { ContentsByWell } from '../../labware-ingred/types'
 
@@ -53,6 +57,7 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
   const { onClose } = props
   const { t } = useTranslation(['liquids', 'shared'])
   const dispatch = useDispatch()
+  const [showDefineLiquidModal, setDefineLiquidModal] = useState<boolean>(false)
   const liquids = useSelector(labwareIngredSelectors.allIngredientNamesIds)
   const labwareId = useSelector(labwareIngredSelectors.getSelectedLabwareId)
   const selectedWellGroups = useSelector(getSelectedWells)
@@ -214,145 +219,180 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
     })
     .filter(Boolean)
   return (
-    <Toolbox
-      title={
-        <StyledText desktopStyle="bodyLargeSemiBold">
-          {labwareDisplayName}
-        </StyledText>
-      }
-      confirmButtonText={t('shared:done')}
-      onConfirmClick={onClose}
-      onCloseClick={handleClearSelectedWells}
-      height="calc(100vh - 64px)"
-      closeButton={
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('clear_wells')}
-        </StyledText>
-      }
-      disableCloseButton={
-        !(labwareId != null && selectedWells != null && selectionHasLiquids)
-      }
-    >
-      <form onSubmit={handleSubmit(handleSaveSubmit)}>
-        <ListItem type="noActive">
-          {selectedWells.length > 0 ? (
-            <Flex
-              padding={SPACING.spacing12}
-              gridGap={SPACING.spacing12}
-              flexDirection={DIRECTION_COLUMN}
-            >
-              <StyledText desktopStyle="bodyDefaultSemiBold">
-                {t('add_liquid')}
-              </StyledText>
-              <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-                <StyledText desktopStyle="bodyDefaultRegular">
-                  {t('liquid')}
+    <>
+      {showDefineLiquidModal ? (
+        <DefineLiquidsModal
+          onClose={() => {
+            setDefineLiquidModal(false)
+          }}
+        />
+      ) : null}
+
+      <Toolbox
+        title={
+          <StyledText desktopStyle="bodyLargeSemiBold">
+            {labwareDisplayName}
+          </StyledText>
+        }
+        confirmButtonText={t('shared:done')}
+        onConfirmClick={onClose}
+        onCloseClick={handleClearSelectedWells}
+        height="calc(100vh - 64px)"
+        closeButton={
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {t('clear_wells')}
+          </StyledText>
+        }
+        disableCloseButton={
+          !(labwareId != null && selectedWells != null && selectionHasLiquids)
+        }
+      >
+        <form onSubmit={handleSubmit(handleSaveSubmit)}>
+          <ListItem type="noActive">
+            {selectedWells.length > 0 ? (
+              <Flex
+                padding={SPACING.spacing12}
+                gridGap={SPACING.spacing12}
+                flexDirection={DIRECTION_COLUMN}
+              >
+                <StyledText desktopStyle="bodyDefaultSemiBold">
+                  {t('add_liquid')}
                 </StyledText>
-                <Controller
-                  name="selectedLiquidId"
-                  control={control}
-                  rules={{
-                    required: true,
-                  }}
-                  render={({ field }) => {
-                    const fullOptions: DropdownOption[] = liquidSelectionOptions.map(
-                      option => {
-                        const liquid = liquids.find(
-                          liquid => liquid.ingredientId === option.value
-                        )
-
-                        return {
-                          name: option.name,
-                          value: option.value,
-                          liquidColor: liquid?.displayColor ?? '',
-                        }
-                      }
-                    )
-                    const selectedLiquid = fullOptions.find(
-                      option => option.value === selectedLiquidId
-                    )
-                    const selectLiquidIdName = selectedLiquid?.name
-                    const selectLiquidColor = selectedLiquid?.liquidColor
-
-                    return (
-                      <DropdownMenu
-                        width="254px"
-                        dropdownType="neutral"
-                        filterOptions={fullOptions}
-                        currentOption={{
-                          value: selectedLiquidId ?? '',
-                          name: selectLiquidIdName ?? '',
-                          liquidColor: selectLiquidColor,
+                {liquidSelectionOptions.length === 0 ? (
+                  <Banner type="warning">
+                    <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
+                      <StyledText desktopStyle="captionRegular">
+                        {t('no_liquids_defined')}
+                      </StyledText>
+                      <Btn
+                        textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                        onClick={() => {
+                          setDefineLiquidModal(true)
+                          dispatch(labwareIngredActions.createNewLiquidGroup())
                         }}
-                        onClick={field.onChange}
-                      />
-                    )
-                  }}
-                />
-              </Flex>
+                      >
+                        <StyledText desktopStyle="captionRegular">
+                          {t('define_liq')}
+                        </StyledText>
+                      </Btn>
+                    </Flex>
+                  </Banner>
+                ) : null}
+                <Flex
+                  flexDirection={DIRECTION_COLUMN}
+                  gridGap={SPACING.spacing8}
+                >
+                  <Controller
+                    name="selectedLiquidId"
+                    control={control}
+                    rules={{
+                      required: true,
+                    }}
+                    render={({ field }) => {
+                      const fullOptions: DropdownOption[] = liquidSelectionOptions.map(
+                        option => {
+                          const liquid = liquids.find(
+                            liquid => liquid.ingredientId === option.value
+                          )
 
-              <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-                <StyledText desktopStyle="bodyDefaultRegular">
-                  {t('liquid_volume')}
-                </StyledText>
-                <Controller
-                  name="volume"
-                  control={control}
-                  rules={{
-                    required: true,
-                  }}
-                  render={({ field }) => (
-                    <InputField
-                      name="volume"
-                      units={t('application:units.microliter')}
-                      value={volume}
-                      error={volumeErrors}
-                      onBlur={field.onBlur}
-                      onChange={handleChangeVolume}
-                    />
-                  )}
-                />
-              </Flex>
-              <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-                <Btn
-                  textDecoration={TYPOGRAPHY.textDecorationUnderline}
-                  onClick={handleCancelForm}
+                          return {
+                            name: option.name,
+                            value: option.value,
+                            liquidColor: liquid?.displayColor ?? '',
+                          }
+                        }
+                      )
+                      const selectedLiquid = fullOptions.find(
+                        option => option.value === selectedLiquidId
+                      )
+                      const selectLiquidIdName = selectedLiquid?.name
+                      const selectLiquidColor = selectedLiquid?.liquidColor
+
+                      return (
+                        <DropdownMenu
+                          title={t('liquid')}
+                          disabled={liquidSelectionOptions.length === 0}
+                          width="15.875rem"
+                          dropdownType="neutral"
+                          filterOptions={fullOptions}
+                          currentOption={{
+                            value: selectedLiquidId ?? '',
+                            name: selectLiquidIdName ?? '',
+                            liquidColor: selectLiquidColor,
+                          }}
+                          onClick={field.onChange}
+                        />
+                      )
+                    }}
+                  />
+                </Flex>
+
+                <Flex
+                  flexDirection={DIRECTION_COLUMN}
+                  gridGap={SPACING.spacing8}
                 >
                   <StyledText desktopStyle="bodyDefaultRegular">
-                    {t('shared:cancel')}
+                    {t('liquid_volume')}
                   </StyledText>
-                </Btn>
-                <PrimaryButton
-                  disabled={
-                    volumeErrors != null ||
-                    volume == null ||
-                    volume === '' ||
-                    selectedLiquidId == null ||
-                    selectedLiquidId === ''
-                  }
-                  type="submit"
-                >
-                  {t('save')}
-                </PrimaryButton>
+                  <Controller
+                    name="volume"
+                    control={control}
+                    rules={{
+                      required: true,
+                    }}
+                    render={({ field }) => (
+                      <InputField
+                        name="volume"
+                        units={t('application:units.microliter')}
+                        value={volume}
+                        error={volumeErrors}
+                        onBlur={field.onBlur}
+                        onChange={handleChangeVolume}
+                      />
+                    )}
+                  />
+                </Flex>
+                <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+                  <Btn
+                    textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                    onClick={handleCancelForm}
+                  >
+                    <StyledText desktopStyle="bodyDefaultRegular">
+                      {t('shared:cancel')}
+                    </StyledText>
+                  </Btn>
+                  <PrimaryButton
+                    disabled={
+                      volumeErrors != null ||
+                      volume == null ||
+                      volume === '' ||
+                      selectedLiquidId == null ||
+                      selectedLiquidId === ''
+                    }
+                    type="submit"
+                  >
+                    {t('save')}
+                  </PrimaryButton>
+                </Flex>
               </Flex>
-            </Flex>
-          ) : null}
-        </ListItem>
-        <Flex
-          flexDirection={DIRECTION_COLUMN}
-          gridGap={SPACING.spacing8}
-          marginTop={SPACING.spacing24}
-        >
-          {liquidInfo.length > 0 ? (
-            <StyledText desktopStyle="bodyDefaultSemiBold">
-              {t('liquids_added')}
-            </StyledText>
-          ) : null}
-          {liquidInfo.map(info => {
-            return <LiquidCard key={info.liquidIndex} info={info} />
-          })}
-        </Flex>
-      </form>
-    </Toolbox>
+            ) : null}
+          </ListItem>
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            gridGap={SPACING.spacing8}
+            marginTop={SPACING.spacing24}
+          >
+            {liquidInfo.length > 0 ? (
+              <StyledText desktopStyle="bodyDefaultSemiBold">
+                {t('liquids_added')}
+              </StyledText>
+            ) : null}
+            {liquidInfo.map(info => {
+              return <LiquidCard key={info.liquidIndex} info={info} />
+            })}
+          </Flex>
+        </form>
+      </Toolbox>
+    </>
   )
 }

--- a/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import {
   Banner,
   Btn,
-  COLORS,
   DIRECTION_COLUMN,
   DropdownMenu,
   Flex,

--- a/protocol-designer/src/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/organisms/DefineLiquidsModal/index.tsx
@@ -168,6 +168,7 @@ export function DefineLiquidsModal(
       }}
     >
       <Modal
+        zIndexOverlay={15}
         width="42.0625rem"
         title={
           selectedIngredFields != null ? (


### PR DESCRIPTION
closes AUTH-1002

# Overview

Add define liquids banner when there are no liquids defined

<img width="328" alt="Screenshot 2024-10-31 at 07 45 14" src="https://github.com/user-attachments/assets/ff4638c8-f9bd-40fe-8396-6812f3226ce9">


## Test Plan and Hands on Testing

Create a protocol and go to add a liquid to a labware when there is no liquid defined. Then see that the banner renders correctly when selecting wells. click on the button in the banner and it should open the define liquids modal

## Changelog

- add define liquids banner
- add disabled state to dropdownMenu
- render defineLiquids modal if the button is clicked in the banner

## Risk assessment

low