### PR TITLE
fix(protocol-designer): fix z-index of models

### DIFF
--- a/protocol-designer/src/organisms/BlockingHintModal/index.tsx
+++ b/protocol-designer/src/organisms/BlockingHintModal/index.tsx
@@ -49,6 +49,7 @@ export function BlockingHintModal(props: HintProps): JSX.Element {
   return createPortal(
     <Modal
       type="warning"
+      zIndexOverlay={15}
       title={t(`hint.${hintKey}.title`)}
       onClose={onCancelClick}
       footer={


### PR DESCRIPTION
closes RQA-3356

# Overview

looks like most modals were fixed already except for this one instance

## Test Plan and Hands on Testing

to replicate the fixed instance, create an ot-2 protocol and add a magnetic module v1 and switch to magentic module v2 to reveal the hint modal

## Changelog

fix a zindex of a modal

## Risk assessment

low
