### PR TITLE
fix(app): Filter out unconfirmable setup steps on desktop

### DIFF
--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -764,6 +764,7 @@ export function ProtocolSetup(): JSX.Element {
   const [providedFixtureOptions, setProvidedFixtureOptions] = React.useState<
     CutoutFixtureId[]
   >([])
+  // TODO(jh 10-31-24): Refactor the below to utilize useMissingStepsModal.
   const [labwareConfirmed, setLabwareConfirmed] = React.useState<boolean>(false)
   const [liquidsConfirmed, setLiquidsConfirmed] = React.useState<boolean>(false)
   const [offsetsConfirmed, setOffsetsConfirmed] = React.useState<boolean>(false)

--- a/app/src/redux/protocol-runs/selectors.ts
+++ b/app/src/redux/protocol-runs/selectors.ts
@@ -76,6 +76,7 @@ export const getSetupStepsMissing: (
   ) as Types.StepMap<boolean>
 }
 
+// Reports all missing setup steps, including those validated on the robot.
 export const getMissingSetupSteps: (
   state: State,
   runId: string


### PR DESCRIPTION
Closes [RQA-3464](https://opentrons.atlassian.net/browse/RQA-3464)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

While the ODD was already filtering out setup steps that can't be confirmed by the app, the desktop app wasn't. This PR just filters out those unconfirmable steps in the "confirm setup" modal.

### Current Behavior

<img width="1021" alt="Screenshot 2024-10-31 at 10 29 43 AM" src="https://github.com/user-attachments/assets/8e3209e0-4552-4c9a-a29f-a6d224d5c0a5">


### Fixed Behavior

<img width="1020" alt="Screenshot 2024-10-31 at 10 30 03 AM" src="https://github.com/user-attachments/assets/44bea96d-de18-4197-8e02-b028632c8c04">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images.
- Verified the modal does not appear if the only "missing steps" are the robot calibration and module setup steps.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed incorrect setup steps appearing in the setup confirmation modal on the desktop app.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3464]: https://opentrons.atlassian.net/browse/RQA-3464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ