### PR TITLE
fix(app): Fix tip drop height during Error Recovery

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/steps/ChooseDeckLocation.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/ChooseDeckLocation.tsx
@@ -36,7 +36,7 @@ export function ChooseDeckLocation({
     )?.id
 
     if (deckSlot != null) {
-      void moveToAddressableArea(deckSlot).then(() => {
+      void moveToAddressableArea(deckSlot, false).then(() => {
         proceedWithConditionalClose()
       })
     }

--- a/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
@@ -98,7 +98,7 @@ export function ChooseLocation({
     toggleIsRobotPipetteMoving()
     void moveToAddressableArea(
       selectedLocation?.slotName as AddressableAreaName,
-      issuedCommandsType === 'fixit' // Because PE has tip state during fixit flows, do not specify a manual offset.
+      true
     ).then(() => {
       void blowoutOrDropTip(currentRoute, () => {
         const successStep =


### PR DESCRIPTION
Closes [RQA-3474](https://opentrons.atlassian.net/browse/RQA-3474)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

See https://github.com/Opentrons/opentrons/pull/16636 for some background context (as well as what caused the regression). The conditional logic for utilizing the manual tip offset during Error Recovery was not quite right, as we were supplying `stayAtHighestPossibleZ` to the `moveToAddressableArea` command in all instances. This PR corrects it.

Thanks @SyntaxColoring for the pairing!

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran through all "choose location" and "drop in removeable trash" permutations in Error Recovery and as a standalone drop tip flow. 
- Confirmed no regressive behavior during drop tip wizard on the OT-2. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed dropping tips too far from the trash during Error Recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3474]: https://opentrons.atlassian.net/browse/RQA-3474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ