### PR TITLE
fix(app): Fix tip selection during Error Recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -7,7 +7,6 @@ import {
   getRelevantWellName,
   getRelevantFailedLabwareCmdFrom,
   useRelevantFailedLwLocations,
-  useInitialSelectedLocationsFrom,
 } from '../useFailedLabwareUtils'
 import { DEFINED_ERROR_TYPES } from '../../constants'
 
@@ -240,24 +239,5 @@ describe('useRelevantFailedLwLocations', () => {
 
     expect(result.current.currentLoc).toStrictEqual({ slotName: 'D1' })
     expect(result.current.newLoc).toStrictEqual({ slotName: 'C2' })
-  })
-})
-
-describe('useInitialSelectedLocationsFrom', () => {
-  it('updates result if the relevant command changes', () => {
-    const cmd = { commandType: 'pickUpTip', params: { wellName: 'A1' } } as any
-    const cmd2 = { commandType: 'pickUpTip', params: { wellName: 'A2' } } as any
-
-    const { result, rerender } = renderHook((cmd: any) =>
-      useInitialSelectedLocationsFrom(cmd)
-    )
-
-    rerender(cmd)
-
-    expect(result.current).toStrictEqual({ A1: null })
-
-    rerender(cmd2)
-
-    expect(result.current).toStrictEqual({ A2: null })
   })
 })


### PR DESCRIPTION
Closes [RQA-3472](https://opentrons.atlassian.net/browse/RQA-3472)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

#16628 fixed stale well issues, but introduced a regression, specifically this code:

```
// Set the initial locs when they first become available or update.
  if (selectedLocs !== initialLocs) {
    setSelectedLocs(initialLocs)
  }
```

Uhhh, woops. Effectively, we were always updating the well location to be the initial location any time the well location was changed.

Looking back on the `useInitialSelectedLocationsFrom` hook in general, we don't really need this additional, internal state within a hook, so let's remove it.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified correct behavior for all permutations of tip selection during Error Recovery: 
- [x] "Full" pipette config on the 1ch/8ch. User can select any well.
- [x] Partial tip config. User is not allowed to select any well.
- [x] Error Recovery the 2nd+ time. The stale data problem is still avoided (see #16628 for context).

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed tip selection during Error Recovery not allowing users to select tips.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3472]: https://opentrons.atlassian.net/browse/RQA-3472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ