### PR TITLE
feat(protocol-designer): add step dragging indicator

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -46,10 +46,11 @@ import type { DeleteModalType } from '../../../../components/modals/ConfirmDelet
 export interface ConnectedStepInfoProps {
   stepId: StepIdType
   stepNumber: number
+  dragHovered?: boolean
 }
 
 export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
-  const { stepId, stepNumber } = props
+  const { stepId, stepNumber, dragHovered = false } = props
   const { t } = useTranslation('application')
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const stepIds = useSelector(getOrderedStepIds)
@@ -215,6 +216,7 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
         title={`${stepNumber}. ${
           step.stepName || t(`stepType.${step.stepType}`)
         }`}
+        dragHovered={dragHovered}
       />
     </>
   )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
@@ -14,7 +14,7 @@ import { selectors as stepFormSelectors } from '../../../../step-forms'
 import { stepIconsByType } from '../../../../form-types'
 import { StepContainer } from './StepContainer'
 import { ConnectedStepInfo } from './ConnectedStepInfo'
-import type { DragLayerMonitor, DropTargetOptions } from 'react-dnd'
+import type { DragLayerMonitor, DropTargetMonitor } from 'react-dnd'
 import type { StepIdType } from '../../../../form-types'
 import type { ConnectedStepItemProps } from '../../../../containers/ConnectedStepItem'
 
@@ -44,7 +44,7 @@ function DragDropStep(props: DragDropStepProps): JSX.Element {
     [orderedStepIds]
   )
 
-  const [{ handlerId }, drop] = useDrop(
+  const [{ handlerId, hovered }, drop] = useDrop(
     () => ({
       accept: DND_TYPES.STEP_ITEM,
       canDrop: () => {
@@ -57,8 +57,9 @@ function DragDropStep(props: DragDropStepProps): JSX.Element {
           moveStep(draggedId, overIndex)
         }
       },
-      collect: (monitor: DropTargetOptions) => ({
+      collect: (monitor: DropTargetMonitor) => ({
         handlerId: monitor.getHandlerId(),
+        hovered: monitor.isOver(),
       }),
     }),
     [orderedStepIds]
@@ -71,7 +72,11 @@ function DragDropStep(props: DragDropStepProps): JSX.Element {
       style={{ opacity: isDragging ? 0.3 : 1 }}
       data-handler-id={handlerId}
     >
-      <ConnectedStepInfo stepNumber={stepNumber} stepId={stepId} />
+      <ConnectedStepInfo
+        stepNumber={stepNumber}
+        stepId={stepId}
+        dragHovered={hovered}
+      />
     </Box>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -256,7 +256,6 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
         </Btn>
         {dragHovered ? (
           <Divider
-            data-testid={`${stepId}-divider`}
             marginY="0"
             height="0.25rem"
             width="100%"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -9,6 +9,7 @@ import {
   CURSOR_DEFAULT,
   CURSOR_POINTER,
   DIRECTION_COLUMN,
+  Divider,
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
@@ -254,11 +255,12 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
           </Flex>
         </Btn>
         {dragHovered ? (
-          <Flex
+          <Divider
             data-testid={`${stepId}-divider`}
-            backgroundColor={COLORS.blue50}
+            marginY="0"
             height="0.25rem"
             width="100%"
+            backgroundColor={COLORS.blue50}
             borderRadius={BORDERS.borderRadius2}
           />
         ) : null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -4,11 +4,11 @@ import { useDispatch, useSelector } from 'react-redux'
 import {
   ALIGN_CENTER,
   BORDERS,
-  Box,
   Btn,
   COLORS,
   CURSOR_DEFAULT,
   CURSOR_POINTER,
+  DIRECTION_COLUMN,
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
@@ -55,6 +55,7 @@ export interface StepContainerProps {
   hovered?: boolean
   hasError?: boolean
   isStepAfterError?: boolean
+  dragHovered?: boolean
 }
 
 export function StepContainer(props: StepContainerProps): JSX.Element {
@@ -71,6 +72,7 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
     title,
     hasError = false,
     isStepAfterError = false,
+    dragHovered = false,
   } = props
   const [top, setTop] = React.useState<number>(0)
   const menuRootRef = React.useRef<HTMLDivElement | null>(null)
@@ -188,12 +190,14 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
           onCancelClick={cancelMultiDelete}
         />
       )}
-      <Box
+      <Flex
         id={stepId}
         {...{
           onMouseEnter: isStepAfterError ? undefined : onMouseEnter,
           onMouseLeave: isStepAfterError ? undefined : onMouseLeave,
         }}
+        gridGap={SPACING.spacing4}
+        flexDirection={DIRECTION_COLUMN}
       >
         <Btn
           onDoubleClick={onDoubleClick}
@@ -249,7 +253,16 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
             ) : null}
           </Flex>
         </Btn>
-      </Box>
+        {dragHovered ? (
+          <Flex
+            data-testid={`${stepId}-divider`}
+            backgroundColor={COLORS.blue50}
+            height="0.25rem"
+            width="100%"
+            borderRadius={BORDERS.borderRadius2}
+          />
+        ) : null}
+      </Flex>
       {stepOverflowMenu && stepId != null
         ? createPortal(
             <StepOverflowMenu

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/StepContainer.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/StepContainer.test.tsx
@@ -49,4 +49,8 @@ describe('StepContainer', () => {
     render(props)
     screen.getByText('Final deck state')
   })
+  it('renders the divider if hover targets that step', () => {
+    render({ ...props, dragHovered: true })
+    screen.getByTestId('mockStepId-divider')
+  })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/StepContainer.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/StepContainer.test.tsx
@@ -51,6 +51,6 @@ describe('StepContainer', () => {
   })
   it('renders the divider if hover targets that step', () => {
     render({ ...props, dragHovered: true })
-    screen.getByTestId('mockStepId-divider')
+    screen.getByTestId('divider')
   })
 })


### PR DESCRIPTION
# Overview

Adds logic to display a divider under a target step when a step is being dragged (for reordering) over that target step.

Closes AUTH-1013

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/4b0bb4d9-3383-47e0-aba0-fd6d04b5e434


- create a PD protocol with several steps
- drag and drop any step around the timeline
- verify that blue divider shows target location for drop

## Changelog

- retrieve hovered `DragDropStep` from `DropTargetMonitor` in `useDrop`
- pass down hovered state to `StepContainer`
- add test

## Review requests

- see test plan

## Risk assessment

low