### PR TITLE
refactor(app): adjust ODD simple style predefined location option margin

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
@@ -16,8 +16,10 @@ import {
 import { BLOWOUT_SUCCESS, DROP_TIP_SUCCESS, DT_ROUTES } from '../constants'
 import { DropTipFooterButtons } from '../shared'
 
+import type { FlattenSimpleInterpolation } from 'styled-components'
 import type { AddressableAreaName } from '@opentrons/shared-data'
 import type {
+  DropTipModalStyle,
   DropTipWizardContainerProps,
   ValidDropTipBlowoutLocation,
 } from '../types'
@@ -129,13 +131,7 @@ export function ChooseLocation({
   }
 
   return (
-    <Flex
-      css={
-        modalStyle === 'simple'
-          ? CONTAINER_STYLE_SIMPLE
-          : CONTAINER_STYLE_INTERVENTION
-      }
-    >
+    <Flex css={buildContainerStyle(modalStyle, dropTipCommandLocations.length)}>
       <Flex css={OPTION_CONTAINER_STYLE}>
         <StyledText
           oddStyle="level4HeaderSemiBold"
@@ -169,6 +165,17 @@ export function ChooseLocation({
   )
 }
 
+// TODO(jh, 10-31-24): The numLocations logic is a hack to get around some unexpected ODD-specific CSS behavior in RadioButton.
+//  Investigate RadioButton ODD styling.
+const buildContainerStyle = (
+  modalStyle: DropTipModalStyle,
+  numLocations: number
+): FlattenSimpleInterpolation => {
+  return modalStyle === 'simple'
+    ? containerStyleSimple(numLocations)
+    : CONTAINER_STYLE_INTERVENTION
+}
+
 const CONTAINER_STYLE_BASE = `
   overflow: ${OVERFLOW_AUTO};
   flex-direction: ${DIRECTION_COLUMN};
@@ -182,12 +189,14 @@ const CONTAINER_STYLE_INTERVENTION = css`
   ${CONTAINER_STYLE_BASE}
 `
 
-const CONTAINER_STYLE_SIMPLE = css`
+const containerStyleSimple = (
+  numLocations: number
+): FlattenSimpleInterpolation => css`
   ${CONTAINER_STYLE_BASE}
   justify-content: ${JUSTIFY_SPACE_BETWEEN};
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    height: 80%;
+    height: ${numLocations >= 4 ? '80%' : '100%'};
     flex-grow: 0;
   }
 `


### PR DESCRIPTION
Closes [EXEC-798](https://opentrons.atlassian.net/browse/EXEC-798)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a continue/go back margin issue with `simple` style drop tip flows on the ODD. Unfortunately the fix is unideal for two reasons:

- There are easy CSS properties to get the margin to work correctly when the list of drop tip locations is less than 3 (ie, they don't overflow on the screen), but the go back/continue buttons are entirely occluded when there is overflow because...
- Some ODD-specific CSS (`overflow` behavior) in the `RadioButton` component causes unexpected behavior. Unfortunately, there are a lot of child components which are also in the `components` directory, and I'd rather avoid touching all these widely-used components during bug-fix phase. I've talked to some other FE devs, and we can revisit `RadioButton` after the release if the issue isn't solved by ongoing AUTH work.

### Current Behavior

<img width="1024" alt="Screenshot 2024-10-31 at 4 24 26 PM" src="https://github.com/user-attachments/assets/6bb85f2f-9907-468e-bc04-fa18063e8c9f">

### Fixed Behavior

<img width="1023" alt="Screenshot 2024-10-31 at 4 23 49 PM" src="https://github.com/user-attachments/assets/38a4c0de-44e2-4b6f-aad5-2f0361644a20">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran all permutations of drop tip wizard in and out of Error Recovery and confirmed the CSS is correct.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-798]: https://opentrons.atlassian.net/browse/EXEC-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ