### PR TITLE
feat(api,app,shared-data): Track air gaps

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -104,6 +104,19 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             pipette_id=self._pipette_id, speed=speed
         )
 
+    def air_gap_in_place(self, volume: float, flow_rate: float) -> None:
+        """Aspirate a given volume of air from the current location of the pipette.
+
+        Args:
+            volume: The volume of air to aspirate, in microliters.
+            folw_rate: The flow rate of air into the pipette, in microliters/s
+        """
+        self._engine_client.execute_command(
+            cmd.AirGapInPlaceParams(
+                pipetteId=self._pipette_id, volume=volume, flowRate=flow_rate
+            )
+        )
+
     def aspirate(
         self,
         location: Location,

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -25,6 +25,14 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         ...
 
     @abstractmethod
+    def air_gap_in_place(self, volume: float, flow_rate: float) -> None:
+        """Aspirate a given volume of air from the current location of the pipette.
+        Args:
+            volume: The volume of air to aspirate, in microliters.
+            flow_rate: The flow rate of air into the pipette, in microliters.
+        """
+
+    @abstractmethod
     def aspirate(
         self,
         location: types.Location,

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -72,6 +72,9 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
         """Sets the speed at which the robot's gantry moves."""
         self._default_speed = speed
 
+    def air_gap_in_place(self, volume: float, flow_rate: float) -> None:
+        assert False, "Air gap tracking only available in API version 2.22 and later"
+
     def aspirate(
         self,
         location: types.Location,

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -83,6 +83,9 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
     def set_default_speed(self, speed: float) -> None:
         self._default_speed = speed
 
+    def air_gap_in_place(self, volume: float, flow_rate: float) -> None:
+        assert False, "Air gap tracking only available in API version 2.22 and later"
+
     def aspirate(
         self,
         location: types.Location,

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -41,6 +41,14 @@ from .command_unions import (
     CommandDefinedErrorData,
 )
 
+from .air_gap_in_place import (
+    AirGapInPlace,
+    AirGapInPlaceParams,
+    AirGapInPlaceCreate,
+    AirGapInPlaceResult,
+    AirGapInPlaceCommandType,
+)
+
 from .aspirate import (
     Aspirate,
     AspirateParams,
@@ -355,6 +363,12 @@ __all__ = [
     "hash_protocol_command_params",
     # command schema generation
     "generate_command_schema",
+    # air gap command models
+    "AirGapInPlace",
+    "AirGapInPlaceCreate",
+    "AirGapInPlaceParams",
+    "AirGapInPlaceResult",
+    "AirGapInPlaceCommandType",
     # aspirate command models
     "Aspirate",
     "AspirateCreate",

--- a/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
@@ -1,0 +1,160 @@
+"""AirGap in place command request, result, and implementation models."""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional, Type, Union
+from typing_extensions import Literal
+
+from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
+
+from opentrons.hardware_control import HardwareControlAPI
+
+from .pipetting_common import (
+    PipetteIdMixin,
+    AspirateVolumeMixin,
+    FlowRateMixin,
+    BaseLiquidHandlingResult,
+    OverpressureError,
+)
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    SuccessData,
+    DefinedErrorData,
+)
+from ..errors.error_occurrence import ErrorOccurrence
+from ..errors.exceptions import PipetteNotReadyToAspirateError
+from ..state.update_types import StateUpdate
+from ..types import AspiratedFluid, FluidKind
+
+if TYPE_CHECKING:
+    from ..execution import PipettingHandler, GantryMover
+    from ..resources import ModelUtils
+    from ..state.state import StateView
+    from ..notes import CommandNoteAdder
+
+AirGapInPlaceCommandType = Literal["airGapInPlace"]
+
+
+class AirGapInPlaceParams(PipetteIdMixin, AspirateVolumeMixin, FlowRateMixin):
+    """Payload required to aspirate in place."""
+
+    pass
+
+
+class AirGapInPlaceResult(BaseLiquidHandlingResult):
+    """Result data from the execution of a AirGapInPlace command."""
+
+    pass
+
+
+_ExecuteReturn = Union[
+    SuccessData[AirGapInPlaceResult],
+    DefinedErrorData[OverpressureError],
+]
+
+
+class AirGapInPlaceImplementation(
+    AbstractCommandImpl[AirGapInPlaceParams, _ExecuteReturn]
+):
+    """AirGapInPlace command implementation."""
+
+    def __init__(
+        self,
+        pipetting: PipettingHandler,
+        hardware_api: HardwareControlAPI,
+        state_view: StateView,
+        command_note_adder: CommandNoteAdder,
+        model_utils: ModelUtils,
+        gantry_mover: GantryMover,
+        **kwargs: object,
+    ) -> None:
+        self._pipetting = pipetting
+        self._state_view = state_view
+        self._hardware_api = hardware_api
+        self._command_note_adder = command_note_adder
+        self._model_utils = model_utils
+        self._gantry_mover = gantry_mover
+
+    async def execute(self, params: AirGapInPlaceParams) -> _ExecuteReturn:
+        """Air gap without moving the pipette.
+
+        Raises:
+            TipNotAttachedError: if no tip is attached to the pipette.
+            PipetteNotReadyToAirGapError: pipette plunger is not ready.
+        """
+        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
+            pipette_id=params.pipetteId,
+        )
+
+        if not ready_to_aspirate:
+            raise PipetteNotReadyToAspirateError(
+                "Pipette cannot air gap in place because of a previous blow out."
+                " The first aspirate following a blow-out must be from a specific well"
+                " so the plunger can be reset in a known safe position."
+            )
+
+        state_update = StateUpdate()
+
+        try:
+            current_position = await self._gantry_mover.get_position(params.pipetteId)
+            volume = await self._pipetting.aspirate_in_place(
+                pipette_id=params.pipetteId,
+                volume=params.volume,
+                flow_rate=params.flowRate,
+                command_note_adder=self._command_note_adder,
+            )
+        except PipetteOverpressureError as e:
+            return DefinedErrorData(
+                public=OverpressureError(
+                    id=self._model_utils.generate_id(),
+                    createdAt=self._model_utils.get_timestamp(),
+                    wrappedErrors=[
+                        ErrorOccurrence.from_failed(
+                            id=self._model_utils.generate_id(),
+                            createdAt=self._model_utils.get_timestamp(),
+                            error=e,
+                        )
+                    ],
+                    errorInfo=(
+                        {
+                            "retryLocation": (
+                                current_position.x,
+                                current_position.y,
+                                current_position.z,
+                            )
+                        }
+                    ),
+                ),
+                state_update=state_update,
+            )
+        else:
+            state_update.set_fluid_aspirated(
+                pipette_id=params.pipetteId,
+                fluid=AspiratedFluid(kind=FluidKind.AIR, volume=volume),
+            )
+            return SuccessData(
+                public=AirGapInPlaceResult(volume=volume),
+                state_update=state_update,
+            )
+
+
+class AirGapInPlace(
+    BaseCommand[AirGapInPlaceParams, AirGapInPlaceResult, OverpressureError]
+):
+    """AirGapInPlace command model."""
+
+    commandType: AirGapInPlaceCommandType = "airGapInPlace"
+    params: AirGapInPlaceParams
+    result: Optional[AirGapInPlaceResult]
+
+    _ImplementationCls: Type[AirGapInPlaceImplementation] = AirGapInPlaceImplementation
+
+
+class AirGapInPlaceCreate(BaseCommandCreate[AirGapInPlaceParams]):
+    """AirGapInPlace command request model."""
+
+    commandType: AirGapInPlaceCommandType = "airGapInPlace"
+    params: AirGapInPlaceParams
+
+    _CommandCls: Type[AirGapInPlace] = AirGapInPlace

--- a/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
@@ -37,7 +37,7 @@ AirGapInPlaceCommandType = Literal["airGapInPlace"]
 
 
 class AirGapInPlaceParams(PipetteIdMixin, AspirateVolumeMixin, FlowRateMixin):
-    """Payload required to aspirate in place."""
+    """Payload required to air gap in place."""
 
     pass
 

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -25,7 +25,14 @@ from ..errors.error_occurrence import ErrorOccurrence
 from opentrons.hardware_control import HardwareControlAPI
 
 from ..state.update_types import StateUpdate, CLEAR
-from ..types import WellLocation, WellOrigin, CurrentWell, DeckPoint
+from ..types import (
+    WellLocation,
+    WellOrigin,
+    CurrentWell,
+    DeckPoint,
+    AspiratedFluid,
+    FluidKind,
+)
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler, PipettingHandler
@@ -141,6 +148,7 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
                 well_name=well_name,
                 volume_added=CLEAR,
             )
+            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),
@@ -161,6 +169,10 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
                 labware_id=labware_id,
                 well_name=well_name,
                 volume_added=-volume_aspirated,
+            )
+            state_update.set_fluid_aspirated(
+                pipette_id=params.pipetteId,
+                fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=volume_aspirated),
             )
             return SuccessData(
                 public=AspirateResult(

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -25,7 +25,7 @@ from .command import (
 from ..errors.error_occurrence import ErrorOccurrence
 from ..errors.exceptions import PipetteNotReadyToAspirateError
 from ..state.update_types import StateUpdate, CLEAR
-from ..types import CurrentWell
+from ..types import CurrentWell, AspiratedFluid, FluidKind
 
 if TYPE_CHECKING:
     from ..execution import PipettingHandler, GantryMover
@@ -115,6 +115,7 @@ class AspirateInPlaceImplementation(
                     well_name=current_location.well_name,
                     volume_added=CLEAR,
                 )
+            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),
@@ -139,6 +140,10 @@ class AspirateInPlaceImplementation(
                 state_update=state_update,
             )
         else:
+            state_update.set_fluid_aspirated(
+                pipette_id=params.pipetteId,
+                fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=volume),
+            )
             if (
                 isinstance(current_location, CurrentWell)
                 and current_location.pipette_id == params.pipetteId
@@ -148,6 +153,7 @@ class AspirateInPlaceImplementation(
                     well_name=current_location.well_name,
                     volume_added=-volume,
                 )
+
             return SuccessData(
                 public=AspirateInPlaceResult(volume=volume),
                 state_update=state_update,

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -93,6 +93,7 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, _ExecuteReturn]):
                 pipette_id=params.pipetteId, flow_rate=params.flowRate
             )
         except PipetteOverpressureError as e:
+            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),
@@ -112,8 +113,10 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, _ExecuteReturn]):
                         )
                     },
                 ),
+                state_update=state_update,
             )
         else:
+            state_update.set_fluid_empty(pipette_id=params.pipetteId)
             return SuccessData(
                 public=BlowOutResult(position=deck_point),
                 state_update=state_update,

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -19,6 +19,7 @@ from .command import (
     SuccessData,
 )
 from ..errors.error_occurrence import ErrorOccurrence
+from ..state import update_types
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -72,12 +73,14 @@ class BlowOutInPlaceImplementation(
 
     async def execute(self, params: BlowOutInPlaceParams) -> _ExecuteReturn:
         """Blow-out without moving the pipette."""
+        state_update = update_types.StateUpdate()
         try:
             current_position = await self._gantry_mover.get_position(params.pipetteId)
             await self._pipetting.blow_out_in_place(
                 pipette_id=params.pipetteId, flow_rate=params.flowRate
             )
         except PipetteOverpressureError as e:
+            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),
@@ -97,11 +100,11 @@ class BlowOutInPlaceImplementation(
                         )
                     },
                 ),
+                state_update=state_update,
             )
         else:
-            return SuccessData(
-                public=BlowOutInPlaceResult(),
-            )
+            state_update.set_fluid_empty(pipette_id=params.pipetteId)
+            return SuccessData(public=BlowOutInPlaceResult(), state_update=state_update)
 
 
 class BlowOutInPlace(

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -31,6 +31,14 @@ from .set_rail_lights import (
     SetRailLightsResult,
 )
 
+from .air_gap_in_place import (
+    AirGapInPlace,
+    AirGapInPlaceParams,
+    AirGapInPlaceCreate,
+    AirGapInPlaceResult,
+    AirGapInPlaceCommandType,
+)
+
 from .aspirate import (
     Aspirate,
     AspirateParams,
@@ -320,6 +328,7 @@ from .liquid_probe import (
 
 Command = Annotated[
     Union[
+        AirGapInPlace,
         Aspirate,
         AspirateInPlace,
         Comment,
@@ -398,6 +407,7 @@ Command = Annotated[
 ]
 
 CommandParams = Union[
+    AirGapInPlaceParams,
     AspirateParams,
     AspirateInPlaceParams,
     CommentParams,
@@ -474,6 +484,7 @@ CommandParams = Union[
 ]
 
 CommandType = Union[
+    AirGapInPlaceCommandType,
     AspirateCommandType,
     AspirateInPlaceCommandType,
     CommentCommandType,
@@ -551,6 +562,7 @@ CommandType = Union[
 
 CommandCreate = Annotated[
     Union[
+        AirGapInPlaceCreate,
         AspirateCreate,
         AspirateInPlaceCreate,
         CommentCreate,
@@ -629,6 +641,7 @@ CommandCreate = Annotated[
 ]
 
 CommandResult = Union[
+    AirGapInPlaceResult,
     AspirateResult,
     AspirateInPlaceResult,
     CommentResult,

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -112,6 +112,7 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
                 well_name=well_name,
                 volume_added=CLEAR,
             )
+            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),
@@ -128,11 +129,17 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
                 state_update=state_update,
             )
         else:
+            volume_added = (
+                self._state_view.pipettes.get_liquid_dispensed_by_ejecting_volume(
+                    pipette_id=params.pipetteId, volume=volume
+                )
+            )
             state_update.set_liquid_operated(
                 labware_id=labware_id,
                 well_name=well_name,
-                volume_added=volume,
+                volume_added=volume_added if volume_added is not None else CLEAR,
             )
+            state_update.set_fluid_ejected(pipette_id=params.pipetteId, volume=volume)
             return SuccessData(
                 public=DispenseResult(volume=volume, position=deck_point),
                 state_update=state_update,

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -94,6 +94,7 @@ class DispenseInPlaceImplementation(
                     well_name=current_location.well_name,
                     volume_added=CLEAR,
                 )
+            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
                 public=OverpressureError(
                     id=self._model_utils.generate_id(),
@@ -118,14 +119,20 @@ class DispenseInPlaceImplementation(
                 state_update=state_update,
             )
         else:
+            state_update.set_fluid_ejected(pipette_id=params.pipetteId, volume=volume)
             if (
                 isinstance(current_location, CurrentWell)
                 and current_location.pipette_id == params.pipetteId
             ):
+                volume_added = (
+                    self._state_view.pipettes.get_liquid_dispensed_by_ejecting_volume(
+                        pipette_id=params.pipetteId, volume=volume
+                    )
+                )
                 state_update.set_liquid_operated(
                     labware_id=current_location.labware_id,
                     well_name=current_location.well_name,
-                    volume_added=volume,
+                    volume_added=volume_added if volume_added is not None else CLEAR,
                 )
             return SuccessData(
                 public=DispenseInPlaceResult(volume=volume),

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -151,7 +151,6 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
                 pipette_id=params.pipetteId, tip_geometry=None
             )
             state_update.set_fluid_unknown(pipette_id=pipette_id)
-            state_update_if_false_positive.set_fluid_unknown(pipette_id=pipette_id)
             return DefinedErrorData(
                 public=error,
                 state_update=state_update,

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -150,12 +150,15 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
             state_update_if_false_positive.update_pipette_tip_state(
                 pipette_id=params.pipetteId, tip_geometry=None
             )
+            state_update.set_fluid_unknown(pipette_id=pipette_id)
+            state_update_if_false_positive.set_fluid_unknown(pipette_id=pipette_id)
             return DefinedErrorData(
                 public=error,
                 state_update=state_update,
                 state_update_if_false_positive=state_update_if_false_positive,
             )
         else:
+            state_update.set_fluid_unknown(pipette_id=pipette_id)
             state_update.update_pipette_tip_state(
                 pipette_id=params.pipetteId, tip_geometry=None
             )

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -75,9 +75,6 @@ class DropTipInPlaceImplementation(
                 pipette_id=params.pipetteId, tip_geometry=None
             )
             state_update.set_fluid_unknown(pipette_id=params.pipetteId)
-            state_update_if_false_positive.set_fluid_unknown(
-                pipette_id=params.pipetteId
-            )
             error = TipPhysicallyAttachedError(
                 id=self._model_utils.generate_id(),
                 createdAt=self._model_utils.get_timestamp(),

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -65,7 +65,6 @@ class DropTipInPlaceImplementation(
     async def execute(self, params: DropTipInPlaceParams) -> _ExecuteReturn:
         """Drop a tip using the requested pipette."""
         state_update = update_types.StateUpdate()
-
         try:
             await self._tip_handler.drop_tip(
                 pipette_id=params.pipetteId, home_after=params.homeAfter
@@ -74,6 +73,10 @@ class DropTipInPlaceImplementation(
             state_update_if_false_positive = update_types.StateUpdate()
             state_update_if_false_positive.update_pipette_tip_state(
                 pipette_id=params.pipetteId, tip_geometry=None
+            )
+            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
+            state_update_if_false_positive.set_fluid_unknown(
+                pipette_id=params.pipetteId
             )
             error = TipPhysicallyAttachedError(
                 id=self._model_utils.generate_id(),
@@ -92,6 +95,7 @@ class DropTipInPlaceImplementation(
                 state_update_if_false_positive=state_update_if_false_positive,
             )
         else:
+            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             state_update.update_pipette_tip_state(
                 pipette_id=params.pipetteId, tip_geometry=None
             )

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -127,6 +127,7 @@ class LoadPipetteImplementation(
             serial_number=loaded_pipette.serial_number,
             config=loaded_pipette.static_config,
         )
+        state_update.set_fluid_unknown(pipette_id=loaded_pipette.pipette_id)
 
         return SuccessData(
             public=LoadPipetteResult(pipetteId=loaded_pipette.pipette_id),

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -146,9 +146,11 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 pipette_id=pipette_id,
                 tip_geometry=e.tip_geometry,
             )
+            state_update_if_false_positive.set_fluid_empty(pipette_id=pipette_id)
             state_update.mark_tips_as_used(
                 pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
             )
+            state_update.set_fluid_unknown(pipette_id=pipette_id)
             return DefinedErrorData(
                 public=TipPhysicallyMissingError(
                     id=self._model_utils.generate_id(),
@@ -172,6 +174,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
             state_update.mark_tips_as_used(
                 pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
             )
+            state_update.set_fluid_empty(pipette_id=pipette_id)
             return SuccessData(
                 public=PickUpTipResult(
                     tipVolume=tip_geometry.volume,

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
@@ -10,6 +10,7 @@ from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, Succe
 from ..pipetting_common import PipetteIdMixin, FlowRateMixin
 from ...resources import ensure_ot3_hardware
 from ...errors.error_occurrence import ErrorOccurrence
+from ...state import update_types
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import Axis
@@ -66,9 +67,11 @@ class UnsafeBlowOutInPlaceImplementation(
         await self._pipetting.blow_out_in_place(
             pipette_id=params.pipetteId, flow_rate=params.flowRate
         )
+        state_update = update_types.StateUpdate()
+        state_update.set_fluid_empty(pipette_id=params.pipetteId)
 
         return SuccessData(
-            public=UnsafeBlowOutInPlaceResult(),
+            public=UnsafeBlowOutInPlaceResult(), state_update=state_update
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -77,6 +77,7 @@ class UnsafeDropTipInPlaceImplementation(
         state_update.update_pipette_tip_state(
             pipette_id=params.pipetteId, tip_geometry=None
         )
+        state_update.set_fluid_unknown(pipette_id=params.pipetteId)
 
         return SuccessData(
             public=UnsafeDropTipInPlaceResult(), state_update=state_update

--- a/api/src/opentrons/protocol_engine/state/fluid_stack.py
+++ b/api/src/opentrons/protocol_engine/state/fluid_stack.py
@@ -2,9 +2,9 @@
 
 Inside a pipette's tip, there can be a mix of kinds of fluids - here, "fluid" means "liquid" (i.e. a protocol-relevant
 working liquid that is aspirated or dispensed from wells) or "air" (i.e. because there was an air gap). Since sometimes
-you want air gaps in different places - below liquid to prevent dripping, above liquid to provide extra room to push the
-plunger - we need to support some notion of at least ordinal position of air and liquid, and we do so as a stack because
-that's physically relevant.
+you want air gaps in different places - physicall-ybelow liquid to prevent dripping, physically-above liquid to provide
+extra room to push the plunger - we need to support some notion of at least phsyical ordinal position of air and liquid,
+and we do so as a logical stack because that's physically relevant.
 """
 from logging import getLogger
 from numpy import isclose
@@ -16,8 +16,9 @@ _LOG = getLogger(__name__)
 class FluidStack:
     """A FluidStack data structure is a list of AspiratedFluids, with stack-style (last-in-first-out) ordering.
 
-    The front of the list is the top of the liquid stack and the back of the list is the bottom of the liquid stack. The
-    state is internal and the interaction surface is the methods. This is a mutating API.
+    The front of the list is the physical-top of the liquid stack (logical-bottom of the stack data structure)
+    and the back of the list is the physical-bottom of the liquid stack (logical-top of the stack data structure).
+    The state is internal and the interaction surface is the methods. This is a mutating API.
     """
 
     _FluidStack = list[AspiratedFluid]
@@ -34,8 +35,9 @@ class FluidStack:
     def add_fluid(self, new: AspiratedFluid) -> None:
         """Add fluid to a stack.
 
-        If the new fluid is of a different kind than what's on the bottom of the stack. add a new record; if the same
-        kind, add a new record to the end.
+        If the new fluid is of a different kind than what's on the physical-bottom of the stack, add a new record.
+        If the new fluid is of the same kind as what's on the physical-bottom of the stack, add the new volume to
+        the same record.
         """
         if len(self._fluid_stack) == 0 or self._fluid_stack[-1].kind != new.kind:
             # this is a new kind of fluid, append the record
@@ -62,7 +64,7 @@ class FluidStack:
         self._fluid_stack = removed
 
     def remove_fluid(self, volume: float) -> None:
-        """Remove a specific amount of fluid from the stack.
+        """Remove a specific amount of fluid from the physical-bottom of the stack.
 
         This will consume records that are wholly included in the provided volume and alter the remaining
         final records (if any) to decrement the amount of volume removed from it.
@@ -109,7 +111,7 @@ class FluidStack:
         return volume
 
     def liquid_part_of_dispense_volume(self, volume: float) -> float:
-        """Get the amount of liquid in the specified volume starting at the bottom of the stack."""
+        """Get the amount of liquid in the specified volume starting at the physical-bottom of the stack."""
         liquid_volume = 0.0
         for el in reversed(self._fluid_stack):
             if el.kind == FluidKind.LIQUID:

--- a/api/src/opentrons/protocol_engine/state/fluid_stack.py
+++ b/api/src/opentrons/protocol_engine/state/fluid_stack.py
@@ -2,7 +2,7 @@
 
 Inside a pipette's tip, there can be a mix of kinds of fluids - here, "fluid" means "liquid" (i.e. a protocol-relevant
 working liquid that is aspirated or dispensed from wells) or "air" (i.e. because there was an air gap). Since sometimes
-you want air gaps in different places - physicall-ybelow liquid to prevent dripping, physically-above liquid to provide
+you want air gaps in different places - physically-below liquid to prevent dripping, physically-above liquid to provide
 extra room to push the plunger - we need to support some notion of at least phsyical ordinal position of air and liquid,
 and we do so as a logical stack because that's physically relevant.
 """

--- a/api/src/opentrons/protocol_engine/state/fluid_stack.py
+++ b/api/src/opentrons/protocol_engine/state/fluid_stack.py
@@ -1,0 +1,136 @@
+"""Implements fluid stack tracking for pipettes.
+
+Inside a pipette's tip, there can be a mix of kinds of fluids - here, "fluid" means "liquid" (i.e. a protocol-relevant
+working liquid that is aspirated or dispensed from wells) or "air" (i.e. because there was an air gap). Since sometimes
+you want air gaps in different places - below liquid to prevent dripping, above liquid to provide extra room to push the
+plunger - we need to support some notion of at least ordinal position of air and liquid, and we do so as a stack because
+that's physically relevant.
+"""
+from logging import getLogger
+from numpy import isclose
+from ..types import AspiratedFluid, FluidKind
+
+_LOG = getLogger(__name__)
+
+
+class FluidStack:
+    """A FluidStack data structure is a list of AspiratedFluids, with stack-style (last-in-first-out) ordering.
+
+    The front of the list is the top of the liquid stack and the back of the list is the bottom of the liquid stack. The
+    state is internal and the interaction surface is the methods. This is a mutating API.
+    """
+
+    _FluidStack = list[AspiratedFluid]
+
+    _fluid_stack: _FluidStack
+
+    def __init__(self, _fluid_stack: _FluidStack | None = None) -> None:
+        """Build a FluidStack.
+
+        The argument is provided for testing and shouldn't be generally used.
+        """
+        self._fluid_stack = _fluid_stack or []
+
+    def add_fluid(self, new: AspiratedFluid) -> None:
+        """Add fluid to a stack.
+
+        If the new fluid is of a different kind than what's on the bottom of the stack. add a new record; if the same
+        kind, add a new record to the end.
+        """
+        if len(self._fluid_stack) == 0 or self._fluid_stack[-1].kind != new.kind:
+            # this is a new kind of fluid, append the record
+            self._fluid_stack.append(new)
+        else:
+            # this is more of the same kind of fluid, add the volumes
+            old_fluid = self._fluid_stack.pop(-1)
+            self._fluid_stack.append(
+                AspiratedFluid(kind=new.kind, volume=old_fluid.volume + new.volume)
+            )
+
+    def _alter_fluid_records(
+        self, remove: int, new_last: AspiratedFluid | None
+    ) -> None:
+        if remove >= len(self._fluid_stack) or len(self._fluid_stack) == 0:
+            self._fluid_stack = []
+            return
+        if remove != 0:
+            removed = self._fluid_stack[:-remove]
+        else:
+            removed = self._fluid_stack
+        if new_last:
+            removed[-1] = new_last
+        self._fluid_stack = removed
+
+    def remove_fluid(self, volume: float) -> None:
+        """Remove a specific amount of fluid from the stack.
+
+        This will consume records that are wholly included in the provided volume and alter the remaining
+        final records (if any) to decrement the amount of volume removed from it.
+
+        This function is designed to be used inside pipette store action handlers, which are generally not
+        exception-safe, and therefore swallows and logs errors.
+        """
+        self._fluid_stack_iterator = reversed(self._fluid_stack)
+        removed_elements: list[AspiratedFluid] = []
+        while volume > 0:
+            try:
+                last_stack_element = next(self._fluid_stack_iterator)
+            except StopIteration:
+                _LOG.error(
+                    f"Attempting to remove more fluid than present, {volume}uL left over"
+                )
+                self._alter_fluid_records(len(removed_elements), None)
+                return
+            if last_stack_element.volume < volume:
+                removed_elements.append(last_stack_element)
+                volume -= last_stack_element.volume
+            elif isclose(last_stack_element.volume, volume):
+                self._alter_fluid_records(len(removed_elements) + 1, None)
+                return
+            else:
+                self._alter_fluid_records(
+                    len(removed_elements),
+                    AspiratedFluid(
+                        kind=last_stack_element.kind,
+                        volume=last_stack_element.volume - volume,
+                    ),
+                )
+                return
+
+        _LOG.error(f"Failed to handle removing {volume}uL from {self._fluid_stack}")
+
+    def aspirated_volume(self, kind: FluidKind | None = None) -> float:
+        """Measure the total amount of fluid (optionally filtered by kind) in the stack."""
+        volume = 0.0
+        for el in self._fluid_stack:
+            if kind is not None and el.kind != kind:
+                continue
+            volume += el.volume
+        return volume
+
+    def liquid_part_of_dispense_volume(self, volume: float) -> float:
+        """Get the amount of liquid in the specified volume starting at the bottom of the stack."""
+        liquid_volume = 0.0
+        for el in reversed(self._fluid_stack):
+            if el.kind == FluidKind.LIQUID:
+                liquid_volume += min(volume, el.volume)
+            volume -= min(el.volume, volume)
+            if isclose(volume, 0.0):
+                return liquid_volume
+        return liquid_volume
+
+    def __eq__(self, other: object) -> bool:
+        """Equality."""
+        if isinstance(other, type(self)):
+            return other._fluid_stack == self._fluid_stack
+        return False
+
+    def __repr__(self) -> str:
+        """String representation of a fluid stack."""
+        if self._fluid_stack:
+            stringified_stack = (
+                f'(top) {", ".join([str(item) for item in self._fluid_stack])} (bottom)'
+            )
+        else:
+            stringified_stack = "empty"
+        return f"<{self.__class__.__name__}: {stringified_stack}>"

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -11,6 +11,8 @@ from typing import (
     Tuple,
 )
 
+from typing_extensions import assert_never
+
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons.config.defaults_ot2 import Z_RETRACT_DISTANCE
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -321,9 +323,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         elif state_update.pipette_aspirated_fluid.type == "unknown":
             self._update_unknown(state_update.pipette_aspirated_fluid)
         else:
-            LOG.error(
-                f"Unknown aspirated fluid update type {state_update.pipette_aspirated_fluid.type}"
-            )
+            assert_never(state_update.pipette_aspirated_fluid.type)
 
     def _update_aspirated(
         self, update: update_types.PipetteAspiratedFluidUpdate

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 import dataclasses
+from logging import getLogger
 from typing import (
     Dict,
     List,
     Mapping,
     Optional,
     Tuple,
-    Union,
 )
 
 from opentrons_shared_data.pipette import pipette_definition
@@ -21,8 +21,7 @@ from opentrons.hardware_control.nozzle_manager import (
 )
 from opentrons.types import MountType, Mount as HwMount, Point
 
-from . import update_types
-from .. import commands
+from . import update_types, fluid_stack
 from .. import errors
 from ..types import (
     LoadedPipette,
@@ -36,12 +35,12 @@ from ..types import (
 )
 from ..actions import (
     Action,
-    FailCommandAction,
     SetPipetteMovementSpeedAction,
-    SucceedCommandAction,
     get_state_updates,
 )
 from ._abstract_store import HasState, HandlesActions
+
+LOG = getLogger(__name__)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -108,7 +107,7 @@ class PipetteState:
     # attributes are populated at the appropriate times. Refactor to a
     # single dict-of-many-things instead of many dicts-of-single-things.
     pipettes_by_id: Dict[str, LoadedPipette]
-    aspirated_volume_by_id: Dict[str, Optional[float]]
+    pipette_contents_by_id: Dict[str, Optional[fluid_stack.FluidStack]]
     current_location: Optional[CurrentPipetteLocation]
     current_deck_point: CurrentDeckPoint
     attached_tip_by_id: Dict[str, Optional[TipGeometry]]
@@ -128,7 +127,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         """Initialize a PipetteStore and its state."""
         self._state = PipetteState(
             pipettes_by_id={},
-            aspirated_volume_by_id={},
+            pipette_contents_by_id={},
             attached_tip_by_id={},
             current_location=None,
             current_deck_point=CurrentDeckPoint(mount=None, deck_point=None),
@@ -147,11 +146,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._update_pipette_config(state_update)
             self._update_pipette_nozzle_map(state_update)
             self._update_tip_state(state_update)
+            self._update_volumes(state_update)
 
-        if isinstance(action, (SucceedCommandAction, FailCommandAction)):
-            self._update_volumes(action)
-
-        elif isinstance(action, SetPipetteMovementSpeedAction):
+        if isinstance(action, SetPipetteMovementSpeedAction):
             self._state.movement_speed_by_id[action.pipette_id] = action.speed
 
     def _set_load_pipette(self, state_update: update_types.StateUpdate) -> None:
@@ -166,7 +163,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.liquid_presence_detection_by_id[pipette_id] = (
                 state_update.loaded_pipette.liquid_presence_detection or False
             )
-            self._state.aspirated_volume_by_id[pipette_id] = None
+            self._state.pipette_contents_by_id[pipette_id] = fluid_stack.FluidStack()
             self._state.movement_speed_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None
 
@@ -177,7 +174,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 attached_tip = state_update.pipette_tip_state.tip_geometry
 
                 self._state.attached_tip_by_id[pipette_id] = attached_tip
-                self._state.aspirated_volume_by_id[pipette_id] = 0
+                self._state.pipette_contents_by_id[
+                    pipette_id
+                ] = fluid_stack.FluidStack()
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
                 if static_config:
@@ -204,7 +203,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
             else:
                 pipette_id = state_update.pipette_tip_state.pipette_id
-                self._state.aspirated_volume_by_id[pipette_id] = None
+                self._state.pipette_contents_by_id[
+                    pipette_id
+                ] = fluid_stack.FluidStack()
                 self._state.attached_tip_by_id[pipette_id] = None
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
@@ -308,51 +309,42 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 state_update.pipette_nozzle_map.pipette_id
             ] = state_update.pipette_nozzle_map.nozzle_map
 
-    def _update_volumes(
-        self, action: Union[SucceedCommandAction, FailCommandAction]
+    def _update_volumes(self, state_update: update_types.StateUpdate) -> None:
+        if state_update.pipette_aspirated_fluid == update_types.NO_CHANGE:
+            return
+        if state_update.pipette_aspirated_fluid.type == "aspirated":
+            self._update_aspirated(state_update.pipette_aspirated_fluid)
+        elif state_update.pipette_aspirated_fluid.type == "ejected":
+            self._update_ejected(state_update.pipette_aspirated_fluid)
+        elif state_update.pipette_aspirated_fluid.type == "empty":
+            self._update_empty(state_update.pipette_aspirated_fluid)
+        elif state_update.pipette_aspirated_fluid.type == "unknown":
+            self._update_unknown(state_update.pipette_aspirated_fluid)
+        else:
+            LOG.error(
+                f"Unknown aspirated fluid update type {state_update.pipette_aspirated_fluid.type}"
+            )
+
+    def _update_aspirated(
+        self, update: update_types.PipetteAspiratedFluidUpdate
     ) -> None:
-        # todo(mm, 2024-10-10): Port these isinstance checks to StateUpdate.
-        # https://opentrons.atlassian.net/browse/EXEC-754
+        self._fluid_stack_log_if_empty(update.pipette_id).add_fluid(update.fluid)
 
-        if isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (commands.AspirateResult, commands.AspirateInPlaceResult),
-        ):
-            pipette_id = action.command.params.pipetteId
-            previous_volume = self._state.aspirated_volume_by_id[pipette_id] or 0
-            # PipetteHandler will have clamped action.command.result.volume for us, so
-            # next_volume should always be in bounds.
-            next_volume = previous_volume + action.command.result.volume
+    def _update_ejected(self, update: update_types.PipetteEjectedFluidUpdate) -> None:
+        self._fluid_stack_log_if_empty(update.pipette_id).remove_fluid(update.volume)
 
-            self._state.aspirated_volume_by_id[pipette_id] = next_volume
+    def _update_empty(self, update: update_types.PipetteEmptyFluidUpdate) -> None:
+        self._state.pipette_contents_by_id[update.pipette_id] = fluid_stack.FluidStack()
 
-        elif isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (commands.DispenseResult, commands.DispenseInPlaceResult),
-        ):
-            pipette_id = action.command.params.pipetteId
-            previous_volume = self._state.aspirated_volume_by_id[pipette_id] or 0
-            # PipetteHandler will have clamped action.command.result.volume for us, so
-            # next_volume should always be in bounds.
-            next_volume = previous_volume - action.command.result.volume
-            self._state.aspirated_volume_by_id[pipette_id] = next_volume
+    def _update_unknown(self, update: update_types.PipetteUnknownFluidUpdate) -> None:
+        self._state.pipette_contents_by_id[update.pipette_id] = None
 
-        elif isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result,
-            (
-                commands.BlowOutResult,
-                commands.BlowOutInPlaceResult,
-                commands.unsafe.UnsafeBlowOutInPlaceResult,
-            ),
-        ):
-            pipette_id = action.command.params.pipetteId
-            self._state.aspirated_volume_by_id[pipette_id] = None
-
-        elif isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, commands.PrepareToAspirateResult
-        ):
-            pipette_id = action.command.params.pipetteId
-            self._state.aspirated_volume_by_id[pipette_id] = 0
+    def _fluid_stack_log_if_empty(self, pipette_id: str) -> fluid_stack.FluidStack:
+        stack = self._state.pipette_contents_by_id[pipette_id]
+        if stack is None:
+            LOG.error("Pipette state tried to alter an unknown-contents pipette")
+            return fluid_stack.FluidStack()
+        return stack
 
 
 class PipetteView(HasState[PipetteState]):
@@ -457,6 +449,10 @@ class PipetteView(HasState[PipetteState]):
     def get_aspirated_volume(self, pipette_id: str) -> Optional[float]:
         """Get the currently aspirated volume of a pipette by ID.
 
+        This is the volume currently displaced by the plunger relative to its bottom position,
+        regardless of whether that volume likely contains liquid or air. This makes it the right
+        function to call to know how much more volume the plunger may displace.
+
         Returns:
             The volume the pipette has aspirated.
             None, after blow-out and the plunger is in an unsafe position.
@@ -468,11 +464,48 @@ class PipetteView(HasState[PipetteState]):
         self.validate_tip_state(pipette_id, True)
 
         try:
-            return self._state.aspirated_volume_by_id[pipette_id]
+            stack = self._state.pipette_contents_by_id[pipette_id]
+            if stack is None:
+                return None
+            return stack.aspirated_volume()
 
         except KeyError as e:
             raise errors.PipetteNotLoadedError(
                 f"Pipette {pipette_id} not found; unable to get current volume."
+            ) from e
+
+    def get_liquid_dispensed_by_ejecting_volume(
+        self, pipette_id: str, volume: float
+    ) -> Optional[float]:
+        """Get the amount of liquid (not air) that will be dispensed if the pipette ejects a specified volume.
+
+        For instance, if the pipette contains, in vertical order,
+        10 ul air
+        80 ul liquid
+        5 ul air
+
+        then dispensing 10ul would result in 5ul of liquid; dispensing 85 ul would result in 80ul liquid; dispensing
+        95ul would result in 80ul liquid.
+
+        Returns:
+            The volume of liquid that would be dispensed by the requested volume.
+            None, after blow-out or when the plunger is in an unsafe position.
+
+        Raises:
+            PipetteNotLoadedError: pipette ID does not exist.
+            TipnotAttachedError: No tip is attached to the pipette.
+        """
+        self.validate_tip_state(pipette_id, True)
+
+        try:
+            stack = self._state.pipette_contents_by_id[pipette_id]
+            if stack is None:
+                return None
+            return stack.liquid_part_of_dispense_volume(volume)
+
+        except KeyError as e:
+            raise errors.PipetteNotLoadedError(
+                f"Pipette {pipette_id} not found; unable to get current liquid volume."
             ) from e
 
     def get_working_volume(self, pipette_id: str) -> float:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -176,9 +176,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 attached_tip = state_update.pipette_tip_state.tip_geometry
 
                 self._state.attached_tip_by_id[pipette_id] = attached_tip
-                self._state.pipette_contents_by_id[
-                    pipette_id
-                ] = fluid_stack.FluidStack()
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
                 if static_config:
@@ -205,9 +202,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
             else:
                 pipette_id = state_update.pipette_tip_state.pipette_id
-                self._state.pipette_contents_by_id[
-                    pipette_id
-                ] = fluid_stack.FluidStack()
                 self._state.attached_tip_by_id[pipette_id] = None
 
                 static_config = self._state.static_config_by_id.get(pipette_id)

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -165,7 +165,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.liquid_presence_detection_by_id[pipette_id] = (
                 state_update.loaded_pipette.liquid_presence_detection or False
             )
-            self._state.pipette_contents_by_id[pipette_id] = fluid_stack.FluidStack()
             self._state.movement_speed_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None
 

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -8,7 +8,12 @@ from datetime import datetime
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_engine.resources import pipette_data_provider
-from opentrons.protocol_engine.types import DeckPoint, LabwareLocation, TipGeometry
+from opentrons.protocol_engine.types import (
+    DeckPoint,
+    LabwareLocation,
+    TipGeometry,
+    AspiratedFluid,
+)
 from opentrons.types import MountType
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.pipette.types import PipetteNameType
@@ -206,6 +211,40 @@ class LiquidOperatedUpdate:
 
 
 @dataclasses.dataclass
+class PipetteAspiratedFluidUpdate:
+    """Represents the pipette aspirating something. Might be air or liquid from a well."""
+
+    pipette_id: str
+    fluid: AspiratedFluid
+    type: typing.Literal["aspirated"] = "aspirated"
+
+
+@dataclasses.dataclass
+class PipetteEjectedFluidUpdate:
+    """Represents the pipette pushing something out. Might be air or liquid."""
+
+    pipette_id: str
+    volume: float
+    type: typing.Literal["ejected"] = "ejected"
+
+
+@dataclasses.dataclass
+class PipetteUnknownFluidUpdate:
+    """Represents the amount of fluid in the pipette becoming unknown."""
+
+    pipette_id: str
+    type: typing.Literal["unknown"] = "unknown"
+
+
+@dataclasses.dataclass
+class PipetteEmptyFluidUpdate:
+    """Sets the pipette to be valid and empty."""
+
+    pipette_id: str
+    type: typing.Literal["empty"] = "empty"
+
+
+@dataclasses.dataclass
 class StateUpdate:
     """Represents an update to perform on engine state."""
 
@@ -218,6 +257,10 @@ class StateUpdate:
     pipette_nozzle_map: PipetteNozzleMapUpdate | NoChangeType = NO_CHANGE
 
     pipette_tip_state: PipetteTipStateUpdate | NoChangeType = NO_CHANGE
+
+    pipette_aspirated_fluid: PipetteAspiratedFluidUpdate | PipetteEjectedFluidUpdate | PipetteUnknownFluidUpdate | PipetteEmptyFluidUpdate | NoChangeType = (
+        NO_CHANGE
+    )
 
     labware_location: LabwareLocationUpdate | NoChangeType = NO_CHANGE
 
@@ -405,4 +448,28 @@ class StateUpdate:
             labware_id=labware_id,
             well_name=well_name,
             volume_added=volume_added,
+        )
+
+    def set_fluid_aspirated(self, pipette_id: str, fluid: AspiratedFluid) -> None:
+        """Update record of fluid held inside a pipette. See `PipetteAspiratedFluidUpdate`."""
+        self.pipette_aspirated_fluid = PipetteAspiratedFluidUpdate(
+            type="aspirated", pipette_id=pipette_id, fluid=fluid
+        )
+
+    def set_fluid_ejected(self, pipette_id: str, volume: float) -> None:
+        """Update record of fluid held inside a pipette. See `PipetteEjectedFluidUpdate`."""
+        self.pipette_aspirated_fluid = PipetteEjectedFluidUpdate(
+            type="ejected", pipette_id=pipette_id, volume=volume
+        )
+
+    def set_fluid_unknown(self, pipette_id: str) -> None:
+        """Update record fo fluid held inside a pipette. See `PipetteUnknownFluidUpdate`."""
+        self.pipette_aspirated_fluid = PipetteUnknownFluidUpdate(
+            type="unknown", pipette_id=pipette_id
+        )
+
+    def set_fluid_empty(self, pipette_id: str) -> None:
+        """Update record fo fluid held inside a pipette. See `PipetteEmptyFluidUpdate`."""
+        self.pipette_aspirated_fluid = PipetteEmptyFluidUpdate(
+            type="empty", pipette_id=pipette_id
         )

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -463,7 +463,7 @@ class StateUpdate:
         )
 
     def set_fluid_unknown(self, pipette_id: str) -> None:
-        """Update record fo fluid held inside a pipette. See `PipetteUnknownFluidUpdate`."""
+        """Update record of fluid held inside a pipette. See `PipetteUnknownFluidUpdate`."""
         self.pipette_aspirated_fluid = PipetteUnknownFluidUpdate(
             type="unknown", pipette_id=pipette_id
         )

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -423,6 +423,21 @@ class TipGeometry:
     volume: float
 
 
+class FluidKind(str, Enum):
+    """A kind of fluid that can be inside a pipette."""
+
+    LIQUID = "LIQUID"
+    AIR = "AIR"
+
+
+@dataclass(frozen=True)
+class AspiratedFluid:
+    """Fluid inside a pipette."""
+
+    kind: FluidKind
+    volume: float
+
+
 class MovementAxis(str, Enum):
     """Axis on which to issue a relative movement."""
 

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 21)
+MAX_SUPPORTED_VERSION = APIVersion(2, 22)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/api/tests/opentrons/protocol_engine/commands/test_air_gap_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_air_gap_in_place.py
@@ -1,0 +1,284 @@
+"""Test aspirate-in-place commands."""
+from datetime import datetime
+
+import pytest
+from decoy import Decoy, matchers
+
+from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
+
+from opentrons.types import Point
+from opentrons.hardware_control import API as HardwareAPI
+
+from opentrons.protocol_engine.execution import PipettingHandler, GantryMover
+from opentrons.protocol_engine.commands.air_gap_in_place import (
+    AirGapInPlaceParams,
+    AirGapInPlaceResult,
+    AirGapInPlaceImplementation,
+)
+from opentrons.protocol_engine.commands.command import SuccessData, DefinedErrorData
+from opentrons.protocol_engine.errors.exceptions import PipetteNotReadyToAspirateError
+from opentrons.protocol_engine.notes import CommandNoteAdder
+from opentrons.protocol_engine.resources import ModelUtils
+from opentrons.protocol_engine.state.state import StateStore
+from opentrons.protocol_engine.commands.pipetting_common import OverpressureError
+from opentrons.protocol_engine.types import (
+    CurrentWell,
+    CurrentPipetteLocation,
+    CurrentAddressableArea,
+    AspiratedFluid,
+    FluidKind,
+)
+from opentrons.protocol_engine.state import update_types
+
+
+@pytest.fixture
+def hardware_api(decoy: Decoy) -> HardwareAPI:
+    """Get a mock in the shape of a HardwareAPI."""
+    return decoy.mock(cls=HardwareAPI)
+
+
+@pytest.fixture
+def state_store(decoy: Decoy) -> StateStore:
+    """Get a mock in the shape of a StateStore."""
+    return decoy.mock(cls=StateStore)
+
+
+@pytest.fixture
+def pipetting(decoy: Decoy) -> PipettingHandler:
+    """Get a mock in the shape of a PipettingHandler."""
+    return decoy.mock(cls=PipettingHandler)
+
+
+@pytest.fixture
+def subject(
+    pipetting: PipettingHandler,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    mock_command_note_adder: CommandNoteAdder,
+    model_utils: ModelUtils,
+    gantry_mover: GantryMover,
+) -> AirGapInPlaceImplementation:
+    """Get the impelementation subject."""
+    return AirGapInPlaceImplementation(
+        pipetting=pipetting,
+        hardware_api=hardware_api,
+        state_view=state_store,
+        command_note_adder=mock_command_note_adder,
+        model_utils=model_utils,
+        gantry_mover=gantry_mover,
+    )
+
+
+@pytest.mark.parametrize(
+    "location,stateupdateLabware,stateupdateWell",
+    [
+        (
+            CurrentWell(
+                pipette_id="pipette-id-abc",
+                labware_id="labware-id-1",
+                well_name="well-name-1",
+            ),
+            "labware-id-1",
+            "well-name-1",
+        ),
+        (None, None, None),
+        (CurrentAddressableArea("pipette-id-abc", "addressable-area-1"), None, None),
+    ],
+)
+async def test_air_gap_in_place_implementation(
+    decoy: Decoy,
+    pipetting: PipettingHandler,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    mock_command_note_adder: CommandNoteAdder,
+    subject: AirGapInPlaceImplementation,
+    location: CurrentPipetteLocation | None,
+    stateupdateLabware: str,
+    stateupdateWell: str,
+) -> None:
+    """It should aspirate in place."""
+    data = AirGapInPlaceParams(
+        pipetteId="pipette-id-abc",
+        volume=123,
+        flowRate=1.234,
+    )
+
+    decoy.when(
+        pipetting.get_is_ready_to_aspirate(
+            pipette_id="pipette-id-abc",
+        )
+    ).then_return(True)
+
+    decoy.when(
+        await pipetting.aspirate_in_place(
+            pipette_id="pipette-id-abc",
+            volume=123,
+            flow_rate=1.234,
+            command_note_adder=mock_command_note_adder,
+        )
+    ).then_return(123)
+
+    decoy.when(state_store.pipettes.get_current_location()).then_return(location)
+
+    result = await subject.execute(params=data)
+
+    if isinstance(location, CurrentWell):
+        assert result == SuccessData(
+            public=AirGapInPlaceResult(volume=123),
+            state_update=update_types.StateUpdate(
+                pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
+                    pipette_id="pipette-id-abc",
+                    fluid=AspiratedFluid(kind=FluidKind.AIR, volume=123),
+                )
+            ),
+        )
+    else:
+        assert result == SuccessData(
+            public=AirGapInPlaceResult(volume=123),
+            state_update=update_types.StateUpdate(
+                pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
+                    pipette_id="pipette-id-abc",
+                    fluid=AspiratedFluid(kind=FluidKind.AIR, volume=123),
+                )
+            ),
+        )
+
+
+async def test_handle_air_gap_in_place_request_not_ready_to_aspirate(
+    decoy: Decoy,
+    pipetting: PipettingHandler,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    subject: AirGapInPlaceImplementation,
+) -> None:
+    """Should raise an exception for not ready to aspirate."""
+    data = AirGapInPlaceParams(
+        pipetteId="pipette-id-abc",
+        volume=123,
+        flowRate=1.234,
+    )
+
+    decoy.when(
+        pipetting.get_is_ready_to_aspirate(
+            pipette_id="pipette-id-abc",
+        )
+    ).then_return(False)
+
+    with pytest.raises(
+        PipetteNotReadyToAspirateError,
+        match="Pipette cannot air gap in place because of a previous blow out."
+        " The first aspirate following a blow-out must be from a specific well"
+        " so the plunger can be reset in a known safe position.",
+    ):
+        await subject.execute(params=data)
+
+
+async def test_aspirate_raises_volume_error(
+    decoy: Decoy,
+    pipetting: PipettingHandler,
+    subject: AirGapInPlaceImplementation,
+    mock_command_note_adder: CommandNoteAdder,
+) -> None:
+    """Should raise an assertion error for volume larger than working volume."""
+    data = AirGapInPlaceParams(
+        pipetteId="abc",
+        volume=50,
+        flowRate=1.23,
+    )
+
+    decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id="abc")).then_return(True)
+
+    decoy.when(
+        await pipetting.aspirate_in_place(
+            pipette_id="abc",
+            volume=50,
+            flow_rate=1.23,
+            command_note_adder=mock_command_note_adder,
+        )
+    ).then_raise(AssertionError("blah blah"))
+
+    with pytest.raises(AssertionError):
+        await subject.execute(data)
+
+
+@pytest.mark.parametrize(
+    "location,stateupdateLabware,stateupdateWell",
+    [
+        (
+            CurrentWell(
+                pipette_id="pipette-id",
+                labware_id="labware-id-1",
+                well_name="well-name-1",
+            ),
+            "labware-id-1",
+            "well-name-1",
+        ),
+        (None, None, None),
+        (CurrentAddressableArea("pipette-id", "addressable-area-1"), None, None),
+    ],
+)
+async def test_overpressure_error(
+    decoy: Decoy,
+    gantry_mover: GantryMover,
+    pipetting: PipettingHandler,
+    subject: AirGapInPlaceImplementation,
+    model_utils: ModelUtils,
+    mock_command_note_adder: CommandNoteAdder,
+    state_store: StateStore,
+    location: CurrentPipetteLocation | None,
+    stateupdateLabware: str,
+    stateupdateWell: str,
+) -> None:
+    """It should return an overpressure error if the hardware API indicates that."""
+    pipette_id = "pipette-id"
+
+    position = Point(x=1, y=2, z=3)
+
+    error_id = "error-id"
+    error_timestamp = datetime(year=2020, month=1, day=2)
+
+    data = AirGapInPlaceParams(
+        pipetteId=pipette_id,
+        volume=50,
+        flowRate=1.23,
+    )
+
+    decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
+        True
+    )
+
+    decoy.when(
+        await pipetting.aspirate_in_place(
+            pipette_id=pipette_id,
+            volume=50,
+            flow_rate=1.23,
+            command_note_adder=mock_command_note_adder,
+        ),
+    ).then_raise(PipetteOverpressureError())
+
+    decoy.when(model_utils.generate_id()).then_return(error_id)
+    decoy.when(model_utils.get_timestamp()).then_return(error_timestamp)
+    decoy.when(await gantry_mover.get_position(pipette_id)).then_return(position)
+    decoy.when(state_store.pipettes.get_current_location()).then_return(location)
+
+    result = await subject.execute(data)
+
+    if isinstance(location, CurrentWell):
+        assert result == DefinedErrorData(
+            public=OverpressureError.construct(
+                id=error_id,
+                createdAt=error_timestamp,
+                wrappedErrors=[matchers.Anything()],
+                errorInfo={"retryLocation": (position.x, position.y, position.z)},
+            ),
+            state_update=update_types.StateUpdate(),
+        )
+    else:
+        assert result == DefinedErrorData(
+            public=OverpressureError.construct(
+                id=error_id,
+                createdAt=error_timestamp,
+                wrappedErrors=[matchers.Anything()],
+                errorInfo={"retryLocation": (position.x, position.y, position.z)},
+            ),
+        )

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -29,7 +29,12 @@ from opentrons.protocol_engine.execution import (
     PipettingHandler,
 )
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
-from opentrons.protocol_engine.types import CurrentWell, LoadedPipette
+from opentrons.protocol_engine.types import (
+    CurrentWell,
+    LoadedPipette,
+    AspiratedFluid,
+    FluidKind,
+)
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.notes import CommandNoteAdder
 
@@ -114,6 +119,9 @@ async def test_aspirate_implementation_no_prep(
                 well_name="A3",
                 volume_added=-50,
             ),
+            pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
+                pipette_id="abc", fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=50)
+            ),
         ),
     )
 
@@ -186,6 +194,9 @@ async def test_aspirate_implementation_with_prep(
                 labware_id="123",
                 well_name="A3",
                 volume_added=-50,
+            ),
+            pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
+                pipette_id="abc", fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=50)
             ),
         ),
     )
@@ -327,6 +338,9 @@ async def test_overpressure_error(
                 well_name=well_name,
                 volume_added=update_types.CLEAR,
             ),
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id=pipette_id
+            ),
         ),
     )
 
@@ -391,6 +405,9 @@ async def test_aspirate_implementation_meniscus(
                 labware_id="123",
                 well_name="A3",
                 volume_added=-50,
+            ),
+            pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
+                pipette_id="abc", fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=50)
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
@@ -25,6 +25,8 @@ from opentrons.protocol_engine.types import (
     CurrentWell,
     CurrentPipetteLocation,
     CurrentAddressableArea,
+    AspiratedFluid,
+    FluidKind,
 )
 from opentrons.protocol_engine.state import update_types
 
@@ -128,12 +130,22 @@ async def test_aspirate_in_place_implementation(
                     labware_id=stateupdateLabware,
                     well_name=stateupdateWell,
                     volume_added=-123,
-                )
+                ),
+                pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
+                    pipette_id="pipette-id-abc",
+                    fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=123),
+                ),
             ),
         )
     else:
         assert result == SuccessData(
             public=AspirateInPlaceResult(volume=123),
+            state_update=update_types.StateUpdate(
+                pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
+                    pipette_id="pipette-id-abc",
+                    fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=123),
+                )
+            ),
         )
 
 
@@ -269,7 +281,10 @@ async def test_overpressure_error(
                     labware_id=stateupdateLabware,
                     well_name=stateupdateWell,
                     volume_added=update_types.CLEAR,
-                )
+                ),
+                pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                    pipette_id="pipette-id"
+                ),
             ),
         )
     else:
@@ -279,5 +294,10 @@ async def test_overpressure_error(
                 createdAt=error_timestamp,
                 wrappedErrors=[matchers.Anything()],
                 errorInfo={"retryLocation": (position.x, position.y, position.z)},
+            ),
+            state_update=update_types.StateUpdate(
+                pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                    pipette_id="pipette-id"
+                )
             ),
         )

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -84,7 +84,10 @@ async def test_blow_out_implementation(
                     well_name="C6",
                 ),
                 new_deck_point=DeckPoint(x=1, y=2, z=3),
-            )
+            ),
+            pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
+                pipette_id="pipette-id"
+            ),
         ),
     )
 
@@ -144,5 +147,18 @@ async def test_overpressure_error(
             createdAt=error_timestamp,
             wrappedErrors=[matchers.Anything()],
             errorInfo={"retryLocation": (1, 2, 3)},
+        ),
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="pipette-id",
+                new_location=update_types.Well(
+                    labware_id="labware-id",
+                    well_name="C6",
+                ),
+                new_deck_point=DeckPoint(x=1, y=2, z=3),
+            ),
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id="pipette-id"
+            ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -48,6 +48,7 @@ async def test_dispense_implementation(
     movement: MovementHandler,
     pipetting: PipettingHandler,
     subject: DispenseImplementation,
+    state_view: StateView,
 ) -> None:
     """It should move to the target location and then dispense."""
     well_location = LiquidHandlingWellLocation(
@@ -77,6 +78,11 @@ async def test_dispense_implementation(
             pipette_id="pipette-id-abc123", volume=50, flow_rate=1.23, push_out=None
         )
     ).then_return(42)
+    decoy.when(
+        state_view.pipettes.get_liquid_dispensed_by_ejecting_volume(
+            pipette_id="pipette-id-abc123", volume=42
+        )
+    ).then_return(34)
 
     result = await subject.execute(data)
 
@@ -94,7 +100,10 @@ async def test_dispense_implementation(
             liquid_operated=update_types.LiquidOperatedUpdate(
                 labware_id="labware-id-abc123",
                 well_name="A3",
-                volume_added=42,
+                volume_added=34,
+            ),
+            pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
+                pipette_id="pipette-id-abc123", volume=42
             ),
         ),
     )
@@ -169,6 +178,9 @@ async def test_overpressure_error(
                 labware_id="labware-id",
                 well_name="well-name",
                 volume_added=update_types.CLEAR,
+            ),
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id="pipette-id"
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -141,6 +141,9 @@ async def test_drop_tip_implementation(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc", tip_geometry=None
             ),
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id="abc"
+            ),
         ),
     )
 
@@ -218,6 +221,9 @@ async def test_drop_tip_with_alternating_locations(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc", tip_geometry=None
             ),
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id="abc"
+            ),
         ),
     )
 
@@ -291,11 +297,17 @@ async def test_tip_attached_error(
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id="abc"
+            ),
         ),
         state_update_if_false_positive=update_types.StateUpdate(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
-            )
+            ),
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id="abc"
+            ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -306,8 +306,5 @@ async def test_tip_attached_error(
                 pipette_id="abc",
                 tip_geometry=None,
             ),
-            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
-                pipette_id="abc"
-            ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -100,6 +100,5 @@ async def test_tip_attached_error(
             pipette_tip_state=PipetteTipStateUpdate(
                 pipette_id="abc", tip_geometry=None
             ),
-            pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc"),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -19,6 +19,7 @@ from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.state.update_types import (
     PipetteTipStateUpdate,
     StateUpdate,
+    PipetteUnknownFluidUpdate,
 )
 
 
@@ -50,7 +51,10 @@ async def test_success(
     assert result == SuccessData(
         public=DropTipInPlaceResult(),
         state_update=StateUpdate(
-            pipette_tip_state=PipetteTipStateUpdate(pipette_id="abc", tip_geometry=None)
+            pipette_tip_state=PipetteTipStateUpdate(
+                pipette_id="abc", tip_geometry=None
+            ),
+            pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc"),
         ),
     )
 
@@ -89,8 +93,13 @@ async def test_tip_attached_error(
             createdAt=datetime(year=1, month=2, day=3),
             wrappedErrors=[matchers.Anything()],
         ),
-        state_update=StateUpdate(),
+        state_update=StateUpdate(
+            pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc")
+        ),
         state_update_if_false_positive=StateUpdate(
-            pipette_tip_state=PipetteTipStateUpdate(pipette_id="abc", tip_geometry=None)
+            pipette_tip_state=PipetteTipStateUpdate(
+                pipette_id="abc", tip_geometry=None
+            ),
+            pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc"),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -3,6 +3,7 @@ from opentrons.protocol_engine.state.update_types import (
     LoadPipetteUpdate,
     PipetteConfigUpdate,
     StateUpdate,
+    PipetteUnknownFluidUpdate,
 )
 import pytest
 from decoy import Decoy
@@ -101,6 +102,7 @@ async def test_load_pipette_implementation(
                 serial_number="some-serial-number",
                 config=config_data,
             ),
+            pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="some id"),
         ),
     )
 
@@ -166,6 +168,7 @@ async def test_load_pipette_implementation_96_channel(
                 serial_number="some id",
                 config=config_data,
             ),
+            pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="pipette-id"),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -97,6 +97,9 @@ async def test_success(
             tips_used=update_types.TipsUsedUpdate(
                 pipette_id="pipette-id", labware_id="labware-id", well_name="A3"
             ),
+            pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
+                pipette_id="pipette-id"
+            ),
         ),
     )
 
@@ -163,10 +166,16 @@ async def test_tip_physically_missing_error(
             tips_used=update_types.TipsUsedUpdate(
                 pipette_id="pipette-id", labware_id="labware-id", well_name="well-name"
             ),
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id="pipette-id"
+            ),
         ),
         state_update_if_false_positive=update_types.StateUpdate(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id", tip_geometry=sentinel.tip_geometry
-            )
+            ),
+            pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
+                pipette_id="pipette-id"
+            ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_blow_out_in_place.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.types import MountType
 from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.commands.unsafe.unsafe_blow_out_in_place import (
     UnsafeBlowOutInPlaceParams,
     UnsafeBlowOutInPlaceResult,
@@ -41,7 +42,14 @@ async def test_blow_out_in_place_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SuccessData(public=UnsafeBlowOutInPlaceResult())
+    assert result == SuccessData(
+        public=UnsafeBlowOutInPlaceResult(),
+        state_update=update_types.StateUpdate(
+            pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
+                pipette_id="pipette-id"
+            )
+        ),
+    )
 
     decoy.verify(
         await ot3_hardware_api.update_axis_position_estimations([Axis.P_L]),

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -1,6 +1,7 @@
 """Test unsafe drop tip in place commands."""
 from opentrons.protocol_engine.state.update_types import (
     PipetteTipStateUpdate,
+    PipetteUnknownFluidUpdate,
     StateUpdate,
 )
 import pytest
@@ -51,7 +52,10 @@ async def test_drop_tip_implementation(
     assert result == SuccessData(
         public=UnsafeDropTipInPlaceResult(),
         state_update=StateUpdate(
-            pipette_tip_state=PipetteTipStateUpdate(pipette_id="abc", tip_geometry=None)
+            pipette_tip_state=PipetteTipStateUpdate(
+                pipette_id="abc", tip_geometry=None
+            ),
+            pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc"),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_fluid_stack.py
+++ b/api/tests/opentrons/protocol_engine/state/test_fluid_stack.py
@@ -1,0 +1,219 @@
+"""Test pipette internal fluid tracking."""
+import pytest
+
+from opentrons.protocol_engine.state.fluid_stack import FluidStack
+from opentrons.protocol_engine.types import AspiratedFluid, FluidKind
+
+
+@pytest.mark.parametrize(
+    "fluids,resulting_stack",
+    [
+        (
+            [
+                AspiratedFluid(FluidKind.LIQUID, 10),
+                AspiratedFluid(FluidKind.LIQUID, 10),
+            ],
+            [AspiratedFluid(FluidKind.LIQUID, 20)],
+        ),
+        (
+            [AspiratedFluid(FluidKind.AIR, 10), AspiratedFluid(FluidKind.LIQUID, 20)],
+            [AspiratedFluid(FluidKind.AIR, 10), AspiratedFluid(FluidKind.LIQUID, 20)],
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.AIR, 10),
+                AspiratedFluid(FluidKind.LIQUID, 20),
+                AspiratedFluid(FluidKind.LIQUID, 10),
+                AspiratedFluid(FluidKind.AIR, 20),
+            ],
+            [
+                AspiratedFluid(FluidKind.AIR, 10),
+                AspiratedFluid(FluidKind.LIQUID, 30),
+                AspiratedFluid(FluidKind.AIR, 20),
+            ],
+        ),
+    ],
+)
+def test_add_fluid(
+    fluids: list[AspiratedFluid], resulting_stack: list[AspiratedFluid]
+) -> None:
+    """It should add fluids."""
+    stack = FluidStack()
+    for fluid in fluids:
+        stack.add_fluid(fluid)
+    assert stack._fluid_stack == resulting_stack
+
+
+@pytest.mark.parametrize(
+    "starting_fluids,remove_volume,resulting_stack",
+    [
+        ([], 1, []),
+        ([], 0, []),
+        (
+            [AspiratedFluid(FluidKind.LIQUID, 10)],
+            0,
+            [AspiratedFluid(FluidKind.LIQUID, 10)],
+        ),
+        (
+            [AspiratedFluid(FluidKind.LIQUID, 10)],
+            5,
+            [AspiratedFluid(FluidKind.LIQUID, 5)],
+        ),
+        ([AspiratedFluid(FluidKind.LIQUID, 10)], 11, []),
+        (
+            [AspiratedFluid(FluidKind.LIQUID, 10), AspiratedFluid(FluidKind.AIR, 10)],
+            11,
+            [AspiratedFluid(FluidKind.LIQUID, 9)],
+        ),
+        (
+            [AspiratedFluid(FluidKind.LIQUID, 10), AspiratedFluid(FluidKind.AIR, 10)],
+            20,
+            [],
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.LIQUID, 10),
+                AspiratedFluid(FluidKind.AIR, 10),
+                AspiratedFluid(FluidKind.LIQUID, 10),
+            ],
+            28,
+            [AspiratedFluid(FluidKind.LIQUID, 2)],
+        ),
+    ],
+)
+def test_remove_fluid(
+    starting_fluids: list[AspiratedFluid],
+    remove_volume: float,
+    resulting_stack: list[AspiratedFluid],
+) -> None:
+    """It should remove fluids."""
+    stack = FluidStack(_fluid_stack=[f for f in starting_fluids])
+    stack.remove_fluid(remove_volume)
+    assert stack._fluid_stack == resulting_stack
+
+
+@pytest.mark.parametrize(
+    "starting_fluids,filter,result",
+    [
+        ([], None, 0),
+        ([], FluidKind.LIQUID, 0),
+        ([], FluidKind.AIR, 0),
+        ([AspiratedFluid(FluidKind.LIQUID, 10)], None, 10),
+        ([AspiratedFluid(FluidKind.LIQUID, 10)], FluidKind.LIQUID, 10),
+        ([AspiratedFluid(FluidKind.LIQUID, 10)], FluidKind.AIR, 0),
+        (
+            [AspiratedFluid(FluidKind.LIQUID, 10), AspiratedFluid(FluidKind.AIR, 10)],
+            None,
+            20,
+        ),
+        (
+            [AspiratedFluid(FluidKind.LIQUID, 10), AspiratedFluid(FluidKind.AIR, 10)],
+            FluidKind.LIQUID,
+            10,
+        ),
+        (
+            [AspiratedFluid(FluidKind.LIQUID, 10), AspiratedFluid(FluidKind.AIR, 10)],
+            FluidKind.AIR,
+            10,
+        ),
+    ],
+)
+def test_aspirated_volume(
+    starting_fluids: list[AspiratedFluid], filter: FluidKind | None, result: float
+) -> None:
+    """It should represent aspirated volume with filtering."""
+    stack = FluidStack(_fluid_stack=starting_fluids)
+    assert stack.aspirated_volume(kind=filter) == result
+
+
+@pytest.mark.parametrize(
+    "starting_fluids,dispense_volume,result",
+    [
+        ([], 0, 0),
+        ([], 1, 0),
+        ([AspiratedFluid(FluidKind.AIR, 10)], 10, 0),
+        ([AspiratedFluid(FluidKind.AIR, 10)], 0, 0),
+        ([AspiratedFluid(FluidKind.LIQUID, 10)], 10, 10),
+        ([AspiratedFluid(FluidKind.LIQUID, 10)], 0, 0),
+        (
+            [
+                AspiratedFluid(FluidKind.AIR, 10),
+                AspiratedFluid(FluidKind.LIQUID, 10),
+            ],
+            10,
+            10,
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.AIR, 10),
+                AspiratedFluid(FluidKind.LIQUID, 10),
+            ],
+            20,
+            10,
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.AIR, 10),
+                AspiratedFluid(FluidKind.LIQUID, 10),
+            ],
+            30,
+            10,
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.AIR, 10),
+                AspiratedFluid(FluidKind.LIQUID, 10),
+            ],
+            5,
+            5,
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.LIQUID, 10),
+                AspiratedFluid(FluidKind.AIR, 10),
+            ],
+            5,
+            0,
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.LIQUID, 10),
+                AspiratedFluid(FluidKind.AIR, 10),
+            ],
+            10,
+            0,
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.LIQUID, 10),
+                AspiratedFluid(FluidKind.AIR, 10),
+            ],
+            11,
+            1,
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.LIQUID, 10),
+                AspiratedFluid(FluidKind.AIR, 10),
+            ],
+            20,
+            10,
+        ),
+        (
+            [
+                AspiratedFluid(FluidKind.LIQUID, 10),
+                AspiratedFluid(FluidKind.AIR, 10),
+            ],
+            30,
+            10,
+        ),
+    ],
+)
+def test_liquid_part_of_dispense_volume(
+    starting_fluids: list[AspiratedFluid],
+    dispense_volume: float,
+    result: float,
+) -> None:
+    """It should predict resulting liquid from a dispense."""
+    stack = FluidStack(_fluid_stack=starting_fluids)
+    assert stack.liquid_part_of_dispense_volume(dispense_volume) == result

--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -5,6 +5,7 @@
   "absorbance_reader_read": "Reading plate in Absorbance Reader",
   "adapter_in_mod_in_slot": "{{adapter}} on {{module}} in {{slot}}",
   "adapter_in_slot": "{{adapter}} in {{slot}}",
+  "air_gap_in_place": "Air gapping {{volume}} µL",
   "aspirate": "Aspirating {{volume}} µL from well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",
   "aspirate_in_place": "Aspirating {{volume}} µL in place at {{flow_rate}} µL/sec ",
   "blowout": "Blowing out at well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",

--- a/app/src/local-resources/commands/hooks/useCommandTextString/index.ts
+++ b/app/src/local-resources/commands/hooks/useCommandTextString/index.ts
@@ -90,6 +90,7 @@ export function useCommandTextString(
     case 'dropTip':
     case 'dropTipInPlace':
     case 'pickUpTip':
+    case 'airGapInPlace':
       return {
         kind: 'generic',
         commandText: utils.getPipettingCommandText(fullParams),

--- a/app/src/local-resources/commands/hooks/useCommandTextString/utils/commandText/getPipettingCommandText.ts
+++ b/app/src/local-resources/commands/hooks/useCommandTextString/utils/commandText/getPipettingCommandText.ts
@@ -209,6 +209,10 @@ export const getPipettingCommandText = ({
       const { flowRate, volume } = command.params
       return t('aspirate_in_place', { volume, flow_rate: flowRate })
     }
+    case 'airGapInPlace': {
+      const { volume } = command.params
+      return t('air_gap_in_place', { volume })
+    }
     default: {
       console.warn(
         'PipettingCommandText encountered a command with an unrecognized commandType: ',

--- a/shared-data/command/schemas/10.json
+++ b/shared-data/command/schemas/10.json
@@ -4,6 +4,7 @@
   "discriminator": {
     "propertyName": "commandType",
     "mapping": {
+      "airGapInPlace": "#/definitions/AirGapInPlaceCreate",
       "aspirate": "#/definitions/AspirateCreate",
       "aspirateInPlace": "#/definitions/AspirateInPlaceCreate",
       "comment": "#/definitions/CommentCreate",
@@ -81,6 +82,9 @@
     }
   },
   "oneOf": [
+    {
+      "$ref": "#/definitions/AirGapInPlaceCreate"
+    },
     {
       "$ref": "#/definitions/AspirateCreate"
     },
@@ -302,6 +306,67 @@
     }
   ],
   "definitions": {
+    "AirGapInPlaceParams": {
+      "title": "AirGapInPlaceParams",
+      "description": "Payload required to aspirate in place.",
+      "type": "object",
+      "properties": {
+        "flowRate": {
+          "title": "Flowrate",
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": ["flowRate", "volume", "pipetteId"]
+    },
+    "CommandIntent": {
+      "title": "CommandIntent",
+      "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
+      "enum": ["protocol", "setup", "fixit"],
+      "type": "string"
+    },
+    "AirGapInPlaceCreate": {
+      "title": "AirGapInPlaceCreate",
+      "description": "AirGapInPlace command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "airGapInPlace",
+          "enum": ["airGapInPlace"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/AirGapInPlaceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    MENISCUS: the meniscus-center of the well",
@@ -405,12 +470,6 @@
         }
       },
       "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
-    },
-    "CommandIntent": {
-      "title": "CommandIntent",
-      "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": ["protocol", "setup", "fixit"],
-      "type": "string"
     },
     "AspirateCreate": {
       "title": "AspirateCreate",

--- a/shared-data/command/schemas/10.json
+++ b/shared-data/command/schemas/10.json
@@ -308,7 +308,7 @@
   "definitions": {
     "AirGapInPlaceParams": {
       "title": "AirGapInPlaceParams",
-      "description": "Payload required to aspirate in place.",
+      "description": "Payload required to air gap in place.",
       "type": "object",
       "properties": {
         "flowRate": {

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -20,6 +20,7 @@ export type PipettingRunTimeCommand =
   | VerifyTipPresenceRunTimeCommand
   | LiquidProbeRunTimeCommand
   | TryLiquidProbeRunTimeCommand
+  | AirGapInPlaceRunTimeCommand
 
 export type PipettingCreateCommand =
   | AspirateCreateCommand
@@ -39,6 +40,7 @@ export type PipettingCreateCommand =
   | VerifyTipPresenceCreateCommand
   | LiquidProbeCreateCommand
   | TryLiquidProbeCreateCommand
+  | AirGapInPlaceCreateCommand
 
 export interface ConfigureForVolumeCreateCommand
   extends CommonCommandCreateInfo {
@@ -55,6 +57,22 @@ export interface ConfigureForVolumeRunTimeCommand
     ConfigureForVolumeCreateCommand {
   result?: BasicLiquidHandlingResult
 }
+
+export type AirGapInPlaceParams = FlowRateParams &
+  PipetteIdentityParams &
+  VolumeParams
+
+export interface AirGapInPlaceCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'airGapInPlace'
+  params: AirGapInPlaceParams
+}
+
+export interface AirGapInPlaceRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    AirGapInPlaceCreateCommand {
+  result?: BasicLiquidHandlingResult
+}
+
 export interface AspirateCreateCommand extends CommonCommandCreateInfo {
   commandType: 'aspirate'
   params: AspDispAirgapParams


### PR DESCRIPTION
We now are trying to track the amount of liquid in the wells of the labware on the deck. To do this, we're tracking how much liquid we aspirate from wells and dispense into wells.

Unfortunately, sometimes users want to aspirate air and then dispense it into wells (well, they usually don't want to dispense it _into_ the well, but they want to dispense it). Until now, we'd treat any volume of air that got dispensed as a volume of liquid, and add it to the liquid tracked in the well. This is wrong.

There's a couple things we need to do to fix this, and this PR does them. It also does a couple other things to support that effort. It's big, but well-separated into commits, and that's a decent way to do it.

- a6a0856823a0dfa49182a1e28f1df3fcc2fae02c adds a utility class that can track the pipette contents and the relative ordering of air and liquid slugs within the pipette. It does this so that you can say "Hey I'm going to dispense x ul, how much of that is liquid?" and get a solid answer.
- c19b205d29f6c8c9434bd1e3e0496b5aed68654a integrates that with existing commands and state stores, in the process switching volume state tracking to `StateUpdate`
- 7d81a3c0ae5be131826c62144df5a257b9fd86cc adds `airGapInPlace`, a new command that works exactly like aspirate except that it doesn't take volume out of a well, and it adds air to the pipette internal volume tracking so that a subsequent dispense won't add liquid to the target well
- 3f4d07197c17c79528c50998c11a693031fcd710 makes the python protocol API use that for `air_gap` calls above a certain API version

There's also some supporting commits to add the new API version (since this is going into edge) and a command text for the new command.

This is a pretty in depth thing and will need at least some testing, but it is covered by pretty in-depth automated testing and I eagerly await some failing analysis snapshots. 

## reviewing
- can i get away with not changing the pipette state store tests to just be about state updates? please?
- does the fluid stack thing seem overwrought, underwrought, wroughten to the core?
- am I missing something?

## testing
- [x] inspect engine state that uses air gaps on api version 2.21. it should still work
- [x] inspect engine state that uses air gaps on api version 2.22. it should work in terms of physical actions
  - [x] Inspect the volume trakcing and make sure the air isn't counted as liquid

Closes EXEC-792 [@SyntaxColoring edit: also EXEC-754 incidentally, yay]