### PR TITLE
feat(opentrons-ai-client): add shared-data as dependency

### DIFF
--- a/opentrons-ai-client/package.json
+++ b/opentrons-ai-client/package.json
@@ -22,6 +22,7 @@
     "@auth0/auth0-react": "2.2.4",
     "@fontsource/public-sans": "5.0.3",
     "@opentrons/components": "link:../components",
+    "@opentrons/shared-data": "link:../shared-data",
     "axios": "^0.21.1",
     "i18next": "^19.8.3",
     "jotai": "2.8.0",


### PR DESCRIPTION
# Overview
Oopsy I guess we never added shared-data as an official dep to the ai client. We're gonna start pulling in more stuff from there so this PD just adds it as a dependency