### PR TITLE
fix(step-generation): configureForVolume now volumes the chunk instea…

### DIFF
--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -263,7 +263,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             ? [
                 curryCommandCreator(configureForVolume, {
                   pipetteId: args.pipette,
-                  volume: args.volume,
+                  volume: chunksPerSubTransfer,
                 }),
               ]
             : []


### PR DESCRIPTION
…d of volume

# Overview

This fixes a step-generation bug regarding the volume for `configureForVolume` command. Unclear if this actually causes issues in the field but its an error because its configuring for the full volume instead of the chunk volume (in case there are multiple aspirates for one transfer step)

## Test Plan and Hands on Testing

Just check the logic, i don't think there is anything worth manually testing??

## Changelog

change volume amount from full volume to chunk

## Risk assessment

low
