### PR TITLE
fix(app): Fix flickering screen during gripper Error Recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useHomeGripper.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useHomeGripper.test.ts
@@ -94,7 +94,7 @@ describe('useHomeGripper', () => {
     ).toHaveBeenCalledTimes(1)
   })
 
-  it('should reset hasHomedOnce when step changes to non-manual gripper step and back', async () => {
+  it('should only reset hasHomedOnce when step changes to non-manual gripper step', async () => {
     const { rerender } = renderHook(
       ({ recoveryMap }) => {
         useHomeGripper({
@@ -122,6 +122,10 @@ describe('useHomeGripper', () => {
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 0))
     })
+
+    expect(
+      mockRecoveryCommands.updatePositionEstimatorsAndHomeGripper
+    ).toHaveBeenCalledTimes(1)
 
     rerender({ recoveryMap: mockRecoveryMap })
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useHomeGripper.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useHomeGripper.ts
@@ -29,14 +29,14 @@ export function useHomeGripper({
         } else {
           void handleMotionRouting(true)
             .then(() => updatePositionEstimatorsAndHomeGripper())
-            .then(() => {
+            .finally(() => {
+              handleMotionRouting(false)
               setHasHomedOnce(true)
             })
-            .finally(() => handleMotionRouting(false))
         }
       }
     } else {
-      if (!isManualGripperStep) {
+      if (!isManualGripperStep && hasHomedOnce) {
         setHasHomedOnce(false)
       }
     }


### PR DESCRIPTION
Closes [RQA-3486](https://opentrons.atlassian.net/browse/RQA-3486)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes an infinite re-render caused by control flow issues. Once the robot is on an "in motion" screen, we are no longer on an `isManualGripperStep`, setting some state a little too eagerly and causing the loop. 

Note that the ticket specifies another bug, but the embedded folks are looking at that part. 

### Fixed Behavior

https://github.com/user-attachments/assets/9e0a76f1-ed02-4d09-9c19-9741c1f6e17a

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixes an infinite render loop in gripper error recovery flows
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3486]: https://opentrons.atlassian.net/browse/RQA-3486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ