### PR TITLE
feat(api): add load-empty-liquid

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -130,12 +130,31 @@ class WellCore(AbstractWellCore):
         liquid: Liquid,
         volume: float,
     ) -> None:
-        """Load liquid into a well."""
+        """Load liquid into a well.
+
+        If the well is known to be empty, use ``load_empty()`` instead of calling this with a 0.0 volume.
+        """
         self._engine_client.execute_command(
             cmd.LoadLiquidParams(
                 labwareId=self._labware_id,
                 liquidId=liquid._id,
                 volumeByWell={self._name: volume},
+            )
+        )
+
+    def load_empty(
+        self,
+    ) -> None:
+        """Inform the system that a well is known to be empty.
+
+        This should be done early in the protocol, at the same time as a load_liquid command might
+        be used.
+        """
+        self._engine_client.execute_command(
+            cmd.LoadLiquidParams(
+                labwareId=self._labware_id,
+                liquidId="EMPTY",
+                volumeByWell={self._name: 0.0},
             )
         )
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_well_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_well_core.py
@@ -114,6 +114,10 @@ class LegacyWellCore(AbstractWellCore):
         """Load liquid into a well."""
         raise APIVersionError(api_element="Loading a liquid")
 
+    def load_empty(self) -> None:
+        """Mark a well as empty."""
+        assert False, "load_empty only supported on engine core"
+
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """Gets point in deck coordinates based on percentage of the radius of each axis."""
         return self._geometry.from_center_cartesian(x, y, z)

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -80,6 +80,10 @@ class AbstractWellCore(ABC):
         """Load liquid into a well."""
 
     @abstractmethod
+    def load_empty(self) -> None:
+        """Mark a well as containing no liquid."""
+
+    @abstractmethod
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """Gets point in deck coordinates based on percentage of the radius of each axis."""
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -280,11 +280,19 @@ class Well:
 
         :param Liquid liquid: The liquid to load into the well.
         :param float volume: The volume of liquid to load, in µL.
+
+        .. note::
+            In API Version 2.22 and above, use `load_empty()` to mark a well as empty at the beginning of a protocol.
         """
         self._core.load_liquid(
             liquid=liquid,
             volume=volume,
         )
+
+    @requires_version(2, 22)
+    def load_empty(self) -> None:
+        """Mark a well as empty."""
+        self._core.load_empty()
 
     def _from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -282,7 +282,7 @@ class Well:
         :param float volume: The volume of liquid to load, in µL.
 
         .. note::
-            In API Version 2.22 and above, use `load_empty()` to mark a well as empty at the beginning of a protocol.
+            In API version 2.22 and later, use :py:meth:`~.Well.load_empty()` to mark a well as empty at the beginning of a protocol, rather than using this method with ``volume=0``.
         """
         self._core.load_liquid(
             liquid=liquid,

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -77,6 +77,7 @@ from .exceptions import (
     OperationLocationNotInWellError,
     InvalidDispenseVolumeError,
     StorageLimitReachedError,
+    InvalidLiquidError,
 )
 
 from .error_occurrence import ErrorOccurrence, ProtocolCommandFailedError
@@ -137,6 +138,7 @@ __all__ = [
     "InvalidTargetSpeedError",
     "InvalidBlockVolumeError",
     "InvalidHoldTimeError",
+    "InvalidLiquidError",
     "CannotPerformModuleAction",
     "ResumeFromRecoveryNotAllowedError",
     "PauseNotAllowedError",

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -244,6 +244,19 @@ class LiquidDoesNotExistError(ProtocolEngineError):
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
+class InvalidLiquidError(ProtocolEngineError):
+    """Raised when attempting to add a liquid with an invalid property."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an InvalidLiquidError."""
+        super().__init__(ErrorCodes.INVALID_PROTOCOL_DATA, message, details, wrapping)
+
+
 class LabwareDefinitionDoesNotExistError(ProtocolEngineError):
     """Raised when referencing a labware definition that does not exist."""
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -566,9 +566,12 @@ class ProtocolEngine:
             description=(description or ""),
             displayColor=color,
         )
+        validated_liquid = self._state_store.liquid.validate_liquid_allowed(
+            liquid=liquid
+        )
 
-        self._action_dispatcher.dispatch(AddLiquidAction(liquid=liquid))
-        return liquid
+        self._action_dispatcher.dispatch(AddLiquidAction(liquid=validated_liquid))
+        return validated_liquid
 
     def add_addressable_area(self, addressable_area_name: str) -> None:
         """Add an addressable area to state."""

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -828,6 +828,10 @@ class HexColor(BaseModel):
         return v
 
 
+EmptyLiquidId = Literal["EMPTY"]
+LiquidId = str | EmptyLiquidId
+
+
 class Liquid(BaseModel):
     """Payload required to create a liquid."""
 

--- a/api/tests/opentrons/protocol_api/test_well.py
+++ b/api/tests/opentrons/protocol_api/test_well.py
@@ -8,6 +8,8 @@ from opentrons.protocol_api.core.common import WellCore
 from opentrons.protocol_api._liquid import Liquid
 from opentrons.types import Point, Location
 
+from . import versions_at_or_above
+
 
 @pytest.fixture
 def mock_well_core(decoy: Decoy) -> WellCore:
@@ -138,6 +140,13 @@ def test_load_liquid(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> N
         ),
         times=1,
     )
+
+
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))
+def test_load_empty(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:
+    """It should mark a location as empty."""
+    subject.load_empty()
+    decoy.verify(mock_well_core.load_empty(), times=1)
 
 
 def test_diameter(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:

--- a/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
@@ -9,6 +9,7 @@ from opentrons.protocol_engine.commands import (
     LoadLiquidImplementation,
     LoadLiquidParams,
 )
+from opentrons.protocol_engine.errors import InvalidLiquidError
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.state import update_types
@@ -63,4 +64,38 @@ async def test_load_liquid_implementation(
         mock_state_view.labware.validate_liquid_allowed_in_labware(
             "labware-id", {"A1": 30.0, "B2": 100.0}
         )
+    )
+
+
+async def test_load_empty_liquid_requires_zero_volume(
+    decoy: Decoy,
+    subject: LoadLiquidImplementation,
+    mock_state_view: StateView,
+    model_utils: ModelUtils,
+) -> None:
+    """Test that loadLiquid requires empty liquids to have 0 volume."""
+    data = LoadLiquidParams(
+        labwareId="labware-id", liquidId="EMPTY", volumeByWell={"A1": 1.0}
+    )
+    timestamp = datetime(year=2020, month=1, day=2)
+    decoy.when(model_utils.get_timestamp()).then_return(timestamp)
+
+    with pytest.raises(InvalidLiquidError):
+        await subject.execute(data)
+
+    decoy.verify(mock_state_view.liquid.validate_liquid_id("EMPTY"))
+
+    data2 = LoadLiquidParams(
+        labwareId="labware-id", liquidId="EMPTY", volumeByWell={"A1": 0.0}
+    )
+    result = await subject.execute(data2)
+    assert result == SuccessData(
+        public=LoadLiquidResult(),
+        state_update=update_types.StateUpdate(
+            liquid_loaded=update_types.LiquidLoadedUpdate(
+                labware_id="labware-id",
+                volumes=data2.volumeByWell,
+                last_loaded=timestamp,
+            )
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_liquid_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_liquid_view.py
@@ -3,7 +3,7 @@ import pytest
 
 from opentrons.protocol_engine.state.liquids import LiquidState, LiquidView
 from opentrons.protocol_engine import Liquid
-from opentrons.protocol_engine.errors import LiquidDoesNotExistError
+from opentrons.protocol_engine.errors import LiquidDoesNotExistError, InvalidLiquidError
 
 
 @pytest.fixture
@@ -33,3 +33,22 @@ def test_has_liquid(subject: LiquidView) -> None:
 
     with pytest.raises(LiquidDoesNotExistError):
         subject.validate_liquid_id("no-id")
+
+
+def test_validate_liquid_prevents_empty(subject: LiquidView) -> None:
+    """It should not allow loading a liquid with the special id EMPTY."""
+    with pytest.raises(InvalidLiquidError):
+        subject.validate_liquid_allowed(
+            Liquid(id="EMPTY", displayName="empty", description="nothing")
+        )
+
+
+def test_validate_liquid_allows_non_empty(subject: LiquidView) -> None:
+    """It should allow a valid liquid."""
+    valid_liquid = Liquid(
+        id="some-id",
+        displayName="some-display-name",
+        description="some-description",
+        displayColor=None,
+    )
+    assert subject.validate_liquid_allowed(valid_liquid) == valid_liquid

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -1133,21 +1133,18 @@ def test_add_liquid(
     decoy: Decoy,
     action_dispatcher: ActionDispatcher,
     subject: ProtocolEngine,
+    state_store: StateStore,
 ) -> None:
     """It should dispatch an AddLiquidAction action."""
+    liquid_obj = Liquid(id="water-id", displayName="water", description="water desc")
+    decoy.when(
+        state_store.liquid.validate_liquid_allowed(liquid=liquid_obj)
+    ).then_return(liquid_obj)
     subject.add_liquid(
         id="water-id", name="water", description="water desc", color=None
     )
 
-    decoy.verify(
-        action_dispatcher.dispatch(
-            AddLiquidAction(
-                liquid=Liquid(
-                    id="water-id", displayName="water", description="water desc"
-                )
-            )
-        )
-    )
+    decoy.verify(action_dispatcher.dispatch(AddLiquidAction(liquid=liquid_obj)))
 
 
 async def test_use_attached_temp_and_mag_modules(

--- a/shared-data/command/schemas/10.json
+++ b/shared-data/command/schemas/10.json
@@ -1621,8 +1621,16 @@
       "properties": {
         "liquidId": {
           "title": "Liquidid",
-          "description": "Unique identifier of the liquid to load.",
-          "type": "string"
+          "description": "Unique identifier of the liquid to load. If this is the sentinel value EMPTY, all values of volumeByWell must be 0.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": ["EMPTY"],
+              "type": "string"
+            }
+          ]
         },
         "labwareId": {
           "title": "Labwareid",
@@ -1631,7 +1639,7 @@
         },
         "volumeByWell": {
           "title": "Volumebywell",
-          "description": "Volume of liquid, in \u00b5L, loaded into each well by name, in this labware.",
+          "description": "Volume of liquid, in \u00b5L, loaded into each well by name, in this labware. If the liquid id is the sentinel value EMPTY, all volumes must be 0.",
           "type": "object",
           "additionalProperties": {
             "type": "number"


### PR DESCRIPTION
We have a loadLiquid command and associated python protocol API method, which allow users to specify that a well contains a given amount of a given (predefined) liquid. This was all that we needed for a while because we didn't really do anything with that information except display the starting deck state based on it.

Now that we track liquid, however, this isn't enough, because we also need a way for users to specify that a well is known to be empty. To that end, introduce a special EMPTY sentinel value for liquid ID and restrict loadLiquid commands that use it to setting a 0 volume.

I think we probably should have a better API for setting multiple wells but that's not this PR.

Closes EXEC-801

## reviews
- seem like a valid thing to do? Didn't make sense to have a whole different command

## testing
- make sure empty liquids get loaded

## notes
- [x] will rebase this PR to edge once the current target is merged
