### PR TITLE
fix(protocol-designer): filter out plate reader with ff in deck setup

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/utils.test.ts
@@ -44,7 +44,7 @@ describe('getModuleModelsBySlot', () => {
     ])
   })
   it('renders all flex modules for B1', () => {
-    expect(getModuleModelsBySlot(false, FLEX_ROBOT_TYPE, 'B1')).toEqual(
+    expect(getModuleModelsBySlot(true, FLEX_ROBOT_TYPE, 'B1')).toEqual(
       FLEX_MODULE_MODELS
     )
   })
@@ -52,7 +52,7 @@ describe('getModuleModelsBySlot', () => {
     const noTC = FLEX_MODULE_MODELS.filter(
       model => model !== THERMOCYCLER_MODULE_V2
     )
-    expect(getModuleModelsBySlot(false, FLEX_ROBOT_TYPE, 'C1')).toEqual(noTC)
+    expect(getModuleModelsBySlot(true, FLEX_ROBOT_TYPE, 'C1')).toEqual(noTC)
   })
 })
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -1,5 +1,6 @@
 import some from 'lodash/some'
 import {
+  ABSORBANCE_READER_V1,
   FLEX_ROBOT_TYPE,
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   HEATERSHAKER_MODULE_TYPE,
@@ -55,20 +56,21 @@ export function getModuleModelsBySlot(
 ): ModuleModel[] {
   const FLEX_MIDDLE_SLOTS = ['B2', 'C2', 'A2', 'D2']
   const OT2_MIDDLE_SLOTS = ['2', '5', '8', '11']
+  const FILTERED_MODULES = enableAbsorbanceReader
+    ? FLEX_MODULE_MODELS
+    : FLEX_MODULE_MODELS.filter(model => model !== ABSORBANCE_READER_V1)
 
-  let moduleModels: ModuleModel[] = enableAbsorbanceReader
-    ? FLEX_MODULE_MODELS.filter(model => model !== 'absorbanceReaderV1')
-    : FLEX_MODULE_MODELS
+  let moduleModels: ModuleModel[] = FILTERED_MODULES
 
   switch (robotType) {
     case FLEX_ROBOT_TYPE: {
       if (slot !== 'B1' && !FLEX_MIDDLE_SLOTS.includes(slot)) {
-        moduleModels = FLEX_MODULE_MODELS.filter(
+        moduleModels = FILTERED_MODULES.filter(
           model => model !== THERMOCYCLER_MODULE_V2
         )
       }
       if (FLEX_MIDDLE_SLOTS.includes(slot)) {
-        moduleModels = FLEX_MODULE_MODELS.filter(
+        moduleModels = FILTERED_MODULES.filter(
           model => model === MAGNETIC_BLOCK_V1
         )
       }


### PR DESCRIPTION
closes RQA-3456

# Overview

Properly filter out the plate reader from being selectable in deck setup unless the plate reader ff is turned on

## Test Plan and Hands on Testing

You should not see the plate reader as an option to add to the deck during deck setup unless your plate reader ff is turned on

## Changelog

- reverse the logic and used the filtered array

## Risk assessment

low