### PR TITLE
feat(protocol-designer): comment tools move over from old code

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/CommentTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/CommentTools/index.tsx
@@ -35,6 +35,7 @@ export function CommentTools(props: StepFormProps): JSX.Element {
   )
 }
 
+//  TODO: use TextArea component when we make it
 const StyledTextArea = styled.textarea`
   width: 100%;
   height: 7rem;

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/CommentTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/CommentTools/index.tsx
@@ -1,3 +1,49 @@
-export function CommentTools(): JSX.Element {
-  return <div>TODO: wire this up</div>
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import {
+  BORDERS,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  SPACING,
+  StyledText,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import type { ChangeEvent } from 'react'
+import type { StepFormProps } from '../../types'
+
+export function CommentTools(props: StepFormProps): JSX.Element {
+  const { t, i18n } = useTranslation('form')
+  const { propsForFields } = props
+
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing4}
+      padding={SPACING.spacing16}
+    >
+      <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+        {i18n.format(t('step_edit_form.field.comment.label'), 'capitalize')}
+      </StyledText>
+      <StyledTextArea
+        value={propsForFields.message.value as string}
+        onChange={(e: ChangeEvent<any>) => {
+          propsForFields.message.updateValue(e.currentTarget.value)
+        }}
+      />
+    </Flex>
+  )
 }
+
+const StyledTextArea = styled.textarea`
+  width: 100%;
+  height: 7rem;
+  box-sizing: border-box;
+  border: 1px solid ${COLORS.grey50};
+  border-radius: ${BORDERS.borderRadius4};
+  padding: ${SPACING.spacing8};
+  font-size: ${TYPOGRAPHY.fontSizeH4};
+  line-height: ${TYPOGRAPHY.lineHeight16};
+  font-weight: ${TYPOGRAPHY.fontWeightRegular};
+  resize: none;
+`


### PR DESCRIPTION
closes AUTH-814

# Overview

Just moving this over into the new designs so when we delete the old PD code, we aren't losing this work. Also NOTE: This step type is behind a ff! 

## Test Plan and Hands on Testing

Test that the comment step is behind the ff and when you turn on the ff, the comment step is selectable and usable. do not worry about designs, this is a ff item that will remain behind the ff for the release

## Changelog

- move over the code from `commentForm` to `commentTools`


## Risk assessment

low, behind ff
