### PR TITLE
fix(api): Ensure stack of labware on Staging Area Slot properly resolves ancestor slot

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -19,7 +19,7 @@ from opentrons.protocol_engine.types import (
     LabwareOffsetCreate,
     LabwareOffsetVector,
 )
-from opentrons.types import DeckSlotName, Point
+from opentrons.types import DeckSlotName, Point, StagingSlotName
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 
 
@@ -190,9 +190,15 @@ class LabwareCore(AbstractLabware[WellCore]):
     def get_deck_slot(self) -> Optional[DeckSlotName]:
         """Get the deck slot the labware is in, if on deck."""
         try:
-            return self._engine_client.state.geometry.get_ancestor_slot_name(
+            # CASEY NOTE: this function bubbles up to PAPI - currently we return a deck slot name.
+            # what happens when we do get_deck_slot on a staging slot labware? what do we want to have happen?
+            # for now I'm converting to column 3
+            ancestor = self._engine_client.state.geometry.get_ancestor_slot_name(
                 self.labware_id
             )
+            if isinstance(ancestor, StagingSlotName):
+                ancestor = DeckSlotName.from_primitive(ancestor.name[:1] + "3")
+            return ancestor
         except (
             LabwareNotOnDeckError,
             ModuleNotOnDeckError,

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -190,13 +190,11 @@ class LabwareCore(AbstractLabware[WellCore]):
     def get_deck_slot(self) -> Optional[DeckSlotName]:
         """Get the deck slot the labware is in, if on deck."""
         try:
-            # CASEY NOTE: this function bubbles up to PAPI - currently we return a deck slot name.
-            # what happens when we do get_deck_slot on a staging slot labware? what do we want to have happen?
-            # for now I'm converting to column 3
             ancestor = self._engine_client.state.geometry.get_ancestor_slot_name(
                 self.labware_id
             )
             if isinstance(ancestor, StagingSlotName):
+                # TODO: (chb, 2024-11-04): Do we want to change this PAPI function to be able to return Staging Area Slots? For now returning the cutout that both have as an ancestor.
                 ancestor = DeckSlotName.from_primitive(ancestor.name[:1] + "3")
             return ancestor
         except (

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -194,8 +194,8 @@ class LabwareCore(AbstractLabware[WellCore]):
                 self.labware_id
             )
             if isinstance(ancestor, StagingSlotName):
-                # TODO: (chb, 2024-11-04): Do we want to change this PAPI function to be able to return Staging Area Slots? For now returning the cutout that both have as an ancestor.
-                ancestor = DeckSlotName.from_primitive(ancestor.name[:1] + "3")
+                # The only use case for get_deck_slot is with a legacy OT-2 function which resolves to a numerical deck slot, so we can ignore staging area slots for now
+                return None
             return ancestor
         except (
             LabwareNotOnDeckError,

--- a/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
@@ -125,7 +125,7 @@ def check_safe_for_pipette_movement(  # noqa: C901
     ancestor = engine_state.geometry.get_ancestor_slot_name(labware_id)
     if isinstance(ancestor, StagingSlotName):
         raise LocationIsStagingSlotError(
-            "Cannot preform pipette ations on labware in Staging Area Slot."
+            "Cannot perform pipette actions on labware in Staging Area Slot."
         )
     labware_slot = ancestor
 

--- a/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
@@ -9,6 +9,7 @@ from typing import (
 )
 
 from opentrons_shared_data.errors.exceptions import MotionPlanningFailureError
+from opentrons.protocol_engine.errors import LocationIsStagingSlotError
 from opentrons_shared_data.module import FLEX_TC_LID_COLLISION_ZONE
 
 from opentrons.hardware_control import CriticalPoint
@@ -63,7 +64,7 @@ _FLEX_TC_LID_FRONT_RIGHT_PT = Point(
 )
 
 
-def check_safe_for_pipette_movement(
+def check_safe_for_pipette_movement(  # noqa: C901
     engine_state: StateView,
     pipette_id: str,
     labware_id: str,
@@ -121,8 +122,12 @@ def check_safe_for_pipette_movement(
             f"Requested motion with the {primary_nozzle} nozzle partial configuration"
             f" is outside of robot bounds for the pipette."
         )
-
-    labware_slot = engine_state.geometry.get_ancestor_slot_name(labware_id)
+    ancestor = engine_state.geometry.get_ancestor_slot_name(labware_id)
+    if isinstance(ancestor, StagingSlotName):
+        raise LocationIsStagingSlotError(
+            "Cannot preform pipette ations on labware in Staging Area Slot."
+        )
+    labware_slot = ancestor
 
     surrounding_slots = adjacent_slots_getters.get_surrounding_slots(
         slot=labware_slot.as_int(), robot_type=engine_state.config.robot_type

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -726,8 +726,6 @@ class GeometryView:
             slot_name = self.get_ancestor_slot_name(below_labware_id)
         elif isinstance(labware.location, AddressableAreaLocation):
             area_name = labware.location.addressableAreaName
-            # TODO we might want to eventually return some sort of staging slot name when we're ready to work through
-            #   the linting nightmare it will create
             if self._labware.is_absorbance_reader_lid(labware_id):
                 raise errors.LocationIsLidDockSlotError(
                     "Cannot get ancestor slot name for labware on lid dock slot."

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -734,11 +734,6 @@ class GeometryView:
                 )
             elif fixture_validation.is_staging_slot(area_name):
                 slot_name = StagingSlotName.from_primitive(area_name)
-                # CASEY NOTE: Remove these errors
-                # raise errors.LocationIsStagingSlotError(
-                #     "Cannot get ancestor slot name for labware on staging slot."
-                # )
-                # raise errors.LocationIs
             else:
                 slot_name = DeckSlotName.from_primitive(area_name)
         elif labware.location == OFF_DECK_LOCATION:

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -709,10 +709,12 @@ class GeometryView:
         assert isinstance(labware_location, AddressableAreaLocation)
         return labware_location.addressableAreaName
 
-    def get_ancestor_slot_name(self, labware_id: str) -> DeckSlotName:
+    def get_ancestor_slot_name(
+        self, labware_id: str
+    ) -> Union[DeckSlotName, StagingSlotName]:
         """Get the slot name of the labware or the module that the labware is on."""
         labware = self._labware.get(labware_id)
-        slot_name: DeckSlotName
+        slot_name: Union[DeckSlotName, StagingSlotName]
 
         if isinstance(labware.location, DeckSlotLocation):
             slot_name = labware.location.slotName
@@ -730,12 +732,15 @@ class GeometryView:
                 raise errors.LocationIsLidDockSlotError(
                     "Cannot get ancestor slot name for labware on lid dock slot."
                 )
-            if fixture_validation.is_staging_slot(area_name):
-                raise errors.LocationIsStagingSlotError(
-                    "Cannot get ancestor slot name for labware on staging slot."
-                )
-                raise errors.LocationIs
-            slot_name = DeckSlotName.from_primitive(area_name)
+            elif fixture_validation.is_staging_slot(area_name):
+                slot_name = StagingSlotName.from_primitive(area_name)
+                # CASEY NOTE: Remove these errors
+                # raise errors.LocationIsStagingSlotError(
+                #     "Cannot get ancestor slot name for labware on staging slot."
+                # )
+                # raise errors.LocationIs
+            else:
+                slot_name = DeckSlotName.from_primitive(area_name)
         elif labware.location == OFF_DECK_LOCATION:
             raise errors.LabwareNotOnDeckError(
                 f"Labware {labware_id} does not have a slot associated with it"
@@ -829,7 +834,9 @@ class GeometryView:
         )
 
     def get_extra_waypoints(
-        self, location: Optional[CurrentPipetteLocation], to_slot: DeckSlotName
+        self,
+        location: Optional[CurrentPipetteLocation],
+        to_slot: Union[DeckSlotName, StagingSlotName],
     ) -> List[Tuple[float, float]]:
         """Get extra waypoints for movement if thermocycler needs to be dodged."""
         if location is not None:
@@ -888,8 +895,10 @@ class GeometryView:
         return maybe_labware or maybe_module or maybe_fixture or None
 
     @staticmethod
-    def get_slot_column(slot_name: DeckSlotName) -> int:
+    def get_slot_column(slot_name: Union[DeckSlotName, StagingSlotName]) -> int:
         """Get the column number for the specified slot."""
+        if isinstance(slot_name, StagingSlotName):
+            return 4
         row_col_name = slot_name.to_ot3_equivalent()
         slot_name_match = WELL_NAME_PATTERN.match(row_col_name.value)
         assert (
@@ -1170,7 +1179,13 @@ class GeometryView:
                         )
 
                 assert isinstance(
-                    ancestor, (DeckSlotLocation, ModuleLocation, OnLabwareLocation)
+                    ancestor,
+                    (
+                        DeckSlotLocation,
+                        ModuleLocation,
+                        OnLabwareLocation,
+                        AddressableAreaLocation,
+                    ),
                 ), "No gripper offsets for off-deck labware"
                 return (
                     direct_parent_offset.pickUpOffset
@@ -1217,7 +1232,13 @@ class GeometryView:
                         )
 
                 assert isinstance(
-                    ancestor, (DeckSlotLocation, ModuleLocation, OnLabwareLocation)
+                    ancestor,
+                    (
+                        DeckSlotLocation,
+                        ModuleLocation,
+                        OnLabwareLocation,
+                        AddressableAreaLocation,
+                    ),
                 ), "No gripper offsets for off-deck labware"
                 return (
                     direct_parent_offset.dropOffset
@@ -1293,6 +1314,7 @@ class GeometryView:
                 DeckSlotLocation,
                 ModuleLocation,
                 AddressableAreaLocation,
+                OnLabwareLocation,
             ),
         ), "No gripper offsets for off-deck labware"
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -32,7 +32,7 @@ from opentrons.protocol_engine.commands.calibration.calibrate_module import (
 from opentrons.protocol_engine.state.module_substates.absorbance_reader_substate import (
     AbsorbanceReaderMeasureMode,
 )
-from opentrons.types import DeckSlotName, MountType
+from opentrons.types import DeckSlotName, MountType, StagingSlotName
 from ..errors import ModuleNotConnectedError
 
 from ..types import (
@@ -1124,8 +1124,8 @@ class ModuleView(HasState[ModuleState]):
 
     def should_dodge_thermocycler(
         self,
-        from_slot: DeckSlotName,
-        to_slot: DeckSlotName,
+        from_slot: Union[DeckSlotName, StagingSlotName],
+        to_slot: Union[DeckSlotName, StagingSlotName],
     ) -> bool:
         """Decide if the requested path would cross the thermocycler, if installed.
 

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -334,7 +334,7 @@ class MotionView:
         labware_slot = self._geometry.get_ancestor_slot_name(labware_id)
         if isinstance(labware_slot, StagingSlotName):
             raise errors.LocationIsStagingSlotError(
-                "Cannot preform Touch Tip on labware in Staging Area Slot."
+                "Cannot perform Touch Tip on labware in Staging Area Slot."
             )
         next_to_module = self._modules.is_edge_move_unsafe(mount, labware_slot)
         edge_path_type = self._labware.get_edge_path_type(

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
-from opentrons.types import MountType, Point
+from opentrons.types import MountType, Point, StagingSlotName
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.motion_planning.adjacent_slots_getters import (
     get_east_west_slots,
@@ -277,9 +277,13 @@ class MotionView:
         current_location = self._pipettes.get_current_location()
         if current_location is not None:
             if isinstance(current_location, CurrentWell):
-                pipette_deck_slot = self._geometry.get_ancestor_slot_name(
+                ancestor = self._geometry.get_ancestor_slot_name(
                     current_location.labware_id
-                ).as_int()
+                )
+                if isinstance(ancestor, StagingSlotName):
+                    # Staging Area Slots cannot intersect with the h/s
+                    return False
+                pipette_deck_slot = ancestor.as_int()
             else:
                 pipette_deck_slot = (
                     self._addressable_areas.get_addressable_area_base_slot(
@@ -299,9 +303,13 @@ class MotionView:
         current_location = self._pipettes.get_current_location()
         if current_location is not None:
             if isinstance(current_location, CurrentWell):
-                pipette_deck_slot = self._geometry.get_ancestor_slot_name(
+                ancestor = self._geometry.get_ancestor_slot_name(
                     current_location.labware_id
-                ).as_int()
+                )
+                if isinstance(ancestor, StagingSlotName):
+                    # Staging Area Slots cannot intersect with the h/s
+                    return False
+                pipette_deck_slot = ancestor.as_int()
             else:
                 pipette_deck_slot = (
                     self._addressable_areas.get_addressable_area_base_slot(
@@ -324,6 +332,10 @@ class MotionView:
         """Get a list of touch points for a touch tip operation."""
         mount = self._pipettes.get_mount(pipette_id)
         labware_slot = self._geometry.get_ancestor_slot_name(labware_id)
+        if isinstance(labware_slot, StagingSlotName):
+            raise errors.LocationIsStagingSlotError(
+                "Cannot preform Touch Tip on labware in Staging Area Slot."
+            )
         next_to_module = self._modules.is_edge_move_unsafe(mount, labware_slot)
         edge_path_type = self._labware.get_edge_path_type(
             labware_id, well_name, mount, labware_slot, next_to_module

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -17,7 +17,7 @@ from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.protocols.models import LabwareDefinition
-from opentrons.types import Point, DeckSlotName, MountType
+from opentrons.types import Point, DeckSlotName, MountType, StagingSlotName
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.labware.labware_definition import (
     Dimensions as LabwareDimensions,
@@ -2187,6 +2187,33 @@ def test_get_ancestor_slot_name(
         DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
     )
     assert subject.get_ancestor_slot_name("labware-2") == DeckSlotName.SLOT_1
+
+
+def test_get_ancestor_slot_for_labware_stack_in_staging_area_slot(
+    decoy: Decoy,
+    mock_labware_view: LabwareView,
+    subject: GeometryView,
+) -> None:
+    """It should get name of ancestor slot of a stack of labware in a staging area slot."""
+    decoy.when(mock_labware_view.get("labware-1")).then_return(
+        LoadedLabware(
+            id="labware-1",
+            loadName="load-name",
+            definitionUri="1234",
+            location=AddressableAreaLocation(
+                addressableAreaName=StagingSlotName.SLOT_D4.id
+            ),
+        )
+    )
+    decoy.when(mock_labware_view.get("labware-2")).then_return(
+        LoadedLabware(
+            id="labware-2",
+            loadName="load-name",
+            definitionUri="1234",
+            location=OnLabwareLocation(labwareId="labware-1"),
+        )
+    )
+    assert subject.get_ancestor_slot_name("labware-2") == StagingSlotName.SLOT_D4
 
 
 def test_ensure_location_not_occupied_raises(


### PR DESCRIPTION
# Overview
Covers PLAT-538

Previously attempting to stack TC lids in the staging area slots would result in incorrect "Off-Deck" errors. Any and all labware could not be properly stacked in this location due to the Protocol Engine not being able to properly resolve the 'ancestor slot' of staging area slots. 

In order to fix this, we now allow Staging Area Slot locations to be resolved as an ancestor, and raise errors where this would cause a conflict (due to staging area slots, as a location, being tied to the fixture location of column 3, rather than column 4). Fortunately, only pipetting actions would encounter these cases. Since we do not allow pipetting in column 4, we should theoretically never run into these kinds of problems.

## Test Plan and Hands on Testing

- [x] The following protocol should pass analysis and perform as expected during execution:
```
from typing import List, Dict, Any, Optional
from opentrons.protocol_api import ProtocolContext, Labware

metadata = {"protocolName": "Opentrons Tough Auto-Sealing Lid Test"}
requirements = {"robotType": "Flex", "apiLevel": "2.20"}

LID_STARTING_SLOT = "D4"
LID_ENDING_SLOT = "C1"
LID_COUNT = 5
LID_DEFINITION = "opentrons_tough_pcr_auto_sealing_lid"
LID_BOTTOM_DEFINITION = "opentrons_tough_pcr_auto_sealing_lid"

USING_THERMOCYCLER = False

OFFSET_DECK = {
    "pick-up": {"x": 0, "y": 0, "z": 0},
    "drop": {"x": 0, "y": 0, "z": 0},
}
OFFSET_THERMOCYCLER = {
    "pick-up": {"x": 0, "y": 0, "z": 0},
    "drop": {"x": 0, "y": 0, "z": 0},
}


def _move_labware_with_offset_and_pause(
    protocol: ProtocolContext,
    labware: Labware,
    destination: Any,
    pick_up_offset: Optional[Dict[str, float]] = None,
    drop_offset: Optional[Dict[str, float]] = None,
) -> None:
    protocol.move_labware(
        labware,
        destination,
        use_gripper=True,
        pick_up_offset=pick_up_offset,
        drop_offset=drop_offset,
    )


def run(protocol: ProtocolContext):
    # SETUP
    lids: List[Labware] = [protocol.load_labware(LID_BOTTOM_DEFINITION, 'B4')]
    for i in range(LID_COUNT - 1):
        lids.append(lids[-1].load_labware(LID_DEFINITION))
    lids.reverse()  # NOTE: reversing to more easily loop through lids from top-to-bottom

    # RUN
    prev_moved_lid: Optional[Labware] = None
    for lid in lids:
        _move_labware_with_offset_and_pause(
            protocol,
            lid,
            prev_moved_lid if prev_moved_lid else LID_ENDING_SLOT,
            pick_up_offset=OFFSET_DECK["pick-up"],
            drop_offset=OFFSET_DECK["drop"],
        )
        prev_moved_lid = lid
```

## Changelog

## Review requests
Do the changes here seem to make sense? Any issues that could occur from the error-raising I'm doing to prevent our conflict cases?

What should we do about the PAPI core `get_deck_slot(...)` function? We have historically had it return an optional DeckSlotName object, should we change that to an optional Union including StagingAreaSlotName? Would that have any negative downstream effects on things using that function like `loaded_labwares()`? Right now I just have it mutating the slot to a DeckSlotName for an equivalent slot in column 3, which is a lie but technically is the deck cutout that both columns originate from. Probably want to replace this with something more sensible before merging. 

## Risk assessment
Low - I believe we're covering the conflict cases pretty aggressively here, and such states should be unreachable. As a result, resolving an ancestor to column 4 should be unblocked for the gripper.