### PR TITLE
feat(robot-server): separate can logs from other serial logs

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -221,6 +221,16 @@ CONFIG_ELEMENTS = (
         "relative path it will be relative to log_dir"
         "The location of the file to save serial logs to",
     ),
+    ConfigElement(
+        "can_log_file",
+        "CAN Log File",
+        Path("logs") / "can.log",
+        ConfigElementType.FILE,
+        "The location of the file to save CAN logs to. If this is"
+        " an absolute path, it will be used directly. If it is a "
+        "relative path it will be relative to log_dir"
+        "The location of the file to save CAN logs to",
+    ),
     # Unlike other config elements, the wifi keys dir is still in
     # /data/user_storage/opentrons_data because these paths are fed directly to
     # NetworkManager and stored in connections files there. To change this
@@ -580,7 +590,7 @@ def write_config(config_data: Dict[str, Path], path: Optional[Path] = None) -> N
     valid_names = [ce.name for ce in CONFIG_ELEMENTS]
     try:
         os.makedirs(path, exist_ok=True)
-        with (path / _CONFIG_FILENAME).open("w") as base_f:
+        with (path / _CONFIG_FILENAME).open("w+") as base_f:
             json.dump(
                 {k: str(v) for k, v in config_data.items() if k in valid_names},
                 base_f,

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -221,16 +221,6 @@ CONFIG_ELEMENTS = (
         "relative path it will be relative to log_dir"
         "The location of the file to save serial logs to",
     ),
-    ConfigElement(
-        "can_log_file",
-        "CAN Log File",
-        Path("logs") / "can.log",
-        ConfigElementType.FILE,
-        "The location of the file to save CAN logs to. If this is"
-        " an absolute path, it will be used directly. If it is a "
-        "relative path it will be relative to log_dir"
-        "The location of the file to save CAN logs to",
-    ),
     # Unlike other config elements, the wifi keys dir is still in
     # /data/user_storage/opentrons_data because these paths are fed directly to
     # NetworkManager and stored in connections files there. To change this
@@ -590,7 +580,7 @@ def write_config(config_data: Dict[str, Path], path: Optional[Path] = None) -> N
     valid_names = [ce.name for ce in CONFIG_ELEMENTS]
     try:
         os.makedirs(path, exist_ok=True)
-        with (path / _CONFIG_FILENAME).open("w+") as base_f:
+        with (path / _CONFIG_FILENAME).open("w") as base_f:
             json.dump(
                 {k: str(v) for k, v in config_data.items() if k in valid_names},
                 base_f,

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -16,6 +16,7 @@ def _host_config(level_value: int) -> Dict[str, Any]:
     serial_log_filename = CONFIG["serial_log_file"]
     api_log_filename = CONFIG["api_log_file"]
     sensor_log_filename = CONFIG["sensor_log_file"]
+    can_log_filename = CONFIG["can_log_file"]
     return {
         "version": 1,
         "disable_existing_loggers": False,
@@ -36,7 +37,15 @@ def _host_config(level_value: int) -> Dict[str, Any]:
                 "class": "logging.handlers.RotatingFileHandler",
                 "formatter": "basic",
                 "filename": serial_log_filename,
-                "maxBytes": 5000000,
+                "maxBytes": 1000000,
+                "level": logging.DEBUG,
+                "backupCount": 3,
+            },
+            "can": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "basic",
+                "filename": can_log_filename,
+                "maxBytes": 1000000,
                 "level": logging.DEBUG,
                 "backupCount": 3,
             },
@@ -72,7 +81,7 @@ def _host_config(level_value: int) -> Dict[str, Any]:
                 "propagate": False,
             },
             "opentrons_hardware.drivers.can_bus.can_messenger": {
-                "handlers": ["serial"],
+                "handlers": ["can"],
                 "level": logging.DEBUG,
                 "propagate": False,
             },
@@ -115,6 +124,12 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
                 "formatter": "message_only",
                 "SYSLOG_IDENTIFIER": "opentrons-api-serial",
             },
+            "can": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.DEBUG,
+                "formatter": "message_only",
+                "SYSLOG_IDENTIFIER": "opentrons-api-serial",
+            },
             "can_serial": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
@@ -151,7 +166,8 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
                 "level": level_value,
             },
             "opentrons_hardware.drivers.can_bus.can_messenger": {
-                "handlers": ["can_serial"],
+                # "handlers": ["can_serial"],
+                "handlers": ["can"],
                 "level": logging.DEBUG,
                 "propagate": False,
             },

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -36,7 +36,7 @@ def _host_config(level_value: int) -> Dict[str, Any]:
                 "class": "logging.handlers.RotatingFileHandler",
                 "formatter": "basic",
                 "filename": serial_log_filename,
-                "maxBytes": 5000000,
+                "maxBytes": 1000000,
                 "level": logging.DEBUG,
                 "backupCount": 3,
             },

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -16,7 +16,6 @@ def _host_config(level_value: int) -> Dict[str, Any]:
     serial_log_filename = CONFIG["serial_log_file"]
     api_log_filename = CONFIG["api_log_file"]
     sensor_log_filename = CONFIG["sensor_log_file"]
-    can_log_filename = CONFIG["can_log_file"]
     return {
         "version": 1,
         "disable_existing_loggers": False,
@@ -37,15 +36,7 @@ def _host_config(level_value: int) -> Dict[str, Any]:
                 "class": "logging.handlers.RotatingFileHandler",
                 "formatter": "basic",
                 "filename": serial_log_filename,
-                "maxBytes": 1000000,
-                "level": logging.DEBUG,
-                "backupCount": 3,
-            },
-            "can": {
-                "class": "logging.handlers.RotatingFileHandler",
-                "formatter": "basic",
-                "filename": can_log_filename,
-                "maxBytes": 1000000,
+                "maxBytes": 5000000,
                 "level": logging.DEBUG,
                 "backupCount": 3,
             },
@@ -81,7 +72,7 @@ def _host_config(level_value: int) -> Dict[str, Any]:
                 "propagate": False,
             },
             "opentrons_hardware.drivers.can_bus.can_messenger": {
-                "handlers": ["can"],
+                "handlers": ["serial"],
                 "level": logging.DEBUG,
                 "propagate": False,
             },
@@ -124,12 +115,6 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
                 "formatter": "message_only",
                 "SYSLOG_IDENTIFIER": "opentrons-api-serial",
             },
-            "can": {
-                "class": "systemd.journal.JournalHandler",
-                "level": logging.DEBUG,
-                "formatter": "message_only",
-                "SYSLOG_IDENTIFIER": "opentrons-api-serial",
-            },
             "can_serial": {
                 "class": "systemd.journal.JournalHandler",
                 "level": logging.DEBUG,
@@ -166,8 +151,7 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
                 "level": level_value,
             },
             "opentrons_hardware.drivers.can_bus.can_messenger": {
-                # "handlers": ["can_serial"],
-                "handlers": ["can"],
+                "handlers": ["can_serial"],
                 "level": logging.DEBUG,
                 "propagate": False,
             },

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -30,6 +30,7 @@ OT2_LOG_PATHS = [
 ]
 FLEX_LOG_PATHS = [
     "/logs/serial.log",
+    "/logs/can_bus.log",
     "/logs/api.log",
     "/logs/server.log",
     "/logs/update_server.log",

--- a/robot-server/robot_server/service/legacy/models/logs.py
+++ b/robot-server/robot_server/service/legacy/models/logs.py
@@ -6,6 +6,7 @@ class LogIdentifier(str, Enum):
 
     api = "api.log"
     serial = "serial.log"
+    can = "can_bus.log"
     server = "server.log"
     api_server = "combined_api_server.log"
     update_server = "update_server.log"

--- a/robot-server/robot_server/service/legacy/routers/logs.py
+++ b/robot-server/robot_server/service/legacy/routers/logs.py
@@ -14,6 +14,7 @@ IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, str] = {
     LogIdentifier.api_server: "opentrons-robot-server",
     LogIdentifier.update_server: "opentrons-update-server",
     LogIdentifier.touchscreen: "opentrons-robot-app",
+    LogIdentifier.can: "opentrons-api-serial-can"
 }
 
 

--- a/robot-server/robot_server/service/legacy/routers/logs.py
+++ b/robot-server/robot_server/service/legacy/routers/logs.py
@@ -14,7 +14,7 @@ IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, str] = {
     LogIdentifier.api_server: "opentrons-robot-server",
     LogIdentifier.update_server: "opentrons-update-server",
     LogIdentifier.touchscreen: "opentrons-robot-app",
-    LogIdentifier.can: "opentrons-api-serial-can"
+    LogIdentifier.can: "opentrons-api-serial-can",
 }
 
 

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -50,6 +50,7 @@ def check_ot3_health_response(response: Response) -> None:
         "board_revision": "UNKNOWN",
         "logs": [
             "/logs/serial.log",
+            "/logs/can_bus.log",
             "/logs/api.log",
             "/logs/server.log",
             "/logs/update_server.log",


### PR DESCRIPTION
## Overview
Currently, CAN messages are stored in the same logging file as serial communications from modules. This means that if, for example, an abr bug occurs, and the logs are grabbed even a few minutes later, a present thermocycler will have sent so many status messages that the CAN messages from when the error happened are pushed out of the logs.

Let's give the CAN messages their own file so we have a better idea of what happened when we need to look at logs.

## Changelog

- add an entry for the existing `opentrons-api-serial-canbus` logger to the logs router
- the change in the serial log's `maxbytes` from `1000000` to `5000000` was actually done in an attempt to capture CAN messages along with the serial messages, so revert that 