### PR TITLE
fix(protocol-designer): flow rate field to auto-populate default value

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -59,7 +59,8 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
   let errorMessage: string | null = null
   if (
     (!isPristine && passThruProps.value !== undefined && flowRateNum === 0) ||
-    outOfBounds
+    outOfBounds ||
+    (isPristine && flowRateNum === 0)
   ) {
     errorMessage = i18n.format(
       t('step_edit_form.field.flow_rate.error_out_of_bounds', {
@@ -71,10 +72,10 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
   }
 
   useEffect(() => {
-    if (isPristine && errorMessage != null) {
+    if (isPristine && passThruProps.value == null) {
       passThruProps.updateValue(defaultFlowRate)
     }
-  }, [])
+  }, [isPristine, passThruProps])
 
   return (
     <InputStepFormField


### PR DESCRIPTION
closes RQA-3508

# Overview

The flow rate field is wonky because if its undefined, it gets populated further down the line as the default flow rate. so the empty field was fine. but here i fixed it so it auto-populates to the default field by default

## Test Plan and Hands on Testing

Test out a transfer step and see that the aspirate and dispense flow rate fields are populated to the default flow rate by default and test out a mix step as well

## Changelog

refine the useEffect and the logic for showing the errors

## Risk assessment

low
