### PR TITLE
fix(protocol-designer): add slot clips to deck map views

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -67,6 +67,7 @@ const OT2_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST: string[] = [
   'fixedTrash',
 ]
 export const lightFill = COLORS.grey35
+const darkFill = COLORS.grey60
 
 export function DeckSetupContainer(props: DeckSetupTabType): JSX.Element {
   const { tab } = props
@@ -213,6 +214,7 @@ export function DeckSetupContainer(props: DeckSetupTabType): JSX.Element {
                           key={addressableArea.id}
                           cutoutId={cutoutId}
                           deckDefinition={deckDef}
+                          slotClipColor={darkFill}
                           showExpansion={cutoutId === 'cutoutA1'}
                           fixtureBaseColor={lightFill}
                         />
@@ -228,6 +230,7 @@ export function DeckSetupContainer(props: DeckSetupTabType): JSX.Element {
                             key={fixture.id}
                             cutoutId={fixture.location as StagingAreaLocation}
                             deckDefinition={deckDef}
+                            slotClipColor={darkFill}
                             fixtureBaseColor={lightFill}
                           />
                         )
@@ -284,6 +287,7 @@ export function DeckSetupContainer(props: DeckSetupTabType): JSX.Element {
                               fixture.location as typeof WASTE_CHUTE_CUTOUT
                             }
                             deckDefinition={deckDef}
+                            slotClipColor={darkFill}
                             fixtureBaseColor={lightFill}
                           />
                         )

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -48,6 +48,7 @@ const OT2_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST: string[] = [
 ]
 
 const lightFill = COLORS.grey35
+const darkFill = COLORS.grey60
 
 interface DeckThumbnailProps {
   hoverSlot: DeckSlotId | null
@@ -140,6 +141,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                       deckDefinition={deckDef}
                       showExpansion={cutoutId === 'cutoutA1'}
                       fixtureBaseColor={lightFill}
+                      slotClipColor={darkFill}
                     />
                   ) : null
                 })}
@@ -149,6 +151,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                     cutoutId={fixture.location as StagingAreaLocation}
                     deckDefinition={deckDef}
                     fixtureBaseColor={lightFill}
+                    slotClipColor={darkFill}
                   />
                 ))}
                 {trash != null
@@ -185,6 +188,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                     cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
                     deckDefinition={deckDef}
                     fixtureBaseColor={lightFill}
+                    slotClipColor={darkFill}
                   />
                 ))}
               </>


### PR DESCRIPTION
closes RQA-3404 RQA-3348

# Overview

Add slot clips back to the deck map views in deck setup and deck thumbnail for the flex

<img width="800" alt="Screenshot 2024-11-05 at 10 54 41" src="https://github.com/user-attachments/assets/30c9c6c2-ff0b-4f53-a318-2729f4343d08">

<img width="691" alt="Screenshot 2024-11-05 at 10 54 29" src="https://github.com/user-attachments/assets/03e4f62b-cb4e-4b7d-8fa2-f889f9a43268">

## Test Plan and Hands on Testing

Test to make sure the slot clips are back for the 2 deck map components (deck setup and deck thumbnail)



## Changelog

- add slot clips back to the fixtures in deck thumbnail and deck setup

## Risk assessment

low