### PR TITLE
refactor(api): map ByTipTypeSetting pydantic model to TransferProperties dataclass

### DIFF
--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -8,12 +8,8 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
 )
 
 from ._liquid_properties import (
-    AspirateProperties,
-    SingleDispenseProperties,
-    MultiDispenseProperties,
-    build_aspirate_properties,
-    build_single_dispense_properties,
-    build_multi_dispense_properties,
+    TransferProperties,
+    build_transfer_properties,
 )
 
 
@@ -35,30 +31,6 @@ class Liquid:
     display_color: Optional[str]
 
 
-# TODO (spp, 2024-10-17): create PAPI-equivalent types for all the properties
-#  and have validation on value updates with user-facing error messages
-@dataclass
-class TransferProperties:
-    _aspirate: AspirateProperties
-    _dispense: SingleDispenseProperties
-    _multi_dispense: Optional[MultiDispenseProperties]
-
-    @property
-    def aspirate(self) -> AspirateProperties:
-        """Aspirate properties."""
-        return self._aspirate
-
-    @property
-    def dispense(self) -> SingleDispenseProperties:
-        """Single dispense properties."""
-        return self._dispense
-
-    @property
-    def multi_dispense(self) -> Optional[MultiDispenseProperties]:
-        """Multi dispense properties."""
-        return self._multi_dispense
-
-
 @dataclass
 class LiquidClass:
     """A data class that contains properties of a specific class of liquids."""
@@ -75,13 +47,7 @@ class LiquidClass:
         for by_pipette in liquid_class_definition.byPipette:
             tip_settings: Dict[str, TransferProperties] = {}
             for tip_type in by_pipette.byTipType:
-                tip_settings[tip_type.tiprack] = TransferProperties(
-                    _aspirate=build_aspirate_properties(tip_type.aspirate),
-                    _dispense=build_single_dispense_properties(tip_type.singleDispense),
-                    _multi_dispense=build_multi_dispense_properties(
-                        tip_type.multiDispense
-                    ),
-                )
+                tip_settings[tip_type.tiprack] = build_transfer_properties(tip_type)
             by_pipette_settings[by_pipette.pipetteModel] = tip_settings
 
         return cls(

--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -9,6 +9,7 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     TouchTipProperties as SharedDataTouchTipProperties,
     MixProperties as SharedDataMixProperties,
     BlowoutProperties as SharedDataBlowoutProperties,
+    ByTipTypeSetting as SharedByTipTypeSetting,
     Submerge as SharedDataSubmerge,
     RetractAspirate as SharedDataRetractAspirate,
     RetractDispense as SharedDataRetractDispense,
@@ -361,6 +362,30 @@ class MultiDispenseProperties(BaseLiquidHandlingProperties):
         return self._disposal_by_volume
 
 
+# TODO (spp, 2024-10-17): create PAPI-equivalent types for all the properties
+#  and have validation on value updates with user-facing error messages
+@dataclass
+class TransferProperties:
+    _aspirate: AspirateProperties
+    _dispense: SingleDispenseProperties
+    _multi_dispense: Optional[MultiDispenseProperties]
+
+    @property
+    def aspirate(self) -> AspirateProperties:
+        """Aspirate properties."""
+        return self._aspirate
+
+    @property
+    def dispense(self) -> SingleDispenseProperties:
+        """Single dispense properties."""
+        return self._dispense
+
+    @property
+    def multi_dispense(self) -> Optional[MultiDispenseProperties]:
+        """Multi dispense properties."""
+        return self._multi_dispense
+
+
 def _build_delay_properties(
     delay_properties: SharedDataDelayProperties,
 ) -> DelayProperties:
@@ -500,4 +525,14 @@ def build_multi_dispense_properties(
         _conditioning_by_volume=multi_dispense_properties.conditioningByVolume,
         _disposal_by_volume=multi_dispense_properties.disposalByVolume,
         _delay=_build_delay_properties(multi_dispense_properties.delay),
+    )
+
+
+def build_transfer_properties(
+    by_tip_type_setting: SharedByTipTypeSetting,
+) -> TransferProperties:
+    return TransferProperties(
+        _aspirate=build_aspirate_properties(by_tip_type_setting.aspirate),
+        _dispense=build_single_dispense_properties(by_tip_type_setting.singleDispense),
+        _multi_dispense=build_multi_dispense_properties(by_tip_type_setting.multiDispense),
     )

--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -534,5 +534,7 @@ def build_transfer_properties(
     return TransferProperties(
         _aspirate=build_aspirate_properties(by_tip_type_setting.aspirate),
         _dispense=build_single_dispense_properties(by_tip_type_setting.singleDispense),
-        _multi_dispense=build_multi_dispense_properties(by_tip_type_setting.multiDispense),
+        _multi_dispense=build_multi_dispense_properties(
+            by_tip_type_setting.multiDispense
+        ),
     )


### PR DESCRIPTION
# Overview

Followup to AUTH-835 / AUTH-837.

We want a nice class to bundle together `AspirateProperties`/`SingleDispenseProperties`/`MultiDispenseProperties` plus any potential future liquid class properties.

For Pydantic, we already have the the `ByTipTypeSetting` model that encapsulates all the liquid class properties, so let's use that. The upcoming `loadLiquidClass()` implementation will take a `ByTipTypeSetting` as part of its parameter.

For the Python dataclass, we already have `TransferProperties`, so we'll continue to use that for the Python API.

This is a small refactoring change that:
- Moves `TransferProperties` to live with its friends in _liquid_properties.py, which contains the definitions of the other liquid class property classes.
- Implements a `build_transfer_properties()` to turn a Pydantic `ByTipTypeSetting` into a dataclass `TransferProperties`, in the same way the other `build_*` functions turn the Pydantic object into its corresponding dataclass object.

## Test Plan and Hands on Testing

I ran `make test` to run all the tests under `api/`.

## Review requests

This is my first time making a change to our code! Please let me know if I'm missing anything.

## Risk assessment

My understanding is that liquid classes is not finished and not in production at all, so any impact should be limited to our internal dev and testing.
