### PR TITLE
fix(app, components): Fix TC lid rendering in `runRecord` deck maps

### DIFF
--- a/app/src/local-resources/labware/utils/getLabwareDisplayLocation.ts
+++ b/app/src/local-resources/labware/utils/getLabwareDisplayLocation.ts
@@ -2,6 +2,8 @@ import {
   getModuleDisplayName,
   getModuleType,
   getOccludedSlotCountForModule,
+  THERMOCYCLER_MODULE_V1,
+  THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 import { getLabwareLocation } from './getLabwareLocation'
 
@@ -50,7 +52,10 @@ export function getLabwareDisplayLocation(
   // Module location without adapter
   else if (moduleModel != null && adapterName == null) {
     if (params.detailLevel === 'slot-only') {
-      return t('slot', { slot_name: slotName })
+      return moduleModel === THERMOCYCLER_MODULE_V1 ||
+        moduleModel === THERMOCYCLER_MODULE_V2
+        ? t('slot', { slot_name: 'A1+B1' })
+        : t('slot', { slot_name: slotName })
     } else {
       return isOnDevice
         ? `${getModuleDisplayName(moduleModel)}, ${slotName}`

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -71,6 +71,8 @@ export function useDeckMapUtils({
   const deckConfig = getSimplestDeckConfigForProtocol(protocolAnalysis)
   const deckDef = getDeckDefFromRobotType(robotType)
 
+  // TODO(jh, 11-05-24): Revisit this logic along with deckmap interfaces after deck map redesign.
+
   const currentModulesInfo = useMemo(
     () =>
       getRunCurrentModulesInfo({
@@ -96,12 +98,17 @@ export function useDeckMapUtils({
     [runRecord, labwareDefinitionsByUri]
   )
 
+  const { updatedModules, remainingLabware } = useMemo(
+    () => updateLabwareInModules({ runCurrentModules, currentLabwareInfo }),
+    [runCurrentModules, currentLabwareInfo]
+  )
+
   const runCurrentLabware = useMemo(
     () =>
       getRunCurrentLabwareOnDeck({
         failedLabwareUtils,
         runRecord,
-        currentLabwareInfo,
+        currentLabwareInfo: remainingLabware,
       }),
     [failedLabwareUtils, currentLabwareInfo]
   )
@@ -137,7 +144,7 @@ export function useDeckMapUtils({
 
   return {
     deckConfig,
-    modulesOnDeck: runCurrentModules.map(
+    modulesOnDeck: updatedModules.map(
       ({ moduleModel, moduleLocation, innerProps, nestedLabwareDef }) => ({
         moduleModel,
         moduleLocation,
@@ -149,7 +156,7 @@ export function useDeckMapUtils({
       labwareLocation,
       definition,
     })),
-    highlightLabwareEventuallyIn: [...runCurrentModules, ...runCurrentLabware]
+    highlightLabwareEventuallyIn: [...updatedModules, ...runCurrentLabware]
       .map(el => el.highlight)
       .filter(maybeSlot => maybeSlot != null) as string[],
     kind: 'intervention',
@@ -458,4 +465,41 @@ export function getIsLabwareMatch(
   } else {
     return slotLocation === slotName
   }
+}
+
+// If any labware share a slot with a module, the labware should be nested within the module for rendering purposes.
+// This prevents issues such as TC nested labware rendering in
+export function updateLabwareInModules({
+  runCurrentModules,
+  currentLabwareInfo,
+}: {
+  runCurrentModules: ReturnType<typeof getRunCurrentModulesOnDeck>
+  currentLabwareInfo: ReturnType<typeof getRunCurrentLabwareInfo>
+}): {
+  updatedModules: ReturnType<typeof getRunCurrentModulesOnDeck>
+  remainingLabware: ReturnType<typeof getRunCurrentLabwareInfo>
+} {
+  const usedSlots = new Set<string>()
+
+  const updatedModules = runCurrentModules.map(moduleInfo => {
+    const labwareInSameLoc = currentLabwareInfo.find(
+      lw => moduleInfo.moduleLocation.slotName === lw.slotName
+    )
+
+    if (labwareInSameLoc != null) {
+      usedSlots.add(labwareInSameLoc.slotName)
+      return {
+        ...moduleInfo,
+        nestedLabwareDef: labwareInSameLoc.labwareDef,
+      }
+    } else {
+      return moduleInfo
+    }
+  })
+
+  const remainingLabware = currentLabwareInfo.filter(
+    lw => !usedSlots.has(lw.slotName)
+  )
+
+  return { updatedModules, remainingLabware }
 }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -468,7 +468,7 @@ export function getIsLabwareMatch(
 }
 
 // If any labware share a slot with a module, the labware should be nested within the module for rendering purposes.
-// This prevents issues such as TC nested labware rendering in
+// This prevents issues such as TC nested labware rendering in "B1" instead of the special-cased location.
 export function updateLabwareInModules({
   runCurrentModules,
   currentLabwareInfo,

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import styled from 'styled-components'
-import flatMap from 'lodash/flatMap'
 import { animated, useSpring, easings } from '@react-spring/web'
 import {
   getDeckDefFromRobotType,
   getModuleDef2,
   getPositionFromSlotId,
 } from '@opentrons/shared-data'
+import { LabwareRender } from '../Labware'
 
 import { COLORS } from '../../helix-design-system'
 import { IDENTITY_AFFINE_TRANSFORM, multiplyMatrices } from '../utils'
@@ -14,7 +14,6 @@ import { BaseDeck } from '../BaseDeck'
 
 import type {
   LoadedLabware,
-  LabwareWell,
   LoadedModule,
   Coordinates,
   LabwareDefinition2,
@@ -127,7 +126,6 @@ function getLabwareCoordinates({
   }
 }
 
-const OUTLINE_THICKNESS_MM = 3
 const SPLASH_Y_BUFFER_MM = 10
 
 interface MoveLabwareOnDeckProps extends StyleProps {
@@ -212,7 +210,9 @@ export function MoveLabwareOnDeck(
     loop: true,
   })
 
-  if (deckDef == null) return null
+  if (deckDef == null) {
+    return null
+  }
 
   return (
     <BaseDeck
@@ -229,30 +229,7 @@ export function MoveLabwareOnDeck(
         <g
           transform={`translate(${movedLabwareDef.cornerOffsetFromSlot.x}, ${movedLabwareDef.cornerOffsetFromSlot.y})`}
         >
-          <rect
-            x={OUTLINE_THICKNESS_MM}
-            y={OUTLINE_THICKNESS_MM}
-            strokeWidth={OUTLINE_THICKNESS_MM}
-            stroke={COLORS.blue50}
-            fill={COLORS.white}
-            width={
-              movedLabwareDef.dimensions.xDimension - 2 * OUTLINE_THICKNESS_MM
-            }
-            height={
-              movedLabwareDef.dimensions.yDimension - 2 * OUTLINE_THICKNESS_MM
-            }
-            rx={3 * OUTLINE_THICKNESS_MM}
-          />
-          {flatMap(
-            movedLabwareDef.ordering,
-            (row: string[], i: number, c: string[][]) =>
-              row.map(wellName => (
-                <Well
-                  key={wellName}
-                  wellDef={movedLabwareDef.wells[wellName]}
-                />
-              ))
-          )}
+          <LabwareRender definition={movedLabwareDef} highlight={true} />
           <AnimatedG style={{ opacity: springProps.splashOpacity }}>
             <path
               d="M158.027 111.537L154.651 108.186M145.875 113L145.875 109.253M161 99.3038L156.864 99.3038M11.9733 10.461L15.3495 13.8128M24.1255 9L24.1254 12.747M9 22.6962L13.1357 22.6962"
@@ -272,30 +249,3 @@ export function MoveLabwareOnDeck(
  * These animated components needs to be split out because react-spring and styled-components don't play nice
  * @see https://github.com/pmndrs/react-spring/issues/1515 */
 const AnimatedG = styled(animated.g as any)``
-
-interface WellProps {
-  wellDef: LabwareWell
-}
-function Well(props: WellProps): JSX.Element {
-  const { wellDef } = props
-  const { x, y } = wellDef
-
-  return wellDef.shape === 'rectangular' ? (
-    <rect
-      fill={COLORS.white}
-      stroke={COLORS.black90}
-      x={x - wellDef.xDimension / 2}
-      y={y - wellDef.yDimension / 2}
-      width={wellDef.xDimension}
-      height={wellDef.yDimension}
-    />
-  ) : (
-    <circle
-      fill={COLORS.white}
-      stroke={COLORS.black90}
-      cx={x}
-      cy={y}
-      r={wellDef.diameter / 2}
-    />
-  )
-}


### PR DESCRIPTION
Closes [EXEC-804](https://opentrons.atlassian.net/browse/EXEC-804)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Deck maps that utilize the run record instead of protocol analysis render labware differently and generally behave "not like the other deck maps", so we need to make proper affordances for TC lids. 

192352a1cdbe53d7af3068f8bdaeb5852e440762 - We recently created a `getDisplayLocation` util with the goal of centralizing copy generation for locations. We need to special-case handle labware in the TC slot, which is in slot "A1+B1".

c04ecddd18dbe7a2a8b773784f556f5ce444f993 - The `MoveLabwareOnDeck` deck hard codes the labware color to `COLORS.white`, which worked well until TC lids, which are orange. Looking at this component, it seems we can refactor this down significantly and get the correct behavior by just using `LabwareRender`. I _think_ this is the case, but see test plan. This commit should also correct behavior when manually moving TC lids on the deck during a protocol run.

203249e009b50c2915eb9b4e8c74cafd6b398589 - TC labware renders in B1 instead of the special TC location. In the ER deck map, we need an intermediate step to correct this behavior. It's not a great fix, but there's not too much of a point of improving deck map internals given the imminent redesign. 

### Current Behavior

<img width="733" alt="Screenshot 2024-11-04 at 1 08 19 PM" src="https://github.com/user-attachments/assets/39c57906-9735-481b-ab1a-0a79ca5646cd">

<img width="746" alt="Screenshot 2024-11-05 at 9 08 25 AM" src="https://github.com/user-attachments/assets/61d3092c-2272-4fbd-a5d7-081c54155088">


### Fixed Behavior

<img width="743" alt="Screenshot 2024-11-04 at 4 55 25 PM" src="https://github.com/user-attachments/assets/1271a081-a6b0-4cd7-8d46-55ea4fa4ecb7">

<img width="742" alt="Screenshot 2024-11-05 at 9 46 47 AM" src="https://github.com/user-attachments/assets/d821de0e-c4cc-423e-93f8-47d64a127f79">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran a lot of Error Recovery flows, confirming correct deck map renderings.
- Ran several runs of manual move labware protocols with different labware, ensuring correct deck map behavior (and color).
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed display issues with thermocycler lids during protocol run deck maps.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
medium - This does touch both the manual move intervention deck map and the Error Recovery deck map
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-804]: https://opentrons.atlassian.net/browse/EXEC-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ