### PR TITLE
fix(protocol-designer): fix command summary for dispensing into trash/waste chute

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -63,7 +63,9 @@
   "move_liquid": {
     "consolidate": "<text>Consolidating</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destinationWells}} of {{destination}}</semiBoldText>",
     "distribute": "<text>Distributing</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destinationWells}} of {{destination}}</semiBoldText>",
-    "transfer": "<text>Transferring</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destinationWells}} of {{destination}}</semiBoldText>"
+    "transfer": "<text>Transferring</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destinationWells}} of {{destination}}</semiBoldText>",
+    "consolidate_disposal": "<text>Consolidating</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destination}}</semiBoldText>",
+    "transfer_disposal": "<text>Transferring</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destination}}</semiBoldText>"
   },
   "multi_dispense_options": "Distribute options",
   "multiAspirate": "Consolidate path",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/ChangeTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/ChangeTipField.tsx
@@ -15,13 +15,21 @@ const ALL_CHANGE_TIP_VALUES: ChangeTipOptions[] = [
 type ChangeTipFieldProps = FieldProps & DisabledChangeTipArgs
 
 export function ChangeTipField(props: ChangeTipFieldProps): JSX.Element {
-  const { aspirateWells, dispenseWells, path, stepType, value } = props
+  const {
+    aspirateWells,
+    dispenseWells,
+    path,
+    stepType,
+    value,
+    isDisposalLocation,
+  } = props
   const { t } = useTranslation(['protocol_steps', 'form'])
   const disabledOptions = getDisabledChangeTipOptions({
     aspirateWells,
     dispenseWells,
     path,
     stepType,
+    isDisposalLocation,
   })
 
   const options = ALL_CHANGE_TIP_VALUES.map(value => ({

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PathField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PathField.tsx
@@ -116,6 +116,7 @@ export function PathField(props: PathFieldProps): JSX.Element {
     value,
     updateValue,
     tipRack,
+    isDisposalLocation,
   } = props
   const { t } = useTranslation('form')
   const pipetteEntities = useSelector(stepFormSelectors.getPipetteEntities)
@@ -129,6 +130,7 @@ export function PathField(props: PathFieldProps): JSX.Element {
       pipette,
       volume,
       tipRack,
+      isDisposalLocation,
     },
     pipetteEntities,
     t

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
@@ -15,15 +15,26 @@ export interface DisabledChangeTipArgs {
   dispenseWells?: string[]
   stepType?: StepType
   path?: PathOption | null | undefined
+  isDisposalLocation?: boolean
 }
 export const getDisabledChangeTipOptions = (
   args: DisabledChangeTipArgs
 ): Set<ChangeTipOptions> | null | undefined => {
-  const { path, aspirateWells, dispenseWells, stepType } = args
+  const {
+    path,
+    aspirateWells,
+    dispenseWells,
+    stepType,
+    isDisposalLocation,
+  } = args
 
   switch (stepType) {
     case 'moveLiquid': {
-      const wellRatio = getWellRatio(aspirateWells, dispenseWells)
+      const wellRatio = getWellRatio(
+        aspirateWells,
+        dispenseWells,
+        isDisposalLocation
+      )
 
       //  ensure wells are selected
       if (wellRatio != null && path === 'single') {
@@ -63,6 +74,7 @@ export interface ValuesForPath {
   pipette?: string | null
   volume?: string | null
   tipRack?: string | null
+  isDisposalLocation?: boolean
 }
 export function getDisabledPathMap(
   values: ValuesForPath,
@@ -76,9 +88,15 @@ export function getDisabledPathMap(
     dispense_wells,
     pipette,
     tipRack,
+    isDisposalLocation,
   } = values
   if (!pipette) return null
-  const wellRatio = getWellRatio(aspirate_wells, dispense_wells)
+  const wellRatio = getWellRatio(
+    aspirate_wells,
+    dispense_wells,
+    isDisposalLocation
+  )
+  console.log('well ratio: ', wellRatio)
   let disabledPathMap: Partial<Record<PathOption, string>> = {}
 
   // changeTip is lowest priority disable reasoning

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
@@ -96,7 +96,7 @@ export function getDisabledPathMap(
     dispense_wells,
     isDisposalLocation
   )
-  console.log('well ratio: ', wellRatio)
+
   let disabledPathMap: Partial<Record<PathOption, string>> = {}
 
   // changeTip is lowest priority disable reasoning

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -159,6 +159,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
         pipette={formData.pipette}
         volume={formData.volume}
         tipRack={formData.tipRack}
+        isDisposalLocation={isDisposalLocation}
       />
       <Divider marginY="0" />
       <ChangeTipField
@@ -167,6 +168,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
         dispenseWells={formData.dispense_wells}
         path={formData.path}
         stepType={formData.stepType}
+        isDisposalLocation={isDisposalLocation}
       />
       <Divider marginY="0" />
       {enableReturnTip ? (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -14,6 +14,7 @@ import {
 } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 import {
+  getAdditionalEquipmentEntities,
   getLabwareEntities,
   getModuleEntities,
 } from '../../../step-forms/selectors'
@@ -80,6 +81,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
   const { t } = useTranslation(['protocol_steps', 'application'])
 
   const labwareNicknamesById = useSelector(getLabwareNicknamesById)
+  const additionalEquipmentEntities = useSelector(
+    getAdditionalEquipmentEntities
+  )
 
   const labwareEntities = useSelector(getLabwareEntities)
   const modules = useSelector(getModuleEntities)
@@ -316,14 +320,18 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         dispense_wells as string[],
         flatten(labwareEntities[dispense_labware]?.def.ordering)
       )
+
+      const isTrashBin =
+        additionalEquipmentEntities[dispense_labware]?.name === 'trashBin'
+
       stepSummaryContent = (
         <StyledTrans
           i18nKey={`protocol_steps:move_liquid.${moveLiquidType}`}
           values={{
             sourceWells: aspirateWellsDisplay,
-            destinationWells: dispenseWellsDisplay,
+            destinationWells: isTrashBin ? '' : dispenseWellsDisplay,
             source: sourceLabwareName,
-            destination: destinationLabwareName,
+            destination: isTrashBin ? 'Trash bin' : destinationLabwareName,
           }}
           tagText={`${volume} ${t('application:units.microliter')}`}
         />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -332,7 +332,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           }
           values={{
             sourceWells: aspirateWellsDisplay,
-            destinationWells: isDisposalLocation ? '' : dispenseWellsDisplay,
+            destinationWells: dispenseWellsDisplay,
             source: sourceLabwareName,
             destination: isDisposalLocation
               ? t(`shared:${disposalName}`)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -292,17 +292,6 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       break
     case 'moveLiquid':
       let moveLiquidType
-      if (
-        currentStep.dispense_wells.length > currentStep.aspirate_wells.length
-      ) {
-        moveLiquidType = 'distribute'
-      } else if (
-        currentStep.dispense_wells.length < currentStep.aspirate_wells.length
-      ) {
-        moveLiquidType = 'consolidate'
-      } else {
-        moveLiquidType = 'transfer'
-      }
       const {
         aspirate_labware,
         aspirate_wells,
@@ -321,17 +310,33 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         flatten(labwareEntities[dispense_labware]?.def.ordering)
       )
 
-      const isTrashBin =
-        additionalEquipmentEntities[dispense_labware]?.name === 'trashBin'
+      const disposalName = additionalEquipmentEntities[dispense_labware]?.name
+
+      const isDisposalLocation =
+        disposalName === 'wasteChute' || disposalName === 'trashBin'
+
+      if (currentStep.path === 'single') {
+        moveLiquidType = 'transfer'
+      } else if (currentStep.path === 'multiAspirate') {
+        moveLiquidType = 'consolidate'
+      } else {
+        moveLiquidType = 'distribute'
+      }
 
       stepSummaryContent = (
         <StyledTrans
-          i18nKey={`protocol_steps:move_liquid.${moveLiquidType}`}
+          i18nKey={
+            isDisposalLocation
+              ? `protocol_steps:move_liquid.${moveLiquidType}_disposal`
+              : `protocol_steps:move_liquid.${moveLiquidType}`
+          }
           values={{
             sourceWells: aspirateWellsDisplay,
-            destinationWells: isTrashBin ? '' : dispenseWellsDisplay,
+            destinationWells: isDisposalLocation ? '' : dispenseWellsDisplay,
             source: sourceLabwareName,
-            destination: isTrashBin ? 'Trash bin' : destinationLabwareName,
+            destination: isDisposalLocation
+              ? t(`shared:${disposalName}`)
+              : destinationLabwareName,
           }}
           tagText={`${volume} ${t('application:units.microliter')}`}
         />

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -537,18 +537,17 @@ function updatePatchOnWellRatioChange(
   const appliedPatch = { ...rawForm, ...patch }
   const isDisposalLocation =
     rawForm.dispense_labware?.includes('wasteChute') ||
-    rawForm.dispense_labware?.includes('trashBin') ||
-    false
+    rawForm.dispense_labware?.includes('trashBin')
 
   const prevWellRatio = getWellRatio(
     rawForm.aspirate_wells as string[],
     rawForm.dispense_wells as string[],
-    isDisposalLocation
+    isDisposalLocation as boolean
   )
   const nextWellRatio = getWellRatio(
     appliedPatch.aspirate_wells as string[],
     appliedPatch.dispense_wells as string[],
-    isDisposalLocation
+    isDisposalLocation as boolean
   )
 
   if (nextWellRatio == null || prevWellRatio == null) {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -537,7 +537,8 @@ function updatePatchOnWellRatioChange(
   const appliedPatch = { ...rawForm, ...patch }
   const isDisposalLocation =
     rawForm.dispense_labware?.includes('wasteChute') ||
-    rawForm.dispense_labware?.includes('trashBin')
+    rawForm.dispense_labware?.includes('trashBin') ||
+    false
 
   const prevWellRatio = getWellRatio(
     rawForm.aspirate_wells as string[],

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -536,8 +536,8 @@ function updatePatchOnWellRatioChange(
 ): FormPatch {
   const appliedPatch = { ...rawForm, ...patch }
   const isDisposalLocation =
-    rawForm.dispense_labware.includes('wasteChute') ||
-    rawForm.dispense_labware.includes('trashBin')
+    rawForm.dispense_labware?.includes('wasteChute') ||
+    rawForm.dispense_labware?.includes('trashBin')
 
   const prevWellRatio = getWellRatio(
     rawForm.aspirate_wells as string[],

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -535,13 +535,19 @@ function updatePatchOnWellRatioChange(
   rawForm: FormData
 ): FormPatch {
   const appliedPatch = { ...rawForm, ...patch }
+  const isDisposalLocation =
+    rawForm.dispense_labware.includes('wasteChute') ||
+    rawForm.dispense_labware.includes('trashBin')
+
   const prevWellRatio = getWellRatio(
     rawForm.aspirate_wells as string[],
-    rawForm.dispense_wells as string[]
+    rawForm.dispense_wells as string[],
+    isDisposalLocation
   )
   const nextWellRatio = getWellRatio(
     appliedPatch.aspirate_wells as string[],
-    appliedPatch.dispense_wells as string[]
+    appliedPatch.dispense_wells as string[],
+    isDisposalLocation
   )
 
   if (nextWellRatio == null || prevWellRatio == null) {


### PR DESCRIPTION
fix RQA-3517

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

Updating files that call `getWellRatio()` to pass the optional `isDisposalLocation` prop, which checks whether it’s dispensing into the trash bin or waste chute. This change enables users to select the `Consolidate path` button when multiple source wells are selected. Also updated `stepSummary` to fix the command summary issue where `Consolidating` and `undefined-undefined of` were always displayed when the trash bin or waste chute was chosen as the destination labware, even if the `Single path` button was selected.



## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

1. Add a Transfer step
2. Select multiple source wells and choose trash bin or waste chute as the destination labware
3. Ensure that both `Single path` and `Consolidate path` buttons are enabled for selection 
4. Choose the Single path and and verify that "Transferring" is displayed instead of "Consolidating" in the command summary.



## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
