### PR TITLE
fix(app): fix recovery takeover state cleanup

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useCleanupRecoveryState.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useCleanupRecoveryState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { RECOVERY_MAP } from '../constants'
 
@@ -22,17 +22,15 @@ export function useCleanupRecoveryState({
 }: UseCleanupProps): void {
   const [wasActiveUser, setWasActiveUser] = useState(false)
 
-  useEffect(() => {
-    if (isActiveUser) {
-      setWasActiveUser(true)
-    } else if (wasActiveUser) {
-      setWasActiveUser(false)
+  if (isActiveUser && !wasActiveUser) {
+    setWasActiveUser(true)
+  } else if (!isActiveUser && wasActiveUser) {
+    setWasActiveUser(false)
 
-      stashedMapRef.current = null
-      setRM({
-        route: RECOVERY_MAP.OPTION_SELECTION.ROUTE,
-        step: RECOVERY_MAP.OPTION_SELECTION.STEPS.SELECT,
-      })
-    }
-  }, [isActiveUser])
+    stashedMapRef.current = null
+    setRM({
+      route: RECOVERY_MAP.OPTION_SELECTION.ROUTE,
+      step: RECOVERY_MAP.OPTION_SELECTION.STEPS.SELECT,
+    })
+  }
 }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useCleanupRecoveryState.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useCleanupRecoveryState.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { RECOVERY_MAP } from '../constants'
 
@@ -9,25 +9,30 @@ import type {
 } from '../hooks'
 
 export interface UseCleanupProps {
-  isTakeover: ERUtilsProps['showTakeover']
+  isActiveUser: ERUtilsProps['isActiveUser']
   stashedMapRef: UseRouteUpdateActionsResult['stashedMapRef']
   setRM: UseRecoveryRoutingResult['setRM']
 }
 
-// When certain events (ex, a takeover) occur, reset state that needs to be reset.
+// When certain events (ex, someone terminates this app's recovery session) occur, reset state that needs to be reset.
 export function useCleanupRecoveryState({
-  isTakeover,
+  isActiveUser,
   stashedMapRef,
   setRM,
 }: UseCleanupProps): void {
-  useEffect(() => {
-    if (isTakeover) {
-      stashedMapRef.current = null
+  const [wasActiveUser, setWasActiveUser] = useState(false)
 
+  useEffect(() => {
+    if (isActiveUser) {
+      setWasActiveUser(true)
+    } else if (wasActiveUser) {
+      setWasActiveUser(false)
+
+      stashedMapRef.current = null
       setRM({
         route: RECOVERY_MAP.OPTION_SELECTION.ROUTE,
         step: RECOVERY_MAP.OPTION_SELECTION.STEPS.SELECT,
       })
     }
-  }, [isTakeover])
+  }, [isActiveUser])
 }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -50,7 +50,7 @@ export type ERUtilsProps = Omit<ErrorRecoveryFlowsProps, 'failedCommand'> & {
   isOnDevice: boolean
   robotType: RobotType
   failedCommand: ReturnType<typeof useRetainedFailedCommandBySource>
-  showTakeover: boolean
+  isActiveUser: UseRecoveryTakeoverResult['isActiveUser']
   allRunDefs: LabwareDefinition2[]
   labwareDefinitionsByUri: LabwareDefinitionsByUri | null
 }
@@ -85,7 +85,7 @@ export function useERUtils({
   isOnDevice,
   robotType,
   runStatus,
-  showTakeover,
+  isActiveUser,
   allRunDefs,
   unvalidatedFailedCommand,
   labwareDefinitionsByUri,
@@ -193,7 +193,7 @@ export function useERUtils({
   )
 
   useCleanupRecoveryState({
-    isTakeover: showTakeover,
+    isActiveUser,
     setRM,
     stashedMapRef: routeUpdateActions.stashedMapRef,
   })

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -160,7 +160,7 @@ export function ErrorRecoveryFlows(
     toggleERWizAsActiveUser,
     isOnDevice,
     robotType,
-    showTakeover,
+    isActiveUser,
     failedCommand: failedCommandBySource,
     allRunDefs,
     labwareDefinitionsByUri,


### PR DESCRIPTION
Closes [RQA-3488](https://opentrons.atlassian.net/browse/RQA-3488)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When a different app, app B, cancels the active recovery session for app A, some state cleanup should occur for app A. The exact condition for triggering this state clean up was a bit off: currently we are cleaning up the state for app A when app B _enters_ Error Recovery. Instead, we should clean up  app A's state  when app B cancels app A's recovery session.

### Current Behavior

https://github.com/user-attachments/assets/b353f146-30df-415f-80cd-c8488d75c9ca

### Fixed Behavior

https://github.com/user-attachments/assets/26c75dfb-4f23-40bc-94c2-7fbdc6264b24

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed some confusing behavior that sometimes occurs when a different app terminates an Error Recovery session.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3488]: https://opentrons.atlassian.net/browse/RQA-3488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ