### PR TITLE
fix(app-shell): fix clearing robot update cache after robot cache update

### DIFF
--- a/app-shell/src/robot-update/index.ts
+++ b/app-shell/src/robot-update/index.ts
@@ -254,7 +254,7 @@ export function checkForRobotUpdate(
         })
       })
       .then(() =>
-        cleanupReleaseFiles(cacheDirForMachineFiles(target), CURRENT_VERSION)
+        cleanupReleaseFiles(cacheDirForMachine(target), CURRENT_VERSION)
       )
   }
 


### PR DESCRIPTION
Closes [EXEC-806](https://opentrons.atlassian.net/browse/EXEC-806)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a bug related to clearing the robot update cache after a robot cache update. Woops, we were checking inside the directory of the current version for other version directories instead of in the parent directory itself.


https://github.com/user-attachments/assets/4483046e-30ac-4c48-9137-9c3d8b46dae4


_Occurs on app open and after new robot cache file downloaded._



<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Made a custom build of the app based on 8.1.0 with this branch. You can download it [here](https://opentrons.slack.com/archives/C81CR4VCZ/p1730915831280829) if you want to test it yourself.
- Opened the app. See video. Confirmed this also deleted the stale OT-2 cache files. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The desktop app now clears stale robot update version cache files.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-806]: https://opentrons.atlassian.net/browse/EXEC-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ