### PR TITLE
fix(app-shell, app-shell-odd): Fix devtools not working on built versions of desktop app/ODD

### DIFF
--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -197,7 +197,10 @@ function installDevtools(): void {
 
   log.debug('Installing devtools')
 
-  install(extensions, forceReinstall)
+  install(extensions, {
+    loadExtensionOptions: { allowFileAccess: true },
+    forceDownload: forceReinstall,
+  })
     .then(() => log.debug('Devtools extensions installed'))
     .catch((error: unknown) => {
       log.warn('Failed to install devtools extensions', {

--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -151,7 +151,10 @@ function installDevtools(): Promise<Logger> {
     })
       .then(() => log.debug('Devtools extensions installed'))
       .catch((error: unknown) => {
-        log.warn('Failed to install devtools extensions', { error })
+        log.warn('Failed to install devtools extensions', {
+          forceReinstall,
+          error,
+        })
       })
   } else {
     log.warn('could not resolve electron dev tools installer')

--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -145,13 +145,13 @@ function installDevtools(): Promise<Logger> {
   log.debug('Installing devtools')
 
   if (typeof install === 'function') {
-    return install(extensions, forceReinstall)
+    return install(extensions, {
+      loadExtensionOptions: { allowFileAccess: true },
+      forceDownload: forceReinstall,
+    })
       .then(() => log.debug('Devtools extensions installed'))
       .catch((error: unknown) => {
-        log.warn('Failed to install devtools extensions', {
-          forceReinstall,
-          error,
-        })
+        log.warn('Failed to install devtools extensions', { error })
       })
   } else {
     log.warn('could not resolve electron dev tools installer')


### PR DESCRIPTION
Works toward [EXEC-392](https://opentrons.atlassian.net/browse/EXEC-392)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes React and Redux devtools not being available in the built versions of the desktop app and ODD. Note that remote ODD sessions remain "unfixed", since that remote session works through an entirely separate mechanism.

Also fixes "reinstall devtools", as this isn't a top level option and seemingly doesn't work currently. We actually want to use the `forceDownload` property.

See this Electron issue for [background context](https://github.com/electron/electron/issues/24011). Note that dev/HMR apps are unaffected, but this directly applies to built versions of our Electron apps. [Here is the relevant bit in the Electron docs](https://www.electronjs.org/docs/latest/api/session#sesloadextensionpath-options).

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Do a `make -C app-shell dist-macos-latest` (or whatever OS you'd like), then run the app.
- Validated React and Redux devtools now appear in the Chrome devtools for built apps.
- Toggling the "Developer Tools" option does disable the devtools after rebooting the app.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- React and Redux devtools now work in built versions of the desktop app/ODD.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- I'm like 90% sure this does not change our security policies on anything but the injected devtool options, but it would be nice if someone could gut check me on this.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-392]: https://opentrons.atlassian.net/browse/EXEC-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ