### PR TITLE
fix(app): do not crash when you get a "C" locale

### DIFF
--- a/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
+++ b/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
@@ -28,8 +28,8 @@ import type { DropdownOption } from '@opentrons/components'
 import type { Dispatch } from '/app/redux/types'
 
 type ArrayElement<
-  ArrayType extends readonly unknown[]
-> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never
+  ArrayType extends ReadonlyArray<unknown>
+> = ArrayType extends ReadonlyArray<infer ElementType> ? ElementType : never
 
 export function SystemLanguagePreferenceModal(): JSX.Element | null {
   const { i18n, t } = useTranslation(['app_settings', 'shared', 'branded'])

--- a/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
+++ b/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
@@ -27,6 +27,10 @@ import { getSystemLanguage } from '/app/redux/shell'
 import type { DropdownOption } from '@opentrons/components'
 import type { Dispatch } from '/app/redux/types'
 
+type ArrayElement<
+  ArrayType extends readonly unknown[]
+> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never
+
 export function SystemLanguagePreferenceModal(): JSX.Element | null {
   const { i18n, t } = useTranslation(['app_settings', 'shared', 'branded'])
   const enableLocalization = useFeatureFlag('enableLocalization')
@@ -83,7 +87,9 @@ export function SystemLanguagePreferenceModal(): JSX.Element | null {
   useEffect(() => {
     if (systemLanguage != null) {
       // prefer match entire locale, then match just language e.g. zh-Hant and zh-CN
-      const matchSystemLanguage: () => string | null = () => {
+      const matchSystemLanguage: () => ArrayElement<
+        typeof LANGUAGES
+      > | null = () => {
         try {
           return (
             LANGUAGES.find(lng => lng.value === systemLanguage) ??
@@ -91,7 +97,8 @@ export function SystemLanguagePreferenceModal(): JSX.Element | null {
               lng =>
                 new Intl.Locale(lng.value).language ===
                 new Intl.Locale(systemLanguage).language
-            )
+            ) ??
+            null
           )
         } catch (error: unknown) {
           // Sometimes the language that we get from the shell will not be something

--- a/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
+++ b/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
@@ -28,7 +28,7 @@ import type { DropdownOption } from '@opentrons/components'
 import type { Dispatch } from '/app/redux/types'
 
 type ArrayElement<
-  ArrayType extends ReadonlyArray<unknown>
+  ArrayType extends readonly unknown[]
 > = ArrayType extends ReadonlyArray<infer ElementType> ? ElementType : never
 
 export function SystemLanguagePreferenceModal(): JSX.Element | null {


### PR DESCRIPTION
Some linux systems are configured with one of the POSIX default locales, like "C" or "POSIX", and for some reason this will be returned by electron's getSystemPreferredLanguages() api directly. Unfortunately, passing this to the browser js standard Intl.Locale() will make it throw, and that would whitescreen the app. Instead, catch the error and treat it as an unmatched system language.

Note that this crashes even if the feature flag isn't on.