### PR TITLE
fix(protocol-designer): liquids show up when zooming into slot

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
@@ -6,23 +6,29 @@ import { renderWithProviders } from '../../../../__testing-utils__'
 import {
   FLEX_ROBOT_TYPE,
   HEATERSHAKER_MODULE_V1,
+  fixture12Trough,
+  fixture24Tuberack,
+  fixture96Plate,
   getDeckDefFromRobotType,
 } from '@opentrons/shared-data'
-import { LabwareRender, Module } from '@opentrons/components'
+import { Module } from '@opentrons/components'
 import { selectors } from '../../../../labware-ingred/selectors'
+import { getInitialDeckSetup } from '../../../../step-forms/selectors'
 import { getCustomLabwareDefsByURI } from '../../../../labware-defs/selectors'
+import { LabwareOnDeck } from '../../../../components/DeckSetup/LabwareOnDeck'
 import { FixtureRender } from '../FixtureRender'
 import { SelectedHoveredItems } from '../SelectedHoveredItems'
 import type * as OpentronsComponents from '@opentrons/components'
-
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+vi.mock('../../../../step-forms/selectors')
 vi.mock('../FixtureRender')
 vi.mock('../../../../labware-ingred/selectors')
 vi.mock('../../../../labware-defs/selectors')
+vi.mock('../../../../components/DeckSetup/LabwareOnDeck')
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof OpentronsComponents>()
   return {
     ...actual,
-    LabwareRender: vi.fn(),
     Module: vi.fn(),
   }
 })
@@ -43,6 +49,20 @@ describe('SelectedHoveredItems', () => {
       hoveredFixture: null,
       slotPosition: [0, 0, 0],
     }
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {},
+      additionalEquipmentOnDeck: {},
+      pipettes: {},
+      labware: {
+        labware: {
+          id: 'mockId',
+          def: fixture24Tuberack as LabwareDefinition2,
+          labwareDefURI: 'fixture/fixture_universal_flat_bottom_adapter/1',
+          slot: 'D3',
+        },
+      },
+    })
+    vi.mocked(LabwareOnDeck).mockReturnValue(<div>mock LabwareOnDeck</div>)
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
       selectedLabwareDefUri: null,
       selectedNestedLabwareDefUri: null,
@@ -52,7 +72,6 @@ describe('SelectedHoveredItems', () => {
     })
     vi.mocked(getCustomLabwareDefsByURI).mockReturnValue({})
     vi.mocked(FixtureRender).mockReturnValue(<div>mock FixtureRender</div>)
-    vi.mocked(LabwareRender).mockReturnValue(<div>mock LabwareRender</div>)
     vi.mocked(Module).mockReturnValue(<div>mock Module</div>)
   })
   it('renders a selected fixture by itself', () => {
@@ -70,9 +89,9 @@ describe('SelectedHoveredItems', () => {
     })
     render(props)
     screen.getByText('mock FixtureRender')
-    screen.getByText('mock LabwareRender')
+    screen.getByText('mock LabwareOnDeck')
     expect(screen.queryByText('mock Module')).not.toBeInTheDocument()
-    screen.getByText('Fixture Opentrons Universal Flat Heater-Shaker Adapter')
+    screen.getByText('Opentrons screwcap 2mL tuberack')
   })
   it('renders a selected module', () => {
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
@@ -102,6 +121,25 @@ describe('SelectedHoveredItems', () => {
     screen.getByText('Fixture Opentrons Universal Flat Heater-Shaker Adapter')
   })
   it('renders selected fixture and both labware and nested labware', () => {
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {},
+      additionalEquipmentOnDeck: {},
+      pipettes: {},
+      labware: {
+        labware: {
+          id: 'mockId',
+          def: fixture24Tuberack as LabwareDefinition2,
+          labwareDefURI: 'fixture/fixture_universal_flat_bottom_adapter/1',
+          slot: 'D3',
+        },
+        labware2: {
+          id: 'mockId2',
+          def: fixture24Tuberack as LabwareDefinition2,
+          labwareDefURI: 'fixture/fixture_universal_flat_bottom_adapter/1',
+          slot: 'mockId',
+        },
+      },
+    })
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
       selectedLabwareDefUri: 'fixture/fixture_universal_flat_bottom_adapter/1',
       selectedNestedLabwareDefUri:
@@ -112,10 +150,10 @@ describe('SelectedHoveredItems', () => {
     })
     render(props)
     screen.getByText('mock FixtureRender')
-    expect(screen.getAllByText('mock LabwareRender')).toHaveLength(2)
+    expect(screen.getAllByText('mock LabwareOnDeck')).toHaveLength(2)
     expect(
       screen.getAllByText(
-        'Fixture Opentrons Universal Flat Heater-Shaker Adapter'
+        'Opentrons screwcap 2mL tuberack'
       )
     ).toHaveLength(2)
   })

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
@@ -6,9 +6,7 @@ import { renderWithProviders } from '../../../../__testing-utils__'
 import {
   FLEX_ROBOT_TYPE,
   HEATERSHAKER_MODULE_V1,
-  fixture12Trough,
   fixture24Tuberack,
-  fixture96Plate,
   getDeckDefFromRobotType,
 } from '@opentrons/shared-data'
 import { Module } from '@opentrons/components'
@@ -20,6 +18,7 @@ import { FixtureRender } from '../FixtureRender'
 import { SelectedHoveredItems } from '../SelectedHoveredItems'
 import type * as OpentronsComponents from '@opentrons/components'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
+
 vi.mock('../../../../step-forms/selectors')
 vi.mock('../FixtureRender')
 vi.mock('../../../../labware-ingred/selectors')
@@ -151,11 +150,9 @@ describe('SelectedHoveredItems', () => {
     render(props)
     screen.getByText('mock FixtureRender')
     expect(screen.getAllByText('mock LabwareOnDeck')).toHaveLength(2)
-    expect(
-      screen.getAllByText(
-        'Opentrons screwcap 2mL tuberack'
-      )
-    ).toHaveLength(2)
+    expect(screen.getAllByText('Opentrons screwcap 2mL tuberack')).toHaveLength(
+      2
+    )
   })
   it('renders nothing when there is a hovered module but selected fixture', () => {
     props.hoveredModule = HEATERSHAKER_MODULE_V1


### PR DESCRIPTION
clsoes RQA-3524

# Overview

This fixes a bug where if you edit a slot that has liquid in it, the liquid wasn't showing up. There is still a slightly buggy experience where if you press "done" the liquids get deleted. that will be fixed in a follow up. 

## Test Plan and Hands on Testing

Upload the attached protocol and zoom into the 2 slots with labware that have liquids. see that the liquids are retained when zooming in. the liquids are NOT retained when you press done, that is a separate issue that will be resolved later

[1.0 testing.json](https://github.com/user-attachments/files/17662516/1.0.testing.json)

## Changelog

- use LabwareOnDeck to render the liquids correctly

## Risk assessment

low
