### PR TITLE
refactor(api,robot-server,app): use labwareURI instead of labwareID for placeLabwareState and unsafe/placeLabware command.

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -214,7 +214,7 @@ export interface NozzleLayoutValues {
 }
 
 export interface PlaceLabwareState {
-  labwareId: string
+  labwareURI: string
   location: OnDeckLabwareLocation
   shouldPlaceDown: boolean
 }

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type, cast
 from typing_extensions import Literal
 
+from opentrons.calibration_storage.helpers import details_from_uri
 from opentrons.hardware_control.types import Axis, OT3Mount
 from opentrons.motion_planning.waypoints import get_gripper_labware_placement_waypoints
 from opentrons.protocol_engine.errors.exceptions import (
@@ -13,7 +14,12 @@ from opentrons.protocol_engine.errors.exceptions import (
 )
 from opentrons.types import Point
 
-from ...types import DeckSlotLocation, ModuleModel, OnDeckLabwareLocation
+from ...types import (
+    DeckSlotLocation,
+    LoadedLabware,
+    ModuleModel,
+    OnDeckLabwareLocation,
+)
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ...errors.error_occurrence import ErrorOccurrence
 from ...resources import ensure_ot3_hardware
@@ -32,7 +38,7 @@ UnsafePlaceLabwareCommandType = Literal["unsafe/placeLabware"]
 class UnsafePlaceLabwareParams(BaseModel):
     """Payload required for an UnsafePlaceLabware command."""
 
-    labwareId: str = Field(..., description="The id of the labware to place.")
+    labwareURI: str = Field(..., description="Labware URI for labware.")
     location: OnDeckLabwareLocation = Field(
         ..., description="Where to place the labware."
     )
@@ -66,13 +72,13 @@ class UnsafePlaceLabwareImplementation(
     ) -> SuccessData[UnsafePlaceLabwareResult]:
         """Place Labware.
 
-        This command is used only when the gripper is in the middle of moving
+        This command is used only when ethe gripper is in the middle of moving
         labware but is interrupted before completing the move. (i.e., the e-stop
         is pressed, get into error recovery, etc).
 
         Unlike the `moveLabware` command, where you pick a source and destination
-        location, this command takes the labwareId to be moved and location to
-        move it to.
+        location, this command takes the labwareURI of the labware to be moved
+        and location to move it to.
 
         """
         ot3api = ensure_ot3_hardware(self._hardware_api)
@@ -84,9 +90,35 @@ class UnsafePlaceLabwareImplementation(
                 "Cannot place labware when gripper is not gripping."
             )
 
-        # Allow propagation of LabwareNotLoadedError.
-        labware_id = params.labwareId
-        definition_uri = self._state_view.labware.get(labware_id).definitionUri
+        location = self._state_view.geometry.ensure_valid_gripper_location(
+            params.location,
+        )
+
+        # TODO: We need a way to create temporary labware for moving around,
+        # the labware should get deleted once its used.
+        details = details_from_uri(params.labwareURI)
+        labware = await self._equipment.load_labware(
+            load_name=details.load_name,
+            namespace=details.namespace,
+            version=details.version,
+            location=location,
+            labware_id=None,
+        )
+
+        self._state_view.labware._state.definitions_by_uri[
+            params.labwareURI
+        ] = labware.definition
+        self._state_view.labware._state.labware_by_id[
+            labware.labware_id
+        ] = LoadedLabware.construct(
+            id=labware.labware_id,
+            location=location,
+            loadName=labware.definition.parameters.loadName,
+            definitionUri=params.labwareURI,
+            offsetId=labware.offsetId,
+        )
+
+        labware_id = labware.labware_id
         final_offsets = self._state_view.labware.get_labware_gripper_offsets(
             labware_id, None
         )
@@ -97,10 +129,6 @@ class UnsafePlaceLabwareImplementation(
                 params.location.slotName.id
             )
 
-        location = self._state_view.geometry.ensure_valid_gripper_location(
-            params.location,
-        )
-
         # This is an absorbance reader, move the lid to its dock (staging area).
         if isinstance(location, DeckSlotLocation):
             module = self._state_view.modules.get_by_slot(location.slotName)
@@ -110,7 +138,7 @@ class UnsafePlaceLabwareImplementation(
                 )
 
         new_offset_id = self._equipment.find_applicable_labware_offset_id(
-            labware_definition_uri=definition_uri,
+            labware_definition_uri=params.labwareURI,
             labware_location=location,
         )
 

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
@@ -72,7 +72,7 @@ class UnsafePlaceLabwareImplementation(
     ) -> SuccessData[UnsafePlaceLabwareResult]:
         """Place Labware.
 
-        This command is used only when ethe gripper is in the middle of moving
+        This command is used only when the gripper is in the middle of moving
         labware but is interrupted before completing the move. (i.e., the e-stop
         is pressed, get into error recovery, etc).
 

--- a/app/src/resources/modules/hooks/usePlacePlateReaderLid.ts
+++ b/app/src/resources/modules/hooks/usePlacePlateReaderLid.ts
@@ -36,7 +36,7 @@ export function usePlacePlateReaderLid(
     const location = placeLabware.location
     const loadModuleCommand = buildLoadModuleCommand(location as ModuleLocation)
     const placeLabwareCommand = buildPlaceLabwareCommand(
-      placeLabware.labwareId as string,
+      placeLabware.labwareURI as string,
       location
     )
     commandsToExecute = [loadModuleCommand, placeLabwareCommand]
@@ -72,11 +72,11 @@ const buildLoadModuleCommand = (location: ModuleLocation): CreateCommand => {
 }
 
 const buildPlaceLabwareCommand = (
-  labwareId: string,
+  labwareURI: string,
   location: OnDeckLabwareLocation
 ): CreateCommand => {
   return {
     commandType: 'unsafe/placeLabware' as const,
-    params: { labwareId, location },
+    params: { labwareURI, location },
   }
 }

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -602,6 +602,7 @@ async def get_current_state(  # noqa: C901
             for pipetteId, nozzle_map in active_nozzle_maps.items()
         }
 
+        run = run_data_manager.get(run_id=runId)
         current_command = run_data_manager.get_current_command(run_id=runId)
         last_completed_command = run_data_manager.get_last_completed_command(
             run_id=runId
@@ -636,11 +637,14 @@ async def get_current_state(  # noqa: C901
         if isinstance(command, MoveLabware):
             location = command.params.newLocation
             if isinstance(location, DeckSlotLocation):
-                place_labware = PlaceLabwareState(
-                    location=location,
-                    labwareId=command.params.labwareId,
-                    shouldPlaceDown=False,
-                )
+                for labware in run.labware:
+                    if labware.id == command.params.labwareId:
+                        place_labware = PlaceLabwareState(
+                            location=location,
+                            labwareURI=labware.definitionUri,
+                            shouldPlaceDown=False,
+                        )
+                        break
         # Handle absorbance reader lid
         elif isinstance(command, (OpenLid, CloseLid)):
             for mod in run.modules:
@@ -655,10 +659,10 @@ async def get_current_state(  # noqa: C901
                         and hw_mod.serial_number == mod.serialNumber
                     ):
                         location = mod.location
-                        labware_id = f"{mod.model}Lid{location.slotName}"
+                        labware_uri = "opentrons/opentrons_flex_lid_absorbance_plate_reader_module/1"
                         place_labware = PlaceLabwareState(
                             location=location,
-                            labwareId=labware_id,
+                            labwareURI=labware_uri,
                             shouldPlaceDown=estop_engaged,
                         )
                         break

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -659,6 +659,9 @@ async def get_current_state(  # noqa: C901
                         and hw_mod.serial_number == mod.serialNumber
                     ):
                         location = mod.location
+                        # TODO: Not the best location for this, we should
+                        # remove this once we are no longer defining the plate reader lid
+                        # as a labware.
                         labware_uri = "opentrons/opentrons_flex_lid_absorbance_plate_reader_module/1"
                         place_labware = PlaceLabwareState(
                             location=location,

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -319,7 +319,7 @@ class ActiveNozzleLayout(BaseModel):
 class PlaceLabwareState(BaseModel):
     """Details the labware being placed by the gripper."""
 
-    labwareId: str = Field(..., description="The ID of the labware to place.")
+    labwareURI: str = Field(..., description="The URI of the labware to place.")
     location: OnDeckLabwareLocation = Field(
         ..., description="The location the labware should be in."
     )

--- a/shared-data/command/schemas/10.json
+++ b/shared-data/command/schemas/10.json
@@ -4749,9 +4749,9 @@
       "description": "Payload required for an UnsafePlaceLabware command.",
       "type": "object",
       "properties": {
-        "labwareId": {
-          "title": "Labwareid",
-          "description": "The id of the labware to place.",
+        "labwareURI": {
+          "title": "Labwareuri",
+          "description": "Labware URI for labware.",
           "type": "string"
         },
         "location": {
@@ -4773,7 +4773,7 @@
           ]
         }
       },
-      "required": ["labwareId", "location"]
+      "required": ["labwareURI", "location"]
     },
     "UnsafePlaceLabwareCreate": {
       "title": "UnsafePlaceLabwareCreate",

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -92,7 +92,7 @@ export interface UnsafeUngripLabwareRunTimeCommand
   result?: any
 }
 export interface UnsafePlaceLabwareParams {
-  labwareId: string
+  labwareURI: string
   location: OnDeckLabwareLocation
 }
 export interface UnsafePlaceLabwareCreateCommand


### PR DESCRIPTION
# Overview

The `placeLabwareState` and  `unsafe/placeLabware` commands rely on the `labwareID` to place labware held by the gripper back down to a deck slot. However, as correctly pointed out, this is wrong because the labwareID changes across runs. This was working for the plate reader lid because the lid is loaded with a fixed labwareID, however that would not be the case for other labware across different runs. This pull request replaces the labwareID with labwareURI used by the `placeLabwareState` and `unsafe/placeLabware` commands so the behavior is consistent across runs.

Closes: [PLAT-580](https://opentrons.atlassian.net/browse/PLAT-580)

## Test Plan and Hands on Testing


- [x] Make sure we can run a plate reader protocol without issues
- [x] Make sure that the plate reader `open/close_lid` commands still work
- [x] Make sure the plate reader lid is returned to its dock (staging area) after the stop is physically and logically disengaged.
- [x] Make sure the run is canceled when the estop is pressed
- [x] Make sure the estop modal is shown while placing the plate reader lid back in its dock
- [x] Make sure that we only call `placeLabware` when the estop is pressed
- [x] Make sure all the above works on the ODD and Desktop app.
- [x] Make sure the plate reader does not get disconnected when the e-stop is pressed
- [x] Make sure the plate reader lid can still be moved when loading the module from the protocol setup.

```
from typing import cast
from opentrons import protocol_api
from opentrons.protocol_api.module_contexts import AbsorbanceReaderContext

# metadata
metadata = {
    'protocolName': 'Absorbance Reader Multi read test',
    'author': 'Platform Expansion',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.21",
}

# protocol run function
def run(protocol: protocol_api.ProtocolContext):
    mod = cast(AbsorbanceReaderContext, protocol.load_module("absorbanceReaderV1", "C3"))
    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "C2")
    tiprack_1000 = protocol.load_labware(load_name='opentrons_flex_96_tiprack_1000ul', location="B2")
    trash_labware = protocol.load_trash_bin("B3")
    instrument = protocol.load_instrument("flex_8channel_1000", "right", tip_racks=[tiprack_1000])
    instrument.trash_container = trash_labware

    # pick up tip and perform action
    instrument.pick_up_tip(tiprack_1000.wells_by_name()['A1'])
    instrument.aspirate(100, plate.wells_by_name()['A1'])
    instrument.dispense(100, plate.wells_by_name()['B1'])
    instrument.return_tip()
   
    # Initialize to a single wavelength with reference wavelength
    # Issue: Make sure there is no labware here or youll get an error
    mod.close_lid()
    mod.initialize('single', [600], 450)

    # NOTE: CANNOT INITIALIZE WITH THE LID OPEN

    # Remove the Plate Reader lid using the Gripper.
    mod.open_lid()
    protocol.move_labware(plate, mod, use_gripper=True)
    mod.close_lid()

    # Take a reading and show the resulting absorbance values.
    # Issue: cant read before you initialize or you an get an error
    result = mod.read()
    msg = f"single: {result}"
    protocol.comment(msg=msg)
    protocol.pause(msg=msg)

    # Initialize to multiple wavelengths
    protocol.pause(msg="Perform Multi Read")
    mod.open_lid()
    protocol.move_labware(plate, "C2", use_gripper=True)
    mod.close_lid()
    mod.initialize('multi', [450, 570, 600])

    # Open the lid and move the labware into the reader
    mod.open_lid()
    protocol.move_labware(plate, mod, use_gripper=True)

    # pick up tip and perform action on labware inside plate reader
    instrument.pick_up_tip(tiprack_1000.wells_by_name()['A1'])
    instrument.aspirate(100, plate.wells_by_name()['A1'])
    instrument.dispense(100, plate.wells_by_name()['B1'])
    instrument.return_tip()

    mod.close_lid()

    # Take reading
    result = mod.read()
    msg = f"multi: {result}"
    protocol.comment(msg=msg)
    protocol.pause(msg=msg)

    # Place the Plate Reader lid back on using the Gripper.
    mod.open_lid()
    protocol.move_labware(plate, "C2", use_gripper=True)
    mod.close_lid() 
```

## Changelog

- use `labwareURI` instead of `labwareID` in the `placeLabwareState` object sent in the `/runs/{runID}/currentState` endpoint
- use `labwareURI` instead of `labwareID` in the `unsafe/placeLabware` command
- using the `labwareURI` in the `unsafe/placeLabware` command, load the labware directly 
- use `labwareURI` instead of `labwareID` in the `usePlacePlateReaderLid.ts` react hook

## Review requests

- manually loading in the labware is nasty work, any suggestions or advice are welcome
- anything I might be overlooking?

## Risk assessment
low, unreleased

[PLAT-580]: https://opentrons.atlassian.net/browse/PLAT-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ