### PR TITLE
feat(app): hide unused env vars from vite dist

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -331,6 +331,15 @@ jobs:
           smksp_cert_sync.exe
           smctl.exe healthcheck --all
 
+      # Do the frontend dist bundle
+      - name: 'bundle ${{matrix.variant}} frontend'
+        env:
+          OT_APP_MIXPANEL_ID: ${{ secrets.OT_APP_MIXPANEL_ID }}
+          OT_APP_INTERCOM_ID: ${{ secrets.OT_APP_INTERCOM_ID }}
+          OPENTRONS_PROJECT: ${{ steps.project.outputs.project }}
+        run: |
+          make -C app dist
+
       # build the desktop app and deploy it
       - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'
         if: matrix.target == 'desktop'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -318,12 +318,12 @@ jobs:
         if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
         shell: cmd
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_HOST: ${{ secrets.SM_HOST_V2 }}
           SM_CLIENT_CERT_FILE: "D:\\Certificate_pkcs12.p12"
-          SM_CLIENT_CERT_PASSWORD: ${{secrets.SM_CLIENT_CERT_PASSWORD}}
-          SM_API_KEY: ${{secrets.SM_API_KEY}}
+          SM_CLIENT_CERT_PASSWORD: ${{secrets.SM_CLIENT_CERT_PASSWORD_V2}}
+          SM_API_KEY: ${{secrets.SM_API_KEY_V2}}
         run: |
-          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download -H "x-api-key:${{secrets.SM_API_KEY}}" -o Keylockertools-windows-x64.msi
+          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download -H "x-api-key:${{secrets.SM_API_KEY_V2}}" -o Keylockertools-windows-x64.msi
           msiexec /i Keylockertools-windows-x64.msi /quiet /qn
           smksp_registrar.exe list
           smctl.exe keypair ls
@@ -348,18 +348,14 @@ jobs:
           OT_APP_MIXPANEL_ID: ${{ secrets.OT_APP_MIXPANEL_ID }}
           OT_APP_INTERCOM_ID: ${{ secrets.OT_APP_INTERCOM_ID }}
           WINDOWS_SIGN: ${{ format('{0}', contains(needs.determine-build-type.outputs.type, 'release')) }}
-          SM_HOST: ${{secrets.SM_HOST}}
-          SM_CLIENT_CERT_FILE: "D:\\Certificate_pkcs12.p12"
-          SM_CLIENT_CERT_PASSWORD: ${{secrets.SM_CLIENT_CERT_PASSWORD}}
-          SM_API_KEY: ${{secrets.SM_API_KEY}}
-          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{secrets.SM_CODE_SIGNING_CERT_SHA1_HASH}}
-          SM_KEYPAIR_ALIAS: ${{secrets.SM_KEYPAIR_ALIAS}}
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{secrets.SM_CODE_SIGNING_CERT_SHA1_HASH_V2}}
+          SM_KEYPAIR_ALIAS: ${{secrets.SM_KEYPAIR_ALIAS_V2}}
           WINDOWS_CSC_FILEPATH: "D:\\opentrons_labworks_inc.crt"
-          CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS }}
-          CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS }}
-          APPLE_ID: ${{ secrets.OT_APP_APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.OT_APP_APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.OT_APP_APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS_V2 }}
+          CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS_V2 }}
+          APPLE_ID: ${{ secrets.OT_APP_APPLE_ID_V2 }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.OT_APP_APPLE_ID_PASSWORD_V2 }}
+          APPLE_TEAM_ID: ${{ secrets.OT_APP_APPLE_TEAM_ID_V2 }}
           HOST_PYTHON: python
           OPENTRONS_PROJECT: ${{ steps.project.outputs.project }}
           OT_APP_DEPLOY_BUCKET: ${{ steps.project.outputs.bucket }}

--- a/app-shell-odd/Makefile
+++ b/app-shell-odd/Makefile
@@ -65,12 +65,14 @@ deps:
 .PHONY: package-deps
 package-deps: clean lib deps
 
+# Note: keep the push dep separate from the dist target so it doesn't accidentally
+# do a js dist when we want to only build electron
 .PHONY: dist-ot3
-dist-ot3: package-deps
+dist-ot3: clean lib
 	NO_USB_DETECTION=true OT_APP_DEPLOY_BUCKET=opentrons-app OT_APP_DEPLOY_FOLDER=builds OPENTRONS_PROJECT=$(OPENTRONS_PROJECT) $(builder) --linux --arm64
 
 .PHONY: push-ot3
-push-ot3: dist-ot3
+push-ot3: dist-ot3 deps
 	tar -zcvf opentrons-robot-app.tar.gz -C ./dist/linux-arm64-unpacked/ ./
 	scp $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) -r ./opentrons-robot-app.tar.gz root@$(host):
 	ssh $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) root@$(host) "mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -121,32 +121,34 @@ package dist-posix dist-osx dist-linux dist-win: export BUILD_ID := $(build_id)
 package dist-posix dist-osx dist-linux dist-win: export NO_PYTHON := $(if $(no_python_bundle),true,false)
 package dist-posix dist-osx dist-linux dist-win: export USE_HARD_LINKS := false
 
+# Note: these depend on make -C app dist having been run; do not do this automatically because we separate these
+# tasks in CI and even if you have a file dep it's easy to accidentally make the dist run.
 .PHONY: package
-package: package-deps
+package:
 	$(builder) --dir
 
 .PHONY: dist-posix
-dist-posix: package-deps
+dist-posix: clean lib
 	$(builder) --linux --mac
 	$(MAKE) _dist-collect-artifacts
 
 .PHONY: dist-osx
-dist-osx: package-deps
+dist-osx: clean lib
 	$(builder) --mac --x64
 	$(MAKE) _dist-collect-artifacts
 
 .PHONY: dist-linux
-dist-linux: package-deps
+dist-linux:  clean lib
 	$(builder) --linux
 	$(MAKE) _dist-collect-artifacts
 
 .PHONY: dist-win
-dist-win: package-deps
+dist-win: clean lib
 	$(builder) --win --x64
 	$(MAKE) _dist-collect-artifacts
 
 .PHONY: dist-ot3
-dist-ot3: package-deps
+dist-ot3: clean lib
 	NO_PYTHON=true $(builder) --linux --arm64 --dir
 	cd dist/linux-arm64-unpacked
 

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -46,7 +46,10 @@ export default defineConfig(
         },
       },
       define: {
-        'process.env': process.env,
+        'process.env': {
+          NODE_ENV: process.env.NODE_ENV,
+          OT_APP_MIXPANEL_ID: process.env.OT_APP_MIXPANEL_ID,
+        },
         global: 'globalThis',
         _PKG_VERSION_: JSON.stringify(version),
         _OPENTRONS_PROJECT_: JSON.stringify(project),

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -49,6 +49,7 @@ export default defineConfig(
         'process.env': {
           NODE_ENV: process.env.NODE_ENV,
           OT_APP_MIXPANEL_ID: process.env.OT_APP_MIXPANEL_ID,
+          OPENTRONS_PROJECT: process.env.OPENTRONS_PROJECT,
         },
         global: 'globalThis',
         _PKG_VERSION_: JSON.stringify(version),


### PR DESCRIPTION
# Overview

Oopsy, we were passing in a bunch of env variables into our app builds that the app did not need. This PR only passes in the node env and the mixpanel id for the frontend to use.

## Test Plan and Hands on Testing

Build the app which some rogue env variables and look at the dist, you should only see a mixpanel id and node env, nothing else. 

```
make -C app dist OT_APP_MIXPANEL_ID="somefakeid" THIS_SHOULD_NOT_SHOW_UP="blah" NODE_ENV="development"
```
## Changelog

- Hide unused env variables

## Review requests

See test plan

## Risk assessment

Low/med