### PR TITLE
fix(protocol-designer): wire up dynamic form errors logic

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -50,7 +50,10 @@ import type {
   LiquidHandlingTab,
   StepFormProps,
 } from './types'
-import { getFormLevelErrorsForUnsavedForm } from '../../../../step-forms/selectors'
+import {
+  getDynamicFieldFormErrorsForUnsavedForm,
+  getFormLevelErrorsForUnsavedForm,
+} from '../../../../step-forms/selectors'
 
 type StepFormMap = {
   [K in StepType]?: React.ComponentType<StepFormProps> | null
@@ -107,6 +110,13 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   const formLevelErrorsForUnsavedForm = useSelector(
     getFormLevelErrorsForUnsavedForm
   )
+  const dynamicFormLevelErrorsForUnsavedForm = useSelector(
+    getDynamicFieldFormErrorsForUnsavedForm
+  ).map(error => ({
+    title: error.title,
+    body: error.body,
+    dependentFields: error.dependentProfileFields,
+  }))
   const timeline = useSelector(getRobotStateTimeline)
   const [toolboxStep, setToolboxStep] = useState<number>(0)
   const [
@@ -122,7 +132,10 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   const visibleFormErrors = getVisibleFormErrors({
     focusedField,
     dirtyFields: dirtyFields ?? [],
-    errors: formLevelErrorsForUnsavedForm,
+    errors: [
+      ...formLevelErrorsForUnsavedForm,
+      ...dynamicFormLevelErrorsForUnsavedForm,
+    ],
     page: toolboxStep,
     showErrors: showFormErrorsAndWarnings,
   })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/index.tsx
@@ -1,13 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import {
-  Box,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  SPACING,
-  StyledText,
-} from '@opentrons/components'
+import { Box, COLORS, DIRECTION_COLUMN, Flex } from '@opentrons/components'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { getRobotType } from '../../../../../../file-data/selectors'
 import { CheckboxStepFormField } from '../../../../../../molecules'
@@ -32,9 +25,6 @@ export function MoveLabwareTools(props: StepFormProps): JSX.Element {
   )
 
   const mappedErrorsToField = getFormErrorsMappedToField(visibleFormErrors)
-  const formLevelErrorsWithoutField = visibleFormErrors.filter(
-    error => error.dependentFields.length === 0
-  )
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
@@ -68,19 +58,6 @@ export function MoveLabwareTools(props: StepFormProps): JSX.Element {
         labware={String(propsForFields.labware.value)}
         errorToShow={getFormLevelError('newLocation', mappedErrorsToField)}
       />
-      {formLevelErrorsWithoutField.length > 0 ? (
-        <Flex paddingX={SPACING.spacing16}>
-          {formLevelErrorsWithoutField.map((error, i) => (
-            <StyledText
-              key={`${error.title}_${i}`}
-              desktopStyle="bodyDefaultRegular"
-              color={COLORS.red50}
-            >
-              {error.title}
-            </StyledText>
-          ))}
-        </Flex>
-      ) : null}
     </Flex>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/index.tsx
@@ -1,6 +1,13 @@
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { Box, COLORS, DIRECTION_COLUMN, Flex } from '@opentrons/components'
+import {
+  Box,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  SPACING,
+  StyledText,
+} from '@opentrons/components'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { getRobotType } from '../../../../../../file-data/selectors'
 import { CheckboxStepFormField } from '../../../../../../molecules'
@@ -25,6 +32,9 @@ export function MoveLabwareTools(props: StepFormProps): JSX.Element {
   )
 
   const mappedErrorsToField = getFormErrorsMappedToField(visibleFormErrors)
+  const formLevelErrorsWithoutField = visibleFormErrors.filter(
+    error => error.dependentFields.length === 0
+  )
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
@@ -58,6 +68,19 @@ export function MoveLabwareTools(props: StepFormProps): JSX.Element {
         labware={String(propsForFields.labware.value)}
         errorToShow={getFormLevelError('newLocation', mappedErrorsToField)}
       />
+      {formLevelErrorsWithoutField.length > 0 ? (
+        <Flex paddingX={SPACING.spacing16}>
+          {formLevelErrorsWithoutField.map((error, i) => (
+            <StyledText
+              key={`${error.title}_${i}`}
+              desktopStyle="bodyDefaultRegular"
+              color={COLORS.red50}
+            >
+              {error.title}
+            </StyledText>
+          ))}
+        </Flex>
+      ) : null}
     </Flex>
   )
 }

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -651,13 +651,20 @@ export const getHydratedUnsavedForm: Selector<
 export const getDynamicFieldFormErrorsForUnsavedForm: Selector<
   BaseState,
   ProfileFormError[]
-> = createSelector(getHydratedUnsavedForm, hydratedForm => {
-  if (!hydratedForm) return []
+> = createSelector(
+  getHydratedUnsavedForm,
+  getInvariantContext,
+  (hydratedForm, invariantContext) => {
+    if (!hydratedForm) return []
 
-  const errors = _dynamicFieldFormErrors(hydratedForm)
+    const errors = [
+      ..._dynamicFieldFormErrors(hydratedForm),
+      ..._dynamicMoveLabwareFieldFormErrors(hydratedForm, invariantContext),
+    ]
 
-  return errors
-})
+    return errors
+  }
+)
 export const getFormLevelErrorsForUnsavedForm: Selector<
   BaseState,
   StepFormErrors

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -619,7 +619,8 @@ export const newLabwareLocationRequired = (
   fields: HydratedFormData
 ): FormError | null => {
   const { newLocation } = fields
-  return newLocation == null && newLocation.slotName == null
+  return newLocation == null ||
+    Object.values(newLocation as Object).every(val => val == null)
     ? NEW_LABWARE_LOCATION_REQUIRED
     : null
 }

--- a/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
+++ b/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
@@ -32,7 +32,7 @@ const getMoveLabwareError = (
       invariantContext.moduleEntities[newLocation.moduleId].type
     const modAllowList = COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[moduleType]
     errorString = !modAllowList.includes(loadName)
-      ? 'labware incompatible with this module'
+      ? 'Labware incompatible with this module'
       : null
   } else if ('labwareId' in newLocation) {
     const adapterValueDefUri =
@@ -41,7 +41,7 @@ const getMoveLabwareError = (
     const adapterAllowList =
       COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER[adapterValueDefUri]
     errorString = !adapterAllowList?.includes(selectedLabwareDefUri)
-      ? 'labware incompatible with this adapter'
+      ? 'Labware incompatible with this adapter'
       : null
   }
   return errorString
@@ -68,7 +68,7 @@ export const getMoveLabwareFormErrors = (
     ? ([
         {
           title: errorString,
-          dependentProfileFields: [],
+          dependentProfileFields: ['newLocation'],
         },
       ] as ProfileFormError[])
     : []


### PR DESCRIPTION
# Overview

This PR fixes a bug where moveLabware step form fails silently on save. The issue is that the check for form-level errors is not complete in getVisibleFormErrors, so there is a form state where `canSave` is false, but no visible errors are produced. Here, update `getDynamicFieldFormErrorsForUnsavedForm` to check for our special-cased dynamic move labware form field errors, and append that to our form level errors for unsaved form in `StepFormToolbox`. I also wire up this form error in MoveLabwareTools as it does not point to any specific field.

## Test Plan and Hands on Testing

- on a PD protocol, create a move labware step
- save without selecting a new location and verify that required field error shows
- try to move a labware to an incompatible module or adapter and verify that incompatible module/adapter field shows

## Changelog

- add `_dynamicMoveLabwareFieldFormErrors` to `getDynamicFieldFormErrorsForUnsavedForm` selector
- get dynamic form errors in `StepFormToolbox` wire up in visible form errors
- update error fields for move labware form errors

## Review requests

- see test plan

## Risk assessment

low