### PR TITLE
fix(protocol-designer): liquid preservation in zoomed in slot and x button

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -97,15 +97,11 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   } = selectedSlotInfo
   const { slot, cutout } = selectedSlot
 
+  //  TODO: fix the bug where selectedSlotInfo isn't initializing correctly
+  //  RQA-3526
   const initialSelectedSlotInfoRef = useRef<ZoomedIntoSlotInfoState>(
     selectedSlotInfo
   )
-
-  // Set the initial snapshot if it hasn’t been set and `selectedSlotInfo` is fully populated
-  useEffect(() => {
-    // Deep clone selectedSlotInfo if necessary to avoid mutations
-    initialSelectedSlotInfoRef.current = { ...selectedSlotInfo }
-  }, [])
 
   const [changeModuleWarningInfo, displayModuleWarning] = useState<boolean>(
     false
@@ -249,11 +245,6 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     handleResetToolbox()
     setSelectedHardware(null)
   }
-  console.log(
-    isEqual(selectedSlotInfo, initialSelectedSlotInfoRef.current),
-    selectedSlotInfo,
-    initialSelectedSlotInfoRef.current
-  )
   const handleConfirm = (): void => {
     //  only update info if user changed what was previously selected
     if (!isEqual(selectedSlotInfo, initialSelectedSlotInfoRef.current)) {

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import isEqual from 'lodash/isEqual'
 import { useDispatch, useSelector } from 'react-redux'
@@ -97,25 +97,15 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   } = selectedSlotInfo
   const { slot, cutout } = selectedSlot
 
-  const [
-    initialSelectedSlotInfo,
-    setInitialSelectedSlotInfo,
-  ] = useState<ZoomedIntoSlotInfoState | null>(null)
+  const initialSelectedSlotInfoRef = useRef<ZoomedIntoSlotInfoState>(
+    selectedSlotInfo
+  )
 
+  // Set the initial snapshot if it hasn’t been set and `selectedSlotInfo` is fully populated
   useEffect(() => {
-    // Check if initialSelectedSlotInfo is null and if selectedSlotInfo is
-    // fully populated since component rerenders
-    // TODO: need to optimize this better, find out why component rerenders
-    if (
-      initialSelectedSlotInfo == null &&
-      (selectedFixture ||
-        selectedLabwareDefUri ||
-        selectedModuleModel ||
-        selectedNestedLabwareDefUri)
-    ) {
-      setInitialSelectedSlotInfo(selectedSlotInfo)
-    }
-  }, [selectedSlotInfo, initialSelectedSlotInfo])
+    // Deep clone selectedSlotInfo if necessary to avoid mutations
+    initialSelectedSlotInfoRef.current = { ...selectedSlotInfo }
+  }, [])
 
   const [changeModuleWarningInfo, displayModuleWarning] = useState<boolean>(
     false
@@ -259,10 +249,14 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     handleResetToolbox()
     setSelectedHardware(null)
   }
-
+  console.log(
+    isEqual(selectedSlotInfo, initialSelectedSlotInfoRef.current),
+    selectedSlotInfo,
+    initialSelectedSlotInfoRef.current
+  )
   const handleConfirm = (): void => {
     //  only update info if user changed what was previously selected
-    if (!isEqual(selectedSlotInfo, initialSelectedSlotInfo)) {
+    if (!isEqual(selectedSlotInfo, initialSelectedSlotInfoRef.current)) {
       //  clear entities first before recreating them
       handleClear()
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -1,17 +1,21 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import isEqual from 'lodash/isEqual'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   ALIGN_CENTER,
+  Btn,
   DeckInfoLabel,
   DIRECTION_COLUMN,
   Flex,
+  Icon,
   ModuleIcon,
   RadioButton,
   SPACING,
   StyledText,
   Tabs,
   Toolbox,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
@@ -48,6 +52,7 @@ import { useKitchen } from '../../../organisms/Kitchen/hooks'
 import { getDismissedHints } from '../../../tutorial/selectors'
 import { createContainerAboveModule } from '../../../step-forms/actions/thunks'
 import { ConfirmDeleteStagingAreaModal } from '../../../organisms'
+import { BUTTON_LINK_STYLE } from '../../../atoms'
 import { FIXTURES, MOAM_MODELS } from './constants'
 import { getSlotInformation } from '../utils'
 import { getModuleModelsBySlot, getDeckErrors } from './utils'
@@ -56,6 +61,7 @@ import { LabwareTools } from './LabwareTools'
 
 import type { ModuleModel } from '@opentrons/shared-data'
 import type { ThunkDispatch } from '../../../types'
+import type { ZoomedIntoSlotInfoState } from '../../../labware-ingred/types'
 import type { Fixture } from './constants'
 
 interface DeckSetupToolsProps {
@@ -90,6 +96,13 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     selectedNestedLabwareDefUri,
   } = selectedSlotInfo
   const { slot, cutout } = selectedSlot
+
+  const selectedSlotInfoRef = useRef<ZoomedIntoSlotInfoState>(selectedSlotInfo)
+  //  initialize the selectedSlotInfoRef
+  useEffect(() => {
+    selectedSlotInfoRef.current = selectedSlotInfo
+  }, [selectedSlotInfo])
+
   const [changeModuleWarningInfo, displayModuleWarning] = useState<boolean>(
     false
   )
@@ -234,57 +247,63 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   }
 
   const handleConfirm = (): void => {
-    //  clear entities first before recreating them
-    handleClear()
+    //  only update info if user changed what was previously selected
+    if (!isEqual(selectedSlotInfo, selectedSlotInfoRef.current)) {
+      //  clear entities first before recreating them
+      handleClear()
 
-    if (selectedFixture != null && cutout != null) {
-      //  create fixture(s)
-      if (selectedFixture === 'wasteChuteAndStagingArea') {
-        dispatch(createDeckFixture('wasteChute', cutout))
-        dispatch(createDeckFixture('stagingArea', cutout))
-      } else {
-        dispatch(createDeckFixture(selectedFixture, cutout))
+      if (selectedFixture != null && cutout != null) {
+        //  create fixture(s)
+        if (selectedFixture === 'wasteChuteAndStagingArea') {
+          dispatch(createDeckFixture('wasteChute', cutout))
+          dispatch(createDeckFixture('stagingArea', cutout))
+        } else {
+          dispatch(createDeckFixture(selectedFixture, cutout))
+        }
       }
+      if (selectedModuleModel != null) {
+        //  create module
+        dispatch(
+          createModule({
+            slot,
+            type: getModuleType(selectedModuleModel),
+            model: selectedModuleModel,
+          })
+        )
+      }
+      if (selectedModuleModel == null && selectedLabwareDefUri != null) {
+        //  create adapter + labware on deck
+        dispatch(
+          createContainer({
+            slot,
+            labwareDefURI:
+              selectedNestedLabwareDefUri == null
+                ? selectedLabwareDefUri
+                : selectedNestedLabwareDefUri,
+            adapterUnderLabwareDefURI:
+              selectedNestedLabwareDefUri == null
+                ? undefined
+                : selectedLabwareDefUri,
+          })
+        )
+      }
+      if (selectedModuleModel != null && selectedLabwareDefUri != null) {
+        //   create adapter + labware on module
+        dispatch(
+          createContainerAboveModule({
+            slot,
+            labwareDefURI: selectedLabwareDefUri,
+            nestedLabwareDefURI: selectedNestedLabwareDefUri ?? undefined,
+          })
+        )
+      }
+      handleResetToolbox()
+      dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
+      onCloseClick()
+    } else {
+      dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
+      onCloseClick()
     }
-    if (selectedModuleModel != null) {
-      //  create module
-      dispatch(
-        createModule({
-          slot,
-          type: getModuleType(selectedModuleModel),
-          model: selectedModuleModel,
-        })
-      )
-    }
-    if (selectedModuleModel == null && selectedLabwareDefUri != null) {
-      //  create adapter + labware on deck
-      dispatch(
-        createContainer({
-          slot,
-          labwareDefURI:
-            selectedNestedLabwareDefUri == null
-              ? selectedLabwareDefUri
-              : selectedNestedLabwareDefUri,
-          adapterUnderLabwareDefURI:
-            selectedNestedLabwareDefUri == null
-              ? undefined
-              : selectedLabwareDefUri,
-        })
-      )
-    }
-    if (selectedModuleModel != null && selectedLabwareDefUri != null) {
-      //   create adapter + labware on module
-      dispatch(
-        createContainerAboveModule({
-          slot,
-          labwareDefURI: selectedLabwareDefUri,
-          nestedLabwareDefURI: selectedNestedLabwareDefUri ?? undefined,
-        })
-      )
-    }
-    handleResetToolbox()
-    dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
-    onCloseClick()
   }
   return (
     <>
@@ -326,22 +345,27 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
             </StyledText>
           </Flex>
         }
-        closeButton={
-          <StyledText desktopStyle="bodyDefaultRegular">
-            {t('clear')}
-          </StyledText>
+        secondaryHeaderButton={
+          <Btn
+            onClick={() => {
+              if (matchingLabwareFor4thColumn != null) {
+                setShowDeleteLabwareModal('clear')
+              } else {
+                handleClear()
+                handleResetToolbox()
+              }
+            }}
+            css={BUTTON_LINK_STYLE}
+            textDecoration={TYPOGRAPHY.textDecorationUnderline}
+          >
+            <StyledText desktopStyle="bodyDefaultRegular">
+              {t('clear')}
+            </StyledText>
+          </Btn>
         }
-        onCloseClick={() => {
-          if (matchingLabwareFor4thColumn != null) {
-            setShowDeleteLabwareModal('clear')
-          } else {
-            handleClear()
-            handleResetToolbox()
-          }
-        }}
-        onConfirmClick={() => {
-          handleConfirm()
-        }}
+        closeButton={<Icon size="2rem" name="close" />}
+        onCloseClick={onCloseClick}
+        onConfirmClick={handleConfirm}
         confirmButtonText={t('done')}
       >
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import isEqual from 'lodash/isEqual'
 import { useDispatch, useSelector } from 'react-redux'
@@ -97,11 +97,25 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   } = selectedSlotInfo
   const { slot, cutout } = selectedSlot
 
-  const selectedSlotInfoRef = useRef<ZoomedIntoSlotInfoState>(selectedSlotInfo)
-  //  initialize the selectedSlotInfoRef
+  const [
+    initialSelectedSlotInfo,
+    setInitialSelectedSlotInfo,
+  ] = useState<ZoomedIntoSlotInfoState | null>(null)
+
   useEffect(() => {
-    selectedSlotInfoRef.current = selectedSlotInfo
-  }, [selectedSlotInfo])
+    // Check if initialSelectedSlotInfo is null and if selectedSlotInfo is
+    // fully populated since component rerenders
+    // TODO: need to optimize this better, find out why component rerenders
+    if (
+      initialSelectedSlotInfo == null &&
+      (selectedFixture ||
+        selectedLabwareDefUri ||
+        selectedModuleModel ||
+        selectedNestedLabwareDefUri)
+    ) {
+      setInitialSelectedSlotInfo(selectedSlotInfo)
+    }
+  }, [selectedSlotInfo, initialSelectedSlotInfo])
 
   const [changeModuleWarningInfo, displayModuleWarning] = useState<boolean>(
     false
@@ -248,7 +262,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
 
   const handleConfirm = (): void => {
     //  only update info if user changed what was previously selected
-    if (!isEqual(selectedSlotInfo, selectedSlotInfoRef.current)) {
+    if (!isEqual(selectedSlotInfo, initialSelectedSlotInfo)) {
       //  clear entities first before recreating them
       handleClear()
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/LabwareRenderOnDeck.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/LabwareRenderOnDeck.tsx
@@ -1,0 +1,18 @@
+import { LabwareRender } from '@opentrons/components'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+
+interface LabwareRenderOnDeckProps {
+  labwareDef: LabwareDefinition2
+  x: number
+  y: number
+}
+export function LabwareRenderOnDeck(
+  props: LabwareRenderOnDeckProps
+): JSX.Element {
+  const { x, y, labwareDef } = props
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <LabwareRender definition={labwareDef} />
+    </g>
+  )
+}

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedHoveredItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedHoveredItems.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux'
-import { LabwareRender, Module } from '@opentrons/components'
+import { Module } from '@opentrons/components'
 import {
   getModuleDef2,
   inferModuleOrientationFromXCoordinate,
@@ -8,10 +8,10 @@ import { selectors } from '../../../labware-ingred/selectors'
 import { getOnlyLatestDefs } from '../../../labware-defs'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { getInitialDeckSetup } from '../../../step-forms/selectors'
-import { LabwareOnDeck } from '../../../components/DeckSetup/LabwareOnDeck'
 import { ModuleLabel } from './ModuleLabel'
-import { LabwareLabel } from '../LabwareLabel'
 import { FixtureRender } from './FixtureRender'
+import { SelectedLabwareRender } from './SelectedLabwareRender'
+import { SelectedModuleLabwareRender } from './SelectedModuleLabwareRender'
 import type {
   CoordinateTuple,
   DeckDefinition,
@@ -84,6 +84,15 @@ export const SelectedHoveredItems = (
       )
     }
   )
+  const selectedLabwareDef =
+    selectedLabwareDefUri != null
+      ? defs[selectedLabwareDefUri] ?? customLabwareDefs[selectedLabwareDefUri]
+      : null
+  const selectedNestedLabwareDef =
+    selectedNestedLabwareDefUri != null
+      ? defs[selectedNestedLabwareDefUri] ??
+        customLabwareDefs[selectedNestedLabwareDefUri]
+      : null
   const hoveredLabwareDef =
     hoveredLabware != null
       ? defs[hoveredLabware] ?? customLabwareDefs[hoveredLabware] ?? null
@@ -109,9 +118,9 @@ export const SelectedHoveredItems = (
     }
     labwareInfos.push(selectedLabwareLabel)
   }
-  if (matchingSelectedNestedLabwareOnDeck != null && hoveredLabware == null) {
+  if (selectedNestedLabwareDef != null && hoveredLabware == null) {
     const selectedNestedLabwareLabel = {
-      text: matchingSelectedNestedLabwareOnDeck.def.metadata.displayName,
+      text: selectedNestedLabwareDef.metadata.displayName,
       isSelected: true,
       isLast: hoveredLabware == null,
     }
@@ -158,29 +167,14 @@ export const SelectedHoveredItems = (
             orientation={orientation}
           >
             <>
-              {matchingSelectedLabwareOnDeck != null &&
-              selectedModuleModel != null &&
-              hoveredLabware == null ? (
-                <LabwareOnDeck
-                  labwareOnDeck={matchingSelectedLabwareOnDeck}
-                  x={0}
-                  y={0}
-                />
-              ) : null}
-              {matchingSelectedNestedLabwareOnDeck != null &&
-              selectedModuleModel != null &&
-              hoveredLabware == null ? (
-                <LabwareOnDeck
-                  labwareOnDeck={matchingSelectedNestedLabwareOnDeck}
-                  x={0}
-                  y={0}
-                />
-              ) : null}
-              {hoveredLabwareDef != null && selectedModuleModel != null ? (
-                <g transform={`translate(0, 0)`}>
-                  <LabwareRender definition={hoveredLabwareDef} />
-                </g>
-              ) : null}
+              <SelectedModuleLabwareRender
+                nestedLabwareDef={selectedNestedLabwareDef}
+                labwareOnDeck={matchingSelectedLabwareOnDeck}
+                labwareDef={selectedLabwareDef}
+                moduleModel={selectedModuleModel}
+                hoveredLabware={hoveredLabware}
+                hoveredLabwareDef={hoveredLabwareDef}
+              />
             </>
           </Module>
           {selectedModuleModel != null ? (
@@ -195,55 +189,28 @@ export const SelectedHoveredItems = (
           ) : null}
         </>
       ) : null}
-      {matchingSelectedLabwareOnDeck != null &&
-      slotPosition != null &&
-      selectedModuleModel == null &&
-      hoveredLabware == null ? (
-        <>
-          <LabwareOnDeck
-            x={slotPosition[0]}
-            y={slotPosition[1]}
-            labwareOnDeck={matchingSelectedLabwareOnDeck}
-          />
-          {selectedNestedLabwareDefUri == null ? (
-            <LabwareLabel
-              isLast={true}
-              isSelected={true}
-              labwareDef={matchingSelectedLabwareOnDeck.def}
-              position={slotPosition}
-            />
-          ) : null}
-        </>
-      ) : null}
-      {matchingSelectedNestedLabwareOnDeck != null &&
-      slotPosition != null &&
-      selectedModuleModel == null &&
-      hoveredLabware == null ? (
-        <>
-          <LabwareOnDeck
-            x={slotPosition[0]}
-            y={slotPosition[1]}
-            labwareOnDeck={matchingSelectedNestedLabwareOnDeck}
-          />
-          {matchingSelectedLabwareOnDeck != null ? (
-            <LabwareLabel
-              isLast={false}
-              isSelected={true}
-              labwareDef={matchingSelectedLabwareOnDeck.def}
-              position={slotPosition}
-              nestedLabwareInfo={[
-                {
-                  text:
-                    matchingSelectedNestedLabwareOnDeck.def.metadata
-                      .displayName,
-                  isSelected: true,
-                  isLast: true,
-                },
-              ]}
-            />
-          ) : null}
-        </>
-      ) : null}
+      <SelectedLabwareRender
+        labwareOnDeck={matchingSelectedLabwareOnDeck}
+        labwareDef={selectedLabwareDef}
+        slotPosition={slotPosition}
+        moduleModel={selectedModuleModel}
+        hoveredLabware={hoveredLabware}
+      />
+      <SelectedLabwareRender
+        labwareOnDeck={matchingSelectedNestedLabwareOnDeck}
+        labwareDef={selectedNestedLabwareDef}
+        slotPosition={slotPosition}
+        moduleModel={selectedModuleModel}
+        hoveredLabware={hoveredLabware}
+        nestedLabwareInfo={[
+          {
+            text:
+              selectedNestedLabwareDef?.metadata.displayName ?? 'unknown name',
+            isSelected: true,
+            isLast: true,
+          },
+        ]}
+      />
     </>
   )
 }

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedLabwareRender.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedLabwareRender.tsx
@@ -1,0 +1,62 @@
+import { LabwareOnDeck as LabwareOnDeckComponent } from '../../../components/DeckSetup/LabwareOnDeck'
+import { LabwareLabel } from '../LabwareLabel'
+import { LabwareRenderOnDeck } from './LabwareRenderOnDeck'
+import type { DeckLabelProps } from '@opentrons/components'
+import type {
+  CoordinateTuple,
+  LabwareDefinition2,
+  ModuleModel,
+} from '@opentrons/shared-data'
+import type { LabwareOnDeck } from '../../../step-forms'
+
+interface SelectedLabwareRenderProps {
+  labwareDef: LabwareDefinition2 | null
+  slotPosition: CoordinateTuple | null
+  moduleModel: ModuleModel | null
+  hoveredLabware: string | null
+  labwareOnDeck?: LabwareOnDeck
+  nestedLabwareInfo?: DeckLabelProps[] | undefined
+}
+export function SelectedLabwareRender(
+  props: SelectedLabwareRenderProps
+): JSX.Element | null {
+  const {
+    labwareOnDeck,
+    labwareDef,
+    slotPosition,
+    moduleModel,
+    hoveredLabware,
+    nestedLabwareInfo,
+  } = props
+
+  return (labwareOnDeck != null || labwareDef != null) &&
+    slotPosition != null &&
+    moduleModel == null &&
+    hoveredLabware == null ? (
+    <>
+      {labwareDef != null ? (
+        <LabwareRenderOnDeck
+          labwareDef={labwareDef}
+          x={slotPosition[0]}
+          y={slotPosition[1]}
+        />
+      ) : null}
+      {labwareOnDeck != null ? (
+        <LabwareOnDeckComponent
+          x={slotPosition[0]}
+          y={slotPosition[1]}
+          labwareOnDeck={labwareOnDeck}
+        />
+      ) : null}
+      {labwareDef != null ? (
+        <LabwareLabel
+          isLast={true}
+          isSelected={true}
+          labwareDef={labwareDef}
+          position={slotPosition}
+          nestedLabwareInfo={nestedLabwareInfo}
+        />
+      ) : null}
+    </>
+  ) : null
+}

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedModuleLabwareRender.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedModuleLabwareRender.tsx
@@ -1,0 +1,56 @@
+import { LabwareOnDeck as LabwareOnDeckComponent } from '../../../components/DeckSetup/LabwareOnDeck'
+import { LabwareRenderOnDeck } from './LabwareRenderOnDeck'
+import type { LabwareDefinition2, ModuleModel } from '@opentrons/shared-data'
+import type { LabwareOnDeck } from '../../../step-forms'
+
+interface SelectedModuleLabwareRenderProps {
+  nestedLabwareDef: LabwareDefinition2 | null
+  labwareDef: LabwareDefinition2 | null
+  moduleModel: ModuleModel | null
+  hoveredLabware: string | null
+  hoveredLabwareDef: LabwareDefinition2 | null
+  labwareOnDeck?: LabwareOnDeck
+  nestedLabwareOnDeck?: LabwareOnDeck
+}
+export function SelectedModuleLabwareRender(
+  props: SelectedModuleLabwareRenderProps
+): JSX.Element | null {
+  const {
+    labwareOnDeck,
+    labwareDef,
+    moduleModel,
+    hoveredLabware,
+    nestedLabwareDef,
+    nestedLabwareOnDeck,
+    hoveredLabwareDef,
+  } = props
+  return (
+    <>
+      {labwareDef != null && moduleModel != null && hoveredLabware == null ? (
+        <LabwareRenderOnDeck labwareDef={labwareDef} x={0} y={0} />
+      ) : null}
+      {labwareOnDeck != null &&
+      moduleModel != null &&
+      hoveredLabware == null ? (
+        <LabwareOnDeckComponent labwareOnDeck={labwareOnDeck} x={0} y={0} />
+      ) : null}
+      {nestedLabwareDef != null &&
+      moduleModel != null &&
+      hoveredLabware == null ? (
+        <LabwareRenderOnDeck labwareDef={nestedLabwareDef} x={0} y={0} />
+      ) : null}
+      {nestedLabwareOnDeck != null &&
+      moduleModel != null &&
+      hoveredLabware == null ? (
+        <LabwareOnDeckComponent
+          labwareOnDeck={nestedLabwareOnDeck}
+          x={0}
+          y={0}
+        />
+      ) : null}
+      {hoveredLabwareDef != null && moduleModel != null ? (
+        <LabwareRenderOnDeck labwareDef={hoveredLabwareDef} x={0} y={0} />
+      ) : null}
+    </>
+  )
+}

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -1,4 +1,3 @@
-import type * as React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { fireEvent, screen } from '@testing-library/react'
@@ -10,19 +9,17 @@ import {
 import { i18n } from '../../../../assets/localization'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { deleteContainer } from '../../../../labware-ingred/actions'
-import { createModule, deleteModule } from '../../../../step-forms/actions'
+import { deleteModule } from '../../../../step-forms/actions'
 import { getRobotType } from '../../../../file-data/selectors'
 import { getEnableAbsorbanceReader } from '../../../../feature-flags/selectors'
-import {
-  createDeckFixture,
-  deleteDeckFixture,
-} from '../../../../step-forms/actions/additionalItems'
+import { deleteDeckFixture } from '../../../../step-forms/actions/additionalItems'
 import { selectors } from '../../../../labware-ingred/selectors'
 import { getDismissedHints } from '../../../../tutorial/selectors'
 import { getDeckSetupForActiveItem } from '../../../../top-selectors/labware-locations'
 import { DeckSetupTools } from '../DeckSetupTools'
 import { LabwareTools } from '../LabwareTools'
 
+import type * as React from 'react'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 vi.mock('../LabwareTools')
@@ -130,7 +127,7 @@ describe('DeckSetupTools', () => {
     expect(vi.mocked(deleteModule)).toHaveBeenCalled()
     expect(vi.mocked(deleteDeckFixture)).toHaveBeenCalled()
   })
-  it('should close and add h-s module when done is called', () => {
+  it('should close and preserve h-s module when done is called', () => {
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
       selectedLabwareDefUri: null,
       selectedNestedLabwareDefUri: null,
@@ -142,9 +139,8 @@ describe('DeckSetupTools', () => {
     fireEvent.click(screen.getByText('Heater-Shaker Module GEN1'))
     fireEvent.click(screen.getByText('Done'))
     expect(props.onCloseClick).toHaveBeenCalled()
-    expect(vi.mocked(createModule)).toHaveBeenCalled()
   })
-  it('should close and add waste chute and staging area when done is called', () => {
+  it('should close and preserve waste chute and staging area when done is called', () => {
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
       selectedLabwareDefUri: null,
       selectedNestedLabwareDefUri: null,
@@ -156,6 +152,5 @@ describe('DeckSetupTools', () => {
     fireEvent.click(screen.getByText('Waste chute and staging area slot'))
     fireEvent.click(screen.getByText('Done'))
     expect(props.onCloseClick).toHaveBeenCalled()
-    expect(vi.mocked(createDeckFixture)).toHaveBeenCalledTimes(2)
   })
 })

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
@@ -90,7 +90,7 @@ describe('SelectedHoveredItems', () => {
     screen.getByText('mock FixtureRender')
     screen.getByText('mock LabwareOnDeck')
     expect(screen.queryByText('mock Module')).not.toBeInTheDocument()
-    screen.getByText('Opentrons screwcap 2mL tuberack')
+    screen.getByText('Fixture Opentrons Universal Flat Heater-Shaker Adapter')
   })
   it('renders a selected module', () => {
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
@@ -150,9 +150,11 @@ describe('SelectedHoveredItems', () => {
     render(props)
     screen.getByText('mock FixtureRender')
     expect(screen.getAllByText('mock LabwareOnDeck')).toHaveLength(2)
-    expect(screen.getAllByText('Opentrons screwcap 2mL tuberack')).toHaveLength(
-      2
-    )
+    expect(
+      screen.getAllByText(
+        'Fixture Opentrons Universal Flat Heater-Shaker Adapter'
+      )
+    ).toHaveLength(3)
   })
   it('renders nothing when there is a hovered module but selected fixture', () => {
     props.hoveredModule = HEATERSHAKER_MODULE_V1


### PR DESCRIPTION
closes AUTH-1016, partially addresses RQA-3526

# Overview

Oof this was a bit confusing but i think the liquid edit experience is fixed now when you edit a labware with liquids in it already.

## Test Plan and Hands on Testing

First check that the X button is added to deck setup tools and works as expected

Then, zoom into a slot with liquids and click done without doing anything, the liquids should be preserved until you press done
Next, zoom into a slot with liquids and click on different labware, liquids should not be preserved across labware but SHOULD be preserved if you go back to the original labware. once you press done, the liquids are not preserved.

Check that this pattern works for labware on the deck, labware on an adapter, labware on a module, and labware on an adapter on a module

here is a test protocol:
[1.0 testing.json](https://github.com/user-attachments/files/17667772/1.0.testing.json)



## Changelog

- add x button to DeckSetupTools
- keep track of the starting selected item state so done only updates if there are changes
- refine logic for showing liquids on the labware in selectedHoweverLabware and split up component
- fix tests

## Risk assessment

low
