### PR TITLE
fix(protocol-designer): fix create new protocol SelectPipettes page

### DIFF
--- a/protocol-designer/src/assets/localization/en/create_new_protocol.json
+++ b/protocol-designer/src/assets/localization/en/create_new_protocol.json
@@ -30,7 +30,7 @@
   "robot_type": "What kind of robot do you have?",
   "show_all_tips": "Show more tip types",
   "show_default_tips": "Show default tips",
-  "show_tips": "Show incompatible tips",
+  "show_tips": "Show more tip types",
   "slots_limit_reached": "Slots limit reached",
   "staging_area_has_labware": "This staging area slot has labware",
   "staging_area_will_delete_labware": "The staging area slot that you are about to delete has labware placed on it. If you make these changes to your protocol starting deck, the labware will be deleted as well.",

--- a/protocol-designer/src/assets/localization/en/create_new_protocol.json
+++ b/protocol-designer/src/assets/localization/en/create_new_protocol.json
@@ -4,6 +4,7 @@
   "add_gripper": "Add a gripper",
   "add_modules": "Add your modules",
   "add_pipette": "Add a pipette",
+  "add_pipette_to_continue": "Add a pipette to continue",
   "author_org": "Author/Organization",
   "basics": "Let’s start with the basics",
   "description": "Description",

--- a/protocol-designer/src/assets/localization/en/create_new_protocol.json
+++ b/protocol-designer/src/assets/localization/en/create_new_protocol.json
@@ -28,7 +28,7 @@
   "rename_labware": "Rename labware",
   "robot_pipettes": "Robot pipettes",
   "robot_type": "What kind of robot do you have?",
-  "show_all_tips": "Show all tips",
+  "show_all_tips": "Show more tip types",
   "show_default_tips": "Show default tips",
   "show_tips": "Show incompatible tips",
   "slots_limit_reached": "Slots limit reached",

--- a/protocol-designer/src/organisms/IncompatibleTipsModal/__tests__/IncompatibleTipsModal.test.tsx
+++ b/protocol-designer/src/organisms/IncompatibleTipsModal/__tests__/IncompatibleTipsModal.test.tsx
@@ -28,7 +28,7 @@ describe('IncompatibleTipsModal', () => {
     screen.getByText(
       'Using a pipette with an incompatible tip rack may result reduce pipette accuracy and collisions. We strongly recommend that you do not pair a pipette with an incompatible tip rack.'
     )
-    fireEvent.click(screen.getByText('Show incompatible tips'))
+    fireEvent.click(screen.getByText('Show more tip types'))
     expect(vi.mocked(setFeatureFlags)).toHaveBeenCalled()
     fireEvent.click(screen.getByText('Cancel'))
     expect(props.onClose).toHaveBeenCalled()

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectPipettes.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectPipettes.tsx
@@ -366,10 +366,11 @@ export function SelectPipettes(props: WizardTileProps): JSX.Element | null {
                                 />
                               )
                             )}
-                          </Box>
-                          <Flex gridGap={SPACING.spacing4}>
                             <StyledLabel>
-                              <StyledText desktopStyle="bodyDefaultRegular">
+                              <StyledText
+                                desktopStyle="bodyDefaultRegular"
+                                padding={SPACING.spacing4}
+                              >
                                 {t('add_custom_tips')}
                               </StyledText>
                               <input
@@ -398,14 +399,17 @@ export function SelectPipettes(props: WizardTileProps): JSX.Element | null {
                                   TYPOGRAPHY.textDecorationUnderline
                                 }
                               >
-                                <StyledText desktopStyle="bodyDefaultRegular">
+                                <StyledText
+                                  desktopStyle="bodyDefaultRegular"
+                                  padding={SPACING.spacing4}
+                                >
                                   {allowAllTipracks
                                     ? t('show_default_tips')
                                     : t('show_all_tips')}
                                 </StyledText>
                               </Btn>
                             )}
-                          </Flex>
+                          </Box>
                         </Flex>
                       </Flex>
                     )

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectPipettes.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectPipettes.tsx
@@ -177,6 +177,7 @@ export function SelectPipettes(props: WizardTileProps): JSX.Element | null {
             handleGoBack()
           }}
           disabled={isDisabled}
+          tooltipOnDisabled={t('add_pipette_to_continue')}
         >
           {page === 'add' ? (
             <Flex

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/WizardBody.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/WizardBody.tsx
@@ -13,6 +13,8 @@ import {
   SPACING,
   StyledText,
   TYPOGRAPHY,
+  Tooltip,
+  useHoverTooltip,
 } from '@opentrons/components'
 import temporaryImg from '../../assets/images/placeholder_image_delete.png'
 import { BUTTON_LINK_STYLE } from '../../atoms'
@@ -26,6 +28,7 @@ interface WizardBodyProps {
   goBack?: () => void
   subHeader?: string
   imgSrc?: string
+  tooltipOnDisabled?: string
 }
 export function WizardBody(props: WizardBodyProps): JSX.Element {
   const {
@@ -37,8 +40,12 @@ export function WizardBody(props: WizardBodyProps): JSX.Element {
     proceed,
     disabled = false,
     imgSrc,
+    tooltipOnDisabled,
   } = props
   const { t } = useTranslation('shared')
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: 'top',
+  })
 
   return (
     <Flex
@@ -88,12 +95,17 @@ export function WizardBody(props: WizardBodyProps): JSX.Element {
               </StyledText>
             </Btn>
           ) : null}
-          <LargeButton
-            ariaDisabled={disabled}
-            onClick={proceed}
-            iconName="arrow-right"
-            buttonText={t('shared:confirm')}
-          />
+          <Flex {...targetProps}>
+            <LargeButton
+              disabled={disabled}
+              onClick={proceed}
+              iconName="arrow-right"
+              buttonText={t('shared:confirm')}
+            />
+          </Flex>
+          {tooltipOnDisabled != null ? (
+            <Tooltip tooltipProps={tooltipProps}>{tooltipOnDisabled}</Tooltip>
+          ) : null}
         </Flex>
       </Flex>
       <StyledImg

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectPipettes.test.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectPipettes.test.tsx
@@ -151,7 +151,7 @@ describe('SelectPipettes', () => {
     expect(vi.mocked(createCustomTiprackDef)).toHaveBeenCalled()
 
     //  change all tip setting
-    fireEvent.click(screen.getByText('Show all tips'))
+    fireEvent.click(screen.getByText('Show more tip types'))
     screen.getByText('mock incompatible tips modal')
   })
 })


### PR DESCRIPTION
# Overview

Updates copy, padding, and alignment for SelectPipettes page tiprack links. Adds tooltip for disabled "confirm" button on pipettes wizard page

Closes RQA-3323
Closes RQA-3368
Closes RQA-3317

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/6b57049e-16d9-4b08-bd6d-7f5aeac4c7aa

- Create a new OT-2 protocol. Don't add a pipette and verify that hovering the "confirm" button renders a tooltip
- Add a pipette and continue
- Select type, generation, and volume , and scroll down to verify that "Add custom pipette tips" and "Show more tip types" links are padded and spaced properly (see ticket)
- Click "Show more tip types" and verify that the modal footer secondary button says "Show more tip types"

## Changelog

- add tooltip for disabled pipettes confirm button
- update style and copy for tiprack links
- update footer for modal

## Review requests

see test plan

## Risk assessment

low