### PR TITLE
fix(protocol-designer): fix newlocation display name in StepSummary

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -69,6 +69,7 @@
   "multiAspirate": "Consolidate path",
   "multiDispense": "Distribute path",
   "new_location": "New location",
+  "off_deck": "Off-Deck",
   "pause": {
     "untilResume": "Pausing until manually told to resume",
     "untilTemperature": "<text>Pausing until</text><semiBoldText>{{module}}</semiBoldText><text>reaches</text><tag/>",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -272,6 +272,14 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
     case 'moveLabware':
       const { labware, newLocation, useGripper } = currentStep
       const labwareName = labwareNicknamesById[labware]
+      let newLocationName = newLocation
+      if (newLocation in modules) {
+        newLocationName = getModuleDisplayName(modules[newLocation].model)
+      } else if (newLocation in labwareEntities) {
+        newLocationName = labwareNicknamesById[newLocation]
+      } else if (newLocation === 'offDeck') {
+        newLocationName = t('off_deck')
+      }
       stepSummaryContent = (
         <StyledTrans
           i18nKey={
@@ -282,7 +290,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           values={{
             labware: labwareName,
           }}
-          tagText={newLocation}
+          tagText={newLocationName}
         />
       )
       break


### PR DESCRIPTION
# Overview

For moveLabware StepSummary, we need grab the correct newLocation display name if the newLocation is not a slot. Here, I check for the newLocation type and retrieve the appropriate display name.

Closes RQA-3420

## Test Plan and Hands on Testing

- create a move labware step and select a module as the new location
- save the step and verify that the step summary correctly shows the module display name
- repeat with the new location as an adapter, deck slot, and off deck

https://github.com/user-attachments/assets/5ba099cc-6c9f-4b66-b608-3b8bc5d572b8


## Changelog

- get correct display name for newLocation depending on type of location

## Review requests

- see test plan

## Risk assessment

low