### PR TITLE
fix(app): add an exit button for failed moveToAddressable area commands during Error Recovery

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
@@ -68,9 +68,11 @@ export function DropTipWizardFlows(
   // after it closes.
   useEffect(() => {
     return () => {
-      dropTipWithTypeUtils.dropTipCommands.handleCleanUpAndClose()
+      if (issuedCommandsType === 'setup') {
+        void dropTipWithTypeUtils.dropTipCommands.handleCleanUpAndClose()
+      }
     }
-  }, [])
+  }, [issuedCommandsType])
 
   return (
     <DropTipWizard

--- a/app/src/organisms/DropTipWizardFlows/hooks/errors.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/errors.tsx
@@ -43,7 +43,11 @@ export function useDropTipCommandErrors(
       })
     } else {
       const messageText = message ?? ''
-      setErrorDetails({ header, message: messageText, type })
+      setErrorDetails({
+        header: header ?? t('cant_safely_drop_tips'),
+        message: messageText ?? t('remove_the_tips_manually'),
+        type,
+      })
     }
   }
 }

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -109,35 +109,38 @@ export function useDropTipCommands({
     isPredefinedLocation: boolean
   ): Promise<void> => {
     return new Promise((resolve, reject) => {
-      const addressableAreaFromConfig = getAddressableAreaFromConfig(
-        addressableArea,
-        deckConfig,
-        instrumentModelSpecs.channels,
-        robotType
-      )
+      Promise.resolve()
+        .then(() => {
+          const addressableAreaFromConfig = getAddressableAreaFromConfig(
+            addressableArea,
+            deckConfig,
+            instrumentModelSpecs.channels,
+            robotType
+          )
 
-      if (addressableAreaFromConfig == null) {
-        throw new Error('invalid addressable area.')
-      }
+          if (addressableAreaFromConfig == null) {
+            throw new Error('invalid addressable area.')
+          }
 
-      const moveToAACommand = buildMoveToAACommand(
-        addressableAreaFromConfig,
-        pipetteId,
-        isPredefinedLocation,
-        issuedCommandsType
-      )
+          const moveToAACommand = buildMoveToAACommand(
+            addressableAreaFromConfig,
+            pipetteId,
+            isPredefinedLocation,
+            issuedCommandsType
+          )
 
-      return chainRunCommands(
-        isFlex
-          ? [
-              ENGAGE_AXES,
-              UPDATE_ESTIMATORS_EXCEPT_PLUNGERS,
-              Z_HOME,
-              moveToAACommand,
-            ]
-          : [Z_HOME, moveToAACommand],
-        false
-      )
+          return chainRunCommands(
+            isFlex
+              ? [
+                  ENGAGE_AXES,
+                  UPDATE_ESTIMATORS_EXCEPT_PLUNGERS,
+                  Z_HOME,
+                  moveToAACommand,
+                ]
+              : [Z_HOME, moveToAACommand],
+            false
+          )
+        })
         .then((commandData: CommandData[]) => {
           const error = commandData[0].data.error
           if (error != null) {

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -116,51 +116,49 @@ export function useDropTipCommands({
         robotType
       )
 
-      if (addressableAreaFromConfig != null) {
-        const moveToAACommand = buildMoveToAACommand(
-          addressableAreaFromConfig,
-          pipetteId,
-          isPredefinedLocation,
-          issuedCommandsType
-        )
-        return chainRunCommands(
-          isFlex
-            ? [
-                ENGAGE_AXES,
-                UPDATE_ESTIMATORS_EXCEPT_PLUNGERS,
-                Z_HOME,
-                moveToAACommand,
-              ]
-            : [Z_HOME, moveToAACommand],
-          false
-        )
-          .then((commandData: CommandData[]) => {
-            const error = commandData[0].data.error
-            if (error != null) {
-              setErrorDetails({
-                runCommandError: error,
-                message: `Error moving to position: ${error.detail}`,
-              })
-            }
-          })
-          .then(resolve)
-          .catch(error => {
-            if (
-              fixitCommandTypeUtils != null &&
-              issuedCommandsType === 'fixit'
-            ) {
-              fixitCommandTypeUtils.errorOverrides.generalFailure()
-            }
-
-            reject(
-              new Error(`Error issuing move to addressable area: ${error}`)
-            )
-          })
-      } else {
-        setErrorDetails({
-          message: `Error moving to position: invalid addressable area.`,
-        })
+      if (addressableAreaFromConfig == null) {
+        throw new Error('invalid addressable area.')
       }
+
+      const moveToAACommand = buildMoveToAACommand(
+        addressableAreaFromConfig,
+        pipetteId,
+        isPredefinedLocation,
+        issuedCommandsType
+      )
+
+      return chainRunCommands(
+        isFlex
+          ? [
+              ENGAGE_AXES,
+              UPDATE_ESTIMATORS_EXCEPT_PLUNGERS,
+              Z_HOME,
+              moveToAACommand,
+            ]
+          : [Z_HOME, moveToAACommand],
+        false
+      )
+        .then((commandData: CommandData[]) => {
+          const error = commandData[0].data.error
+          if (error != null) {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw error
+          }
+          resolve()
+        })
+        .catch(error => {
+          if (fixitCommandTypeUtils != null && issuedCommandsType === 'fixit') {
+            fixitCommandTypeUtils.errorOverrides.generalFailure()
+          } else {
+            setErrorDetails({
+              runCommandError: error,
+              message: error.detail
+                ? `Error moving to position: ${error.detail}`
+                : 'Error moving to position: invalid addressable area.',
+            })
+          }
+          reject(error)
+        })
     })
   }
 


### PR DESCRIPTION
Closes [RQA-3542](https://opentrons.atlassian.net/browse/RQA-3542)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

See the ticket for the steps to reproduce. The `moveToAddressableArea` command did not have correct conditional logic in some spots for handling the error if it occurred during a `fixit` flow. This PR refactors the command logic, so any error will be handled correctly if the flow is `fixit`.

Also, recent fixes for unrendering pipette cards made it so that errors which occur during drop tip wizard during error recovery would automatically cancel the run instead of showing users the proper "error" modal, so that is fixed as well.

### Current Behavior

![Screenshot 2024-11-07 at 2 25 41 PM](https://github.com/user-attachments/assets/be4746ec-b9e6-4b38-b77a-08960a34b38e)

### Fixed Behavior

<img width="748" alt="Screenshot 2024-11-07 at 4 04 18 PM" src="https://github.com/user-attachments/assets/485532b1-0f0e-476a-ae56-1006ff588890">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See tickets for steps to reproduce. 
- Verified the button exists (see picture), and the flows don't automatically cancel the run after the error occurs (also see picture).
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a bug during error recovery in which certain errors during drop tip wizard flows did not render an escape button.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3542]: https://opentrons.atlassian.net/browse/RQA-3542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ