### PR TITLE
feat(hardware_control): Handle Q moves in the hardware controller move function

### DIFF
--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -221,7 +221,7 @@ class FlexBackend(Protocol):
         ...
 
     async def tip_action(
-        self, origin: Dict[Axis, float], targets: List[Tuple[Dict[Axis, float], float]]
+        self, origin: float, targets: List[Tuple[float, float]]
     ) -> None:
         ...
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -597,30 +597,103 @@ class OT3Controller(FlexBackend):
         return axis_convert(self._encoder_position, 0.0)
 
     def _handle_motor_status_response(
-        self,
-        response: NodeMap[MotorPositionStatus],
+        self, response: NodeMap[MotorPositionStatus], handle_gear_move: bool = False
     ) -> None:
         for axis, pos in response.items():
-            self._position.update({axis: pos.motor_position})
-            self._encoder_position.update({axis: pos.encoder_position})
-            # TODO (FPS 6-01-2023): Remove this once the Feature Flag to ignore stall detection is removed.
-            # This check will latch the motor status for an axis at "true" if it was ever set to true.
-            # To account for the case where a motor axis has its power reset, we also depend on the
-            # "encoder_ok" flag staying set (it will only be False if the motor axis has not been
-            # homed since a power cycle)
-            motor_ok_latch = (
-                (not self._feature_flags.stall_detection_enabled)
-                and ((axis in self._motor_status) and self._motor_status[axis].motor_ok)
-                and self._motor_status[axis].encoder_ok
-            )
-            self._motor_status.update(
-                {
-                    axis: MotorStatus(
-                        motor_ok=(pos.motor_ok or motor_ok_latch),
-                        encoder_ok=pos.encoder_ok,
+            if handle_gear_move and axis == NodeId.pipette_left:
+                self._gear_motor_position = {axis: pos.motor_position}
+            else:
+                self._position.update({axis: pos.motor_position})
+                self._encoder_position.update({axis: pos.encoder_position})
+                # TODO (FPS 6-01-2023): Remove this once the Feature Flag to ignore stall detection is removed.
+                # This check will latch the motor status for an axis at "true" if it was ever set to true.
+                # To account for the case where a motor axis has its power reset, we also depend on the
+                # "encoder_ok" flag staying set (it will only be False if the motor axis has not been
+                # homed since a power cycle)
+                motor_ok_latch = (
+                    (not self._feature_flags.stall_detection_enabled)
+                    and (
+                        (axis in self._motor_status)
+                        and self._motor_status[axis].motor_ok
                     )
-                }
+                    and self._motor_status[axis].encoder_ok
+                )
+                self._motor_status.update(
+                    {
+                        axis: MotorStatus(
+                            motor_ok=(pos.motor_ok or motor_ok_latch),
+                            encoder_ok=pos.encoder_ok,
+                        )
+                    }
+                )
+
+    def _build_move_node_axis_runner(
+        self,
+        origin: Dict[Axis, float],
+        target: Dict[Axis, float],
+        speed: float,
+        stop_condition: HWStopCondition,
+        nodes_in_moves_only: bool,
+    ) -> Tuple[Optional[MoveGroupRunner], bool]:
+        if not target:
+            return None, False
+        move_target = MoveTarget.build(position=target, max_speed=speed)
+        log.info(f"The origin: {origin} and {target} position at speed: {speed}")
+        try:
+            _, movelist = self._move_manager.plan_motion(
+                origin=origin, target_list=[move_target]
             )
+        except ZeroLengthMoveError as zme:
+            log.debug(f"Not moving because move was zero length {str(zme)}")
+            return None, False
+        moves = movelist[0]
+        log.info(f"move: machine {target} from {origin} requires {moves}")
+
+        ordered_nodes = self._motor_nodes()
+        if nodes_in_moves_only:
+            moving_axes = {
+                axis_to_node(ax) for move in moves for ax in move.unit_vector.keys()
+            }
+            ordered_nodes = ordered_nodes.intersection(moving_axes)
+
+        move_group, _ = create_move_group(
+            origin, moves, ordered_nodes, MoveStopCondition[stop_condition.name]
+        )
+        return (
+            MoveGroupRunner(
+                move_groups=[move_group],
+                ignore_stalls=True
+                if not self._feature_flags.stall_detection_enabled
+                else False,
+            ),
+            False,
+        )
+
+    def _build_move_gear_axis_runner(
+        self,
+        possible_q_axis_origin: Optional[float],
+        possible_q_axis_target: Optional[float],
+        speed: float,
+        nodes_in_moves_only: bool,
+    ) -> Tuple[Optional[MoveGroupRunner], bool]:
+        if possible_q_axis_origin is None or possible_q_axis_target is None:
+            return None, True
+        tip_motor_move_group = self._build_tip_action_group(
+            possible_q_axis_origin, [(possible_q_axis_target, speed)]
+        )
+        if nodes_in_moves_only:
+            ordered_nodes = self._motor_nodes()
+
+            ordered_nodes.intersection({axis_to_node(Axis.Q)})
+        return (
+            MoveGroupRunner(
+                move_groups=[tip_motor_move_group],
+                ignore_stalls=True
+                if not self._feature_flags.stall_detection_enabled
+                else False,
+            ),
+            True,
+        )
 
     @requires_update
     @requires_estop
@@ -648,40 +721,51 @@ class OT3Controller(FlexBackend):
         Returns:
             None
         """
-        move_target = MoveTarget.build(position=target, max_speed=speed)
-        try:
-            _, movelist = self._move_manager.plan_motion(
-                origin=origin, target_list=[move_target]
-            )
-        except ZeroLengthMoveError as zme:
-            log.debug(f"Not moving because move was zero length {str(zme)}")
-            return
-        moves = movelist[0]
-        log.info(f"move: machine {target} from {origin} requires {moves}")
+        possible_q_axis_origin = origin.pop(Axis.Q, None)
+        possible_q_axis_target = target.pop(Axis.Q, None)
 
-        ordered_nodes = self._motor_nodes()
-        if nodes_in_moves_only:
-            moving_axes = {
-                axis_to_node(ax) for move in moves for ax in move.unit_vector.keys()
-            }
-            ordered_nodes = ordered_nodes.intersection(moving_axes)
-
-        group = create_move_group(
-            origin, moves, ordered_nodes, MoveStopCondition[stop_condition.name]
+        maybe_runners = (
+            self._build_move_node_axis_runner(
+                origin, target, speed, stop_condition, nodes_in_moves_only
+            ),
+            self._build_move_gear_axis_runner(
+                possible_q_axis_origin,
+                possible_q_axis_target,
+                speed,
+                nodes_in_moves_only,
+            ),
         )
-        move_group, _ = group
-        runner = MoveGroupRunner(
-            move_groups=[move_group],
-            ignore_stalls=True
-            if not self._feature_flags.stall_detection_enabled
-            else False,
+        log.debug(f"The move groups are {maybe_runners}.")
+
+        gather_moving_nodes = set()
+        all_moving_nodes = set()
+        for runner, _ in maybe_runners:
+            if runner:
+                for n in runner.all_nodes():
+                    gather_moving_nodes.add(n)
+                for n in runner.all_moving_nodes():
+                    all_moving_nodes.add(n)
+
+        pipettes_moving = moving_pipettes_in_move_group(
+            gather_moving_nodes, all_moving_nodes
         )
 
-        pipettes_moving = moving_pipettes_in_move_group(move_group)
-
-        async with self._monitor_overpressure(pipettes_moving):
+        async def _runner_coroutine(
+            runner: MoveGroupRunner, is_gear_move: bool
+        ) -> Tuple[Dict[NodeId, MotorPositionStatus], bool]:
             positions = await runner.run(can_messenger=self._messenger)
-        self._handle_motor_status_response(positions)
+            return positions, is_gear_move
+
+        coros = [
+            _runner_coroutine(runner, is_gear_move)
+            for runner, is_gear_move in maybe_runners
+            if runner
+        ]
+        async with self._monitor_overpressure(pipettes_moving):
+            all_positions = await asyncio.gather(*coros)
+
+        for positions, handle_gear_move in all_positions:
+            self._handle_motor_status_response(positions, handle_gear_move)
 
     def _get_axis_home_distance(self, axis: Axis) -> float:
         if self.check_motor_status([axis]):
@@ -796,6 +880,7 @@ class OT3Controller(FlexBackend):
                     Axis.to_kind(Axis.Q)
                 ],
             )
+
         for position in positions:
             self._handle_motor_status_response(position)
         return axis_convert(self._position, 0.0)
@@ -840,17 +925,25 @@ class OT3Controller(FlexBackend):
             self._gear_motor_position = {}
             raise e
 
-    async def tip_action(
-        self, origin: Dict[Axis, float], targets: List[Tuple[Dict[Axis, float], float]]
-    ) -> None:
+    def _build_tip_action_group(
+        self, origin: float, targets: List[Tuple[float, float]]
+    ) -> MoveGroup:
+
         move_targets = [
-            MoveTarget.build(target_pos, speed) for target_pos, speed in targets
+            MoveTarget.build({Axis.Q: target_pos}, speed)
+            for target_pos, speed in targets
         ]
         _, moves = self._move_manager.plan_motion(
-            origin=origin, target_list=move_targets
+            origin={Axis.Q: origin}, target_list=move_targets
         )
-        move_group = create_tip_action_group(moves[0], [NodeId.pipette_left], "clamp")
 
+        return create_tip_action_group(moves[0], [NodeId.pipette_left], "clamp")
+
+    async def tip_action(
+        self, origin: float, targets: List[Tuple[float, float]]
+    ) -> None:
+
+        move_group = self._build_tip_action_group(origin, targets)
         runner = MoveGroupRunner(
             move_groups=[move_group],
             ignore_stalls=True

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -638,7 +638,6 @@ class OT3Controller(FlexBackend):
         if not target:
             return None, False
         move_target = MoveTarget.build(position=target, max_speed=speed)
-        log.info(f"The origin: {origin} and {target} position at speed: {speed}")
         try:
             _, movelist = self._move_manager.plan_motion(
                 origin=origin, target_list=[move_target]
@@ -647,7 +646,9 @@ class OT3Controller(FlexBackend):
             log.debug(f"Not moving because move was zero length {str(zme)}")
             return None, False
         moves = movelist[0]
-        log.info(f"move: machine {target} from {origin} requires {moves}")
+        log.debug(
+            f"move: machine coordinates {target} from origin: machine coordinates {origin} at speed: {speed} requires {moves}"
+        )
 
         ordered_nodes = self._motor_nodes()
         if nodes_in_moves_only:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -439,10 +439,12 @@ class OT3Simulator(FlexBackend):
         return self._sim_jaw_state
 
     async def tip_action(
-        self, origin: Dict[Axis, float], targets: List[Tuple[Dict[Axis, float], float]]
+        self, origin: float, targets: List[Tuple[float, float]]
     ) -> None:
         self._gear_motor_position.update(
-            coalesce_move_segments(origin, [target[0] for target in targets])
+            coalesce_move_segments(
+                {Axis.Q: origin}, [{Axis.Q: target[0]} for target in targets]
+            )
         )
         await asyncio.sleep(0)
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -498,10 +498,10 @@ def create_gripper_jaw_hold_group(encoder_position_um: int) -> MoveGroup:
     return move_group
 
 
-def moving_pipettes_in_move_group(group: MoveGroup) -> List[NodeId]:
+def moving_pipettes_in_move_group(
+    all_nodes: Set[NodeId], moving_nodes: Set[NodeId]
+) -> List[NodeId]:
     """Utility function to get which pipette nodes are moving either in z or their plunger."""
-    all_nodes = [node for step in group for node, _ in step.items()]
-    moving_nodes = moving_axes_in_move_group(group)
     pipettes_moving: List[NodeId] = [
         k for k in moving_nodes if k in [NodeId.pipette_left, NodeId.pipette_right]
     ]
@@ -510,16 +510,6 @@ def moving_pipettes_in_move_group(group: MoveGroup) -> List[NodeId]:
     if NodeId.head_r in moving_nodes and NodeId.pipette_right in all_nodes:
         pipettes_moving.append(NodeId.pipette_right)
     return pipettes_moving
-
-
-def moving_axes_in_move_group(group: MoveGroup) -> Set[NodeId]:
-    """Utility function to get only the moving nodes in a move group."""
-    ret: Set[NodeId] = set()
-    for step in group:
-        for node, node_step in step.items():
-            if node_step.is_moving_step():
-                ret.add(node)
-    return ret
 
 
 AxisMapPayload = TypeVar("AxisMapPayload")

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -943,8 +943,8 @@ class OT3API(
         ):
             # move toward home until a safe distance
             await self._backend.tip_action(
-                origin={Axis.Q: current_pos_float},
-                targets=[({Axis.Q: self._config.safe_home_distance}, 400)],
+                origin=current_pos_float,
+                targets=[(self._config.safe_home_distance, 400)],
             )
 
             # update current position
@@ -1439,6 +1439,10 @@ class OT3API(
         check_motion_bounds(to_check, target_position, bounds, check_bounds)
         self._log.info(f"Move: deck {target_position} becomes machine {machine_pos}")
         origin = await self._backend.update_position()
+
+        if self._gantry_load == GantryLoad.HIGH_THROUGHPUT:
+            origin[Axis.Q] = self._backend.gear_motor_position or 0.0
+
         async with contextlib.AsyncExitStack() as stack:
             if acquire_lock:
                 await stack.enter_async_context(self._motion_lock)
@@ -2156,8 +2160,8 @@ class OT3API(
         # only move tip motors if they are not already below the sensor
         if tip_motor_pos_float < tip_presence_check_target:
             await self._backend.tip_action(
-                origin={Axis.Q: tip_motor_pos_float},
-                targets=[({Axis.Q: tip_presence_check_target}, 400)],
+                origin=tip_motor_pos_float,
+                targets=[(tip_presence_check_target, 400)],
             )
         try:
             yield
@@ -2228,11 +2232,11 @@ class OT3API(
             gear_origin_float = self._backend.gear_motor_position or 0.0
 
             move_targets = [
-                ({Axis.Q: move_segment.distance}, move_segment.speed or 400)
+                (move_segment.distance, move_segment.speed or 400)
                 for move_segment in pipette_spec
             ]
             await self._backend.tip_action(
-                origin={Axis.Q: gear_origin_float}, targets=move_targets
+                origin=gear_origin_float, targets=move_targets
             )
             await self.home_gear_motors()
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -338,7 +338,7 @@ home_test_params = [
 ]
 
 
-def move_group_run_side_effect(
+def move_group_run_side_effect_home(
     controller: OT3Controller, axes_to_home: List[Axis]
 ) -> Iterator[Dict[NodeId, MotorPositionStatus]]:
     """Return homed position for axis that is present and was commanded to home."""
@@ -366,7 +366,7 @@ async def test_home_execute(
     mock_present_devices: None,
     mock_check_overpressure: None,
 ) -> None:
-    config = {"run.side_effect": move_group_run_side_effect(controller, axes)}
+    config = {"run.side_effect": move_group_run_side_effect_home(controller, axes)}
     with mock.patch(  # type: ignore [call-overload]
         "opentrons.hardware_control.backends.ot3controller.MoveGroupRunner",
         spec=MoveGroupRunner,
@@ -485,7 +485,7 @@ async def test_home_only_present_devices(
 
     controller._position = starting_position
 
-    mock_move_group_run.side_effect = move_group_run_side_effect(controller, axes)
+    mock_move_group_run.side_effect = move_group_run_side_effect_home(controller, axes)
 
     # nothing has been homed
     assert not controller._motor_status
@@ -1292,3 +1292,123 @@ def test_grip_error_detection(
             hard_max,
             hard_min,
         )
+
+
+def move_group_run_side_effect(
+    controller: OT3Controller, target_pos: Dict[Axis, float]
+) -> Iterator[Dict[NodeId, MotorPositionStatus]]:
+    """Return homed position for axis that is present and was commanded to home."""
+    motor_nodes = controller._motor_nodes()
+    target_nodes = {axis_to_node(ax): ax for ax in target_pos.keys() if ax != Axis.Q}
+    res = {}
+    for node in motor_nodes:
+        pos = 0.0
+        if target_nodes.get(node):
+            pos = target_pos[target_nodes[node]]
+        res[node] = MotorPositionStatus(pos, pos, True, True, MoveCompleteAck(1))
+    yield res
+
+
+@pytest.mark.parametrize(
+    argnames=["origin_pos", "target_pos", "expected_pos", "gear_position"],
+    argvalues=[
+        [
+            {
+                Axis.X: 0,
+                Axis.Y: 0,
+                Axis.Z_L: 0,
+                Axis.Z_R: 0,
+                Axis.P_L: 0,
+                Axis.P_R: 0,
+                Axis.Z_G: 0,
+                Axis.G: 0,
+                Axis.Q: 0,
+            },
+            {Axis.Q: 10},
+            {
+                Axis.X: 0,
+                Axis.Y: 0,
+                Axis.Z_L: 0,
+                Axis.Z_R: 0,
+                Axis.P_L: 0,
+                Axis.P_R: 0,
+                Axis.Z_G: 0,
+                Axis.G: 0,
+            },
+            10,
+        ],
+        [
+            {
+                Axis.X: 0,
+                Axis.Y: 0,
+                Axis.Z_L: 0,
+                Axis.Z_R: 0,
+                Axis.P_L: 0,
+                Axis.P_R: 0,
+                Axis.Z_G: 0,
+                Axis.G: 0,
+            },
+            {Axis.Q: 10},
+            {
+                Axis.X: 0,
+                Axis.Y: 0,
+                Axis.Z_L: 0,
+                Axis.Z_R: 0,
+                Axis.P_L: 0,
+                Axis.P_R: 0,
+                Axis.Z_G: 0,
+                Axis.G: 0,
+            },
+            None,
+        ],
+        [
+            {
+                Axis.X: 0,
+                Axis.Y: 0,
+                Axis.Z_L: 0,
+                Axis.Z_R: 0,
+            },
+            {
+                Axis.X: 10,
+                Axis.Y: 10,
+                Axis.Z_L: 10,
+            },
+            {
+                Axis.X: 10,
+                Axis.Y: 10,
+                Axis.Z_L: 10,
+                Axis.Z_R: 0,
+                Axis.P_L: 0,
+                Axis.P_R: 0,
+                Axis.Z_G: 0,
+                Axis.G: 0,
+            },
+            None,
+        ],
+    ],
+)
+async def test_controller_move(
+    controller: OT3Controller,
+    mock_present_devices: mock.AsyncMock,
+    origin_pos: Dict[Axis, float],
+    target_pos: Dict[Axis, float],
+    expected_pos: Dict[Axis, float],
+    gear_position: Optional[float],
+) -> None:
+    from copy import deepcopy
+
+    controller.update_constraints_for_gantry_load(GantryLoad.HIGH_THROUGHPUT)
+
+    run_target_pos = deepcopy(target_pos)
+    config = {"run.side_effect": move_group_run_side_effect(controller, run_target_pos)}
+    with mock.patch(  # type: ignore [call-overload]
+        "opentrons.hardware_control.backends.ot3controller.MoveGroupRunner",
+        spec=MoveGroupRunner,
+        **config
+    ):
+        await controller.move(origin_pos, target_pos, 100)
+        position = await controller.update_position()
+        gear_position = controller.gear_motor_position
+
+        assert position == expected_pos
+        assert gear_position == gear_position

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -1,9 +1,6 @@
 import pytest
 from typing import List
 from opentrons_hardware.hardware_control.motion_planning import Move
-from opentrons_hardware.hardware_control.motion import (
-    create_step,
-)
 from opentrons.hardware_control.backends import ot3utils
 from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons.hardware_control.types import Axis, OT3Mount
@@ -37,31 +34,6 @@ def test_create_step() -> None:
     assert len(move_group) == 3
     for step in move_group:
         assert set(present_nodes) == set(step.keys())
-
-
-def test_get_moving_nodes() -> None:
-    """Test that we can filter out the nonmoving nodes."""
-    # Create a dummy group where X has velocity but no accel, and Y has accel but no velocity.
-    present_nodes = [NodeId.gantry_x, NodeId.gantry_y, NodeId.head_l, NodeId.head_r]
-    move_group = [
-        create_step(
-            distance={NodeId.gantry_x: f64(100), NodeId.gantry_y: f64(100)},
-            velocity={NodeId.gantry_x: f64(100), NodeId.gantry_y: f64(0)},
-            acceleration={NodeId.gantry_x: f64(0), NodeId.gantry_y: f64(100)},
-            duration=f64(1),
-            present_nodes=present_nodes,
-        )
-    ]
-    assert len(move_group[0]) == 4
-
-    print(move_group)
-
-    moving_nodes = ot3utils.moving_axes_in_move_group(move_group)
-    assert len(moving_nodes) == 2
-    assert NodeId.gantry_x in moving_nodes
-    assert NodeId.gantry_y in moving_nodes
-    assert NodeId.head_l not in moving_nodes
-    assert NodeId.head_r not in moving_nodes
 
 
 def test_filter_zero_duration_step() -> None:
@@ -154,15 +126,8 @@ def test_moving_pipettes_in_move_group(
         NodeId.gripper_g,
         NodeId.gripper_z,
     ]
-    move_group = [
-        create_step(
-            distance={node: f64(100) for node in moving},
-            velocity={node: f64(100) for node in moving},
-            acceleration={node: f64(0) for node in moving},
-            duration=f64(1),
-            present_nodes=present_nodes,
-        )
-    ]
 
-    moving_pipettes = ot3utils.moving_pipettes_in_move_group(move_group)
+    moving_pipettes = ot3utils.moving_pipettes_in_move_group(
+        set(present_nodes), set(moving)
+    )
     assert set(moving_pipettes) == set(expected)

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -2026,12 +2026,10 @@ async def test_drop_tip_full_tiprack(
         assert len(tip_action.call_args_list) == 2
         # first call should be "clamp", moving down
         first_target = tip_action.call_args_list[0][-1]["targets"][0][0]
-        assert list(first_target.keys()) == [Axis.Q]
-        assert first_target[Axis.Q] == 10
+        assert first_target == 10
         # next call should be "clamp", moving back up
         second_target = tip_action.call_args_list[1][-1]["targets"][0][0]
-        assert list(second_target.keys()) == [Axis.Q]
-        assert second_target[Axis.Q] < 10
+        assert second_target < 10
         # home should be called after tip_action is done
         assert len(mock_home_gear_motors.call_args_list) == 1
 

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -619,16 +619,13 @@ async def move_tip_motor_relative_ot3(
     if not api.hardware_pipettes[OT3Mount.LEFT.to_mount()]:
         raise RuntimeError("No pipette found on LEFT mount")
 
-    current_gear_pos_float = api._backend.gear_motor_position or 0.0
-    current_gear_pos_dict = {Axis.Q: current_gear_pos_float}
-    target_pos_dict = {Axis.Q: current_gear_pos_float + distance}
+    current_gear_pos = api._backend.gear_motor_position or 0.0
+    target_pos = current_gear_pos + distance
 
     if speed is not None and distance < 0:
         speed *= -1
 
-    _move_coro = api._backend.tip_action(
-        current_gear_pos_dict, [(target_pos_dict, speed or 400)]
-    )
+    _move_coro = api._backend.tip_action(current_gear_pos, [(target_pos, speed or 400)])
     if motor_current is None:
         await _move_coro
     else:

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -237,12 +237,22 @@ class MoveGroupRunner:
             log.warning("Clear move group failed")
 
     def all_nodes(self) -> Set[NodeId]:
-        """Get all of the nodes in the move group runner's move gruops."""
+        """Get all of the nodes in the move group runner's move groups."""
         node_set: Set[NodeId] = set()
         for group in self._move_groups:
             for sequence in group:
                 for node in sequence.keys():
                     node_set.add(node)
+        return node_set
+
+    def all_moving_nodes(self) -> Set[NodeId]:
+        """Get all of the moving nodes in the move group runner's move groups."""
+        node_set: Set[NodeId] = set()
+        for group in self._move_groups:
+            for sequence in group:
+                for node, node_step in sequence.items():
+                    if node_step.is_moving_step():
+                        node_set.add(node)
         return node_set
 
     async def _send_groups(self, can_messenger: CanMessenger) -> None:


### PR DESCRIPTION
# Overview

To support requirements for the RobotContext, we need to be able to command the Q motor outside of specific tip pickup/drop commands.

## Test Plan and Hands on Testing

Already been tested on a robot.

## Changelog

- Add support for Q moves in `ot3controller.py`
- Modify the signature of `tip_action`

## Review requests

Check that the structure is OK.

## Risk assessment

High. Affects robot movement.
