### PR TITLE
feat(app-shell, app-shell-odd): filter out unused env vars

### DIFF
--- a/app-shell-odd/vite.config.mts
+++ b/app-shell-odd/vite.config.mts
@@ -59,7 +59,10 @@ export default defineConfig(
         },
       },
       define: {
-        'process.env': process.env,
+        'process.env': {
+          NODE_ENV: process.env.NODE_ENV,
+          OPENTRONS_PROJECT: process.env.OPENTRONS_PROJECT,
+        },
         global: 'globalThis',
         _PKG_VERSION_: JSON.stringify(version),
         _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),

--- a/app-shell/vite.config.mts
+++ b/app-shell/vite.config.mts
@@ -37,7 +37,10 @@ export default defineConfig(
         exclude: ['node_modules'],
       },
       define: {
-        'process.env': process.env,
+        'process.env': {
+          NODE_ENV: process.env.NODE_ENV,
+          OPENTRONS_PROJECT: process.env.OPENTRONS_PROJECT,
+        },
         global: 'globalThis',
         _PKG_VERSION_: JSON.stringify(version),
         _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),


### PR DESCRIPTION
# Overview

Filter out unused env vars so they don't appear in electron dists.

Same as https://github.com/Opentrons/opentrons/pull/16720 but for the app shell and app shell odd just to be safe

## Risk assessment
Low