### PR TITLE
fix(app): fix ODD IntersectionObserver reference cycle

### DIFF
--- a/app/src/local-resources/dom-utils/hooks/__tests__/useScrollPosition.test.ts
+++ b/app/src/local-resources/dom-utils/hooks/__tests__/useScrollPosition.test.ts
@@ -1,0 +1,76 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { useScrollPosition } from '../useScrollPosition'
+
+describe('useScrollPosition', () => {
+  const mockObserve = vi.fn()
+  const mockDisconnect = vi.fn()
+  let intersectionCallback: (entries: IntersectionObserverEntry[]) => void
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      vi.fn(callback => {
+        intersectionCallback = callback
+        return {
+          observe: mockObserve,
+          disconnect: mockDisconnect,
+          unobserve: vi.fn(),
+        }
+      })
+    )
+  })
+
+  it('should return initial state and ref', () => {
+    const { result } = renderHook(() => useScrollPosition())
+
+    expect(result.current.isScrolled).toBe(false)
+    expect(result.current.scrollRef).toBeDefined()
+    expect(result.current.scrollRef.current).toBe(null)
+  })
+
+  it('should observe when ref is set', async () => {
+    const { result } = renderHook(() => useScrollPosition())
+
+    const div = document.createElement('div')
+
+    await act(async () => {
+      // @ts-expect-error we're forcibly setting readonly ref
+      result.current.scrollRef.current = div
+
+      const observer = new IntersectionObserver(intersectionCallback)
+      observer.observe(div)
+    })
+
+    expect(mockObserve).toHaveBeenCalledWith(div)
+  })
+
+  it('should update isScrolled when intersection changes for both scrolled and unscrolled cases', () => {
+    const { result } = renderHook(() => useScrollPosition())
+
+    act(() => {
+      intersectionCallback([
+        { isIntersecting: false } as IntersectionObserverEntry,
+      ])
+    })
+
+    expect(result.current.isScrolled).toBe(true)
+
+    act(() => {
+      intersectionCallback([
+        { isIntersecting: true } as IntersectionObserverEntry,
+      ])
+    })
+
+    expect(result.current.isScrolled).toBe(false)
+  })
+
+  it('should disconnect observer on unmount', () => {
+    const { unmount } = renderHook(() => useScrollPosition())
+
+    unmount()
+
+    expect(mockDisconnect).toHaveBeenCalled()
+  })
+})

--- a/app/src/local-resources/dom-utils/hooks/index.ts
+++ b/app/src/local-resources/dom-utils/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useScrollPosition'

--- a/app/src/local-resources/dom-utils/hooks/useScrollPosition.ts
+++ b/app/src/local-resources/dom-utils/hooks/useScrollPosition.ts
@@ -1,0 +1,27 @@
+import { useRef, useState, useEffect } from 'react'
+
+import type { RefObject } from 'react'
+
+export function useScrollPosition(): {
+  scrollRef: RefObject<HTMLDivElement>
+  isScrolled: boolean
+} {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [isScrolled, setIsScrolled] = useState<boolean>(false)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsScrolled(!entry.isIntersecting)
+    })
+
+    if (scrollRef.current != null) {
+      observer.observe(scrollRef.current)
+    }
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  return { scrollRef, isScrolled }
+}

--- a/app/src/local-resources/dom-utils/index.ts
+++ b/app/src/local-resources/dom-utils/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks'

--- a/app/src/organisms/ODD/Navigation/__tests__/Navigation.test.tsx
+++ b/app/src/organisms/ODD/Navigation/__tests__/Navigation.test.tsx
@@ -10,30 +10,14 @@ import { mockConnectedRobot } from '/app/redux/discovery/__fixtures__'
 import { useNetworkConnection } from '/app/resources/networking/hooks/useNetworkConnection'
 import { NavigationMenu } from '../NavigationMenu'
 import { Navigation } from '..'
+import { useScrollPosition } from '/app/local-resources/dom-utils'
 
 vi.mock('/app/resources/networking/hooks/useNetworkConnection')
 vi.mock('/app/redux/discovery')
 vi.mock('../NavigationMenu')
+vi.mock('/app/local-resources/dom-utils')
 
 mockConnectedRobot.name = '12345678901234567'
-
-class MockIntersectionObserver {
-  observe = vi.fn()
-  disconnect = vi.fn()
-  unobserve = vi.fn()
-}
-
-Object.defineProperty(window, 'IntersectionObserver', {
-  writable: true,
-  configurable: true,
-  value: MockIntersectionObserver,
-})
-
-Object.defineProperty(global, 'IntersectionObserver', {
-  writable: true,
-  configurable: true,
-  value: MockIntersectionObserver,
-})
 
 const render = (props: React.ComponentProps<typeof Navigation>) => {
   return renderWithProviders(
@@ -55,6 +39,10 @@ describe('Navigation', () => {
       isWifiConnected: false,
       isUsbConnected: false,
       connectionStatus: 'Not connected',
+    })
+    vi.mocked(useScrollPosition).mockReturnValue({
+      isScrolled: false,
+      scrollRef: {} as any,
     })
   })
   it('should render text and they have attribute', () => {

--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -27,6 +27,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import { ODD_FOCUS_VISIBLE } from '/app/atoms/buttons/constants'
+import { useScrollPosition } from '/app/local-resources/dom-utils'
 
 import { useNetworkConnection } from '/app/resources/networking/hooks/useNetworkConnection'
 import { getLocalRobot } from '/app/redux/discovery'
@@ -92,15 +93,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
     setShowNavMenu(openMenu)
   }
 
-  const scrollRef = React.useRef<HTMLDivElement>(null)
-  const [isScrolled, setIsScrolled] = React.useState<boolean>(false)
-
-  const observer = new IntersectionObserver(([entry]) => {
-    setIsScrolled(!entry.isIntersecting)
-  })
-  if (scrollRef.current != null) {
-    observer.observe(scrollRef.current)
-  }
+  const { scrollRef, isScrolled } = useScrollPosition()
 
   const navBarScrollRef = React.useRef<HTMLDivElement>(null)
   React.useEffect(() => {

--- a/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -24,21 +24,10 @@ import { Deck } from '../Deck'
 import { Hardware } from '../Hardware'
 import { Labware } from '../Labware'
 import { Parameters } from '../Parameters'
+import { useScrollPosition } from '/app/local-resources/dom-utils'
 
 import type { HostConfig } from '@opentrons/api-client'
 
-// Mock IntersectionObserver
-class IntersectionObserver {
-  observe = vi.fn()
-  disconnect = vi.fn()
-  unobserve = vi.fn()
-}
-
-Object.defineProperty(window, 'IntersectionObserver', {
-  writable: true,
-  configurable: true,
-  value: IntersectionObserver,
-})
 vi.mock(
   '/app/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters'
 )
@@ -55,6 +44,7 @@ vi.mock('../Hardware')
 vi.mock('../Labware')
 vi.mock('../Parameters')
 vi.mock('/app/redux/config')
+vi.mock('/app/local-resources/dom-utils')
 
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})
@@ -119,6 +109,10 @@ describe('ODDProtocolDetails', () => {
     vi.mocked(getProtocol).mockResolvedValue({
       data: { links: { referencingRuns: [{ id: '1' }, { id: '2' }] } },
     } as any)
+    vi.mocked(useScrollPosition).mockReturnValue({
+      isScrolled: false,
+      scrollRef: {} as any,
+    })
   })
   afterEach(() => {
     vi.resetAllMocks()

--- a/app/src/pages/ODD/ProtocolDetails/index.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState } from 'react'
 import last from 'lodash/last'
 import { useTranslation } from 'react-i18next'
 import { useQueryClient } from 'react-query'
@@ -56,6 +56,7 @@ import { Hardware } from './Hardware'
 import { Labware } from './Labware'
 import { Liquids } from './Liquids'
 import { formatTimeWithUtcLabel } from '/app/resources/runs'
+import { useScrollPosition } from '/app/local-resources/dom-utils'
 
 import type { Protocol } from '@opentrons/api-client'
 import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
@@ -335,14 +336,7 @@ export function ProtocolDetails(): JSX.Element | null {
   })
 
   // Watch for scrolling to toggle dropshadow
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const [isScrolled, setIsScrolled] = useState<boolean>(false)
-  const observer = new IntersectionObserver(([entry]) => {
-    setIsScrolled(!entry.isIntersecting)
-  })
-  if (scrollRef.current != null) {
-    observer.observe(scrollRef.current)
-  }
+  const { scrollRef, isScrolled } = useScrollPosition()
 
   let pinnedProtocolIds = useSelector(getPinnedProtocolIds) ?? []
   const pinned = pinnedProtocolIds.includes(protocolId)

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -64,22 +64,11 @@ import {
 } from '/app/resources/runs'
 import { mockConnectableRobot } from '/app/redux/discovery/__fixtures__'
 import { mockRunTimeParameterData } from '/app/organisms/ODD/ProtocolSetup/__fixtures__'
+import { useScrollPosition } from '/app/local-resources/dom-utils'
 
 import type { UseQueryResult } from 'react-query'
 import type * as SharedData from '@opentrons/shared-data'
 import type { NavigateFunction } from 'react-router-dom'
-// Mock IntersectionObserver
-class IntersectionObserver {
-  observe = vi.fn()
-  disconnect = vi.fn()
-  unobserve = vi.fn()
-}
-
-Object.defineProperty(window, 'IntersectionObserver', {
-  writable: true,
-  configurable: true,
-  value: IntersectionObserver,
-})
 
 let mockNavigate = vi.fn()
 
@@ -125,6 +114,7 @@ vi.mock('../ConfirmSetupStepsCompleteModal')
 vi.mock('/app/redux-resources/analytics')
 vi.mock('/app/redux-resources/robots')
 vi.mock('/app/resources/modules')
+vi.mock('/app/local-resources/dom-utils')
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -334,6 +324,10 @@ describe('ProtocolSetup', () => {
     when(vi.mocked(useTrackProtocolRunEvent))
       .calledWith(RUN_ID, ROBOT_NAME)
       .thenReturn({ trackProtocolRunEvent: mockTrackProtocolRunEvent })
+    vi.mocked(useScrollPosition).mockReturnValue({
+      isScrolled: false,
+      scrollRef: {} as any,
+    })
   })
 
   it('should render text, image, and buttons', () => {

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -81,6 +81,7 @@ import {
   useModuleCalibrationStatus,
   useProtocolAnalysisErrors,
 } from '/app/resources/runs'
+import { useScrollPosition } from '/app/local-resources/dom-utils'
 
 import type { Run } from '@opentrons/api-client'
 import type { CutoutFixtureId, CutoutId } from '@opentrons/shared-data'
@@ -129,14 +130,7 @@ function PrepareToRun({
   const { t, i18n } = useTranslation(['protocol_setup', 'shared'])
   const navigate = useNavigate()
   const { makeSnackbar } = useToaster()
-  const scrollRef = React.useRef<HTMLDivElement>(null)
-  const [isScrolled, setIsScrolled] = React.useState<boolean>(false)
-  const observer = new IntersectionObserver(([entry]) => {
-    setIsScrolled(!entry.isIntersecting)
-  })
-  if (scrollRef.current != null) {
-    observer.observe(scrollRef.current)
-  }
+  const { scrollRef, isScrolled } = useScrollPosition()
 
   const protocolId = runRecord?.data?.protocolId ?? null
   const { data: protocolRecord } = useProtocolQuery(protocolId, {

--- a/app/src/pages/ODD/QuickTransferDetails/__tests__/QuickTransferDetails.test.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/__tests__/QuickTransferDetails.test.tsx
@@ -26,21 +26,10 @@ import { QuickTransferDetails } from '..'
 import { Deck } from '../Deck'
 import { Hardware } from '../Hardware'
 import { Labware } from '../Labware'
+import { useScrollPosition } from '/app/local-resources/dom-utils'
 
 import type { HostConfig } from '@opentrons/api-client'
 
-// Mock IntersectionObserver
-class IntersectionObserver {
-  observe = vi.fn()
-  disconnect = vi.fn()
-  unobserve = vi.fn()
-}
-
-Object.defineProperty(window, 'IntersectionObserver', {
-  writable: true,
-  configurable: true,
-  value: IntersectionObserver,
-})
 vi.mock('/app/organisms/ODD/ProtocolSetup/ProtocolSetupParameters')
 vi.mock('@opentrons/api-client')
 vi.mock('@opentrons/react-api-client')
@@ -55,6 +44,7 @@ vi.mock('../Deck')
 vi.mock('../Hardware')
 vi.mock('../Labware')
 vi.mock('/app/redux/config')
+vi.mock('/app/local-resources/dom-utils')
 
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})
@@ -125,6 +115,10 @@ describe('ODDQuickTransferDetails', () => {
       },
     } as any)
     when(vi.mocked(useHost)).calledWith().thenReturn(MOCK_HOST_CONFIG)
+    vi.mocked(useScrollPosition).mockReturnValue({
+      isScrolled: false,
+      scrollRef: {} as any,
+    })
   })
   afterEach(() => {
     vi.resetAllMocks()

--- a/app/src/pages/ODD/QuickTransferDetails/index.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import last from 'lodash/last'
 import { useTranslation } from 'react-i18next'
 import { useQueryClient } from 'react-query'
@@ -57,6 +57,7 @@ import { Deck } from './Deck'
 import { Hardware } from './Hardware'
 import { Labware } from './Labware'
 import { formatTimeWithUtcLabel } from '/app/resources/runs'
+import { useScrollPosition } from '/app/local-resources/dom-utils'
 
 import type { Protocol } from '@opentrons/api-client'
 import type { Dispatch } from '/app/redux/types'
@@ -321,14 +322,7 @@ export function QuickTransferDetails(): JSX.Element | null {
   })
 
   // Watch for scrolling to toggle dropshadow
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const [isScrolled, setIsScrolled] = useState<boolean>(false)
-  const observer = new IntersectionObserver(([entry]) => {
-    setIsScrolled(!entry.isIntersecting)
-  })
-  if (scrollRef.current != null) {
-    observer.observe(scrollRef.current)
-  }
+  const { scrollRef, isScrolled } = useScrollPosition()
 
   let pinnedTransferIds = useSelector(getPinnedQuickTransferIds) ?? []
   const pinned = pinnedTransferIds.includes(transferId)


### PR DESCRIPTION
Works toward [EXEC-807](https://opentrons.atlassian.net/browse/EXEC-807)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We have this code in the ODD that runs every render cycle on a lot of the "idle" views. We instantiate a new observer on every render, and the old observer is never cleaned up. This leads to the following:

https://github.com/user-attachments/assets/e76a04cb-a564-496f-8712-29a9e923e632

Although I don't have the heap snapshots for some other robots, `IntersectionObserver` leaks seem to be one of the more egregious leaks, and I'd sometimes see a 100x increase in the number of these observers in about 10 minutes.

We might have more memory issues than just this by going through the heap snapshots and other profiling tools, but this is a start!

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified the scrolling still works as expected on refactored screens.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a memory issue on the ODD.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-807]: https://opentrons.atlassian.net/browse/EXEC-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ