### PR TITLE
feat(api): add labware-scope liquid loading api

### DIFF
--- a/api/docs/v2/parameters/use_case_sample_count.rst
+++ b/api/docs/v2/parameters/use_case_sample_count.rst
@@ -166,7 +166,7 @@ Now we'll bring sample count into consideration as we :ref:`load the liquids <lo
     * - Tagmentation Wash Buffer
       - 900
 
-To calculate the total volume for each liquid, we'll multiply these numbers by ``column_count`` and by 1.1 (to ensure that the pipette can aspirate the required volume without drawing in air at the bottom of the well). This calculation can be done inline as the ``volume`` value of :py:meth:`~Well.load_liquid`::
+To calculate the total volume for each liquid, we'll multiply these numbers by ``column_count`` and by 1.1 (to ensure that the pipette can aspirate the required volume without drawing in air at the bottom of the well). This calculation can be done inline as the ``volume`` value of :py:meth:`~.Well.load_liquid`::
 
     reservoir["A1"].load_liquid(
         liquid=ampure_liquid, volume=180 * column_count * 1.1

--- a/api/docs/v2/parameters/use_case_sample_count.rst
+++ b/api/docs/v2/parameters/use_case_sample_count.rst
@@ -166,7 +166,7 @@ Now we'll bring sample count into consideration as we :ref:`load the liquids <lo
     * - Tagmentation Wash Buffer
       - 900
 
-To calculate the total volume for each liquid, we'll multiply these numbers by ``column_count`` and by 1.1 (to ensure that the pipette can aspirate the required volume without drawing in air at the bottom of the well). This calculation can be done inline as the ``volume`` value of :py:meth:`.load_liquid`::
+To calculate the total volume for each liquid, we'll multiply these numbers by ``column_count`` and by 1.1 (to ensure that the pipette can aspirate the required volume without drawing in air at the bottom of the well). This calculation can be done inline as the ``volume`` value of :py:meth:`~Well.load_liquid`::
 
     reservoir["A1"].load_liquid(
         liquid=ampure_liquid, volume=180 * column_count * 1.1

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -1,5 +1,6 @@
 """ProtocolEngine-based Labware core implementations."""
-from typing import List, Optional, cast
+
+from typing import List, Optional, cast, Dict
 
 from opentrons_shared_data.labware.types import (
     LabwareParameters as LabwareParametersDict,
@@ -22,7 +23,9 @@ from opentrons.protocol_engine.types import (
 from opentrons.types import DeckSlotName, Point, NozzleMapInterface
 
 
+from ..._liquid import Liquid
 from ..labware import AbstractLabware, LabwareLoadParams
+
 from .well import WellCore
 
 
@@ -194,3 +197,21 @@ class LabwareCore(AbstractLabware[WellCore]):
             LocationIsStagingSlotError,
         ):
             return None
+
+    def load_liquid(self, volumes: Dict[str, float], liquid: Liquid) -> None:
+        """Load liquid into wells of the labware."""
+        self._engine_client.execute_command(
+            cmd.LoadLiquidParams(
+                labwareId=self._labware_id, liquidId=liquid._id, volumeByWell=volumes
+            )
+        )
+
+    def load_empty(self, wells: List[str]) -> None:
+        """Mark wells of the labware as empty."""
+        self._engine_client.execute_command(
+            cmd.LoadLiquidParams(
+                labwareId=self._labware_id,
+                liquidId="EMPTY",
+                volumeByWell={well: 0.0 for well in wells},
+            )
+        )

--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -142,22 +142,6 @@ class WellCore(AbstractWellCore):
             )
         )
 
-    def load_empty(
-        self,
-    ) -> None:
-        """Inform the system that a well is known to be empty.
-
-        This should be done early in the protocol, at the same time as a load_liquid command might
-        be used.
-        """
-        self._engine_client.execute_command(
-            cmd.LoadLiquidParams(
-                labwareId=self._labware_id,
-                liquidId="EMPTY",
-                volumeByWell={self._name: 0.0},
-            )
-        )
-
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """Gets point in deck coordinates based on percentage of the radius of each axis."""
         well_size = self._engine_client.state.labware.get_well_size(

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -1,8 +1,9 @@
 """The interface that implements InstrumentContext."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, List, NamedTuple, Optional, TypeVar
+from typing import Any, Generic, List, NamedTuple, Optional, TypeVar, Dict
 
 from opentrons_shared_data.labware.types import (
     LabwareUri,
@@ -11,6 +12,7 @@ from opentrons_shared_data.labware.types import (
 )
 
 from opentrons.types import DeckSlotName, Point, NozzleMapInterface
+from .._liquid import Liquid
 
 from .well import WellCoreType
 
@@ -128,6 +130,14 @@ class AbstractLabware(ABC, Generic[WellCoreType]):
     @abstractmethod
     def get_deck_slot(self) -> Optional[DeckSlotName]:
         """Get the deck slot the labware or its parent is in, if any."""
+
+    @abstractmethod
+    def load_liquid(self, volumes: Dict[str, float], liquid: Liquid) -> None:
+        """Load liquid into wells of the labware."""
+
+    @abstractmethod
+    def load_empty(self, wells: List[str]) -> None:
+        """Mark wells of the labware as empty."""
 
 
 LabwareCoreType = TypeVar("LabwareCoreType", bound=AbstractLabware[Any])

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from opentrons.calibration_storage import helpers
 from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
@@ -8,6 +8,7 @@ from opentrons.types import DeckSlotName, Location, Point, NozzleMapInterface
 
 from opentrons_shared_data.labware.types import LabwareParameters, LabwareDefinition
 
+from ..._liquid import Liquid
 from ..labware import AbstractLabware, LabwareLoadParams
 from .legacy_well_core import LegacyWellCore
 from .well_geometry import WellGeometry
@@ -215,3 +216,11 @@ class LegacyLabwareCore(AbstractLabware[LegacyWellCore]):
         """Get the deck slot the labware is in, if in a deck slot."""
         slot = self._geometry.parent.labware.first_parent()
         return DeckSlotName.from_primitive(slot) if slot is not None else None
+
+    def load_liquid(self, volumes: Dict[str, float], liquid: Liquid) -> None:
+        """Load liquid into wells of the labware."""
+        assert False, "load_liquid only supported in API version 2.22 & later"
+
+    def load_empty(self, wells: List[str]) -> None:
+        """Mark wells of the labware as empty."""
+        assert False, "load_empty only supported in API version 2.22 & later"

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_well_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_well_core.py
@@ -114,10 +114,6 @@ class LegacyWellCore(AbstractWellCore):
         """Load liquid into a well."""
         raise APIVersionError(api_element="Loading a liquid")
 
-    def load_empty(self) -> None:
-        """Mark a well as empty."""
-        assert False, "load_empty only supported on engine core"
-
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """Gets point in deck coordinates based on percentage of the radius of each axis."""
         return self._geometry.from_center_cartesian(x, y, z)

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -80,10 +80,6 @@ class AbstractWellCore(ABC):
         """Load liquid into a well."""
 
     @abstractmethod
-    def load_empty(self) -> None:
-        """Mark a well as containing no liquid."""
-
-    @abstractmethod
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """Gets point in deck coordinates based on percentage of the radius of each axis."""
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1166,7 +1166,11 @@ class Labware:
                 well_names.append(well.well_name)
             else:
                 raise TypeError(
-                    "The elements of wells should be Well instances or well names."
+                    f"Unexpected type for element {repr(well)}. The elements of wells should be Well instances or well names."
+                )
+            if not isinstance(volume, (float, int)):
+                raise TypeError(
+                    f"Unexpected type for volume {repr(volume)}. Volume should be a number in microliters."
                 )
         self._core.load_liquid({well_name: volume for well_name in well_names}, liquid)
 
@@ -1211,7 +1215,11 @@ class Labware:
                 verified_volumes[well.well_name] = volume
             else:
                 raise TypeError(
-                    "The elements of wells should be Well instances or well names."
+                    f"Unexpected type for well name {repr(well)}. The keys of volumes should be Well instances or well names."
+                )
+            if not isinstance(volume, (float, int)):
+                raise TypeError(
+                    f"Unexpected type for volume {repr(volume)}. The values of volumes should be numbers in microliters."
                 )
         self._core.load_liquid(verified_volumes, liquid)
 
@@ -1235,18 +1243,18 @@ class Labware:
             if isinstance(well, str):
                 if well not in self:
                     raise KeyError(
-                        "The elements of wells should name wells in this labware."
+                        f"{well} is not a well in {self.name}. The elements of wells should name wells in this labware."
                     )
                 well_names.append(well)
             elif isinstance(well, Well):
                 if well.parent is not self:
                     raise KeyError(
-                        "The elements of wells should be wells of this labware."
+                        f"{well.well_name} is not a well in {self.name}. The elements of wells should be wells of this labware."
                     )
                 well_names.append(well.well_name)
             else:
                 raise TypeError(
-                    "The elements of wells should be Well instances or well names."
+                    f"Unexpected type for well name {repr(well)}. The elements of wells should be Well instances or well names."
                 )
         self._core.load_empty(well_names)
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -406,9 +406,6 @@ class Labware:
     def __getitem__(self, key: str) -> Well:
         return self.wells_by_name()[key]
 
-    def __contains__(self, key: str) -> bool:
-        return key in self.wells_by_name()
-
     @property
     @requires_version(2, 0)
     def uri(self) -> str:
@@ -1153,7 +1150,7 @@ class Labware:
         well_names: List[str] = []
         for well in wells:
             if isinstance(well, str):
-                if well not in self:
+                if well not in self.wells_by_name():
                     raise KeyError(
                         f"{well} is not a well in labware {self.name}. The elements of wells should name wells in this labware."
                     )
@@ -1202,7 +1199,7 @@ class Labware:
         verified_volumes: Dict[str, float] = {}
         for well, volume in volumes.items():
             if isinstance(well, str):
-                if well not in self:
+                if well not in self.wells_by_name():
                     raise KeyError(
                         f"{well} is not a well in {self.name}. The keys of volumes should name wells in this labware"
                     )
@@ -1241,7 +1238,7 @@ class Labware:
         well_names: List[str] = []
         for well in wells:
             if isinstance(well, str):
-                if well not in self:
+                if well not in self.wells_by_name():
                     raise KeyError(
                         f"{well} is not a well in {self.name}. The elements of wells should name wells in this labware."
                     )

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1,4 +1,4 @@
-""" opentrons.protocol_api.labware: classes and functions for labware handling
+"""opentrons.protocol_api.labware: classes and functions for labware handling
 
 This module provides things like :py:class:`Labware`, and :py:class:`Well`
 to encapsulate labware instances used in protocols
@@ -13,7 +13,18 @@ from __future__ import annotations
 import logging
 
 from itertools import dropwhile
-from typing import TYPE_CHECKING, Any, List, Dict, Optional, Union, Tuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    List,
+    Dict,
+    Optional,
+    Union,
+    Tuple,
+    cast,
+    Sequence,
+    Mapping,
+)
 
 from opentrons_shared_data.labware.types import LabwareDefinition, LabwareParameters
 
@@ -281,18 +292,14 @@ class Well:
         :param Liquid liquid: The liquid to load into the well.
         :param float volume: The volume of liquid to load, in µL.
 
-        .. note::
-            In API version 2.22 and later, use :py:meth:`~.Well.load_empty()` to mark a well as empty at the beginning of a protocol, rather than using this method with ``volume=0``.
+        .. deprecated:: 2.22
+            In API version 2.22 and later, use :py:meth:`~Labware.load_liquid`, :py:meth:`~Labware.load_liquid_by_well`,
+            or :py:meth:`~Labware.load_empty` to load liquid into a well.
         """
         self._core.load_liquid(
             liquid=liquid,
             volume=volume,
         )
-
-    @requires_version(2, 22)
-    def load_empty(self) -> None:
-        """Mark a well as empty."""
-        self._core.load_empty()
 
     def _from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """
@@ -398,6 +405,9 @@ class Labware:
 
     def __getitem__(self, key: str) -> Well:
         return self.wells_by_name()[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.wells_by_name()
 
     @property
     @requires_version(2, 0)
@@ -1112,6 +1122,133 @@ class Labware:
             a tip rack. Formerly, it would do nothing.
         """
         self._core.reset_tips()
+
+    @requires_version(2, 22)
+    def load_liquid(
+        self, wells: Sequence[Union[str, Well]], volume: float, liquid: Liquid
+    ) -> None:
+        """Mark several wells as containing the same amount of liquid.
+
+        This method should be called at the beginning of a protocol, soon after loading the labware and before
+        liquid handling operations begin. It is a base of information for liquid tracking functionality. If a well in a labware
+        has not been named in a call to :py:meth:`~Labware.load_empty`, :py:meth:`~Labware.load_liquid`, or
+        :py:meth:`~Labware.load_liquid_by_well`, the volume it contains is unknown and the well's liquid will not be tracked.
+
+        For example, to load 10µL of a liquid named ``water`` (defined with :py:meth:`~ProtocolContext.load_liquid`)
+        into all the wells of a labware, you could call ``labware.load_liquid(labware.wells(), 10, water)``.
+
+        If you want to load different volumes of liquid into different wells, use :py:meth:`~Labware.load_liquid_by_well`.
+
+        If you want to mark the well as containing no liquid, use :py:meth:`~Labware.load_empty`.
+
+        :param wells: The wells to load the liquid into.
+        :type wells: List of well names or list of Well objects, for instance from :py:meth:`~Labware.wells`.
+
+        :param volume: The volume of liquid to load into each well, in 10µL.
+        :type volume: float
+
+        :param liquid: The liquid to load into each well, previously defined by :py:meth:`~ProtocolContext.load_liquid`
+        :type liquid: Liquid
+        """
+        well_names: List[str] = []
+        for well in wells:
+            if isinstance(well, str):
+                if well not in self:
+                    raise KeyError(
+                        "The elements of wells should name wells in this labware."
+                    )
+                well_names.append(well)
+            elif isinstance(well, Well):
+                if well.parent is not self:
+                    raise KeyError(
+                        "The elements of wells should be wells of this labware."
+                    )
+                well_names.append(well.well_name)
+            else:
+                raise TypeError(
+                    "The elements of wells should be Well instances or well names."
+                )
+        self._core.load_liquid({well_name: volume for well_name in well_names}, liquid)
+
+    @requires_version(2, 22)
+    def load_liquid_by_well(
+        self, volumes: Mapping[Union[str, Well], float], liquid: Liquid
+    ) -> None:
+        """Mark several wells as containing unique volumes of liquid.
+
+        This method should be called at the beginning of a protocol, soon after loading the labware and before
+        liquid handling operations begin. It is a base of information for liquid tracking functionality. If a well in a labware
+        has not been named in a call to :py:meth:`~Labware.load_empty`, :py:meth:`~Labware.load_liquid`, or
+        :py:meth:`~Labware.load_liquid_by_well`, the volume it contains is unknown and the well's liquid will not be tracked.
+
+        For example, to load a decreasing amount of of a liquid named ``water`` (defined with :py:meth:`~ProtocolContext.load_liquid`)
+        into each successive well of a row, you could call
+        ``labware.load_liquid_by_well({'A1': 1000, 'A2': 950, 'A3': 900, ..., 'A12': 600}, water)``
+
+        If you want to load the same volume of a liquid into multiple wells, it is often easier to use :py:meth:`~Labware.load_liquid`.
+
+        If you want to mark the well as containing no liquid, use :py:meth:`~Labware.load_empty`.
+
+        :param volumes: A dictionary of well names (or :py:class:`Well` objects, for instance from ``labware['A1']``)
+        :type wells: Dict[Union[str, Well], float]
+
+        :param liquid: The liquid to load into each well, previously defined by :py:meth:`~ProtocolContext.load_liquid`
+        :type liquid: Liquid
+        """
+        verified_volumes: Dict[str, float] = {}
+        for well, volume in volumes.items():
+            if isinstance(well, str):
+                if well not in self:
+                    raise KeyError(
+                        "The keys of volumes should name wells in this labware"
+                    )
+                verified_volumes[well] = volume
+            elif isinstance(well, Well):
+                if well.parent is not self:
+                    raise KeyError(
+                        "The keys of volumes should be wells of this labware"
+                    )
+                verified_volumes[well.well_name] = volume
+            else:
+                raise TypeError(
+                    "The elements of wells should be Well instances or well names."
+                )
+        self._core.load_liquid(verified_volumes, liquid)
+
+    @requires_version(2, 22)
+    def load_empty(self, wells: Sequence[Union[Well, str]]) -> None:
+        """Mark several wells as empty.
+
+        This method should be called at the beginning of a protocol, soon after loading the labware and before liquid handling
+        operations begin. It is a base of information for liquid tracking functionality. If a well in a labware has not been named
+        in a call to :py:meth:`Labware.load_empty`, :py:meth:`Labware.load_liquid`, or :py:meth:`Labware.load_liquid_by_well`, the
+        volume it contains is unknown and the well's liquid will not be tracked.
+
+        For instance, to mark all wells in the labware as empty, you can call ``labware.load_empty(labware.wells())``.
+
+        :param wells: The list of wells to mark empty. To mark all wells as empty, pass ``labware.wells()``. You can also specify
+                      wells by their names (for instance, ``labware.load_empty(['A1', 'A2'])``).
+        :type wells: Union[List[Well], List[str]]
+        """
+        well_names: List[str] = []
+        for well in wells:
+            if isinstance(well, str):
+                if well not in self:
+                    raise KeyError(
+                        "The elements of wells should name wells in this labware."
+                    )
+                well_names.append(well)
+            elif isinstance(well, Well):
+                if well.parent is not self:
+                    raise KeyError(
+                        "The elements of wells should be wells of this labware."
+                    )
+                well_names.append(well.well_name)
+            else:
+                raise TypeError(
+                    "The elements of wells should be Well instances or well names."
+                )
+        self._core.load_empty(well_names)
 
 
 # TODO(mc, 2022-11-09): implementation detail, move to core

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1134,7 +1134,7 @@ class Labware:
         has not been named in a call to :py:meth:`~Labware.load_empty`, :py:meth:`~Labware.load_liquid`, or
         :py:meth:`~Labware.load_liquid_by_well`, the volume it contains is unknown and the well's liquid will not be tracked.
 
-        For example, to load 10µL of a liquid named ``water`` (defined with :py:meth:`~ProtocolContext.load_liquid`)
+        For example, to load 10µL of a liquid named ``water`` (defined with :py:meth:`~ProtocolContext.define_liquid`)
         into all the wells of a labware, you could call ``labware.load_liquid(labware.wells(), 10, water)``.
 
         If you want to load different volumes of liquid into different wells, use :py:meth:`~Labware.load_liquid_by_well`.
@@ -1147,7 +1147,7 @@ class Labware:
         :param volume: The volume of liquid to load into each well, in 10µL.
         :type volume: float
 
-        :param liquid: The liquid to load into each well, previously defined by :py:meth:`~ProtocolContext.load_liquid`
+        :param liquid: The liquid to load into each well, previously defined by :py:meth:`~ProtocolContext.define_liquid`
         :type liquid: Liquid
         """
         well_names: List[str] = []
@@ -1181,7 +1181,7 @@ class Labware:
         has not been named in a call to :py:meth:`~Labware.load_empty`, :py:meth:`~Labware.load_liquid`, or
         :py:meth:`~Labware.load_liquid_by_well`, the volume it contains is unknown and the well's liquid will not be tracked.
 
-        For example, to load a decreasing amount of of a liquid named ``water`` (defined with :py:meth:`~ProtocolContext.load_liquid`)
+        For example, to load a decreasing amount of of a liquid named ``water`` (defined with :py:meth:`~ProtocolContext.define_liquid`)
         into each successive well of a row, you could call
         ``labware.load_liquid_by_well({'A1': 1000, 'A2': 950, 'A3': 900, ..., 'A12': 600}, water)``
 
@@ -1192,7 +1192,7 @@ class Labware:
         :param volumes: A dictionary of well names (or :py:class:`Well` objects, for instance from ``labware['A1']``)
         :type wells: Dict[Union[str, Well], float]
 
-        :param liquid: The liquid to load into each well, previously defined by :py:meth:`~ProtocolContext.load_liquid`
+        :param liquid: The liquid to load into each well, previously defined by :py:meth:`~ProtocolContext.define_liquid`
         :type liquid: Liquid
         """
         verified_volumes: Dict[str, float] = {}

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1155,13 +1155,13 @@ class Labware:
             if isinstance(well, str):
                 if well not in self:
                     raise KeyError(
-                        "The elements of wells should name wells in this labware."
+                        f"{well} is not a well in labware {self.name}. The elements of wells should name wells in this labware."
                     )
                 well_names.append(well)
             elif isinstance(well, Well):
                 if well.parent is not self:
                     raise KeyError(
-                        "The elements of wells should be wells of this labware."
+                        f"{well.well_name} is not a well in labware {self.name}. The elements of wells should be wells of this labware."
                     )
                 well_names.append(well.well_name)
             else:
@@ -1200,13 +1200,13 @@ class Labware:
             if isinstance(well, str):
                 if well not in self:
                     raise KeyError(
-                        "The keys of volumes should name wells in this labware"
+                        f"{well} is not a well in {self.name}. The keys of volumes should name wells in this labware"
                     )
                 verified_volumes[well] = volume
             elif isinstance(well, Well):
                 if well.parent is not self:
                     raise KeyError(
-                        "The keys of volumes should be wells of this labware"
+                        f"{well.well_name} is not a well in {self.name}. The keys of volumes should be wells of this labware"
                     )
                 verified_volumes[well.well_name] = volume
             else:

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -1,4 +1,5 @@
 """Tests for the InstrumentContext public interface."""
+
 import inspect
 from typing import cast
 
@@ -21,6 +22,7 @@ from opentrons.protocol_api.core.common import (
 from opentrons.protocol_api.core.labware import LabwareLoadParams
 from opentrons.protocol_api.core.core_map import LoadedCoreMap
 from opentrons.protocol_api import TemperatureModuleContext
+from opentrons.protocol_api._liquid import Liquid
 
 from opentrons.types import Point
 
@@ -364,3 +366,313 @@ def test_separate_calibration_raises_on_high_api_version(
     """It should raise an error, on high API versions."""
     with pytest.raises(UnsupportedAPIError):
         subject.separate_calibration
+
+
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))
+def test_load_liquid_handles_valid_inputs(
+    decoy: Decoy,
+    mock_labware_core: LabwareCore,
+    api_version: APIVersion,
+    mock_protocol_core: ProtocolCore,
+    mock_map_core: LoadedCoreMap,
+) -> None:
+    """It should load volumes for list of wells."""
+    mock_well_core_1 = decoy.mock(cls=WellCore)
+    mock_well_core_2 = decoy.mock(cls=WellCore)
+    grid = well_grid.WellGrid(
+        columns_by_name={"1": ["A1", "B1"]},
+        rows_by_name={"A": ["A1"], "B": ["B1"]},
+    )
+    decoy.when(mock_well_core_1.get_name()).then_return("A1")
+    decoy.when(mock_well_core_2.get_name()).then_return("B1")
+
+    decoy.when(mock_labware_core.get_well_columns()).then_return([["A1", "B1"]])
+    decoy.when(mock_labware_core.get_well_core("A1")).then_return(mock_well_core_1)
+    decoy.when(mock_labware_core.get_well_core("B1")).then_return(mock_well_core_2)
+    decoy.when(well_grid.create([["A1", "B1"]])).then_return(grid)
+
+    subject = Labware(
+        core=mock_labware_core,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+    mock_liquid = decoy.mock(cls=Liquid)
+
+    subject.load_liquid(["A1", subject["B1"]], 10, mock_liquid)
+    decoy.verify(
+        mock_labware_core.load_liquid(
+            {
+                "A1": 10,
+                "B1": 10,
+            },
+            mock_liquid,
+        )
+    )
+
+
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))
+def test_load_liquid_rejects_invalid_inputs(
+    decoy: Decoy,
+    mock_labware_core: LabwareCore,
+    api_version: APIVersion,
+    mock_protocol_core: ProtocolCore,
+    mock_map_core: LoadedCoreMap,
+) -> None:
+    """It should require valid load inputs."""
+    mock_well_core_1 = decoy.mock(cls=WellCore)
+    mock_well_core_2 = decoy.mock(cls=WellCore)
+
+    grid = well_grid.WellGrid(
+        columns_by_name={"1": ["A1", "B1"]},
+        rows_by_name={"A": ["A1"], "B": ["B1"]},
+    )
+    decoy.when(mock_well_core_1.get_name()).then_return("A1")
+    decoy.when(mock_well_core_2.get_name()).then_return("B1")
+    decoy.when(mock_labware_core.get_well_columns()).then_return([["A1", "B1"]])
+    decoy.when(mock_labware_core.get_well_core("A1")).then_return(mock_well_core_1)
+    decoy.when(mock_labware_core.get_well_core("B1")).then_return(mock_well_core_2)
+    decoy.when(well_grid.create([["A1", "B1"]])).then_return(grid)
+    subject = Labware(
+        core=mock_labware_core,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+
+    core_2 = decoy.mock(cls=LabwareCore)
+    mock_well_core_3 = decoy.mock(cls=WellCore)
+    grid_2 = well_grid.WellGrid(
+        columns_by_name={"1": ["A1"]}, rows_by_name={"A": ["A1"]}
+    )
+    decoy.when(mock_well_core_3.get_name()).then_return("A1")
+    decoy.when(core_2.get_well_columns()).then_return([["A1", "B1"]])
+    decoy.when(core_2.get_well_core("A1")).then_return(mock_well_core_1)
+    decoy.when(core_2.get_well_core("B1")).then_return(mock_well_core_2)
+
+    decoy.when(well_grid.create([["A1"]])).then_return(grid_2)
+    other_labware = Labware(
+        core=core_2,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+    mock_liquid = decoy.mock(cls=Liquid)
+    with pytest.raises(KeyError):
+        subject.load_liquid(["A1", "C1"], 10, mock_liquid)
+
+    with pytest.raises(KeyError):
+        subject.load_liquid([subject["A1"], other_labware["A1"]], 10, mock_liquid)
+
+    with pytest.raises(TypeError):
+        subject.load_liquid([2], 10, mock_liquid)  # type: ignore[list-item]
+
+    mock_liquid = decoy.mock(cls=Liquid)
+
+    subject.load_liquid(["A1", subject["B1"]], 10, mock_liquid)
+    decoy.verify(
+        mock_labware_core.load_liquid(
+            {
+                "A1": 10,
+                "B1": 10,
+            },
+            mock_liquid,
+        )
+    )
+
+
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))
+def test_load_liquid_by_well_handles_valid_inputs(
+    decoy: Decoy,
+    mock_labware_core: LabwareCore,
+    api_version: APIVersion,
+    mock_protocol_core: ProtocolCore,
+    mock_map_core: LoadedCoreMap,
+) -> None:
+    """It should load liquids of different volumes in different wells."""
+    mock_well_core_1 = decoy.mock(cls=WellCore)
+    mock_well_core_2 = decoy.mock(cls=WellCore)
+    grid = well_grid.WellGrid(
+        columns_by_name={"1": ["A1", "B1"]},
+        rows_by_name={"A": ["A1"], "B": ["B1"]},
+    )
+    decoy.when(mock_well_core_1.get_name()).then_return("A1")
+    decoy.when(mock_well_core_2.get_name()).then_return("B1")
+
+    decoy.when(mock_labware_core.get_well_columns()).then_return([["A1", "B1"]])
+    decoy.when(mock_labware_core.get_well_core("A1")).then_return(mock_well_core_1)
+    decoy.when(mock_labware_core.get_well_core("B1")).then_return(mock_well_core_2)
+    decoy.when(well_grid.create([["A1", "B1"]])).then_return(grid)
+    decoy.when(mock_well_core_2.get_display_name()).then_return("well 2")
+    subject = Labware(
+        core=mock_labware_core,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+    mock_liquid = decoy.mock(cls=Liquid)
+
+    subject.load_liquid_by_well({"A1": 10, subject["B1"]: 11}, mock_liquid)
+    decoy.verify(
+        mock_labware_core.load_liquid(
+            {
+                "A1": 10,
+                "B1": 11,
+            },
+            mock_liquid,
+        )
+    )
+
+
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))
+def test_load_liquid_by_well_rejects_invalid_inputs(
+    decoy: Decoy,
+    mock_labware_core: LabwareCore,
+    api_version: APIVersion,
+    mock_protocol_core: ProtocolCore,
+    mock_map_core: LoadedCoreMap,
+) -> None:
+    """It should require valid well specs."""
+    mock_well_core_1 = decoy.mock(cls=WellCore)
+    mock_well_core_2 = decoy.mock(cls=WellCore)
+
+    grid = well_grid.WellGrid(
+        columns_by_name={"1": ["A1", "B1"]},
+        rows_by_name={"A": ["A1"], "B": ["B1"]},
+    )
+    decoy.when(mock_well_core_1.get_name()).then_return("A1")
+    decoy.when(mock_well_core_2.get_name()).then_return("B1")
+    decoy.when(mock_well_core_1.get_display_name()).then_return("well 1")
+    decoy.when(mock_well_core_2.get_display_name()).then_return("well 2")
+    decoy.when(mock_well_core_1.get_top(z_offset=0.0)).then_return(Point(4, 5, 6))
+    decoy.when(mock_well_core_1.get_top(z_offset=0.0)).then_return(Point(7, 8, 9))
+    decoy.when(mock_labware_core.get_well_columns()).then_return([["A1", "B1"]])
+    decoy.when(mock_labware_core.get_well_core("A1")).then_return(mock_well_core_1)
+    decoy.when(mock_labware_core.get_well_core("B1")).then_return(mock_well_core_2)
+    decoy.when(well_grid.create([["A1", "B1"]])).then_return(grid)
+    subject = Labware(
+        core=mock_labware_core,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+    core_2 = decoy.mock(cls=LabwareCore)
+    mock_well_core_3 = decoy.mock(cls=WellCore)
+    decoy.when(mock_well_core_3.get_display_name()).then_return("well 3")
+    grid_2 = well_grid.WellGrid(
+        columns_by_name={"1": ["A1"]}, rows_by_name={"A": ["A1"]}
+    )
+    decoy.when(mock_well_core_3.get_name()).then_return("A1")
+    decoy.when(core_2.get_well_columns()).then_return([["A1"]])
+    decoy.when(core_2.get_well_core("A1")).then_return(mock_well_core_3)
+    decoy.when(mock_well_core_3.get_top(z_offset=0.0)).then_return(Point(1, 2, 3))
+
+    decoy.when(well_grid.create([["A1"]])).then_return(grid_2)
+    other_labware = Labware(
+        core=core_2,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+
+    mock_liquid = decoy.mock(cls=Liquid)
+    with pytest.raises(KeyError):
+        subject.load_liquid_by_well({"A1": 10, "C1": 11}, mock_liquid)
+
+    with pytest.raises(KeyError):
+        subject.load_liquid_by_well(
+            {subject["A1"]: 10, other_labware["A1"]: 11}, mock_liquid
+        )
+
+    with pytest.raises(TypeError):
+        subject.load_liquid_by_well({2: 10}, mock_liquid)  # type: ignore[dict-item]
+
+
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))
+def test_load_empty_handles_valid_inputs(
+    decoy: Decoy,
+    mock_labware_core: LabwareCore,
+    api_version: APIVersion,
+    mock_protocol_core: ProtocolCore,
+    mock_map_core: LoadedCoreMap,
+) -> None:
+    """It should load lists of wells as empty."""
+    mock_well_core_1 = decoy.mock(cls=WellCore)
+    mock_well_core_2 = decoy.mock(cls=WellCore)
+    grid = well_grid.WellGrid(
+        columns_by_name={"1": ["A1", "B1"]},
+        rows_by_name={"A": ["A1"], "B": ["B1"]},
+    )
+    decoy.when(mock_well_core_1.get_name()).then_return("A1")
+    decoy.when(mock_well_core_2.get_name()).then_return("B1")
+
+    decoy.when(mock_labware_core.get_well_columns()).then_return([["A1", "B1"]])
+    decoy.when(mock_labware_core.get_well_core("A1")).then_return(mock_well_core_1)
+    decoy.when(mock_labware_core.get_well_core("B1")).then_return(mock_well_core_2)
+    decoy.when(well_grid.create([["A1", "B1"]])).then_return(grid)
+
+    subject = Labware(
+        core=mock_labware_core,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+
+    subject.load_empty(["A1", subject["B1"]])
+    decoy.verify(mock_labware_core.load_empty(["A1", "B1"]))
+
+
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))
+def test_load_empty_rejects_invalid_inputs(
+    decoy: Decoy,
+    mock_labware_core: LabwareCore,
+    api_version: APIVersion,
+    mock_protocol_core: ProtocolCore,
+    mock_map_core: LoadedCoreMap,
+) -> None:
+    """It should require valid well specs."""
+    mock_well_core_1 = decoy.mock(cls=WellCore)
+    mock_well_core_2 = decoy.mock(cls=WellCore)
+
+    grid = well_grid.WellGrid(
+        columns_by_name={"1": ["A1", "B1"]},
+        rows_by_name={"A": ["A1"], "B": ["B1"]},
+    )
+    decoy.when(mock_well_core_1.get_name()).then_return("A1")
+    decoy.when(mock_well_core_2.get_name()).then_return("B1")
+    decoy.when(mock_labware_core.get_well_columns()).then_return([["A1", "B1"]])
+    decoy.when(mock_labware_core.get_well_core("A1")).then_return(mock_well_core_1)
+    decoy.when(mock_labware_core.get_well_core("B1")).then_return(mock_well_core_2)
+    decoy.when(well_grid.create([["A1", "B1"]])).then_return(grid)
+    subject = Labware(
+        core=mock_labware_core,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+
+    core_2 = decoy.mock(cls=LabwareCore)
+    mock_well_core_3 = decoy.mock(cls=WellCore)
+    grid_2 = well_grid.WellGrid(
+        columns_by_name={"1": ["A1"]}, rows_by_name={"A": ["A1"]}
+    )
+    decoy.when(mock_well_core_3.get_name()).then_return("A1")
+    decoy.when(core_2.get_well_columns()).then_return([["A1", "B1"]])
+    decoy.when(core_2.get_well_core("A1")).then_return(mock_well_core_1)
+    decoy.when(core_2.get_well_core("B1")).then_return(mock_well_core_2)
+
+    decoy.when(well_grid.create([["A1"]])).then_return(grid_2)
+    other_labware = Labware(
+        core=core_2,
+        api_version=api_version,
+        protocol_core=mock_protocol_core,
+        core_map=mock_map_core,
+    )
+    with pytest.raises(KeyError):
+        subject.load_empty(["A1", "C1"])
+
+    with pytest.raises(KeyError):
+        subject.load_empty([subject["A1"], other_labware["A1"]])
+
+    with pytest.raises(TypeError):
+        subject.load_empty([2])  # type: ignore[list-item]

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -467,6 +467,8 @@ def test_load_liquid_rejects_invalid_inputs(
     with pytest.raises(TypeError):
         subject.load_liquid([2], 10, mock_liquid)  # type: ignore[list-item]
 
+    with pytest.raises(TypeError):
+        subject.load_liquid(["A1"], "A1", mock_liquid)  # type: ignore[arg-type]
     mock_liquid = decoy.mock(cls=Liquid)
 
     subject.load_liquid(["A1", subject["B1"]], 10, mock_liquid)
@@ -586,6 +588,9 @@ def test_load_liquid_by_well_rejects_invalid_inputs(
 
     with pytest.raises(TypeError):
         subject.load_liquid_by_well({2: 10}, mock_liquid)  # type: ignore[dict-item]
+
+    with pytest.raises(TypeError):
+        subject.load_liquid_by_well({"A1": "A3"}, mock_liquid)  # type: ignore[dict-item]
 
 
 @pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))

--- a/api/tests/opentrons/protocol_api/test_well.py
+++ b/api/tests/opentrons/protocol_api/test_well.py
@@ -1,4 +1,5 @@
 """Tests for the InstrumentContext public interface."""
+
 import pytest
 from decoy import Decoy
 
@@ -7,8 +8,6 @@ from opentrons.protocol_api import MAX_SUPPORTED_VERSION, Labware, Well
 from opentrons.protocol_api.core.common import WellCore
 from opentrons.protocol_api._liquid import Liquid
 from opentrons.types import Point, Location
-
-from . import versions_at_or_above
 
 
 @pytest.fixture
@@ -140,13 +139,6 @@ def test_load_liquid(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> N
         ),
         times=1,
     )
-
-
-@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 22)))
-def test_load_empty(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:
-    """It should mark a location as empty."""
-    subject.load_empty()
-    decoy.verify(mock_well_core.load_empty(), times=1)
 
 
 def test_diameter(decoy: Decoy, mock_well_core: WellCore, subject: Well) -> None:


### PR DESCRIPTION
We had the ability to load liquids on individual Wells, but this creates an engine command per well - which can be very onerous for large labware - and requires loops and such to load liquids. The common case for loading liquids is that everything is the same, and the second common case is that you care about a labware as a whole at a time (e.g. because you're reading from a platemap).

We can support these uses better by having Labware.load_liquid (for many wells with the same amount of liquid), Labware.load_liquid_by_well (more complex, for more complex use cases) and Labware.load_empty, all taking arguments of the type that you can derive from other PAPI methods or domain-specific reasoning.

Also, remove well.load_empty because it wasn't shipped yet and is now duplicative.

Closes EXEC-825
