### PR TITLE
app(fix): Fix liquids always required during protocol setup

### DIFF
--- a/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
+++ b/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
@@ -56,14 +56,19 @@ const keysInOrder = (
     protocolAnalysis == null
       ? NO_ANALYSIS_STEPS_IN_ORDER
       : ALL_STEPS_IN_ORDER.filter((stepKey: StepKey) => {
-          if (protocolAnalysis.modules.length === 0) {
-            return stepKey !== MODULE_SETUP_STEP_KEY
+          if (
+            stepKey === MODULE_SETUP_STEP_KEY &&
+            protocolAnalysis.modules.length === 0
+          ) {
+            return false
+          } else if (
+            stepKey === LIQUID_SETUP_STEP_KEY &&
+            protocolAnalysis.liquids.length === 0
+          ) {
+            return false
+          } else {
+            return true
           }
-
-          if (protocolAnalysis.liquids.length === 0) {
-            return stepKey !== LIQUID_SETUP_STEP_KEY
-          }
-          return true
         })
   return { orderedSteps: orderedSteps as StepKey[], orderedApplicableSteps }
 }


### PR DESCRIPTION
Closes [RQA-3535](https://opentrons.atlassian.net/browse/RQA-3535)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a bug in which we were short circuiting a `filter` too early if there are no modules in protocol analysis. If this condition is true, we are always returning the liquid setup as required. 

### Current Behavior

<img width="1021" alt="Screenshot 2024-11-12 at 11 26 32 AM" src="https://github.com/user-attachments/assets/d5ce9ff9-a67c-4199-ba0f-08188676d7c4">

### Fixed Behavior

<img width="934" alt="Screenshot 2024-11-12 at 11 26 14 AM" src="https://github.com/user-attachments/assets/279ffae7-9aa7-4803-b78c-9776988bb2a9">


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See screenshots.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed liquids errantly requiring setup if no modules are in the protocol.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3535]: https://opentrons.atlassian.net/browse/RQA-3535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ