### PR TITLE
fix(labware-library): make all category visible when click on lid category

### DIFF
--- a/labware-library/src/components/App/styles.module.css
+++ b/labware-library/src/components/App/styles.module.css
@@ -70,6 +70,7 @@
   }
 
   .content_container {
+    height: 100vh;
     padding-top: var(--spacing-7);
     padding-right: var(--spacing-7);
 

--- a/labware-library/src/components/App/styles.module.css
+++ b/labware-library/src/components/App/styles.module.css
@@ -33,7 +33,7 @@
 }
 
 .content_container {
-  min-height: 100vh;
+  min-height: 87vh;
   width: 100%;
   padding: var(--spacing-5);
   margin: 0;

--- a/labware-library/src/components/App/styles.module.css
+++ b/labware-library/src/components/App/styles.module.css
@@ -33,6 +33,7 @@
 }
 
 .content_container {
+  min-height: 100vh;
   width: 100%;
   padding: var(--spacing-5);
   margin: 0;
@@ -70,7 +71,6 @@
   }
 
   .content_container {
-    height: 100vh;
     padding-top: var(--spacing-7);
     padding-right: var(--spacing-7);
 


### PR DESCRIPTION
fix AUTH-1023

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

Noticing that when clicking on the Lid category, you need to scroll down the side navigation bar to see some other categories in the Labware Library.

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
- Added a `min-height` to `content-container` because currently there is only one labware in the Lid category, causing the container height to be smaller and hiding other categories that extend beyond the visible area

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
