### PR TITLE
test(robot-server): Test for SQL parity between metadata.create_all() and the migration path

### DIFF
--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -569,9 +569,11 @@ def _normalize_statement(statement: str) -> str:
 def test_creating_from_metadata_emits_expected_statements(
     metadata: sqlalchemy.MetaData, expected_statements: List[str]
 ) -> None:
-    """Test that fresh databases are created with the expected statements.
+    """Test that each schema compiles down to the expected SQL statements.
 
     This is a snapshot test to help catch accidental changes to our SQL schema.
+    For example, we might refactor the way we define the schema on the Python side,
+    but we probably expect the way that it compiles down to SQL to stay stable.
 
     Based on:
     https://docs.sqlalchemy.org/en/14/faq/metadata_schema.html#faq-ddl-as-string
@@ -597,6 +599,15 @@ def test_creating_from_metadata_emits_expected_statements(
 
 
 def test_migrated_db_matches_db_created_from_metadata(tmp_path: Path) -> None:
+    """Test that the output of migration matches `metadata.create_all()`.
+
+    In other words, constructing the database by going through our migration system
+    should have the same final result as if we created the database directly from
+    the latest schema version.
+
+    This prevents migrations from sneaking in arbitrary changes and causing the actual
+    database to not exactly match what our SQLAlchemy `metadata` object declares.
+    """
     migration_orchestrator = make_migration_orchestrator(prepared_root=tmp_path)
     active_subdirectory = migration_orchestrator.migrate_to_latest()
 

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -598,6 +598,18 @@ def test_creating_from_metadata_emits_expected_statements(
     assert set(normalized_actual) == set(normalized_expected)
 
 
+# FIXME(mm, 2024-11-12): https://opentrons.atlassian.net/browse/EXEC-827
+#
+# There are at least these mismatches:
+#
+# - `ix_data_files_source` is present in metadata, but not emitted by the migration path
+# - `ix_run_command_command_intent` is present in metadata, but not emitted by the migration path
+# - `data_files.source` is nullable as emitted by the migration path, but not as declared in metadata
+# - `command.command_intent` is nullable as emitted by the migration path, but not as declared in metadata
+# - constraint `datafilesourcesqlenum` is present in metadata, but not not emitted by the migration path
+#
+# Remove this xfail mark when the mismatches are resolved.
+@pytest.mark.xfail(strict=True)
 def test_migrated_db_matches_db_created_from_metadata(tmp_path: Path) -> None:
     """Test that the output of migration matches `metadata.create_all()`.
 

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -624,7 +624,6 @@ def test_migrated_db_matches_db_created_from_metadata(tmp_path: Path) -> None:
             .all()
         )
 
-    # breakpoint()
     normalized_actual = [_normalize_statement(s) for s in actual_statements]
     normalized_expected = [_normalize_statement(s) for s in expected_statements]
 


### PR DESCRIPTION
## Overview

This covers EXEC-827 with a test. The test is currently marked as expected-to-fail. See EXEC-827 for background.

## Test Plan and Hands on Testing

None needed.

## Review requests

Are the names and docstrings clear?

## Risk assessment

No risk.