### PR TITLE
feat(opentrons-ai-client): filter out retired and old labware

### DIFF
--- a/opentrons-ai-client/src/molecules/ControlledLabwareListItems/__tests__/ControlledLabwareListItems.test.tsx
+++ b/opentrons-ai-client/src/molecules/ControlledLabwareListItems/__tests__/ControlledLabwareListItems.test.tsx
@@ -10,11 +10,11 @@ const TestFormProviderComponent = () => {
     defaultValues: {
       labwares: [
         {
-          labwareURI: 'opentrons/eppendorf_96_tiprack_1000ul_eptips/1',
+          labwareURI: 'opentrons/opentrons_flex_96_tiprack_1000ul/1',
           count: 1,
         },
         {
-          labwareURI: 'opentrons/eppendorf_96_tiprack_10ul_eptips/1',
+          labwareURI: 'opentrons/opentrons_flex_96_tiprack_50ul/1',
           count: 1,
         },
       ],
@@ -39,10 +39,10 @@ describe('ControlledLabwareListItems', () => {
     render()
 
     expect(
-      screen.getByText('(Retired) Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
+      screen.getByText('Opentrons Flex 96 Tip Rack 1000 µL')
     ).toBeInTheDocument()
     expect(
-      screen.getByText('(Retired) Eppendorf epT.I.P.S. 96 Tip Rack 10 µL')
+      screen.getByText('Opentrons Flex 96 Tip Rack 50 µL')
     ).toBeInTheDocument()
   })
 
@@ -64,7 +64,7 @@ describe('ControlledLabwareListItems', () => {
     render()
 
     expect(
-      screen.getByText('(Retired) Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
+      screen.getByText('Opentrons Flex 96 Tip Rack 1000 µL')
     ).toBeInTheDocument()
 
     const removeButton = screen.getAllByText('Remove')[0]
@@ -72,7 +72,7 @@ describe('ControlledLabwareListItems', () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByText('(Retired) Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
+        screen.queryByText('Opentrons Flex 96 Tip Rack 1000 µL')
       ).not.toBeInTheDocument()
     })
   })

--- a/opentrons-ai-client/src/molecules/ControlledLabwareListItems/index.tsx
+++ b/opentrons-ai-client/src/molecules/ControlledLabwareListItems/index.tsx
@@ -10,13 +10,11 @@ import {
 import type { DropdownBorder } from '@opentrons/components'
 import { Controller, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import {
-  getAllDefinitions,
-  getLabwareDisplayName,
-} from '@opentrons/shared-data'
+import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { LabwareDiagram } from '../../molecules/LabwareDiagram'
 import type { DisplayLabware } from '../../organisms/LabwareLiquidsSection'
 import { LABWARES_FIELD_NAME } from '../../organisms/LabwareLiquidsSection'
+import { getAllDefinitions } from '../../resources/utils'
 
 export function ControlledLabwareListItems(): JSX.Element | null {
   const { t } = useTranslation('create_protocol')

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -23,7 +23,7 @@ import {
   tokenAtom,
 } from '../../resources/atoms'
 import { useApiCall } from '../../resources/hooks'
-import { calcTextAreaHeight } from '../../resources/utils/utils'
+import { calcTextAreaHeight } from '../../resources/utils'
 import {
   STAGING_END_POINT,
   PROD_END_POINT,

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -10,7 +10,6 @@ import {
 import type { DropdownBorder } from '@opentrons/components'
 import {
   ABSORBANCE_READER_TYPE,
-  getAllDefinitions,
   getModuleDisplayName,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_BLOCK_TYPE,
@@ -23,6 +22,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { ModuleDiagram } from '../ModelDiagram'
 import { MODULES_FIELD_NAME } from '../../organisms/ModulesSection'
 import type { DisplayModules } from '../../organisms/ModulesSection'
+import { getAllDefinitions } from '../../resources/utils'
 import { useTranslation } from 'react-i18next'
 import { useMemo } from 'react'
 

--- a/opentrons-ai-client/src/organisms/LabwareLiquidsSection/__tests__/LabwareLiquidsSection.test.tsx
+++ b/opentrons-ai-client/src/organisms/LabwareLiquidsSection/__tests__/LabwareLiquidsSection.test.tsx
@@ -44,7 +44,7 @@ describe('LabwareLiquidsSection', () => {
 
     fireEvent.click(screen.getByText('Tip rack'))
     fireEvent.click(
-      await screen.findByText('Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
+      await screen.findByText('Opentrons Flex 96 Tip Rack 1000 µL')
     )
     fireEvent.click(screen.getByText('Save'))
 
@@ -61,7 +61,7 @@ describe('LabwareLiquidsSection', () => {
 
   //     fireEvent.click(screen.getByText('Tip rack'))
   //     fireEvent.click(
-  //       await screen.findByText('Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
+  //       await screen.findByText('Opentrons Flex 96 Tip Rack 1000 µL')
   //     )
   //     fireEvent.click(screen.getByText('Save'))
 

--- a/opentrons-ai-client/src/organisms/LabwareModal/__tests__/LabwareModal.test.tsx
+++ b/opentrons-ai-client/src/organisms/LabwareModal/__tests__/LabwareModal.test.tsx
@@ -73,7 +73,7 @@ describe('LabwareModal', () => {
     render()
 
     expect(
-      screen.queryByText('Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
+      screen.queryByText('Opentrons Flex 96 Tip Rack 1000 µL')
     ).not.toBeInTheDocument()
 
     const categoryButton = screen.getByText('Tip rack')
@@ -81,7 +81,7 @@ describe('LabwareModal', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
+        screen.getByText('Opentrons Flex 96 Tip Rack 1000 µL')
       ).toBeInTheDocument()
     })
   })
@@ -94,7 +94,7 @@ describe('LabwareModal', () => {
     categoryButton.click()
 
     const labware = await screen.findByLabelText(
-      'Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL'
+      'Opentrons Flex 96 Tip Rack 1000 µL'
     )
     expect(labware).not.toBeChecked()
 
@@ -111,10 +111,10 @@ describe('LabwareModal', () => {
     categoryButton.click()
 
     const labware1 = await screen.findByLabelText(
-      'Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL'
+      'Opentrons Flex 96 Tip Rack 1000 µL'
     )
     const labware2 = await screen.findByLabelText(
-      'Eppendorf epT.I.P.S. 96 Tip Rack 10 µL'
+      'Opentrons Flex 96 Tip Rack 50 µL'
     )
 
     labware1.click()
@@ -132,7 +132,7 @@ describe('LabwareModal', () => {
     categoryButton.click()
 
     const labware = await screen.findByLabelText(
-      'Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL'
+      'Opentrons Flex 96 Tip Rack 1000 µL'
     )
     labware.click()
     labware.click()
@@ -152,7 +152,7 @@ describe('LabwareModal', () => {
     categoryButton.click()
 
     const labware1 = await screen.findByLabelText(
-      'Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL'
+      'Opentrons Flex 96 Tip Rack 1000 µL'
     )
     labware1.click()
 
@@ -180,7 +180,7 @@ describe('LabwareModal', () => {
     categoryButton.click()
 
     const labware1 = await screen.findByLabelText(
-      'Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL'
+      'Opentrons Flex 96 Tip Rack 1000 µL'
     )
     labware1.click()
 
@@ -191,7 +191,7 @@ describe('LabwareModal', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('opentrons/eppendorf_96_tiprack_1000ul_eptips/1')
+        screen.getByText('opentrons/opentrons_flex_96_tiprack_1000ul/1')
       ).toBeInTheDocument()
     })
   })
@@ -208,7 +208,7 @@ describe('LabwareModal', () => {
     categoryButton.click()
 
     const labware1 = await screen.findByLabelText(
-      'Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL'
+      'Opentrons Flex 96 Tip Rack 1000 µL'
     )
     labware1.click()
 
@@ -219,7 +219,7 @@ describe('LabwareModal', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('opentrons/eppendorf_96_tiprack_1000ul_eptips/1')
+        screen.getByText('opentrons/opentrons_flex_96_tiprack_1000ul/1')
       ).toBeInTheDocument()
     })
 
@@ -230,7 +230,7 @@ describe('LabwareModal', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('opentrons/eppendorf_96_tiprack_1000ul_eptips/1')
+        screen.getByText('opentrons/opentrons_flex_96_tiprack_1000ul/1')
       ).toBeInTheDocument()
     })
   })
@@ -241,7 +241,7 @@ describe('LabwareModal', () => {
 
     const searchInput = screen.getByPlaceholderText('Search for labware...')
     fireEvent.change(searchInput, {
-      target: { value: 'Eppendorf epT.I.P.S. 96 Tip Rack 10 µL' },
+      target: { value: 'Opentrons Flex 96 Tip Rack 50 µL' },
     })
 
     const categoryButton = screen.getByText('Tip rack')
@@ -249,12 +249,12 @@ describe('LabwareModal', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('Eppendorf epT.I.P.S. 96 Tip Rack 10 µL')
+        screen.getByText('Opentrons Flex 96 Tip Rack 50 µL')
       ).toBeInTheDocument()
     })
 
     expect(
-      screen.queryByText('Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
+      screen.queryByText('Opentrons Flex 96 Tip Rack 1000 µL')
     ).not.toBeInTheDocument()
   })
 })

--- a/opentrons-ai-client/src/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/organisms/LabwareModal/index.tsx
@@ -13,17 +13,20 @@ import {
 } from '@opentrons/components'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import type {
-  LabwareDefByDefURI,
-  LabwareDefinition2,
+import {
+  getLabwareDefURI,
 } from '@opentrons/shared-data'
-import { getLabwareDefURI, getAllDefinitions } from '@opentrons/shared-data'
 import React, { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { reduce } from 'lodash'
 import { ListButtonCheckbox } from '../../atoms/ListButtonCheckbox/ListButtonCheckbox'
-import type { DisplayLabware } from '../LabwareLiquidsSection'
 import { LABWARES_FIELD_NAME } from '../LabwareLiquidsSection'
+import { getAllDefinitions } from '../../resources/utils'
+import type { DisplayLabware } from '../LabwareLiquidsSection'
+import type {
+  LabwareDefByDefURI,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 
 const ORDERED_CATEGORIES: string[] = [
   'tipRack',

--- a/opentrons-ai-client/src/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/organisms/LabwareModal/index.tsx
@@ -13,9 +13,7 @@ import {
 } from '@opentrons/components'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import {
-  getLabwareDefURI,
-} from '@opentrons/shared-data'
+import { getLabwareDefURI } from '@opentrons/shared-data'
 import React, { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { reduce } from 'lodash'

--- a/opentrons-ai-client/src/pages/CreateProtocol/__tests__/CreateProtocol.test.tsx
+++ b/opentrons-ai-client/src/pages/CreateProtocol/__tests__/CreateProtocol.test.tsx
@@ -163,7 +163,7 @@ describe('CreateProtocol', () => {
 
     expect(previewItems).toHaveLength(9)
     expect(previewItems[7]).toHaveTextContent(
-      'Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL'
+      'Opentrons Flex 96 Tip Rack 1000 µL'
     )
     expect(previewItems[8]).toHaveTextContent('Test liquid')
   })

--- a/opentrons-ai-client/src/resources/utils/__tests__/utils.test.ts
+++ b/opentrons-ai-client/src/resources/utils/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calcTextAreaHeight } from '../utils'
+import { calcTextAreaHeight } from '../index'
 
 describe('calcTextAreaHeight', () => {
   it('should return the correct number of lines', () => {

--- a/opentrons-ai-client/src/resources/utils/createProtocolTestUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolTestUtils.tsx
@@ -62,9 +62,7 @@ export async function fillLabwareLiquidsSectionAndClickConfirm(): Promise<void> 
   fireEvent.click(addButton)
 
   fireEvent.click(screen.getByText('Tip rack'))
-  fireEvent.click(
-    await screen.findByText('Eppendorf epT.I.P.S. 96 Tip Rack 1000 µL')
-  )
+  fireEvent.click(await screen.findByText('Opentrons Flex 96 Tip Rack 1000 µL'))
   fireEvent.click(screen.getByText('Save'))
 
   fireEvent.change(screen.getByRole('textbox'), {

--- a/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
@@ -1,5 +1,4 @@
 import {
-  getAllDefinitions,
   getLabwareDisplayName,
   getPipetteSpecsV2,
 } from '@opentrons/shared-data'
@@ -14,6 +13,7 @@ import {
 } from '../../organisms/InstrumentsSection'
 import type { UseFormWatch } from 'react-hook-form'
 import type { CreateProtocolFormData } from '../../pages/CreateProtocol'
+import { getAllDefinitions } from './labware'
 
 export function generatePromptPreviewApplicationItems(
   watch: UseFormWatch<CreateProtocolFormData>,

--- a/opentrons-ai-client/src/resources/utils/index.ts
+++ b/opentrons-ai-client/src/resources/utils/index.ts
@@ -19,3 +19,5 @@ export const isLocalhost = (): boolean => {
     host === 'localhost' || host === '127.0.0.1' || host.startsWith('192.168.')
   )
 }
+
+export * from './labware'

--- a/opentrons-ai-client/src/resources/utils/labware.ts
+++ b/opentrons-ai-client/src/resources/utils/labware.ts
@@ -1,0 +1,17 @@
+import {
+  LABWAREV2_DO_NOT_LIST,
+  RETIRED_LABWARE,
+  getAllDefinitions as _getAllDefinitions,
+} from '@opentrons/shared-data'
+import type { LabwareDefByDefURI } from '@opentrons/shared-data'
+
+let _definitions: LabwareDefByDefURI | null = null
+export function getAllDefinitions(): LabwareDefByDefURI {
+  if (_definitions == null) {
+    _definitions = _getAllDefinitions([
+      ...RETIRED_LABWARE,
+      ...LABWAREV2_DO_NOT_LIST,
+    ])
+  }
+  return _definitions
+}

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -59,7 +59,7 @@ export const constructLabwareDefURI = (
 // Load names of "retired" labware
 // TODO(mc, 2019-12-3): how should this correspond to LABWAREV2_DO_NOT_LIST?
 // see shared-data/js/getLabware.js
-const RETIRED_LABWARE = [
+export const RETIRED_LABWARE = [
   'geb_96_tiprack_10ul',
   'geb_96_tiprack_1000ul',
   'opentrons_1_trash_850ml_fixed',


### PR DESCRIPTION
# Overview

This PR filters out old and no longer supported labware for use in all of the opentrons ai app.

## Changelog

- Filter out retired labware

## Review requests

Make sure old labware (like GEB tip racks) no longer show up in the app

## Risk assessment

Low