### PR TITLE
fix(app, shared-data, components): add calibration not req text for plate reader, remove lid filtration

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -177,6 +177,7 @@
   "never": "Never",
   "new_features": "New Features",
   "next_step": "Next step",
+  "no_calibration_required": "No calibration required",
   "no_connection_found": "No connection found",
   "no_gripper_attached": "No gripper attached",
   "no_modules_attached": "No modules attached",

--- a/app/src/organisms/Desktop/ProtocolDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/index.tsx
@@ -47,7 +47,6 @@ import {
   parseInitialLoadedLabwareBySlot,
   parseInitialLoadedModulesBySlot,
   parseInitialPipetteNamesByMount,
-  NON_USER_ADDRESSABLE_LABWARE,
 } from '@opentrons/shared-data'
 
 import { getTopPortalEl } from '/app/App/portal'
@@ -285,9 +284,7 @@ export function ProtocolDetails(
               : []
           ),
         }).filter(
-          labware =>
-            labware.result?.definition?.parameters?.format !== 'trash' &&
-            !NON_USER_ADDRESSABLE_LABWARE.includes(labware?.params?.loadName)
+          labware => labware.result?.definition?.parameters?.format !== 'trash'
         )
       : []
 

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/ModuleCalibrationItems.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/ModuleCalibrationItems.tsx
@@ -8,7 +8,10 @@ import {
   LegacyStyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  getModuleDisplayName,
+  ABSORBANCE_READER_TYPE,
+} from '@opentrons/shared-data'
 
 import { formatLastCalibrated } from './utils'
 import { ModuleCalibrationOverflowMenu } from './ModuleCalibrationOverflowMenu'
@@ -41,42 +44,51 @@ export function ModuleCalibrationItems({
         </tr>
       </thead>
       <tbody css={BODY_STYLE}>
-        {attachedModules.map(attachedModule => (
-          <StyledTableRow key={attachedModule.id}>
-            <StyledTableCell>
-              <LegacyStyledText as="p">
-                {getModuleDisplayName(attachedModule.moduleModel)}
-              </LegacyStyledText>
-            </StyledTableCell>
-            <StyledTableCell>
-              <LegacyStyledText as="p">
-                {attachedModule.serialNumber}
-              </LegacyStyledText>
-            </StyledTableCell>
-            <StyledTableCell>
-              <LegacyStyledText as="p">
-                {attachedModule.moduleOffset?.last_modified != null
-                  ? formatLastCalibrated(
-                      attachedModule.moduleOffset?.last_modified
-                    )
-                  : t('not_calibrated_short')}
-              </LegacyStyledText>
-            </StyledTableCell>
-            <StyledTableCell>
-              <ModuleCalibrationOverflowMenu
-                isCalibrated={
-                  attachedModule.moduleOffset?.last_modified != null
-                }
-                attachedModule={attachedModule}
-                updateRobotStatus={updateRobotStatus}
-                formattedPipetteOffsetCalibrations={
-                  formattedPipetteOffsetCalibrations
-                }
-                robotName={robotName}
-              />
-            </StyledTableCell>
-          </StyledTableRow>
-        ))}
+        {attachedModules.map(attachedModule => {
+          const noCalibrationCopy =
+            attachedModule.moduleType === ABSORBANCE_READER_TYPE
+              ? t('no_calibration_required')
+              : t('not_calibrated_short')
+
+          return (
+            <StyledTableRow key={attachedModule.id}>
+              <StyledTableCell>
+                <LegacyStyledText as="p">
+                  {getModuleDisplayName(attachedModule.moduleModel)}
+                </LegacyStyledText>
+              </StyledTableCell>
+              <StyledTableCell>
+                <LegacyStyledText as="p">
+                  {attachedModule.serialNumber}
+                </LegacyStyledText>
+              </StyledTableCell>
+              <StyledTableCell>
+                <LegacyStyledText as="p">
+                  {attachedModule.moduleOffset?.last_modified != null
+                    ? formatLastCalibrated(
+                        attachedModule.moduleOffset?.last_modified
+                      )
+                    : noCalibrationCopy}
+                </LegacyStyledText>
+              </StyledTableCell>
+              <StyledTableCell>
+                {attachedModule.moduleType !== ABSORBANCE_READER_TYPE ? (
+                  <ModuleCalibrationOverflowMenu
+                    isCalibrated={
+                      attachedModule.moduleOffset?.last_modified != null
+                    }
+                    attachedModule={attachedModule}
+                    updateRobotStatus={updateRobotStatus}
+                    formattedPipetteOffsetCalibrations={
+                      formattedPipetteOffsetCalibrations
+                    }
+                    robotName={robotName}
+                  />
+                ) : null}
+              </StyledTableCell>
+            </StyledTableRow>
+          )
+        })}
       </tbody>
     </StyledTable>
   )

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/ModuleCalibrationItems.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/ModuleCalibrationItems.test.tsx
@@ -9,6 +9,7 @@ import { formatLastCalibrated } from '../utils'
 import { ModuleCalibrationItems } from '../ModuleCalibrationItems'
 
 import type { AttachedModule } from '@opentrons/api-client'
+import { ABSORBANCE_READER_TYPE } from '@opentrons/shared-data'
 
 vi.mock('../ModuleCalibrationOverflowMenu')
 
@@ -42,7 +43,7 @@ const mockCalibratedModule = {
     totalCycleCount: 1,
     currentStepIndex: 1,
     totalStepCount: 1,
-  },
+  } as any,
   usbPort: {
     port: 3,
     portGroup: 'left',
@@ -100,5 +101,24 @@ describe('ModuleCalibrationItems', () => {
     }
     render(props)
     screen.getByText(formatLastCalibrated('2023-06-01T14:42:20.131798+00:00'))
+  })
+
+  it('should say no calibration required if module is absorbance reader', () => {
+    const absorbanceReaderAttachedModule = {
+      ...mockCalibratedModule,
+      moduleType: ABSORBANCE_READER_TYPE,
+      moduleOffset: undefined,
+    }
+    props = {
+      ...props,
+      attachedModules: [
+        absorbanceReaderAttachedModule as AttachedModule,
+      ] as AttachedModule[],
+    }
+    render(props)
+    expect(
+      screen.queryByText('mock ModuleCalibrationOverflowMenu')
+    ).not.toBeInTheDocument()
+    screen.getByText('No calibration required')
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/getPrepCommands.ts
@@ -3,7 +3,6 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
   ABSORBANCE_READER_TYPE,
-  NON_USER_ADDRESSABLE_LABWARE,
 } from '@opentrons/shared-data'
 
 import type {
@@ -49,8 +48,7 @@ export function getPrepCommands(
           return [...acc, loadWithPipetteId]
         } else if (
           command.commandType === 'loadLabware' &&
-          command.result?.labwareId != null &&
-          !NON_USER_ADDRESSABLE_LABWARE.includes(command.params.loadName)
+          command.result?.labwareId != null
         ) {
           // load all labware off-deck so that LPC can move them on individually later
           return [

--- a/app/src/transformations/analysis/getProtocolModulesInfo.ts
+++ b/app/src/transformations/analysis/getProtocolModulesInfo.ts
@@ -3,7 +3,6 @@ import {
   getModuleDef2,
   getLoadedLabwareDefinitionsByUri,
   getPositionFromSlotId,
-  NON_USER_ADDRESSABLE_LABWARE,
 } from '@opentrons/shared-data'
 import { getModuleInitialLoadInfo } from '../commands'
 import type {
@@ -39,8 +38,7 @@ export const getProtocolModulesInfo = (
         protocolData.commands
           .filter(
             (command): command is LoadLabwareRunTimeCommand =>
-              command.commandType === 'loadLabware' &&
-              !NON_USER_ADDRESSABLE_LABWARE.includes(command.params.loadName)
+              command.commandType === 'loadLabware'
           )
           .find(
             (command: LoadLabwareRunTimeCommand) =>

--- a/app/src/transformations/commands/transformations/getLabwareSetupItemGroups.ts
+++ b/app/src/transformations/commands/transformations/getLabwareSetupItemGroups.ts
@@ -1,8 +1,5 @@
 import partition from 'lodash/partition'
-import {
-  getLabwareDisplayName,
-  NON_USER_ADDRESSABLE_LABWARE,
-} from '@opentrons/shared-data'
+import { getLabwareDisplayName } from '@opentrons/shared-data'
 
 import type {
   LabwareDefinition2,
@@ -46,8 +43,7 @@ export function getLabwareSetupItemGroups(
     commands.reduce<LabwareSetupItem[]>((acc, c) => {
       if (
         c.commandType === 'loadLabware' &&
-        c.result?.definition?.metadata?.displayCategory !== 'trash' &&
-        !NON_USER_ADDRESSABLE_LABWARE.includes(c.params?.loadName)
+        c.result?.definition?.metadata?.displayCategory !== 'trash'
       ) {
         const { location, displayName } = c.params
         const { definition } = c.result ?? {}

--- a/components/src/hardware-sim/ProtocolDeck/utils/getModulesInSlots.ts
+++ b/components/src/hardware-sim/ProtocolDeck/utils/getModulesInSlots.ts
@@ -2,7 +2,6 @@ import {
   SPAN7_8_10_11_SLOT,
   getModuleDef2,
   getLoadedLabwareDefinitionsByUri,
-  NON_USER_ADDRESSABLE_LABWARE,
 } from '@opentrons/shared-data'
 import type {
   CompletedProtocolAnalysis,
@@ -37,8 +36,7 @@ export const getModulesInSlots = (
         commands
           .filter(
             (command): command is LoadLabwareRunTimeCommand =>
-              command.commandType === 'loadLabware' &&
-              !NON_USER_ADDRESSABLE_LABWARE.includes(command.params.loadName)
+              command.commandType === 'loadLabware'
           )
           .find(
             (command: LoadLabwareRunTimeCommand) =>

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -589,12 +589,6 @@ export const WASTE_CHUTE_STAGING_AREA_FIXTURES: CutoutFixtureId[] = [
 
 export const LOW_VOLUME_PIPETTES = ['p50_single_flex', 'p50_multi_flex']
 
-// robot server loads absorbance reader lid as a labware but it is not
-// user addressable so we need to hide it where we show labware in the app
-export const NON_USER_ADDRESSABLE_LABWARE = [
-  'opentrons_flex_lid_absorbance_plate_reader_module',
-]
-
 // default hex values for liquid colors
 const electricPurple = '#b925ff'
 const goldenYellow = '#ffd600'


### PR DESCRIPTION
fix RQA-3396
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add text that shows plate reader calibration is not needed on device settings calibration on desktop app and remove provision that filtered out the plate reader lid from the UI
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
1. Look at desktop device settings calibration screen for a device with a plate reader attached
2. Made sure all `NON_USER_ADDRESSABLE_LABWARE` that was added in https://github.com/Opentrons/opentrons/pull/16489 has been correctly removed 
<img width="903" alt="Screen Shot 2024-11-12 at 3 14 04 PM" src="https://github.com/user-attachments/assets/903a4580-6d05-45cb-a162-ef1366762276">


<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Added "No calibration required" copy for plate reader in device settings calibraiton
2. Removed provision that was added to filter out the absorbance reader lid from UI touchpoints including protocol details, protocol deck map, and protocol setup labware tab since the lid will no longer be implicitly loaded through a `loadLabware` command after this PR merged https://github.com/Opentrons/opentrons/commit/60dca5409a9313d952557f8e995828581d1a844d

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Verify that we no longer receive `loadLabware` commands for absorbance reader lid after analysis 
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
