### PR TITLE
fix(api): use encoder position instead of homing gantry when holding plate reader lid.

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
@@ -131,6 +131,9 @@ class UnsafePlaceLabwareImplementation(
 
         # NOTE: When the estop is pressed, the gantry loses position, lets use
         # the encoders to sync position.
+        # Ideally, we'd do a full home, but this command is used when
+        # the gripper is holding the plate reader, and a full home would
+        # bang it into the right window.
         await ot3api.home(axes=[Axis.Z_L, Axis.Z_R, Axis.Z_G])
         await ot3api.engage_axes([Axis.X, Axis.Y])
         await ot3api.update_axis_position_estimations([Axis.X, Axis.Y])

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
@@ -129,9 +129,11 @@ class UnsafePlaceLabwareImplementation(
                     module.id
                 )
 
-        # NOTE: When the estop is pressed, the gantry loses position,
-        # so the robot needs to home x, y to sync.
-        await ot3api.home(axes=[Axis.Z_L, Axis.Z_R, Axis.Z_G, Axis.X, Axis.Y])
+        # NOTE: When the estop is pressed, the gantry loses position, lets use
+        # the encoders to sync position.
+        await ot3api.home(axes=[Axis.Z_L, Axis.Z_R, Axis.Z_G])
+        await ot3api.engage_axes([Axis.X, Axis.Y])
+        await ot3api.update_axis_position_estimations([Axis.X, Axis.Y])
 
         # Place the labware down
         await self._start_movement(ot3api, definition, location, drop_offset)


### PR DESCRIPTION
# Overview

The plate reader lid hits the Flex side window when the gantry homes while the gripper holds the lid, don't do that :)
Instead, let's update the gantry position from the encoders, so we don't have to go home at all.

[RQA-3550](https://opentrons.atlassian.net/browse/RQA-3550)

## Test Plan and Hands on Testing

- [x] Make sure we don't sideswipe the plate reader lid on the Flex after estop
- [x] Make sure we can still handle the plate reader lid estop case

## Changelog

- don't home the x and y axes so we don't sideswipe the flex window with the plate reader lid
- use `engage_axes` and `update_axis_position_estimations` instead of homing the axes

## Review requests

makes sense?

## Risk assessment

low, unreleased



[RQA-3550]: https://opentrons.atlassian.net/browse/RQA-3550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ