### PR TITLE
fix(protocol-designer): properly select and disable column dropdown o…

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -285,7 +285,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
             {filterOptions.map((option, index) => (
               <React.Fragment key={`${option.name}-${index}`}>
                 <MenuItem
-                  disabled={disabled ?? option.disabled}
+                  disabled={option.disabled}
                   zIndex={3}
                   key={`${option.name}-${index}`}
                   onClick={() => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
@@ -32,6 +32,10 @@ export function PartialTipField(props: FieldProps): JSX.Element {
       name: t('column'),
       value: COLUMN,
       disabled: tipracksNotOnAdapter.length === 0,
+      tooltipText:
+        tipracksNotOnAdapter.length === 0
+          ? t('form:step_edit_form.field.nozzles.option_tooltip.COLUMN')
+          : undefined,
     },
   ]
 
@@ -50,7 +54,9 @@ export function PartialTipField(props: FieldProps): JSX.Element {
         dropdownType="neutral"
         filterOptions={options}
         title={t('select_nozzles')}
-        currentOption={options[0]}
+        currentOption={
+          options.find(option => option.value === selectedValue) ?? options[0]
+        }
         onClick={value => {
           updateValue(value)
           setSelectedValue(value)


### PR DESCRIPTION
…ption
closes RQA-3528

# Overview

Fix the partial tip nozzle field for 96-channel. now you can properly select the column field and its properly disabled

## Test Plan and Hands on Testing

Create a flex protocol with a 96-channel. create a transfer form and see that the column option is disabled. Then add a tiprack to the deck without an adapter and see that the column field is not enabled.

NOTE: the all and column text is not capitalized. @ncdiehl11  is fixing that in his PR: https://github.com/Opentrons/opentrons/pull/16777

## Changelog

- fix tooltip text and current Option logic
- fix when a menu item is disabled

## Risk assessment

low