### PR TITLE
feat(api): add monadic error passing to protocol engine

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -1,24 +1,20 @@
 """Prepare to aspirate command request, result, and implementation models."""
 
 from __future__ import annotations
-from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
 from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type, Union
 from typing_extensions import Literal
 
-from .pipetting_common import (
-    OverpressureError,
-    PipetteIdMixin,
-)
+from .pipetting_common import OverpressureError, PipetteIdMixin, prepare_for_aspirate
 from .command import (
     AbstractCommandImpl,
     BaseCommand,
     BaseCommandCreate,
     DefinedErrorData,
     SuccessData,
+    Maybe,
 )
 from ..errors.error_occurrence import ErrorOccurrence
-from ..state import update_types
 
 if TYPE_CHECKING:
     from ..execution import PipettingHandler, GantryMover
@@ -46,6 +42,11 @@ _ExecuteReturn = Union[
 ]
 
 
+_ExecuteMaybe = Maybe[
+    SuccessData[PrepareToAspirateResult], DefinedErrorData[OverpressureError]
+]
+
+
 class PrepareToAspirateImplementation(
     AbstractCommandImpl[PrepareToAspirateParams, _ExecuteReturn]
 ):
@@ -62,44 +63,29 @@ class PrepareToAspirateImplementation(
         self._model_utils = model_utils
         self._gantry_mover = gantry_mover
 
+    def _transform_result(self, result: SuccessData[BaseModel]) -> _ExecuteMaybe:
+        return _ExecuteMaybe.from_result(
+            SuccessData(
+                public=PrepareToAspirateResult(), state_update=result.state_update
+            )
+        )
+
     async def execute(self, params: PrepareToAspirateParams) -> _ExecuteReturn:
         """Prepare the pipette to aspirate."""
         current_position = await self._gantry_mover.get_position(params.pipetteId)
-        state_update = update_types.StateUpdate()
-        try:
-            await self._pipetting_handler.prepare_for_aspirate(
-                pipette_id=params.pipetteId,
-            )
-        except PipetteOverpressureError as e:
-            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
-            return DefinedErrorData(
-                public=OverpressureError(
-                    id=self._model_utils.generate_id(),
-                    createdAt=self._model_utils.get_timestamp(),
-                    wrappedErrors=[
-                        ErrorOccurrence.from_failed(
-                            id=self._model_utils.generate_id(),
-                            createdAt=self._model_utils.get_timestamp(),
-                            error=e,
-                        )
-                    ],
-                    errorInfo=(
-                        {
-                            "retryLocation": (
-                                current_position.x,
-                                current_position.y,
-                                current_position.z,
-                            )
-                        }
-                    ),
-                ),
-                state_update=state_update,
-            )
-        else:
-            state_update.set_fluid_empty(pipette_id=params.pipetteId)
-            return SuccessData(
-                public=PrepareToAspirateResult(), state_update=state_update
-            )
+        prepare_result = await prepare_for_aspirate(
+            pipette_id=params.pipetteId,
+            pipetting=self._pipetting_handler,
+            model_utils=self._model_utils,
+            location_if_error={
+                "retryLocation": (
+                    current_position.x,
+                    current_position.y,
+                    current_position.z,
+                )
+            },
+        )
+        return prepare_result.and_then(self._transform_result).unwrap()
 
 
 class PrepareToAspirate(

--- a/api/tests/opentrons/protocol_engine/commands/test_prepare_to_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_prepare_to_aspirate.py
@@ -34,14 +34,19 @@ def subject(
 
 
 async def test_prepare_to_aspirate_implementation(
-    decoy: Decoy, subject: PrepareToAspirateImplementation, pipetting: PipettingHandler
+    decoy: Decoy,
+    gantry_mover: GantryMover,
+    subject: PrepareToAspirateImplementation,
+    pipetting: PipettingHandler,
 ) -> None:
     """A PrepareToAspirate command should have an executing implementation."""
     data = PrepareToAspirateParams(pipetteId="some id")
+    position = Point(x=1, y=2, z=3)
 
     decoy.when(await pipetting.prepare_for_aspirate(pipette_id="some id")).then_return(
         None
     )
+    decoy.when(await gantry_mover.get_position("some id")).then_return(position)
 
     result = await subject.execute(data)
     assert result == SuccessData(


### PR DESCRIPTION
Let's make an intermediate layer of command execution, inside the command domain so we don't have to move a bunch of types, that calls execution layer functions and returns a new Maybe class that has nice monadic chaining calls like a JS promise or some other burrito-style implementations.

As an example, let's use it for overpressure errors in PrepareToAspirate.

## reviews
- does this seem worth it? in your mind's eye, imagine doing this for a new `gantry_common.move_to()` that wraps `gantry_mover.move_to()` and returns a stall defined error.

## testing
- none, this is a refactor that passes tests with few changes

Closes EXEC-830
