### PR TITLE
fix(protocol-designer): fix multi-channel to single-channel switch issue with trash bin destination

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -485,6 +485,7 @@ const updatePatchOnPipetteChannelChange = (
     // reset all well selection
     // @ts-expect-error(sa, 2021-6-14): appliedPatch.pipette does not exist. Address in #3161
     const pipetteId: string = appliedPatch.pipette
+
     update = {
       aspirate_wells: getDefaultWells({
         // @ts-expect-error(sa, 2021-6-14): appliedPatch.aspirate_labware does not exist. Address in #3161
@@ -512,18 +513,29 @@ const updatePatchOnPipetteChannelChange = (
     const sourceLabware = labwareEntities[sourceLabwareId]
     const sourceLabwareDef = sourceLabware.def
     const destLabware = labwareEntities[destLabwareId]
-    const destLabwareDef = destLabware.def
+
+    // @ts-expect-error(sa, 2021-6-14): appliedPatch.pipette does not exist. Address in #3161
+    const pipetteId: string = appliedPatch.pipette
     update = {
       aspirate_wells: getAllWellsFromPrimaryWells(
         appliedPatch.aspirate_wells as string[],
         sourceLabwareDef,
         channels as 8 | 96
       ),
-      dispense_wells: getAllWellsFromPrimaryWells(
-        appliedPatch.dispense_wells as string[],
-        destLabwareDef,
-        channels as 8 | 96
-      ),
+      dispense_wells:
+        destLabwareId.includes('trashBin') ||
+        destLabwareId.includes('wasteChute')
+          ? getDefaultWells({
+              labwareId: destLabwareId,
+              pipetteId,
+              labwareEntities,
+              pipetteEntities,
+            })
+          : getAllWellsFromPrimaryWells(
+              appliedPatch.dispense_wells as string[],
+              destLabware.def,
+              channels as 8 | 96
+            ),
     }
   }
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -481,11 +481,10 @@ const updatePatchOnPipetteChannelChange = (
   const multiToSingle =
     (prevChannels === 8 || prevChannels === 96) && nextChannels === 1
 
+  const pipetteId: string = appliedPatch.pipette as string
+
   if (patch.pipette === null || singleToMulti) {
     // reset all well selection
-    // @ts-expect-error(sa, 2021-6-14): appliedPatch.pipette does not exist. Address in #3161
-    const pipetteId: string = appliedPatch.pipette
-
     update = {
       aspirate_wells: getDefaultWells({
         // @ts-expect-error(sa, 2021-6-14): appliedPatch.aspirate_labware does not exist. Address in #3161
@@ -514,8 +513,6 @@ const updatePatchOnPipetteChannelChange = (
     const sourceLabwareDef = sourceLabware.def
     const destLabware = labwareEntities[destLabwareId]
 
-    // @ts-expect-error(sa, 2021-6-14): appliedPatch.pipette does not exist. Address in #3161
-    const pipetteId: string = appliedPatch.pipette
     update = {
       aspirate_wells: getAllWellsFromPrimaryWells(
         appliedPatch.aspirate_wells as string[],


### PR DESCRIPTION
fix RQA-3543

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

Fixing a TypeError when switching from a multi-channel to a single-channel pipette with the trash bin or waste chute as the destination labware, caused by an inability to get the labware definition for these destinations.


## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

- Added a condition to differentiate trash bin/waste chute from other labware when updating `dispense_wells` with a multi-channel pipette. Used `getDefaultWells` for the trash bin/waste chute, as they lack well locations and labware definitions.

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
