### PR TITLE
fix(protocol-designer): add dependent fields when tiprack changes 

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -131,12 +131,30 @@ const updatePatchOnPipetteChannelChange = (
 
 const updatePatchOnPipetteChange = (
   patch: FormPatch,
-  rawForm: FormData,
-  pipetteEntities: PipetteEntities
+  rawForm: FormData
 ): FormPatch => {
   // when pipette ID is changed (to another ID, or to null),
   // set any flow rates to null
   if (fieldHasChanged(rawForm, patch, 'pipette')) {
+    return {
+      ...patch,
+      ...getDefaultFields(
+        'aspirate_flowRate',
+        'dispense_flowRate',
+        'tipRack',
+        'nozzles'
+      ),
+    }
+  }
+
+  return patch
+}
+
+const updatePatchOnTiprackChange = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (fieldHasChanged(rawForm, patch, 'tipRack')) {
     return {
       ...patch,
       ...getDefaultFields('aspirate_flowRate', 'dispense_flowRate'),
@@ -168,7 +186,7 @@ export function dependentFieldsUpdateMix(
         labwareEntities,
         pipetteEntities
       ),
-    chainPatch =>
-      updatePatchOnPipetteChange(chainPatch, rawForm, pipetteEntities),
+    chainPatch => updatePatchOnPipetteChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnTiprackChange(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -248,7 +248,40 @@ const updatePatchOnPipetteChange = (
         'dispense_mix_volume',
         'disposalVolume_volume',
         'aspirate_mmFromBottom',
-        'dispense_mmFromBottom'
+        'dispense_mmFromBottom',
+        'nozzles',
+        'tipRack'
+      ),
+      aspirate_airGap_volume: airGapVolume,
+      dispense_airGap_volume: airGapVolume,
+    }
+  }
+
+  return patch
+}
+
+const updatePatchOnTiprackChange = (
+  patch: FormPatch,
+  rawForm: FormData,
+  pipetteEntities: PipetteEntities
+): FormPatch => {
+  if (fieldHasChanged(rawForm, patch, 'tipRack')) {
+    const pipette = patch.pipette
+    let airGapVolume: string | null = null
+
+    if (typeof pipette === 'string' && pipette in pipetteEntities) {
+      const minVolume = getMinPipetteVolume(pipetteEntities[pipette])
+      airGapVolume = minVolume.toString()
+    }
+
+    return {
+      ...patch,
+      ...getDefaultFields(
+        'aspirate_flowRate',
+        'dispense_flowRate',
+        'aspirate_mix_volume',
+        'dispense_mix_volume',
+        'disposalVolume_volume'
       ),
       aspirate_airGap_volume: airGapVolume,
       dispense_airGap_volume: airGapVolume,
@@ -662,5 +695,7 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch => updatePatchBlowoutFields(chainPatch, rawForm),
     chainPatch =>
       clampDispenseAirGapVolume(chainPatch, rawForm, pipetteEntities),
+    chainPatch =>
+      updatePatchOnTiprackChange(chainPatch, rawForm, pipetteEntities),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
@@ -94,6 +94,8 @@ describe('well selection should update', () => {
       wells: [],
       aspirate_flowRate: null,
       dispense_flowRate: null,
+      nozzles: null,
+      tipRack: null,
     })
   })
   it('pipette single -> multi', () => {
@@ -105,6 +107,8 @@ describe('well selection should update', () => {
       wells: [],
       aspirate_flowRate: null,
       dispense_flowRate: null,
+      nozzles: null,
+      tipRack: null,
     })
   })
   it('pipette multi -> single', () => {
@@ -117,6 +121,8 @@ describe('well selection should update', () => {
       wells: ['A10', 'B10', 'C10', 'D10', 'E10', 'F10', 'G10', 'H10'],
       aspirate_flowRate: null,
       dispense_flowRate: null,
+      nozzles: null,
+      tipRack: null,
     })
   })
   it('select single-well labware', () => {


### PR DESCRIPTION
closes RQA-3541

# Overview

Reset the flow rate fields when the tiprack changes, also reset the nozzle and tiprack fields when pipette changes. For mix and transfer forms

## Test Plan and Hands on Testing

Create a protocol and add 3 tipracks for 1 pipette. Create a transfer form and add a custom aspirate and dispense flow rate. then go back and change the tiprack to another one. see that the flow rates got reset back to default. Test it also with the mix form.

## Changelog

- add a patch in mix and transfer to reset the fields when tiprack changes and expand a few fields for when pipette changes

## Risk assessment

low
