### PR TITLE
fix(app): Bubble pipette command errors during drop tip wizard

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/DropTipWizard.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizard.tsx
@@ -246,7 +246,13 @@ export const DropTipWizardContent = (
 
   function buildModalContent(): JSX.Element {
     // Don't render the spinner screen for 1 render cycle on fixit commands.
-    if (currentStep === BEFORE_BEGINNING && issuedCommandsType === 'fixit') {
+
+    if (errorDetails != null) {
+      return buildErrorScreen()
+    } else if (
+      currentStep === BEFORE_BEGINNING &&
+      issuedCommandsType === 'fixit'
+    ) {
       return buildBeforeBeginning()
     } else if (
       activeMaintenanceRunId == null &&
@@ -259,8 +265,6 @@ export const DropTipWizardContent = (
       return buildRobotInMotion()
     } else if (showConfirmExit) {
       return buildShowExitConfirmation()
-    } else if (errorDetails != null) {
-      return buildErrorScreen()
     } else if (currentStep === BEFORE_BEGINNING) {
       return buildBeforeBeginning()
     } else if (currentStep === CHOOSE_LOCATION_OPTION) {

--- a/app/src/organisms/DropTipWizardFlows/hooks/__tests__/useDropTipRouting.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/__tests__/useDropTipRouting.test.tsx
@@ -144,4 +144,15 @@ describe('getInitialRouteAndStep', () => {
     expect(initialRoute).toBe(DT_ROUTES.DROP_TIP)
     expect(initialStep).toBe(DT_ROUTES.DROP_TIP[2])
   })
+
+  it('should return the overridden route and first step when fixitUtils.routeOverride.route is provided but routeOverride.step is not provided', () => {
+    const fixitUtils = {
+      routeOverride: { route: DT_ROUTES.DROP_TIP, step: null },
+    } as any
+
+    const [initialRoute, initialStep] = getInitialRouteAndStep(fixitUtils)
+
+    expect(initialRoute).toBe(DT_ROUTES.DROP_TIP)
+    expect(initialStep).toBe(DT_ROUTES.DROP_TIP[0])
+  })
 })

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipRouting.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipRouting.tsx
@@ -218,7 +218,10 @@ export function getInitialRouteAndStep(
 ): [DropTipFlowsRoute, DropTipFlowsStep] {
   const routeOverride = fixitUtils?.routeOverride
   const initialRoute = routeOverride?.route ?? DT_ROUTES.BEFORE_BEGINNING
-  const initialStep = routeOverride?.step ?? BEFORE_BEGINNING_STEPS[0]
+  const initialStep =
+    routeOverride?.step ??
+    routeOverride?.route?.[0] ??
+    BEFORE_BEGINNING_STEPS[0]
 
   return [initialRoute, initialStep]
 }

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryError.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryError.tsx
@@ -92,6 +92,7 @@ export function RecoveryDropTipFlowErrors({
   routeUpdateActions,
   getRecoveryOptionCopy,
   errorKind,
+  subMapUtils,
 }: RecoveryContentProps): JSX.Element {
   const { t } = useTranslation('error_recovery')
   const { step } = recoveryMap
@@ -107,6 +108,9 @@ export function RecoveryDropTipFlowErrors({
     selectedRecoveryOption,
     errorKind
   )
+
+  // Whenever there is an error during drop tip wizard, reset the submap so properly re-entry routing occurs.
+  subMapUtils.updateSubMap(null)
 
   const buildTitle = (): string => {
     switch (step) {

--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/RecoveryError.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/RecoveryError.test.tsx
@@ -25,12 +25,14 @@ describe('RecoveryError', () => {
   let getRecoverOptionCopyMock: Mock
   let handleMotionRoutingMock: Mock
   let homePipetteZAxesMock: Mock
+  let updateSubMapMock: Mock
 
   beforeEach(() => {
     proceedToRouteAndStepMock = vi.fn()
     getRecoverOptionCopyMock = vi.fn()
     handleMotionRoutingMock = vi.fn().mockResolvedValue(undefined)
     homePipetteZAxesMock = vi.fn().mockResolvedValue(undefined)
+    updateSubMapMock = vi.fn()
 
     props = {
       ...mockRecoveryContentProps,
@@ -48,6 +50,7 @@ describe('RecoveryError', () => {
         route: ERROR_WHILE_RECOVERING.ROUTE,
         step: ERROR_WHILE_RECOVERING.STEPS.RECOVERY_ACTION_FAILED,
       },
+      subMapUtils: { subMap: null, updateSubMap: updateSubMapMock },
     }
 
     getRecoverOptionCopyMock.mockReturnValue('Retry step')
@@ -95,7 +98,7 @@ describe('RecoveryError', () => {
     expect(screen.queryAllByText('Continue to drop tip')[0]).toBeInTheDocument()
   })
 
-  it(`renders RecoveryDropTipFlowErrors when step is ${ERROR_WHILE_RECOVERING.STEPS.DROP_TIP_TIP_DROP_FAILED}`, () => {
+  it(`renders RecoveryDropTipFlowErrors when step is ${ERROR_WHILE_RECOVERING.STEPS.DROP_TIP_TIP_DROP_FAILED} and resets the submap`, () => {
     props.recoveryMap.step =
       RECOVERY_MAP.ERROR_WHILE_RECOVERING.STEPS.DROP_TIP_TIP_DROP_FAILED
     render(props)
@@ -107,6 +110,7 @@ describe('RecoveryError', () => {
       )[0]
     ).toBeInTheDocument()
     expect(screen.queryAllByText('Return to menu')[0]).toBeInTheDocument()
+    expect(updateSubMapMock).toHaveBeenCalledWith(null)
   })
 
   it(`calls proceedToRouteAndStep with ${RECOVERY_MAP.OPTION_SELECTION.ROUTE} when the "Return to menu" button is clicked in RecoveryDropTipFlowErrors with step ${ERROR_WHILE_RECOVERING.STEPS.DROP_TIP_GENERAL_ERROR}`, () => {


### PR DESCRIPTION
Works toward [RQA-3569](https://opentrons.atlassian.net/browse/RQA-3569)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

50c314cb464f670a0ba990b8642d23cf1c9aedad - Something lower level recently changed that causes blowout commands to fail, but the app was not properly bubbling up the errors specifically related to blowout/drop tip actions during drop tip wizard. This PR fixes that.

6f0c61880f59474d900ee223e33da0696af1736a - When an error fails during blowout, we show a "you can still drop tips" modal during error recovery. The "proceed to drop tips" CTA should route users directly to the tip drop flow in drop tip wizard, but it was routing to the option to select blowout or drop tips. This commit fixes just that.

### Current Behavior

<img width="949" alt="Screenshot 2024-11-13 at 11 53 33 AM" src="https://github.com/user-attachments/assets/7c6267b9-6ebb-4473-97b2-7e4c2f2979c8">

### Fixed Behavior

https://github.com/user-attachments/assets/6fdf9fba-72c3-4cb2-8d52-3c2d269af464

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Drop tip wizard correctly shows an error screen if an error occurs during the actual blowout or drop tip action.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3569]: https://opentrons.atlassian.net/browse/RQA-3569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ