### PR TITLE
fix(protocol-designer): fix WellOrderModal image and reset bugs

### DIFF
--- a/protocol-designer/src/organisms/WellOrderModal/index.tsx
+++ b/protocol-designer/src/organisms/WellOrderModal/index.tsx
@@ -92,8 +92,7 @@ export function WellOrderModal(props: WellOrderModalProps): JSX.Element | null {
   }
 
   const handleReset = (): void => {
-    setWellOrder({ firstValue: DEFAULT_FIRST, secondValue: DEFAULT_SECOND })
-    applyChanges()
+    updateValues(DEFAULT_FIRST, DEFAULT_SECOND)
     closeModal()
   }
 
@@ -143,6 +142,13 @@ export function WellOrderModal(props: WellOrderModalProps): JSX.Element | null {
   }
 
   if (!isOpen) return null
+
+  let secondaryOptions = WELL_ORDER_VALUES
+  if (VERTICAL_VALUES.includes(wellOrder.firstValue)) {
+    secondaryOptions = HORIZONTAL_VALUES
+  } else if (HORIZONTAL_VALUES.includes(wellOrder.firstValue)) {
+    secondaryOptions = VERTICAL_VALUES
+  }
 
   return createPortal(
     <Modal
@@ -210,7 +216,7 @@ export function WellOrderModal(props: WellOrderModalProps): JSX.Element | null {
                 value: wellOrder.secondValue,
               }}
               onClick={makeOnChange('second')}
-              filterOptions={WELL_ORDER_VALUES.map(value => ({
+              filterOptions={secondaryOptions.map(value => ({
                 value,
                 name: t(`step_edit_form.field.well_order.option.${value}`),
                 disabled: isSecondOptionDisabled(value),


### PR DESCRIPTION
# Overview

This PR fixes 2 bugs in the `WellOrderModal` component.

1. The first bug arose when attempting to set both primary and secondary order to the same axis. This is fixed by filtering secondary order based on the selected primary order. 
2. The second bug stemmed from using a stale state when applying changes and closing the modal after reset-- our helper function to reset values to default set state and applied changes in the same render, resulting in old values being applied. Here, I fix this by directly applying the new values on reset.

Closes RQA-3531, Closes RQA-3532

https://github.com/user-attachments/assets/4883a6c2-5106-4b99-b8bc-ab629352b39e

## Test Plan and Hands on Testing

- create or edit transfer or mix form advanced settings
- open well order modal
- verify that secondary order options are limited to the 2 orders of the opposite axis of the selected primary order 
- modify the selected primary order to the other axis, and verify that the secondary order options filter accordingly
- select 'reset to default' and verify that the toolbox shows the default after the first try (top to bottom, left to right)

## Changelog

- fix runtime bug for reset
- filter secondary order options based on primary order selection

## Review requests

see test plan

## Risk assessment

low