### PR TITLE
fix(app): Fix run setup buttons

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabware.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabware.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, screen } from '@testing-library/react'
 import { describe, it, beforeEach, vi, afterEach, expect } from 'vitest'
 import { when } from 'vitest-when'
 
+import { useHoverTooltip } from '@opentrons/components'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useLPCSuccessToast } from '../../../hooks/useLPCSuccessToast'
@@ -20,6 +22,13 @@ import {
   useUnmatchedModulesForProtocol,
 } from '/app/resources/runs'
 
+vi.mock('@opentrons/components', async () => {
+  const actual = await vi.importActual('@opentrons/components')
+  return {
+    ...actual,
+    useHoverTooltip: vi.fn(),
+  }
+})
 vi.mock('../SetupLabwareList')
 vi.mock('../SetupLabwareMap')
 vi.mock('/app/organisms/LabwarePositionCheck')
@@ -78,7 +87,6 @@ describe('SetupLabware', () => {
       .thenReturn({
         complete: true,
       })
-    when(vi.mocked(useRunHasStarted)).calledWith(RUN_ID).thenReturn(false)
     vi.mocked(getIsLabwareOffsetCodeSnippetsOn).mockReturnValue(false)
     vi.mocked(SetupLabwareMap).mockReturnValue(
       <div>mock setup labware map</div>
@@ -88,6 +96,8 @@ describe('SetupLabware', () => {
     )
     vi.mocked(useLPCDisabledReason).mockReturnValue(null)
     vi.mocked(useNotifyRunQuery).mockReturnValue({} as any)
+    vi.mocked(useHoverTooltip).mockReturnValue([{}, {}] as any)
+    vi.mocked(useRunHasStarted).mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -98,8 +108,21 @@ describe('SetupLabware', () => {
     render()
     screen.getByText('mock setup labware list')
     screen.getByRole('button', { name: 'List View' })
+    screen.getByRole('button', { name: 'Confirm placements' })
     const mapView = screen.getByRole('button', { name: 'Map View' })
     fireEvent.click(mapView)
     screen.getByText('mock setup labware map')
+  })
+
+  it('disables the confirmation button if the run has already started', () => {
+    vi.mocked(useRunHasStarted).mockReturnValue(true)
+
+    render()
+
+    const btn = screen.getByRole('button', {
+      name: 'Confirm placements',
+    })
+
+    expect(btn).toBeDisabled()
   })
 })

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/index.tsx
@@ -1,17 +1,22 @@
 import { useTranslation } from 'react-i18next'
 import map from 'lodash/map'
+
 import {
   JUSTIFY_CENTER,
   Flex,
   SPACING,
   PrimaryButton,
   DIRECTION_COLUMN,
+  Tooltip,
+  useHoverTooltip,
 } from '@opentrons/components'
+
 import { useToggleGroup } from '/app/molecules/ToggleGroup/useToggleGroup'
 import { getModuleTypesThatRequireExtraAttention } from '../utils/getModuleTypesThatRequireExtraAttention'
 import {
   useMostRecentCompletedAnalysis,
   useModuleRenderInfoForProtocolById,
+  useRunHasStarted,
 } from '/app/resources/runs'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { useStoredProtocolAnalysis } from '/app/resources/analysis'
@@ -46,6 +51,11 @@ export function SetupLabware(props: SetupLabwareProps): JSX.Element {
     moduleModels
   )
 
+  // TODO(jh, 11-13-24): These disabled tooltips are used throughout setup flows. Let's consolidate them.
+  const [targetProps, tooltipProps] = useHoverTooltip()
+  const runHasStarted = useRunHasStarted(runId)
+  const tooltipText = runHasStarted ? t('protocol_run_started') : null
+
   return (
     <>
       <Flex
@@ -70,10 +80,14 @@ export function SetupLabware(props: SetupLabwareProps): JSX.Element {
           onClick={() => {
             setLabwareConfirmed(true)
           }}
-          disabled={labwareConfirmed}
+          disabled={labwareConfirmed || runHasStarted}
+          {...targetProps}
         >
           {t('confirm_placements')}
         </PrimaryButton>
+        {tooltipText != null ? (
+          <Tooltip tooltipProps={tooltipProps}>{tooltipText}</Tooltip>
+        ) : null}
       </Flex>
     </>
   )

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
@@ -143,7 +143,6 @@ export function SetupLabwarePositionCheck(
         ) : null}
         <PrimaryButton
           textTransform={TYPOGRAPHY.textTransformCapitalize}
-          title={t('run_labware_position_check')}
           onClick={() => {
             launchLPC()
             setIsShowingLPCSuccessToast(false)

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquids.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquids.test.tsx
@@ -1,15 +1,26 @@
 import type * as React from 'react'
-import { describe, it, beforeEach, vi } from 'vitest'
+import { describe, it, beforeEach, vi, expect } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
+
+import { useHoverTooltip } from '@opentrons/components'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { SetupLiquids } from '../index'
 import { SetupLiquidsList } from '../SetupLiquidsList'
 import { SetupLiquidsMap } from '../SetupLiquidsMap'
+import { useRunHasStarted } from '/app/resources/runs'
 
+vi.mock('@opentrons/components', async () => {
+  const actual = await vi.importActual('@opentrons/components')
+  return {
+    ...actual,
+    useHoverTooltip: vi.fn(),
+  }
+})
 vi.mock('../SetupLiquidsList')
 vi.mock('../SetupLiquidsMap')
+vi.mock('/app/resources/runs')
 
 describe('SetupLiquids', () => {
   const render = (
@@ -44,6 +55,8 @@ describe('SetupLiquids', () => {
     vi.mocked(SetupLiquidsMap).mockReturnValue(
       <div>Mock setup liquids map</div>
     )
+    vi.mocked(useHoverTooltip).mockReturnValue([{}, {}] as any)
+    vi.mocked(useRunHasStarted).mockReturnValue(false)
   })
 
   it('renders the list and map view buttons and proceed button', () => {
@@ -63,5 +76,16 @@ describe('SetupLiquids', () => {
     const mapViewButton = screen.getByRole('button', { name: 'List View' })
     fireEvent.click(mapViewButton)
     screen.getByText('Mock setup liquids list')
+  })
+  it('disables the confirmation button if the run has already started', () => {
+    vi.mocked(useRunHasStarted).mockReturnValue(true)
+
+    render(props)
+
+    const btn = screen.getByRole('button', {
+      name: 'Confirm locations and volumes',
+    })
+
+    expect(btn).toBeDisabled()
   })
 })

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLiquids/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLiquids/index.tsx
@@ -6,11 +6,14 @@ import {
   DIRECTION_COLUMN,
   ALIGN_CENTER,
   PrimaryButton,
+  useHoverTooltip,
+  Tooltip,
 } from '@opentrons/components'
 import { useToggleGroup } from '/app/molecules/ToggleGroup/useToggleGroup'
 import { ANALYTICS_LIQUID_SETUP_VIEW_TOGGLE } from '/app/redux/analytics'
 import { SetupLiquidsList } from './SetupLiquidsList'
 import { SetupLiquidsMap } from './SetupLiquidsMap'
+import { useRunHasStarted } from '/app/resources/runs'
 
 import type {
   CompletedProtocolAnalysis,
@@ -38,6 +41,12 @@ export function SetupLiquids({
     t('map_view') as string,
     ANALYTICS_LIQUID_SETUP_VIEW_TOGGLE
   )
+
+  // TODO(jh, 11-13-24): These disabled tooltips are used throughout setup flows. Let's consolidate them.
+  const [targetProps, tooltipProps] = useHoverTooltip()
+  const runHasStarted = useRunHasStarted(runId)
+  const tooltipText = runHasStarted ? t('protocol_run_started') : null
+
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}
@@ -56,10 +65,14 @@ export function SetupLiquids({
           onClick={() => {
             setLiquidSetupConfirmed(true)
           }}
-          disabled={isLiquidSetupConfirmed}
+          disabled={isLiquidSetupConfirmed || runHasStarted}
+          {...targetProps}
         >
           {t('confirm_locations_and_volumes')}
         </PrimaryButton>
+        {tooltipText != null ? (
+          <Tooltip tooltipProps={tooltipProps}>{tooltipText}</Tooltip>
+        ) : null}
       </Flex>
     </Flex>
   )


### PR DESCRIPTION
Closes [RQA-3578](https://opentrons.atlassian.net/browse/RQA-3578) and [RQA-3577](https://opentrons.atlassian.net/browse/RQA-3577)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a few buttons in setup flows on the desktop app.

69e4aa6b71afb7bab0ee1bf2ae081ea8cb090bba - If you hover the LPC button, you can get some unexpected title text. We simply remove the title prop here. 

a60445815fa210b0ade4e466182e719d4e56be91 - We were missing disabled status/tooltips on these two buttons in particular, so this adds them. Left a TODO to consolidate this behavior, since we use it for every step in the setup fows.

https://github.com/user-attachments/assets/43312289-6234-4049-90bc-d4b0b5a41a1a


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Labware and Liquid setup buttons are now disabled once a run has started.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3578]: https://opentrons.atlassian.net/browse/RQA-3578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-3577]: https://opentrons.atlassian.net/browse/RQA-3577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ