### PR TITLE
chore(components): do not bundle styled components in dist

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/Opentrons/opentrons#readme",
   "peerDependencies": {
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "styled-components": "5.3.6"
   },
   "dependencies": {
     "@opentrons/shared-data": "link:../shared-data",

--- a/components/vite.config.mts
+++ b/components/vite.config.mts
@@ -10,14 +10,18 @@ import lostCss from 'lost'
 export default defineConfig({
   build: {
     // Relative to the root
-    ssr: 'src/index.ts',
     outDir: 'lib',
     // do not delete the outdir, typescript types might live there and we dont want to delete them
     emptyOutDir: false,
-    commonjsOptions: {
-      transformMixedEsModules: true,
-      esmExternals: true,
+    lib: {
+      entry: 'src/index.ts',
+      formats: ['es', 'cjs'], // Generate both ES Module and CommonJS outputs
+      fileName: (format) => (format === 'es' ? 'index.mjs' : 'index.cjs'),
     },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'styled-components'], // Ensure peer dependencies are not bundled
+    },
+    target: 'es2017', // Transpile down to a compatible version for Next.js (for Protocol Library)
   },
   plugins: [
     react({
@@ -32,6 +36,7 @@ export default defineConfig({
     esbuildOptions: {
       target: 'es2020',
     },
+    exclude: ['styled-components'], // Avoid pre-bundling styled-components
   },
   css: {
     postcss: {
@@ -55,5 +60,6 @@ export default defineConfig({
         '../components/src/index.module.css'
       ),
     },
+    dedupe: ['styled-components'], // Prevent duplicate styled-components instances
   },
 })


### PR DESCRIPTION
# Overview

This PR transpiles the components library in a way that next js can use. The main change is that we don't bundle styled-components anymore and instead force dependencies to provide it so there is one single version being used throughout the entire application.

closes RPLC-1013

## Test Plan and Hands on Testing

Tough to really test, but this is pretty much the same code as `components@0.1.6-alpha.9` which @y3rsh confirmed works for PL. 

## Changelog

- do not bundle styled components in dist

## Review requests

Let's poke around the app, PD, and LL to make sure none of our components broke. stuff seems to look fine though:

https://sandbox.designer.opentrons.com/components_exclude-styled-components-from-build
http://sandbox.labware.opentrons.com/components_exclude-styled-components-from-build/

## Risk assessment

Med
