### PR TITLE
refactor(robot-server): Adjust SQL declarations to match reality

### DIFF
--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -253,7 +253,6 @@ data_files_table = sqlalchemy.Table(
             validate_strings=True,
             create_constraint=True,
         ),
-        index=True,
         nullable=False,
     ),
 )

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -251,7 +251,11 @@ data_files_table = sqlalchemy.Table(
             DataFileSourceSQLEnum,
             values_callable=lambda obj: [e.value for e in obj],
             validate_strings=True,
-            create_constraint=True,
+            # create_constraint=False to match the underlying SQL, which omits
+            # the constraint because of a bug in the migration that introduced this
+            # column. This is not intended to ever have values other than those in
+            # DataFileSourceSQLEnum.
+            create_constraint=False,
         ),
         # nullable=True to match the underlying SQL, which is nullable because of a bug
         # in the migration that introduced this column. This is not intended to ever be

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -207,7 +207,7 @@ run_command_table = sqlalchemy.Table(
     sqlalchemy.Column("index_in_run", sqlalchemy.Integer, nullable=False),
     sqlalchemy.Column("command_id", sqlalchemy.String, nullable=False),
     sqlalchemy.Column("command", sqlalchemy.String, nullable=False),
-    sqlalchemy.Column("command_intent", sqlalchemy.String, nullable=False, index=True),
+    sqlalchemy.Column("command_intent", sqlalchemy.String, nullable=False),
     sqlalchemy.Index(
         "ix_run_run_id_command_id",  # An arbitrary name for the index.
         "run_id",

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -253,7 +253,10 @@ data_files_table = sqlalchemy.Table(
             validate_strings=True,
             create_constraint=True,
         ),
-        nullable=False,
+        # nullable=True to match the underlying SQL, which is nullable because of a bug
+        # in the migration that introduced this column. This is not intended to ever be
+        # null in practice.
+        nullable=True,
     ),
 )
 

--- a/robot-server/robot_server/persistence/tables/schema_7.py
+++ b/robot-server/robot_server/persistence/tables/schema_7.py
@@ -207,7 +207,14 @@ run_command_table = sqlalchemy.Table(
     sqlalchemy.Column("index_in_run", sqlalchemy.Integer, nullable=False),
     sqlalchemy.Column("command_id", sqlalchemy.String, nullable=False),
     sqlalchemy.Column("command", sqlalchemy.String, nullable=False),
-    sqlalchemy.Column("command_intent", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column(
+        "command_intent",
+        sqlalchemy.String,
+        # nullable=True to match the underlying SQL, which is nullable because of a bug
+        # in the migration that introduced this column. This is not intended to ever be
+        # null in practice.
+        nullable=True,
+    ),
     sqlalchemy.Index(
         "ix_run_run_id_command_id",  # An arbitrary name for the index.
         "run_id",

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -109,7 +109,7 @@ EXPECTED_STATEMENTS_LATEST = [
         index_in_run INTEGER NOT NULL,
         command_id VARCHAR NOT NULL,
         command VARCHAR NOT NULL,
-        command_intent VARCHAR NOT NULL,
+        command_intent VARCHAR,
         PRIMARY KEY (row_id),
         FOREIGN KEY(run_id) REFERENCES run (id)
     )
@@ -595,11 +595,6 @@ def test_creating_from_metadata_emits_expected_statements(
 
 
 # FIXME(mm, 2024-11-12): https://opentrons.atlassian.net/browse/EXEC-827
-#
-# There are at least these mismatches:
-#
-# - `command.command_intent` is nullable as emitted by the migration path, but not as declared in metadata
-#
 # Remove this xfail mark when the mismatches are resolved.
 @pytest.mark.xfail(strict=True)
 def test_migrated_db_matches_db_created_from_metadata(tmp_path: Path) -> None:

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -542,7 +542,7 @@ EXPECTED_STATEMENTS_V2 = [
 
 
 def _normalize_statement(statement: str) -> str:
-    """Fix up the formatting of a SQL statement for easier comparison."""
+    """Fix up the internal formatting of a single SQL statement for easier comparison."""
     lines = statement.splitlines()
 
     # Remove whitespace at the beginning and end of each line.
@@ -551,7 +551,10 @@ def _normalize_statement(statement: str) -> str:
     # Filter out blank lines.
     lines = [line for line in lines if line != ""]
 
-    return "\n".join(lines)
+    # Normalize line breaks to spaces. When we ask SQLite for its schema, it appears
+    # inconsistent in whether it uses spaces or line breaks to separate tokens.
+    # That may have to do with whether `ALTER TABLE` has been used on the table.
+    return " ".join(lines)
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -129,7 +129,7 @@ EXPECTED_STATEMENTS_LATEST = [
         name VARCHAR NOT NULL,
         file_hash VARCHAR NOT NULL,
         created_at DATETIME NOT NULL,
-        source VARCHAR(9) NOT NULL,
+        source VARCHAR(9),
         PRIMARY KEY (id),
         CONSTRAINT datafilesourcesqlenum CHECK (source IN ('uploaded', 'generated'))
     )
@@ -599,7 +599,6 @@ def test_creating_from_metadata_emits_expected_statements(
 #
 # There are at least these mismatches:
 #
-# - `data_files.source` is nullable as emitted by the migration path, but not as declared in metadata
 # - `command.command_intent` is nullable as emitted by the migration path, but not as declared in metadata
 # - constraint `datafilesourcesqlenum` is present in metadata, but not not emitted by the migration path
 #

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -594,9 +594,6 @@ def test_creating_from_metadata_emits_expected_statements(
     assert set(normalized_actual) == set(normalized_expected)
 
 
-# FIXME(mm, 2024-11-12): https://opentrons.atlassian.net/browse/EXEC-827
-# Remove this xfail mark when the mismatches are resolved.
-@pytest.mark.xfail(strict=True)
 def test_migrated_db_matches_db_created_from_metadata(tmp_path: Path) -> None:
     """Test that the output of migration matches `metadata.create_all()`.
 

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -121,9 +121,6 @@ EXPECTED_STATEMENTS_LATEST = [
     CREATE UNIQUE INDEX ix_run_run_id_index_in_run ON run_command (run_id, index_in_run)
     """,
     """
-    CREATE INDEX ix_data_files_source ON data_files (source)
-    """,
-    """
     CREATE INDEX ix_protocol_protocol_kind ON protocol (protocol_kind)
     """,
     """
@@ -605,7 +602,6 @@ def test_creating_from_metadata_emits_expected_statements(
 #
 # There are at least these mismatches:
 #
-# - `ix_data_files_source` is present in metadata, but not emitted by the migration path
 # - `ix_run_command_command_intent` is present in metadata, but not emitted by the migration path
 # - `data_files.source` is nullable as emitted by the migration path, but not as declared in metadata
 # - `command.command_intent` is nullable as emitted by the migration path, but not as declared in metadata

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -124,9 +124,6 @@ EXPECTED_STATEMENTS_LATEST = [
     CREATE INDEX ix_protocol_protocol_kind ON protocol (protocol_kind)
     """,
     """
-    CREATE INDEX ix_run_command_command_intent ON run_command (command_intent)
-    """,
-    """
     CREATE TABLE data_files (
         id VARCHAR NOT NULL,
         name VARCHAR NOT NULL,
@@ -602,7 +599,6 @@ def test_creating_from_metadata_emits_expected_statements(
 #
 # There are at least these mismatches:
 #
-# - `ix_run_command_command_intent` is present in metadata, but not emitted by the migration path
 # - `data_files.source` is nullable as emitted by the migration path, but not as declared in metadata
 # - `command.command_intent` is nullable as emitted by the migration path, but not as declared in metadata
 # - constraint `datafilesourcesqlenum` is present in metadata, but not not emitted by the migration path

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -130,8 +130,7 @@ EXPECTED_STATEMENTS_LATEST = [
         file_hash VARCHAR NOT NULL,
         created_at DATETIME NOT NULL,
         source VARCHAR(9),
-        PRIMARY KEY (id),
-        CONSTRAINT datafilesourcesqlenum CHECK (source IN ('uploaded', 'generated'))
+        PRIMARY KEY (id)
     )
     """,
     """
@@ -600,7 +599,6 @@ def test_creating_from_metadata_emits_expected_statements(
 # There are at least these mismatches:
 #
 # - `command.command_intent` is nullable as emitted by the migration path, but not as declared in metadata
-# - constraint `datafilesourcesqlenum` is present in metadata, but not not emitted by the migration path
 #
 # Remove this xfail mark when the mismatches are resolved.
 @pytest.mark.xfail(strict=True)


### PR DESCRIPTION
## Overview

This is step 2 towards fixing EXEC-827.

This retroactively edits our SQLAlchemy definitions to match what is actually running on robots. What is actually running on robots is decided by our migration system, and our migration system sometimes does manual `ALTER TABLE` fixups that do not exactly match our SQLAlchemy definitions. See EXEC-827 for details.

So this PR shows some constraints and indexes that were accidentally omitted. The next step after this PR is to find a way to actually get them back. We're figuring that out over in https://github.com/Opentrons/opentrons/pull/16697#discussion_r1831756306. It will probably piggyback on the new migration, v7->v8, that that PR is adding.

## Test Plan and Hands on Testing

The correctness of these reconciliations is checked by a test added in #16772.

## Review requests

None in particular.

## Risk assessment

Low. This shouldn't cause any behavioral change.