### PR TITLE
fix(app): enable about plate reader button when run is in progress

### DIFF
--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -150,7 +150,7 @@ export const ModuleOverflowMenu = (
               <Fragment key={`${index}_${String(module.moduleType)}`}>
                 <MenuItem
                   onClick={() => item.onClick(item.isSecondary)}
-                  disabled={item.disabledReason || isDisabled}
+                  disabled={item.isSettingDisabled}
                   whiteSpace={NO_WRAP}
                 >
                   {item.setSetting}

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -80,6 +80,7 @@ export function useLatchControls(module: AttachedModule): LatchControls {
 export type MenuItemsByModuleType = {
   [moduleType in AttachedModule['moduleType']]: Array<{
     setSetting: string
+    isSettingDisabled: boolean
     isSecondary: boolean
     menuButtons: JSX.Element[] | null
     onClick: (isSecondary: boolean) => void
@@ -267,6 +268,7 @@ export function useModuleOverflowMenu(
           module.data.lidTargetTemperature != null
             ? t('overflow_menu_deactivate_lid')
             : t('overflow_menu_lid_temp'),
+        isSettingDisabled: isDisabled,
         isSecondary: true,
         menuButtons: null,
         onClick:
@@ -285,6 +287,7 @@ export function useModuleOverflowMenu(
           module.data.lidStatus === 'open'
             ? t('close_lid')
             : t('open_lid'),
+        isSettingDisabled: isDisabled,
         isSecondary: false,
         menuButtons: [thermoSetBlockTempBtn, aboutModuleBtn],
         onClick: controlTCLid,
@@ -298,6 +301,7 @@ export function useModuleOverflowMenu(
             ? t('overflow_menu_deactivate_temp')
             : t('overflow_menu_mod_temp'),
         isSecondary: false,
+        isSettingDisabled: isDisabled,
         menuButtons: [aboutModuleBtn],
         onClick:
           module.data.status !== 'idle'
@@ -317,6 +321,7 @@ export function useModuleOverflowMenu(
             ? t('overflow_menu_disengage')
             : t('overflow_menu_engage'),
         isSecondary: false,
+        isSettingDisabled: isDisabled,
         menuButtons: [aboutModuleBtn],
         onClick:
           module.data.status !== 'disengaged'
@@ -336,6 +341,7 @@ export function useModuleOverflowMenu(
             ? t('heater_shaker:deactivate_heater')
             : t('heater_shaker:set_temperature'),
         isSecondary: false,
+        isSettingDisabled: isDisabled,
         menuButtons: [
           labwareLatchBtn,
           aboutModuleBtn,
@@ -358,6 +364,7 @@ export function useModuleOverflowMenu(
       {
         setSetting: t('overflow_menu_about'),
         isSecondary: false,
+        isSettingDisabled: false,
         menuButtons: [],
         onClick: handleAboutClick,
       },


### PR DESCRIPTION
fix RQA-3561

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Enable plate reader card "About Module" button while run is in progress
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Check the module overflow button on a desktop devices page module card for a plate reader while the device has a run in progress. This should now be enabled
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Add `isSettingDisabled` prop to allow for some modules to have enabled overflow menu items even if a run is in progress. Make this `false` for plate reader "About Module" item so that it's always enabled
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick code check/test if you're in office
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
