### PR TITLE
fix(api): Skip updating position estimators for axes that are not present

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -775,12 +775,12 @@ class OT3API(
         """
         Function to update motor estimation for a set of axes
         """
+        if axes is None:
+            axes = [ax for ax in Axis]
 
-        if axes:
-            checked_axes = [ax for ax in axes if ax in Axis]
-        else:
-            checked_axes = [ax for ax in Axis]
-        await self._backend.update_motor_estimation(checked_axes)
+        axes = [ax for ax in axes if self._backend.axis_is_present(ax)]
+
+        await self._backend.update_motor_estimation(axes)
 
     # Global actions API
     def pause(self, pause_type: PauseType) -> None:

--- a/api/src/opentrons/hardware_control/protocols/position_estimator.py
+++ b/api/src/opentrons/hardware_control/protocols/position_estimator.py
@@ -10,7 +10,7 @@ class PositionEstimator(Protocol):
         """Update the specified axes' position estimators from their encoders.
 
         This will allow these axes to make a non-home move even if they do not currently have
-        a position estimation (unless there is no tracked poition from the encoders, as would be
+        a position estimation (unless there is no tracked position from the encoders, as would be
         true immediately after boot).
 
         Axis encoders have less precision than their position estimators. Calling this function will
@@ -19,6 +19,8 @@ class PositionEstimator(Protocol):
 
         This function updates only the requested axes. If other axes have bad position estimation,
         moves that require those axes or attempts to get the position of those axes will still fail.
+        Axes that are not currently available (like a plunger for a pipette that is not connected)
+        will be ignored.
         """
         ...
 

--- a/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
@@ -23,7 +23,11 @@ class UpdatePositionEstimatorsParams(BaseModel):
     """Payload required for an UpdatePositionEstimators command."""
 
     axes: List[MotorAxis] = Field(
-        ..., description="The axes for which to update the position estimators."
+        ...,
+        description=(
+            "The axes for which to update the position estimators."
+            " Any axes that are not physically present will be ignored."
+        ),
     )
 
 

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -2037,23 +2037,36 @@ async def test_drop_tip_full_tiprack(
 
 
 @pytest.mark.parametrize(
-    "axes",
-    [[Axis.X], [Axis.X, Axis.Y], [Axis.X, Axis.Y, Axis.P_L], None],
+    ("axes_in", "axes_present", "expected_axes"),
+    [
+        ([Axis.X, Axis.Y], [Axis.X, Axis.Y], [Axis.X, Axis.Y]),
+        ([Axis.X, Axis.Y], [Axis.Y, Axis.Z_L], [Axis.Y]),
+        (None, list(Axis), list(Axis)),
+        (None, [Axis.Y, Axis.Z_L], [Axis.Y, Axis.Z_L]),
+    ],
 )
 async def test_update_position_estimation(
     ot3_hardware: ThreadManager[OT3API],
     hardware_backend: OT3Simulator,
-    axes: List[Axis],
+    axes_in: List[Axis],
+    axes_present: List[Axis],
+    expected_axes: List[Axis],
 ) -> None:
+    def _axis_is_present(axis: Axis) -> bool:
+        return axis in axes_present
+
     with patch.object(
         hardware_backend,
         "update_motor_estimation",
         AsyncMock(spec=hardware_backend.update_motor_estimation),
-    ) as mock_update:
-        await ot3_hardware._update_position_estimation(axes)
-        if axes is None:
-            axes = [ax for ax in Axis]
-        mock_update.assert_called_once_with(axes)
+    ) as mock_update, patch.object(
+        hardware_backend,
+        "axis_is_present",
+        Mock(spec=hardware_backend.axis_is_present),
+    ) as mock_axis_is_present:
+        mock_axis_is_present.side_effect = _axis_is_present
+        await ot3_hardware._update_position_estimation(axes_in)
+        mock_update.assert_called_once_with(expected_axes)
 
 
 async def test_refresh_positions(

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -369,12 +369,6 @@ const buildBlowoutCommands = (
             ),
           },
         },
-        {
-          commandType: 'prepareToAspirate',
-          params: {
-            pipetteId: pipetteId ?? MANAGED_PIPETTE_ID,
-          },
-        },
         Z_HOME,
       ]
     : [

--- a/hardware/opentrons_hardware/hardware_control/motor_position_status.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_position_status.py
@@ -152,11 +152,7 @@ async def update_motor_position_estimation(
                 log.warning("Update motor position estimation timed out")
                 raise CommandTimedOutError(
                     "Update motor position estimation timed out",
-                    detail={
-                        "missing-nodes": ", ".join(
-                            node.name for node in set(nodes).difference(set(data))
-                        )
-                    },
+                    detail={"missing-node": node.name},
                 )
 
     return data

--- a/shared-data/command/schemas/10.json
+++ b/shared-data/command/schemas/10.json
@@ -4624,7 +4624,7 @@
       "type": "object",
       "properties": {
         "axes": {
-          "description": "The axes for which to update the position estimators.",
+          "description": "The axes for which to update the position estimators. Any axes that are not physically present will be ignored.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/MotorAxis"


### PR DESCRIPTION
## Overview

Fixes RQA-3569.

## Test Plan and Hands on Testing

* [x] Follow the steps to reproduce in RQA-3569. The robot should not complain about any missing nodes; the `unsafe/updatePositionEstimators` commands should succeed.

## Changelog

* At the hardware API level, if the caller tries to update the position estimations for axes that aren't physically present, just skip those axes.
* Also, remove a `prepareToAspirate` command from the drop tip wizard. This was causing the wizard to fail with a "no tip attached" error. @mjhuff, @sfoster1 and I couldn't remember why we added it in the first place in #15869.

## Review requests

* On the robot I tested with, I noticed that `gripper_g` always timed out, even with a gripper attached. Is that expected, or should we investigate further?
* Any reason not to delete the `prepareToAspirate` command?

## Risk assessment

Medium. We're not so sure about the `prepareToAspirate` command. If it breaks something, it'll probably break something somewhere in error recovery.