### PR TITLE
feat(opentrons-ai-client): only load latest labware defs

### DIFF
--- a/opentrons-ai-client/src/molecules/ControlledLabwareListItems/index.tsx
+++ b/opentrons-ai-client/src/molecules/ControlledLabwareListItems/index.tsx
@@ -14,7 +14,7 @@ import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { LabwareDiagram } from '../../molecules/LabwareDiagram'
 import type { DisplayLabware } from '../../organisms/LabwareLiquidsSection'
 import { LABWARES_FIELD_NAME } from '../../organisms/LabwareLiquidsSection'
-import { getAllDefinitions } from '../../resources/utils'
+import { getOnlyLatestDefs } from '../../resources/utils'
 
 export function ControlledLabwareListItems(): JSX.Element | null {
   const { t } = useTranslation('create_protocol')
@@ -22,7 +22,7 @@ export function ControlledLabwareListItems(): JSX.Element | null {
 
   const labwares: DisplayLabware[] = watch(LABWARES_FIELD_NAME) ?? []
 
-  const defs = getAllDefinitions()
+  const defs = getOnlyLatestDefs()
 
   return (
     <Controller

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -22,7 +22,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { ModuleDiagram } from '../ModelDiagram'
 import { MODULES_FIELD_NAME } from '../../organisms/ModulesSection'
 import type { DisplayModules } from '../../organisms/ModulesSection'
-import { getAllDefinitions } from '../../resources/utils'
+import { getOnlyLatestDefs } from '../../resources/utils'
 import { useTranslation } from 'react-i18next'
 import { useMemo } from 'react'
 
@@ -70,7 +70,7 @@ export function ModuleListItemGroup(): JSX.Element | null {
   const modulesWatch: DisplayModules[] = watch(MODULES_FIELD_NAME) ?? []
 
   const allDefinitionsValues = useMemo(
-    () => Object.values(getAllDefinitions()),
+    () => Object.values(getOnlyLatestDefs()),
     []
   )
 

--- a/opentrons-ai-client/src/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/organisms/LabwareModal/index.tsx
@@ -19,7 +19,7 @@ import { createPortal } from 'react-dom'
 import { reduce } from 'lodash'
 import { ListButtonCheckbox } from '../../atoms/ListButtonCheckbox/ListButtonCheckbox'
 import { LABWARES_FIELD_NAME } from '../LabwareLiquidsSection'
-import { getAllDefinitions } from '../../resources/utils'
+import { getOnlyLatestDefs } from '../../resources/utils'
 import type { DisplayLabware } from '../LabwareLiquidsSection'
 import type {
   LabwareDefByDefURI,
@@ -56,7 +56,7 @@ export function LabwareModal({
   const searchFilter = (termToCheck: string): boolean =>
     termToCheck.toLowerCase().includes(searchTerm.toLowerCase())
 
-  const defs = getAllDefinitions()
+  const defs = getOnlyLatestDefs()
 
   const labwareByCategory: Record<
     string,

--- a/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../organisms/InstrumentsSection'
 import type { UseFormWatch } from 'react-hook-form'
 import type { CreateProtocolFormData } from '../../pages/CreateProtocol'
-import { getAllDefinitions } from './labware'
+import { getOnlyLatestDefs } from './labware'
 import type { CreatePrompt } from '../types'
 
 export function generatePromptPreviewApplicationItems(
@@ -92,7 +92,7 @@ export function generatePromptPreviewLabwareLiquidsItems(
   const { labwares, liquids } = watch()
 
   const items: string[] = []
-  const defs = getAllDefinitions()
+  const defs = getOnlyLatestDefs()
 
   labwares?.forEach(labware => {
     items.push(
@@ -159,7 +159,7 @@ export function generateChatPrompt(
     args_0: CreatePrompt | ((prev: CreatePrompt) => CreatePrompt)
   ) => void
 ): string {
-  const defs = getAllDefinitions()
+  const defs = getOnlyLatestDefs()
 
   const robotType = t(values.instruments.robot)
   const scientificApplication = t(values.application.scientificApplication)

--- a/opentrons-ai-client/src/resources/utils/labware.ts
+++ b/opentrons-ai-client/src/resources/utils/labware.ts
@@ -2,16 +2,52 @@ import {
   LABWAREV2_DO_NOT_LIST,
   RETIRED_LABWARE,
   getAllDefinitions as _getAllDefinitions,
+  getLabwareDefURI,
 } from '@opentrons/shared-data'
-import type { LabwareDefByDefURI } from '@opentrons/shared-data'
+import { groupBy } from 'lodash'
+import type {
+  LabwareDefByDefURI,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 
 let _definitions: LabwareDefByDefURI | null = null
+
+const BLOCK_LIST = [...RETIRED_LABWARE, ...LABWAREV2_DO_NOT_LIST]
+
 export function getAllDefinitions(): LabwareDefByDefURI {
   if (_definitions == null) {
-    _definitions = _getAllDefinitions([
-      ...RETIRED_LABWARE,
-      ...LABWAREV2_DO_NOT_LIST,
-    ])
+    _definitions = _getAllDefinitions(BLOCK_LIST)
   }
   return _definitions
+}
+
+// filter out all but the latest version of each labware
+// NOTE: this is similar to labware-library's getOnlyLatestDefs, but this one
+// has the {labwareDefURI: def} shape, instead of an array of labware defs
+let _latestDefs: LabwareDefByDefURI | null = null
+export function getOnlyLatestDefs(): LabwareDefByDefURI {
+  if (!_latestDefs) {
+    const allDefs = getAllDefinitions()
+    const allURIs = Object.keys(allDefs)
+    const labwareDefGroups: Record<string, LabwareDefinition2[]> = groupBy(
+      allURIs.map((uri: string) => allDefs[uri]),
+      d => `${d.namespace}/${d.parameters.loadName}`
+    )
+    _latestDefs = Object.keys(labwareDefGroups).reduce(
+      (acc, groupKey: string) => {
+        const group = labwareDefGroups[groupKey]
+        const allVersions = group.map(d => d.version)
+        const highestVersionNum = Math.max(...allVersions)
+        const resultIdx = group.findIndex(d => d.version === highestVersionNum)
+        const latestDefInGroup = group[resultIdx]
+        return {
+          ...acc,
+          [getLabwareDefURI(latestDefInGroup)]: latestDefInGroup,
+        }
+      },
+      {}
+    )
+  }
+
+  return _latestDefs
 }


### PR DESCRIPTION
# Overview

This PR only loads latest labware defs into the ai client, rather than every single version of every labware. 

## Review requests

Make sure labware duplicates no longer show up in the ai client

## Risk assessment

Low