### PR TITLE
fix(app): add error handling for failed maintenance run creation

### DIFF
--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -71,6 +71,7 @@ export function GripperWizardFlows(
   const [createdMaintenanceRunId, setCreatedMaintenanceRunId] = useState<
     string | null
   >(null)
+  const [errorMessage, setErrorMessage] = useState<null | string>(null)
 
   // we should start checking for run deletion only after the maintenance run is created
   // and the useCurrentRun poll has returned that created id
@@ -85,6 +86,9 @@ export function GripperWizardFlows(
   } = useCreateTargetedMaintenanceRunMutation({
     onSuccess: response => {
       setCreatedMaintenanceRunId(response.data.id)
+    },
+    onError: error => {
+      setErrorMessage(error.message)
     },
   })
 
@@ -117,7 +121,6 @@ export function GripperWizardFlows(
   ])
 
   const [isExiting, setIsExiting] = useState<boolean>(false)
-  const [errorMessage, setErrorMessage] = useState<null | string>(null)
 
   const handleClose = (): void => {
     if (props?.onComplete != null) {
@@ -298,9 +301,12 @@ export const GripperWizard = (
         isRobotMoving={isRobotMoving}
       />
     )
-  } else if (
+  }
+  // These flows often have custom error messaging, so this fallback modal is shown only in specific circumstances.
+  else if (
     (isExiting && errorMessage != null) ||
-    maintenanceRunStatus === RUN_STATUS_FAILED
+    maintenanceRunStatus === RUN_STATUS_FAILED ||
+    (errorMessage != null && createdMaintenanceRunId == null)
   ) {
     onExit = handleClose
     modalContent = (

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -113,6 +113,7 @@ export const PipetteWizardFlows = (
   const [createdMaintenanceRunId, setCreatedMaintenanceRunId] = useState<
     string | null
   >(null)
+  const [errorMessage, setShowErrorMessage] = useState<null | string>(null)
   // we should start checking for run deletion only after the maintenance run is created
   // and the useCurrentRun poll has returned that created id
   const [
@@ -143,6 +144,9 @@ export const PipetteWizardFlows = (
       onSuccess: response => {
         setCreatedMaintenanceRunId(response.data.id)
       },
+      onError: error => {
+        setShowErrorMessage(error.message)
+      },
     },
     host
   )
@@ -169,7 +173,6 @@ export const PipetteWizardFlows = (
     closeFlow,
   ])
 
-  const [errorMessage, setShowErrorMessage] = useState<null | string>(null)
   const [isExiting, setIsExiting] = useState<boolean>(false)
   const proceed = (): void => {
     if (!isCommandMutationLoading) {
@@ -281,9 +284,11 @@ export const PipetteWizardFlows = (
   let onExit
   if (currentStep == null) return null
   let modalContent: JSX.Element = <div>UNASSIGNED STEP</div>
+  // These flows often have custom error messaging, so this fallback modal is shown only in specific circumstances.
   if (
     (isExiting && errorMessage != null) ||
-    maintenanceRunData?.data.status === RUN_STATUS_FAILED
+    maintenanceRunData?.data.status === RUN_STATUS_FAILED ||
+    (errorMessage != null && createdMaintenanceRunId == null)
   ) {
     modalContent = (
       <SimpleWizardBody


### PR DESCRIPTION
Closes [RABR-663](https://opentrons.atlassian.net/browse/RABR-663) and [RABR-667](https://opentrons.atlassian.net/browse/RABR-667)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

During calibration flows, we currently don't have any error handling for failure to create a maintenance run. If a user exits pipette calibration and re-enters too quickly, for example, the "Move gantry to front" button is disabled indefinitely. This PR just adds some basic error handling if a maintenance run fails to be created successfully.

https://github.com/user-attachments/assets/ea178a57-9b68-4e08-b88d-70bbafbd4b83


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The "Move Gantry to Front" button during calibration flows is no longer disabled indefinitely. Errors are now surfaced.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RABR-663]: https://opentrons.atlassian.net/browse/RABR-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RABR-667]: https://opentrons.atlassian.net/browse/RABR-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ