### PR TITLE
chore(release): known issue for downgrading with plate reader

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -24,6 +24,10 @@ Welcome to the v8.2.0 release of the Opentrons robot software! This release adds
 
 - Error recovery no longer causes an `AssertionError` when a Python protocol changes the pipette speed.
 
+### Known Issues
+
+- You can't downgrade the robot software with an Absorbance Plate Reader attached. Disconnect the module first if you need to downgrade.
+
 ---
 
 ## Opentrons Robot Software Changes in 8.1.0

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -30,6 +30,9 @@ Welcome to the v8.2.0 release of the Opentrons App! This release adds support fo
 
 - Fixed an app crash when performing certain error recovery steps with Python API version 2.15 protocols.
 
+### Known Issues
+- If you attach an Absorbance Plate Reader to _any_ Flex on your local network, you must update all copies of the Opentrons App on the same network to at least v8.1.0.
+
 ---
 
 ## Opentrons App Changes in 8.1.0


### PR DESCRIPTION
# Overview

Known issue for downgrading below 8.2 with a plate reader attached.

## Test Plan and Hands on Testing

Check in next alpha.

## Changelog

Single bullet in API release notes.

## Review requests

- Does this capture the issue properly? Is there a related app-side issue?
- Do we need to mention the problem of downgrading a robot _on the same network_ as a plate reader?

## Risk assessment

nil