### PR TITLE
fix(app): support special cased slot name copy

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -78,6 +78,7 @@
   "tc_starting_extended_profile_cycle": "{{repetitions}} repetitions of the following steps:",
   "tc_starting_profile": "Running thermocycler profile with {{stepCount}} steps:",
   "touch_tip": "Touching tip",
+  "trash_bin": "Trash Bin",
   "trash_bin_in_slot": "Trash Bin in {{slot_name}}",
   "turning_rail_lights_off": "Turning rail lights off",
   "turning_rail_lights_on": "Turning rail lights on",

--- a/app/src/local-resources/labware/utils/__tests__/getLabwareDisplayLocation.test.tsx
+++ b/app/src/local-resources/labware/utils/__tests__/getLabwareDisplayLocation.test.tsx
@@ -137,6 +137,24 @@ describe('getLabwareDisplayLocation with translations', () => {
     screen.getByText('Slot C1')
   })
 
+  it('should special case the slotName if it contains "waste chute"', () => {
+    render({
+      location: { slotName: 'gripperWasteChute' },
+      params: { ...defaultParams, detailLevel: 'slot-only' },
+    })
+
+    screen.getByText('Waste Chute')
+  })
+
+  it('should special case the slotName if it contains "trash bin"', () => {
+    render({
+      location: { slotName: 'trashBin' },
+      params: { ...defaultParams, detailLevel: 'slot-only' },
+    })
+
+    screen.getByText('Trash Bin')
+  })
+
   it('should handle an adapter on module location when the detail level is full', () => {
     const mockLoadedLabwares = [
       {

--- a/app/src/local-resources/labware/utils/getLabwareDisplayLocation.ts
+++ b/app/src/local-resources/labware/utils/getLabwareDisplayLocation.ts
@@ -47,7 +47,8 @@ export function getLabwareDisplayLocation(
   }
   // Simple slot location
   else if (moduleModel == null && adapterName == null) {
-    return isOnDevice ? slotName : t('slot', { slot_name: slotName })
+    const validatedSlotCopy = handleSpecialSlotNames(slotName, t)
+    return isOnDevice ? validatedSlotCopy.odd : validatedSlotCopy.desktop
   }
   // Module location without adapter
   else if (moduleModel != null && adapterName == null) {
@@ -89,5 +90,24 @@ export function getLabwareDisplayLocation(
     }
   } else {
     return ''
+  }
+}
+
+// Sometimes we don't want to show the actual slotName, so we special case the text here.
+function handleSpecialSlotNames(
+  slotName: string,
+  t: TFunction
+): { odd: string; desktop: string } {
+  const nameLc = slotName.toLowerCase()
+
+  if (nameLc.includes('wastechute')) {
+    return { odd: t('waste_chute'), desktop: t('waste_chute') }
+  } else if (nameLc.includes('trashbin')) {
+    return { odd: t('trash_bin'), desktop: t('trash_bin') }
+  } else {
+    return {
+      odd: slotName,
+      desktop: t('slot', { slot_name: slotName }),
+    }
   }
 }

--- a/app/src/local-resources/labware/utils/getLabwareDisplayLocation.ts
+++ b/app/src/local-resources/labware/utils/getLabwareDisplayLocation.ts
@@ -4,6 +4,8 @@ import {
   getOccludedSlotCountForModule,
   THERMOCYCLER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
+  TRASH_BIN_FIXTURE,
+  WASTE_CHUTE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 import { getLabwareLocation } from './getLabwareLocation'
 
@@ -12,6 +14,7 @@ import type {
   LocationSlotOnlyParams,
   LocationFullParams,
 } from './getLabwareLocation'
+import type { AddressableAreaName } from '@opentrons/shared-data'
 
 export interface DisplayLocationSlotOnlyParams extends LocationSlotOnlyParams {
   t: TFunction
@@ -98,11 +101,9 @@ function handleSpecialSlotNames(
   slotName: string,
   t: TFunction
 ): { odd: string; desktop: string } {
-  const nameLc = slotName.toLowerCase()
-
-  if (nameLc.includes('wastechute')) {
+  if (WASTE_CHUTE_ADDRESSABLE_AREAS.includes(slotName as AddressableAreaName)) {
     return { odd: t('waste_chute'), desktop: t('waste_chute') }
-  } else if (nameLc.includes('trashbin')) {
+  } else if (slotName === TRASH_BIN_FIXTURE) {
     return { odd: t('trash_bin'), desktop: t('trash_bin') }
   } else {
     return {

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -513,6 +513,7 @@ export const SINGLE_RIGHT_SLOT_FIXTURE: 'singleRightSlot' = 'singleRightSlot'
 export const STAGING_AREA_RIGHT_SLOT_FIXTURE: 'stagingAreaRightSlot' =
   'stagingAreaRightSlot'
 
+export const TRASH_BIN_FIXTURE: 'trashBin' = 'trashBin'
 export const TRASH_BIN_ADAPTER_FIXTURE: 'trashBinAdapter' = 'trashBinAdapter'
 
 export const WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE: 'wasteChuteRightAdapterCovered' =


### PR DESCRIPTION
Closes [RQA-3585](https://opentrons.atlassian.net/browse/RQA-3585)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We recently refactored the way we handle display text, but there's never been a clear mechanism for handling waste chute/trash bin copy. This PR adds that. Instead of showing "Slot Waste Chute" or "Slot Trash Bin", it probably makes more sense to show just the name of the special cased `slotName`. 


### Current Behavior

<img width="766" alt="Screenshot 2024-11-14 at 12 09 18 PM" src="https://github.com/user-attachments/assets/c86a8b96-c8a7-44d2-ba1a-cc30d306dcd3">

### Fixed Behavior

<img width="757" alt="Screenshot 2024-11-14 at 12 04 03 PM" src="https://github.com/user-attachments/assets/c546725f-5d88-47b5-b5b9-26010a10d92d">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See pictures
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed styling/copy issues when recovering from an error involving the waste chute or trash bin.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3585]: https://opentrons.atlassian.net/browse/RQA-3585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ