### PR TITLE
fix(api): update the plate reader parsing of the serial + version to account for the new format.

### DIFF
--- a/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
+++ b/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
@@ -23,7 +23,8 @@ from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnect
 
 
 SN_PARSER = re.compile(r'ATTRS{serial}=="(?P<serial>.+?)"')
-VERSION_PARSER = re.compile(r"Absorbance (?P<version>V\d+\.\d+\.\d+)")
+# match semver V0.0.0 (old format) or one integer (latest format)
+VERSION_PARSER = re.compile(r"(?P<version>(V\d+\.\d+\.\d+|^\d+$))")
 SERIAL_PARSER = re.compile(r"(?P<serial>(OPT|BYO)[A-Z]{3}[0-9]+)")
 
 
@@ -157,9 +158,9 @@ class AsyncByonoy:
         )
         self._raise_if_error(err.name, f"Error getting device information: {err}")
         serial_match = SERIAL_PARSER.match(device_info.sn)
-        version_match = VERSION_PARSER.match(device_info.version)
+        version_match = VERSION_PARSER.search(device_info.version)
         serial = serial_match["serial"].strip() if serial_match else "OPTMAA00000"
-        version = version_match["version"].lower() if version_match else "v0.0.0"
+        version = version_match["version"].lower() if version_match else "v0"
         info = {
             "serial": serial,
             "version": version,

--- a/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
+++ b/api/src/opentrons/drivers/absorbance_reader/async_byonoy.py
@@ -156,7 +156,7 @@ class AsyncByonoy:
             func=partial(self._interface.get_device_information, handle),
         )
         self._raise_if_error(err.name, f"Error getting device information: {err}")
-        serial_match = SERIAL_PARSER.fullmatch(device_info.sn)
+        serial_match = SERIAL_PARSER.match(device_info.sn)
         version_match = VERSION_PARSER.match(device_info.version)
         serial = serial_match["serial"].strip() if serial_match else "OPTMAA00000"
         version = version_match["version"].lower() if version_match else "v0.0.0"

--- a/api/tests/opentrons/drivers/absorbance_reader/test_driver.py
+++ b/api/tests/opentrons/drivers/absorbance_reader/test_driver.py
@@ -124,6 +124,36 @@ async def test_driver_get_device_info(
     mock_interface.get_device_information.assert_called_once()
     mock_interface.reset_mock()
 
+    # Test Device info with updated version format
+    DEVICE_INFO.sn = "OPTMAA00034"
+    DEVICE_INFO.version = "8"
+
+    mock_interface.get_device_information.return_value = (
+        MockErrorCode.NO_ERROR,
+        DEVICE_INFO,
+    )
+
+    info = await connected_driver.get_device_info()
+
+    assert info == {"serial": "OPTMAA00034", "model": "ABS96", "version": "8"}
+    mock_interface.get_device_information.assert_called_once()
+    mock_interface.reset_mock()
+
+    # Test Device info with invalid version format
+    DEVICE_INFO.sn = "OPTMAA00034"
+    DEVICE_INFO.version = "asd"
+
+    mock_interface.get_device_information.return_value = (
+        MockErrorCode.NO_ERROR,
+        DEVICE_INFO,
+    )
+
+    info = await connected_driver.get_device_info()
+
+    assert info == {"serial": "OPTMAA00034", "model": "ABS96", "version": "v0"}
+    mock_interface.get_device_information.assert_called_once()
+    mock_interface.reset_mock()
+
 
 @pytest.mark.parametrize(
     "parts_aligned, module_status",


### PR DESCRIPTION
# Overview

The RMA plate reader we just got back from byonoy has the old serial format in their eeprom, so we can't parse the serial number correctly, leading to issues addressing the device. Let's change the serial parsing to account for this, so we can continue to use the old byonoy devices. The version format has also changed from semver `v1.0.0` to just an integer, so let's update that as well.

Goes towards: [RQA-3580](https://opentrons.atlassian.net/browse/RQA-3580)

## Test Plan and Hands on Testing

- [x] Make sure new and old format is parsed correctly
- [x] Make sure you can update the fw on plate readers with new/old formatted serial
- [x] Make sure the parsing works with the latest PVT plate readers

## Changelog

- use `match` instead of `fullmatch` when parsing the plate reader serial number to account for old format
- update the regex for parsing the version number to account for just integers instead of semver

## Review requests

## Risk assessment
low, unreleased


[RQA-3580]: https://opentrons.atlassian.net/browse/RQA-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ