### PR TITLE
fix(components, protocol-designer): fix labware thermocycler render issue

### DIFF
--- a/components/src/hardware-sim/Module/index.tsx
+++ b/components/src/hardware-sim/Module/index.tsx
@@ -32,7 +32,6 @@ import type {
   ModuleDefinition,
   ThermocyclerModuleModel,
 } from '@opentrons/shared-data'
-import type { ThermocyclerVizProps } from './Thermocycler'
 
 export * from './Thermocycler'
 
@@ -190,15 +189,12 @@ export const Module = (props: Props): JSX.Element => {
   } else if (moduleType === MAGNETIC_MODULE_TYPE) {
     moduleViz = <MagneticModule />
   } else if (moduleType === THERMOCYCLER_MODULE_TYPE) {
-    const thermocyclerProps: ThermocyclerVizProps = {
+    const thermocyclerProps = {
+      lidMotorState: 'open' as const,
       ...innerProps,
-      lidMotorState:
-        (innerProps as React.ComponentProps<typeof Thermocycler>)
-          .lidMotorState !== 'closed'
-          ? 'open'
-          : 'closed',
       model: def.model as ThermocyclerModuleModel,
     }
+
     moduleViz = <Thermocycler {...thermocyclerProps} />
   } else if (moduleType === HEATERSHAKER_MODULE_TYPE) {
     moduleViz = (

--- a/components/src/hardware-sim/Module/index.tsx
+++ b/components/src/hardware-sim/Module/index.tsx
@@ -32,6 +32,7 @@ import type {
   ModuleDefinition,
   ThermocyclerModuleModel,
 } from '@opentrons/shared-data'
+import type { ThermocyclerVizProps } from './Thermocycler'
 
 export * from './Thermocycler'
 
@@ -189,12 +190,15 @@ export const Module = (props: Props): JSX.Element => {
   } else if (moduleType === MAGNETIC_MODULE_TYPE) {
     moduleViz = <MagneticModule />
   } else if (moduleType === THERMOCYCLER_MODULE_TYPE) {
-    const thermocyclerProps = {
-      lidMotorState: 'open' as const,
+    const thermocyclerProps: ThermocyclerVizProps = {
       ...innerProps,
+      lidMotorState:
+        (innerProps as React.ComponentProps<typeof Thermocycler>)
+          .lidMotorState !== 'closed'
+          ? 'open'
+          : 'closed',
       model: def.model as ThermocyclerModuleModel,
     }
-
     moduleViz = <Thermocycler {...thermocyclerProps} />
   } else if (moduleType === HEATERSHAKER_MODULE_TYPE) {
     moduleViz = (

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -2,7 +2,7 @@ import values from 'lodash/values'
 import { Fragment, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Module, ThermocyclerVizProps } from '@opentrons/components'
+import { Module } from '@opentrons/components'
 import { MODULES_WITH_COLLISION_ISSUES } from '@opentrons/step-generation'
 import {
   getAddressableAreaFromSlotId,
@@ -31,6 +31,7 @@ import { SelectedHoveredItems } from './SelectedHoveredItems'
 import { getAdjacentLabware } from './utils'
 
 import type { ComponentProps, Dispatch, SetStateAction } from 'react'
+import type { ThermocyclerVizProps } from '@opentrons/components'
 import type {
   ModuleTemporalProperties,
   ThermocyclerModuleState,

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -2,7 +2,7 @@ import values from 'lodash/values'
 import { Fragment, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Module } from '@opentrons/components'
+import { Module, ThermocyclerVizProps } from '@opentrons/components'
 import { MODULES_WITH_COLLISION_ISSUES } from '@opentrons/step-generation'
 import {
   getAddressableAreaFromSlotId,
@@ -198,9 +198,23 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
           zDimension: labwareLoadedOnModule?.def.dimensions.zDimension ?? 0,
         }
         const isLabwareOccludedByThermocyclerLid =
-          moduleOnDeck.type === 'thermocyclerModuleType' &&
+          moduleOnDeck.type === THERMOCYCLER_MODULE_TYPE &&
           (moduleOnDeck.moduleState as ThermocyclerModuleState).lidOpen ===
             false
+
+        const tempInnerProps = getModuleInnerProps(moduleOnDeck.moduleState)
+        const innerProps =
+          moduleOnDeck.type === THERMOCYCLER_MODULE_TYPE
+            ? {
+                ...tempInnerProps,
+                lidMotorState:
+                  (tempInnerProps as ThermocyclerVizProps).lidMotorState !==
+                  'closed'
+                    ? 'open'
+                    : 'closed',
+              }
+            : tempInnerProps
+
         return moduleOnDeck.slot !== selectedSlot.slot ? (
           <Fragment key={moduleOnDeck.id}>
             <Module
@@ -211,7 +225,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
               orientation={inferModuleOrientationFromXCoordinate(
                 slotPosition[0]
               )}
-              innerProps={getModuleInnerProps(moduleOnDeck.moduleState)}
+              innerProps={innerProps}
               targetSlotId={slotId}
               targetDeckId={deckDef.otId}
             >

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -31,7 +31,10 @@ import { SelectedHoveredItems } from './SelectedHoveredItems'
 import { getAdjacentLabware } from './utils'
 
 import type { ComponentProps, Dispatch, SetStateAction } from 'react'
-import type { ModuleTemporalProperties } from '@opentrons/step-generation'
+import type {
+  ModuleTemporalProperties,
+  ThermocyclerModuleState,
+} from '@opentrons/step-generation'
 import type {
   AddressableArea,
   AddressableAreaName,
@@ -194,6 +197,10 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
           yDimension: labwareLoadedOnModule?.def.dimensions.yDimension ?? 0,
           zDimension: labwareLoadedOnModule?.def.dimensions.zDimension ?? 0,
         }
+        const isLabwareOccludedByThermocyclerLid =
+          moduleOnDeck.type === 'thermocyclerModuleType' &&
+          (moduleOnDeck.moduleState as ThermocyclerModuleState).lidOpen ===
+            false
         return moduleOnDeck.slot !== selectedSlot.slot ? (
           <Fragment key={moduleOnDeck.id}>
             <Module
@@ -208,7 +215,8 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
               targetSlotId={slotId}
               targetDeckId={deckDef.otId}
             >
-              {labwareLoadedOnModule != null ? (
+              {labwareLoadedOnModule != null &&
+              !isLabwareOccludedByThermocyclerLid ? (
                 <>
                   <LabwareOnDeck
                     x={0}


### PR DESCRIPTION
# Overview

Because protocol designer is unaware of actual thermocycler lid state until a thermocycler step explicitly sets its state, we default to a gray box. This PR resets that logic to show the lid as open if the lid state is indeterminate to avoid confusion; however, error messages prompting the user to open the lid before moving labware/liquid to or from the thermocycler will persist, as the thermocycler lid is neither open nor closed. Also, this fixes a rendering issue where labware was shown on top of the closed thermocycler lid.

Closes RQA-3556

## Test Plan and Hands on Testing

before fix:
https://github.com/user-attachments/assets/97282948-cc4d-4181-8c82-c099f1af4a4c

after fix:
https://github.com/user-attachments/assets/1db4582f-9e01-4f03-a767-976c307d338b


- create or upload a protocol that uses a Thermocycler 
- edit protocol and navigate to protocol steps tab
- verify that there is no longer a grey rectangle placeholder on the robot state deck for steps preceding a thermocycler step— it is now defaulted to the open image
- verify that labware does not show on top of closed lid for steps in which the thermocycler lid state is closed

## Changelog

- default lid position to open in deck setup details component to open (to handle unknown thermocycler state upstream of any thermocycler step in which the lid position is set to open or closed)
- conditionally render module children based on position of thermocycler lid

## Review requests

see test plan

## Risk assessment

low