### PR TITLE
fix(app): add affordances for tip detection failures

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/hooks/useTipAttachmentStatus/getPipettesWithTipAttached.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useTipAttachmentStatus/getPipettesWithTipAttached.ts
@@ -31,15 +31,17 @@ export function getPipettesWithTipAttached({
     return Promise.resolve([])
   }
 
-  return getCommandsExecutedDuringRun(
-    host as HostConfig,
-    runId
-  ).then(executedCmdData =>
-    checkPipettesForAttachedTips(
-      executedCmdData.data,
-      runRecord.data.pipettes,
-      attachedInstruments.data as PipetteData[]
-    )
+  return (
+    getCommandsExecutedDuringRun(host as HostConfig, runId)
+      .then(executedCmdData =>
+        checkPipettesForAttachedTips(
+          executedCmdData.data,
+          runRecord.data.pipettes,
+          attachedInstruments.data as PipetteData[]
+        )
+      )
+      // If any network error occurs, return all attached pipettes as having tips attached for safety reasons.
+      .catch(() => Promise.resolve(getPipettesDataFrom(attachedInstruments)))
   )
 }
 
@@ -119,8 +121,10 @@ function checkPipettesForAttachedTips(
   }
 
   // Convert the array of mounts with attached tips to PipetteData with attached tips.
-  const pipettesWithTipAttached = attachedPipettes.filter(attachedPipette =>
-    mountsWithTipAttached.includes(attachedPipette.mount)
+  const pipettesWithTipAttached = attachedPipettes.filter(
+    attachedPipette =>
+      mountsWithTipAttached.includes(attachedPipette.mount) &&
+      attachedPipette.ok
   )
 
   // Preferentially assign the left mount as the first element.
@@ -135,4 +139,14 @@ function checkPipettesForAttachedTips(
   }
 
   return pipettesWithTipAttached
+}
+
+function getPipettesDataFrom(
+  attachedInstruments: Instruments | null
+): PipetteData[] {
+  return attachedInstruments != null
+    ? (attachedInstruments.data.filter(
+        instrument => instrument.instrumentType === 'pipette' && instrument.ok
+      ) as PipetteData[])
+    : []
 }


### PR DESCRIPTION
Closes [RQA-3589](https://opentrons.atlassian.net/browse/RQA-3589)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

At the end of a protocol run, we execute tip detection logic to determine whether or not we should pop drop tip CTAs. There are a few network requests necessary to make this work, and we are not error handling if any of these requests fail.

This PR adds a general fallback: if _almost any_ network request fails, let's just assume both pipettes have tips attached and pop the CTAs (assuming the pipettes have `ok` firmware status). It's probably better to be more conservative here, and in practice, this exact scenario should occur rarely. 

Note that the very first request we make is to get the currently attached instruments. If this request fails, we can't do drop tip wizard, so we shouldn't show CTAs. The only workaround here would be going to design and coming up with some sort of "can't detect tips" copy. At the very least, the user can always go to drop tip wizard manually and handle tips there.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran drop tip wizard in various places, confirming it worked.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added better error handling to tip detection logic.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3589]: https://opentrons.atlassian.net/browse/RQA-3589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ