### PR TITLE
fix(protocol-designer): step overflow menu positioning and prevent multiple opened

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux'
-import { useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useConditionalConfirm } from '@opentrons/components'
 import * as timelineWarningSelectors from '../../../../top-selectors/timelineWarnings'
@@ -47,14 +47,19 @@ export interface ConnectedStepInfoProps {
   stepId: StepIdType
   stepNumber: number
   dragHovered?: boolean
+  openedOverflowMenuId?: string | null
+  setOpenedOverflowMenuId?: Dispatch<SetStateAction<string | null>>
 }
 
 export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
-  const { stepId, stepNumber, dragHovered = false } = props
+  const {
+    stepId,
+    stepNumber,
+    dragHovered = false,
+    openedOverflowMenuId,
+    setOpenedOverflowMenuId,
+  } = props
   const { t } = useTranslation('application')
-  const [openedOverflowMenuId, setOpenedOverflowMenuId] = useState<
-    string | null
-  >(null)
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const stepIds = useSelector(getOrderedStepIds)
   const step = useSelector(stepFormSelectors.getSavedStepForms)[stepId]

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -1,4 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useConditionalConfirm } from '@opentrons/components'
 import * as timelineWarningSelectors from '../../../../top-selectors/timelineWarnings'
@@ -33,7 +34,6 @@ import {
   nonePressed,
 } from './utils'
 
-import type * as React from 'react'
 import type { ThunkDispatch } from 'redux-thunk'
 import type {
   HoverOnStepAction,
@@ -52,6 +52,9 @@ export interface ConnectedStepInfoProps {
 export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
   const { stepId, stepNumber, dragHovered = false } = props
   const { t } = useTranslation('application')
+  const [openedOverflowMenuId, setOpenedOverflowMenuId] = useState<
+    string | null
+  >(null)
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const stepIds = useSelector(getOrderedStepIds)
   const step = useSelector(stepFormSelectors.getSavedStepForms)[stepId]
@@ -203,6 +206,8 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
         />
       )}
       <StepContainer
+        openedOverflowMenuId={openedOverflowMenuId}
+        setOpenedOverflowMenuId={setOpenedOverflowMenuId}
         hasError={hasError}
         isStepAfterError={stepAfterError}
         stepId={stepId}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { useDrop, useDrag } from 'react-dnd'
@@ -14,6 +14,7 @@ import { selectors as stepFormSelectors } from '../../../../step-forms'
 import { stepIconsByType } from '../../../../form-types'
 import { StepContainer } from './StepContainer'
 import { ConnectedStepInfo } from './ConnectedStepInfo'
+import type { Dispatch, SetStateAction } from 'react'
 import type { DragLayerMonitor, DropTargetMonitor } from 'react-dnd'
 import type { StepIdType } from '../../../../form-types'
 import type { ConnectedStepItemProps } from '../../../../containers/ConnectedStepItem'
@@ -23,6 +24,8 @@ interface DragDropStepProps extends ConnectedStepItemProps {
   moveStep: (stepId: StepIdType, value: number) => void
   findStepIndex: (stepId: StepIdType) => number
   orderedStepIds: string[]
+  openedOverflowMenuId?: string | null
+  setOpenedOverflowMenuId?: Dispatch<SetStateAction<string | null>>
 }
 
 interface DropType {
@@ -30,7 +33,15 @@ interface DropType {
 }
 
 function DragDropStep(props: DragDropStepProps): JSX.Element {
-  const { stepId, moveStep, findStepIndex, orderedStepIds, stepNumber } = props
+  const {
+    stepId,
+    moveStep,
+    findStepIndex,
+    orderedStepIds,
+    stepNumber,
+    openedOverflowMenuId,
+    setOpenedOverflowMenuId,
+  } = props
   const stepRef = useRef<HTMLDivElement>(null)
 
   const [{ isDragging }, drag] = useDrag(
@@ -73,6 +84,8 @@ function DragDropStep(props: DragDropStepProps): JSX.Element {
       data-handler-id={handlerId}
     >
       <ConnectedStepInfo
+        openedOverflowMenuId={openedOverflowMenuId}
+        setOpenedOverflowMenuId={setOpenedOverflowMenuId}
         stepNumber={stepNumber}
         stepId={stepId}
         dragHovered={hovered}
@@ -88,6 +101,9 @@ interface DraggableStepsProps {
 export function DraggableSteps(props: DraggableStepsProps): JSX.Element | null {
   const { orderedStepIds, reorderSteps } = props
   const { t } = useTranslation('shared')
+  const [openedOverflowMenuId, setOpenedOverflowMenuId] = useState<
+    string | null
+  >(null)
 
   const findStepIndex = (stepId: StepIdType): number =>
     orderedStepIds.findIndex(id => stepId === id)
@@ -123,6 +139,8 @@ export function DraggableSteps(props: DraggableStepsProps): JSX.Element | null {
           moveStep={moveStep}
           findStepIndex={findStepIndex}
           orderedStepIds={orderedStepIds}
+          openedOverflowMenuId={openedOverflowMenuId}
+          setOpenedOverflowMenuId={setOpenedOverflowMenuId}
         />
       ))}
       <StepDragPreview />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -35,6 +35,11 @@ import { LINE_CLAMP_TEXT_STYLE } from '../../../../atoms'
 import { StepOverflowMenu } from './StepOverflowMenu'
 import { capitalizeFirstLetterAfterNumber } from './utils'
 
+import type {
+  SetStateAction,
+  Dispatch,
+  MouseEvent as ReactMouseEvent,
+} from 'react'
 import type { ThunkDispatch } from 'redux-thunk'
 import type { IconName } from '@opentrons/components'
 import type { StepIdType } from '../../../../form-types'
@@ -46,12 +51,14 @@ const FINAL_DECK_STATE = 'Final deck state'
 export interface StepContainerProps {
   title: string
   iconName: IconName
+  openedOverflowMenuId?: string | null
+  setOpenedOverflowMenuId?: Dispatch<SetStateAction<string | null>>
   stepId?: string
   iconColor?: string
-  onClick?: (event: React.MouseEvent) => void
-  onDoubleClick?: (event: React.MouseEvent) => void
-  onMouseEnter?: (event: React.MouseEvent) => void
-  onMouseLeave?: (event: React.MouseEvent) => void
+  onClick?: (event: ReactMouseEvent) => void
+  onDoubleClick?: (event: ReactMouseEvent) => void
+  onMouseEnter?: (event: ReactMouseEvent) => void
+  onMouseLeave?: (event: ReactMouseEvent) => void
   selected?: boolean
   hovered?: boolean
   hasError?: boolean
@@ -74,10 +81,11 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
     hasError = false,
     isStepAfterError = false,
     dragHovered = false,
+    setOpenedOverflowMenuId,
+    openedOverflowMenuId,
   } = props
   const [top, setTop] = useState<number>(0)
   const menuRootRef = useRef<HTMLDivElement | null>(null)
-  const [stepOverflowMenu, setStepOverflowMenu] = useState<boolean>(false)
   const isStartingOrEndingState =
     title === STARTING_DECK_STATE || title === FINAL_DECK_STATE
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
@@ -104,22 +112,21 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
       menuRootRef.current?.contains(event.target)
     )
 
-    if (wasOutside && stepOverflowMenu) {
-      setStepOverflowMenu(false)
+    if (wasOutside && setOpenedOverflowMenuId) {
+      setOpenedOverflowMenuId(null)
     }
   }
 
-  const handleOverflowClick = (event: React.MouseEvent): void => {
-    const { clientY } = event
-
+  const handleOverflowClick = (event: ReactMouseEvent): void => {
+    const buttonRect = event.currentTarget.getBoundingClientRect()
     const screenHeight = window.innerHeight
-    const rootHeight = menuRootRef.current
-      ? menuRootRef.current.offsetHeight
-      : 0
+    const rootHeight = menuRootRef.current?.offsetHeight || 0
+
+    const spaceBelow = screenHeight - buttonRect.bottom
     const top =
-      screenHeight - clientY > rootHeight
-        ? clientY + 5
-        : clientY - rootHeight - 5
+      spaceBelow > rootHeight
+        ? buttonRect.bottom - 32
+        : buttonRect.top - rootHeight + 32
 
     setTop(top)
   }
@@ -135,7 +142,7 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
     if (stepId != null) {
       dispatch(populateForm(stepId))
     }
-    setStepOverflowMenu(false)
+    setOpenedOverflowMenuId?.(null)
   }
 
   const onDeleteClickAction = (): void => {
@@ -168,13 +175,12 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
       )
     }
   }
-
   const {
     confirm: confirmDelete,
     showConfirmation: showDeleteConfirmation,
     cancel: cancelDelete,
   } = useConditionalConfirm(handleDelete, true)
-
+  console.log(openedOverflowMenuId, stepId)
   return (
     <>
       {showDeleteConfirmation && (
@@ -238,15 +244,26 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
                 {capitalizeFirstLetterAfterNumber(title)}
               </StyledText>
             </Flex>
-            {selected && !isStartingOrEndingState ? (
+            {selected &&
+            !isStartingOrEndingState &&
+            openedOverflowMenuId != null &&
+            openedOverflowMenuId !== stepId ? (
               <OverflowBtn
                 data-testid={`StepContainer_${stepId}`}
                 fillColor={COLORS.white}
-                onClick={(e: React.MouseEvent) => {
+                onClick={(e: ReactMouseEvent) => {
                   e.preventDefault()
                   e.stopPropagation()
-                  setStepOverflowMenu(prev => !prev)
-                  handleOverflowClick(e)
+                  if (setOpenedOverflowMenuId != null) {
+                    if (openedOverflowMenuId === stepId) {
+                      setOpenedOverflowMenuId(null)
+                    } else if (openedOverflowMenuId == null) {
+                      setOpenedOverflowMenuId(stepId ?? null)
+                      handleOverflowClick(e)
+                    } else {
+                      setOpenedOverflowMenuId(stepId ?? null)
+                    }
+                  }
                 }}
               />
             ) : null}
@@ -262,10 +279,12 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
           />
         ) : null}
       </Flex>
-      {stepOverflowMenu && stepId != null
+      {stepId != null &&
+      openedOverflowMenuId === stepId &&
+      setOpenedOverflowMenuId != null
         ? createPortal(
             <StepOverflowMenu
-              setStepOverflowMenu={setStepOverflowMenu}
+              setOpenedOverflowMenuId={setOpenedOverflowMenuId}
               stepId={stepId}
               menuRootRef={menuRootRef}
               top={top}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -244,10 +244,7 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
                 {capitalizeFirstLetterAfterNumber(title)}
               </StyledText>
             </Flex>
-            {selected &&
-            !isStartingOrEndingState &&
-            openedOverflowMenuId != null &&
-            openedOverflowMenuId !== stepId ? (
+            {selected && !isStartingOrEndingState ? (
               <OverflowBtn
                 data-testid={`StepContainer_${stepId}`}
                 fillColor={COLORS.white}
@@ -257,13 +254,11 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
                   if (setOpenedOverflowMenuId != null) {
                     if (openedOverflowMenuId === stepId) {
                       setOpenedOverflowMenuId(null)
-                    } else if (openedOverflowMenuId == null) {
-                      setOpenedOverflowMenuId(stepId ?? null)
-                      handleOverflowClick(e)
                     } else {
                       setOpenedOverflowMenuId(stepId ?? null)
                     }
                   }
+                  handleOverflowClick(e)
                 }}
               />
             ) : null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -47,7 +47,7 @@ import type { BaseState } from '../../../../types'
 
 const STARTING_DECK_STATE = 'Starting deck state'
 const FINAL_DECK_STATE = 'Final deck state'
-
+const PX_HEIGHT_TO_TOP_OF_CONTAINER = 32
 export interface StepContainerProps {
   title: string
   iconName: IconName
@@ -112,8 +112,8 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
       menuRootRef.current?.contains(event.target)
     )
 
-    if (wasOutside && setOpenedOverflowMenuId) {
-      setOpenedOverflowMenuId(null)
+    if (wasOutside) {
+      setOpenedOverflowMenuId?.(null)
     }
   }
 
@@ -125,8 +125,8 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
     const spaceBelow = screenHeight - buttonRect.bottom
     const top =
       spaceBelow > rootHeight
-        ? buttonRect.bottom - 32
-        : buttonRect.top - rootHeight + 32
+        ? buttonRect.bottom - PX_HEIGHT_TO_TOP_OF_CONTAINER
+        : buttonRect.top - rootHeight + PX_HEIGHT_TO_TOP_OF_CONTAINER
 
     setTop(top)
   }
@@ -180,7 +180,7 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
     showConfirmation: showDeleteConfirmation,
     cancel: cancelDelete,
   } = useConditionalConfirm(handleDelete, true)
-  console.log(openedOverflowMenuId, stepId)
+
   return (
     <>
       {showDeleteConfirmation && (
@@ -251,13 +251,12 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
                 onClick={(e: ReactMouseEvent) => {
                   e.preventDefault()
                   e.stopPropagation()
-                  if (setOpenedOverflowMenuId != null) {
-                    if (openedOverflowMenuId === stepId) {
-                      setOpenedOverflowMenuId(null)
-                    } else {
-                      setOpenedOverflowMenuId(stepId ?? null)
-                    }
+                  if (openedOverflowMenuId === stepId) {
+                    setOpenedOverflowMenuId?.(null)
+                  } else {
+                    setOpenedOverflowMenuId?.(stepId ?? null)
                   }
+
                   handleOverflowClick(e)
                 }}
               />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepOverflowMenu.tsx
@@ -32,7 +32,7 @@ interface StepOverflowMenuProps {
   stepId: string
   menuRootRef: React.MutableRefObject<HTMLDivElement | null>
   top: number
-  setStepOverflowMenu: React.Dispatch<React.SetStateAction<boolean>>
+  setOpenedOverflowMenuId: React.Dispatch<React.SetStateAction<string | null>>
   handleEdit: () => void
   confirmDelete: () => void
   confirmMultiDelete: () => void
@@ -44,7 +44,7 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
     stepId,
     menuRootRef,
     top,
-    setStepOverflowMenu,
+    setOpenedOverflowMenuId,
     handleEdit,
     confirmDelete,
     confirmMultiDelete,
@@ -91,7 +91,7 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
         ref={menuRootRef}
         zIndex={12}
         top={top}
-        left="19.5rem"
+        left="18.75rem"
         position={POSITION_ABSOLUTE}
         whiteSpace={NO_WRAP}
         borderRadius={BORDERS.borderRadius8}
@@ -109,7 +109,7 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
               disabled={batchEditFormHasUnstagedChanges}
               onClick={() => {
                 duplicateMultipleSteps()
-                setStepOverflowMenu(false)
+                setOpenedOverflowMenuId(null)
               }}
             >
               {t('duplicate_steps')}
@@ -118,7 +118,7 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
             <MenuItem
               onClick={() => {
                 confirmMultiDelete()
-                setStepOverflowMenu(false)
+                setOpenedOverflowMenuId(null)
               }}
             >
               {t('delete_steps')}
@@ -133,7 +133,7 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
               <MenuItem
                 disabled={formData != null}
                 onClick={() => {
-                  setStepOverflowMenu(false)
+                  setOpenedOverflowMenuId(null)
                   dispatch(hoverOnStep(stepId))
                   dispatch(toggleViewSubstep(stepId))
                   dispatch(analyticsEvent(selectViewDetailsEvent))
@@ -146,7 +146,7 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
               disabled={singleEditFormHasUnsavedChanges}
               onClick={() => {
                 duplicateStep(stepId)
-                setStepOverflowMenu(false)
+                setOpenedOverflowMenuId(null)
               }}
             >
               {t('duplicate')}
@@ -155,7 +155,7 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
             <MenuItem
               onClick={() => {
                 confirmDelete()
-                setStepOverflowMenu(false)
+                setOpenedOverflowMenuId(null)
               }}
             >
               {t('delete')}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/StepOverflowMenu.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/StepOverflowMenu.test.tsx
@@ -58,7 +58,7 @@ describe('StepOverflowMenu', () => {
       stepId: moveLiquidStepId,
       top: 0,
       menuRootRef: { current: null },
-      setStepOverflowMenu: vi.fn(),
+      setOpenedOverflowMenuId: vi.fn(),
       multiSelectItemIds: [],
       handleEdit: vi.fn(),
       confirmDelete: mockConfirm,


### PR DESCRIPTION
closes RQA-3408 RQA-3358, partially closes RQA-3402 (item 4 i think)

# Overview

Multipel fixes with the step overflow menu:
1. positioning (RQA-3402)
2. prevent multilple from being opened at once (RQA-3408 RQA-3358)

## Test Plan and Hands on Testing

Make a protocol with multiple steps (or upload the attached one). First open the step overflow menus and see that they are aligned properly (I also confirmed with mel that they're aligned properly). Then multi-select more steps by command + click and see that you can only open one overflow menu of the selected steps at a time

## Changelog

- add a state setter for which step id overflow menu is opened and replace with the boolean state setter for showing the overflow menu
- refine the logic for determining where the overflow menu opens in the dom
- fix tests

## Risk assessment

low
