### PR TITLE
docs(api): fix typo in deck extents table

### DIFF
--- a/api/docs/v2/pipettes/partial_tip_pickup.rst
+++ b/api/docs/v2/pipettes/partial_tip_pickup.rst
@@ -399,7 +399,7 @@ The following table summarizes the limitations in place along each side of the d
     * - A1–D1 (left edge)
       - Rightmost column
       - None (all wells accessible)
-    * - A1–D3 (back edge)
+    * - A1–A3 (back edge)
       - Frontmost row
       - Rows A–G
     * - A3–D3 (right edge)


### PR DESCRIPTION

# Overview

Fixing a typo in the deck extents table for partial pickup. Thanks to 

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-fix-deck-extents-typo/v2/pipettes/partial_tip_pickup.html#deck-extents)

## Changelog

1 character

## Review requests

A≠D

## Risk assessment

zero