### PR TITLE
fix(protocol-designer): fix padding and footer position in onboard wizard

### DIFF
--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectPipettes.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectPipettes.tsx
@@ -182,7 +182,6 @@ export function SelectPipettes(props: WizardTileProps): JSX.Element | null {
           {page === 'add' ? (
             <Flex
               flexDirection={DIRECTION_COLUMN}
-              height="41.5vh"
               overflowY={OVERFLOW_AUTO}
               gridGap={SPACING.spacing32}
             >

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/WizardBody.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/WizardBody.tsx
@@ -2,8 +2,8 @@ import type * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import {
-  ALIGN_END,
   ALIGN_CENTER,
+  ALIGN_END,
   BORDERS,
   Btn,
   COLORS,
@@ -11,10 +11,11 @@ import {
   Flex,
   JUSTIFY_SPACE_BETWEEN,
   LargeButton,
+  OVERFLOW_SCROLL,
   SPACING,
   StyledText,
-  TYPOGRAPHY,
   Tooltip,
+  TYPOGRAPHY,
   useHoverTooltip,
 } from '@opentrons/components'
 import temporaryImg from '../../assets/images/placeholder_image_delete.png'
@@ -56,13 +57,19 @@ export function WizardBody(props: WizardBodyProps): JSX.Element {
     >
       <Flex
         width="60%"
-        padding={`${SPACING.spacing40} ${SPACING.spacing80} ${SPACING.spacing80} ${SPACING.spacing80}`}
+        padding={SPACING.spacing80}
         flexDirection={DIRECTION_COLUMN}
         backgroundColor={COLORS.white}
         borderRadius={BORDERS.borderRadius16}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
+        gridGap={SPACING.spacing24}
       >
-        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          gridGap={SPACING.spacing8}
+          height="100%"
+          overflowY={OVERFLOW_SCROLL}
+        >
           <StyledText
             color={COLORS.grey60}
             desktopStyle="bodyDefaultSemiBold"


### PR DESCRIPTION
# Overview

This PR fixes two bugs in the onboarding wizard. Here, I set a minimum grid gap between the left side content and footer buttons so that the buttons don't reposition on steps of different heights. I also fix the padding for the left side content to be a constant 5rem.

Closes RQA-3313, Closes RQA-3316

## Test Plan and Hands on Testing

- create a new protocol
- when clicking through the steps, verify that the footer button container position is maintained
- verify that padding between left content and footer buttons is a constant 24px

## Changelog

- fix padding and footer alignment

## Review requests

- see test plan

## Risk assessment

low