### PR TITLE
fix(api): refactor protocol api integration tests to prevent thread leakage

### DIFF
--- a/api/tests/opentrons/protocol_api_integration/conftest.py
+++ b/api/tests/opentrons/protocol_api_integration/conftest.py
@@ -5,6 +5,7 @@ from _pytest.fixtures import SubRequest
 from typing import Generator
 
 from opentrons import simulate, protocol_api
+from opentrons.protocol_api.core.engine import ENGINE_CORE_API_VERSION
 
 
 @pytest.fixture
@@ -17,4 +18,11 @@ def simulated_protocol_context(
     try:
         yield context
     finally:
-        simulate._LIVE_PROTOCOL_ENGINE_CONTEXTS.close()
+        if context.api_version >= ENGINE_CORE_API_VERSION:
+            # TODO(jbl, 2024-11-14) this is a hack of a hack to close the hardware and the PE thread when a test is
+            #  complete. At some point this should be replaced with a more holistic way of safely cleaning up these
+            #  threads so they don't leak and cause tests to fail when `get_protocol_api` is called too many times.
+            simulate._LIVE_PROTOCOL_ENGINE_CONTEXTS.close()
+        else:
+            # If this is a non-PE context we need to clean up the hardware thread manually
+            context._hw_manager.hardware.clean_up()

--- a/api/tests/opentrons/protocol_api_integration/conftest.py
+++ b/api/tests/opentrons/protocol_api_integration/conftest.py
@@ -8,7 +8,7 @@ from opentrons import simulate, protocol_api
 
 
 @pytest.fixture
-def protocol(
+def simulated_protocol_context(
     request: SubRequest,
 ) -> Generator[protocol_api.ProtocolContext, None, None]:
     """Return a protocol context with requested version and robot."""

--- a/api/tests/opentrons/protocol_api_integration/conftest.py
+++ b/api/tests/opentrons/protocol_api_integration/conftest.py
@@ -1,0 +1,20 @@
+"""Fixtures for protocol api integration tests."""
+
+import pytest
+from _pytest.fixtures import SubRequest
+from typing import Generator
+
+from opentrons import simulate, protocol_api
+
+
+@pytest.fixture
+def protocol(
+    request: SubRequest,
+) -> Generator[protocol_api.ProtocolContext, None, None]:
+    """Return a protocol context with requested version and robot."""
+    version, robot_type = request.param
+    context = simulate.get_protocol_api(version=version, robot_type=robot_type)
+    try:
+        yield context
+    finally:
+        simulate._LIVE_PROTOCOL_ENGINE_CONTEXTS.close()

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -8,19 +8,25 @@ from opentrons.config import feature_flags as ff
 
 
 @pytest.mark.ot2_only
-@pytest.mark.parametrize("protocol", [("2.20", "OT-2")], indirect=True)
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.20", "OT-2")], indirect=True
+)
 def test_liquid_class_creation_and_property_fetching(
     decoy: Decoy,
     mock_feature_flags: None,
-    protocol: ProtocolContext,
+    simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should create the liquid class and provide access to its properties."""
     decoy.when(ff.allow_liquid_classes(RobotTypeEnum.OT2)).then_return(True)
-    pipette_left = protocol.load_instrument("p20_single_gen2", mount="left")
-    pipette_right = protocol.load_instrument("p300_multi", mount="right")
-    tiprack = protocol.load_labware("opentrons_96_tiprack_20ul", "1")
+    pipette_left = simulated_protocol_context.load_instrument(
+        "p20_single_gen2", mount="left"
+    )
+    pipette_right = simulated_protocol_context.load_instrument(
+        "p300_multi", mount="right"
+    )
+    tiprack = simulated_protocol_context.load_labware("opentrons_96_tiprack_20ul", "1")
 
-    glycerol_50 = protocol.define_liquid_class("fixture_glycerol50")
+    glycerol_50 = simulated_protocol_context.define_liquid_class("fixture_glycerol50")
 
     assert glycerol_50.name == "fixture_glycerol50"
     assert glycerol_50.display_name == "Glycerol 50%"
@@ -52,11 +58,13 @@ def test_liquid_class_creation_and_property_fetching(
         glycerol_50.display_name = "bar"  # type: ignore
 
     with pytest.raises(ValueError, match="Liquid class definition not found"):
-        protocol.define_liquid_class("non-existent-liquid")
+        simulated_protocol_context.define_liquid_class("non-existent-liquid")
 
 
-@pytest.mark.parametrize("protocol", [("2.20", "OT-2")], indirect=True)
-def test_liquid_class_feature_flag(protocol: ProtocolContext) -> None:
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.20", "OT-2")], indirect=True
+)
+def test_liquid_class_feature_flag(simulated_protocol_context: ProtocolContext) -> None:
     """It should raise a not implemented error without the allowLiquidClass flag set."""
     with pytest.raises(NotImplementedError):
-        protocol.define_liquid_class("fixture_glycerol50")
+        simulated_protocol_context.define_liquid_class("fixture_glycerol50")

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -3,22 +3,24 @@ import pytest
 from decoy import Decoy
 from opentrons_shared_data.robot.types import RobotTypeEnum
 
-from opentrons import simulate
+from opentrons.protocol_api import ProtocolContext
 from opentrons.config import feature_flags as ff
 
 
 @pytest.mark.ot2_only
+@pytest.mark.parametrize("protocol", [("2.20", "OT-2")], indirect=True)
 def test_liquid_class_creation_and_property_fetching(
-    decoy: Decoy, mock_feature_flags: None
+    decoy: Decoy,
+    mock_feature_flags: None,
+    protocol: ProtocolContext,
 ) -> None:
     """It should create the liquid class and provide access to its properties."""
     decoy.when(ff.allow_liquid_classes(RobotTypeEnum.OT2)).then_return(True)
-    protocol_context = simulate.get_protocol_api(version="2.20", robot_type="OT-2")
-    pipette_left = protocol_context.load_instrument("p20_single_gen2", mount="left")
-    pipette_right = protocol_context.load_instrument("p300_multi", mount="right")
-    tiprack = protocol_context.load_labware("opentrons_96_tiprack_20ul", "1")
+    pipette_left = protocol.load_instrument("p20_single_gen2", mount="left")
+    pipette_right = protocol.load_instrument("p300_multi", mount="right")
+    tiprack = protocol.load_labware("opentrons_96_tiprack_20ul", "1")
 
-    glycerol_50 = protocol_context.define_liquid_class("fixture_glycerol50")
+    glycerol_50 = protocol.define_liquid_class("fixture_glycerol50")
 
     assert glycerol_50.name == "fixture_glycerol50"
     assert glycerol_50.display_name == "Glycerol 50%"
@@ -50,11 +52,11 @@ def test_liquid_class_creation_and_property_fetching(
         glycerol_50.display_name = "bar"  # type: ignore
 
     with pytest.raises(ValueError, match="Liquid class definition not found"):
-        protocol_context.define_liquid_class("non-existent-liquid")
+        protocol.define_liquid_class("non-existent-liquid")
 
 
-def test_liquid_class_feature_flag() -> None:
+@pytest.mark.parametrize("protocol", [("2.20", "OT-2")], indirect=True)
+def test_liquid_class_feature_flag(protocol: ProtocolContext) -> None:
     """It should raise a not implemented error without the allowLiquidClass flag set."""
-    protocol_context = simulate.get_protocol_api(version="2.20", robot_type="OT-2")
     with pytest.raises(NotImplementedError):
-        protocol_context.define_liquid_class("fixture_glycerol50")
+        protocol.define_liquid_class("fixture_glycerol50")

--- a/api/tests/opentrons/protocol_api_integration/test_modules.py
+++ b/api/tests/opentrons/protocol_api_integration/test_modules.py
@@ -3,12 +3,14 @@
 import typing
 import pytest
 
-from opentrons import simulate, protocol_api
+from opentrons import protocol_api
 
 
-def test_absorbance_reader_labware_load_conflict() -> None:
+@pytest.mark.parametrize("protocol", [("2.21", "Flex")], indirect=True)
+def test_absorbance_reader_labware_load_conflict(
+    protocol: protocol_api.ProtocolContext,
+) -> None:
     """It should prevent loading a labware onto a closed absorbance reader."""
-    protocol = simulate.get_protocol_api(version="2.21", robot_type="Flex")
     module = protocol.load_module("absorbanceReaderV1", "A3")
 
     # The lid should be treated as initially closed.
@@ -27,9 +29,11 @@ def test_absorbance_reader_labware_load_conflict() -> None:
         module.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt")
 
 
-def test_absorbance_reader_labware_move_conflict() -> None:
+@pytest.mark.parametrize("protocol", [("2.21", "Flex")], indirect=True)
+def test_absorbance_reader_labware_move_conflict(
+    protocol: protocol_api.ProtocolContext,
+) -> None:
     """It should prevent moving a labware onto a closed absorbance reader."""
-    protocol = simulate.get_protocol_api(version="2.21", robot_type="Flex")
     module = protocol.load_module("absorbanceReaderV1", "A3")
     labware = protocol.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt", "A1")
 
@@ -49,9 +53,11 @@ def test_absorbance_reader_labware_move_conflict() -> None:
         protocol.move_labware(labware, module, use_gripper=True)
 
 
-def test_absorbance_reader_read_preconditions() -> None:
+@pytest.mark.parametrize("protocol", [("2.21", "Flex")], indirect=True)
+def test_absorbance_reader_read_preconditions(
+    protocol: protocol_api.ProtocolContext,
+) -> None:
     """Test the preconditions for triggering an absorbance reader read."""
-    protocol = simulate.get_protocol_api(version="2.21", robot_type="Flex")
     module = typing.cast(
         protocol_api.AbsorbanceReaderContext,
         protocol.load_module("absorbanceReaderV1", "A3"),

--- a/api/tests/opentrons/protocol_api_integration/test_modules.py
+++ b/api/tests/opentrons/protocol_api_integration/test_modules.py
@@ -6,12 +6,14 @@ import pytest
 from opentrons import protocol_api
 
 
-@pytest.mark.parametrize("protocol", [("2.21", "Flex")], indirect=True)
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.21", "Flex")], indirect=True
+)
 def test_absorbance_reader_labware_load_conflict(
-    protocol: protocol_api.ProtocolContext,
+    simulated_protocol_context: protocol_api.ProtocolContext,
 ) -> None:
     """It should prevent loading a labware onto a closed absorbance reader."""
-    module = protocol.load_module("absorbanceReaderV1", "A3")
+    module = simulated_protocol_context.load_module("absorbanceReaderV1", "A3")
 
     # The lid should be treated as initially closed.
     with pytest.raises(Exception):
@@ -21,7 +23,7 @@ def test_absorbance_reader_labware_load_conflict(
     # Should not raise after opening the lid.
     labware_1 = module.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt")
 
-    protocol.move_labware(labware_1, protocol_api.OFF_DECK)
+    simulated_protocol_context.move_labware(labware_1, protocol_api.OFF_DECK)
 
     # Should raise after closing the lid again.
     module.close_lid()  # type: ignore[union-attr]
@@ -29,38 +31,44 @@ def test_absorbance_reader_labware_load_conflict(
         module.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt")
 
 
-@pytest.mark.parametrize("protocol", [("2.21", "Flex")], indirect=True)
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.21", "Flex")], indirect=True
+)
 def test_absorbance_reader_labware_move_conflict(
-    protocol: protocol_api.ProtocolContext,
+    simulated_protocol_context: protocol_api.ProtocolContext,
 ) -> None:
     """It should prevent moving a labware onto a closed absorbance reader."""
-    module = protocol.load_module("absorbanceReaderV1", "A3")
-    labware = protocol.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt", "A1")
+    module = simulated_protocol_context.load_module("absorbanceReaderV1", "A3")
+    labware = simulated_protocol_context.load_labware(
+        "opentrons_96_wellplate_200ul_pcr_full_skirt", "A1"
+    )
 
     with pytest.raises(Exception):
         # The lid should be treated as initially closed.
-        protocol.move_labware(labware, module, use_gripper=True)
+        simulated_protocol_context.move_labware(labware, module, use_gripper=True)
 
     module.open_lid()  # type: ignore[union-attr]
     # Should not raise after opening the lid.
-    protocol.move_labware(labware, module, use_gripper=True)
+    simulated_protocol_context.move_labware(labware, module, use_gripper=True)
 
-    protocol.move_labware(labware, "A1", use_gripper=True)
+    simulated_protocol_context.move_labware(labware, "A1", use_gripper=True)
 
     # Should raise after closing the lid again.
     module.close_lid()  # type: ignore[union-attr]
     with pytest.raises(Exception):
-        protocol.move_labware(labware, module, use_gripper=True)
+        simulated_protocol_context.move_labware(labware, module, use_gripper=True)
 
 
-@pytest.mark.parametrize("protocol", [("2.21", "Flex")], indirect=True)
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.21", "Flex")], indirect=True
+)
 def test_absorbance_reader_read_preconditions(
-    protocol: protocol_api.ProtocolContext,
+    simulated_protocol_context: protocol_api.ProtocolContext,
 ) -> None:
     """Test the preconditions for triggering an absorbance reader read."""
     module = typing.cast(
         protocol_api.AbsorbanceReaderContext,
-        protocol.load_module("absorbanceReaderV1", "A3"),
+        simulated_protocol_context.load_module("absorbanceReaderV1", "A3"),
     )
 
     with pytest.raises(Exception, match="initialize"):

--- a/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
+++ b/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
@@ -9,38 +9,54 @@ from opentrons.protocol_api.core.engine.pipette_movement_conflict import (
 
 
 @pytest.mark.ot3_only
-@pytest.mark.parametrize("protocol", [("2.16", "Flex")], indirect=True)
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.16", "Flex")], indirect=True
+)
 def test_deck_conflicts_for_96_ch_a12_column_configuration(
-    protocol: ProtocolContext,
+    simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should raise errors for the expected deck conflicts."""
-    trash_labware = protocol.load_labware("opentrons_1_trash_3200ml_fixed", "A3")
-    badly_placed_tiprack = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
-    well_placed_tiprack = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "C1")
-    tiprack_on_adapter = protocol.load_labware(
+    trash_labware = simulated_protocol_context.load_labware(
+        "opentrons_1_trash_3200ml_fixed", "A3"
+    )
+    badly_placed_tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_50ul", "C2"
+    )
+    well_placed_tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_50ul", "C1"
+    )
+    tiprack_on_adapter = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul",
         "C3",
         adapter="opentrons_flex_96_tiprack_adapter",
     )
 
-    thermocycler = protocol.load_module("thermocyclerModuleV2")
-    tc_adjacent_plate = protocol.load_labware(
+    thermocycler = simulated_protocol_context.load_module("thermocyclerModuleV2")
+    tc_adjacent_plate = simulated_protocol_context.load_labware(
         "opentrons_96_wellplate_200ul_pcr_full_skirt", "A2"
     )
     accessible_plate = thermocycler.load_labware(
         "opentrons_96_wellplate_200ul_pcr_full_skirt"
     )
 
-    instrument = protocol.load_instrument("flex_96channel_1000", mount="left")
+    instrument = simulated_protocol_context.load_instrument(
+        "flex_96channel_1000", mount="left"
+    )
     instrument.trash_container = trash_labware
 
     # ############  SHORT LABWARE  ################
     # These labware should be to the west of tall labware to avoid any partial tip deck conflicts
-    badly_placed_labware = protocol.load_labware("nest_96_wellplate_200ul_flat", "D2")
-    well_placed_labware = protocol.load_labware("nest_96_wellplate_200ul_flat", "D3")
+    badly_placed_labware = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "D2"
+    )
+    well_placed_labware = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "D3"
+    )
 
     # ############ TALL LABWARE ##############
-    protocol.load_labware("opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical", "D1")
+    simulated_protocol_context.load_labware(
+        "opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical", "D1"
+    )
 
     # ########### Use Partial Nozzles #############
     instrument.configure_nozzle_layout(style=COLUMN, start="A12")
@@ -93,26 +109,30 @@ def test_deck_conflicts_for_96_ch_a12_column_configuration(
 
 
 @pytest.mark.ot3_only
-@pytest.mark.parametrize("protocol", [("2.20", "Flex")], indirect=True)
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.20", "Flex")], indirect=True
+)
 def test_close_shave_deck_conflicts_for_96_ch_a12_column_configuration(
-    protocol: ProtocolContext,
+    simulated_protocol_context: ProtocolContext,
 ) -> None:
     """Shouldn't raise errors for "almost collision"s."""
-    res12 = protocol.load_labware("nest_12_reservoir_15ml", "C3")
+    res12 = simulated_protocol_context.load_labware("nest_12_reservoir_15ml", "C3")
 
     # Mag block and tiprack adapter are very close to the destination reservoir labware
-    protocol.load_module("magneticBlockV1", "D2")
-    protocol.load_labware(
+    simulated_protocol_context.load_module("magneticBlockV1", "D2")
+    simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_200ul",
         "B3",
         adapter="opentrons_flex_96_tiprack_adapter",
     )
-    tiprack_8 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "B2")
-    hs = protocol.load_module("heaterShakerModuleV1", "C1")
+    tiprack_8 = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_200ul", "B2"
+    )
+    hs = simulated_protocol_context.load_module("heaterShakerModuleV1", "C1")
     hs_adapter = hs.load_adapter("opentrons_96_deep_well_adapter")
     deepwell = hs_adapter.load_labware("nest_96_wellplate_2ml_deep")
-    protocol.load_trash_bin("A3")
-    p1000_96 = protocol.load_instrument("flex_96channel_1000")
+    simulated_protocol_context.load_trash_bin("A3")
+    p1000_96 = simulated_protocol_context.load_instrument("flex_96channel_1000")
     p1000_96.configure_nozzle_layout(style=SINGLE, start="A12", tip_racks=[tiprack_8])
 
     hs.close_labware_latch()  # type: ignore[union-attr]
@@ -126,18 +146,28 @@ def test_close_shave_deck_conflicts_for_96_ch_a12_column_configuration(
 
 
 @pytest.mark.ot3_only
-@pytest.mark.parametrize("protocol", [("2.16", "Flex")], indirect=True)
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.16", "Flex")], indirect=True
+)
 def test_deck_conflicts_for_96_ch_a1_column_configuration(
-    protocol: ProtocolContext,
+    simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should raise errors for expected deck conflicts."""
-    instrument = protocol.load_instrument("flex_96channel_1000", mount="left")
-    trash_labware = protocol.load_labware("opentrons_1_trash_3200ml_fixed", "A3")
+    instrument = simulated_protocol_context.load_instrument(
+        "flex_96channel_1000", mount="left"
+    )
+    trash_labware = simulated_protocol_context.load_labware(
+        "opentrons_1_trash_3200ml_fixed", "A3"
+    )
     instrument.trash_container = trash_labware
 
-    badly_placed_tiprack = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
-    well_placed_tiprack = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "A1")
-    tiprack_on_adapter = protocol.load_labware(
+    badly_placed_tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_50ul", "C2"
+    )
+    well_placed_tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_50ul", "A1"
+    )
+    tiprack_on_adapter = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul",
         "C3",
         adapter="opentrons_flex_96_tiprack_adapter",
@@ -145,11 +175,15 @@ def test_deck_conflicts_for_96_ch_a1_column_configuration(
 
     # ############  SHORT LABWARE  ################
     # These labware should be to the east of tall labware to avoid any partial tip deck conflicts
-    badly_placed_plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "B1")
-    well_placed_plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "B3")
+    badly_placed_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "B1"
+    )
+    well_placed_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "B3"
+    )
 
     # ############ TALL LABWARE ###############
-    my_tuberack = protocol.load_labware(
+    my_tuberack = simulated_protocol_context.load_labware(
         "opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical", "B2"
     )
 
@@ -201,7 +235,7 @@ def test_deck_conflicts_for_96_ch_a1_column_configuration(
         instrument.drop_tip()
 
     instrument.trash_container = None  # type: ignore
-    protocol.load_trash_bin("C1")
+    simulated_protocol_context.load_trash_bin("C1")
 
     # This doesn't raise an error because it now treats the trash bin as an addressable area
     # and the bounds check doesn't yet check moves to addressable areas.
@@ -222,28 +256,38 @@ def test_deck_conflicts_for_96_ch_a1_column_configuration(
 
 
 @pytest.mark.ot3_only
-@pytest.mark.parametrize("protocol", [("2.20", "Flex")], indirect=True)
-def test_deck_conflicts_for_96_ch_and_reservoirs(protocol: ProtocolContext) -> None:
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.20", "Flex")], indirect=True
+)
+def test_deck_conflicts_for_96_ch_and_reservoirs(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
     """It should raise errors for expected deck conflicts when moving to reservoirs.
 
     This test checks that the critical point of the pipette is taken into account,
     specifically when it differs from the primary nozzle.
     """
-    instrument = protocol.load_instrument("flex_96channel_1000", mount="left")
+    instrument = simulated_protocol_context.load_instrument(
+        "flex_96channel_1000", mount="left"
+    )
     # trash_labware = protocol.load_labware("opentrons_1_trash_3200ml_fixed", "A3")
     # instrument.trash_container = trash_labware
 
-    protocol.load_trash_bin("A3")
-    right_tiprack = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "C3")
-    front_tiprack = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "D2")
+    simulated_protocol_context.load_trash_bin("A3")
+    right_tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_50ul", "C3"
+    )
+    front_tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_50ul", "D2"
+    )
     # Tall deck item in B3
-    protocol.load_labware(
+    simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul",
         "B3",
         adapter="opentrons_flex_96_tiprack_adapter",
     )
     # Tall deck item in B1
-    protocol.load_labware(
+    simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul",
         "B1",
         adapter="opentrons_flex_96_tiprack_adapter",
@@ -251,8 +295,12 @@ def test_deck_conflicts_for_96_ch_and_reservoirs(protocol: ProtocolContext) -> N
 
     # ############  RESERVOIRS  ################
     # These labware should be to the east of tall labware to avoid any partial tip deck conflicts
-    reservoir_1_well = protocol.load_labware("nest_1_reservoir_195ml", "C2")
-    reservoir_12_well = protocol.load_labware("nest_12_reservoir_15ml", "B2")
+    reservoir_1_well = simulated_protocol_context.load_labware(
+        "nest_1_reservoir_195ml", "C2"
+    )
+    reservoir_12_well = simulated_protocol_context.load_labware(
+        "nest_12_reservoir_15ml", "B2"
+    )
 
     # ########### Use COLUMN A1 Config #############
     instrument.configure_nozzle_layout(style=COLUMN, start="A1")

--- a/api/tests/opentrons/protocol_api_integration/test_trashes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_trashes.py
@@ -56,7 +56,8 @@ def test_fixed_trash_presence(
         with pytest.raises(
             UnsupportedAPIError,
             match=re.escape(
-                "Error 4002 API_REMOVED (UnsupportedAPIError): Fixed Trash is not available after API version 2.16. You are currently using API version 2.16. Fixed trash is no longer supported on Flex protocols."
+                "Error 4002 API_REMOVED (UnsupportedAPIError): Fixed Trash is not available after API version 2.16."
+                " You are currently using API version 2.16. Fixed trash is no longer supported on Flex protocols."
             ),
         ):
             protocol.fixed_trash
@@ -78,7 +79,8 @@ def test_trash_search(protocol: protocol_api.ProtocolContext) -> None:
     with pytest.raises(
         UnsupportedAPIError,
         match=re.escape(
-            "Error 4002 API_REMOVED (UnsupportedAPIError): Fixed Trash is not available after API version 2.16. You are currently using API version 2.16. Fixed trash is no longer supported on Flex protocols."
+            "Error 4002 API_REMOVED (UnsupportedAPIError): Fixed Trash is not available after API version 2.16."
+            " You are currently using API version 2.16. Fixed trash is no longer supported on Flex protocols."
         ),
     ):
         protocol.fixed_trash
@@ -92,7 +94,8 @@ def test_trash_search(protocol: protocol_api.ProtocolContext) -> None:
     with pytest.raises(
         UnsupportedAPIError,
         match=re.escape(
-            "Error 4002 API_REMOVED (UnsupportedAPIError): Fixed Trash is not available after API version 2.16. You are currently using API version 2.16. Fixed trash is no longer supported on Flex protocols."
+            "Error 4002 API_REMOVED (UnsupportedAPIError): Fixed Trash is not available after API version 2.16."
+            " You are currently using API version 2.16. Fixed trash is no longer supported on Flex protocols."
         ),
     ):
         protocol.fixed_trash


### PR DESCRIPTION
# Overview

This fixes an issue found where after a recent mergeback commit into edge, API unit tests were hanging and when escaped, would show as a bunch of `OSError: [Errno 24] Too many open files`.

Through investigation this was found to be caused by too many integration tests that individually called `simulate.get_protocol_api`. There is a known issue with this in that the threads this creates (Hardware API and for 2.14 and above contexts, Protocol Engine) are not cleaned up properly. This was not causing any issues in our test suite until recently when the magic number of tests that could be run without too many threads opening was hit.

In order to fix this, the simulating context was refactored to be a pytest fixture. In this new fixture, we yield a `ProtocolContext` and then afterwards, we close the threads. For engine based contexts, we take advantage of the glboal `ExitStack()` `simulate` uses to create the PE context to close and unwind the context stack they are created in, allowing it to be properly garbage collected. For older contexts we just call the `clean_up` function on the hardware API instance.

## Test Plan and Hands on Testing

This is a test only fix, so if CI passes this covers this PR.

## Changelog

- refactor `protocol_api_integration` tests to prevent thread leakage

## Review requests

Can someone else who has this failing test this on their machine to ensure this fix works for not just me.

## Risk assessment

Low.