### PR TITLE
fix(protocol-designer): default unknown TC lid state to closed

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -200,8 +200,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         }
         const isLabwareOccludedByThermocyclerLid =
           moduleOnDeck.type === THERMOCYCLER_MODULE_TYPE &&
-          (moduleOnDeck.moduleState as ThermocyclerModuleState).lidOpen ===
-            false
+          (moduleOnDeck.moduleState as ThermocyclerModuleState).lidOpen !== true
 
         const tempInnerProps = getModuleInnerProps(moduleOnDeck.moduleState)
         const innerProps =
@@ -210,9 +209,9 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
                 ...tempInnerProps,
                 lidMotorState:
                   (tempInnerProps as ThermocyclerVizProps).lidMotorState !==
-                  'closed'
-                    ? 'open'
-                    : 'closed',
+                  'open'
+                    ? 'closed'
+                    : 'open',
               }
             : tempInnerProps
 


### PR DESCRIPTION
# Overview

Latest designs specify that the thermocycler lid position should be default to closed at the Protocol Steps tab (all upstream steps of the first thermocycler step).

[reference](https://github.com/Opentrons/opentrons/pull/16826)

## Test Plan and Hands on Testing

- create or upload a protocol that uses a Thermocycler
- edit protocol and navigate to protocol steps tab— the thermocycler is now defaulted to the closed svg

## Changelog

- default null thermocycler lid state to 'closed'

## Review requests

see test plan

## Risk assessment

low