### PR TITLE
fix(api): rename TouchTipParams -> LiquidClassTouchTipParams to avoid name conflict

### DIFF
--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -84,6 +84,7 @@ class DelayProperties(BaseModel):
 
 class LiquidClassTouchTipParams(BaseModel):
     """Parameters for touch-tip."""
+
     # Note: Do not call this `TouchTipParams`, because that class name is used by the
     # unrelated touchTip command in PE. Both classes are exported to things like the
     # command schema JSON files, so the classes can't have the same name.

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -82,8 +82,11 @@ class DelayProperties(BaseModel):
         return v
 
 
-class TouchTipParams(BaseModel):
+class LiquidClassTouchTipParams(BaseModel):
     """Parameters for touch-tip."""
+    # Note: Do not call this `TouchTipParams`, because that class name is used by the
+    # unrelated touchTip command in PE. Both classes are exported to things like the
+    # command schema JSON files, so the classes can't have the same name.
 
     zOffset: _Number = Field(
         ...,
@@ -101,14 +104,14 @@ class TouchTipProperties(BaseModel):
     """Shared properties for the touch-tip function."""
 
     enable: bool = Field(..., description="Whether touch-tip is enabled.")
-    params: Optional[TouchTipParams] = Field(
+    params: Optional[LiquidClassTouchTipParams] = Field(
         None, description="Parameters for the touch-tip function."
     )
 
     @validator("params")
     def _validate_params(
-        cls, v: Optional[TouchTipParams], values: Dict[str, Any]
-    ) -> Optional[TouchTipParams]:
+        cls, v: Optional[LiquidClassTouchTipParams], values: Dict[str, Any]
+    ) -> Optional[LiquidClassTouchTipParams]:
         if v is None and values["enable"]:
             raise ValueError(
                 "If enable is true parameters for touch tip must be defined."


### PR DESCRIPTION
# Overview

Liquid classes defined a new class `TouchTipParams` to configure the touch-tip settings for a liquid. But there's already an existing class called [`TouchTipParams`](../blob/edge/api/src/opentrons/protocol_engine/commands/touch_tip.py) that's used as the argument to the Protocol Engine `touchTip` command. When we generate the [command schema](../blob/edge/shared-data/command/schemas/11.json), both classes get pulled in, and the names clash.

This PR renames the liquid class `TouchTipParams` to `LiquidClassTouchTipParams` to avoid the conflict.

## Test Plan and Hands on Testing

I ran `make -C api test`, everything seems to pass.

## Risk assessment

If this breaks anything, it should only affect our team for now.
