### PR TITLE
fix(api): update error message to title case

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -82,7 +82,7 @@ class TipPhysicallyMissingError(ErrorOccurrence):
     isDefined: bool = True
     errorType: Literal["tipPhysicallyMissing"] = "tipPhysicallyMissing"
     errorCode: str = ErrorCodes.TIP_PICKUP_FAILED.value.code
-    detail: str = "No Tip Detected."
+    detail: str = "No Tip Detected"
 
 
 _ExecuteReturn = Union[

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -82,7 +82,7 @@ class TipPhysicallyMissingError(ErrorOccurrence):
     isDefined: bool = True
     errorType: Literal["tipPhysicallyMissing"] = "tipPhysicallyMissing"
     errorCode: str = ErrorCodes.TIP_PICKUP_FAILED.value.code
-    detail: str = "No tip detected."
+    detail: str = "No Tip Detected."
 
 
 _ExecuteReturn = Union[


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-3587.
title case error message

## Test Plan and Hands on Testing

reproduce a tip not attached error and make sure when you view the details they are in title case 
