### PR TITLE
fix(shared-data): deck riser and auto sealing lid labware definition updates

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_flex_deck_riser/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_deck_riser/1.json
@@ -13,7 +13,7 @@
   "dimensions": {
     "xDimension": 140,
     "yDimension": 98,
-    "zDimension": 21
+    "zDimension": 55
   },
   "wells": {},
   "groups": [

--- a/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
@@ -69,7 +69,7 @@
     "opentrons_flex_deck_riser": {
       "x": 0,
       "y": 0,
-      "z": 0
+      "z": 34
     }
   },
   "gripForce": 15,


### PR DESCRIPTION

# Overview
Covers PLAT-602

The Deck Riser design was updated to include guide channels that ensure the auto sealing lids are always properly aligned when stacked up to 5 high. This PR includes that new maximum height dimension of the risers overall size, while adjusting the stacking offset of the labware to appropriately reflect that.

The deck riser's heigh increase from 21mm to 55mm, meaning the TC lids stacking offset (which was originally 0) has increase to reflect the difference of 34mm.

## Test Plan and Hands on Testing

- [x] Run a protocol moving the TC lids from the adapter to the deck and back

## Changelog
Updated the Riser's z-height dimension and the auto sealing lid's stacking offset on the adapter.

## Review requests


## Risk assessment
Lower than the Mariana Trench