### PR TITLE
fix(api): add stopped state so a stop request doesn't mean the gripper needs to re-home

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -652,6 +652,7 @@ _gripper_jaw_state_lookup: Dict[FirmwareGripperjawState, GripperJawState] = {
     FirmwareGripperjawState.force_controlling_home: GripperJawState.HOMED_READY,
     FirmwareGripperjawState.force_controlling: GripperJawState.GRIPPING,
     FirmwareGripperjawState.position_controlling: GripperJawState.HOLDING,
+    FirmwareGripperjawState.stopped: GripperJawState.STOPPED,
 }
 
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -625,6 +625,8 @@ class GripperJawState(enum.Enum):
     #: the gripper is actively force-control gripping something
     HOLDING = enum.auto()
     #: the gripper is in position-control mode
+    STOPPED = enum.auto()
+    #: the gripper has been homed before but is stopped now
 
 
 class InstrumentProbeType(enum.Enum):

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -461,3 +461,4 @@ class GripperJawState(int, Enum):
     force_controlling_home = 0x1
     force_controlling = 0x2
     position_controlling = 0x3
+    stopped = 0x4


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This fixes an error that happens during error recovery where the gripper needs to re-home because the error flow sends a stop request. 

This fixes that by adding a new state called stop, and if the firmware responds with STOPPED instead of UNHOMED then we know we can just continue on without re-homing.

The gripper will still go into a UNHOMED state during the following:
Labware droped
Collision
Estop

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
