### PR TITLE
fix(components, protocol-designer): fix background color in file creation

### DIFF
--- a/components/src/organisms/EndUserAgreementFooter/index.tsx
+++ b/components/src/organisms/EndUserAgreementFooter/index.tsx
@@ -14,7 +14,7 @@ const EULA_URL = 'https://opentrons.com/eula'
 export function EndUserAgreementFooter(): JSX.Element {
   return (
     <Flex
-      backgroundColor={COLORS.grey20}
+      backgroundColor={COLORS.grey10}
       padding={SPACING.spacing24}
       width="100%"
       alignItems={ALIGN_CENTER}

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/index.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/index.tsx
@@ -373,7 +373,7 @@ export function CreateNewProtocolWizard(): JSX.Element | null {
   }
 
   return showWizard ? (
-    <Box backgroundColor={COLORS.grey20} height="calc(100vh - 48px)">
+    <Box backgroundColor={COLORS.grey10} height="calc(100vh - 48px)">
       <CreateFileForm
         currentWizardStep={currentWizardStep}
         createProtocolFile={createProtocolFile}

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -95,7 +95,7 @@ export function Landing(): JSX.Element {
       ) : null}
       <Flex
         data-cy="landing-page"
-        backgroundColor={COLORS.grey20}
+        backgroundColor={COLORS.grey10}
         flexDirection={DIRECTION_COLUMN}
         alignItems={ALIGN_CENTER}
         justifyContent={JUSTIFY_CENTER}


### PR DESCRIPTION
# Overview

Update background color in new protocol wizard from grey20 to grey10

Closes RQA-3361

## Test Plan and Hands on Testing

- verify that background color for wizard body and footer are grey10, at initial landing page and each protocol step

## Changelog

- update color

## Review requests

see test plan

## Risk assessment

lowest