### PR TITLE
fix(protocol-designer): add white space below deck and remove module tag

### DIFF
--- a/protocol-designer/src/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/organisms/SlotInformation/index.tsx
@@ -76,7 +76,10 @@ export const SlotInformation: FC<SlotInformationProps> = ({
         {liquids.length > 1 ? (
           <ListItem type="noActive" width="max-content">
             <ListItemDescriptor
-              changeFlexDirection={breakPointSize === 'medium'}
+              changeFlexDirection={
+                breakPointSize === 'medium' &&
+                pathLocation.pathname === '/designer'
+              }
               type="default"
               content={
                 <StyledText
@@ -147,11 +150,14 @@ interface StackInfoProps {
 function StackInfo({ title, stackInformation }: StackInfoProps): JSX.Element {
   const { t } = useTranslation('shared')
   const breakPointSize = useDeckSetupWindowBreakPoint()
+  const pathLocation = useLocation()
 
   return (
     <ListItem type="noActive">
       <ListItemDescriptor
-        changeFlexDirection={breakPointSize === 'medium'}
+        changeFlexDirection={
+          breakPointSize === 'medium' && pathLocation.pathname === '/designer'
+        }
         type="default"
         content={
           <StyledText

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/HoveredItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/HoveredItems.test.tsx
@@ -11,6 +11,7 @@ import {
 import { LabwareRender, Module } from '@opentrons/components'
 import { selectors } from '../../../../labware-ingred/selectors'
 import { getCustomLabwareDefsByURI } from '../../../../labware-defs/selectors'
+import { getDesignerTab } from '../../../../file-data/selectors'
 import { FixtureRender } from '../FixtureRender'
 import { HoveredItems } from '../HoveredItems'
 import type * as OpentronsComponents from '@opentrons/components'
@@ -18,6 +19,7 @@ import type * as OpentronsComponents from '@opentrons/components'
 vi.mock('../FixtureRender')
 vi.mock('../../../../labware-ingred/selectors')
 vi.mock('../../../../labware-defs/selectors')
+vi.mock('../../../../file-data/selectors')
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof OpentronsComponents>()
   return {
@@ -54,6 +56,7 @@ describe('HoveredItems', () => {
     vi.mocked(FixtureRender).mockReturnValue(<div>mock FixtureRender</div>)
     vi.mocked(LabwareRender).mockReturnValue(<div>mock LabwareRender</div>)
     vi.mocked(Module).mockReturnValue(<div>mock Module</div>)
+    vi.mocked(getDesignerTab).mockReturnValue('startingDeck')
   })
   it('renders a hovered fixture', () => {
     render(props)

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
@@ -13,12 +13,14 @@ import { Module } from '@opentrons/components'
 import { selectors } from '../../../../labware-ingred/selectors'
 import { getInitialDeckSetup } from '../../../../step-forms/selectors'
 import { getCustomLabwareDefsByURI } from '../../../../labware-defs/selectors'
+import { getDesignerTab } from '../../../../file-data/selectors'
 import { LabwareOnDeck } from '../../../../components/DeckSetup/LabwareOnDeck'
 import { FixtureRender } from '../FixtureRender'
 import { SelectedHoveredItems } from '../SelectedHoveredItems'
 import type * as OpentronsComponents from '@opentrons/components'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
+vi.mock('../../../../file-data/selectors')
 vi.mock('../../../../step-forms/selectors')
 vi.mock('../FixtureRender')
 vi.mock('../../../../labware-ingred/selectors')
@@ -48,6 +50,7 @@ describe('SelectedHoveredItems', () => {
       hoveredFixture: null,
       slotPosition: [0, 0, 0],
     }
+    vi.mocked(getDesignerTab).mockReturnValue('startingDeck')
     vi.mocked(getInitialDeckSetup).mockReturnValue({
       modules: {},
       additionalEquipmentOnDeck: {},

--- a/protocol-designer/src/pages/Designer/LabwareLabel.tsx
+++ b/protocol-designer/src/pages/Designer/LabwareLabel.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState, useEffect } from 'react'
+import { useSelector } from 'react-redux'
 import { DeckLabelSet } from '@opentrons/components'
+import { getDesignerTab } from '../../file-data/selectors'
 import type { DeckLabelProps } from '@opentrons/components'
 import type {
   CoordinateTuple,
@@ -22,16 +24,20 @@ export const LabwareLabel = (props: ModuleLabelProps): JSX.Element => {
     nestedLabwareInfo = [],
   } = props
   const labelContainerRef = useRef<HTMLDivElement>(null)
+  const designerTab = useSelector(getDesignerTab)
   const [labelContainerHeight, setLabelContainerHeight] = useState(0)
 
-  const deckLabels = [
-    ...nestedLabwareInfo,
-    {
-      text: labwareDef.metadata.displayName,
-      isSelected: isSelected,
-      isLast: isLast,
-    },
-  ]
+  const deckLabels =
+    designerTab === 'startingDeck'
+      ? [
+          ...nestedLabwareInfo,
+          {
+            text: labwareDef.metadata.displayName,
+            isSelected: isSelected,
+            isLast: isLast,
+          },
+        ]
+      : []
 
   useEffect(() => {
     if (labelContainerRef.current) {

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import debounce from 'lodash/debounce'
 
 import {
   ALIGN_CENTER,
@@ -26,8 +25,6 @@ import type {
 } from '@opentrons/shared-data'
 
 import type { Dispatch, SetStateAction } from 'react'
-
-const DEBOUNCE_DURATION_MS = 600
 
 interface SlotHoverProps {
   hover: string | null
@@ -56,13 +53,6 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
       slotId as AddressableAreaName,
       deckDef.cutoutFixtures
     ) ?? 'cutoutD1'
-
-  const debouncedSetHover = useCallback(
-    debounce((slotId: string | null) => {
-      setHover(slotId)
-    }, DEBOUNCE_DURATION_MS),
-    [setHover]
-  )
 
   //  return null for TC slots
   if (slotPosition === null || (hasTCOnSlot && tcSlots.includes(slotId)))
@@ -126,10 +116,10 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
           opacity: hoverOpacity,
           flex: '1',
           onMouseEnter: () => {
-            debouncedSetHover(slotId)
+            setHover(slotId)
           },
           onMouseLeave: () => {
-            debouncedSetHover(null)
+            setHover(null)
           },
         }}
       >
@@ -152,10 +142,10 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
           opacity: hoverOpacity,
           flex: '1',
           onMouseEnter: () => {
-            debouncedSetHover(slotId)
+            setHover(slotId)
           },
           onMouseLeave: () => {
-            debouncedSetHover(null)
+            setHover(null)
           },
         }}
       >

--- a/protocol-designer/src/pages/ProtocolOverview/StartingDeck.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/StartingDeck.tsx
@@ -11,6 +11,7 @@ import {
   Btn,
   TYPOGRAPHY,
   ToggleGroup,
+  Box,
 } from '@opentrons/components'
 
 import { BUTTON_LINK_STYLE } from '../../atoms'
@@ -88,11 +89,13 @@ export function StartingDeck({
         ) : (
           <OffDeckThumbnail hover={hover} setHover={setHover} width="100%" />
         )}
-        <SlotDetailsContainer
-          robotType={robotType}
-          slot={isOffDeckHover ? 'offDeck' : hover}
-          offDeckLabwareId={isOffDeckHover ? hover : null}
-        />
+        <Box width="100%" height="12.5rem">
+          <SlotDetailsContainer
+            robotType={robotType}
+            slot={isOffDeckHover ? 'offDeck' : hover}
+            offDeckLabwareId={isOffDeckHover ? hover : null}
+          />
+        </Box>
       </Flex>
     </>
   )


### PR DESCRIPTION
closes RQA-3604 RQA-3603

# Overview

Remove the module tags in protocol steps because they're too small and can't be read
Add white space below protocol overview's deck map when viewport shows 1 column

## Test Plan and Hands on Testing

Test slot details in protocol overview when screensize is small enough for 1 column. make sure there is no flickering
Then go to protocol steps and make some steps and see that the module tag is removed from the labware

## Changelog

- remove deck labels
- add hardcoded white space
- remove unnecessary debounce due to the white space

## Risk assessment

low