### PR TITLE
refactor(api): create micro-operations for motion and pipetting

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -9,8 +9,10 @@ from .pipetting_common import (
     PipetteIdMixin,
     AspirateVolumeMixin,
     FlowRateMixin,
-    LiquidHandlingWellLocationMixin,
     BaseLiquidHandlingResult,
+)
+from .movement_common import (
+    LiquidHandlingWellLocationMixin,
     DestinationPositionResult,
 )
 from .command import (

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -1,7 +1,7 @@
 """Aspirate command request, result, and implementation models."""
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type, Union
-from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
 from typing_extensions import Literal
 
 from .pipetting_common import (
@@ -10,10 +10,12 @@ from .pipetting_common import (
     AspirateVolumeMixin,
     FlowRateMixin,
     BaseLiquidHandlingResult,
+    aspirate_in_place,
 )
 from .movement_common import (
     LiquidHandlingWellLocationMixin,
     DestinationPositionResult,
+    move_to_well,
 )
 from .command import (
     AbstractCommandImpl,
@@ -22,7 +24,6 @@ from .command import (
     DefinedErrorData,
     SuccessData,
 )
-from ..errors.error_occurrence import ErrorOccurrence
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -31,9 +32,6 @@ from ..types import (
     WellLocation,
     WellOrigin,
     CurrentWell,
-    DeckPoint,
-    AspiratedFluid,
-    FluidKind,
 )
 
 if TYPE_CHECKING:
@@ -101,7 +99,6 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
         )
 
         current_well = None
-        state_update = StateUpdate()
 
         if not ready_to_aspirate:
             await self._movement.move_to_well(
@@ -121,7 +118,8 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
                 well_name=well_name,
             )
 
-        position = await self._movement.move_to_well(
+        move_result = await move_to_well(
+            movement=self._movement,
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
@@ -129,66 +127,61 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
             current_well=current_well,
             operation_volume=-params.volume,
         )
-        deck_point = DeckPoint.construct(x=position.x, y=position.y, z=position.z)
-        state_update.set_pipette_location(
-            pipette_id=pipette_id,
-            new_labware_id=labware_id,
-            new_well_name=well_name,
-            new_deck_point=deck_point,
-        )
 
-        try:
-            volume_aspirated = await self._pipetting.aspirate_in_place(
-                pipette_id=pipette_id,
-                volume=params.volume,
-                flow_rate=params.flowRate,
-                command_note_adder=self._command_note_adder,
-            )
-        except PipetteOverpressureError as e:
-            state_update.set_liquid_operated(
-                labware_id=labware_id,
-                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                    labware_id, well_name, pipette_id
-                ),
-                volume_added=CLEAR,
-            )
-            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
+        aspirate_result = await aspirate_in_place(
+            pipette_id=pipette_id,
+            volume=params.volume,
+            flow_rate=params.flowRate,
+            location_if_error={
+                "retryLocation": (
+                    move_result.public.position.x,
+                    move_result.public.position.y,
+                    move_result.public.position.z,
+                )
+            },
+            command_note_adder=self._command_note_adder,
+            pipetting=self._pipetting,
+            model_utils=self._model_utils,
+        )
+        if isinstance(aspirate_result, DefinedErrorData):
             return DefinedErrorData(
-                public=OverpressureError(
-                    id=self._model_utils.generate_id(),
-                    createdAt=self._model_utils.get_timestamp(),
-                    wrappedErrors=[
-                        ErrorOccurrence.from_failed(
-                            id=self._model_utils.generate_id(),
-                            createdAt=self._model_utils.get_timestamp(),
-                            error=e,
-                        )
-                    ],
-                    errorInfo={"retryLocation": (position.x, position.y, position.z)},
+                public=aspirate_result.public,
+                state_update=StateUpdate.reduce(
+                    move_result.state_update, aspirate_result.state_update
+                ).set_liquid_operated(
+                    labware_id=labware_id,
+                    well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                        labware_id,
+                        well_name,
+                        params.pipetteId,
+                    ),
+                    volume_added=CLEAR,
                 ),
-                state_update=state_update,
+                state_update_if_false_positive=StateUpdate.reduce(
+                    move_result.state_update,
+                    aspirate_result.state_update_if_false_positive,
+                ),
             )
         else:
-            state_update.set_liquid_operated(
-                labware_id=labware_id,
-                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                    labware_id, well_name, pipette_id
-                ),
-                volume_added=-volume_aspirated
-                * self._state_view.geometry.get_nozzles_per_well(
-                    labware_id, well_name, pipette_id
-                ),
-            )
-            state_update.set_fluid_aspirated(
-                pipette_id=params.pipetteId,
-                fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=volume_aspirated),
-            )
             return SuccessData(
                 public=AspirateResult(
-                    volume=volume_aspirated,
-                    position=deck_point,
+                    volume=aspirate_result.public.volume,
+                    position=move_result.public.position,
                 ),
-                state_update=state_update,
+                state_update=StateUpdate.reduce(
+                    move_result.state_update, aspirate_result.state_update
+                ).set_liquid_operated(
+                    labware_id=labware_id,
+                    well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                        labware_id, well_name, pipette_id
+                    ),
+                    volume_added=-aspirate_result.public.volume
+                    * self._state_view.geometry.get_nozzles_per_well(
+                        labware_id,
+                        well_name,
+                        params.pipetteId,
+                    ),
+                ),
             )
 
 

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -1,21 +1,17 @@
 """Blow-out command request, result, and implementation models."""
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type, Union
-from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
 from typing_extensions import Literal
 
 
-from ..state.update_types import StateUpdate
-from ..types import DeckPoint
 from .pipetting_common import (
     OverpressureError,
     PipetteIdMixin,
     FlowRateMixin,
+    blow_out_in_place,
 )
-from .movement_common import (
-    WellLocationMixin,
-    DestinationPositionResult,
-)
+from .movement_common import WellLocationMixin, DestinationPositionResult, move_to_well
 from .command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -24,6 +20,7 @@ from .command import (
     SuccessData,
 )
 from ..errors.error_occurrence import ErrorOccurrence
+from ..state.update_types import StateUpdate
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -75,53 +72,43 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, _ExecuteReturn]):
 
     async def execute(self, params: BlowOutParams) -> _ExecuteReturn:
         """Move to and blow-out the requested well."""
-        state_update = StateUpdate()
-
-        x, y, z = await self._movement.move_to_well(
+        move_result = await move_to_well(
+            movement=self._movement,
             pipette_id=params.pipetteId,
             labware_id=params.labwareId,
             well_name=params.wellName,
             well_location=params.wellLocation,
         )
-        deck_point = DeckPoint.construct(x=x, y=y, z=z)
-        state_update.set_pipette_location(
+        blow_out_result = await blow_out_in_place(
             pipette_id=params.pipetteId,
-            new_labware_id=params.labwareId,
-            new_well_name=params.wellName,
-            new_deck_point=deck_point,
+            flow_rate=params.flowRate,
+            location_if_error={
+                "retryLocation": (
+                    move_result.public.position.x,
+                    move_result.public.position.y,
+                    move_result.public.position.z,
+                )
+            },
+            pipetting=self._pipetting,
+            model_utils=self._model_utils,
         )
-        try:
-            await self._pipetting.blow_out_in_place(
-                pipette_id=params.pipetteId, flow_rate=params.flowRate
-            )
-        except PipetteOverpressureError as e:
-            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
+        if isinstance(blow_out_result, DefinedErrorData):
             return DefinedErrorData(
-                public=OverpressureError(
-                    id=self._model_utils.generate_id(),
-                    createdAt=self._model_utils.get_timestamp(),
-                    wrappedErrors=[
-                        ErrorOccurrence.from_failed(
-                            id=self._model_utils.generate_id(),
-                            createdAt=self._model_utils.get_timestamp(),
-                            error=e,
-                        )
-                    ],
-                    errorInfo={
-                        "retryLocation": (
-                            x,
-                            y,
-                            z,
-                        )
-                    },
+                public=blow_out_result.public,
+                state_update=StateUpdate.reduce(
+                    move_result.state_update, blow_out_result.state_update
                 ),
-                state_update=state_update,
+                state_update_if_false_positive=StateUpdate.reduce(
+                    move_result.state_update,
+                    blow_out_result.state_update_if_false_positive,
+                ),
             )
         else:
-            state_update.set_fluid_empty(pipette_id=params.pipetteId)
             return SuccessData(
-                public=BlowOutResult(position=deck_point),
-                state_update=state_update,
+                public=BlowOutResult(position=move_result.public.position),
+                state_update=StateUpdate.reduce(
+                    move_result.state_update, blow_out_result.state_update
+                ),
             )
 
 

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -11,6 +11,8 @@ from .pipetting_common import (
     OverpressureError,
     PipetteIdMixin,
     FlowRateMixin,
+)
+from .movement_common import (
     WellLocationMixin,
     DestinationPositionResult,
 )

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -1,6 +1,5 @@
 """Base command data model and type definitions."""
 
-
 from __future__ import annotations
 
 import dataclasses
@@ -8,7 +7,6 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 import enum
 from typing import (
-    cast,
     TYPE_CHECKING,
     Generic,
     Optional,
@@ -16,11 +14,6 @@ from typing import (
     List,
     Type,
     Union,
-    Callable,
-    Awaitable,
-    Literal,
-    Final,
-    TypeAlias,
 )
 
 from pydantic import BaseModel, Field
@@ -246,240 +239,6 @@ class BaseCommand(
             ],
         ]
     ]
-
-
-class IsErrorValue(Exception):
-    """Panic exception if a Maybe contains an Error."""
-
-    pass
-
-
-class _NothingEnum(enum.Enum):
-    _NOTHING = enum.auto()
-
-
-NOTHING: Final = _NothingEnum._NOTHING
-NothingT: TypeAlias = Literal[_NothingEnum._NOTHING]
-
-
-class _UnknownEnum(enum.Enum):
-    _UNKNOWN = enum.auto()
-
-
-UNKNOWN: Final = _UnknownEnum._UNKNOWN
-UnknownT: TypeAlias = Literal[_UnknownEnum._UNKNOWN]
-
-_ResultT_co_general = TypeVar("_ResultT_co_general", covariant=True)
-_ErrorT_co_general = TypeVar("_ErrorT_co_general", covariant=True)
-
-
-_SecondResultT_co_general = TypeVar("_SecondResultT_co_general", covariant=True)
-_SecondErrorT_co_general = TypeVar("_SecondErrorT_co_general", covariant=True)
-
-
-@dataclasses.dataclass
-class Maybe(Generic[_ResultT_co_general, _ErrorT_co_general]):
-    """Represents an possibly completed, possibly errored result.
-
-    By using this class's chaining methods like and_then or or_else, you can build
-    functions that preserve previous defined errors and augment them or transform them
-    and transform the results.
-
-    Build objects of this type using from_result or from_error on fully type-qualified
-    aliases. For instance,
-
-    MyFunctionReturn = Maybe[SuccessData[SomeSuccessModel], DefinedErrorData[SomeErrorKind]]
-
-    def my_function(args...) -> MyFunctionReturn:
-        try:
-            do_thing(args...)
-        except SomeException as e:
-            return MyFunctionReturn.from_error(ErrorOccurrence.from_error(e))
-        else:
-            return MyFunctionReturn.from_result(SuccessData(SomeSuccessModel(args...)))
-
-    Then, in the calling function, you can react to the results and unwrap to a union:
-
-    OuterMaybe = Maybe[SuccessData[SomeOtherModel], DefinedErrorData[SomeErrors]]
-    OuterReturn = Union[SuccessData[SomeOtherModel], DefinedErrorData[SomeErrors]]
-
-    def my_calling_function(args...) -> OuterReturn:
-        def handle_result(result: SuccessData[SomeSuccessModel]) -> OuterMaybe:
-            return OuterMaybe.from_result(result=some_result_transformer(result))
-        return do_thing.and_then(handle_result).unwrap()
-    """
-
-    _contents: tuple[_ResultT_co_general, NothingT] | tuple[
-        NothingT, _ErrorT_co_general
-    ]
-
-    _CtorErrorT = TypeVar("_CtorErrorT")
-    _CtorResultT = TypeVar("_CtorResultT")
-
-    @classmethod
-    def from_result(
-        cls: Type[Maybe[_CtorResultT, _CtorErrorT]], result: _CtorResultT
-    ) -> Maybe[_CtorResultT, _CtorErrorT]:
-        """Build a Maybe from a valid result."""
-        return cls(_contents=(result, NOTHING))
-
-    @classmethod
-    def from_error(
-        cls: Type[Maybe[_CtorResultT, _CtorErrorT]], error: _CtorErrorT
-    ) -> Maybe[_CtorResultT, _CtorErrorT]:
-        """Build a Maybe from a known error."""
-        return cls(_contents=(NOTHING, error))
-
-    def result_or_panic(self) -> _ResultT_co_general:
-        """Unwrap to a result or throw if the Maybe is an error."""
-        contents = self._contents
-        if contents[1] is NOTHING:
-            # https://github.com/python/mypy/issues/12364
-            return cast(_ResultT_co_general, contents[0])
-        else:
-            raise IsErrorValue()
-
-    def unwrap(self) -> _ResultT_co_general | _ErrorT_co_general:
-        """Unwrap to a union, which is useful for command returns."""
-        # https://github.com/python/mypy/issues/12364
-        if self._contents[1] is NOTHING:
-            return cast(_ResultT_co_general, self._contents[0])
-        else:
-            return self._contents[1]
-
-    # note: casts in these methods  are because of https://github.com/python/mypy/issues/11730
-    def and_then(
-        self,
-        functor: Callable[
-            [_ResultT_co_general],
-            Maybe[_SecondResultT_co_general, _SecondErrorT_co_general],
-        ],
-    ) -> Maybe[
-        _SecondResultT_co_general, _ErrorT_co_general | _SecondErrorT_co_general
-    ]:
-        """Conditionally execute functor if the Maybe contains a result.
-
-        Functor should take the result type and return a new Maybe. Since this function returns
-        a Maybe, it can be chained. The result type will have only the Result type of the Maybe
-        returned by the functor, but the error type is the union of the error type in the Maybe
-        returned by the functor and the error type in this Maybe, since the functor may not have
-        actually been called.
-        """
-        match self._contents:
-            case (result, _NothingEnum._NOTHING):
-                return cast(
-                    Maybe[
-                        _SecondResultT_co_general,
-                        _ErrorT_co_general | _SecondErrorT_co_general,
-                    ],
-                    functor(cast(_ResultT_co_general, result)),
-                )
-            case _:
-                return cast(
-                    Maybe[
-                        _SecondResultT_co_general,
-                        _ErrorT_co_general | _SecondErrorT_co_general,
-                    ],
-                    self,
-                )
-
-    def or_else(
-        self,
-        functor: Callable[
-            [_ErrorT_co_general],
-            Maybe[_SecondResultT_co_general, _SecondErrorT_co_general],
-        ],
-    ) -> Maybe[
-        _SecondResultT_co_general | _ResultT_co_general, _SecondErrorT_co_general
-    ]:
-        """Conditionally execute functor if the Maybe contains an error.
-
-        The functor should take the error type and return a new Maybe. Since this function returns
-        a Maybe, it can be chained. The result type will have only the Error type of the Maybe
-        returned by the functor, but the result type is the union of the Result of the Maybe returned
-        by the functor and the Result of this Maybe, since the functor may not have been called.
-        """
-        match self._contents:
-            case (_NothingEnum._NOTHING, error):
-                return cast(
-                    Maybe[
-                        _ResultT_co_general | _SecondResultT_co_general,
-                        _SecondErrorT_co_general,
-                    ],
-                    functor(cast(_ErrorT_co_general, error)),
-                )
-            case _:
-                return cast(
-                    Maybe[
-                        _ResultT_co_general | _SecondResultT_co_general,
-                        _SecondErrorT_co_general,
-                    ],
-                    self,
-                )
-
-    async def and_then_async(
-        self,
-        functor: Callable[
-            [_ResultT_co_general],
-            Awaitable[Maybe[_SecondResultT_co_general, _SecondErrorT_co_general]],
-        ],
-    ) -> Awaitable[
-        Maybe[_SecondResultT_co_general, _ErrorT_co_general | _SecondErrorT_co_general]
-    ]:
-        """As and_then, but for an async functor."""
-        match self._contents:
-            case (result, _NothingEnum._NOTHING):
-                return cast(
-                    Awaitable[
-                        Maybe[
-                            _SecondResultT_co_general,
-                            _ErrorT_co_general | _SecondErrorT_co_general,
-                        ]
-                    ],
-                    await functor(cast(_ResultT_co_general, result)),
-                )
-            case _:
-                return cast(
-                    Awaitable[
-                        Maybe[
-                            _SecondResultT_co_general,
-                            _ErrorT_co_general | _SecondErrorT_co_general,
-                        ]
-                    ],
-                    self,
-                )
-
-    async def or_else_async(
-        self,
-        functor: Callable[
-            [_ErrorT_co_general],
-            Awaitable[Maybe[_SecondResultT_co_general, _SecondErrorT_co_general]],
-        ],
-    ) -> Awaitable[
-        Maybe[_SecondResultT_co_general | _ResultT_co_general, _SecondErrorT_co_general]
-    ]:
-        """As or_else, but for an async functor."""
-        match self._contents:
-            case (_NothingEnum._NOTHING, error):
-                return cast(
-                    Awaitable[
-                        Maybe[
-                            _ResultT_co_general | _SecondResultT_co_general,
-                            _SecondErrorT_co_general,
-                        ]
-                    ],
-                    await functor(cast(_ErrorT_co_general, error)),
-                )
-            case _:
-                return cast(
-                    Awaitable[
-                        Maybe[
-                            _ResultT_co_general | _SecondResultT_co_general,
-                            _SecondErrorT_co_general,
-                        ]
-                    ],
-                    self,
-                )
 
 
 _ExecuteReturnT_co = TypeVar(

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -14,10 +14,12 @@ from .pipetting_common import (
     PipetteIdMixin,
     DispenseVolumeMixin,
     FlowRateMixin,
-    LiquidHandlingWellLocationMixin,
     BaseLiquidHandlingResult,
-    DestinationPositionResult,
     OverpressureError,
+)
+from .movement_common import (
+    LiquidHandlingWellLocationMixin,
+    DestinationPositionResult,
 )
 from .command import (
     AbstractCommandImpl,

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type, Union
 from typing_extensions import Literal
 
-from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
 
 from pydantic import Field
 
-from ..types import DeckPoint
 from ..state.update_types import StateUpdate, CLEAR
 from .pipetting_common import (
     PipetteIdMixin,
@@ -16,10 +14,12 @@ from .pipetting_common import (
     FlowRateMixin,
     BaseLiquidHandlingResult,
     OverpressureError,
+    dispense_in_place,
 )
 from .movement_common import (
     LiquidHandlingWellLocationMixin,
     DestinationPositionResult,
+    move_to_well,
 )
 from .command import (
     AbstractCommandImpl,
@@ -28,7 +28,6 @@ from .command import (
     DefinedErrorData,
     SuccessData,
 )
-from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler, PipettingHandler
@@ -80,7 +79,6 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
 
     async def execute(self, params: DispenseParams) -> _ExecuteReturn:
         """Move to and dispense to the requested well."""
-        state_update = StateUpdate()
         well_location = params.wellLocation
         labware_id = params.labwareId
         well_name = params.wellName
@@ -88,72 +86,76 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
 
         # TODO(pbm, 10-15-24): call self._state_view.geometry.validate_dispense_volume_into_well()
 
-        position = await self._movement.move_to_well(
+        move_result = await move_to_well(
+            movement=self._movement,
             pipette_id=params.pipetteId,
             labware_id=labware_id,
             well_name=well_name,
             well_location=well_location,
         )
-        deck_point = DeckPoint.construct(x=position.x, y=position.y, z=position.z)
-        state_update.set_pipette_location(
+        dispense_result = await dispense_in_place(
             pipette_id=params.pipetteId,
-            new_labware_id=labware_id,
-            new_well_name=well_name,
-            new_deck_point=deck_point,
+            volume=volume,
+            flow_rate=params.flowRate,
+            push_out=params.pushOut,
+            location_if_error={
+                "retryLocation": (
+                    move_result.public.position.x,
+                    move_result.public.position.y,
+                    move_result.public.position.z,
+                )
+            },
+            pipetting=self._pipetting,
+            model_utils=self._model_utils,
         )
 
-        try:
-            volume = await self._pipetting.dispense_in_place(
-                pipette_id=params.pipetteId,
-                volume=volume,
-                flow_rate=params.flowRate,
-                push_out=params.pushOut,
-            )
-        except PipetteOverpressureError as e:
-            state_update.set_liquid_operated(
-                labware_id=labware_id,
-                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                    labware_id, well_name, params.pipetteId
-                ),
-                volume_added=CLEAR,
-            )
-            state_update.set_fluid_unknown(pipette_id=params.pipetteId)
+        if isinstance(dispense_result, DefinedErrorData):
             return DefinedErrorData(
-                public=OverpressureError(
-                    id=self._model_utils.generate_id(),
-                    createdAt=self._model_utils.get_timestamp(),
-                    wrappedErrors=[
-                        ErrorOccurrence.from_failed(
-                            id=self._model_utils.generate_id(),
-                            createdAt=self._model_utils.get_timestamp(),
-                            error=e,
-                        )
-                    ],
-                    errorInfo={"retryLocation": (position.x, position.y, position.z)},
+                public=dispense_result.public,
+                state_update=(
+                    StateUpdate.reduce(
+                        move_result.state_update, dispense_result.state_update
+                    ).set_liquid_operated(
+                        labware_id=labware_id,
+                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                            labware_id, well_name, params.pipetteId
+                        ),
+                        volume_added=CLEAR,
+                    )
                 ),
-                state_update=state_update,
+                state_update_if_false_positive=StateUpdate.reduce(
+                    move_result.state_update,
+                    dispense_result.state_update_if_false_positive,
+                ),
             )
         else:
             volume_added = (
                 self._state_view.pipettes.get_liquid_dispensed_by_ejecting_volume(
-                    pipette_id=params.pipetteId, volume=volume
+                    pipette_id=params.pipetteId, volume=dispense_result.public.volume
                 )
             )
             if volume_added is not None:
                 volume_added *= self._state_view.geometry.get_nozzles_per_well(
                     labware_id, well_name, params.pipetteId
                 )
-            state_update.set_liquid_operated(
-                labware_id=labware_id,
-                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                    labware_id, well_name, params.pipetteId
-                ),
-                volume_added=volume_added if volume_added is not None else CLEAR,
-            )
-            state_update.set_fluid_ejected(pipette_id=params.pipetteId, volume=volume)
             return SuccessData(
-                public=DispenseResult(volume=volume, position=deck_point),
-                state_update=state_update,
+                public=DispenseResult(
+                    volume=dispense_result.public.volume,
+                    position=move_result.public.position,
+                ),
+                state_update=(
+                    StateUpdate.reduce(
+                        move_result.state_update, dispense_result.state_update
+                    ).set_liquid_operated(
+                        labware_id=labware_id,
+                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                            labware_id, well_name, params.pipetteId
+                        ),
+                        volume_added=volume_added
+                        if volume_added is not None
+                        else CLEAR,
+                    )
+                ),
             )
 
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -1,4 +1,5 @@
 """Drop tip command request, result, and implementation models."""
+
 from __future__ import annotations
 
 from pydantic import Field
@@ -8,15 +9,13 @@ from typing_extensions import Literal
 from opentrons.protocol_engine.errors.exceptions import TipAttachedError
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 
-from ..state import update_types
-from ..types import DropTipWellLocation, DeckPoint
+from ..state.update_types import StateUpdate
+from ..types import DropTipWellLocation
 from .pipetting_common import (
     PipetteIdMixin,
     TipPhysicallyAttachedError,
 )
-from .movement_common import (
-    DestinationPositionResult,
-)
+from .movement_common import DestinationPositionResult, move_to_well
 from .command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -97,8 +96,6 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
         well_name = params.wellName
         home_after = params.homeAfter
 
-        state_update = update_types.StateUpdate()
-
         if params.alternateDropLocation:
             well_location = self._state_view.geometry.get_next_tip_drop_location(
                 labware_id=labware_id,
@@ -118,18 +115,12 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
             partially_configured=is_partially_configured,
         )
 
-        position = await self._movement_handler.move_to_well(
+        move_result = await move_to_well(
+            movement=self._movement_handler,
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
             well_location=tip_drop_location,
-        )
-        deck_point = DeckPoint.construct(x=position.x, y=position.y, z=position.z)
-        state_update.set_pipette_location(
-            pipette_id=pipette_id,
-            new_labware_id=labware_id,
-            new_well_name=well_name,
-            new_deck_point=deck_point,
         )
 
         try:
@@ -148,24 +139,23 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
                     )
                 ],
             )
-            state_update_if_false_positive = update_types.StateUpdate()
-            state_update_if_false_positive.update_pipette_tip_state(
-                pipette_id=params.pipetteId, tip_geometry=None
-            )
-            state_update.set_fluid_unknown(pipette_id=pipette_id)
             return DefinedErrorData(
                 public=error,
-                state_update=state_update,
-                state_update_if_false_positive=state_update_if_false_positive,
+                state_update=StateUpdate.reduce(
+                    StateUpdate(), move_result.state_update
+                ).set_fluid_unknown(pipette_id=pipette_id),
+                state_update_if_false_positive=move_result.state_update.update_pipette_tip_state(
+                    pipette_id=params.pipetteId, tip_geometry=None
+                ),
             )
         else:
-            state_update.set_fluid_unknown(pipette_id=pipette_id)
-            state_update.update_pipette_tip_state(
-                pipette_id=params.pipetteId, tip_geometry=None
-            )
             return SuccessData(
-                public=DropTipResult(position=deck_point),
-                state_update=state_update,
+                public=DropTipResult(position=move_result.public.position),
+                state_update=move_result.state_update.set_fluid_unknown(
+                    pipette_id=pipette_id
+                ).update_pipette_tip_state(
+                    pipette_id=params.pipetteId, tip_geometry=None
+                ),
             )
 
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -12,8 +12,10 @@ from ..state import update_types
 from ..types import DropTipWellLocation, DeckPoint
 from .pipetting_common import (
     PipetteIdMixin,
-    DestinationPositionResult,
     TipPhysicallyAttachedError,
+)
+from .movement_common import (
+    DestinationPositionResult,
 )
 from .command import (
     AbstractCommandImpl,

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -27,6 +27,7 @@ from .pipetting_common import (
 from .movement_common import (
     WellLocationMixin,
     DestinationPositionResult,
+    move_to_well,
 )
 from .command import (
     AbstractCommandImpl,
@@ -119,8 +120,6 @@ async def _execute_common(
             "Either the front right or back left nozzle must have a tip attached to probe liquid height."
         )
 
-    state_update = update_types.StateUpdate()
-
     # May raise TipNotAttachedError.
     aspirated_volume = state_view.pipettes.get_aspirated_volume(pipette_id)
 
@@ -144,18 +143,12 @@ async def _execute_common(
         )
 
     # liquid_probe process start position
-    position = await movement.move_to_well(
+    move_result = await move_to_well(
+        movement=movement,
         pipette_id=pipette_id,
         labware_id=labware_id,
         well_name=well_name,
         well_location=params.wellLocation,
-    )
-    deck_point = DeckPoint.construct(x=position.x, y=position.y, z=position.z)
-    state_update.set_pipette_location(
-        pipette_id=pipette_id,
-        new_labware_id=labware_id,
-        new_well_name=well_name,
-        new_deck_point=deck_point,
     )
 
     try:
@@ -167,11 +160,15 @@ async def _execute_common(
         )
     except PipetteLiquidNotFoundError as exception:
         return _ExecuteCommonResult(
-            z_pos_or_error=exception, state_update=state_update, deck_point=deck_point
+            z_pos_or_error=exception,
+            state_update=move_result.state_update,
+            deck_point=move_result.public.position,
         )
     else:
         return _ExecuteCommonResult(
-            z_pos_or_error=z_pos, state_update=state_update, deck_point=deck_point
+            z_pos_or_error=z_pos,
+            state_update=move_result.state_update,
+            deck_point=move_result.public.position,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -23,6 +23,8 @@ from ..types import DeckPoint
 from .pipetting_common import (
     LiquidNotFoundError,
     PipetteIdMixin,
+)
+from .movement_common import (
     WellLocationMixin,
     DestinationPositionResult,
 )

--- a/api/src/opentrons/protocol_engine/commands/move_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/move_relative.py
@@ -9,7 +9,7 @@ from ..state import update_types
 from ..types import MovementAxis, DeckPoint
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors.error_occurrence import ErrorOccurrence
-from .pipetting_common import DestinationPositionResult
+from .movement_common import DestinationPositionResult
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
@@ -12,6 +12,8 @@ from ..types import DeckPoint, AddressableOffsetVector
 from ..resources import fixture_validation
 from .pipetting_common import (
     PipetteIdMixin,
+)
+from .movement_common import (
     MovementMixin,
     DestinationPositionResult,
 )

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
@@ -10,6 +10,8 @@ from ..types import DeckPoint, AddressableOffsetVector
 from ..resources import fixture_validation
 from .pipetting_common import (
     PipetteIdMixin,
+)
+from .movement_common import (
     MovementMixin,
     DestinationPositionResult,
 )

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -8,7 +8,8 @@ from typing_extensions import Literal
 
 from ..state import update_types
 from ..types import DeckPoint
-from .pipetting_common import PipetteIdMixin, MovementMixin, DestinationPositionResult
+from .pipetting_common import PipetteIdMixin
+from .movement_common import MovementMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors.error_occurrence import ErrorOccurrence
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -6,6 +6,8 @@ from typing_extensions import Literal
 from ..types import DeckPoint
 from .pipetting_common import (
     PipetteIdMixin,
+)
+from .movement_common import (
     WellLocationMixin,
     MovementMixin,
     DestinationPositionResult,

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -1,9 +1,9 @@
 """Move to well command request, result, and implementation models."""
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from ..types import DeckPoint
 from .pipetting_common import (
     PipetteIdMixin,
 )
@@ -11,10 +11,10 @@ from .movement_common import (
     WellLocationMixin,
     MovementMixin,
     DestinationPositionResult,
+    move_to_well,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors.error_occurrence import ErrorOccurrence
-from ..state import update_types
 from ..errors import LabwareIsTipRackError
 
 if TYPE_CHECKING:
@@ -54,8 +54,6 @@ class MoveToWellImplementation(
         well_name = params.wellName
         well_location = params.wellLocation
 
-        state_update = update_types.StateUpdate()
-
         if (
             self._state_view.labware.is_tiprack(labware_id)
             and well_location.volumeOffset
@@ -64,7 +62,8 @@ class MoveToWellImplementation(
                 "Cannot specify a WellLocation with a volumeOffset with movement to a tip rack"
             )
 
-        x, y, z = await self._movement.move_to_well(
+        move_result = await move_to_well(
+            movement=self._movement,
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
@@ -73,17 +72,10 @@ class MoveToWellImplementation(
             minimum_z_height=params.minimumZHeight,
             speed=params.speed,
         )
-        deck_point = DeckPoint.construct(x=x, y=y, z=z)
-        state_update.set_pipette_location(
-            pipette_id=pipette_id,
-            new_labware_id=labware_id,
-            new_well_name=well_name,
-            new_deck_point=deck_point,
-        )
 
         return SuccessData(
-            public=MoveToWellResult(position=deck_point),
-            state_update=state_update,
+            public=MoveToWellResult(position=move_result.public.position),
+            state_update=move_result.state_update,
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/movement_common.py
+++ b/api/src/opentrons/protocol_engine/commands/movement_common.py
@@ -1,0 +1,140 @@
+"""Common movement base models."""
+
+from __future__ import annotations
+
+from typing import Optional, Union, TYPE_CHECKING
+from pydantic import BaseModel, Field
+from ..types import WellLocation, LiquidHandlingWellLocation, DeckPoint, CurrentWell
+from ..state.update_types import StateUpdate
+from .command import SuccessData
+
+
+if TYPE_CHECKING:
+    from ..execution.movement import MovementHandler
+
+
+class WellLocationMixin(BaseModel):
+    """Mixin for command requests that take a location that's somewhere in a well."""
+
+    labwareId: str = Field(
+        ...,
+        description="Identifier of labware to use.",
+    )
+    wellName: str = Field(
+        ...,
+        description="Name of well to use in labware.",
+    )
+    wellLocation: WellLocation = Field(
+        default_factory=WellLocation,
+        description="Relative well location at which to perform the operation",
+    )
+
+
+class LiquidHandlingWellLocationMixin(BaseModel):
+    """Mixin for command requests that take a location that's somewhere in a well."""
+
+    labwareId: str = Field(
+        ...,
+        description="Identifier of labware to use.",
+    )
+    wellName: str = Field(
+        ...,
+        description="Name of well to use in labware.",
+    )
+    wellLocation: LiquidHandlingWellLocation = Field(
+        default_factory=LiquidHandlingWellLocation,
+        description="Relative well location at which to perform the operation",
+    )
+
+
+class MovementMixin(BaseModel):
+    """Mixin for command requests that move a pipette."""
+
+    minimumZHeight: Optional[float] = Field(
+        None,
+        description=(
+            "Optional minimal Z margin in mm."
+            " If this is larger than the API's default safe Z margin,"
+            " it will make the arc higher. If it's smaller, it will have no effect."
+        ),
+    )
+
+    forceDirect: bool = Field(
+        False,
+        description=(
+            "If true, moving from one labware/well to another"
+            " will not arc to the default safe z,"
+            " but instead will move directly to the specified location."
+            " This will also force the `minimumZHeight` param to be ignored."
+            " A 'direct' movement is in X/Y/Z simultaneously."
+        ),
+    )
+
+    speed: Optional[float] = Field(
+        None,
+        description=(
+            "Override the travel speed in mm/s."
+            " This controls the straight linear speed of motion."
+        ),
+    )
+
+
+class DestinationPositionResult(BaseModel):
+    """Mixin for command results that move a pipette."""
+
+    # todo(mm, 2024-08-02): Consider deprecating or redefining this.
+    #
+    # This is here because opentrons.protocol_engine needed it for internal bookkeeping
+    # and, at the time, we didn't have a way to do that without adding this to the
+    # public command results. Its usefulness to callers outside
+    # opentrons.protocol_engine is questionable because they would need to know which
+    # critical point is in play, and I think that can change depending on obscure
+    # things like labware quirks.
+    position: DeckPoint = Field(
+        DeckPoint(x=0, y=0, z=0),
+        description=(
+            "The (x,y,z) coordinates of the pipette's critical point in deck space"
+            " after the move was completed."
+        ),
+    )
+
+
+MoveToWellOperationReturn = SuccessData[DestinationPositionResult]
+
+
+async def move_to_well(
+    movement: MovementHandler,
+    pipette_id: str,
+    labware_id: str,
+    well_name: str,
+    well_location: Optional[Union[WellLocation, LiquidHandlingWellLocation]] = None,
+    current_well: Optional[CurrentWell] = None,
+    force_direct: bool = False,
+    minimum_z_height: Optional[float] = None,
+    speed: Optional[float] = None,
+    operation_volume: Optional[float] = None,
+) -> MoveToWellOperationReturn:
+    """Execute a move to well microoperation."""
+    position = await movement.move_to_well(
+        pipette_id=pipette_id,
+        labware_id=labware_id,
+        well_name=well_name,
+        well_location=well_location,
+        current_well=current_well,
+        force_direct=force_direct,
+        minimum_z_height=minimum_z_height,
+        speed=speed,
+        operation_volume=operation_volume,
+    )
+    deck_point = DeckPoint.construct(x=position.x, y=position.y, z=position.z)
+    return SuccessData(
+        public=DestinationPositionResult(
+            position=deck_point,
+        ),
+        state_update=StateUpdate().set_pipette_location(
+            pipette_id=pipette_id,
+            new_labware_id=labware_id,
+            new_well_name=well_name,
+            new_deck_point=deck_point,
+        ),
+    )

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -1,4 +1,5 @@
 """Pick up tip command request, result, and implementation models."""
+
 from __future__ import annotations
 from opentrons_shared_data.errors import ErrorCodes
 from pydantic import Field
@@ -9,13 +10,11 @@ from typing_extensions import Literal
 from ..errors import ErrorOccurrence, PickUpTipTipNotAttachedError
 from ..resources import ModelUtils
 from ..state import update_types
-from ..types import PickUpTipWellLocation, DeckPoint
+from ..types import PickUpTipWellLocation
 from .pipetting_common import (
     PipetteIdMixin,
 )
-from .movement_common import (
-    DestinationPositionResult,
-)
+from .movement_common import DestinationPositionResult, move_to_well
 from .command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -117,23 +116,15 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
         labware_id = params.labwareId
         well_name = params.wellName
 
-        state_update = update_types.StateUpdate()
-
         well_location = self._state_view.geometry.convert_pick_up_tip_well_location(
             well_location=params.wellLocation
         )
-        position = await self._movement.move_to_well(
+        move_result = await move_to_well(
+            movement=self._movement,
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
             well_location=well_location,
-        )
-        deck_point = DeckPoint.construct(x=position.x, y=position.y, z=position.z)
-        state_update.set_pipette_location(
-            pipette_id=pipette_id,
-            new_labware_id=labware_id,
-            new_well_name=well_name,
-            new_deck_point=deck_point,
         )
 
         try:
@@ -143,16 +134,28 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 well_name=well_name,
             )
         except PickUpTipTipNotAttachedError as e:
-            state_update_if_false_positive = update_types.StateUpdate()
-            state_update_if_false_positive.update_pipette_tip_state(
-                pipette_id=pipette_id,
-                tip_geometry=e.tip_geometry,
+            state_update_if_false_positive = (
+                update_types.StateUpdate.reduce(
+                    update_types.StateUpdate(), move_result.state_update
+                )
+                .update_pipette_tip_state(
+                    pipette_id=pipette_id,
+                    tip_geometry=e.tip_geometry,
+                )
+                .set_fluid_empty(pipette_id=pipette_id)
+                .mark_tips_as_used(
+                    pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
+                )
             )
-            state_update_if_false_positive.set_fluid_empty(pipette_id=pipette_id)
-            state_update.mark_tips_as_used(
-                pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
+            state_update = (
+                update_types.StateUpdate.reduce(
+                    update_types.StateUpdate(), move_result.state_update
+                )
+                .mark_tips_as_used(
+                    pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
+                )
+                .set_fluid_unknown(pipette_id=pipette_id)
             )
-            state_update.set_fluid_unknown(pipette_id=pipette_id)
             return DefinedErrorData(
                 public=TipPhysicallyMissingError(
                     id=self._model_utils.generate_id(),
@@ -169,20 +172,22 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 state_update_if_false_positive=state_update_if_false_positive,
             )
         else:
-            state_update.update_pipette_tip_state(
-                pipette_id=pipette_id,
-                tip_geometry=tip_geometry,
+            state_update = (
+                move_result.state_update.update_pipette_tip_state(
+                    pipette_id=pipette_id,
+                    tip_geometry=tip_geometry,
+                )
+                .mark_tips_as_used(
+                    pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
+                )
+                .set_fluid_empty(pipette_id=pipette_id)
             )
-            state_update.mark_tips_as_used(
-                pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
-            )
-            state_update.set_fluid_empty(pipette_id=pipette_id)
             return SuccessData(
                 public=PickUpTipResult(
                     tipVolume=tip_geometry.volume,
                     tipLength=tip_geometry.length,
                     tipDiameter=tip_geometry.diameter,
-                    position=deck_point,
+                    position=move_result.public.position,
                 ),
                 state_update=state_update,
             )

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -12,6 +12,8 @@ from ..state import update_types
 from ..types import PickUpTipWellLocation, DeckPoint
 from .pipetting_common import (
     PipetteIdMixin,
+)
+from .movement_common import (
     DestinationPositionResult,
 )
 from .command import (

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -1,15 +1,15 @@
 """Common pipetting command base models."""
+
 from __future__ import annotations
 from opentrons_shared_data.errors import ErrorCodes
 from pydantic import BaseModel, Field
-from typing import Literal, Optional, Tuple, TypedDict, TYPE_CHECKING
+from typing import Literal, Tuple, TypedDict, TYPE_CHECKING
 
 from opentrons.protocol_engine.errors.error_occurrence import ErrorOccurrence
 from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
 from .command import Maybe, DefinedErrorData, SuccessData
 from opentrons.protocol_engine.state.update_types import StateUpdate
 
-from ..types import WellLocation, LiquidHandlingWellLocation, DeckPoint
 
 if TYPE_CHECKING:
     from ..execution.pipetting import PipettingHandler
@@ -59,72 +59,6 @@ class FlowRateMixin(BaseModel):
     )
 
 
-class WellLocationMixin(BaseModel):
-    """Mixin for command requests that take a location that's somewhere in a well."""
-
-    labwareId: str = Field(
-        ...,
-        description="Identifier of labware to use.",
-    )
-    wellName: str = Field(
-        ...,
-        description="Name of well to use in labware.",
-    )
-    wellLocation: WellLocation = Field(
-        default_factory=WellLocation,
-        description="Relative well location at which to perform the operation",
-    )
-
-
-class LiquidHandlingWellLocationMixin(BaseModel):
-    """Mixin for command requests that take a location that's somewhere in a well."""
-
-    labwareId: str = Field(
-        ...,
-        description="Identifier of labware to use.",
-    )
-    wellName: str = Field(
-        ...,
-        description="Name of well to use in labware.",
-    )
-    wellLocation: LiquidHandlingWellLocation = Field(
-        default_factory=LiquidHandlingWellLocation,
-        description="Relative well location at which to perform the operation",
-    )
-
-
-class MovementMixin(BaseModel):
-    """Mixin for command requests that move a pipette."""
-
-    minimumZHeight: Optional[float] = Field(
-        None,
-        description=(
-            "Optional minimal Z margin in mm."
-            " If this is larger than the API's default safe Z margin,"
-            " it will make the arc higher. If it's smaller, it will have no effect."
-        ),
-    )
-
-    forceDirect: bool = Field(
-        False,
-        description=(
-            "If true, moving from one labware/well to another"
-            " will not arc to the default safe z,"
-            " but instead will move directly to the specified location."
-            " This will also force the `minimumZHeight` param to be ignored."
-            " A 'direct' movement is in X/Y/Z simultaneously."
-        ),
-    )
-
-    speed: Optional[float] = Field(
-        None,
-        description=(
-            "Override the travel speed in mm/s."
-            " This controls the straight linear speed of motion."
-        ),
-    )
-
-
 class BaseLiquidHandlingResult(BaseModel):
     """Base properties of a liquid handling result."""
 
@@ -132,26 +66,6 @@ class BaseLiquidHandlingResult(BaseModel):
         ...,
         description="Amount of liquid in uL handled in the operation.",
         ge=0,
-    )
-
-
-class DestinationPositionResult(BaseModel):
-    """Mixin for command results that move a pipette."""
-
-    # todo(mm, 2024-08-02): Consider deprecating or redefining this.
-    #
-    # This is here because opentrons.protocol_engine needed it for internal bookkeeping
-    # and, at the time, we didn't have a way to do that without adding this to the
-    # public command results. Its usefulness to callers outside
-    # opentrons.protocol_engine is questionable because they would need to know which
-    # critical point is in play, and I think that can change depending on obscure
-    # things like labware quirks.
-    position: DeckPoint = Field(
-        DeckPoint(x=0, y=0, z=0),
-        description=(
-            "The (x,y,z) coordinates of the pipette's critical point in deck space"
-            " after the move was completed."
-        ),
     )
 
 

--- a/api/src/opentrons/protocol_engine/commands/robot/move_to.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/move_to.py
@@ -5,7 +5,7 @@ from typing import Literal, Type, Optional, TYPE_CHECKING
 from pydantic import BaseModel, Field
 from opentrons.types import MountType
 
-from ..pipetting_common import DestinationPositionResult
+from ..movement_common import DestinationPositionResult
 from ..command import (
     AbstractCommandImpl,
     BaseCommand,

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -1,10 +1,11 @@
 """Touch tip command request, result, and implementation models."""
+
 from __future__ import annotations
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from opentrons.protocol_engine.state import update_types
+from opentrons.types import Point
 
 from ..errors import TouchTipDisabledError, LabwareIsTipRackError
 from ..types import DeckPoint
@@ -16,6 +17,7 @@ from .pipetting_common import (
 from .movement_common import (
     WellLocationMixin,
     DestinationPositionResult,
+    move_to_well,
 )
 
 if TYPE_CHECKING:
@@ -73,8 +75,6 @@ class TouchTipImplementation(
         labware_id = params.labwareId
         well_name = params.wellName
 
-        state_update = update_types.StateUpdate()
-
         if self._state_view.labware.get_has_quirk(labware_id, "touchTipDisabled"):
             raise TouchTipDisabledError(
                 f"Touch tip not allowed on labware {labware_id}"
@@ -83,7 +83,8 @@ class TouchTipImplementation(
         if self._state_view.labware.is_tiprack(labware_id):
             raise LabwareIsTipRackError("Cannot touch tip on tip rack")
 
-        center_point = await self._movement.move_to_well(
+        center_result = await move_to_well(
+            movement=self._movement,
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
@@ -99,7 +100,11 @@ class TouchTipImplementation(
             labware_id=labware_id,
             well_name=well_name,
             radius=params.radius,
-            center_point=center_point,
+            center_point=Point(
+                center_result.public.position.x,
+                center_result.public.position.y,
+                center_result.public.position.z,
+            ),
         )
 
         final_point = await self._gantry_mover.move_to(
@@ -110,7 +115,7 @@ class TouchTipImplementation(
         final_deck_point = DeckPoint.construct(
             x=final_point.x, y=final_point.y, z=final_point.z
         )
-        state_update.set_pipette_location(
+        state_update = center_result.state_update.set_pipette_location(
             pipette_id=pipette_id,
             new_labware_id=labware_id,
             new_well_name=well_name,

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -12,6 +12,8 @@ from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, Succes
 from ..errors.error_occurrence import ErrorOccurrence
 from .pipetting_common import (
     PipetteIdMixin,
+)
+from .movement_common import (
     WellLocationMixin,
     DestinationPositionResult,
 )

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -1,9 +1,9 @@
 """Structures to represent changes that commands want to make to engine state."""
 
-
 import dataclasses
 import enum
 import typing
+from typing_extensions import Self
 from datetime import datetime
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
@@ -275,9 +275,13 @@ class StateUpdate:
 
     pipette_tip_state: PipetteTipStateUpdate | NoChangeType = NO_CHANGE
 
-    pipette_aspirated_fluid: PipetteAspiratedFluidUpdate | PipetteEjectedFluidUpdate | PipetteUnknownFluidUpdate | PipetteEmptyFluidUpdate | NoChangeType = (
-        NO_CHANGE
-    )
+    pipette_aspirated_fluid: (
+        PipetteAspiratedFluidUpdate
+        | PipetteEjectedFluidUpdate
+        | PipetteUnknownFluidUpdate
+        | PipetteEmptyFluidUpdate
+        | NoChangeType
+    ) = NO_CHANGE
 
     labware_location: LabwareLocationUpdate | NoChangeType = NO_CHANGE
 
@@ -300,35 +304,35 @@ class StateUpdate:
 
     @typing.overload
     def set_pipette_location(
-        self,
+        self: Self,
         *,
         pipette_id: str,
         new_labware_id: str,
         new_well_name: str,
         new_deck_point: DeckPoint,
-    ) -> None:
+    ) -> Self:
         """Schedule a pipette's location to be set to a well."""
 
     @typing.overload
     def set_pipette_location(
-        self,
+        self: Self,
         *,
         pipette_id: str,
         new_addressable_area_name: str,
         new_deck_point: DeckPoint,
-    ) -> None:
+    ) -> Self:
         """Schedule a pipette's location to be set to an addressable area."""
         pass
 
     def set_pipette_location(  # noqa: D102
-        self,
+        self: Self,
         *,
         pipette_id: str,
         new_labware_id: str | NoChangeType = NO_CHANGE,
         new_well_name: str | NoChangeType = NO_CHANGE,
         new_addressable_area_name: str | NoChangeType = NO_CHANGE,
         new_deck_point: DeckPoint,
-    ) -> None:
+    ) -> Self:
         if new_addressable_area_name != NO_CHANGE:
             self.pipette_location = PipetteLocationUpdate(
                 pipette_id=pipette_id,
@@ -347,33 +351,36 @@ class StateUpdate:
                 new_location=Well(labware_id=new_labware_id, well_name=new_well_name),
                 new_deck_point=new_deck_point,
             )
+        return self
 
-    def clear_all_pipette_locations(self) -> None:
+    def clear_all_pipette_locations(self) -> Self:
         """Mark all pipettes as having an unknown location."""
         self.pipette_location = CLEAR
+        return self
 
     def set_labware_location(
-        self,
+        self: Self,
         *,
         labware_id: str,
         new_location: LabwareLocation,
         new_offset_id: str | None,
-    ) -> None:
+    ) -> Self:
         """Set a labware's location. See `LabwareLocationUpdate`."""
         self.labware_location = LabwareLocationUpdate(
             labware_id=labware_id,
             new_location=new_location,
             offset_id=new_offset_id,
         )
+        return self
 
     def set_loaded_labware(
-        self,
+        self: Self,
         definition: LabwareDefinition,
         labware_id: str,
         offset_id: typing.Optional[str],
         display_name: typing.Optional[str],
         location: LabwareLocation,
-    ) -> None:
+    ) -> Self:
         """Add a new labware to state. See `LoadedLabwareUpdate`."""
         self.loaded_labware = LoadedLabwareUpdate(
             definition=definition,
@@ -382,14 +389,15 @@ class StateUpdate:
             new_location=location,
             display_name=display_name,
         )
+        return self
 
     def set_load_pipette(
-        self,
+        self: Self,
         pipette_id: str,
         pipette_name: PipetteNameType,
         mount: MountType,
         liquid_presence_detection: typing.Optional[bool],
-    ) -> None:
+    ) -> Self:
         """Add a new pipette to state. See `LoadPipetteUpdate`."""
         self.loaded_pipette = LoadPipetteUpdate(
             pipette_id=pipette_id,
@@ -397,61 +405,69 @@ class StateUpdate:
             mount=mount,
             liquid_presence_detection=liquid_presence_detection,
         )
+        return self
 
     def update_pipette_config(
-        self,
+        self: Self,
         pipette_id: str,
         config: pipette_data_provider.LoadedStaticPipetteData,
         serial_number: str,
-    ) -> None:
+    ) -> Self:
         """Update a pipette's config. See `PipetteConfigUpdate`."""
         self.pipette_config = PipetteConfigUpdate(
             pipette_id=pipette_id, config=config, serial_number=serial_number
         )
+        return self
 
-    def update_pipette_nozzle(self, pipette_id: str, nozzle_map: NozzleMap) -> None:
+    def update_pipette_nozzle(
+        self: Self, pipette_id: str, nozzle_map: NozzleMap
+    ) -> Self:
         """Update a pipette's nozzle map. See `PipetteNozzleMapUpdate`."""
         self.pipette_nozzle_map = PipetteNozzleMapUpdate(
             pipette_id=pipette_id, nozzle_map=nozzle_map
         )
+        return self
 
     def update_pipette_tip_state(
-        self, pipette_id: str, tip_geometry: typing.Optional[TipGeometry]
-    ) -> None:
+        self: Self, pipette_id: str, tip_geometry: typing.Optional[TipGeometry]
+    ) -> Self:
         """Update a pipette's tip state. See `PipetteTipStateUpdate`."""
         self.pipette_tip_state = PipetteTipStateUpdate(
             pipette_id=pipette_id, tip_geometry=tip_geometry
         )
+        return self
 
     def mark_tips_as_used(
-        self, pipette_id: str, labware_id: str, well_name: str
-    ) -> None:
+        self: Self, pipette_id: str, labware_id: str, well_name: str
+    ) -> Self:
         """Mark tips in a tip rack as used. See `TipsUsedUpdate`."""
         self.tips_used = TipsUsedUpdate(
             pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
         )
+        return self
 
     def set_liquid_loaded(
-        self,
+        self: Self,
         labware_id: str,
         volumes: typing.Dict[str, float],
         last_loaded: datetime,
-    ) -> None:
+    ) -> Self:
         """Add liquid volumes to well state. See `LoadLiquidUpdate`."""
         self.liquid_loaded = LiquidLoadedUpdate(
             labware_id=labware_id,
             volumes=volumes,
             last_loaded=last_loaded,
         )
+        return self
 
     def set_liquid_probed(
-        self,
+        self: Self,
         labware_id: str,
         well_name: str,
         last_probed: datetime,
         height: float | ClearType,
         volume: float | ClearType,
-    ) -> None:
+    ) -> Self:
         """Add a liquid height and volume to well state. See `ProbeLiquidUpdate`."""
         self.liquid_probed = LiquidProbedUpdate(
             labware_id=labware_id,
@@ -460,43 +476,53 @@ class StateUpdate:
             volume=volume,
             last_probed=last_probed,
         )
+        return self
 
     def set_liquid_operated(
-        self, labware_id: str, well_names: list[str], volume_added: float | ClearType
-    ) -> None:
+        self: Self,
+        labware_id: str,
+        well_names: list[str],
+        volume_added: float | ClearType,
+    ) -> Self:
         """Update liquid volumes in well state. See `OperateLiquidUpdate`."""
         self.liquid_operated = LiquidOperatedUpdate(
             labware_id=labware_id,
             well_names=well_names,
             volume_added=volume_added,
         )
+        return self
 
-    def set_fluid_aspirated(self, pipette_id: str, fluid: AspiratedFluid) -> None:
+    def set_fluid_aspirated(self: Self, pipette_id: str, fluid: AspiratedFluid) -> Self:
         """Update record of fluid held inside a pipette. See `PipetteAspiratedFluidUpdate`."""
         self.pipette_aspirated_fluid = PipetteAspiratedFluidUpdate(
             type="aspirated", pipette_id=pipette_id, fluid=fluid
         )
+        return self
 
-    def set_fluid_ejected(self, pipette_id: str, volume: float) -> None:
+    def set_fluid_ejected(self: Self, pipette_id: str, volume: float) -> Self:
         """Update record of fluid held inside a pipette. See `PipetteEjectedFluidUpdate`."""
         self.pipette_aspirated_fluid = PipetteEjectedFluidUpdate(
             type="ejected", pipette_id=pipette_id, volume=volume
         )
+        return self
 
-    def set_fluid_unknown(self, pipette_id: str) -> None:
+    def set_fluid_unknown(self: Self, pipette_id: str) -> Self:
         """Update record of fluid held inside a pipette. See `PipetteUnknownFluidUpdate`."""
         self.pipette_aspirated_fluid = PipetteUnknownFluidUpdate(
             type="unknown", pipette_id=pipette_id
         )
+        return self
 
-    def set_fluid_empty(self, pipette_id: str) -> None:
+    def set_fluid_empty(self: Self, pipette_id: str) -> Self:
         """Update record fo fluid held inside a pipette. See `PipetteEmptyFluidUpdate`."""
         self.pipette_aspirated_fluid = PipetteEmptyFluidUpdate(
             type="empty", pipette_id=pipette_id
         )
+        return self
 
-    def set_absorbance_reader_lid(self, module_id: str, is_lid_on: bool) -> None:
+    def set_absorbance_reader_lid(self: Self, module_id: str, is_lid_on: bool) -> Self:
         """Update an absorbance reader's lid location. See `AbsorbanceReaderLidUpdate`."""
         self.absorbance_reader_lid = AbsorbanceReaderLidUpdate(
             module_id=module_id, is_lid_on=is_lid_on
         )
+        return self

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -299,6 +299,27 @@ class StateUpdate:
 
     liquid_class_loaded: LiquidClassLoadedUpdate | NoChangeType = NO_CHANGE
 
+    @classmethod
+    def reduce(cls: typing.Type[Self], *args: Self) -> Self:
+        """Fuse multiple state updates into a single one.
+
+        State updates that are later in the parameter list are preferred to those that are earlier;
+        NO_CHANGE is ignored.
+        """
+        fields = dataclasses.fields(cls)
+        changes_dicts = [
+            {
+                field.name: update.__dict__[field.name]
+                for field in fields
+                if update.__dict__[field.name] != NO_CHANGE
+            }
+            for update in args
+        ]
+        changes = {}
+        for changes_dict in changes_dicts:
+            changes.update(changes_dict)
+        return cls(**changes)
+
     # These convenience functions let the caller avoid the boilerplate of constructing a
     # complicated dataclass tree.
 

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -106,6 +106,9 @@ async def test_aspirate_implementation_no_prep(
             well_name="A3",
             well_location=location,
             current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
             operation_volume=-50,
         ),
     ).then_return(Point(x=1, y=2, z=3))
@@ -195,6 +198,9 @@ async def test_aspirate_implementation_with_prep(
                 labware_id="123",
                 well_name="A3",
             ),
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
             operation_volume=-50,
         ),
     ).then_return(Point(x=1, y=2, z=3))
@@ -285,6 +291,9 @@ async def test_aspirate_raises_volume_error(
             well_name="A3",
             well_location=location,
             current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
             operation_volume=-50,
         ),
     ).then_return(Point(1, 2, 3))
@@ -358,6 +367,9 @@ async def test_overpressure_error(
             well_name=well_name,
             well_location=well_location,
             current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
             operation_volume=-50,
         ),
     ).then_return(position)
@@ -398,6 +410,15 @@ async def test_overpressure_error(
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id=pipette_id
+            ),
+        ),
+        state_update_if_false_positive=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id=pipette_id,
+                new_location=update_types.Well(
+                    labware_id=labware_id, well_name=well_name
+                ),
+                new_deck_point=DeckPoint(x=position.x, y=position.y, z=position.z),
             ),
         ),
     )
@@ -450,6 +471,9 @@ async def test_aspirate_implementation_meniscus(
             well_name="A3",
             well_location=location,
             current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
             operation_volume=-50,
         ),
     ).then_return(Point(x=1, y=2, z=3))

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
@@ -88,6 +88,7 @@ def subject(
 )
 async def test_aspirate_in_place_implementation(
     decoy: Decoy,
+    gantry_mover: GantryMover,
     pipetting: PipettingHandler,
     state_store: StateStore,
     hardware_api: HardwareAPI,
@@ -131,6 +132,10 @@ async def test_aspirate_in_place_implementation(
         )
     ).then_return(123)
 
+    decoy.when(await gantry_mover.get_position("pipette-id-abc")).then_return(
+        Point(1, 2, 3)
+    )
+
     decoy.when(state_store.pipettes.get_current_location()).then_return(location)
 
     result = await subject.execute(params=data)
@@ -164,6 +169,7 @@ async def test_aspirate_in_place_implementation(
 
 async def test_handle_aspirate_in_place_request_not_ready_to_aspirate(
     decoy: Decoy,
+    gantry_mover: GantryMover,
     pipetting: PipettingHandler,
     state_store: StateStore,
     hardware_api: HardwareAPI,
@@ -175,7 +181,9 @@ async def test_handle_aspirate_in_place_request_not_ready_to_aspirate(
         volume=123,
         flowRate=1.234,
     )
-
+    decoy.when(await gantry_mover.get_position("pipette-id-abc")).then_return(
+        Point(1, 2, 3)
+    )
     decoy.when(
         pipetting.get_is_ready_to_aspirate(
             pipette_id="pipette-id-abc",
@@ -196,6 +204,7 @@ async def test_aspirate_raises_volume_error(
     pipetting: PipettingHandler,
     subject: AspirateInPlaceImplementation,
     mock_command_note_adder: CommandNoteAdder,
+    gantry_mover: GantryMover,
 ) -> None:
     """Should raise an assertion error for volume larger than working volume."""
     data = AspirateInPlaceParams(
@@ -203,7 +212,7 @@ async def test_aspirate_raises_volume_error(
         volume=50,
         flowRate=1.23,
     )
-
+    decoy.when(await gantry_mover.get_position("abc")).then_return(Point(x=1, y=2, z=3))
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id="abc")).then_return(True)
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -1,4 +1,5 @@
 """Test blow-out command."""
+
 from datetime import datetime
 from decoy import Decoy, matchers
 
@@ -69,6 +70,11 @@ async def test_blow_out_implementation(
             labware_id="labware-id",
             well_name="C6",
             well_location=location,
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -136,6 +142,11 @@ async def test_overpressure_error(
             labware_id="labware-id",
             well_name="C6",
             well_location=location,
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -159,6 +170,16 @@ async def test_overpressure_error(
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="pipette-id"
+            ),
+        ),
+        state_update_if_false_positive=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="pipette-id",
+                new_location=update_types.Well(
+                    labware_id="labware-id",
+                    well_name="C6",
+                ),
+                new_deck_point=DeckPoint(x=1, y=2, z=3),
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
@@ -43,6 +43,7 @@ def subject(
 
 async def test_blow_out_in_place_implementation(
     decoy: Decoy,
+    gantry_mover: GantryMover,
     subject: BlowOutInPlaceImplementation,
     pipetting: PipettingHandler,
 ) -> None:
@@ -51,9 +52,11 @@ async def test_blow_out_in_place_implementation(
         pipetteId="pipette-id",
         flowRate=1.234,
     )
+    decoy.when(await gantry_mover.get_position("pipette-id")).then_return(
+        Point(1, 2, 3)
+    )
 
     result = await subject.execute(data)
-
     assert result == SuccessData(
         public=BlowOutInPlaceResult(),
         state_update=update_types.StateUpdate(

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -71,6 +71,11 @@ async def test_dispense_implementation(
             labware_id="labware-id-abc123",
             well_name="A3",
             well_location=well_location,
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -174,6 +179,11 @@ async def test_overpressure_error(
             labware_id=labware_id,
             well_name=well_name,
             well_location=well_location,
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         ),
     ).then_return(position)
 
@@ -211,6 +221,16 @@ async def test_overpressure_error(
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="pipette-id"
+            ),
+        ),
+        state_update_if_false_positive=update_types.StateUpdate(
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="pipette-id",
+                new_location=update_types.Well(
+                    labware_id="labware-id",
+                    well_name="well-name",
+                ),
+                new_deck_point=DeckPoint.construct(x=1, y=2, z=3),
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
@@ -61,6 +61,7 @@ def subject(
 )
 async def test_dispense_in_place_implementation(
     decoy: Decoy,
+    gantry_mover: GantryMover,
     pipetting: PipettingHandler,
     state_view: StateView,
     subject: DispenseInPlaceImplementation,
@@ -101,6 +102,9 @@ async def test_dispense_in_place_implementation(
             stateupdateLabware, stateupdateWell, "pipette-id-abc"
         )
     ).then_return(["A3", "A4"])
+    decoy.when(await gantry_mover.get_position("pipette-id-abc")).then_return(
+        Point(1, 2, 3)
+    )
 
     result = await subject.execute(data)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -1,4 +1,5 @@
 """Test drop tip commands."""
+
 from datetime import datetime
 
 import pytest
@@ -122,6 +123,11 @@ async def test_drop_tip_implementation(
             labware_id="123",
             well_name="A3",
             well_location=WellLocation(offset=WellOffset(x=4, y=5, z=6)),
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=111, y=222, z=333))
 
@@ -203,6 +209,11 @@ async def test_drop_tip_with_alternating_locations(
             labware_id="123",
             well_name="A3",
             well_location=WellLocation(offset=WellOffset(x=4, y=5, z=6)),
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=111, y=222, z=333))
 
@@ -269,6 +280,11 @@ async def test_tip_attached_error(
             labware_id="123",
             well_name="A3",
             well_location=WellLocation(offset=WellOffset(x=4, y=5, z=6)),
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=111, y=222, z=333))
     decoy.when(
@@ -305,6 +321,14 @@ async def test_tip_attached_error(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
+            ),
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="abc",
+                new_location=update_types.Well(
+                    labware_id="123",
+                    well_name="A3",
+                ),
+                new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -127,6 +127,11 @@ async def test_liquid_probe_implementation(
             labware_id="123",
             well_name="A3",
             well_location=location,
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         ),
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -212,6 +217,11 @@ async def test_liquid_not_found_error(
             labware_id=labware_id,
             well_name=well_name,
             well_location=well_location,
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         ),
     ).then_return(position)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -54,6 +54,8 @@ async def test_move_to_well_implementation(
             force_direct=True,
             minimum_z_height=4.56,
             speed=7.89,
+            current_well=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=9, y=8, z=7))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -57,6 +57,11 @@ async def test_success(
             labware_id="labware-id",
             well_name="A3",
             well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=111, y=222, z=333))
 
@@ -137,6 +142,11 @@ async def test_tip_physically_missing_error(
             labware_id="labware-id",
             well_name="well-name",
             well_location=WellLocation(offset=WellOffset()),
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=111, y=222, z=333))
     decoy.when(
@@ -176,6 +186,16 @@ async def test_tip_physically_missing_error(
             ),
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="pipette-id"
+            ),
+            tips_used=update_types.TipsUsedUpdate(
+                pipette_id="pipette-id", labware_id="labware-id", well_name="well-name"
+            ),
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="pipette-id",
+                new_location=update_types.Well(
+                    labware_id="labware-id", well_name="well-name"
+                ),
+                new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
@@ -73,6 +73,11 @@ async def test_touch_tip_implementation(
             labware_id="123",
             well_name="A3",
             well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
         )
     ).then_return(Point(x=1, y=2, z=3))
 


### PR DESCRIPTION
Make some intermediates for `move_to_well` and the pipetting operations that can handle and format exceptions and pass defined errors upstream. In addition, make some state update changes that will pave the way for having multiple micro-operations that can fail in each command, and get rid of maybes.

Specifically,
- You can now chain `StateUpdate` setter calls
- New classmethod `StateUpdate.reduce()` that does a reduce over a group of state updates
- New "micro operations" in `pipetting_common` and new `movement_common` that basically just do exception handling for things like `pipetting.aspirate_in_place()` and `movement.move_to_wells()` so that the commands can treat defined errors entirely as data
- Give up on the `Maybe` experiment because it's really awful to chain async calls in python

## testing
- No behavior should have changed. Some `state_update_if_false_positive`s are now full overrides instead of just extensions. Tests should cover this.

Works toward EXEC-830