### PR TITLE
fix(app): fix post run tip detection after error recovery

### DIFF
--- a/app/src/local-resources/commands/utils/index.ts
+++ b/app/src/local-resources/commands/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './getCommandTextData'
+export * from './lastRunCommandPromptedErrorRecovery'

--- a/app/src/local-resources/commands/utils/lastRunCommandPromptedErrorRecovery.ts
+++ b/app/src/local-resources/commands/utils/lastRunCommandPromptedErrorRecovery.ts
@@ -1,0 +1,13 @@
+import type { RunCommandSummary } from '@opentrons/api-client'
+
+// Whether the last run protocol command prompted Error Recovery.
+export function lastRunCommandPromptedErrorRecovery(
+  summary: RunCommandSummary[]
+): boolean {
+  const lastProtocolCommand = summary.findLast(
+    command => command.intent !== 'fixit' && command.error != null
+  )
+
+  // All recoverable protocol commands have defined errors.
+  return lastProtocolCommand?.error?.isDefined ?? false
+}

--- a/app/src/organisms/DropTipWizardFlows/hooks/useTipAttachmentStatus/getPipettesWithTipAttached.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useTipAttachmentStatus/getPipettesWithTipAttached.ts
@@ -63,7 +63,12 @@ function getCommandsExecutedDuringRun(
   })
 }
 
-const TIP_EXCHANGE_COMMAND_TYPES = ['dropTip', 'dropTipInPlace', 'pickUpTip']
+const TIP_EXCHANGE_COMMAND_TYPES = [
+  'dropTip',
+  'dropTipInPlace',
+  'pickUpTip',
+  'moveToAddressableAreaForDropTip',
+]
 
 function checkPipettesForAttachedTips(
   commands: RunCommandSummary[],

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -65,11 +65,13 @@ import {
   useRunCreatedAtTimestamp,
   useCloseCurrentRun,
   EMPTY_TIMESTAMP,
+  useCurrentRunCommands,
 } from '/app/resources/runs'
 import {
   useTipAttachmentStatus,
   handleTipsAttachedModal,
 } from '/app/organisms/DropTipWizardFlows'
+import { lastRunCommandPromptedErrorRecovery } from '/app/local-resources/commands'
 
 import type { IconName } from '@opentrons/components'
 import type { OnDeviceRouteParams } from '/app/App/types'
@@ -238,11 +240,21 @@ export function RunSummary(): JSX.Element {
   })
 
   // Determine tip status on initial render only. Error Recovery always handles tip status, so don't show it twice.
+  const runSummaryNoFixit = useCurrentRunCommands({
+    includeFixitCommands: false,
+    pageLength: 1,
+    cursor: null,
+  })
   useEffect(() => {
-    if (isRunCurrent && enteredER === false) {
+    if (
+      isRunCurrent &&
+      runSummaryNoFixit != null &&
+      !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit)
+    ) {
+      console.log('HITTING THIS')
       void determineTipStatus()
     }
-  }, [isRunCurrent, enteredER])
+  }, [runSummaryNoFixit, isRunCurrent])
 
   const returnToQuickTransfer = (): void => {
     closeCurrentRunIfValid(() => {


### PR DESCRIPTION
Closes [RQA-3589](https://opentrons.atlassian.net/browse/RQA-3589)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

It's insufficient to check if a run entered error recovery as the sole condition for whether or not to run the post-run drop tip wizard, because it's possible for a run to proceed through error recovery then encounter a terminal error. In these spots, we must show drop tip wizard.

To fix, determine whether the run just entered error recovery (or not). If it didn't, do the tip detection logic.

https://github.com/user-attachments/assets/14d9f5ea-0203-4f62-8e80-ecda85b7a5f7

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video. Also confirmed fix on ODD.
- Verified there's no prompting after doing doing drop tip wizard during error recovery.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed an instance in which the user does not receive drop tip wizard prompts after a terminal error.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low -- This util only touches two spots, and the blast radius is small.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3589]: https://opentrons.atlassian.net/browse/RQA-3589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ