### PR TITLE
feat(api): express stalls in a recoverable way

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -13,6 +13,7 @@ from .pipetting_common import (
     LiquidNotFoundError,
     TipPhysicallyAttachedError,
 )
+from .movement_common import StallOrCollisionError
 
 from . import absorbance_reader
 from . import heater_shaker
@@ -754,6 +755,7 @@ CommandDefinedErrorData = Union[
     DefinedErrorData[OverpressureError],
     DefinedErrorData[LiquidNotFoundError],
     DefinedErrorData[GripperMovementError],
+    DefinedErrorData[StallOrCollisionError],
 ]
 
 

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -27,6 +27,7 @@ from .pipetting_common import (
 from .movement_common import (
     WellLocationMixin,
     DestinationPositionResult,
+    StallOrCollisionError,
     move_to_well,
 )
 from .command import (
@@ -91,9 +92,11 @@ class TryLiquidProbeResult(DestinationPositionResult):
 
 _LiquidProbeExecuteReturn = Union[
     SuccessData[LiquidProbeResult],
-    DefinedErrorData[LiquidNotFoundError],
+    DefinedErrorData[LiquidNotFoundError] | DefinedErrorData[StallOrCollisionError],
 ]
-_TryLiquidProbeExecuteReturn = SuccessData[TryLiquidProbeResult]
+_TryLiquidProbeExecuteReturn = (
+    SuccessData[TryLiquidProbeResult] | DefinedErrorData[StallOrCollisionError]
+)
 
 
 class _ExecuteCommonResult(NamedTuple):
@@ -110,8 +113,9 @@ async def _execute_common(
     state_view: StateView,
     movement: MovementHandler,
     pipetting: PipettingHandler,
+    model_utils: ModelUtils,
     params: _CommonParams,
-) -> _ExecuteCommonResult:
+) -> _ExecuteCommonResult | DefinedErrorData[StallOrCollisionError]:
     pipette_id = params.pipetteId
     labware_id = params.labwareId
     well_name = params.wellName
@@ -145,12 +149,14 @@ async def _execute_common(
     # liquid_probe process start position
     move_result = await move_to_well(
         movement=movement,
+        model_utils=model_utils,
         pipette_id=pipette_id,
         labware_id=labware_id,
         well_name=well_name,
         well_location=params.wellLocation,
     )
-
+    if isinstance(move_result, DefinedErrorData):
+        return move_result
     try:
         z_pos = await pipetting.liquid_probe_in_place(
             pipette_id=pipette_id,
@@ -206,9 +212,16 @@ class LiquidProbeImplementation(
             MustHomeError: as an undefined error, if the plunger is not in a valid
                 position.
         """
-        z_pos_or_error, state_update, deck_point = await _execute_common(
-            self._state_view, self._movement, self._pipetting, params
+        result = await _execute_common(
+            state_view=self._state_view,
+            movement=self._movement,
+            pipetting=self._pipetting,
+            model_utils=self._model_utils,
+            params=params,
         )
+        if isinstance(result, DefinedErrorData):
+            return result
+        z_pos_or_error, state_update, deck_point = result
         if isinstance(z_pos_or_error, PipetteLiquidNotFoundError):
             state_update.set_liquid_probed(
                 labware_id=params.labwareId,
@@ -282,9 +295,16 @@ class TryLiquidProbeImplementation(
         found, `tryLiquidProbe` returns a success result with `z_position=null` instead
         of a defined error.
         """
-        z_pos_or_error, state_update, deck_point = await _execute_common(
-            self._state_view, self._movement, self._pipetting, params
+        result = await _execute_common(
+            state_view=self._state_view,
+            movement=self._movement,
+            pipetting=self._pipetting,
+            model_utils=self._model_utils,
+            params=params,
         )
+        if isinstance(result, DefinedErrorData):
+            return result
+        z_pos_or_error, state_update, deck_point = result
 
         if isinstance(z_pos_or_error, PipetteLiquidNotFoundError):
             z_pos = None
@@ -316,7 +336,11 @@ class TryLiquidProbeImplementation(
 
 
 class LiquidProbe(
-    BaseCommand[LiquidProbeParams, LiquidProbeResult, LiquidNotFoundError]
+    BaseCommand[
+        LiquidProbeParams,
+        LiquidProbeResult,
+        LiquidNotFoundError | StallOrCollisionError,
+    ]
 ):
     """The model for a full `liquidProbe` command."""
 
@@ -328,7 +352,7 @@ class LiquidProbe(
 
 
 class TryLiquidProbe(
-    BaseCommand[TryLiquidProbeParams, TryLiquidProbeResult, ErrorOccurrence]
+    BaseCommand[TryLiquidProbeParams, TryLiquidProbeResult, StallOrCollisionError]
 ):
     """The model for a full `tryLiquidProbe` command."""
 

--- a/api/src/opentrons/protocol_engine/commands/move_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/move_relative.py
@@ -5,14 +5,23 @@ from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 
-from ..state import update_types
-from ..types import MovementAxis, DeckPoint
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
-from ..errors.error_occurrence import ErrorOccurrence
-from .movement_common import DestinationPositionResult
+from ..types import MovementAxis
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    SuccessData,
+    DefinedErrorData,
+)
+from .movement_common import (
+    DestinationPositionResult,
+    move_relative,
+    StallOrCollisionError,
+)
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
+    from ..resources.model_utils import ModelUtils
 
 
 MoveRelativeCommandType = Literal["moveRelative"]
@@ -39,40 +48,41 @@ class MoveRelativeResult(DestinationPositionResult):
 
 
 class MoveRelativeImplementation(
-    AbstractCommandImpl[MoveRelativeParams, SuccessData[MoveRelativeResult]]
+    AbstractCommandImpl[
+        MoveRelativeParams,
+        SuccessData[MoveRelativeResult] | DefinedErrorData[StallOrCollisionError],
+    ]
 ):
     """Move relative command implementation."""
 
-    def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
+    def __init__(
+        self, movement: MovementHandler, model_utils: ModelUtils, **kwargs: object
+    ) -> None:
         self._movement = movement
+        self._model_utils = model_utils
 
     async def execute(
         self, params: MoveRelativeParams
-    ) -> SuccessData[MoveRelativeResult]:
+    ) -> SuccessData[MoveRelativeResult] | DefinedErrorData[StallOrCollisionError]:
         """Move (jog) a given pipette a relative distance."""
-        state_update = update_types.StateUpdate()
-
-        x, y, z = await self._movement.move_relative(
+        result = await move_relative(
+            movement=self._movement,
+            model_utils=self._model_utils,
             pipette_id=params.pipetteId,
             axis=params.axis,
             distance=params.distance,
         )
-        deck_point = DeckPoint.construct(x=x, y=y, z=z)
-        state_update.pipette_location = update_types.PipetteLocationUpdate(
-            pipette_id=params.pipetteId,
-            # TODO(jbl 2023-02-14): Need to investigate whether move relative should clear current location
-            new_location=update_types.NO_CHANGE,
-            new_deck_point=deck_point,
-        )
-
-        return SuccessData(
-            public=MoveRelativeResult(position=deck_point),
-            state_update=state_update,
-        )
+        if isinstance(result, DefinedErrorData):
+            return result
+        else:
+            return SuccessData(
+                public=MoveRelativeResult(position=result.public.position),
+                state_update=result.state_update,
+            )
 
 
 class MoveRelative(
-    BaseCommand[MoveRelativeParams, MoveRelativeResult, ErrorOccurrence]
+    BaseCommand[MoveRelativeParams, MoveRelativeResult, StallOrCollisionError]
 ):
     """Command to move (jog) a given pipette a relative distance."""
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -6,15 +6,25 @@ from typing import Optional, Type, TYPE_CHECKING
 from typing_extensions import Literal
 
 
-from ..state import update_types
 from ..types import DeckPoint
 from .pipetting_common import PipetteIdMixin
-from .movement_common import MovementMixin, DestinationPositionResult
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
-from ..errors.error_occurrence import ErrorOccurrence
+from .movement_common import (
+    MovementMixin,
+    DestinationPositionResult,
+    move_to_coordinates,
+    StallOrCollisionError,
+)
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    SuccessData,
+    DefinedErrorData,
+)
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
+    from ..resources.model_utils import ModelUtils
 
 
 MoveToCoordinatesCommandType = Literal["moveToCoordinates"]
@@ -35,44 +45,47 @@ class MoveToCoordinatesResult(DestinationPositionResult):
     pass
 
 
+_ExecuteReturn = (
+    SuccessData[MoveToCoordinatesResult] | DefinedErrorData[StallOrCollisionError]
+)
+
+
 class MoveToCoordinatesImplementation(
-    AbstractCommandImpl[MoveToCoordinatesParams, SuccessData[MoveToCoordinatesResult]]
+    AbstractCommandImpl[MoveToCoordinatesParams, _ExecuteReturn]
 ):
     """Move to coordinates command implementation."""
 
     def __init__(
         self,
         movement: MovementHandler,
+        model_utils: ModelUtils,
         **kwargs: object,
     ) -> None:
         self._movement = movement
+        self._model_utils = model_utils
 
-    async def execute(
-        self, params: MoveToCoordinatesParams
-    ) -> SuccessData[MoveToCoordinatesResult]:
+    async def execute(self, params: MoveToCoordinatesParams) -> _ExecuteReturn:
         """Move the requested pipette to the requested coordinates."""
-        state_update = update_types.StateUpdate()
-
-        x, y, z = await self._movement.move_to_coordinates(
+        result = await move_to_coordinates(
+            movement=self._movement,
+            model_utils=self._model_utils,
             pipette_id=params.pipetteId,
             deck_coordinates=params.coordinates,
             direct=params.forceDirect,
             additional_min_travel_z=params.minimumZHeight,
             speed=params.speed,
         )
-        deck_point = DeckPoint.construct(x=x, y=y, z=z)
-        state_update.pipette_location = update_types.PipetteLocationUpdate(
-            pipette_id=params.pipetteId, new_location=None, new_deck_point=deck_point
-        )
-
-        return SuccessData(
-            public=MoveToCoordinatesResult(position=DeckPoint(x=x, y=y, z=z)),
-            state_update=state_update,
-        )
+        if isinstance(result, DefinedErrorData):
+            return result
+        else:
+            return SuccessData(
+                public=MoveToCoordinatesResult(position=result.public.position),
+                state_update=result.state_update,
+            )
 
 
 class MoveToCoordinates(
-    BaseCommand[MoveToCoordinatesParams, MoveToCoordinatesResult, ErrorOccurrence]
+    BaseCommand[MoveToCoordinatesParams, MoveToCoordinatesResult, StallOrCollisionError]
 ):
     """Move to well command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -11,15 +11,22 @@ from .movement_common import (
     WellLocationMixin,
     MovementMixin,
     DestinationPositionResult,
+    StallOrCollisionError,
     move_to_well,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
-from ..errors.error_occurrence import ErrorOccurrence
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    SuccessData,
+    DefinedErrorData,
+)
 from ..errors import LabwareIsTipRackError
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
     from ..state.state import StateView
+    from ..resources.model_utils import ModelUtils
 
 MoveToWellCommandType = Literal["moveToWell"]
 
@@ -37,17 +44,27 @@ class MoveToWellResult(DestinationPositionResult):
 
 
 class MoveToWellImplementation(
-    AbstractCommandImpl[MoveToWellParams, SuccessData[MoveToWellResult]]
+    AbstractCommandImpl[
+        MoveToWellParams,
+        SuccessData[MoveToWellResult] | DefinedErrorData[StallOrCollisionError],
+    ]
 ):
     """Move to well command implementation."""
 
     def __init__(
-        self, state_view: StateView, movement: MovementHandler, **kwargs: object
+        self,
+        state_view: StateView,
+        movement: MovementHandler,
+        model_utils: ModelUtils,
+        **kwargs: object,
     ) -> None:
         self._state_view = state_view
         self._movement = movement
+        self._model_utils = model_utils
 
-    async def execute(self, params: MoveToWellParams) -> SuccessData[MoveToWellResult]:
+    async def execute(
+        self, params: MoveToWellParams
+    ) -> SuccessData[MoveToWellResult] | DefinedErrorData[StallOrCollisionError]:
         """Move the requested pipette to the requested well."""
         pipette_id = params.pipetteId
         labware_id = params.labwareId
@@ -63,6 +80,7 @@ class MoveToWellImplementation(
             )
 
         move_result = await move_to_well(
+            model_utils=self._model_utils,
             movement=self._movement,
             pipette_id=pipette_id,
             labware_id=labware_id,
@@ -72,14 +90,18 @@ class MoveToWellImplementation(
             minimum_z_height=params.minimumZHeight,
             speed=params.speed,
         )
+        if isinstance(move_result, DefinedErrorData):
+            return move_result
+        else:
+            return SuccessData(
+                public=MoveToWellResult(position=move_result.public.position),
+                state_update=move_result.state_update,
+            )
 
-        return SuccessData(
-            public=MoveToWellResult(position=move_result.public.position),
-            state_update=move_result.state_update,
-        )
 
-
-class MoveToWell(BaseCommand[MoveToWellParams, MoveToWellResult, ErrorOccurrence]):
+class MoveToWell(
+    BaseCommand[MoveToWellParams, MoveToWellResult, StallOrCollisionError]
+):
     """Move to well command model."""
 
     commandType: MoveToWellCommandType = "moveToWell"

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -322,6 +322,11 @@ class StateUpdate:
 
     # These convenience functions let the caller avoid the boilerplate of constructing a
     # complicated dataclass tree.
+    @typing.overload
+    def set_pipette_location(
+        self: Self, *, pipette_id: str, new_deck_point: DeckPoint
+    ) -> Self:
+        """Schedule a pipette's coordinates to be changed while preserving its logical location."""
 
     @typing.overload
     def set_pipette_location(
@@ -362,10 +367,13 @@ class StateUpdate:
                 ),
                 new_deck_point=new_deck_point,
             )
+        elif new_labware_id == NO_CHANGE or new_well_name == NO_CHANGE:
+            self.pipette_location = PipetteLocationUpdate(
+                pipette_id=pipette_id,
+                new_location=NO_CHANGE,
+                new_deck_point=new_deck_point,
+            )
         else:
-            # These asserts should always pass because of the overloads.
-            assert new_labware_id != NO_CHANGE
-            assert new_well_name != NO_CHANGE
 
             self.pipette_location = PipetteLocationUpdate(
                 pipette_id=pipette_id,

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -2,11 +2,15 @@
 
 from datetime import datetime
 
-from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
+from opentrons_shared_data.errors.exceptions import (
+    PipetteOverpressureError,
+    StallOrCollisionDetectedError,
+)
 from decoy import matchers, Decoy
 import pytest
 
 from opentrons.protocol_engine.commands.pipetting_common import OverpressureError
+from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 from opentrons.protocol_engine.state import update_types
 from opentrons.types import MountType, Point
 from opentrons.protocol_engine import (
@@ -506,4 +510,64 @@ async def test_aspirate_implementation_meniscus(
                 pipette_id="abc", fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=50)
             ),
         ),
+    )
+
+
+async def test_stall_error(
+    decoy: Decoy,
+    movement: MovementHandler,
+    pipetting: PipettingHandler,
+    subject: AspirateImplementation,
+    model_utils: ModelUtils,
+    state_view: StateView,
+) -> None:
+    """It should return an overpressure error if the hardware API indicates that."""
+    pipette_id = "pipette-id"
+    labware_id = "labware-id"
+    well_name = "well-name"
+    well_location = LiquidHandlingWellLocation(
+        origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1)
+    )
+
+    error_id = "error-id"
+    error_timestamp = datetime(year=2020, month=1, day=2)
+    decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
+        True
+    )
+
+    data = AspirateParams(
+        pipetteId=pipette_id,
+        labwareId=labware_id,
+        wellName=well_name,
+        wellLocation=well_location,
+        volume=50,
+        flowRate=1.23,
+    )
+
+    decoy.when(
+        await movement.move_to_well(
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=-50,
+        ),
+    ).then_raise(StallOrCollisionDetectedError())
+
+    decoy.when(model_utils.generate_id()).then_return(error_id)
+    decoy.when(model_utils.get_timestamp()).then_return(error_timestamp)
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=StallOrCollisionError.construct(
+            id=error_id,
+            createdAt=error_timestamp,
+            wrappedErrors=[matchers.Anything()],
+        ),
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -5,7 +5,10 @@ from datetime import datetime
 import pytest
 from decoy import Decoy, matchers
 
-from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
+from opentrons_shared_data.errors.exceptions import (
+    PipetteOverpressureError,
+    StallOrCollisionDetectedError,
+)
 
 from opentrons.protocol_engine import (
     LiquidHandlingWellLocation,
@@ -26,6 +29,7 @@ from opentrons.protocol_engine.commands.dispense import (
 )
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.commands.pipetting_common import OverpressureError
+from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 
 
 @pytest.fixture
@@ -233,4 +237,61 @@ async def test_overpressure_error(
                 new_deck_point=DeckPoint.construct(x=1, y=2, z=3),
             ),
         ),
+    )
+
+
+async def test_stall_error(
+    decoy: Decoy,
+    movement: MovementHandler,
+    pipetting: PipettingHandler,
+    subject: DispenseImplementation,
+    model_utils: ModelUtils,
+    state_view: StateView,
+) -> None:
+    """It should return an overpressure error if the hardware API indicates that."""
+    pipette_id = "pipette-id"
+    labware_id = "labware-id"
+    well_name = "well-name"
+    well_location = LiquidHandlingWellLocation(
+        origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1)
+    )
+
+    error_id = "error-id"
+    error_timestamp = datetime(year=2020, month=1, day=2)
+
+    data = DispenseParams(
+        pipetteId=pipette_id,
+        labwareId=labware_id,
+        wellName=well_name,
+        wellLocation=well_location,
+        volume=50,
+        flowRate=1.23,
+    )
+
+    decoy.when(
+        await movement.move_to_well(
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+            current_well=None,
+            force_direct=False,
+            minimum_z_height=None,
+            speed=None,
+            operation_volume=None,
+        ),
+    ).then_raise(StallOrCollisionDetectedError())
+
+    decoy.when(model_utils.generate_id()).then_return(error_id)
+    decoy.when(model_utils.get_timestamp()).then_return(error_timestamp)
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=StallOrCollisionError.construct(
+            id=error_id,
+            createdAt=error_timestamp,
+            wrappedErrors=[matchers.Anything()],
+        ),
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -248,7 +248,7 @@ async def test_stall_error(
     model_utils: ModelUtils,
     state_view: StateView,
 ) -> None:
-    """It should return an overpressure error if the hardware API indicates that."""
+    """It should return a stall error if the hardware API indicates that."""
     pipette_id = "pipette-id"
     labware_id = "labware-id"
     well_name = "well-name"

--- a/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
@@ -1,25 +1,38 @@
 """Test move relative commands."""
-from decoy import Decoy
+from datetime import datetime
+
+from decoy import Decoy, matchers
+import pytest
+
+from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.types import DeckPoint, MovementAxis
 from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.types import Point
 
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.command import SuccessData, DefinedErrorData
+from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 from opentrons.protocol_engine.commands.move_relative import (
     MoveRelativeParams,
     MoveRelativeResult,
     MoveRelativeImplementation,
 )
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
+
+
+@pytest.fixture
+def subject(
+    movement: MovementHandler, model_utils: ModelUtils
+) -> MoveRelativeImplementation:
+    """Build a MoveRelativeImplementation with injected dependencies."""
+    return MoveRelativeImplementation(movement=movement, model_utils=model_utils)
 
 
 async def test_move_relative_implementation(
-    decoy: Decoy,
-    movement: MovementHandler,
+    decoy: Decoy, movement: MovementHandler, subject: MoveRelativeImplementation
 ) -> None:
     """A MoveRelative command should have an execution implementation."""
-    subject = MoveRelativeImplementation(movement=movement)
     data = MoveRelativeParams(
         pipetteId="pipette-id",
         axis=MovementAxis.X,
@@ -45,4 +58,35 @@ async def test_move_relative_implementation(
                 new_deck_point=DeckPoint(x=1, y=2, z=3),
             )
         ),
+    )
+
+
+async def test_move_relative_stalls(
+    decoy: Decoy,
+    movement: MovementHandler,
+    model_utils: ModelUtils,
+    subject: MoveRelativeImplementation,
+) -> None:
+    """A MoveRelative command should handle stalls."""
+    data = MoveRelativeParams(pipetteId="pipette-id", axis=MovementAxis.Y, distance=40)
+
+    decoy.when(
+        await movement.move_relative(
+            pipette_id="pipette-id", axis=MovementAxis.Y, distance=40
+        )
+    ).then_raise(StallOrCollisionDetectedError())
+
+    timestamp = datetime.now()
+    test_id = "test-id"
+
+    decoy.when(model_utils.get_timestamp()).then_return(timestamp)
+    decoy.when(model_utils.generate_id()).then_return(test_id)
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=StallOrCollisionError.construct(
+            id=test_id, createdAt=timestamp, wrappedErrors=[matchers.Anything()]
+        ),
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
@@ -1,7 +1,10 @@
 """Test move to addressable area commands."""
-from decoy import Decoy
+from datetime import datetime
+
+from decoy import Decoy, matchers
 import pytest
 
+from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.protocol_engine import DeckPoint, AddressableOffsetVector, LoadedPipette
 from opentrons.protocol_engine.execution import MovementHandler
@@ -9,12 +12,24 @@ from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.types import Point, MountType
 
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.command import SuccessData, DefinedErrorData
 from opentrons.protocol_engine.commands.move_to_addressable_area import (
     MoveToAddressableAreaParams,
     MoveToAddressableAreaResult,
     MoveToAddressableAreaImplementation,
 )
+from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
+
+
+@pytest.fixture
+def subject(
+    movement: MovementHandler, state_view: StateView, model_utils: ModelUtils
+) -> MoveToAddressableAreaImplementation:
+    """Build an execution implementation with injected dependencies."""
+    return MoveToAddressableAreaImplementation(
+        movement=movement, state_view=state_view, model_utils=model_utils
+    )
 
 
 @pytest.mark.parametrize(
@@ -39,12 +54,9 @@ async def test_move_to_addressable_area_implementation_non_gen1(
     state_view: StateView,
     movement: MovementHandler,
     pipette_name: PipetteNameType,
+    subject: MoveToAddressableAreaImplementation,
 ) -> None:
     """A MoveToAddressableArea command should have an execution implementation."""
-    subject = MoveToAddressableAreaImplementation(
-        movement=movement, state_view=state_view
-    )
-
     data = MoveToAddressableAreaParams(
         pipetteId="abc",
         addressableAreaName="123",
@@ -67,6 +79,7 @@ async def test_move_to_addressable_area_implementation_non_gen1(
             minimum_z_height=4.56,
             speed=7.89,
             stay_at_highest_possible_z=True,
+            ignore_tip_configuration=True,
             highest_possible_z_extra_offset=None,
         )
     ).then_return(Point(x=9, y=8, z=7))
@@ -102,12 +115,9 @@ async def test_move_to_addressable_area_implementation_with_gen1(
     state_view: StateView,
     movement: MovementHandler,
     pipette_name: PipetteNameType,
+    subject: MoveToAddressableAreaImplementation,
 ) -> None:
     """A MoveToAddressableArea command should have an execution implementation."""
-    subject = MoveToAddressableAreaImplementation(
-        movement=movement, state_view=state_view
-    )
-
     data = MoveToAddressableAreaParams(
         pipetteId="abc",
         addressableAreaName="123",
@@ -130,6 +140,7 @@ async def test_move_to_addressable_area_implementation_with_gen1(
             minimum_z_height=4.56,
             speed=7.89,
             stay_at_highest_possible_z=True,
+            ignore_tip_configuration=True,
             highest_possible_z_extra_offset=5.0,
         )
     ).then_return(Point(x=9, y=8, z=7))
@@ -145,4 +156,55 @@ async def test_move_to_addressable_area_implementation_with_gen1(
                 new_deck_point=DeckPoint(x=9, y=8, z=7),
             )
         ),
+    )
+
+
+async def test_move_to_addressable_area_implementation_handles_stalls(
+    decoy: Decoy,
+    state_view: StateView,
+    movement: MovementHandler,
+    model_utils: ModelUtils,
+    subject: MoveToAddressableAreaImplementation,
+) -> None:
+    """A MoveToAddressableArea command should handle stalls."""
+    data = MoveToAddressableAreaParams(
+        pipetteId="abc",
+        addressableAreaName="123",
+        offset=AddressableOffsetVector(x=1, y=2, z=3),
+        forceDirect=True,
+        minimumZHeight=4.56,
+        speed=7.89,
+        stayAtHighestPossibleZ=True,
+    )
+    test_id = "test-id"
+    timestamp = datetime.now()
+
+    decoy.when(state_view.pipettes.get("abc")).then_return(
+        LoadedPipette(
+            id="abc", pipetteName=PipetteNameType.P1000_SINGLE, mount=MountType.LEFT
+        )
+    )
+    decoy.when(model_utils.generate_id()).then_return(test_id)
+    decoy.when(model_utils.get_timestamp()).then_return(timestamp)
+    decoy.when(
+        await movement.move_to_addressable_area(
+            pipette_id="abc",
+            addressable_area_name="123",
+            offset=AddressableOffsetVector(x=1, y=2, z=3),
+            force_direct=True,
+            minimum_z_height=4.56,
+            speed=7.89,
+            stay_at_highest_possible_z=True,
+            ignore_tip_configuration=True,
+            highest_possible_z_extra_offset=5.0,
+        )
+    ).then_raise(StallOrCollisionDetectedError())
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=StallOrCollisionError.construct(
+            id=test_id, createdAt=timestamp, wrappedErrors=[matchers.Anything()]
+        ),
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
@@ -1,5 +1,10 @@
 """Test move to addressable area for drop tip commands."""
-from decoy import Decoy
+from datetime import datetime
+
+from decoy import Decoy, matchers
+import pytest
+
+from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 
 from opentrons.protocol_engine import DeckPoint, AddressableOffsetVector
 from opentrons.protocol_engine.execution import MovementHandler
@@ -7,24 +12,33 @@ from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.types import Point
 
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
+from opentrons.protocol_engine.commands.command import SuccessData, DefinedErrorData
 from opentrons.protocol_engine.commands.move_to_addressable_area_for_drop_tip import (
     MoveToAddressableAreaForDropTipParams,
     MoveToAddressableAreaForDropTipResult,
     MoveToAddressableAreaForDropTipImplementation,
 )
+from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
+
+
+@pytest.fixture
+def subject(
+    state_view: StateView, movement: MovementHandler, model_utils: ModelUtils
+) -> MoveToAddressableAreaForDropTipImplementation:
+    """Get a command implementation with injected dependencies."""
+    return MoveToAddressableAreaForDropTipImplementation(
+        state_view=state_view, movement=movement, model_utils=model_utils
+    )
 
 
 async def test_move_to_addressable_area_for_drop_tip_implementation(
     decoy: Decoy,
     state_view: StateView,
     movement: MovementHandler,
+    subject: MoveToAddressableAreaForDropTipImplementation,
 ) -> None:
     """A MoveToAddressableAreaForDropTip command should have an execution implementation."""
-    subject = MoveToAddressableAreaForDropTipImplementation(
-        movement=movement, state_view=state_view
-    )
-
     data = MoveToAddressableAreaForDropTipParams(
         pipetteId="abc",
         addressableAreaName="123",
@@ -50,7 +64,9 @@ async def test_move_to_addressable_area_for_drop_tip_implementation(
             force_direct=True,
             minimum_z_height=4.56,
             speed=7.89,
+            stay_at_highest_possible_z=False,
             ignore_tip_configuration=False,
+            highest_possible_z_extra_offset=None,
         )
     ).then_return(Point(x=9, y=8, z=7))
 
@@ -65,4 +81,57 @@ async def test_move_to_addressable_area_for_drop_tip_implementation(
                 new_deck_point=DeckPoint(x=9, y=8, z=7),
             )
         ),
+    )
+
+
+async def test_move_to_addressable_area_for_drop_tip_handles_stalls(
+    decoy: Decoy,
+    state_view: StateView,
+    movement: MovementHandler,
+    model_utils: ModelUtils,
+    subject: MoveToAddressableAreaForDropTipImplementation,
+) -> None:
+    """A MoveToAddressableAreaForDropTip command should have an execution implementation."""
+    data = MoveToAddressableAreaForDropTipParams(
+        pipetteId="abc",
+        addressableAreaName="123",
+        offset=AddressableOffsetVector(x=1, y=2, z=3),
+        forceDirect=True,
+        minimumZHeight=4.56,
+        speed=7.89,
+        alternateDropLocation=True,
+        ignoreTipConfiguration=False,
+    )
+
+    decoy.when(
+        state_view.geometry.get_next_tip_drop_location_for_addressable_area(
+            addressable_area_name="123", pipette_id="abc"
+        )
+    ).then_return(AddressableOffsetVector(x=10, y=11, z=12))
+
+    decoy.when(
+        await movement.move_to_addressable_area(
+            pipette_id="abc",
+            addressable_area_name="123",
+            offset=AddressableOffsetVector(x=10, y=11, z=12),
+            force_direct=True,
+            minimum_z_height=4.56,
+            speed=7.89,
+            stay_at_highest_possible_z=False,
+            ignore_tip_configuration=False,
+            highest_possible_z_extra_offset=None,
+        )
+    ).then_raise(StallOrCollisionDetectedError())
+    timestamp = datetime.now()
+    test_id = "test-id"
+    decoy.when(model_utils.generate_id()).then_return(test_id)
+    decoy.when(model_utils.get_timestamp()).then_return(timestamp)
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=StallOrCollisionError.construct(
+            id=test_id, createdAt=timestamp, wrappedErrors=[matchers.Anything()]
+        ),
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
@@ -1,14 +1,19 @@
 """Test move-to-coordinates commands."""
-from decoy import Decoy
+from datetime import datetime
 
-from opentrons.hardware_control import HardwareControlAPI
+import pytest
+from decoy import Decoy, matchers
+
+from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
+
 from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.protocol_engine.state import update_types
-from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.types import DeckPoint
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.types import Point
 
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
+from opentrons.protocol_engine.commands.command import SuccessData, DefinedErrorData
 from opentrons.protocol_engine.commands.move_to_coordinates import (
     MoveToCoordinatesParams,
     MoveToCoordinatesResult,
@@ -16,26 +21,18 @@ from opentrons.protocol_engine.commands.move_to_coordinates import (
 )
 
 
+@pytest.fixture
+def subject(
+    movement: MovementHandler, model_utils: ModelUtils
+) -> MoveToCoordinatesImplementation:
+    """Build a command implementation with injected dependencies."""
+    return MoveToCoordinatesImplementation(movement=movement, model_utils=model_utils)
+
+
 async def test_move_to_coordinates_implementation(
-    decoy: Decoy,
-    state_view: StateView,
-    hardware_api: HardwareControlAPI,
-    movement: MovementHandler,
+    decoy: Decoy, movement: MovementHandler, subject: MoveToCoordinatesImplementation
 ) -> None:
-    """Test the `moveToCoordinates` implementation.
-
-    It should:
-
-    1. Query the hardware controller for the given pipette's current position
-       and how high it can go with its current tip.
-    2. Plan the movement, taking the above into account, plus the input parameters.
-    3. Iterate through the waypoints of the movement.
-    """
-    subject = MoveToCoordinatesImplementation(
-        state_view=state_view,
-        movement=movement,
-    )
-
+    """Test the `moveToCoordinates` implementation."""
     params = MoveToCoordinatesParams(
         pipetteId="pipette-id",
         coordinates=DeckPoint(x=1.11, y=2.22, z=3.33),
@@ -65,4 +62,43 @@ async def test_move_to_coordinates_implementation(
                 new_deck_point=DeckPoint(x=4.44, y=5.55, z=6.66),
             )
         ),
+    )
+
+
+async def test_move_to_coordinates_stall(
+    decoy: Decoy,
+    movement: MovementHandler,
+    model_utils: ModelUtils,
+    subject: MoveToCoordinatesImplementation,
+) -> None:
+    """It should handle stall errors."""
+    params = MoveToCoordinatesParams(
+        pipetteId="pipette-id",
+        coordinates=DeckPoint(x=1.11, y=2.22, z=3.33),
+        minimumZHeight=1234,
+        forceDirect=True,
+        speed=567.8,
+    )
+
+    decoy.when(
+        await movement.move_to_coordinates(
+            pipette_id="pipette-id",
+            deck_coordinates=DeckPoint(x=1.11, y=2.22, z=3.33),
+            direct=True,
+            additional_min_travel_z=1234,
+            speed=567.8,
+        )
+    ).then_raise(StallOrCollisionDetectedError())
+    test_id = "test-id"
+    timestamp = datetime.now()
+    decoy.when(model_utils.get_timestamp()).then_return(timestamp)
+    decoy.when(model_utils.generate_id()).then_return(test_id)
+
+    result = await subject.execute(params=params)
+
+    assert result == DefinedErrorData(
+        public=StallOrCollisionError.construct(
+            id=test_id, createdAt=timestamp, wrappedErrors=[matchers.Anything()]
+        ),
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -1,6 +1,11 @@
 """Test move to well commands."""
+
+from datetime import datetime
+
 import pytest
-from decoy import Decoy
+from decoy import Decoy, matchers
+
+from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 
 from opentrons.protocol_engine import (
     WellLocation,
@@ -12,13 +17,15 @@ from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.protocol_engine.state import update_types
 from opentrons.types import Point
 
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.command import SuccessData, DefinedErrorData
 from opentrons.protocol_engine.commands.move_to_well import (
     MoveToWellParams,
     MoveToWellResult,
     MoveToWellImplementation,
 )
+from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
 
 
 @pytest.fixture
@@ -27,13 +34,22 @@ def mock_state_view(decoy: Decoy) -> StateView:
     return decoy.mock(cls=StateView)
 
 
+@pytest.fixture
+def mock_model_utils(decoy: Decoy) -> ModelUtils:
+    """Get a mock ModelUtils."""
+    return decoy.mock(cls=ModelUtils)
+
+
 async def test_move_to_well_implementation(
     decoy: Decoy,
     state_view: StateView,
     movement: MovementHandler,
+    mock_model_utils: ModelUtils,
 ) -> None:
     """A MoveToWell command should have an execution implementation."""
-    subject = MoveToWellImplementation(state_view=state_view, movement=movement)
+    subject = MoveToWellImplementation(
+        state_view=state_view, movement=movement, model_utils=mock_model_utils
+    )
 
     data = MoveToWellParams(
         pipetteId="abc",
@@ -77,9 +93,12 @@ async def test_move_to_well_with_tip_rack_and_volume_offset(
     decoy: Decoy,
     mock_state_view: StateView,
     movement: MovementHandler,
+    mock_model_utils: ModelUtils,
 ) -> None:
     """It should disallow movement to a tip rack when volumeOffset is specified."""
-    subject = MoveToWellImplementation(state_view=mock_state_view, movement=movement)
+    subject = MoveToWellImplementation(
+        state_view=mock_state_view, movement=movement, model_utils=mock_model_utils
+    )
 
     data = MoveToWellParams(
         pipetteId="abc",
@@ -95,3 +114,52 @@ async def test_move_to_well_with_tip_rack_and_volume_offset(
 
     with pytest.raises(errors.LabwareIsTipRackError):
         await subject.execute(data)
+
+
+async def test_move_to_well_stall_defined_error(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    movement: MovementHandler,
+    mock_model_utils: ModelUtils,
+) -> None:
+    """It should catch StallOrCollisionError exceptions and make them DefinedErrors."""
+    error_id = "error-id"
+    error_timestamp = datetime(year=2020, month=1, day=2)
+    decoy.when(
+        movement.move_to_well(
+            pipette_id="abc",
+            labware_id="123",
+            well_name="A3",
+            well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+            force_direct=True,
+            minimum_z_height=4.56,
+            speed=7.89,
+            current_well=None,
+            operation_volume=None,
+        )
+    ).then_raise(StallOrCollisionDetectedError())
+    decoy.when(mock_model_utils.generate_id()).then_return(error_id)
+    decoy.when(mock_model_utils.get_timestamp()).then_return(error_timestamp)
+
+    subject = MoveToWellImplementation(
+        state_view=mock_state_view, movement=movement, model_utils=mock_model_utils
+    )
+
+    data = MoveToWellParams(
+        pipetteId="abc",
+        labwareId="123",
+        wellName="A3",
+        wellLocation=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+        forceDirect=True,
+        minimumZHeight=4.56,
+        speed=7.89,
+    )
+
+    result = await subject.execute(data)
+    assert isinstance(result, DefinedErrorData)
+    assert result == DefinedErrorData(
+        public=StallOrCollisionError.construct(
+            id=error_id, createdAt=error_timestamp, wrappedErrors=[matchers.Anything()]
+        ),
+        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
@@ -1,10 +1,12 @@
 """Test touch tip commands."""
+
 import pytest
 from decoy import Decoy
 
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.motion_planning import Waypoint
 from opentrons.protocol_engine import WellLocation, WellOffset, DeckPoint, errors
+from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.execution import MovementHandler, GantryMover
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
@@ -25,6 +27,12 @@ def mock_state_view(decoy: Decoy) -> StateView:
 
 
 @pytest.fixture
+def mock_model_utils(decoy: Decoy) -> ModelUtils:
+    """Get a mock ModelUtils."""
+    return decoy.mock(cls=ModelUtils)
+
+
+@pytest.fixture
 def mock_movement_handler(decoy: Decoy) -> MovementHandler:
     """Get a mock MovementHandler."""
     return decoy.mock(cls=MovementHandler)
@@ -41,12 +49,14 @@ def subject(
     mock_state_view: StateView,
     mock_movement_handler: MovementHandler,
     mock_gantry_mover: GantryMover,
+    mock_model_utils: ModelUtils,
 ) -> TouchTipImplementation:
     """Get the test subject."""
     return TouchTipImplementation(
         state_view=mock_state_view,
         movement=mock_movement_handler,
         gantry_mover=mock_gantry_mover,
+        model_utils=mock_model_utils,
     )
 
 


### PR DESCRIPTION
Commands that use `move_to_well`, `move_to_coordinates`,  `move_to_addressable_area`, and `move_relative` now will return stalls as DefinedErrors, which means they can be hooked into error recovery en masse.

This just leaves move labware.

Closes EXEC-831

## Reviews
- Feel like it paid off?

## Testing
- Do some stalls and make sure they end up with defined errors

## Further work and questions
- I think we should probably handle errors during `aspirate`'s automatic prepare for aspirate at the beginning and probably the same with drop tip but we didn't handle it at all so far so I don't know