### PR TITLE
fix(protocol-designer): incompatible tips modal copy update

### DIFF
--- a/protocol-designer/src/assets/localization/en/create_new_protocol.json
+++ b/protocol-designer/src/assets/localization/en/create_new_protocol.json
@@ -11,7 +11,7 @@
   "edit": "Edit",
   "fixtures_added": "Fixtures added",
   "fixtures_replace": "Fixtures replace standard deck slots and let you add functionality to your Flex.",
-  "incompatible_tip_body": "Using a pipette with an incompatible tip rack may result reduce pipette accuracy and collisions. We strongly recommend that you do not pair a pipette with an incompatible tip rack.",
+  "incompatible_tip_body": "Protocol Designer only accepts custom JSON labware definitions made with our Labware Creator. Upload a valid file to continue.",
   "incompatible_tips": "Incompatible tips",
   "labware_name": "Labware name",
   "left_right": "Left + Right",

--- a/protocol-designer/src/organisms/IncompatibleTipsModal/__tests__/IncompatibleTipsModal.test.tsx
+++ b/protocol-designer/src/organisms/IncompatibleTipsModal/__tests__/IncompatibleTipsModal.test.tsx
@@ -26,7 +26,7 @@ describe('IncompatibleTipsModal', () => {
     render(props)
     screen.getByText('Incompatible tips')
     screen.getByText(
-      'Using a pipette with an incompatible tip rack may result reduce pipette accuracy and collisions. We strongly recommend that you do not pair a pipette with an incompatible tip rack.'
+      'Protocol Designer only accepts custom JSON labware definitions made with our Labware Creator. Upload a valid file to continue.'
     )
     fireEvent.click(screen.getByText('Show more tip types'))
     expect(vi.mocked(setFeatureFlags)).toHaveBeenCalled()


### PR DESCRIPTION
closes RQA-3318

# Overview

Update copy in incompatible tips modal when uploading custom tips

## Test Plan and Hands on Testing

Just check that the copy matches what is in the ticket. You can also try to upload a bad JSON file as well to the flow when adding custom tips in the onboarding flow to trigger the modal

## Changelog

- update copy
- fix test

## Risk assessment

low
