### PR TITLE
fix(protocol-designer): fix spacing on starting deck title

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/StartingDeck.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/StartingDeck.tsx
@@ -47,7 +47,7 @@ export function StartingDeck({
   return (
     <>
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
-        <Flex gridGap="1.875rem" alignItems={ALIGN_CENTER}>
+        <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
           <StyledText desktopStyle="headingSmallBold">
             {t('starting_deck')}
           </StyledText>


### PR DESCRIPTION
# Overview

Fix grid gap between title and materials list link on protocol starting deck at ProtocolOverview

Closes RQA-3382

## Test Plan and Hands on Testing

verify 0.5rem spacing between protocol starting deck title and materials list link at ProtocolOverview
<img width="316" alt="Screenshot 2024-11-18 at 10 55 07 AM" src="https://github.com/user-attachments/assets/c2574e3e-df9d-4494-bb56-0e7bbb79bca1">

## Changelog

- fix gridGap

## Review requests

see test plan

## Risk assessment

lowest