### PR TITLE
fix(components, protocol-designer): fix toolbox and transfer tools styling

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -205,15 +205,11 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
     <Flex
       flexDirection={DIRECTION_COLUMN}
       ref={dropDownMenuWrapperRef}
-      gridGap={SPACING.spacing4}
+      gridGap={SPACING.spacing8}
       width={width}
     >
       {title !== null ? (
-        <Flex
-          gridGap={SPACING.spacing8}
-          paddingBottom={SPACING.spacing8}
-          alignItems={ALIGN_CENTER}
-        >
+        <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
           <StyledText
             desktopStyle="bodyDefaultRegular"
             color={disabled ? COLORS.grey35 : COLORS.grey60}

--- a/components/src/organisms/Toolbox/index.tsx
+++ b/components/src/organisms/Toolbox/index.tsx
@@ -25,6 +25,7 @@ export interface ToolboxProps {
   closeButton?: JSX.Element
   side?: 'left' | 'right'
   horizontalSide?: 'top' | 'bottom'
+  titlePadding?: string
   childrenPadding?: string
   subHeader?: JSX.Element | null
   secondaryHeaderButton?: JSX.Element
@@ -45,6 +46,7 @@ export function Toolbox(props: ToolboxProps): JSX.Element {
     side = 'right',
     horizontalSide = 'bottom',
     confirmButton,
+    titlePadding = SPACING.spacing16,
     childrenPadding = SPACING.spacing16,
     subHeader,
     secondaryHeaderButton,
@@ -97,7 +99,7 @@ export function Toolbox(props: ToolboxProps): JSX.Element {
         justifyContent={JUSTIFY_SPACE_BETWEEN}
       >
         <Flex
-          padding={`${SPACING.spacing20} ${SPACING.spacing16}`}
+          padding={titlePadding}
           flexDirection={DIRECTION_COLUMN}
           borderBottom={`1px solid ${COLORS.grey30}`}
         >

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -133,6 +133,7 @@
     }
   },
   "time": "Time",
+  "timeline": "Timeline",
   "tiprack": "Tiprack",
   "tip_handling": "Tip handling",
   "tip_position": "{{prefix}} tip position",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubstepsToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubstepsToolbox.tsx
@@ -5,7 +5,6 @@ import {
   Flex,
   Icon,
   PrimaryButton,
-  SPACING,
   StyledText,
   Toolbox,
 } from '@opentrons/components'
@@ -62,7 +61,6 @@ export function SubstepsToolbox(
     substeps.substepType === THERMOCYCLER_PROFILE ? (
     <Toolbox
       width={FLEX_MAX_CONTENT}
-      childrenPadding="0"
       closeButton={<Icon size="2rem" name="close" />}
       onCloseClick={handleClose}
       confirmButton={
@@ -81,7 +79,7 @@ export function SubstepsToolbox(
         </StyledText>
       }
     >
-      <Flex padding={SPACING.spacing12}>
+      <Flex>
         {substeps.substepType === THERMOCYCLER_PROFILE ? (
           <ThermocyclerProfileSubsteps key="substeps" stepId={stepId} />
         ) : (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -66,6 +66,8 @@ export const TimelineToolbox = (): JSX.Element => {
           {t('protocol_timeline')}
         </StyledText>
       }
+      titlePadding={SPACING.spacing12}
+      childrenPadding={SPACING.spacing12}
       confirmButton={formData != null ? undefined : <AddStepButton />}
     >
       <Flex

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -63,7 +63,7 @@ export const TimelineToolbox = (): JSX.Element => {
       width="19.5rem"
       title={
         <StyledText desktopStyle="bodyLargeSemiBold">
-          {t('protocol_timeline')}
+          {t('timeline')}
         </StyledText>
       }
       titlePadding={SPACING.spacing12}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/TimelineToolbox.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/TimelineToolbox.test.tsx
@@ -36,7 +36,7 @@ describe('TimelineToolbox', () => {
   })
   it('renders 2 terminal item steps, a draggable step and presaved step with toolbox title', () => {
     render()
-    screen.getByText('Protocol timeline')
+    screen.getByText('Timeline')
     screen.getByText('mock AddStepButton')
     screen.getByText('mock PresavedStep')
     screen.getByText('mock DraggableSteps')


### PR DESCRIPTION
# Overview

Add title padding prop to toolbox and set default. Fix shared DropdownMenu component spacing between title and dropdown

Closes RQA-3414

## Test Plan and Hands on Testing

- open any step form toolbox and verify 16px padding around title and children
- inspect timeline toolbox and verify 12px padding around title and children, and that title reads "Timeline" rather than "Protocol Timeline"
- inspect step details for move liquid or thermocycler step and verify 16px padding around title and children
 
## Changelog

- fix timeline padding
- fix dropdown padding
- update timeline toolbox copy

## Review requests

- see test plan

## Risk assessment

low