### PR TITLE
fix(api): Must home as a defined error

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -12,6 +12,7 @@ from .pipetting_common import (
     OverpressureError,
     LiquidNotFoundError,
     TipPhysicallyAttachedError,
+    MustHomeError,
 )
 
 from . import absorbance_reader
@@ -709,6 +710,7 @@ CommandResult = Union[
 CommandDefinedErrorData = Union[
     DefinedErrorData[TipPhysicallyMissingError],
     DefinedErrorData[TipPhysicallyAttachedError],
+    DefinedErrorData[MustHomeError],
     DefinedErrorData[OverpressureError],
     DefinedErrorData[LiquidNotFoundError],
     DefinedErrorData[GripperMovementError],

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -45,9 +45,8 @@ class DropTipInPlaceResult(BaseModel):
 
 _ExecuteReturn = (
     SuccessData[DropTipInPlaceResult]
-    | Union[
-        DefinedErrorData[TipPhysicallyAttachedError], DefinedErrorData[MustHomeError]
-    ]
+    | DefinedErrorData[TipPhysicallyAttachedError]
+    | DefinedErrorData[MustHomeError]
 )
 
 
@@ -102,7 +101,7 @@ class DropTipInPlaceImplementation(
         except pe_MustHomeError as exception:
             state_update_if_false_positive = update_types.StateUpdate()
             state_update_if_false_positive.clear_all_pipette_locations()
-            error = MustHomeError(
+            home_error = MustHomeError(
                 id=self._model_utils.generate_id(),
                 createdAt=self._model_utils.get_timestamp(),
                 wrappedErrors=[
@@ -114,7 +113,7 @@ class DropTipInPlaceImplementation(
                 ],
             )
             return DefinedErrorData(
-                public=error,
+                public=home_error,
                 state_update=state_update,
                 state_update_if_false_positive=state_update_if_false_positive,
             )
@@ -126,7 +125,11 @@ class DropTipInPlaceImplementation(
 
 
 class DropTipInPlace(
-    BaseCommand[DropTipInPlaceParams, DropTipInPlaceResult, TipPhysicallyAttachedError]
+    BaseCommand[
+        DropTipInPlaceParams,
+        DropTipInPlaceResult,
+        TipPhysicallyAttachedError | MustHomeError,
+    ]
 ):
     """Drop tip in place command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -189,7 +189,7 @@ class MustHomeError(ErrorOccurrence):
 
     isDefined: bool = True
 
-    errorType: Literal["mustHome"] = "mustHome"
+    errorType: Literal["MustHomeError"] = "MustHomeError"
 
     errorCode: str = ErrorCodes.MUST_HOME_ERROR.value.code
     detail: str = ErrorCodes.MUST_HOME_ERROR.value.detail

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -190,11 +190,10 @@ class MustHomeError(ErrorOccurrence):
 
     isDefined: bool = True
 
-    errorType: Literal["musthome"] = "musthome"
+    errorType: Literal["mustHome"] = "mustHome"
 
-    # TODO(tz, 15-11-2024): should add a MUST_HOME error code?
-    errorCode: str = ErrorCodes.POSITION_UNKNOWN.value.code
-    detail: str = ErrorCodes.POSITION_UNKNOWN.value.detail
+    errorCode: str = ErrorCodes.MUST_HOME_ERROR.value.code
+    detail: str = ErrorCodes.MUST_HOME_ERROR.value.detail
 
 
 class LiquidNotFoundError(ErrorOccurrence):

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -179,13 +179,12 @@ class OverpressureError(ErrorOccurrence):
 
 
 class MustHomeError(ErrorOccurrence):
-    """Returned when sensors detect an overpressure error while moving liquid.
+    """Returned when the plunger position is unknown.
 
     The pipette plunger motion is stopped at the point of the error.
 
     The next thing to move the plunger must account for the robot not having a valid
-    estimate of its position. It should be a `home`, `unsafe/updatePositionEstimators`,
-    `unsafe/dropTipInPlace`, or `unsafe/blowOutInPlace`.
+    estimate of its position. It should be a `home`.
     """
 
     isDefined: bool = True

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -178,6 +178,25 @@ class OverpressureError(ErrorOccurrence):
     errorInfo: ErrorLocationInfo
 
 
+class MustHomeError(ErrorOccurrence):
+    """Returned when sensors detect an overpressure error while moving liquid.
+
+    The pipette plunger motion is stopped at the point of the error.
+
+    The next thing to move the plunger must account for the robot not having a valid
+    estimate of its position. It should be a `home`, `unsafe/updatePositionEstimators`,
+    `unsafe/dropTipInPlace`, or `unsafe/blowOutInPlace`.
+    """
+
+    isDefined: bool = True
+
+    errorType: Literal["musthome"] = "musthome"
+
+    # TODO(tz, 15-11-2024): should add a MUST_HOME error code?
+    errorCode: str = ErrorCodes.POSITION_UNKNOWN.value.code
+    detail: str = ErrorCodes.POSITION_UNKNOWN.value.detail
+
+
 class LiquidNotFoundError(ErrorOccurrence):
     """Returned when no liquid is detected during the liquid probe process/move.
 

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -130,6 +130,10 @@
       "detail": "Tip Hit Well Bottom",
       "category": "roboticsControlError"
     },
+    "2019": {
+      "detail": "Must Home Plunger",
+      "category": "roboticsControlError"
+    },
     "3000": {
       "detail": "A robotics interaction error occurred.",
       "category": "roboticsInteractionError"

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -62,6 +62,7 @@ class ErrorCodes(Enum):
     MOTOR_DRIVER_ERROR = _code_from_dict_entry("2016")
     PIPETTE_LIQUID_NOT_FOUND = _code_from_dict_entry("2017")
     TIP_HIT_WELL_BOTTOM = _code_from_dict_entry("2018")
+    MUST_HOME_ERROR = _code_from_dict_entry("2019")
     ROBOTICS_INTERACTION_ERROR = _code_from_dict_entry("3000")
     LABWARE_DROPPED = _code_from_dict_entry("3001")
     LABWARE_NOT_PICKED_UP = _code_from_dict_entry("3002")
@@ -93,7 +94,6 @@ class ErrorCodes(Enum):
     MISSING_CONFIGURATION_DATA = _code_from_dict_entry("4009")
     RUNTIME_PARAMETER_VALUE_REQUIRED = _code_from_dict_entry("4010")
     INCORRECT_API_VERSION = _code_from_dict_entry("4011")
-    MUST_HOME_ERROR = _code_from_dict_entry("4012")
 
     @classmethod
     @lru_cache(25)

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -93,6 +93,7 @@ class ErrorCodes(Enum):
     MISSING_CONFIGURATION_DATA = _code_from_dict_entry("4009")
     RUNTIME_PARAMETER_VALUE_REQUIRED = _code_from_dict_entry("4010")
     INCORRECT_API_VERSION = _code_from_dict_entry("4011")
+    MUST_HOME_ERROR = _code_from_dict_entry("4012")
 
     @classmethod
     @lru_cache(25)


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-3583.
make a MustHomeError as a defined error.

## Test Plan and Hands on Testing

in the jira ticket.

## Changelog

catch the must home error and raise a defined must home error (FE is expecting a MustHomeError type).

## Review requests

- I wanted this to match https://github.com/Opentrons/opentrons/pull/16861/files but its injecting the model_utils in a bunch of new places. thoughts? 
- what about other errors that catch this exception? 

## Risk assessment

low. bug fix - just for drop tip in place for now. 
