### PR TITLE
fix(app): Fix `failedCommand` caching issues

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useCurrentlyRecoveringFrom.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useCurrentlyRecoveringFrom.test.ts
@@ -42,9 +42,11 @@ describe('useCurrentlyRecoveringFrom', () => {
           },
         },
       },
+      isFetching: false,
     } as any)
     vi.mocked(useCommandQuery).mockReturnValue({
       data: { data: 'mockCommandDetails' },
+      isFetching: false,
     } as any)
 
     const { result } = renderHook(() =>
@@ -69,8 +71,11 @@ describe('useCurrentlyRecoveringFrom', () => {
       data: {
         links: {},
       },
+      isFetching: false,
     } as any)
-    vi.mocked(useCommandQuery).mockReturnValue({} as any)
+    vi.mocked(useCommandQuery).mockReturnValue({
+      isFetching: false,
+    } as any)
 
     const { result } = renderHook(() =>
       useCurrentlyRecoveringFrom(MOCK_RUN_ID, RUN_STATUS_AWAITING_RECOVERY)
@@ -94,9 +99,11 @@ describe('useCurrentlyRecoveringFrom', () => {
           },
         },
       },
+      isFetching: false,
     } as any)
     vi.mocked(useCommandQuery).mockReturnValue({
       data: { data: 'mockCommandDetails' },
+      isFetching: false,
     } as any)
 
     const { result } = renderHook(() =>
@@ -109,6 +116,91 @@ describe('useCurrentlyRecoveringFrom', () => {
       { enabled: true }
     )
     expect(result.current).toStrictEqual('mockCommandDetails')
+  })
+
+  it('returns null if all commands query is still fetching', () => {
+    vi.mocked(useNotifyAllCommandsQuery).mockReturnValue({
+      data: {
+        links: {
+          currentlyRecoveringFrom: {
+            meta: {
+              runId: MOCK_RUN_ID,
+              commandId: MOCK_COMMAND_ID,
+            },
+          },
+        },
+      },
+      isFetching: true,
+    } as any)
+    vi.mocked(useCommandQuery).mockReturnValue({
+      data: { data: 'mockCommandDetails' },
+      isFetching: false,
+    } as any)
+
+    const { result } = renderHook(() =>
+      useCurrentlyRecoveringFrom(MOCK_RUN_ID, RUN_STATUS_AWAITING_RECOVERY)
+    )
+
+    expect(result.current).toStrictEqual(null)
+  })
+
+  it('returns null if command query is still fetching', () => {
+    vi.mocked(useNotifyAllCommandsQuery).mockReturnValue({
+      data: {
+        links: {
+          currentlyRecoveringFrom: {
+            meta: {
+              runId: MOCK_RUN_ID,
+              commandId: MOCK_COMMAND_ID,
+            },
+          },
+        },
+      },
+      isFetching: false,
+    } as any)
+    vi.mocked(useCommandQuery).mockReturnValue({
+      data: { data: 'mockCommandDetails' },
+      isFetching: true,
+    } as any)
+
+    const { result } = renderHook(() =>
+      useCurrentlyRecoveringFrom(MOCK_RUN_ID, RUN_STATUS_AWAITING_RECOVERY)
+    )
+
+    expect(result.current).toStrictEqual(null)
+  })
+
+  it('resets isReadyToShow when run exits recovery mode', () => {
+    const { rerender, result } = renderHook(
+      ({ status }) => useCurrentlyRecoveringFrom(MOCK_RUN_ID, status),
+      { initialProps: { status: RUN_STATUS_AWAITING_RECOVERY } }
+    )
+
+    vi.mocked(useNotifyAllCommandsQuery).mockReturnValue({
+      data: {
+        links: {
+          currentlyRecoveringFrom: {
+            meta: {
+              runId: MOCK_RUN_ID,
+              commandId: MOCK_COMMAND_ID,
+            },
+          },
+        },
+      },
+      isFetching: false,
+    } as any)
+    vi.mocked(useCommandQuery).mockReturnValue({
+      data: { data: 'mockCommandDetails' },
+      isFetching: false,
+    } as any)
+
+    rerender({ status: RUN_STATUS_AWAITING_RECOVERY })
+
+    expect(result.current).toStrictEqual('mockCommandDetails')
+
+    rerender({ status: RUN_STATUS_IDLE } as any)
+
+    expect(result.current).toStrictEqual(null)
   })
 
   it('calls invalidateQueries when the run enters recovery mode', () => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useQueryClient } from 'react-query'
 
 import {
@@ -23,13 +23,15 @@ const VALID_RECOVERY_FETCH_STATUSES = [
 ] as Array<RunStatus | null>
 
 // Return the `currentlyRecoveringFrom` command returned by the server, if any.
-// Otherwise, returns null.
+// The command will only be returned after the initial fetches are complete to prevent rendering of stale data.
 export function useCurrentlyRecoveringFrom(
   runId: string,
   runStatus: RunStatus | null
 ): FailedCommand | null {
   const queryClient = useQueryClient()
   const host = useHost()
+  const [isReadyToShow, setIsReadyToShow] = useState(false)
+
   // There can only be a currentlyRecoveringFrom command when the run is in recovery mode.
   // In case we're falling back to polling, only enable queries when that is the case.
   const isRunInRecoveryMode = VALID_RECOVERY_FETCH_STATUSES.includes(runStatus)
@@ -38,10 +40,15 @@ export function useCurrentlyRecoveringFrom(
   useEffect(() => {
     if (isRunInRecoveryMode) {
       void queryClient.invalidateQueries([host, 'runs', runId])
+    } else {
+      setIsReadyToShow(false)
     }
   }, [isRunInRecoveryMode, host, runId])
 
-  const { data: allCommandsQueryData } = useNotifyAllCommandsQuery(
+  const {
+    data: allCommandsQueryData,
+    isFetching: isAllCommandsFetching,
+  } = useNotifyAllCommandsQuery(
     runId,
     { cursor: null, pageLength: 0 }, // pageLength 0 because we only care about the links.
     {
@@ -54,7 +61,10 @@ export function useCurrentlyRecoveringFrom(
 
   // TODO(mm, 2024-05-21): When the server supports fetching the
   // currentlyRecoveringFrom command in one step, do that instead of this chained query.
-  const { data: commandQueryData } = useCommandQuery(
+  const {
+    data: commandQueryData,
+    isFetching: isCommandFetching,
+  } = useCommandQuery(
     currentlyRecoveringFromLink?.meta.runId ?? null,
     currentlyRecoveringFromLink?.meta.commandId ?? null,
     {
@@ -62,5 +72,25 @@ export function useCurrentlyRecoveringFrom(
     }
   )
 
-  return isRunInRecoveryMode ? commandQueryData?.data ?? null : null
+  // Only mark as ready to show when waterfall fetches are complete
+  useEffect(() => {
+    if (
+      isRunInRecoveryMode &&
+      !isAllCommandsFetching &&
+      !isCommandFetching &&
+      !isReadyToShow
+    ) {
+      setIsReadyToShow(true)
+    }
+  }, [
+    isRunInRecoveryMode,
+    isAllCommandsFetching,
+    isCommandFetching,
+    isReadyToShow,
+  ])
+
+  const shouldShowCommand =
+    isRunInRecoveryMode && isReadyToShow && commandQueryData?.data
+
+  return shouldShowCommand ? commandQueryData.data : null
 }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 
 import { useRouteUpdateActions } from './useRouteUpdateActions'
@@ -13,12 +15,12 @@ import {
 } from '/app/resources/runs'
 import { useRecoveryOptionCopy } from './useRecoveryOptionCopy'
 import { useRecoveryActionMutation } from './useRecoveryActionMutation'
-import { useRunningStepCounts } from '/app/resources/protocols/hooks'
 import { useRecoveryToasts } from './useRecoveryToasts'
 import { useRecoveryAnalytics } from '/app/redux-resources/analytics'
 import { useShowDoorInfo } from './useShowDoorInfo'
 import { useCleanupRecoveryState } from './useCleanupRecoveryState'
 import { useFailedPipetteUtils } from './useFailedPipetteUtils'
+import { getRunningStepCountsFrom } from '/app/resources/protocols'
 
 import type {
   LabwareDefinition2,
@@ -102,7 +104,14 @@ export function useERUtils({
     pageLength: 999,
   })
 
-  const stepCounts = useRunningStepCounts(runId, runCommands)
+  const stepCounts = useMemo(
+    () =>
+      getRunningStepCountsFrom(
+        protocolAnalysis?.commands ?? [],
+        failedCommand?.byRunRecord ?? null
+      ),
+    [protocolAnalysis != null, failedCommand]
+  )
 
   const analytics = useRecoveryAnalytics()
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRetainedFailedCommandBySource.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRetainedFailedCommandBySource.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useLayoutEffect } from 'react'
 
 import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { ErrorRecoveryFlowsProps } from '..'
@@ -27,7 +27,7 @@ export function useRetainedFailedCommandBySource(
     setRetainedFailedCommand,
   ] = useState<FailedCommandBySource | null>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (failedCommandByRunRecord !== null) {
       const failedCommandByAnalysis =
         protocolAnalysis?.commands.find(

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -74,8 +74,8 @@ export function useErrorRecoveryFlows(
   const isValidERStatus = (status: RunStatus | null): boolean => {
     return (
       status !== null &&
-      VALID_ER_RUN_STATUSES.includes(status) &&
-      (status === RUN_STATUS_AWAITING_RECOVERY || hasSeenAwaitingRecovery)
+      (status === RUN_STATUS_AWAITING_RECOVERY ||
+        (VALID_ER_RUN_STATUSES.includes(status) && hasSeenAwaitingRecovery))
     )
   }
 

--- a/app/src/resources/protocols/hooks/useRunningStepCounts.ts
+++ b/app/src/resources/protocols/hooks/useRunningStepCounts.ts
@@ -3,6 +3,7 @@ import { useMostRecentCompletedAnalysis } from '/app/resources/runs'
 import { useLastRunProtocolCommand } from './useLastRunProtocolCommand'
 
 import type { CommandsData } from '@opentrons/api-client'
+import { getRunningStepCountsFrom } from '/app/resources/protocols'
 
 export interface StepCounts {
   /* Excludes "fixit" commands. Returns null if the step is not found. */
@@ -35,21 +36,5 @@ export function useRunningStepCounts(
     commandsData ?? null
   )
 
-  const lastRunAnalysisCommandIndex = analysisCommands.findIndex(
-    c => c.key === lastRunCommandNoFixit?.key
-  )
-
-  const currentStepNumberByAnalysis =
-    lastRunAnalysisCommandIndex === -1 ? null : lastRunAnalysisCommandIndex + 1
-
-  const hasRunDiverged =
-    lastRunCommandNoFixit?.key == null || currentStepNumberByAnalysis == null
-
-  const totalStepCount = !hasRunDiverged ? analysisCommands.length : null
-
-  return {
-    currentStepNumber: currentStepNumberByAnalysis,
-    totalStepCount,
-    hasRunDiverged,
-  }
+  return getRunningStepCountsFrom(analysisCommands, lastRunCommandNoFixit)
 }

--- a/app/src/resources/protocols/utils.ts
+++ b/app/src/resources/protocols/utils.ts
@@ -1,4 +1,6 @@
 import type { RunTimeCommand } from '@opentrons/shared-data'
+import type { RunCommandSummary } from '@opentrons/api-client'
+import type { StepCounts } from '/app/resources/protocols/hooks'
 
 export function isGripperInCommands(commands: RunTimeCommand[]): boolean {
   return (
@@ -7,4 +9,28 @@ export function isGripperInCommands(commands: RunTimeCommand[]): boolean {
         c.commandType === 'moveLabware' && c.params.strategy === 'usingGripper'
     ) ?? false
   )
+}
+
+// See useRunningStepCounts.
+export function getRunningStepCountsFrom(
+  analysisCommands: RunTimeCommand[],
+  lastRunProtocolCommand: RunCommandSummary | null
+): StepCounts {
+  const lastRunAnalysisCommandIndex = analysisCommands.findIndex(
+    c => c.key === lastRunProtocolCommand?.key
+  )
+
+  const currentStepNumberByAnalysis =
+    lastRunAnalysisCommandIndex === -1 ? null : lastRunAnalysisCommandIndex + 1
+
+  const hasRunDiverged =
+    lastRunProtocolCommand?.key == null || currentStepNumberByAnalysis == null
+
+  const totalStepCount = !hasRunDiverged ? analysisCommands.length : null
+
+  return {
+    currentStepNumber: currentStepNumberByAnalysis,
+    totalStepCount,
+    hasRunDiverged,
+  }
 }


### PR DESCRIPTION
Closes [RABR-671](https://opentrons.atlassian.net/browse/RABR-671), [RQA-3213](https://opentrons.atlassian.net/browse/RQA-3213), and [RQA-3595](https://opentrons.atlassian.net/browse/RQA-3595)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes rendering issues resulting from state derived from the `failedCommand`, supplied from `useCurrentlyRecoveringFrom`, a waterfall request hook.

3a6726985c201d4740e353eee872dccee3576595 - No "functional" changes here. Error Recovery once in a blue moon persisting past the point that is should is almost certainly a result of race conditions that occur given multiple state updates happening in sequence. Let's just confine things to `useEffects` properly and simplify the logic a bit. 

a0e0330f3ac7f17da5d160e7abcf21928c877270 - Since it sounds like we view the error recovery splash flickering as a bug, we should gate error recovery behind insurances that the waterfall requests are completed. The normal React Query pattern for doing this is utilizing the `isFetching` status, so we need to amalgamate our requests' `isFetching` statuses together and make sure we only gate the condition behind the first time we enter Error Recovery (since it's possible to continually fetch during Error Recovery if polling conditions occur). 

8f953a4f4757a380d7955d9d8978691ad8ffd840 - This is just an optimization. We actually can avoid a couple network requests during Error Recovery to get `stepCounts`, since we already have that data. 

Note: I intentionally did not gate the "At step: ..." copy updating from preventing Error Recovery to render, since this is a command scanning operation, and it could take a while. If we want prevent this updating after the splash screen renders, we should tackle this server side IMO.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran various Error Recovery protocols, ensuring that there is no "flickering" when Error Recovery begins. If a second, different error populates the splash page, it does not cause a screen flicker, too.
- Ensured that doing things like cancelling the run during Error Recovery persist the Error Recovery modal as expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed Error Recovery "flickering" with the incorrect error type at initial render.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low - We're well covered by existing tests, and the new `isFetching` logic is pretty innocuous.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RABR-671]: https://opentrons.atlassian.net/browse/RABR-671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-3213]: https://opentrons.atlassian.net/browse/RQA-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-3595]: https://opentrons.atlassian.net/browse/RQA-3595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ