### PR TITLE
fix(protocol-designer): fix disposal volume settings

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -69,7 +69,7 @@
     "consolidate_disposal": "<text>Consolidating</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destination}}</semiBoldText>",
     "transfer_disposal": "<text>Transferring</text><tag/><text>from</text><semiBoldText>{{sourceWells}} of {{source}}</semiBoldText><text>to</text><semiBoldText>{{destination}}</semiBoldText>"
   },
-  "multi_dispense_options": "Distribute options",
+  "multi_dispense_options": "Disposal volume",
   "multiAspirate": "Consolidate path",
   "multiDispense": "Distribute path",
   "new_location": "New location",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DisposalField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DisposalField.tsx
@@ -100,6 +100,7 @@ export function DisposalField(props: DisposalFieldProps): JSX.Element {
             pipetteId={pipette}
             flowRateType="blowout"
             volume={propsForFields.volume?.value ?? 0}
+            padding="0"
             tiprack={propsForFields.tipRack.value}
           />
           <BlowoutOffsetField


### PR DESCRIPTION
# Overview

In transfer toolbox multi-dispense advanced settings, fix copy and padding for disposal volume.

## Test Plan and Hands on Testing

- create or edit a transfer step with distribute path
- navigate to dispense advanced settings in toolbox
- verify that disposal volume settings match designs (consistent padding and correct title copy)

before fix:
<img width="300" alt="Screenshot 2024-11-18 at 4 52 21 PM" src="https://github.com/user-attachments/assets/e4f2078b-6fbc-4701-9e3a-9d4fb6b4a33d">

after fix:
<img width="316" alt="Screenshot 2024-11-18 at 4 50 57 PM" src="https://github.com/user-attachments/assets/e3fb23a6-c254-4dbf-84f0-f9ea93df64d5">

## Changelog

- fix padding on FlowRateField
- fix copy

## Review requests

- see test plan

## Risk assessment

low