### PR TITLE
fix(api): add 10s delay after updating the plate reader to give time to boot-up.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/absorbance_reader.py
+++ b/api/src/opentrons/hardware_control/modules/absorbance_reader.py
@@ -312,6 +312,8 @@ class AbsorbanceReader(mod_abc.AbstractModule):
         log.debug(f"Updating {self.name}: {self.port} with {firmware_file_path}")
         self._updating = True
         success, res = await self._driver.update_firmware(firmware_file_path)
+        # it takes time for the plate reader to re-init after an update.
+        await asyncio.sleep(10)
         self._device_info = await self._driver.get_device_info()
         await self._poller.start()
         self._updating = False


### PR DESCRIPTION
# Overview

The new plate reader firmware takes longer for the device to boot up after an update, even after the `update_firmware` command returns. When we get the device information with `self._driver.get_device_info()`, it can sometimes lead to an error because the device has not finished booting up. Although the update goes through, it leaves the system in a bad state, so, let's add a 10-second delay after the `update_firmware` returns so we can account for this issue.

## Test Plan and Hands on Testing

- [x] Make sure we can update PVT plate readers from `7 -> 8` 10 times in a row

## Changelog

- add 10s delay after updating the plate reader to give time for the device to boot up

## Review requests
## Risk assessment
low, unreleased