### PR TITLE
fix(app): fix estimator update command failure copy during drop tip

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/hooks/__tests__/errors.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/__tests__/errors.test.tsx
@@ -29,9 +29,9 @@ describe('useDropTipCommandErrors', () => {
 
     act(() => {
       result.current({
-        runCommandError: {
-          errorType: DROP_TIP_SPECIAL_ERROR_TYPES.MUST_HOME_ERROR,
-        } as any,
+        type: DROP_TIP_SPECIAL_ERROR_TYPES.MUST_HOME_ERROR,
+        message: 'remove_the_tips_manually',
+        header: 'cant_safely_drop_tips',
       })
     })
 

--- a/app/src/organisms/DropTipWizardFlows/hooks/errors.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/errors.tsx
@@ -9,8 +9,7 @@ import type { RunCommandError } from '@opentrons/shared-data'
 import type { ErrorDetails } from '../types'
 
 export interface SetRobotErrorDetailsParams {
-  runCommandError?: RunCommandError
-  message?: string
+  message: string | null
   header?: string
   type?: RunCommandError['errorType']
 }
@@ -23,16 +22,8 @@ export function useDropTipCommandErrors(
 ): (cbProps: SetRobotErrorDetailsParams) => void {
   const { t } = useTranslation('drop_tip_wizard')
 
-  return ({
-    runCommandError,
-    message,
-    header,
-    type,
-  }: SetRobotErrorDetailsParams) => {
-    if (
-      runCommandError?.errorType ===
-      DROP_TIP_SPECIAL_ERROR_TYPES.MUST_HOME_ERROR
-    ) {
+  return ({ message, header, type }: SetRobotErrorDetailsParams) => {
+    if (type === DROP_TIP_SPECIAL_ERROR_TYPES.MUST_HOME_ERROR) {
       const headerText = t('cant_safely_drop_tips')
       const messageText = t('remove_the_tips_manually')
 


### PR DESCRIPTION
Closes [RQA-3583](https://opentrons.atlassian.net/browse/RQA-3583)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Currently, the app inspects an `errorType` on a failed drop tip command to determine whether to throw the special case "home the gantry" error modal. Recently, the error type changed for failed update estimator commands, so the special modal was broken. Instead of special-casing the errorType for failed estimator commands, let's just assume that any failed estimator command is caused by an unknown position error and pop the special modal.

Note that this also handles any error in the same manner with a "MustHomeError" errorType, too.

<img width="772" alt="Screenshot 2024-11-19 at 10 39 06 AM" src="https://github.com/user-attachments/assets/b114ea9b-1271-4c6f-8dfb-fbb8c974a966">

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Tested the following:
- [x] Drop tip flows work as expected outside of ER.
- [x] Drop tip flows work as expected in ER.
- [x] Throwing any non-estimator error shows the correct error modal during blowout.
- [x] Throwing any non-estimator error shows the correct error modal during move to addressable area.
- [x] Throwing any non-estimator error pops the correct error modal during error recovery.
- [x] The special error modal is shown when position is unknown during a move to addressable area command.

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The "must home" error modal correctly displays during drop tip wizard.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish. This is just a refactor with quasi-monkey patching of the `error` object.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3583]: https://opentrons.atlassian.net/browse/RQA-3583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ