### PR TITLE
fix(api): update motor position before homing

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -776,7 +776,7 @@ class OT3API(
         """
         Function to update motor estimation for a set of axes
         """
-
+        await self._backend.update_motor_status()
         if axes:
             checked_axes = [ax for ax in axes if ax in Axis]
         else:
@@ -1587,7 +1587,6 @@ class OT3API(
 
     async def _home(self, axes: Sequence[Axis]) -> None:
         """Home one axis at a time."""
-        await self._backend.update_motor_status()
         for axis in axes:
             try:
                 if axis == Axis.G:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1587,6 +1587,7 @@ class OT3API(
 
     async def _home(self, axes: Sequence[Axis]) -> None:
         """Home one axis at a time."""
+        await self._backend.update_motor_status()
         for axis in axes:
             try:
                 if axis == Axis.G:


### PR DESCRIPTION
# Overview

fix for part of https://opentrons.atlassian.net/browse/RQA-3576.

## Test Plan and Hands on Testing

move the gantry before homing and then home the whole gantry. 
then move the gantry again and home again. 

## Changelog

update motor status in _update_position_estimation

## Risk assessment

low? 
