### PR TITLE
fix(app): Fix post run drop tip wizard always displaying after error recovery

### DIFF
--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -1,8 +1,8 @@
 import type { RunTimeCommand, RunCommandError } from '@opentrons/shared-data'
 
 export interface GetCommandsParams {
-  cursor: number | null // the index of the command at the center of the window
   pageLength: number // the number of items to include
+  cursor?: number
 }
 
 export interface GetRunCommandsParams extends GetCommandsParams {
@@ -10,7 +10,7 @@ export interface GetRunCommandsParams extends GetCommandsParams {
 }
 
 export interface GetRunCommandsParamsRequest extends GetCommandsParams {
-  includeFixitCommands: boolean | null
+  includeFixitCommands?: boolean
 }
 
 export interface RunCommandErrors {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -132,6 +132,7 @@ export function useActionButtonProperties({
     handleButtonClick = () => {
       isResetRunLoadingRef.current = true
       reset()
+      runHeaderModalContainerUtils.dropTipUtils.resetTipStatus()
       trackEvent({
         name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
         properties: { sourceLocation: 'RunRecordDetail', robotSerialNumber },

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
@@ -22,6 +22,7 @@ import type { Run, RunStatus } from '@opentrons/api-client'
 import type {
   DropTipWizardFlowsProps,
   PipetteWithTip,
+  TipAttachmentStatusResult,
 } from '/app/organisms/DropTipWizardFlows'
 import type { UseProtocolDropTipModalResult } from '../modals'
 import type { PipetteDetails } from '/app/resources/maintenance_runs'
@@ -40,6 +41,7 @@ export interface UseRunHeaderDropTipParams {
 export interface UseRunHeaderDropTipResult {
   dropTipModalUtils: UseProtocolDropTipModalResult
   dropTipWizardUtils: RunHeaderDropTipWizProps
+  resetTipStatus: TipAttachmentStatusResult['resetTipStatus']
 }
 
 // Handles all the tip related logic during a protocol run on the desktop app.
@@ -111,11 +113,9 @@ export function useRunHeaderDropTip({
     {
       includeFixitCommands: false,
       pageLength: 1,
-      cursor: null,
     },
     { enabled: isTerminalRunStatus(runStatus) }
   )
-
   // Manage tip checking
   useEffect(() => {
     // If a user begins a new run without navigating away from the run page, reset tip status.
@@ -127,7 +127,9 @@ export function useRunHeaderDropTip({
       // have to do it here if done during Error Recovery.
       else if (
         runSummaryNoFixit != null &&
-        !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit)
+        runSummaryNoFixit.length > 0 &&
+        !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit) &&
+        isTerminalRunStatus(runStatus)
       ) {
         void determineTipStatus()
       }
@@ -150,7 +152,11 @@ export function useRunHeaderDropTip({
     }
   }, [runStatus, isRunCurrent, enteredER, initialPipettesWithTipsCount])
 
-  return { dropTipModalUtils, dropTipWizardUtils: buildDTWizUtils() }
+  return {
+    dropTipModalUtils,
+    dropTipWizardUtils: buildDTWizUtils(),
+    resetTipStatus,
+  }
 }
 
 // TODO(jh, 09-12-24): Consolidate this with the same utility that exists elsewhere.

--- a/app/src/organisms/Desktop/Devices/hooks/useDownloadRunLog.ts
+++ b/app/src/organisms/Desktop/Devices/hooks/useDownloadRunLog.ts
@@ -27,7 +27,6 @@ export function useDownloadRunLog(
     if (host == null) return
     // first getCommands to get total length of commands
     getCommands(host, runId, {
-      cursor: null,
       pageLength: 0,
       includeFixitCommands: true,
     })

--- a/app/src/organisms/Desktop/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -77,7 +77,6 @@ describe('RunProgressMeter', () => {
       .thenReturn(null)
     when(useNotifyAllCommandsQuery)
       .calledWith(NON_DETERMINISTIC_RUN_ID, {
-        cursor: null,
         pageLength: 1,
       })
       .thenReturn(mockUseAllCommandsResponseNonDeterministic)

--- a/app/src/organisms/Desktop/RunProgressMeter/index.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/index.tsx
@@ -67,7 +67,6 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   const runData = runRecord?.data ?? null
 
   const { data: mostRecentCommandData } = useNotifyAllCommandsQuery(runId, {
-    cursor: null,
     pageLength: 1,
   })
   // This lastRunCommand also includes "fixit" commands.

--- a/app/src/organisms/DropTipWizardFlows/hooks/useTipAttachmentStatus/getPipettesWithTipAttached.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useTipAttachmentStatus/getPipettesWithTipAttached.ts
@@ -50,7 +50,6 @@ function getCommandsExecutedDuringRun(
   runId: string
 ): Promise<CommandsData> {
   return getCommands(host, runId, {
-    cursor: null,
     pageLength: 0,
     includeFixitCommands: true,
   }).then(response => {
@@ -58,7 +57,6 @@ function getCommandsExecutedDuringRun(
     return getCommands(host, runId, {
       cursor: 0,
       pageLength: totalLength,
-      includeFixitCommands: null,
     }).then(response => response.data)
   })
 }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useCurrentlyRecoveringFrom.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useCurrentlyRecoveringFrom.test.ts
@@ -55,7 +55,7 @@ describe('useCurrentlyRecoveringFrom', () => {
 
     expect(vi.mocked(useNotifyAllCommandsQuery)).toHaveBeenCalledWith(
       MOCK_RUN_ID,
-      { cursor: null, pageLength: 0 },
+      { pageLength: 0 },
       { enabled: false, refetchInterval: 5000 }
     )
     expect(vi.mocked(useCommandQuery)).toHaveBeenCalledWith(

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
@@ -50,7 +50,7 @@ export function useCurrentlyRecoveringFrom(
     isFetching: isAllCommandsFetching,
   } = useNotifyAllCommandsQuery(
     runId,
-    { cursor: null, pageLength: 0 }, // pageLength 0 because we only care about the links.
+    { pageLength: 0 }, // pageLength 0 because we only care about the links.
     {
       enabled: isRunInRecoveryMode,
       refetchInterval: ALL_COMMANDS_POLL_MS,

--- a/app/src/organisms/ODD/RunningProtocol/CurrentRunningProtocolCommand.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/CurrentRunningProtocolCommand.tsx
@@ -149,7 +149,6 @@ export function CurrentRunningProtocolCommand({
 }: CurrentRunningProtocolCommandProps): JSX.Element | null {
   const { t } = useTranslation('run_details')
   const { data: mostRecentCommandData } = useNotifyAllCommandsQuery(runId, {
-    cursor: null,
     pageLength: 1,
   })
 

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -243,15 +243,14 @@ export function RunSummary(): JSX.Element {
   const runSummaryNoFixit = useCurrentRunCommands({
     includeFixitCommands: false,
     pageLength: 1,
-    cursor: null,
   })
   useEffect(() => {
     if (
       isRunCurrent &&
       runSummaryNoFixit != null &&
+      runSummaryNoFixit.length > 0 &&
       !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit)
     ) {
-      console.log('HITTING THIS')
       void determineTipStatus()
     }
   }, [runSummaryNoFixit, isRunCurrent])

--- a/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
+++ b/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
@@ -146,7 +146,6 @@ describe('RunningProtocol', () => {
       .thenReturn(mockRobotSideAnalysis)
     when(vi.mocked(useNotifyAllCommandsQuery))
       .calledWith(RUN_ID, {
-        cursor: null,
         pageLength: 1,
       })
       .thenReturn(mockUseAllCommandsResponseNonDeterministic)

--- a/app/src/resources/runs/__tests__/useRunTimestamps.test.ts
+++ b/app/src/resources/runs/__tests__/useRunTimestamps.test.ts
@@ -24,7 +24,7 @@ vi.mock('../useNotifyRunQuery')
 describe('useRunTimestamps hook', () => {
   beforeEach(() => {
     when(useRunCommands)
-      .calledWith(RUN_ID_2, { cursor: null, pageLength: 1 }, expect.any(Object))
+      .calledWith(RUN_ID_2, { pageLength: 1 }, expect.any(Object))
       .thenReturn([mockCommand.data as any])
   })
 

--- a/app/src/resources/runs/useLastRunCommand.ts
+++ b/app/src/resources/runs/useLastRunCommand.ts
@@ -18,7 +18,7 @@ export function useLastRunCommand(
   const runStatus = useRunStatus(runId)
   const { data: commandsData } = useNotifyAllCommandsQuery(
     runId,
-    { cursor: null, pageLength: 1 },
+    { pageLength: 1 },
     {
       ...options,
       refetchInterval:

--- a/app/src/resources/runs/useNotifyAllCommandsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllCommandsQuery.ts
@@ -3,23 +3,12 @@ import { useAllCommandsQuery } from '@opentrons/react-api-client'
 import { useNotifyDataReady } from '../useNotifyDataReady'
 
 import type { UseQueryResult } from 'react-query'
-import type {
-  CommandsData,
-  GetRunCommandsParams,
-  GetCommandsParams,
-} from '@opentrons/api-client'
+import type { CommandsData, GetRunCommandsParams } from '@opentrons/api-client'
 import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
-
-const DEFAULT_PAGE_LENGTH = 30
-
-export const DEFAULT_PARAMS: GetCommandsParams = {
-  cursor: null,
-  pageLength: DEFAULT_PAGE_LENGTH,
-}
 
 export function useNotifyAllCommandsQuery<TError = Error>(
   runId: string | null,
-  params?: GetRunCommandsParams | null,
+  params?: GetRunCommandsParams,
   options: QueryOptionsWithPolling<CommandsData, TError> = {}
 ): UseQueryResult<CommandsData, TError> {
   // Assume the useAllCommandsQuery() response can only change when the command links change.
@@ -32,19 +21,8 @@ export function useNotifyAllCommandsQuery<TError = Error>(
     topic: 'robot-server/runs/commands_links',
     options,
   })
-  const nullCheckedParams = params ?? DEFAULT_PARAMS
 
-  const nullCheckedFixitCommands = params?.includeFixitCommands ?? null
-  const finalizedNullCheckParams = {
-    ...nullCheckedParams,
-    includeFixitCommands: nullCheckedFixitCommands,
-  }
-
-  const httpQueryResult = useAllCommandsQuery(
-    runId,
-    finalizedNullCheckParams,
-    queryOptionsNotify
-  )
+  const httpQueryResult = useAllCommandsQuery(runId, params, queryOptionsNotify)
 
   if (shouldRefetch) {
     void httpQueryResult.refetch()

--- a/app/src/resources/runs/useRunTimestamps.ts
+++ b/app/src/resources/runs/useRunTimestamps.ts
@@ -30,7 +30,7 @@ export function useRunTimestamps(runId: string | null): RunTimestamps {
   const runCommands =
     useRunCommands(
       runId,
-      { cursor: null, pageLength: 1 },
+      { pageLength: 1 },
       {
         enabled:
           runStatus === RUN_STATUS_SUCCEEDED ||

--- a/react-api-client/src/runs/useAllCommandsAsPreSerializedList.ts
+++ b/react-api-client/src/runs/useAllCommandsAsPreSerializedList.ts
@@ -14,10 +14,6 @@ import type {
 } from '@opentrons/api-client'
 
 const DEFAULT_PAGE_LENGTH = 30
-export const DEFAULT_PARAMS: GetRunCommandsParams = {
-  cursor: null,
-  pageLength: DEFAULT_PAGE_LENGTH,
-}
 
 export function useAllCommandsAsPreSerializedList<TError = Error>(
   runId: string | null,
@@ -25,17 +21,15 @@ export function useAllCommandsAsPreSerializedList<TError = Error>(
   options: UseQueryOptions<CommandsData, TError> = {}
 ): UseQueryResult<CommandsData, TError> {
   const host = useHost()
-  const nullCheckedParams = params ?? DEFAULT_PARAMS
 
   const allOptions: UseQueryOptions<CommandsData, TError> = {
     ...options,
     enabled: host !== null && runId != null && options.enabled !== false,
   }
-  const { cursor, pageLength } = nullCheckedParams
-  const nullCheckedFixitCommands = params?.includeFixitCommands ?? null
-  const finalizedNullCheckParams = {
-    ...nullCheckedParams,
-    includeFixitCommands: nullCheckedFixitCommands,
+  const { cursor, pageLength, includeFixitCommands } = params ?? {}
+  const finalizedParams = {
+    ...params,
+    pageLength: params?.pageLength ?? DEFAULT_PAGE_LENGTH,
   }
 
   // map undefined values to null to agree with react query caching
@@ -50,13 +44,13 @@ export function useAllCommandsAsPreSerializedList<TError = Error>(
       'getCommandsAsPreSerializedList',
       cursor,
       pageLength,
-      nullCheckedFixitCommands,
+      includeFixitCommands,
     ],
     () => {
       return getCommandsAsPreSerializedList(
         host as HostConfig,
         runId as string,
-        finalizedNullCheckParams
+        finalizedParams
       ).then(response => {
         const responseData = response.data
         return {

--- a/react-api-client/src/runs/useAllCommandsQuery.ts
+++ b/react-api-client/src/runs/useAllCommandsQuery.ts
@@ -9,45 +9,30 @@ import type {
 } from '@opentrons/api-client'
 
 const DEFAULT_PAGE_LENGTH = 30
-export const DEFAULT_PARAMS: GetRunCommandsParamsRequest = {
-  cursor: null,
-  pageLength: DEFAULT_PAGE_LENGTH,
-  includeFixitCommands: null,
-}
 
 export function useAllCommandsQuery<TError = Error>(
   runId: string | null,
-  params?: GetRunCommandsParamsRequest | null,
+  params?: GetRunCommandsParamsRequest,
   options: UseQueryOptions<CommandsData, TError> = {}
 ): UseQueryResult<CommandsData, TError> {
   const host = useHost()
-  const nullCheckedParams = params ?? DEFAULT_PARAMS
-
   const allOptions: UseQueryOptions<CommandsData, TError> = {
     ...options,
     enabled: host !== null && runId != null && options.enabled !== false,
   }
-  const { cursor, pageLength } = nullCheckedParams
-  const nullCheckedFixitCommands = params?.includeFixitCommands ?? null
-  const finalizedNullCheckParams = {
-    ...nullCheckedParams,
-    includeFixitCommands: nullCheckedFixitCommands,
+
+  const { cursor, pageLength, includeFixitCommands } = params ?? {}
+  const finalizedParams = {
+    ...params,
+    pageLength: params?.pageLength ?? DEFAULT_PAGE_LENGTH,
   }
   const query = useQuery<CommandsData, TError>(
-    [
-      host,
-      'runs',
-      runId,
-      'commands',
-      cursor,
-      pageLength,
-      finalizedNullCheckParams,
-    ],
+    [host, 'runs', runId, 'commands', cursor, pageLength, includeFixitCommands],
     () => {
       return getCommands(
         host as HostConfig,
         runId as string,
-        finalizedNullCheckParams
+        finalizedParams
       ).then(response => response.data)
     },
     allOptions

--- a/react-api-client/src/runs/useRunCommandErrors.ts
+++ b/react-api-client/src/runs/useRunCommandErrors.ts
@@ -9,10 +9,6 @@ import type {
 } from '@opentrons/api-client'
 
 const DEFAULT_PAGE_LENGTH = 30
-export const DEFAULT_PARAMS: GetCommandsParams = {
-  cursor: null,
-  pageLength: DEFAULT_PAGE_LENGTH,
-}
 
 export function useRunCommandErrors<TError = Error>(
   runId: string | null,
@@ -20,20 +16,23 @@ export function useRunCommandErrors<TError = Error>(
   options: UseQueryOptions<RunCommandErrors, TError> = {}
 ): UseQueryResult<RunCommandErrors, TError> {
   const host = useHost()
-  const nullCheckedParams = params ?? DEFAULT_PARAMS
-
   const allOptions: UseQueryOptions<RunCommandErrors, TError> = {
     ...options,
     enabled: host !== null && runId != null && options.enabled !== false,
   }
-  const { cursor, pageLength } = nullCheckedParams
+
+  const { cursor, pageLength } = params ?? {}
+  const finalizedParams = {
+    ...params,
+    pageLength: params?.pageLength ?? DEFAULT_PAGE_LENGTH,
+  }
   const query = useQuery<RunCommandErrors, TError>(
     [host, 'runs', runId, 'commandErrors', cursor, pageLength],
     () => {
       return getRunCommandErrors(
         host as HostConfig,
         runId as string,
-        nullCheckedParams
+        finalizedParams
       ).then(response => response.data)
     },
     allOptions


### PR DESCRIPTION
Closes [RQA-3614](https://opentrons.atlassian.net/browse/RQA-3614)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We recently updated post-run tip checking to get the last run command via `useCurrentRunCommands` with parameters

```
{
      includeFixitCommands: false,
      pageLength: 1,
     cursor: null
}
```

Something on the server (likely Pydantic) deserializes the cursor: 'null' string to 0, which causes unexpected behavior (ex, we always pop drop tip wizard post-run, which we don't always want to do). 

412e29fd94080988d2e8d207c847a0a8edcf7253 - The `api-client` typing involving command queries requires supplying a `cursor: null` if none is specified, so to fix, we must change the types and then update all usages of the relevant queries.

0cdec49f1f2f96cb9ce4017dbe0b05b88dbd3ebe - This fixes some unexpected behavior on the desktop app in which the post run CTA sometimes appears while "run again" is cloning the run. The fix is just to clear tip status while the run is resetting (on click on the `ActionButton`). 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran a lot of runs with various types of drop tip wizard CTAs, both in and out of Error Recovery, confirming expected behavior.
- Confirmed that "run again" does not flash the post-run drop tip CTA.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the post-run drop tip CTA always appearing after error recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- low. This touches a lot of files, but the only real functional change is the one liner in `useActionButtonProperties.ts`
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3614]: https://opentrons.atlassian.net/browse/RQA-3614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ