### PR TITLE
chore: fix failing lint on release notes

### DIFF
--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -31,6 +31,7 @@ Welcome to the v8.2.0 release of the Opentrons App! This release adds support fo
 - Fixed an app crash when performing certain error recovery steps with Python API version 2.15 protocols.
 
 ### Known Issues
+
 - If you attach an Absorbance Plate Reader to _any_ Flex on your local network, you must update all copies of the Opentrons App on the same network to at least v8.1.0.
 
 ---


### PR DESCRIPTION

# Overview

Prettier (or whatever runs in our JS lint action) demands a newline after a markdown header. OK.

## Test Plan and Hands on Testing

Pass automated tests plz.

## Changelog

`\n`

## Review requests

Forgive this shameful and time-wasting PR.

## Risk assessment

none