### PR TITLE
fix(protocol-designer): render labware on Thermocycler in deck setup

### DIFF
--- a/protocol-designer/src/pages/CreateNewProtocolWizard/PDListItemCustomize.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/PDListItemCustomize.tsx
@@ -27,7 +27,6 @@ interface PDListItemCustomizeProps {
   label?: string
   dropdown?: DropdownMenuProps
   tag?: TagProps
-  forceDirection?: boolean
 }
 
 export function PDListItemCustomize({
@@ -38,7 +37,6 @@ export function PDListItemCustomize({
   label,
   dropdown,
   tag,
-  forceDirection = false,
 }: PDListItemCustomizeProps): JSX.Element {
   const responsiveType = useResponsiveBreakpoints()
   const isLargeScreen = responsiveType === 'xl' || responsiveType === 'lg'
@@ -53,7 +51,7 @@ export function PDListItemCustomize({
       )}
       {dropdown != null && (
         <Flex paddingBottom={SPACING.spacing8}>
-          <DropdownMenu {...dropdown} forceDirection={forceDirection} />
+          <DropdownMenu {...dropdown} menuPlacement="bottom" />
         </Flex>
       )}
       {tag != null && <Tag {...tag} />}

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectFixtures.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectFixtures.tsx
@@ -158,7 +158,6 @@ export function SelectFixtures(props: WizardTileProps): JSX.Element | null {
                 return (
                   <ListItem type="noActive" key={ae}>
                     <ListItemCustomize
-                      menuPlacement="bottom"
                       linkText={t('remove')}
                       onClick={() => {
                         setValue(

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
@@ -258,7 +258,6 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
                       return (
                         <ListItem type="noActive" key={`${module.model}`}>
                           <ListItemCustomize
-                            menuPlacement="bottom"
                             dropdown={
                               MOAM_MODULE_TYPES.includes(module.type) &&
                               robotType === FLEX_ROBOT_TYPE

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -200,7 +200,9 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         }
         const isLabwareOccludedByThermocyclerLid =
           moduleOnDeck.type === THERMOCYCLER_MODULE_TYPE &&
-          (moduleOnDeck.moduleState as ThermocyclerModuleState).lidOpen !== true
+          (moduleOnDeck.moduleState as ThermocyclerModuleState).lidOpen !==
+            true &&
+          tab === 'protocolSteps'
 
         const tempInnerProps = getModuleInnerProps(moduleOnDeck.moduleState)
         const innerProps =


### PR DESCRIPTION
# Overview

Fixes a bug introduced by this pr: https://github.com/Opentrons/opentrons/pull/16826 by making sure the labware always renders during startingDeck tab

Also fixes the js-check error in edge

## Test Plan and Hands on Testing

make sure you can add a labware to a thermocycler in deck setup

## Changelog

- fix boolean logic

## Risk assessment

low
