### PR TITLE
fix(protocol-designer): remove flickering in timeline and fix distrib…

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -27,7 +27,7 @@
   "duplicate": "Duplicate step",
   "edit_step": "Edit step",
   "engage_height": "Engage height",
-  "final_deck_state": "Ending deck",
+  "ending_deck": "Ending deck",
   "flow_type_title": "{{type}} flow rate",
   "from": "from",
   "heater_shaker": {
@@ -104,7 +104,7 @@
   "shake": "Shake",
   "single": "Single path",
   "speed": "Speed",
-  "starting_deck_state": "Starting deck",
+  "starting_deck": "Starting deck",
   "step_substeps": "{{stepType}} details",
   "temperature": "Temperature",
   "temperature_module": {

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -120,8 +120,8 @@
     "substep_settings": "<text>Set block temperature to</text><tagTemperature/><text>for</text><tagDuration/>",
     "thermocycler_profile": {
       "end_hold": {
-        "block": "<text>End at thermocycler block</text><tag/>",
-        "lid_position": "<text>Thermocycler lid</text><tag/>"
+        "block": "<text>End with block at</text><tag/>",
+        "lid_position": "<text>and lid</text><tag/>"
       },
       "lid_temperature": "<text>and lid temperature at</text><tag/>",
       "volume": "<text>Run thermocycler profile with</text><tag/>"

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -27,7 +27,7 @@
   "duplicate": "Duplicate step",
   "edit_step": "Edit step",
   "engage_height": "Engage height",
-  "final_deck_state": "Final deck state",
+  "final_deck_state": "Ending deck",
   "flow_type_title": "{{type}} flow rate",
   "from": "from",
   "heater_shaker": {
@@ -104,7 +104,7 @@
   "shake": "Shake",
   "single": "Single path",
   "speed": "Speed",
-  "starting_deck_state": "Starting deck state",
+  "starting_deck_state": "Starting deck",
   "step_substeps": "{{stepType}} details",
   "temperature": "Temperature",
   "temperature_module": {

--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -1,4 +1,7 @@
 {
+  "__end__": "Ending deck",
+  "__initial_setup__": "Starting deck",
+  "__presaved_step__": "Unsaved step",
   "adapter_compatible_lab": "Adapter compatible labware",
   "adapter": "Adapters",
   "add_fixture": "Add a fixture",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -182,16 +182,20 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           </Flex>
         ) : (
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-            <StyledTrans
-              i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.volume"
-              tagText={`${profileVolume} ${t('application:units.microliter')}`}
-            />
-            <StyledTrans
-              i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.lid_temperature"
-              tagText={`${profileTargetLidTemp}${t(
-                'application:units.degrees'
-              )}`}
-            />
+            <Flex gridGap={SPACING.spacing20}>
+              <StyledTrans
+                i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.volume"
+                tagText={`${profileVolume} ${t(
+                  'application:units.microliter'
+                )}`}
+              />
+              <StyledTrans
+                i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.lid_temperature"
+                tagText={`${profileTargetLidTemp}${t(
+                  'application:units.degrees'
+                )}`}
+              />
+            </Flex>
             <Flex gridGap={SPACING.spacing20}>
               <StyledTrans
                 i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.end_hold.block"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -79,7 +79,6 @@ interface StepSummaryProps {
 export function StepSummary(props: StepSummaryProps): JSX.Element | null {
   const { currentStep, stepDetails } = props
   const { t } = useTranslation(['protocol_steps', 'application'])
-
   const labwareNicknamesById = useSelector(getLabwareNicknamesById)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
@@ -91,7 +90,6 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
     return null
   }
   const { stepType } = currentStep
-
   let stepSummaryContent: JSX.Element | null = null
   switch (stepType) {
     case 'mix':
@@ -405,7 +403,6 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
     default:
       stepSummaryContent = null
   }
-
   return stepSummaryContent != null || stepDetails != null ? (
     <Flex
       flexDirection={DIRECTION_COLUMN}
@@ -414,7 +411,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
     >
       {stepSummaryContent != null ? (
         <ListItem type="noActive">
-          <Flex padding={SPACING.spacing12}>{stepSummaryContent}</Flex>
+          <Flex padding={SPACING.spacing12} height="4.75rem">
+            {stepSummaryContent}
+          </Flex>
         </ListItem>
       ) : null}
       {stepDetails != null && stepDetails !== '' ? (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/MultichannelSubstep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/MultichannelSubstep.tsx
@@ -23,7 +23,6 @@ import type {
 interface MultichannelSubstepProps {
   trashName: AdditionalEquipmentName | null
   rowGroup: StepItemSourceDestRow[]
-  ingredNames: WellIngredientNames
   stepId: string
   substepIndex: number
   selectSubstep: (substepIdentifier: SubstepIdentifier) => void
@@ -39,7 +38,6 @@ export function MultichannelSubstep(
     stepId,
     selectSubstep,
     substepIndex,
-    ingredNames,
     trashName,
     isSameLabware,
   } = props
@@ -107,7 +105,6 @@ export function MultichannelSubstep(
                     trashName={trashName}
                     key={rowKey}
                     volume={row.volume}
-                    ingredNames={ingredNames}
                     source={row.source}
                     dest={row.dest}
                     stepId={stepId}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/MultichannelSubstep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/MultichannelSubstep.tsx
@@ -17,7 +17,6 @@ import type { AdditionalEquipmentName } from '@opentrons/step-generation'
 import type {
   StepItemSourceDestRow,
   SubstepIdentifier,
-  WellIngredientNames,
 } from '../../../../steplist'
 
 interface MultichannelSubstepProps {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/PipettingSubsteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/PipettingSubsteps.tsx
@@ -4,7 +4,6 @@ import { MultichannelSubstep } from './MultichannelSubstep'
 import type {
   SourceDestSubstepItem,
   SubstepIdentifier,
-  WellIngredientNames,
 } from '../../../../steplist'
 import { useSelector } from 'react-redux'
 import {
@@ -14,13 +13,12 @@ import {
 
 interface PipettingSubstepsProps {
   substeps: SourceDestSubstepItem
-  ingredNames: WellIngredientNames
   selectSubstep: (substepIdentifier: SubstepIdentifier) => void
   hoveredSubstep?: SubstepIdentifier | null
 }
 
 export function PipettingSubsteps(props: PipettingSubstepsProps): JSX.Element {
-  const { substeps, selectSubstep, hoveredSubstep, ingredNames } = props
+  const { substeps, selectSubstep, hoveredSubstep } = props
   const stepId = substeps.parentStepId
   const formData = useSelector(getSavedStepForms)[stepId]
   const additionalEquipment = useSelector(getAdditionalEquipment)
@@ -52,7 +50,6 @@ export function PipettingSubsteps(props: PipettingSubstepsProps): JSX.Element {
             stepId={substeps.parentStepId}
             substepIndex={groupKey}
             selectSubstep={selectSubstep}
-            ingredNames={ingredNames}
             isSameLabware={isSameLabware}
           />
         )
@@ -64,7 +61,6 @@ export function PipettingSubsteps(props: PipettingSubstepsProps): JSX.Element {
           selectSubstep={selectSubstep}
           stepId={substeps.parentStepId}
           substepIndex={substepIndex}
-          ingredNames={ingredNames}
           volume={row.volume}
           source={row.source}
           dest={row.dest}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -45,8 +45,8 @@ import type { IconName } from '@opentrons/components'
 import type { StepIdType } from '../../../../form-types'
 import type { BaseState } from '../../../../types'
 
-const STARTING_DECK_STATE = 'Starting deck state'
-const FINAL_DECK_STATE = 'Final deck state'
+const STARTING_DECK_STATE = 'Starting deck'
+const FINAL_DECK_STATE = 'Ending deck'
 const PX_HEIGHT_TO_TOP_OF_CONTAINER = 32
 export interface StepContainerProps {
   title: string

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepOverflowMenu.tsx
@@ -64,7 +64,9 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
   const isPipetteStep =
     savedStepFormData.stepType === 'moveLiquid' ||
     savedStepFormData.stepType === 'mix'
-  const isThermocyclerProfile = savedStepFormData.stepType === 'thermocycler'
+  const isThermocyclerProfile =
+    savedStepFormData.stepType === 'thermocycler' &&
+    savedStepFormData.thermocyclerFormType === 'thermocyclerProfile'
 
   const duplicateStep = (
     stepId: StepIdType

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Substep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Substep.tsx
@@ -12,7 +12,7 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
-import { compactPreIngreds, formatVolume } from './utils'
+import { formatVolume } from './utils'
 import type { AdditionalEquipmentName } from '@opentrons/step-generation'
 
 import type { SubstepIdentifier, SubstepWellData } from '../../../../steplist'
@@ -44,13 +44,8 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
     'protocol_steps',
     'shared',
   ])
-  const compactedSourcePreIngreds = source
-    ? compactPreIngreds(source.preIngreds)
-    : {}
 
   const selectSubstep = propSelectSubstep ?? noop
-
-  const ingredIds: string[] = Object.keys(compactedSourcePreIngreds)
 
   const volumeTag = (
     <Tag

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Substep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Substep.tsx
@@ -1,38 +1,24 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 import noop from 'lodash/noop'
-import { AIR } from '@opentrons/step-generation'
 import {
   ALIGN_CENTER,
-  COLORS,
   DIRECTION_COLUMN,
   DeckInfoLabel,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
-  LiquidIcon,
   ListItem,
   SPACING,
   StyledText,
   Tag,
 } from '@opentrons/components'
-import { selectors } from '../../../../labware-ingred/selectors'
-import {
-  MIXED_WELL_COLOR,
-  swatchColors,
-} from '../../../../components/swatchColors'
 import { compactPreIngreds, formatVolume } from './utils'
 import type { AdditionalEquipmentName } from '@opentrons/step-generation'
 
-import type {
-  SubstepIdentifier,
-  SubstepWellData,
-  WellIngredientNames,
-} from '../../../../steplist'
+import type { SubstepIdentifier, SubstepWellData } from '../../../../steplist'
 
 interface SubstepProps {
   trashName: AdditionalEquipmentName | null
-  ingredNames: WellIngredientNames
   stepId: string
   substepIndex: number
   volume?: number | string | null
@@ -45,7 +31,6 @@ interface SubstepProps {
 function SubstepComponent(props: SubstepProps): JSX.Element {
   const {
     volume,
-    ingredNames,
     stepId,
     substepIndex,
     source,
@@ -54,7 +39,11 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
     selectSubstep: propSelectSubstep,
     isSameLabware,
   } = props
-  const { t } = useTranslation(['application', 'protocol_steps', 'shared'])
+  const { i18n, t } = useTranslation([
+    'application',
+    'protocol_steps',
+    'shared',
+  ])
   const compactedSourcePreIngreds = source
     ? compactPreIngreds(source.preIngreds)
     : {}
@@ -62,15 +51,6 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
   const selectSubstep = propSelectSubstep ?? noop
 
   const ingredIds: string[] = Object.keys(compactedSourcePreIngreds)
-  const liquidDisplayColors = useSelector(selectors.getLiquidDisplayColors)
-  const noColor = ingredIds.filter(id => id !== AIR).length === 0
-  let color = MIXED_WELL_COLOR
-  if (ingredIds.length === 1) {
-    color =
-      liquidDisplayColors[Number(ingredIds[0])] ?? swatchColors(ingredIds[0])
-  } else if (noColor) {
-    color = COLORS.transparent
-  }
 
   const volumeTag = (
     <Tag
@@ -104,16 +84,6 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
             width="100%"
             alignItems={ALIGN_CENTER}
           >
-            {ingredIds.length > 0 ? (
-              <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
-                <LiquidIcon color={color} size="medium" />
-
-                <StyledText desktopStyle="bodyDefaultRegular">
-                  {ingredIds.map(groupId => ingredNames[groupId]).join(',')}
-                </StyledText>
-              </Flex>
-            ) : null}
-
             <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
               <StyledText desktopStyle="bodyDefaultRegular">
                 {t('protocol_steps:mix')}
@@ -123,9 +93,12 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
                 {t('protocol_steps:in')}
               </StyledText>
               <DeckInfoLabel
-                deckLabel={t('protocol_steps:well_name', {
-                  wellName: source?.well ?? '',
-                })}
+                deckLabel={i18n.format(
+                  t('protocol_steps:well_name', {
+                    wellName: source?.well ?? '',
+                  }),
+                  'upperCase'
+                )}
               />
             </Flex>
           </Flex>
@@ -141,16 +114,6 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
                 width="100%"
                 alignItems={ALIGN_CENTER}
               >
-                {ingredIds.length > 0 ? (
-                  <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
-                    <LiquidIcon color={color} size="medium" />
-
-                    <StyledText desktopStyle="bodyDefaultRegular">
-                      {ingredIds.map(groupId => ingredNames[groupId]).join(',')}
-                    </StyledText>
-                  </Flex>
-                ) : null}
-
                 <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
                   <StyledText desktopStyle="bodyDefaultRegular">
                     {t('protocol_steps:aspirated')}
@@ -160,9 +123,12 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
                     {t('protocol_steps:from')}
                   </StyledText>
                   <DeckInfoLabel
-                    deckLabel={t('protocol_steps:well_name', {
-                      wellName: source.well,
-                    })}
+                    deckLabel={i18n.format(
+                      t('protocol_steps:well_name', {
+                        wellName: source.well,
+                      }),
+                      'upperCase'
+                    )}
                   />
                 </Flex>
               </Flex>
@@ -177,14 +143,6 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
                 width="100%"
                 alignItems={ALIGN_CENTER}
               >
-                {ingredIds.length > 0 ? (
-                  <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
-                    <LiquidIcon color={color} size="medium" />
-                    <StyledText desktopStyle="bodyDefaultRegular">
-                      {ingredIds.map(groupId => ingredNames[groupId]).join(',')}
-                    </StyledText>
-                  </Flex>
-                ) : null}
                 {dest != null || trashName != null ? (
                   <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
                     <StyledText desktopStyle="bodyDefaultRegular">
@@ -196,13 +154,14 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
                     </StyledText>
 
                     <DeckInfoLabel
-                      deckLabel={
+                      deckLabel={i18n.format(
                         dest?.well != null
                           ? t('protocol_steps:well_name', {
                               wellName: dest.well,
                             })
-                          : t(`shared:${trashName}`)
-                      }
+                          : t(`shared:${trashName}`),
+                        'upperCase'
+                      )}
                     />
                   </Flex>
                 ) : null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Substep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Substep.tsx
@@ -132,24 +132,25 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
         </ListItem>
       ) : (
         <>
-          <ListItem type="noActive">
-            <Flex
-              gridGap={SPACING.spacing4}
-              padding={SPACING.spacing12}
-              justifyContent={JUSTIFY_SPACE_BETWEEN}
-              width="100%"
-              alignItems={ALIGN_CENTER}
-            >
-              {ingredIds.length > 0 ? (
-                <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
-                  <LiquidIcon color={color} size="medium" />
+          {source != null ? (
+            <ListItem type="noActive">
+              <Flex
+                gridGap={SPACING.spacing4}
+                padding={SPACING.spacing12}
+                justifyContent={JUSTIFY_SPACE_BETWEEN}
+                width="100%"
+                alignItems={ALIGN_CENTER}
+              >
+                {ingredIds.length > 0 ? (
+                  <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
+                    <LiquidIcon color={color} size="medium" />
 
-                  <StyledText desktopStyle="bodyDefaultRegular">
-                    {ingredIds.map(groupId => ingredNames[groupId]).join(',')}
-                  </StyledText>
-                </Flex>
-              ) : null}
-              {source != null ? (
+                    <StyledText desktopStyle="bodyDefaultRegular">
+                      {ingredIds.map(groupId => ingredNames[groupId]).join(',')}
+                    </StyledText>
+                  </Flex>
+                ) : null}
+
                 <Flex gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
                   <StyledText desktopStyle="bodyDefaultRegular">
                     {t('protocol_steps:aspirated')}
@@ -164,11 +165,11 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
                     })}
                   />
                 </Flex>
-              ) : null}
-            </Flex>
-          </ListItem>
-          <ListItem type="noActive">
-            {dest !== undefined ? (
+              </Flex>
+            </ListItem>
+          ) : null}
+          {dest != null ? (
+            <ListItem type="noActive">
               <Flex
                 gridGap={SPACING.spacing4}
                 padding={SPACING.spacing12}
@@ -206,8 +207,8 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
                   </Flex>
                 ) : null}
               </Flex>
-            ) : null}
-          </ListItem>
+            </ListItem>
+          ) : null}
         </>
       )}
     </Flex>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubstepsToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubstepsToolbox.tsx
@@ -8,7 +8,6 @@ import {
   StyledText,
   Toolbox,
 } from '@opentrons/components'
-import { selectors as labwareIngredSelectors } from '../../../../labware-ingred/selectors'
 import { getSubsteps } from '../../../../file-data/selectors'
 import { getHoveredSubstep } from '../../../../ui/steps'
 import {
@@ -40,7 +39,6 @@ export function SubstepsToolbox(
   const substeps = useSelector(getSubsteps)[stepId]
   const formData = useSelector(getSavedStepForms)[stepId]
   const hoveredSubstep = useSelector(getHoveredSubstep)
-  const ingredNames = useSelector(labwareIngredSelectors.getLiquidNamesById)
   const highlightSubstep = (payload: SubstepIdentifier): HoverOnSubstepAction =>
     dispatch(hoverOnSubstep(payload))
 
@@ -85,7 +83,6 @@ export function SubstepsToolbox(
         ) : (
           <PipettingSubsteps
             key="substeps"
-            ingredNames={ingredNames}
             substeps={substeps}
             hoveredSubstep={hoveredSubstep}
             selectSubstep={highlightSubstep}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -77,7 +77,7 @@ export const TimelineToolbox = (): JSX.Element => {
       >
         <TerminalItemStep
           id={START_TERMINAL_ITEM_ID}
-          title={t('starting_deck_state')}
+          title={t('starting_deck')}
         />
         <DraggableSteps
           orderedStepIds={orderedStepIds}
@@ -86,10 +86,7 @@ export const TimelineToolbox = (): JSX.Element => {
           }}
         />
         <PresavedStep />
-        <TerminalItemStep
-          id={END_TERMINAL_ITEM_ID}
-          title={t('final_deck_state')}
-        />
+        <TerminalItemStep id={END_TERMINAL_ITEM_ID} title={t('ending_deck')} />
       </Flex>
     </Toolbox>
   )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
@@ -1,8 +1,6 @@
 import round from 'lodash/round'
-import omitBy from 'lodash/omitBy'
 import uniq from 'lodash/uniq'
 import { UAParser } from 'ua-parser-js'
-import type { WellIngredientVolumeData } from '../../../../steplist'
 import type { StepIdType } from '../../../../form-types'
 
 export const capitalizeFirstLetterAfterNumber = (title: string): string =>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
@@ -29,31 +29,6 @@ export const formatPercentage = (part: number, total: number): string => {
   return `${round((part / total) * 100, PERCENTAGE_DECIMALS_ALLOWED)}%`
 }
 
-export const compactPreIngreds = (
-  preIngreds: WellIngredientVolumeData
-): Partial<
-  | {
-      [ingredId: string]:
-        | {
-            volume: number
-          }
-        | undefined
-    }
-  | {
-      [well: string]:
-        | {
-            [ingredId: string]: {
-              volume: number
-            }
-          }
-        | undefined
-    }
-> => {
-  return omitBy(preIngreds, ingred => {
-    return typeof ingred?.volume === 'number' && ingred.volume <= 0
-  })
-}
-
 export const getMetaSelectedSteps = (
   multiSelectItemIds: StepIdType[] | null,
   stepId: StepIdType,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
@@ -10,6 +10,7 @@ import {
 import {
   getSelectedStepId,
   getSelectedSubstep,
+  getSelectedTerminalItemId,
 } from '../../../../ui/steps/selectors'
 import { getDesignerTab } from '../../../../file-data/selectors'
 import { getEnableHotKeysDisplay } from '../../../../feature-flags/selectors'
@@ -60,6 +61,7 @@ describe('ProtocolSteps', () => {
     vi.mocked(DeckSetupContainer).mockReturnValue(
       <div>mock DeckSetupContainer</div>
     )
+    vi.mocked(getSelectedTerminalItemId).mockReturnValue(null)
     vi.mocked(OffDeck).mockReturnValue(<div>mock OffDeck</div>)
     vi.mocked(getUnsavedForm).mockReturnValue(null)
     vi.mocked(getSelectedSubstep).mockReturnValue(null)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -8,7 +8,6 @@ import {
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_CENTER,
-  JUSTIFY_FLEX_END,
   JUSTIFY_FLEX_START,
   JUSTIFY_SPACE_BETWEEN,
   POSITION_FIXED,
@@ -27,6 +26,7 @@ import {
   getSelectedSubstep,
   getSelectedStepId,
   getHoveredStepId,
+  getSelectedTerminalItemId,
 } from '../../../ui/steps/selectors'
 import { DeckSetupContainer } from '../DeckSetup'
 import { OffDeck } from '../Offdeck'
@@ -42,6 +42,7 @@ const CONTENT_MAX_WIDTH = '46.9375rem'
 export function ProtocolSteps(): JSX.Element {
   const { i18n, t } = useTranslation('starting_deck_state')
   const formData = useSelector(getUnsavedForm)
+  const selectedTerminalItem = useSelector(getSelectedTerminalItemId)
   const isMultiSelectMode = useSelector(getIsMultiSelectMode)
   const selectedSubstep = useSelector(getSelectedSubstep)
   const enableHoyKeyDisplay = useSelector(getEnableHotKeysDisplay)
@@ -89,14 +90,12 @@ export function ProtocolSteps(): JSX.Element {
           {tab === 'protocolSteps' ? (
             <TimelineAlerts justifyContent={JUSTIFY_CENTER} width="100%" />
           ) : null}
-          <Flex
-            justifyContent={
-              currentStep != null ? JUSTIFY_SPACE_BETWEEN : JUSTIFY_FLEX_END
-            }
-          >
-            {currentStep != null ? (
+          <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+            {currentStep != null || selectedTerminalItem != null ? (
               <StyledText desktopStyle="headingSmallBold">
-                {i18n.format(currentStep.stepName, 'capitalize')}
+                {currentStep != null
+                  ? i18n.format(currentStep.stepName, 'capitalize')
+                  : t(selectedTerminalItem)}
               </StyledText>
             ) : null}
             <ToggleGroup
@@ -122,6 +121,9 @@ export function ProtocolSteps(): JSX.Element {
                 currentStep={currentStep}
                 stepDetails={stepDetails}
               />
+            ) : null}
+            {selectedTerminalItem != null && currentHoveredStepId == null ? (
+              <Flex height="4.75rem" width="100%" />
             ) : null}
           </Flex>
         </Flex>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -27,6 +27,7 @@ import {
   getSelectedStepId,
   getHoveredStepId,
   getSelectedTerminalItemId,
+  getHoveredTerminalItemId,
 } from '../../../ui/steps/selectors'
 import { DeckSetupContainer } from '../DeckSetup'
 import { OffDeck } from '../Offdeck'
@@ -43,6 +44,7 @@ export function ProtocolSteps(): JSX.Element {
   const { i18n, t } = useTranslation('starting_deck_state')
   const formData = useSelector(getUnsavedForm)
   const selectedTerminalItem = useSelector(getSelectedTerminalItemId)
+  const hoveredTerminalItem = useSelector(getHoveredTerminalItemId)
   const isMultiSelectMode = useSelector(getIsMultiSelectMode)
   const selectedSubstep = useSelector(getSelectedSubstep)
   const enableHoyKeyDisplay = useSelector(getEnableHotKeysDisplay)
@@ -91,13 +93,18 @@ export function ProtocolSteps(): JSX.Element {
             <TimelineAlerts justifyContent={JUSTIFY_CENTER} width="100%" />
           ) : null}
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-            {currentStep != null || selectedTerminalItem != null ? (
+            {currentStep != null && hoveredTerminalItem == null ? (
               <StyledText desktopStyle="headingSmallBold">
-                {currentStep != null
-                  ? i18n.format(currentStep.stepName, 'capitalize')
-                  : t(selectedTerminalItem)}
+                {i18n.format(currentStep.stepName, 'capitalize')}
               </StyledText>
             ) : null}
+            {(hoveredTerminalItem != null || selectedTerminalItem != null) &&
+            currentHoveredStepId == null ? (
+              <StyledText desktopStyle="headingSmallBold">
+                {t(hoveredTerminalItem ?? selectedTerminalItem)}
+              </StyledText>
+            ) : null}
+
             <ToggleGroup
               selectedValue={deckView}
               leftText={leftString}


### PR DESCRIPTION
…ute details

closes RQA-3630 RQA-3624

# Overview

This PR does 2 things:
1. fixes the step details when you have distributed something
2. adds fixed box to step summary to avoid flickering, updates copy for terminal steps, and adds a title copy for terminal text

## Test Plan and Hands on Testing

Create a protocol and make a distribute step: basically aspirate from 1 well and dispense into multiple wells and add a small volume like 10uL and the distribute path should be selectable. Then click "view details" on the step's overflow menu and see that it looks as expected with no extra blank list items

Then upload the attached protocol and hover through the steps in the timeline, see that there is no flickering

[1.0 testing.json](https://github.com/user-attachments/files/17831380/1.0.testing.json)

## Changelog

- only show aspirate list item if there is an aspirate well present
- add a fixed box to avoid flickering in protocol steps
- add copy to terminal step items

## Risk assessment

low
