### PR TITLE
fix(shared-data): Add biorad pcr plate compatibility with tough_pcr_lid_auto_seal_lid to release

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
@@ -66,6 +66,11 @@
       "y": 0,
       "z": 8.193
     },
+    "biorad_96_wellplate_200ul_pcr": {
+      "x": 0,
+      "y": 0,
+      "z": 8.08
+    },
     "opentrons_flex_deck_riser": {
       "x": 0,
       "y": 0,


### PR DESCRIPTION
# Overview
Covers RABR-669

Adds compatibility between `biorad_96_wellplate_200ul_pcr` and `opentrons_tough_pcr_auto_sealing_lid` with stacking z offset

Originally these changes merged to edge, retargeting to chore in separate PR for 8.2.0.

See the following PR for further details on change as well as measurement details for the stacking offset used:
https://github.com/Opentrons/opentrons/pull/16849