### PR TITLE
fix(protocol-designer): move volume field above paths

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -186,6 +186,11 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
         )}
       </Flex>
       <Divider marginY="0" />
+      <VolumeField
+        {...propsForFields.volume}
+        errorToShow={getFormLevelError('volume', mappedErrorsToField)}
+      />
+      <Divider marginY="0" />
       <PathField
         {...propsForFields.path}
         aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
@@ -208,11 +213,6 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
         stepType={formData.stepType}
         isDisposalLocation={isDisposalLocation}
         tooltipContent={null}
-      />
-      <Divider marginY="0" />
-      <VolumeField
-        {...propsForFields.volume}
-        errorToShow={getFormLevelError('volume', mappedErrorsToField)}
       />
       {enableReturnTip ? (
         <>


### PR DESCRIPTION
closes RQA-3639

# Overview

move volume field above path since its a dependency for path

## Test Plan and Hands on Testing

Check that the volume field appears above the path selection in the transfer form

## Changelog

- move volume field

## Risk assessment

low
