### PR TITLE
fix(protocol-designer): add scroll to top functionality between parts

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -254,8 +254,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
         setShowFormErrors(false)
       } else {
         setShowFormErrors(true)
-        handleScrollToTop()
       }
+      handleScrollToTop()
     } else {
       handleSaveClick()
     }
@@ -304,6 +304,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
                 onClick={() => {
                   setToolboxStep(0)
                   setShowFormErrors(false)
+                  handleScrollToTop()
                 }}
               >
                 {i18n.format(t('shared:back'), 'capitalize')}


### PR DESCRIPTION
# Overview

Scroll to top when continuing on a multi-part step form

Closes RQA-3555

https://github.com/user-attachments/assets/8fc70ef4-826b-4ace-9f92-0e13c07cd038

## Test Plan and Hands on Testing

- create a multipart step (like transfer/mix) and scroll down
- click continue and verify that you autoscroll to the top of part 2
- expand advanced settings, scroll down
- click back and verify that you autoscroll to the top of part 1
- scroll down, click continue and verify that you autoscroll to the top of part 2

## Changelog

- add `handleScroll` to continue and back onClicks

## Review requests

- see test plan

## Risk assessment

low