### PR TITLE
fix(protocol-designer): fix OffDeck starting protocol deck component

### DIFF
--- a/protocol-designer/src/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/organisms/SlotInformation/index.tsx
@@ -63,7 +63,11 @@ export const SlotInformation: FC<SlotInformationProps> = ({
     <Flex
       flexDirection={DIRECTION_COLUMN}
       gridGap={SPACING.spacing12}
-      maxWidth={pathLocation.pathname === '/designer' ? '23.4375rem' : '100%'}
+      maxWidth={
+        pathLocation.pathname === '/designer' && !isOffDeck
+          ? '23.4375rem'
+          : '100%'
+      }
       width="100%"
     >
       <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -66,6 +66,7 @@ interface SlotOverflowMenuProps {
   setShowMenuList: (value: SetStateAction<boolean>) => void
   addEquipment: (slotId: string) => void
   menuListSlotPosition?: CoordinateTuple
+  invertY?: true
 }
 export function SlotOverflowMenu(
   props: SlotOverflowMenuProps
@@ -75,6 +76,7 @@ export function SlotOverflowMenu(
     setShowMenuList,
     addEquipment,
     menuListSlotPosition,
+    invertY = false,
   } = props
   const { t } = useTranslation('starting_deck_state')
   const navigate = useNavigate()
@@ -325,7 +327,7 @@ export function SlotOverflowMenu(
       innerDivProps={{
         style: {
           position: POSITION_ABSOLUTE,
-          transform: 'rotate(180deg) scaleX(-1)',
+          transform: `rotate(180deg) scaleX(-1) ${invertY ? 'scaleY(-1)' : ''}`,
         },
       }}
     >

--- a/protocol-designer/src/pages/Designer/Offdeck/OffDeckDetails.tsx
+++ b/protocol-designer/src/pages/Designer/Offdeck/OffDeckDetails.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import {
+  ALIGN_CENTER,
   BORDERS,
   COLORS,
   DIRECTION_COLUMN,
@@ -26,6 +27,8 @@ import { SlotOverflowMenu } from '../DeckSetup/SlotOverflowMenu'
 import type { DeckSlotId } from '@opentrons/shared-data'
 import type { DeckSetupTabType } from '../types'
 
+const OFFDECK_MAP_WIDTH = '41.625rem'
+
 interface OffDeckDetailsProps extends DeckSetupTabType {
   addLabware: () => void
 }
@@ -43,19 +46,30 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
   const allWellContentsForActiveItem = useSelector(
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
+  const containerWidth = tab === 'startingDeck' ? '100vw' : '75vh'
+  const paddingLeftWithHover =
+    hoverSlot == null
+      ? `calc((${containerWidth} - (${SPACING.spacing24}  * 2) - ${OFFDECK_MAP_WIDTH}) / 2)`
+      : SPACING.spacing24
+  const paddingLeft = tab === 'startingDeck' ? paddingLeftWithHover : undefined
+  const padding =
+    tab === 'protocolSteps'
+      ? SPACING.spacing24
+      : `${SPACING.spacing24} ${paddingLeft}`
+  const stepDetailsContainerWidth = `calc(((${containerWidth} - ${OFFDECK_MAP_WIDTH}) / 2) - (${SPACING.spacing24}  * 3))`
 
   return (
     <Flex
       backgroundColor={COLORS.white}
       borderRadius={BORDERS.borderRadius8}
-      width={tab === 'startingDeck' ? '100vw' : '75vh'}
+      width={containerWidth}
       height="65vh"
-      padding={`${SPACING.spacing40} ${SPACING.spacing24}`}
-      justifyContent={JUSTIFY_CENTER}
+      padding={padding}
       gridGap={SPACING.spacing24}
+      alignItems={ALIGN_CENTER}
     >
       {hoverSlot != null ? (
-        <Flex width="17.625rem" height="6.25rem" marginTop="4.75rem">
+        <Flex width={stepDetailsContainerWidth} height="6.25rem">
           <SlotDetailsContainer
             robotType={robotType}
             slot="offDeck"
@@ -64,13 +78,8 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
         </Flex>
       ) : null}
       <Flex
-        marginRight={tab === 'startingDeck' ? '17.375rem' : '0'}
-        marginLeft={
-          (tab === 'startingDeck' && hoverSlot) || tab === 'protocolSteps'
-            ? '0'
-            : '17.375rem'
-        }
-        width="100%"
+        width={OFFDECK_MAP_WIDTH}
+        height="100%"
         borderRadius={SPACING.spacing12}
         padding={`${SPACING.spacing16} ${SPACING.spacing40}`}
         backgroundColor={COLORS.grey20}
@@ -143,6 +152,8 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
                       setShowMenuList={() => {
                         setShowMenuListForId(null)
                       }}
+                      menuListSlotPosition={[0, 0, 0]}
+                      invertY
                     />
                   </Flex>
                 ) : null}


### PR DESCRIPTION
# Overview

Fixes positioning and hover behavior for OffDeck component, overflow menu positioning, and SlotInformation component when hovering an offdeck labware.

Closes RQA-3592

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/d9de1005-8559-4aef-b9e1-c9ccb012c6e2

- upload or create a protocol with a bunch of off deck labware (see [full.json.zip](https://github.com/user-attachments/files/17835309/full.json.zip))
- navigate to starting deck > off deck
- hover over labware and verify that slot details show correctly, including when you change the window width or height
- click to edit an off deck labware and verify that overflow menu doesn't move other labware
- navigate to protocol timeline and open the off deck tab for any selected step
- verify that positioning looks correct here as well

## Changelog

- fix overflow positioning and add optional scaleY transform
- calculate correct positions for map and slot hover details

## Review requests

see test plan

## Risk assessment

low