### PR TITLE
fix(api): update motor position before homing #16887

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -775,6 +775,7 @@ class OT3API(
         """
         Function to update motor estimation for a set of axes
         """
+        await self._backend.update_motor_status()
         if axes is None:
             axes = [ax for ax in Axis]
 


### PR DESCRIPTION
# Overview

fix for part of https://opentrons.atlassian.net/browse/RQA-3576.

## Test Plan and Hands on Testing

move the gantry before homing and then home the whole gantry. 
then move the gantry again and home again. 

## Changelog

update motor status in _update_position_estimation

## Risk assessment

low
