### PR TITLE
fix(api): truncate plate reader floating point results to third decimal place

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1268,7 +1268,10 @@ class ModuleView(HasState[ModuleState]):
                 row = chr(ord("A") + i // 12)  # Convert index to row (A-H)
                 col = (i % 12) + 1  # Convert index to column (1-12)
                 well_key = f"{row}{col}"
-                well_map[well_key] = value
+                truncated_value = float(
+                    "{:.5}".format(str(value))
+                )  # Truncate the returned value to the third decimal place
+                well_map[well_key] = truncated_value
             return well_map
         else:
             raise ValueError(


### PR DESCRIPTION
# Overview
Covers EXEC-1019

Ensure that the plate reader values are truncated to the third decimal place after being read during a protocol. This value should both be returned during a protocol run and as a part of the CSV file saved.

## Test Plan and Hands on Testing
- [x]  Run a plate reader protocol, ensure resulting value is truncated to the third decimal place in both the in-run dictionary result and the CSV file saved

## Changelog

Added truncation formatting step to plate reader read result formatting method.

## Review requests
Small change, anything look awry? Truncating to 5 characters total should cover us here because the plate reader only supports readings between 0 and 4 on a whole-number scale.

## Risk assessment
Low - affects new behavior for 8.2 read result only.