### PR TITLE
fix(app): home gripper G during recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -105,6 +105,7 @@ export function useRecoveryCommands({
   } = useUpdateErrorRecoveryPolicy(runId)
   const { makeSuccessToast } = recoveryToastUtils
 
+  // TODO(jh, 11-21-24): Some commands return a 200 with an error body. We should catch these and propagate the error.
   const chainRunRecoveryCommands = useCallback(
     (
       commands: CreateCommand[],
@@ -354,8 +355,8 @@ export const HOME_PIPETTE_Z_AXES: CreateCommand = {
 }
 
 export const RELEASE_GRIPPER_JAW: CreateCommand = {
-  commandType: 'unsafe/ungripLabware',
-  params: {},
+  commandType: 'home',
+  params: { axes: ['extensionJaw'] },
   intent: 'fixit',
 }
 


### PR DESCRIPTION
Closes [RQA-3645](https://opentrons.atlassian.net/browse/RQA-3645)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Recent gripper firmware changes add new degrees of G axis "home" state, and this ultimately causes the `unsafe/ungripLabware` command to fail, since a successful completion of the ungrip does not set the `HOME` flag. Because we ultimately want to ungrip the labware AND home the gripper G axis, let's use a parameterized `home` command instead.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Followed the steps outlined in the ticket. The command succeeds as expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the "release from gripper jaws" command sometimes failing during Error Recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3645]: https://opentrons.atlassian.net/browse/RQA-3645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ