### PR TITLE
feat(protocol-designer): add ability to clear staging slots directly

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -18,6 +18,7 @@ import {
 } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
+  FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   getModuleDisplayName,
   getModuleType,
   MAGNETIC_MODULE_TYPE,
@@ -58,7 +59,7 @@ import { LabwareTools } from './LabwareTools'
 import { MagnetModuleChangeContent } from './MagnetModuleChangeContent'
 import { getModuleModelsBySlot, getDeckErrors } from './utils'
 
-import type { ModuleModel } from '@opentrons/shared-data'
+import type { AddressableAreaName, ModuleModel } from '@opentrons/shared-data'
 import type { ThunkDispatch } from '../../../types'
 import type { Fixture } from './constants'
 
@@ -268,15 +269,22 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
         dispatch(deleteContainer({ labwareId: createdNestedLabwareForSlot.id }))
       }
       // clear labware on staging area 4th column slot
-      if (matchingLabwareFor4thColumn != null) {
+      if (matchingLabwareFor4thColumn != null && !keepExistingLabware) {
         dispatch(deleteContainer({ labwareId: matchingLabwareFor4thColumn.id }))
       }
-      //  clear fixture(s) from slot and zoom out
+      //  clear fixture(s) from slot
       if (createFixtureForSlots != null && createFixtureForSlots.length > 0) {
         createFixtureForSlots.forEach(fixture =>
           dispatch(deleteDeckFixture(fixture.id))
         )
-        dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
+        // zoom out if you're clearing a staging area slot directly from a 4th column
+        if (
+          FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS.includes(
+            slot as AddressableAreaName
+          )
+        ) {
+          dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
+        }
       }
     }
     handleResetToolbox()

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -242,7 +242,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     handleResetSearchTerm()
   }
 
-  const handleClear = (): void => {
+  const handleClear = (keepExistingLabware = false): void => {
     onDeckProps?.setHoveredModule(null)
     onDeckProps?.setHoveredFixture(null)
     if (slot !== 'offDeck') {
@@ -250,30 +250,33 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       if (createdModuleForSlot != null) {
         dispatch(deleteModule(createdModuleForSlot.id))
       }
-      //  clear fixture(s) from slot
-      if (createFixtureForSlots != null && createFixtureForSlots.length > 0) {
-        createFixtureForSlots.forEach(fixture =>
-          dispatch(deleteDeckFixture(fixture.id))
-        )
-      }
       //  clear labware from slot
       if (
         createdLabwareForSlot != null &&
-        createdLabwareForSlot.labwareDefURI !== selectedLabwareDefUri
+        (!keepExistingLabware ||
+          createdLabwareForSlot.labwareDefURI !== selectedLabwareDefUri)
       ) {
         dispatch(deleteContainer({ labwareId: createdLabwareForSlot.id }))
       }
       //  clear nested labware from slot
       if (
         createdNestedLabwareForSlot != null &&
-        createdNestedLabwareForSlot.labwareDefURI !==
-          selectedNestedLabwareDefUri
+        (!keepExistingLabware ||
+          createdNestedLabwareForSlot.labwareDefURI !==
+            selectedNestedLabwareDefUri)
       ) {
         dispatch(deleteContainer({ labwareId: createdNestedLabwareForSlot.id }))
       }
       // clear labware on staging area 4th column slot
       if (matchingLabwareFor4thColumn != null) {
         dispatch(deleteContainer({ labwareId: matchingLabwareFor4thColumn.id }))
+      }
+      //  clear fixture(s) from slot and zoom out
+      if (createFixtureForSlots != null && createFixtureForSlots.length > 0) {
+        createFixtureForSlots.forEach(fixture =>
+          dispatch(deleteDeckFixture(fixture.id))
+        )
+        dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
       }
     }
     handleResetToolbox()
@@ -285,7 +288,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   }
   const handleConfirm = (): void => {
     //  clear entities first before recreating them
-    handleClear()
+    handleClear(true)
 
     if (selectedFixture != null && cutout != null) {
       //  create fixture(s)

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -15,6 +15,12 @@ import {
   StyledText,
   useOnClickOutside,
 } from '@opentrons/components'
+import {
+  FLEX_ROBOT_TYPE,
+  FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
+  getCutoutIdFromAddressableArea,
+  getDeckDefFromRobotType,
+} from '@opentrons/shared-data'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 
 import { deleteModule } from '../../../step-forms/actions'
@@ -31,16 +37,13 @@ import {
 import { getStagingAreaAddressableAreas } from '../../../utils'
 import { selectors as labwareIngredSelectors } from '../../../labware-ingred/selectors'
 import type { MouseEvent, SetStateAction } from 'react'
-import {
-  FLEX_ROBOT_TYPE,
-  FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
-  getCutoutIdFromAddressableArea,
-  getDeckDefFromRobotType,
-  type AddressableAreaName,
-  type CoordinateTuple,
-  type CutoutId,
-  type DeckSlotId,
+import type {
+  AddressableAreaName,
+  CoordinateTuple,
+  CutoutId,
+  DeckSlotId,
 } from '@opentrons/shared-data'
+
 import type { LabwareOnDeck } from '../../../step-forms'
 import type { ThunkDispatch } from '../../../types'
 
@@ -142,8 +145,9 @@ export function SlotOverflowMenu(
   const hasNoItems =
     moduleOnSlot == null && labwareOnSlot == null && fixturesOnSlot.length === 0
 
-  const isStagingSlot = FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS.includes(location as AddressableAreaName)
-
+  const isStagingSlot = FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS.includes(
+    location as AddressableAreaName
+  )
 
   const handleClear = (): void => {
     //  clear module from slot
@@ -167,14 +171,18 @@ export function SlotOverflowMenu(
       dispatch(deleteContainer({ labwareId: matchingLabware.id }))
     }
     // delete staging slot if addressable area is on staging slot
-    if(isStagingSlot){
+    if (isStagingSlot) {
       const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
       const cutoutId = getCutoutIdFromAddressableArea(location, deckDef)
-      const stagingAreaEquipmentId = Object.values(additionalEquipmentOnDeck).find(({location}) => location === cutoutId)?.id
-      if(stagingAreaEquipmentId != null){
+      const stagingAreaEquipmentId = Object.values(
+        additionalEquipmentOnDeck
+      ).find(({ location }) => location === cutoutId)?.id
+      if (stagingAreaEquipmentId != null) {
         dispatch(deleteDeckFixture(stagingAreaEquipmentId))
       } else {
-        console.error(`could not find equipment id for entity in ${location} with cutout id ${cutoutId}`)
+        console.error(
+          `could not find equipment id for entity in ${location} with cutout id ${cutoutId}`
+        )
       }
     }
   }

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -32,11 +32,11 @@ import { getStagingAreaAddressableAreas } from '../../../utils'
 import { selectors as labwareIngredSelectors } from '../../../labware-ingred/selectors'
 import type { MouseEvent, SetStateAction } from 'react'
 import {
-  AddressableAreaName,
   FLEX_ROBOT_TYPE,
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   getCutoutIdFromAddressableArea,
   getDeckDefFromRobotType,
+  type AddressableAreaName,
   type CoordinateTuple,
   type CutoutId,
   type DeckSlotId,

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { fireEvent, screen } from '@testing-library/react'
 import {
@@ -67,6 +67,9 @@ describe('DeckSetupTools', () => {
     })
     vi.mocked(getDismissedHints).mockReturnValue([])
   })
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
   it('should render the relevant modules and fixtures for slot D3 on Flex with tabs', () => {
     render(props)
     screen.getByText('Add a module')
@@ -92,6 +95,14 @@ describe('DeckSetupTools', () => {
     screen.getByText('mock labware tools')
   })
   it('should clear the slot from all items when the clear cta is called', () => {
+    vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
+      selectedLabwareDefUri: 'mockUri',
+      selectedNestedLabwareDefUri: 'mockUri',
+      selectedFixture: null,
+      selectedModuleModel: null,
+      selectedSlot: { slot: 'D3', cutout: 'cutoutD3' },
+    })
+
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
       labware: {
         labId: {

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -10,6 +10,7 @@ import type {
   RobotType,
   ThermalAdapterName,
 } from '../types'
+import type { AddressableAreaName, CutoutId } from '../../deck/types/schemaV5'
 
 export { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
 export { getWellTotalVolume } from './getWellTotalVolume'
@@ -372,4 +373,29 @@ export const getDeckDefFromRobotType = (
   return robotType === 'OT-3 Standard'
     ? standardFlexDeckDef
     : standardOt2DeckDef
+}
+
+export const getCutoutIdFromAddressableArea = (
+  addressableAreaName: string,
+  deckDefinition: DeckDefinition
+): CutoutId | null => {
+  /**
+   * Given an addressable area name, returns the cutout ID associated with it, or null if there is none
+   */
+
+  for (const cutoutFixture of deckDefinition.cutoutFixtures) {
+    for (const [cutoutId, providedAreas] of Object.entries(
+      cutoutFixture.providesAddressableAreas
+    ) as Array<[CutoutId, AddressableAreaName[]]>) {
+      if (providedAreas.includes(addressableAreaName as AddressableAreaName)) {
+        return cutoutId
+      }
+    }
+  }
+
+  console.error(
+    `${addressableAreaName} is not provided by any cutout fixtures in deck definition ${deckDefinition.otId}`
+  )
+
+  return null
 }


### PR DESCRIPTION
# Overview
This PR adds the ability to clear staging area slots directly by interacting with a column 4 slot.

In order to preserve the functionality where pressing "done" does NOT delete labware in a slot of the labware is the same labware when users opened the toolbox, i added a parameter to the `handleClear` function to conditionally clear existing labware. 

closes RQA-3626


## Test Plan and Hands on Testing

Mess around with the deck setup tools. Add staging areas, add adapters, labware, modules, etc. Clear the slot both from the toolbox and the slot overflow menu. Just generally try to break it.

## Changelog

- add ability to clear staging slots directly


## Review requests

See test plan

## Risk assessment

Low