### PR TITLE
fix(api): ungrip gripper should home g

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_ungrip_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_ungrip_labware.py
@@ -1,6 +1,8 @@
 """Ungrip labware payload, result, and implementaiton."""
 
 from __future__ import annotations
+
+from opentrons.hardware_control.types import Axis
 from opentrons.protocol_engine.errors.exceptions import GripperNotAttachedError
 from pydantic import BaseModel
 from typing import Optional, Type
@@ -46,7 +48,7 @@ class UnsafeUngripLabwareImplementation(
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         if not ot3_hardware_api.has_gripper():
             raise GripperNotAttachedError("No gripper found to perform ungrip.")
-        await ot3_hardware_api.ungrip()
+        await ot3_hardware_api.home([Axis.G])
         return SuccessData(
             public=UnsafeUngripLabwareResult(),
         )

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_ungrip_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_ungrip_labware.py
@@ -1,6 +1,7 @@
 """Test update-position-estimator commands."""
 from decoy import Decoy
 
+from opentrons.hardware_control.types import Axis
 from opentrons.protocol_engine.commands.unsafe.unsafe_ungrip_labware import (
     UnsafeUngripLabwareParams,
     UnsafeUngripLabwareResult,
@@ -25,7 +26,7 @@ async def test_ungrip_labware_implementation(
     assert result == SuccessData(public=UnsafeUngripLabwareResult())
 
     decoy.verify(
-        await ot3_hardware_api.ungrip(),
+        await ot3_hardware_api.home([Axis.G]),
     )
 
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -355,8 +355,8 @@ export const HOME_PIPETTE_Z_AXES: CreateCommand = {
 }
 
 export const RELEASE_GRIPPER_JAW: CreateCommand = {
-  commandType: 'home',
-  params: { axes: ['extensionJaw'] },
+  commandType: 'unsafe/ungripLabware',
+  params: {},
   intent: 'fixit',
 }
 


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-3645.
`unsafe/ungrip` should call home G instead of ungrip.
revert https://github.com/Opentrons/opentrons/pull/16928

## Test Plan and Hands on Testing

as explained in the ticket + door open/close should work. 

## Changelog

make ungrip command call hardware api home G instead of ungrip

## Risk assessment

low.
