### PR TITLE
fix(app): fix intervention modal icon sizing

### DIFF
--- a/app/src/molecules/InterventionModal/index.tsx
+++ b/app/src/molecules/InterventionModal/index.tsx
@@ -23,7 +23,6 @@ import {
 
 import { getIsOnDevice } from '/app/redux/config'
 
-import type { IconName } from '@opentrons/components'
 import { ModalContentOneColSimpleButtons } from './ModalContentOneColSimpleButtons'
 import { TwoColumn } from './TwoColumn'
 import { OneColumn } from './OneColumn'
@@ -32,6 +31,10 @@ import { ModalContentMixed } from './ModalContentMixed'
 import { DescriptionContent } from './DescriptionContent'
 import { DeckMapContent } from './DeckMapContent'
 import { CategorizedStepContent } from './CategorizedStepContent'
+
+import type { FlattenSimpleInterpolation } from 'styled-components'
+import type { IconName } from '@opentrons/components'
+
 export {
   ModalContentOneColSimpleButtons,
   TwoColumn,
@@ -122,6 +125,8 @@ export interface InterventionModalProps {
   type?: ModalType
   /** optional icon name */
   iconName?: IconName | null | undefined
+  /* Optional icon size override. */
+  iconSize?: string
   /** modal contents */
   children: React.ReactNode
 }
@@ -133,6 +138,7 @@ export function InterventionModal({
   iconName,
   iconHeading,
   children,
+  iconSize,
 }: InterventionModalProps): JSX.Element {
   const modalType = type ?? 'intervention-required'
   const headerColor =
@@ -166,7 +172,7 @@ export function InterventionModal({
             {titleHeading}
             <Flex alignItems={ALIGN_CENTER} onClick={iconHeadingOnClick}>
               {iconName != null ? (
-                <Icon name={iconName} css={ICON_STYLE} />
+                <Icon name={iconName} css={buildIconStyle(iconSize)} />
               ) : null}
               {iconHeading != null ? iconHeading : null}
             </Flex>
@@ -178,9 +184,11 @@ export function InterventionModal({
   )
 }
 
-const ICON_STYLE = css`
-  width: ${SPACING.spacing32};
-  height: ${SPACING.spacing32};
+const buildIconStyle = (
+  iconSize: string | undefined
+): FlattenSimpleInterpolation => css`
+  width: ${iconSize ?? SPACING.spacing16};
+  height: ${iconSize ?? SPACING.spacing16};
   margin: ${SPACING.spacing4};
   cursor: ${CURSOR_POINTER};
 

--- a/app/src/organisms/InterventionModal/index.tsx
+++ b/app/src/organisms/InterventionModal/index.tsx
@@ -165,7 +165,7 @@ export function InterventionModal({
     }
   })()
 
-  const { iconName, headerTitle, headerTitleOnDevice } = (() => {
+  const { iconName, headerTitle, headerTitleOnDevice, iconSize } = (() => {
     switch (command.commandType) {
       case 'waitForResume':
       case 'pause':
@@ -173,12 +173,14 @@ export function InterventionModal({
           iconName: 'pause-circle' as IconName,
           headerTitle: t('pause_on', { robot_name: robotName }),
           headerTitleOnDevice: t('pause'),
+          iconSize: SPACING.spacing32,
         }
       case 'moveLabware':
         return {
           iconName: 'move-xy-circle' as IconName,
           headerTitle: t('move_labware_on', { robot_name: robotName }),
           headerTitleOnDevice: t('move_labware'),
+          iconSize: SPACING.spacing32,
         }
       default:
         console.warn(
@@ -189,6 +191,7 @@ export function InterventionModal({
           iconName: null,
           headerTitle: '',
           headerTitleOnDevice: '',
+          iconSize: undefined,
         }
     }
   })()
@@ -228,6 +231,7 @@ export function InterventionModal({
       iconHeading={<LegacyStyledText as="h1">{headerTitle}</LegacyStyledText>}
       iconName={iconName}
       type="intervention-required"
+      iconSize={iconSize}
     >
       <Box {...CONTENT_STYLE}>
         {childContent}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a regression introduced by https://github.com/Opentrons/opentrons/pull/16916. We use `InterventionalModal` in three places: [protocol run interventions](https://www.figma.com/design/Nx7ORMnfyJNP4FQYxN4e5x/Primary%3A-Desktop-App?node-id=2043-352011&t=reMA7G0vFPlSKL1Z-4), [Error Recovery](https://www.figma.com/design/OGssKRmCOvuXSqUpK2qXrV/Feature%3A-Error-Recovery-November-Release?node-id=9766-67331&t=LRMoxmlSM5uICsqp-4), and [incompatible modules](https://www.figma.com/design/Nx7ORMnfyJNP4FQYxN4e5x/Primary%3A-Desktop-App?node-id=2032-304267&t=reMA7G0vFPlSKL1Z-4).  ER and run interventions have different icon sizing, which I didn't catch during [this ticket](https://opentrons.atlassian.net/browse/RQA-3627).

Let's just specify an override for the icon sizing to keep this simple. It's not a design component. 

### Current Behavior

<img width="760" alt="Screenshot 2024-11-21 at 3 01 35 PM" src="https://github.com/user-attachments/assets/6e9fa605-28bb-40c4-81d3-528da41dc774">


### Fixed Behavior

<img width="763" alt="Screenshot 2024-11-21 at 3 01 25 PM" src="https://github.com/user-attachments/assets/04b30a6a-f6a6-4fde-a99d-ccfe942c942e">

<img width="791" alt="Screenshot 2024-11-21 at 3 04 18 PM" src="https://github.com/user-attachments/assets/d90a03e8-0327-4714-b9f8-61c289a1d6cc">

_Just to show there's no regression._


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
