### PR TITLE
fix(api): raise error during analysis plate reader read without lid closed

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -80,6 +80,10 @@ class ReadAbsorbanceImpl(
             raise CannotPerformModuleAction(
                 "Cannot perform Read action on Absorbance Reader without calling `.initialize(...)` first."
             )
+        if abs_reader_substate.is_lid_on is False:
+            raise CannotPerformModuleAction(
+                "Cannot perform Read action on Absorbance Reader with the lid open. Try calling `.close_lid()` first."
+            )
 
         # TODO: we need to return a file ID and increase the file count even when a moduel is not attached
         if (

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -82,7 +82,7 @@ class ReadAbsorbanceImpl(
             )
         if abs_reader_substate.is_lid_on is False:
             raise CannotPerformModuleAction(
-                "Cannot perform Read action on Absorbance Reader with the lid open. Try calling `.close_lid()` first."
+                "Absorbance Plate Reader can't read a plate with the lid open. Call `close_lid()` first."
             )
 
         # TODO: we need to return a file ID and increase the file count even when a moduel is not attached


### PR DESCRIPTION

# Overview
Covers RABR-674

Ensures that an error is raised during analysis when the lid is not closed and a read is attempted, and that the error goes away if the lid is closed.

## Test Plan and Hands on Testing

- [x] Run the following Protocol, get an analysis error of type CannotPerformModuleAction
```
from opentrons.protocol_api import ProtocolContext
metadata = {
    "protocolName": "plate reader test for read without lid",
}

requirements = {"robotType": "Flex", "apiLevel": "2.21"}

def run(ctx: ProtocolContext) -> None:
    """Protocol."""
    plate_reader = ctx.load_module(
        "absorbanceReaderV1", "A3"
    )
    sample_plate = ctx.load_labware(
        "armadillo_96_wellplate_200ul_pcr_full_skirt", "D1", "Sample Plate 1"
    )
    plate_reader.close_lid()
    plate_reader.initialize("single", [450])
    plate_reader.open_lid()
    ctx.move_labware(sample_plate, plate_reader, use_gripper=True)
    result = plate_reader.read()
```


## Changelog
Added new error to the engine command executor for the Read function of the plate reader.

## Review requests

## Risk assessment
Low