### PR TITLE
test(api): fix or ignore Decoy related warnings in unit tests

### DIFF
--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -5,3 +5,9 @@ markers =
         ot3_only: Test only functions using the OT3 hardware
 addopts = --color=yes --strict-markers
 asyncio_mode = auto
+
+# TODO this should be looked into being removed upon updating the Decoy library. The purpose of this warning is to
+#   catch missing attributes, but it raises for any property referenced in a test which accounts for about ~250 warnings
+#   which aren't serving any useful purpose and obscure other warnings.
+filterwarnings =
+    ignore::decoy.warnings.MissingSpecAttributeWarning

--- a/api/tests/opentrons/protocol_engine/commands/test_verify_tip_presence.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_verify_tip_presence.py
@@ -23,13 +23,13 @@ async def test_verify_tip_presence_implementation(
         expectedState=TipPresenceStatus.PRESENT,
     )
 
-    decoy.when(
-        await tip_handler.verify_tip_presence(
-            pipette_id="pipette-id",
-            expected=TipPresenceStatus.PRESENT,
-        )
-    ).then_return(None)
-
     result = await subject.execute(data)
 
     assert result == SuccessData(public=VerifyTipPresenceResult())
+    decoy.verify(
+        await tip_handler.verify_tip_presence(
+            pipette_id="pipette-id",
+            expected=TipPresenceStatus.PRESENT,
+            follow_singular_sensor=None,
+        )
+    )

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_update_position_estimators.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_update_position_estimators.py
@@ -37,11 +37,6 @@ async def test_update_position_estimators_implementation(
     decoy.when(gantry_mover.motor_axis_to_hardware_axis(MotorAxis.Y)).then_return(
         Axis.Y
     )
-    decoy.when(
-        await ot3_hardware_api.update_axis_position_estimations(
-            [Axis.Z_L, Axis.P_L, Axis.X, Axis.Y]
-        )
-    ).then_return(None)
 
     result = await subject.execute(data)
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -997,8 +997,7 @@ async def test_estop_noops_if_invalid(
     subject.estop()  # Should not raise.
 
     decoy.verify(
-        action_dispatcher.dispatch(),  # type: ignore
-        ignore_extra_args=True,
+        action_dispatcher.dispatch(expected_action),
         times=0,
     )
     decoy.verify(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -448,6 +448,7 @@ async def test_run_json_runner_stop_requested_stops_enqueuing(
         await run_func()
 
 
+@pytest.mark.filterwarnings("ignore::decoy.warnings.RedundantVerifyWarning")
 @pytest.mark.parametrize(
     "schema_version, json_protocol",
     [


### PR DESCRIPTION
# Overview

This PR aims to reduce the amount of warnings generated by the API unit tests by fixing or selectively ignoring specific Decoy warnings.

Across the entire test suite, `MissingSpecAttributeWarning` has been suppressed. The purpose of this is to catch non-existent attributes of decoy mock objects, but it's being raised for any property that is referenced, which accounts for about 250 warnings. Ignoring these should not cause any issues because if a property is not being referred to properly, the vast majority of the time that will cause the test to fail anyway due to some rehearsal not occurring.

The other warning being suppressed is `RedundantVerifyWarning` for `protocol_runner.py: test_load_json_runner`, which cannot be fixed without harming the coverage of the test. Because there is a long explanation of why it is needed, I've chosen to simply ignore that for this specific test.

Otherwise I've fixed up a bunch of `IncorrectCallWarning`, `RedundantVerifyWarning` and `MiscalledStubWarning` throughout the unit tests.

There are still a few existing `DeprecationWarning`s and a bunch of `RuntimeWarning`s related to `CanMessenger._read_task_shield' was never awaited` but fixing those would involve more effort or changing packages/editing hardware code, so those have not been fixed.

Overall this reduces the amount of warnings from ~330 to ~40 warnings.

## Changelog

- fix/ignore Decoy warnings in api tests

## Review requests

If anybody has an easy fix for any remaining errors, feel free to push it to this branch.

## Risk assessment

Low
