### PR TITLE
fix(app): Plate reader DQA

### DIFF
--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -11,6 +11,7 @@
   "change_robot": "Change robot",
   "clear_data": "clear data",
   "close": "close",
+  "closed": "closed",
   "close_robot_door": "Close the robot door before starting the run.",
   "confirm": "Confirm",
   "confirm_placement": "Confirm placement",

--- a/app/src/molecules/WizardRequiredEquipmentList/index.tsx
+++ b/app/src/molecules/WizardRequiredEquipmentList/index.tsx
@@ -155,7 +155,7 @@ function RequiredEquipmentCard(props: RequiredEquipmentCardProps): JSX.Element {
           </Flex>
         ) : null}
         <Flex
-          flex="0 1 70%"
+          flex={imageSrc == null ? '0 1 100%' : '0 1 70%'}
           flexDirection={DIRECTION_COLUMN}
           justifyContent={JUSTIFY_SPACE_AROUND}
         >

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
@@ -41,12 +41,15 @@ export function HistoricalProtocolRun(
   const { t } = useTranslation('run_details')
   const { run, protocolName, robotIsBusy, robotName, protocolKey } = props
   const [drawerOpen, setDrawerOpen] = useState(false)
-  const countRunDataFiles =
+  let countRunDataFiles =
     'runTimeParameters' in run
       ? run?.runTimeParameters.filter(
           parameter => parameter.type === 'csv_file'
         ).length
       : 0
+  if ('outputFileIds' in run) {
+    countRunDataFiles += run.outputFileIds.length
+  }
   const runStatus = run.status
   const runDisplayName = formatTimestamp(run.createdAt)
   let duration = EMPTY_TIMESTAMP

--- a/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
@@ -156,6 +156,13 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
     t as TFunction,
     i18n
   )
+  const slotOnlyDisplayLocation = getDisplayLocation(
+    location,
+    labwareDefs,
+    t as TFunction,
+    i18n,
+    true
+  )
   const labwareDisplayName = getLabwareDisplayName(labwareDef)
 
   let placeItemInstruction: JSX.Element = (
@@ -445,7 +452,7 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
         <JogToWell
           header={t('check_item_in_location', {
             item: isTiprack ? t('tip_rack') : t('labware'),
-            location: displayLocation,
+            location: slotOnlyDisplayLocation,
           })}
           body={
             <Trans
@@ -483,7 +490,7 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
           {...props}
           header={t('prepare_item_in_location', {
             item: isTiprack ? t('tip_rack') : t('labware'),
-            location: displayLocation,
+            location: slotOnlyDisplayLocation,
           })}
           body={
             <UnorderedList

--- a/app/src/organisms/LabwarePositionCheck/utils/getDisplayLocation.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getDisplayLocation.ts
@@ -12,12 +12,16 @@ export function getDisplayLocation(
   location: LabwareOffsetLocation,
   labwareDefinitions: LabwareDefinition2[],
   t: TFunction,
-  i18n: i18n
+  i18n: i18n,
+  slotOnly?: boolean
 ): string {
   const slotDisplayLocation = i18n.format(
     t('slot_name', { slotName: location.slotName }),
     'titleCase'
   )
+  if (slotOnly) {
+    return slotDisplayLocation
+  }
 
   if ('definitionUri' in location && location.definitionUri != null) {
     const adapterDisplayName = labwareDefinitions.find(

--- a/app/src/organisms/ModuleCard/AbsorbanceReaderData.tsx
+++ b/app/src/organisms/ModuleCard/AbsorbanceReaderData.tsx
@@ -12,7 +12,7 @@ export const AbsorbanceReaderData = (
   props: AbsorbanceReaderProps
 ): JSX.Element | null => {
   const { moduleData } = props
-  const { t } = useTranslation('device_details')
+  const { t, i18n } = useTranslation(['device_details', 'shared'])
 
   const StatusLabelProps = {
     status: 'Idle',
@@ -37,6 +37,10 @@ export const AbsorbanceReaderData = (
       break
     }
   }
+  const lidDisplayStatus =
+    moduleData.lidStatus === 'on'
+      ? i18n.format(t('shared:closed'), 'capitalize')
+      : i18n.format(t('shared:open'), 'capitalize')
 
   return (
     <>
@@ -46,7 +50,7 @@ export const AbsorbanceReaderData = (
         data-testid="abs_module_data"
       >
         {t('abs_reader_lid_status', {
-          status: moduleData.lidStatus === 'on' ? 'closed' : 'open',
+          status: lidDisplayStatus,
         })}
       </StyledText>
     </>


### PR DESCRIPTION
fix RQA-3570, RQA-3572, RQA-3573, RQA-3633, RQA-3634
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
DQA for plate reader including some LPC items
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->
<img width="453" alt="Screen Shot 2024-11-21 at 2 44 59 PM" src="https://github.com/user-attachments/assets/97323784-4cc5-4290-90ea-da4b204fc210">
<img width="437" alt="Screen Shot 2024-11-21 at 2 44 01 PM" src="https://github.com/user-attachments/assets/dd3f75db-72f5-413d-985e-1066fcb6280f">
<img width="899" alt="Screen Shot 2024-11-21 at 2 44 21 PM" src="https://github.com/user-attachments/assets/4a068e84-1f59-42fb-8eb8-42b7602f65d1">
<img width="831" alt="Screen Shot 2024-11-19 at 4 54 44 PM" src="https://github.com/user-attachments/assets/31e1b3e2-0b27-4763-9d32-363b10c137a7">

## Changelog
1. In the will you need section of LPC, make instructional text full width instead of 70% width
2. Change LPC headers to use slot only location detail level to ensure module and adapter names don't make the header too long
3. Capitalize open and closed plate reader lid status
4. Add plate reader output file count to protocol file count in historical protocol run

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
