### PR TITLE
docs(api): Python API 2.21 versioning page

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -99,7 +99,7 @@ extensions += ['sphinx-prompt', 'sphinx_substitution_extensions']
 # use rst_prolog to hold the subsitution
 # update the apiLevel value whenever a new minor version is released
 rst_prolog = f"""
-.. |apiLevel| replace:: 2.20
+.. |apiLevel| replace:: 2.21
 .. |release| replace:: {release}
 """
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -138,7 +138,7 @@ Changes in API Versions
 
 Version 2.21
 ------------
-- Adds :py:class:`.AbsorbanceReaderContext` to support the :ref:`Absorbance Plate Reader Module <absorbance-plate-reader-module>`. Use the load name ``absorbanceReaderV1`` with :py:meth:`.ProtocolContext.load_module` to add a Heater-Shaker to a protocol.
+- Adds :py:class:`.AbsorbanceReaderContext` to support the :ref:`Absorbance Plate Reader Module <absorbance-plate-reader-module>`. Use the load name ``absorbanceReaderV1`` with :py:meth:`.ProtocolContext.load_module` to add an Absorbance Plate Reader to a protocol.
 - :ref:`Liquid presence detection <lpd>` now only checks on the first aspiration of the :py:meth:`.mix` cycle.
 - Improved the run log output of :py:meth:`.ThermocyclerContext.execute_profile`.
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -68,7 +68,7 @@ The maximum supported API version for your robot is listed in the Opentrons App 
 
 If you upload a protocol that specifies a higher API level than the maximum supported, your robot won't be able to analyze or run your protocol. You can increase the maximum supported version by updating your robot software and Opentrons App. 
 
-Opentrons robots running the latest software (8.0.0) support the following version ranges: 
+Opentrons robots running the latest software (8.2.0) support the following version ranges: 
 
     * **Flex:** version 2.15–|apiLevel|.
     * **OT-2:** versions 2.0–|apiLevel|.
@@ -84,6 +84,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+------------------------------+
 | API Version | Introduced in Robot Software |
 +=============+==============================+
+|     2.21    |          8.2.0               |
++-------------+------------------------------+
 |     2.20    |          8.0.0               |
 +-------------+------------------------------+
 |     2.19    |          7.3.1               |
@@ -136,7 +138,9 @@ Changes in API Versions
 
 Version 2.21
 ------------
-- :ref:`Liquid presence detection <lpd>` now only checks on the first aspiration of the :py:meth:`.mix` cycle. 
+- Adds :py:class:`.AbsorbanceReaderContext` to support the :ref:`Absorbance Plate Reader Module <absorbance-plate-reader-module>`. Use the load name ``absorbanceReaderV1`` with :py:meth:`.ProtocolContext.load_module` to add a Heater-Shaker to a protocol.
+- :ref:`Liquid presence detection <lpd>` now only checks on the first aspiration of the :py:meth:`.mix` cycle.
+- Improved the run log output of :py:meth:`.ThermocyclerContext.execute_profile`.
 
 Version 2.20
 ------------


### PR DESCRIPTION

# Overview

List the new features of PAPI 2.21 on the Versioning page.

Replaces #16935 

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-versioning-2.21/v2/versioning.html#version-2-21)

## Changelog

- New feature bullets (these are software-focused so they don't list all _docs_ changes)
- Update version table
- Bump `|apiLevel|` replacement

## Review requests

Am I missing something? Feels light. But Thermocycler lids are not new API features (work in 2.16+).

## Risk assessment

none, docs
