### PR TITLE
fix(protocol-designer): fix padding on batch edit toolbox

### DIFF
--- a/protocol-designer/src/organisms/EditInstrumentsModal/index.tsx
+++ b/protocol-designer/src/organisms/EditInstrumentsModal/index.tsx
@@ -89,7 +89,7 @@ export function EditInstrumentsModal(
 ): JSX.Element {
   const { onClose } = props
   const dispatch = useDispatch<ThunkDispatch<any>>()
-  const { t } = useTranslation([
+  const { i18n, t } = useTranslation([
     'create_new_protocol',
     'protocol_overview',
     'shared',
@@ -347,7 +347,7 @@ export function EditInstrumentsModal(
                             desktopStyle="bodyDefaultRegular"
                             color={COLORS.grey60}
                           >
-                            {t('gripper')}
+                            {i18n.format(t('gripper'), 'capitalize')}
                           </StyledText>
                         </Flex>
                         <Btn

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
@@ -71,12 +71,17 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
   }
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} width="100%">
-      <Flex padding={SPACING.spacing16}>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      width="100%"
+      spacing={SPACING.spacing12}
+      gridGap={SPACING.spacing16}
+    >
+      <Flex padding={`${SPACING.spacing16} ${SPACING.spacing16} 0`}>
         <Tabs tabs={[aspirateTab, dispenseTab]} />
       </Flex>
       <Divider marginY="0" />
-      <Flex padding={SPACING.spacing16} width="100%">
+      <Flex width="100%">
         <FlowRateField
           {...propsForFields[`${tab}_flowRate`]}
           pipetteId={getPipetteIdForForm()}
@@ -115,7 +120,7 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
       ) : null}
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        padding={SPACING.spacing12}
+        padding={`0 ${SPACING.spacing16}`}
         gridGap={SPACING.spacing8}
       >
         <StyledText desktopStyle="bodyDefaultSemiBold">
@@ -159,6 +164,7 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
                   options={getBlowoutLocationOptionsForForm({
                     stepType: 'mix',
                   })}
+                  padding="0"
                 />
               ) : null}
             </CheckboxExpandStepFormField>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -73,12 +73,16 @@ export function BatchEditMoveLiquidTools(
   }
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} width="100%">
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      width="100%"
+      gridGap={SPACING.spacing12}
+    >
       <Flex padding={SPACING.spacing16}>
         <Tabs tabs={[aspirateTab, dispenseTab]} />
       </Flex>
       <Divider marginY="0" />
-      <Flex padding={SPACING.spacing16} width="100%">
+      <Flex width="100%">
         <FlowRateField
           {...propsForFields[addFieldNamePrefix('flowRate')]}
           pipetteId={getPipetteIdForForm()}
@@ -119,7 +123,7 @@ export function BatchEditMoveLiquidTools(
       <Divider marginY="0" />
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        padding={SPACING.spacing12}
+        padding={`0 ${SPACING.spacing16}`}
         gridGap={SPACING.spacing8}
       >
         <StyledText desktopStyle="bodyDefaultSemiBold">
@@ -227,6 +231,7 @@ export function BatchEditMoveLiquidTools(
                     path: propsForFields.path.value as any,
                     stepType: 'moveLiquid',
                   })}
+                  padding="0"
                 />
                 <FlowRateField
                   {...propsForFields.blowout_flowRate}
@@ -234,6 +239,7 @@ export function BatchEditMoveLiquidTools(
                   flowRateType="blowout"
                   volume={propsForFields.volume?.value ?? 0}
                   tiprack={propsForFields.tipRack.value}
+                  padding="0"
                 />
                 <BlowoutOffsetField
                   {...propsForFields.blowout_z_offset}


### PR DESCRIPTION
# Overview

For both mix and move liquid batch edit toolboxes, fix padding for each field

Closes RQA-3679

## Test Plan and Hands on Testing

- open attached [protocol](https://github.com/user-attachments/files/17873452/full1.json.zip)
 with multiple transfers + mixes
- command + click to select 2 transfer steps and open batch edit toolbox
- click through and verify that padding/grid gaps look correct, including expanded advanced param fields 
- repeat with mix steps

## Changelog

- fix layout on batch edit toolboxes
- sneak in capitalization fix on EditInstrumentsModal

## Review requests

see test plan

## Risk assessment
low