### PR TITLE
refactor(app): do not show progress indication during drop tip wizard

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/DropTipWizardHeader.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizardHeader.tsx
@@ -1,11 +1,9 @@
-import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { BEFORE_BEGINNING, BLOWOUT_SUCCESS, DT_ROUTES } from './constants'
 import { WizardHeader } from '/app/molecules/WizardHeader'
 
 import type { DropTipWizardProps } from './DropTipWizard'
-import type { DropTipFlowsRoute, DropTipFlowsStep, ErrorDetails } from './types'
+import type { ErrorDetails } from './types'
 
 type DropTipWizardHeaderProps = DropTipWizardProps & {
   isExitInitiated: boolean
@@ -16,9 +14,6 @@ type DropTipWizardHeaderProps = DropTipWizardProps & {
 
 export function DropTipWizardHeader({
   confirmExit,
-  currentStep,
-  currentRoute,
-  currentStepIdx,
   isExitInitiated,
   isFinalWizardStep,
   errorDetails,
@@ -36,71 +31,12 @@ export function DropTipWizardHeader({
     handleCleanUpAndClose,
   })
 
-  const { totalSteps, currentStepNumber } = useSeenBlowoutSuccess({
-    currentStep,
-    currentRoute,
-    currentStepIdx,
-  })
-
   return (
     <WizardHeader
       title={i18n.format(t('drop_tips'), 'capitalize')}
-      currentStep={currentStepNumber}
-      totalSteps={totalSteps}
       onExit={!showConfirmExit ? wizardHeaderOnExit : null}
     />
   )
-}
-
-interface UseSeenBlowoutSuccessProps {
-  currentStep: DropTipFlowsStep
-  currentRoute: DropTipFlowsRoute
-  currentStepIdx: number
-}
-
-interface UseSeenBlowoutSuccessResult {
-  currentStepNumber: number | null
-  totalSteps: number | null
-}
-
-// Calculate the props used for determining step count based on the route. Because blowout and drop tip are separate routes,
-// there's a need for state to track whether we've seen blowout, so the step counter is accurate when the drop tip route is active.
-export function useSeenBlowoutSuccess({
-  currentStep,
-  currentRoute,
-  currentStepIdx,
-}: UseSeenBlowoutSuccessProps): UseSeenBlowoutSuccessResult {
-  const [hasSeenBlowoutSuccess, setHasSeenBlowoutSuccess] = useState(false)
-
-  useEffect(() => {
-    if (currentStep === BLOWOUT_SUCCESS) {
-      setHasSeenBlowoutSuccess(true)
-    } else if (currentStep === BEFORE_BEGINNING) {
-      setHasSeenBlowoutSuccess(false)
-    }
-  }, [currentStep])
-
-  const shouldRenderStepCounter = currentRoute !== DT_ROUTES.BEFORE_BEGINNING
-
-  let totalSteps: null | number
-  if (!shouldRenderStepCounter) {
-    totalSteps = null
-  } else if (currentRoute === DT_ROUTES.BLOWOUT || hasSeenBlowoutSuccess) {
-    totalSteps = DT_ROUTES.BLOWOUT.length + DT_ROUTES.DROP_TIP.length
-  } else {
-    totalSteps = currentRoute.length
-  }
-
-  let currentStepNumber: null | number
-  if (!shouldRenderStepCounter) {
-    currentStepNumber = null
-  } else if (hasSeenBlowoutSuccess && currentRoute === DT_ROUTES.DROP_TIP) {
-    currentStepNumber = DT_ROUTES.BLOWOUT.length + currentStepIdx + 1
-  } else {
-    currentStepNumber = currentStepIdx + 1
-  }
-
-  return { currentStepNumber, totalSteps }
 }
 
 export interface UseWizardExitHeaderProps {

--- a/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardHeader.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardHeader.test.tsx
@@ -1,16 +1,14 @@
 import type * as React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { renderHook, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { mockDropTipWizardContainerProps } from '../__fixtures__'
 import {
   useWizardExitHeader,
-  useSeenBlowoutSuccess,
   DropTipWizardHeader,
 } from '../DropTipWizardHeader'
-import { DT_ROUTES } from '../constants'
 
 import type { Mock } from 'vitest'
 import type { UseWizardExitHeaderProps } from '../DropTipWizardHeader'
@@ -31,22 +29,6 @@ describe('DropTipWizardHeader', () => {
   it('renders appropriate copy and onClick behavior', () => {
     render(props)
     screen.getByText('Drop tips')
-    screen.getByText('Step 1 / 5')
-  })
-})
-
-describe('useSeenBlowoutSuccess', () => {
-  it('should not render step counter when currentRoute is BEFORE_BEGINNING', () => {
-    const { result } = renderHook(() =>
-      useSeenBlowoutSuccess({
-        currentStep: 'SOME_STEP' as any,
-        currentRoute: DT_ROUTES.BEFORE_BEGINNING,
-        currentStepIdx: 0,
-      })
-    )
-
-    expect(result.current.totalSteps).toBe(null)
-    expect(result.current.currentStepNumber).toBe(null)
   })
 })
 


### PR DESCRIPTION
Closes [RQA-3643](https://opentrons.atlassian.net/browse/RQA-3643)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Because drop tip flows is no longer deterministic, we shouldn't show the progress bar and step counter.

<img width="1000" alt="Screenshot 2024-11-22 at 12 27 15 PM" src="https://github.com/user-attachments/assets/10f669aa-876f-4feb-b518-cf5f34489160">

<img width="836" alt="Screenshot 2024-11-22 at 12 24 52 PM" src="https://github.com/user-attachments/assets/c2e993b4-4e9c-45d5-a403-f2e746950730">


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images. Also confirmed that this isn't doing anything unexpected in ER (although it definitely shouldn't anyway).
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Removed progress bar and step counter from Drop tip wizard.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3643]: https://opentrons.atlassian.net/browse/RQA-3643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ