### PR TITLE
fix(protocol-designer): add fallback for well order

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
@@ -23,8 +23,8 @@ import {
   getLabwareFieldForPositioningField,
 } from '../StepForm/utils'
 
-import type { FieldPropsByName } from '../StepForm/types'
 import type { WellOrderOption } from '../../../../form-types'
+import type { FieldPropsByName } from '../StepForm/types'
 
 interface BatchEditMixToolsProps {
   propsForFields: FieldPropsByName

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
@@ -22,7 +22,8 @@ import {
   getBlowoutLocationOptionsForForm,
   getLabwareFieldForPositioningField,
 } from '../StepForm/utils'
-import { getWellOrderFieldValue } from './utils'
+
+import type { WellOrderOption } from '../../../../form-types'
 import type { FieldPropsByName } from '../StepForm/types'
 
 interface BatchEditMixToolsProps {
@@ -90,16 +91,14 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
             updateSecondWellOrder={
               propsForFields.mix_wellOrder_second.updateValue
             }
-            firstValue={getWellOrderFieldValue(
-              propsForFields,
-              'mix_wellOrder_first',
-              't2b'
-            )}
-            secondValue={getWellOrderFieldValue(
-              propsForFields,
-              'mix_wellOrder_second',
-              'l2r'
-            )}
+            firstValue={
+              (propsForFields.mix_wellOrder_first.name ??
+                't2b') as WellOrderOption
+            }
+            secondValue={
+              (propsForFields.mix_wellOrder_second.name ??
+                'l2r') as WellOrderOption
+            }
             firstName="mix_wellOrder_first"
             secondName="mix_wellOrder_second"
           />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
@@ -23,8 +23,8 @@ import {
   getLabwareFieldForPositioningField,
 } from '../StepForm/utils'
 
-import type { WellOrderOption } from '../../../../form-types'
 import type { FieldPropsByName } from '../StepForm/types'
+import type { WellOrderOption } from '../../../../form-types'
 
 interface BatchEditMixToolsProps {
   propsForFields: FieldPropsByName

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
@@ -22,7 +22,7 @@ import {
   getBlowoutLocationOptionsForForm,
   getLabwareFieldForPositioningField,
 } from '../StepForm/utils'
-import type { WellOrderOption } from '../../../../form-types'
+import { getWellOrderFieldValue } from './utils'
 import type { FieldPropsByName } from '../StepForm/types'
 
 interface BatchEditMixToolsProps {
@@ -59,17 +59,6 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
     return pipetteId ? String(pipetteId) : null
   }
 
-  const getWellOrderFieldValue = (
-    name: string
-  ): WellOrderOption | null | undefined => {
-    const val = propsForFields[name]?.value
-    if (val === 'l2r' || val === 'r2l' || val === 't2b' || val === 'b2t') {
-      return val
-    } else {
-      return null
-    }
-  }
-
   return (
     <Flex flexDirection={DIRECTION_COLUMN} width="100%">
       <Flex padding={SPACING.spacing16}>
@@ -96,8 +85,16 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
             updateSecondWellOrder={
               propsForFields.mix_wellOrder_second.updateValue
             }
-            firstValue={getWellOrderFieldValue('mix_wellOrder_first')}
-            secondValue={getWellOrderFieldValue('mix_wellOrder_second')}
+            firstValue={getWellOrderFieldValue(
+              propsForFields,
+              'mix_wellOrder_first',
+              't2b'
+            )}
+            secondValue={getWellOrderFieldValue(
+              propsForFields,
+              'mix_wellOrder_second',
+              'l2r'
+            )}
             firstName="mix_wellOrder_first"
             secondName="mix_wellOrder_second"
           />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -23,8 +23,8 @@ import {
   PositionField,
   WellsOrderField,
 } from '../StepForm/PipetteFields'
-import { getWellOrderFieldValue } from './utils'
 import type { FieldPropsByName } from '../StepForm/types'
+import { WellOrderOption } from '../../../../form-types'
 
 interface BatchEditMoveLiquidProps {
   propsForFields: FieldPropsByName
@@ -90,16 +90,12 @@ export function BatchEditMoveLiquidTools(
         updateSecondWellOrder={
           propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
         }
-        firstValue={getWellOrderFieldValue(
-          propsForFields,
-          addFieldNamePrefix('wellOrder_first'),
-          't2b'
-        )}
-        secondValue={getWellOrderFieldValue(
-          propsForFields,
-          addFieldNamePrefix('wellOrder_second'),
-          'l2r'
-        )}
+        firstValue={
+          (propsForFields.wellOrder_first.name ?? 't2b') as WellOrderOption
+        }
+        secondValue={
+          (propsForFields.wellOrder_second.name ?? 'l2r') as WellOrderOption
+        }
         firstName={addFieldNamePrefix('wellOrder_first')}
         secondName={addFieldNamePrefix('wellOrder_second')}
       />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -23,7 +23,7 @@ import {
   PositionField,
   WellsOrderField,
 } from '../StepForm/PipetteFields'
-import type { WellOrderOption } from '../../../../form-types'
+import { getWellOrderFieldValue } from './utils'
 import type { FieldPropsByName } from '../StepForm/types'
 
 interface BatchEditMoveLiquidProps {
@@ -61,16 +61,6 @@ export function BatchEditMoveLiquidTools(
     const labwareId = propsForFields[labwareField]?.value
     return labwareId ? String(labwareId) : null
   }
-  const getWellOrderFieldValue = (
-    name: string
-  ): WellOrderOption | null | undefined => {
-    const val = propsForFields[name]?.value
-    if (val === 'l2r' || val === 'r2l' || val === 't2b' || val === 'b2t') {
-      return val
-    } else {
-      return null
-    }
-  }
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} width="100%">
@@ -97,10 +87,14 @@ export function BatchEditMoveLiquidTools(
           propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
         }
         firstValue={getWellOrderFieldValue(
-          addFieldNamePrefix('wellOrder_first')
+          propsForFields,
+          addFieldNamePrefix('wellOrder_first'),
+          't2b'
         )}
         secondValue={getWellOrderFieldValue(
-          addFieldNamePrefix('wellOrder_second')
+          propsForFields,
+          addFieldNamePrefix('wellOrder_second'),
+          'l2r'
         )}
         firstName={addFieldNamePrefix('wellOrder_first')}
         secondName={addFieldNamePrefix('wellOrder_second')}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -23,8 +23,8 @@ import {
   PositionField,
   WellsOrderField,
 } from '../StepForm/PipetteFields'
+import type { WellOrderOption } from '../../../../form-types'
 import type { FieldPropsByName } from '../StepForm/types'
-import { WellOrderOption } from '../../../../form-types'
 
 interface BatchEditMoveLiquidProps {
   propsForFields: FieldPropsByName

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -23,8 +23,9 @@ import {
   PositionField,
   WellsOrderField,
 } from '../StepForm/PipetteFields'
+
+import type { WellOrderOption } from '../../../../form-types'
 import type { FieldPropsByName } from '../StepForm/types'
-import { WellOrderOption } from '../../../../form-types'
 
 interface BatchEditMoveLiquidProps {
   propsForFields: FieldPropsByName

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -23,9 +23,8 @@ import {
   PositionField,
   WellsOrderField,
 } from '../StepForm/PipetteFields'
-
-import type { WellOrderOption } from '../../../../form-types'
 import type { FieldPropsByName } from '../StepForm/types'
+import { WellOrderOption } from '../../../../form-types'
 
 interface BatchEditMoveLiquidProps {
   propsForFields: FieldPropsByName

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/utils.ts
@@ -7,7 +7,7 @@ import type {
   DisabledFields,
   MultiselectFieldValues,
 } from '../../../../ui/steps/selectors'
-import type { StepFieldName, WellOrderOption } from '../../../../form-types'
+import type { StepFieldName } from '../../../../form-types'
 import type { FieldPropsByName } from '../StepForm/types'
 export const makeBatchEditFieldProps = (
   fieldValues: MultiselectFieldValues,
@@ -45,17 +45,4 @@ export const makeBatchEditFieldProps = (
     }
     return acc
   }, {})
-}
-
-export const getWellOrderFieldValue = (
-  propsForFields: FieldPropsByName,
-  name: string,
-  fallback: 't2b' | 'l2r'
-): WellOrderOption | null | undefined => {
-  const val = propsForFields[name]?.value ?? fallback
-  if (val === 'l2r' || val === 'r2l' || val === 't2b' || val === 'b2t') {
-    return val
-  } else {
-    return null
-  }
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/utils.ts
@@ -7,7 +7,7 @@ import type {
   DisabledFields,
   MultiselectFieldValues,
 } from '../../../../ui/steps/selectors'
-import type { StepFieldName } from '../../../../form-types'
+import type { StepFieldName, WellOrderOption } from '../../../../form-types'
 import type { FieldPropsByName } from '../StepForm/types'
 export const makeBatchEditFieldProps = (
   fieldValues: MultiselectFieldValues,
@@ -45,4 +45,17 @@ export const makeBatchEditFieldProps = (
     }
     return acc
   }, {})
+}
+
+export const getWellOrderFieldValue = (
+  propsForFields: FieldPropsByName,
+  name: string,
+  fallback: 't2b' | 'l2r'
+): WellOrderOption | null | undefined => {
+  const val = propsForFields[name]?.value ?? fallback
+  if (val === 'l2r' || val === 'r2l' || val === 't2b' || val === 'b2t') {
+    return val
+  } else {
+    return null
+  }
 }


### PR DESCRIPTION
# Overview

This fixes a case where in batch edit move liquid toolbox, well order was set to null, displaying an
unknown translation in the WellOrder component. This PR refactors the util used to set the first and
second well order values, providing a fallback if the value is null.

[reference](https://github.com/Opentrons/opentrons/pull/16953#issuecomment-2494259485)

## Test Plan and Hands on Testing

- create or edit protocol with multiple transfers and multiple mixes
- command + click multiple transfers to open batch edit toolbox
- verify that well order defaults to T2B, L2R
- repeat with mix batch edit toolbox

## Changelog

- refactor well order util and provide fallback for null value
- implement in both batch edit toolboxes

## Review requests

see test plan

## Risk assessment

low