### PR TITLE
fix(shared-data): update tip length mutable map

### DIFF
--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -95,7 +95,7 @@ _MAP_KEY_TO_V2: Dict[str, List[str]] = {
         "liquid_properties",
         "default",
         "supportedTips",
-        "##EACHTIP##",
+        "##EACHTIPTYPE##",
         "defaultTipLength",
     ],
 }


### PR DESCRIPTION
This should be the tip _type_, because that's what the configs say.

## testing
- [ ] push to an ot2 and make sure the error's gone from the logs