### PR TITLE
fix(protocol-designer): only show tooltip if confirm button disabled

### DIFF
--- a/protocol-designer/src/pages/CreateNewProtocolWizard/WizardBody.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/WizardBody.tsx
@@ -160,7 +160,7 @@ export function WizardBody(props: WizardBodyProps): JSX.Element {
               width="8.5625rem"
             />
           </Flex>
-          {tooltipOnDisabled != null ? (
+          {tooltipOnDisabled != null && disabled ? (
             <Tooltip tooltipProps={tooltipProps}>{tooltipOnDisabled}</Tooltip>
           ) : null}
         </Flex>


### PR DESCRIPTION
# Overview

On the WizardBody component used for creating a new protocol file, we optionally pass a tooltip to be shown when hovering the confirm button if it is disabled. This PR fixes a bug where the tooltip showed on hover even if the button is enabled.

## Test Plan and Hands on Testing

- create a new protocol file and land on select pipettes step
- verify that before you add a pipette, the confirm button is disabled, and hovering produces the correct tooltip
- add the pipette to enable the confirm button. verify that hovering the enabled button does not produce tooltip

## Changelog

- add check for disabled to show tooltip

## Review requests

see test plan

## Risk assessment

low