### PR TITLE
refactor(api): Port `ReadAbsorbanceImpl` and `FileStore` to `StateUpdate`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -6,8 +6,6 @@ from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
-from opentrons.protocol_engine.state import update_types
-
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ...errors import CannotPerformModuleAction, StorageLimitReachedError
 from ...errors.error_occurrence import ErrorOccurrence
@@ -18,6 +16,7 @@ from ...resources.file_provider import (
     MAXIMUM_CSV_FILE_LIMIT,
 )
 from ...resources import FileProvider
+from ...state import update_types
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state.state import StateView

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -6,6 +6,8 @@ from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
+from opentrons.protocol_engine.state import update_types
+
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ...errors import CannotPerformModuleAction, StorageLimitReachedError
 from ...errors.error_occurrence import ErrorOccurrence
@@ -143,7 +145,7 @@ class ReadAbsorbanceImpl(
         # Today, the action handler for the FileStore looks for a ReadAbsorbanceResult command action, this will need to be delinked.
 
         # Begin interfacing with the file provider if the user provided a filename
-        file_ids = []
+        file_ids: list[str] = []
         if params.fileName is not None:
             # Create the Plate Reader Transform
             plate_read_result = PlateReaderData.construct(
@@ -175,7 +177,13 @@ class ReadAbsorbanceImpl(
                 )
 
         return SuccessData(
-            public=ReadAbsorbanceResult(data=asbsorbance_result, fileIds=file_ids),
+            public=ReadAbsorbanceResult(
+                data=asbsorbance_result,
+                fileIds=file_ids,
+            ),
+            state_update=update_types.StateUpdate(
+                files_added=update_types.FilesAddedUpdate(file_ids=file_ids)
+            ),
         )
 
 

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -262,6 +262,13 @@ class LiquidClassLoadedUpdate:
 
 
 @dataclasses.dataclass
+class FilesAddedUpdate:
+    """An update that adds a new data file."""
+
+    file_ids: list[str]
+
+
+@dataclasses.dataclass
 class StateUpdate:
     """Represents an update to perform on engine state."""
 
@@ -298,6 +305,8 @@ class StateUpdate:
     absorbance_reader_lid: AbsorbanceReaderLidUpdate | NoChangeType = NO_CHANGE
 
     liquid_class_loaded: LiquidClassLoadedUpdate | NoChangeType = NO_CHANGE
+
+    files_added: FilesAddedUpdate | NoChangeType = NO_CHANGE
 
     def append(self, other: Self) -> Self:
         """Apply another `StateUpdate` "on top of" this one.

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -98,7 +98,7 @@ class LabwareLocationUpdate:
     new_location: LabwareLocation
     """The labware's new location."""
 
-    offset_id: typing.Optional[str]
+    offset_id: str | None
     """The ID of the labware's new offset, for its new location."""
 
 
@@ -112,10 +112,10 @@ class LoadedLabwareUpdate:
     new_location: LabwareLocation
     """The labware's initial location."""
 
-    offset_id: typing.Optional[str]
+    offset_id: str | None
     """The ID of the labware's offset."""
 
-    display_name: typing.Optional[str]
+    display_name: str | None
 
     definition: LabwareDefinition
 
@@ -133,7 +133,7 @@ class LoadPipetteUpdate:
 
     pipette_name: PipetteNameType
     mount: MountType
-    liquid_presence_detection: typing.Optional[bool]
+    liquid_presence_detection: bool | None
 
 
 @dataclasses.dataclass
@@ -162,7 +162,7 @@ class PipetteTipStateUpdate:
     """Update pipette tip state."""
 
     pipette_id: str
-    tip_geometry: typing.Optional[TipGeometry]
+    tip_geometry: TipGeometry | None
 
 
 @dataclasses.dataclass
@@ -378,7 +378,6 @@ class StateUpdate:
                 new_deck_point=new_deck_point,
             )
         else:
-
             self.pipette_location = PipetteLocationUpdate(
                 pipette_id=pipette_id,
                 new_location=Well(labware_id=new_labware_id, well_name=new_well_name),
@@ -410,8 +409,8 @@ class StateUpdate:
         self: Self,
         definition: LabwareDefinition,
         labware_id: str,
-        offset_id: typing.Optional[str],
-        display_name: typing.Optional[str],
+        offset_id: str | None,
+        display_name: str | None,
         location: LabwareLocation,
     ) -> Self:
         """Add a new labware to state. See `LoadedLabwareUpdate`."""
@@ -429,7 +428,7 @@ class StateUpdate:
         pipette_id: str,
         pipette_name: PipetteNameType,
         mount: MountType,
-        liquid_presence_detection: typing.Optional[bool],
+        liquid_presence_detection: bool | None,
     ) -> Self:
         """Add a new pipette to state. See `LoadPipetteUpdate`."""
         self.loaded_pipette = LoadPipetteUpdate(
@@ -462,7 +461,7 @@ class StateUpdate:
         return self
 
     def update_pipette_tip_state(
-        self: Self, pipette_id: str, tip_geometry: typing.Optional[TipGeometry]
+        self: Self, pipette_id: str, tip_geometry: TipGeometry | None
     ) -> Self:
         """Update a pipette's tip state. See `PipetteTipStateUpdate`."""
         self.pipette_tip_state = PipetteTipStateUpdate(

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -126,7 +126,7 @@ async def test_move_to_well_stall_defined_error(
     error_id = "error-id"
     error_timestamp = datetime(year=2020, month=1, day=2)
     decoy.when(
-        movement.move_to_well(
+        await movement.move_to_well(
             pipette_id="abc",
             labware_id="123",
             well_name="A3",


### PR DESCRIPTION
# Overview

Closes https://opentrons.atlassian.net/issues/EXEC-787.

## Test Plan and Hands on Testing

Neither `ReadAbsorbanceImpl` nor `FileStore` have unit tests. I think this is a trivial enough refactor that we can get by with only code review, but I can add tests if anyone's uncomfortable with that.

## Changelog

Port `ReadAbsorbanceImpl` and `FileStore` to the new `StateUpdate` mechanism.

## Review requests

None.

## Risk assessment

Low.