### PR TITLE
fix(protocol-designer): fix copy for pristine well warning

### DIFF
--- a/protocol-designer/src/organisms/Alerts/FormAlerts.tsx
+++ b/protocol-designer/src/organisms/Alerts/FormAlerts.tsx
@@ -118,7 +118,7 @@ function FormAlertsComponent(props: FormAlertsProps): JSX.Element | null {
         width="100%"
         iconMarginLeft={SPACING.spacing4}
       >
-        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+        <Flex flexDirection={DIRECTION_COLUMN}>
           <StyledText desktopStyle="bodyDefaultSemiBold">
             {data.title}
           </StyledText>
@@ -183,7 +183,6 @@ function FormAlertsComponent(props: FormAlertsProps): JSX.Element | null {
   return [...formErrors, ...timelineWarnings, ...formWarnings].length > 0 ? (
     <Flex
       flexDirection={DIRECTION_COLUMN}
-      gridGap={SPACING.spacing4}
       padding={`${SPACING.spacing16} ${SPACING.spacing16} 0`}
     >
       {showFormErrors

--- a/protocol-designer/src/organisms/Alerts/WarningContents.tsx
+++ b/protocol-designer/src/organisms/Alerts/WarningContents.tsx
@@ -1,6 +1,4 @@
 import { useTranslation } from 'react-i18next'
-import { START_TERMINAL_ITEM_ID } from '../../steplist'
-import { TerminalItemLink } from './TerminalItemLink'
 
 import type { AlertLevel } from './types'
 

--- a/protocol-designer/src/organisms/Alerts/WarningContents.tsx
+++ b/protocol-designer/src/organisms/Alerts/WarningContents.tsx
@@ -22,7 +22,6 @@ export function WarningContents(
             {t(`timeline.warning.${warningType}.body`, {
               defaultValue: '',
             })}
-            <TerminalItemLink terminalId={START_TERMINAL_ITEM_ID} />
           </>
         )
       default:


### PR DESCRIPTION
# Overview

Remove starting deck state link from pristine well warning. Also, remove grid gap between timeline warning title and body.

Closes RQA-3710

## Test Plan and Hands on Testing

- create transfer step aspirating from empty well
- verify that warning copy is correct and there is no gridgap between title and body
<img width="304" alt="Screenshot 2024-11-25 at 5 03 52 PM" src="https://github.com/user-attachments/assets/3d400737-86c7-4fab-8f03-9a8180516b41">

## Changelog

- fix copy and gridGap

## Review requests

see test plan

## Risk assessment

low