### PR TITLE
fix(api): peek pipette bug fixes

### DIFF
--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -77,13 +77,12 @@ class FlexBackend(Protocol):
     ) -> None:
         ...
 
-    def update_constraints_for_emulsifying_pipette(
-        self, mount: OT3Mount, gantry_load: GantryLoad
-    ) -> None:
-        ...
-
     def update_constraints_for_plunger_acceleration(
-        self, mount: OT3Mount, acceleration: float, gantry_load: GantryLoad
+        self,
+        mount: OT3Mount,
+        acceleration: float,
+        gantry_load: GantryLoad,
+        em_pipette: bool = False,
     ) -> None:
         ...
 

--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -82,7 +82,7 @@ class FlexBackend(Protocol):
         mount: OT3Mount,
         acceleration: float,
         gantry_load: GantryLoad,
-        em_pipette: bool = False,
+        high_speed_pipette: bool = False,
     ) -> None:
         ...
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -50,7 +50,6 @@ from .ot3utils import (
     get_system_constraints,
     get_system_constraints_for_calibration,
     get_system_constraints_for_plunger_acceleration,
-    get_system_constraints_for_emulsifying_pipette,
 )
 from .tip_presence_manager import TipPresenceManager
 
@@ -406,28 +405,24 @@ class OT3Controller(FlexBackend):
             f"Set system constraints for calibration: {self._move_manager.get_constraints()}"
         )
 
-    def update_constraints_for_emulsifying_pipette(
-        self, mount: OT3Mount, gantry_load: GantryLoad
-    ) -> None:
-        self._move_manager.update_constraints(
-            get_system_constraints_for_emulsifying_pipette(
-                self._configuration.motion_settings, gantry_load, mount
-            )
-        )
-        log.debug(
-            f"Set system constraints for emulsifying pipette: {self._move_manager.get_constraints()}"
-        )
-
     def update_constraints_for_gantry_load(self, gantry_load: GantryLoad) -> None:
         self._move_manager.update_constraints(
             get_system_constraints(self._configuration.motion_settings, gantry_load)
         )
 
     def update_constraints_for_plunger_acceleration(
-        self, mount: OT3Mount, acceleration: float, gantry_load: GantryLoad
+        self,
+        mount: OT3Mount,
+        acceleration: float,
+        gantry_load: GantryLoad,
+        em_pipette: bool = False,
     ) -> None:
         new_constraints = get_system_constraints_for_plunger_acceleration(
-            self._configuration.motion_settings, gantry_load, mount, acceleration
+            self._configuration.motion_settings,
+            gantry_load,
+            mount,
+            acceleration,
+            em_pipette,
         )
         self._move_manager.update_constraints(new_constraints)
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -415,14 +415,14 @@ class OT3Controller(FlexBackend):
         mount: OT3Mount,
         acceleration: float,
         gantry_load: GantryLoad,
-        em_pipette: bool = False,
+        high_speed_pipette: bool = False,
     ) -> None:
         new_constraints = get_system_constraints_for_plunger_acceleration(
             self._configuration.motion_settings,
             gantry_load,
             mount,
             acceleration,
-            em_pipette,
+            high_speed_pipette,
         )
         self._move_manager.update_constraints(new_constraints)
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -234,13 +234,12 @@ class OT3Simulator(FlexBackend):
     ) -> None:
         self._sim_gantry_load = gantry_load
 
-    def update_constraints_for_emulsifying_pipette(
-        self, mount: OT3Mount, gantry_load: GantryLoad
-    ) -> None:
-        pass
-
     def update_constraints_for_plunger_acceleration(
-        self, mount: OT3Mount, acceleration: float, gantry_load: GantryLoad
+        self,
+        mount: OT3Mount,
+        acceleration: float,
+        gantry_load: GantryLoad,
+        em_pipette: bool = False,
     ) -> None:
         self._sim_gantry_load = gantry_load
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -239,7 +239,7 @@ class OT3Simulator(FlexBackend):
         mount: OT3Mount,
         acceleration: float,
         gantry_load: GantryLoad,
-        em_pipette: bool = False,
+        high_speed_pipette: bool = False,
     ) -> None:
         self._sim_gantry_load = gantry_load
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -284,14 +284,14 @@ def get_system_constraints_for_plunger_acceleration(
     gantry_load: GantryLoad,
     mount: OT3Mount,
     acceleration: float,
-    em_pipette: bool = False,
+    high_speed_pipette: bool = False,
 ) -> "SystemConstraints[Axis]":
     old_constraints = config.by_gantry_load(gantry_load)
     new_constraints = {}
     axis_kinds = set([k for _, v in old_constraints.items() for k in v.keys()])
 
     def _get_axis_max_speed(ax: Axis) -> float:
-        if ax == Axis.of_main_tool_actuator(mount) and em_pipette:
+        if ax == Axis.of_main_tool_actuator(mount) and high_speed_pipette:
             _max_speed = float(DEFAULT_EMULSIFYING_PIPETTE_AXIS_MAX_SPEED)
         else:
             _max_speed = old_constraints["default_max_speed"][axis_kind]

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -299,8 +299,9 @@ class OT3API(
     async def set_system_constraints_for_plunger_acceleration(
         self, mount: OT3Mount, acceleration: float
     ) -> None:
+        em_pipette = self._pipette_handler.get_pipette(mount).is_high_speed_pipette()
         self._backend.update_constraints_for_plunger_acceleration(
-            mount, acceleration, self._gantry_load
+            mount, acceleration, self._gantry_load, em_pipette
         )
 
     @contextlib.asynccontextmanager
@@ -636,24 +637,12 @@ class OT3API(
         )
         self._pipette_handler.hardware_instruments[mount] = p
 
-        if self._pipette_handler.has_pipette(mount):
-            self._confirm_pipette_motion_constraints(mount)
-
         if config is not None:
             self._set_pressure_sensor_available(mount, instrument_config=config)
 
         # TODO (lc 12-5-2022) Properly support backwards compatibility
         # when applicable
         return skipped
-
-    def _confirm_pipette_motion_constraints(
-        self,
-        mount: OT3Mount,
-    ) -> None:
-        if self._pipette_handler.get_pipette(mount).is_high_speed_pipette():
-            self._backend.update_constraints_for_emulsifying_pipette(
-                mount, self.gantry_load
-            )
 
     def get_pressure_sensor_available(self, mount: OT3Mount) -> bool:
         pip_axis = Axis.of_main_tool_actuator(mount)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -299,9 +299,11 @@ class OT3API(
     async def set_system_constraints_for_plunger_acceleration(
         self, mount: OT3Mount, acceleration: float
     ) -> None:
-        em_pipette = self._pipette_handler.get_pipette(mount).is_high_speed_pipette()
+        high_speed_pipette = self._pipette_handler.get_pipette(
+            mount
+        ).is_high_speed_pipette()
         self._backend.update_constraints_for_plunger_acceleration(
-            mount, acceleration, self._gantry_load, em_pipette
+            mount, acceleration, self._gantry_load, high_speed_pipette
         )
 
     @contextlib.asynccontextmanager

--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -20,6 +20,7 @@ MOUNT_CONFIG_LOOKUP_TABLE = {
     PipetteGenerationType.FLEX: {
         PipetteChannelType.SINGLE_CHANNEL: RobotMountConfigs(2133.33, 230.15, 80),
         PipetteChannelType.EIGHT_CHANNEL: RobotMountConfigs(2133.33, 230.15, 80),
+        PipetteChannelType.EIGHT_CHANNEL_EM: RobotMountConfigs(2133.33, 230.15, 80),
         PipetteChannelType.NINETY_SIX_CHANNEL: RobotMountConfigs(2133.33, 230.15, 80),
     },
 }

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
@@ -81,6 +81,8 @@ def channels_from_string(channels: str) -> PipetteChannelType:
     if channels == "96":
         return PipetteChannelType.NINETY_SIX_CHANNEL
     elif "multi" in channels:
+        if "em" in channels:
+            return PipetteChannelType.EIGHT_CHANNEL_EM
         return PipetteChannelType.EIGHT_CHANNEL
     elif channels == "single":
         return PipetteChannelType.SINGLE_CHANNEL
@@ -115,6 +117,8 @@ def get_channel_from_pipette_name(pipette_name_tuple: Tuple[str, ...]) -> str:
     elif "96" in pipette_name_tuple:
         return "ninety_six_channel"
     else:
+        if "em" in pipette_name_tuple:
+            return "eight_channel_em"
         return "eight_channel"
 
 
@@ -154,7 +158,6 @@ def version_from_generation(pipette_name_tuple: Tuple[str, ...]) -> PipetteVersi
     )
     model_from_pipette_name = pipette_name_tuple[0]
     channel_from_pipette_name = get_channel_from_pipette_name(pipette_name_tuple)
-
     paths_to_validate = (
         get_shared_data_root() / "pipette" / "definitions" / "2" / "general"
     )
@@ -246,7 +249,12 @@ def convert_pipette_name(
 
     """
     split_pipette_name = name.split("_")
-    channels = channels_from_string(split_pipette_name[1])
+    channels_type = split_pipette_name[1]
+    if len(split_pipette_name) > 2:
+        if split_pipette_name[2] == "em":
+            channels_type = "multi_em"
+
+    channels = channels_from_string(channels_type)
     if provided_version:
         version = version_from_string(provided_version)
     else:

--- a/shared-data/python/opentrons_shared_data/pipette/types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/types.py
@@ -49,6 +49,7 @@ class PipetteTipType(enum.Enum):
 class PipetteChannelType(int, enum.Enum):
     SINGLE_CHANNEL = 1
     EIGHT_CHANNEL = 8
+    EIGHT_CHANNEL_EM = 82
     NINETY_SIX_CHANNEL = 96
 
     def __str__(self) -> str:
@@ -56,6 +57,8 @@ class PipetteChannelType(int, enum.Enum):
             return "96"
         elif self.value == 8:
             return "multi"
+        elif self.value == 82:
+            return "multi_em"
         else:
             return "single"
 


### PR DESCRIPTION
## Overview
On testing the peek pipette on a robot, there are two bugs:

- The peek pipette was getting loaded by _serial _number__ correctly as an `em_pipette`, but the shared-data file getting loaded in was that of the regular 8 channel pipettes
- The custom `default_max_speed` was getting overwritten by `ot3api::set_system_constraints_for_plunger_acceleration`

This pr contains fixes for both of these that have been tested on the robot.

## Changelog

- remove `update_constraints_for_emulsifying_pipette`, instead just place a check for the high speed pipettes inside `set_system_constraints_for_plunger_acceleration`
- add necessary `EIGHT_CHANNEL_EM` types so the correct shared-data file gets loaded in 

## Test Plan

- [x] Load a peek pipette onto the robot using `cache_instruments`
- [x] Aspirate, make sure the speed on the move request on the CAN bus, after conversion, is 90 mm/sec
- [x] Dispense make sure the speed on the move request on the CAN bus, after conversion, is 90 mm/sec
- [x] During both of these, make sure there are no `bind_sensor_output_requests` directed to the peek pipette