### PR TITLE
fix(protocol-designer): use µ symbol in pipette capacities

### DIFF
--- a/protocol-designer/src/assets/localization/en/create_new_protocol.json
+++ b/protocol-designer/src/assets/localization/en/create_new_protocol.json
@@ -41,7 +41,7 @@
   "trash_required": "A trash entity is required",
   "trashBin": "Trash Bin",
   "up_to_3_tipracks": "Up to 3 tip rack types are allowed per pipette",
-  "vol_label": "{{volume}} uL",
+  "vol_label": "{{volume}} µL",
   "wasteChute": "Waste Chute",
   "which_fixtures": "Which fixtures will you be using?",
   "which_modules": "Select modules to use in your protocol.",

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectPipettes.test.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectPipettes.test.tsx
@@ -86,7 +86,7 @@ describe('SelectPipettes', () => {
     fireEvent.click(screen.getByRole('label', { name: '1-Channel' }))
     screen.getByText('Pipette volume')
     // select pip volume
-    fireEvent.click(screen.getByRole('label', { name: '1000 uL' }))
+    fireEvent.click(screen.getByRole('label', { name: '1000 µL' }))
     // select tip
     screen.getByText('Add custom pipette tips')
     screen.getByText('200uL Flex tipracks')
@@ -139,7 +139,7 @@ describe('SelectPipettes', () => {
 
     screen.getByText('Pipette volume')
     // select pip volume
-    fireEvent.click(screen.getByRole('label', { name: '20 uL' }))
+    fireEvent.click(screen.getByRole('label', { name: '20 µL' }))
     // select tip
     screen.getByText('Add custom pipette tips')
     screen.getByText('10uL tipracks')


### PR DESCRIPTION

# Overview

Use the proper prefix symbol for pipette capacities when setting up a new protocol.

## Test Plan and Hands on Testing

Passes automated tests, looks good with `make dev`.

<img width="210" alt="image" src="https://github.com/user-attachments/assets/f22ed4f4-6487-4901-8eb4-9dcfb33b7a55">


## Changelog

1 character + tests

## Review requests

Make sure this doesn't impact anywhere else, but I think the test has it covered.

## Risk assessment

v low