### PR TITLE
chore(protocol-designer): update knowledge link for PD redesign

### DIFF
--- a/protocol-designer/src/organisms/KnowledgeLink.tsx
+++ b/protocol-designer/src/organisms/KnowledgeLink.tsx
@@ -5,7 +5,8 @@ interface KnowledgeLinkProps {
   children: ReactNode
 }
 
-export const DOC_URL = 'https://docs.opentrons.com/protocol-designer/'
+export const DOC_URL =
+  'https://insights.opentrons.com/hubfs/Protocol%20Designer%20Instruction%20Manual.pdf'
 
 export function KnowledgeLink(props: KnowledgeLinkProps): JSX.Element {
   const { children } = props


### PR DESCRIPTION
# Overview

Update link for PD documentation

## Test Plan and Hands on Testing

- on Settings page, verify that "software manual" link directs to new URL (https://insights.opentrons.com/hubfs/Protocol%20Designer%20Instruction%20Manual.pdf)
<img width="630" alt="Screenshot 2024-11-26 at 5 38 52 PM" src="https://github.com/user-attachments/assets/82932a5c-9010-4388-b847-018ab03efe4e">

## Changelog

- update link

## Review requests

see test plan

## Risk assessment

low