### PR TITLE
fix(hardware-testing): stacker qc script add error handling

### DIFF
--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
@@ -117,7 +117,7 @@ class FlexStacker:
         """Constructor."""
         self._simulating = simulating
         if not self._simulating:
-            self._serial = serial.Serial(port, baudrate=STACKER_FREQ, timeout=120)
+            self._serial = serial.Serial(port, baudrate=STACKER_FREQ, timeout=60)
 
     def _send_and_recv(self, msg: str, guard_ret: str = "") -> str:
         """Internal utility to send a command and receive the response."""
@@ -154,6 +154,12 @@ class FlexStacker:
         if self._simulating:
             return
         self._send_and_recv(f"M996 {sn}\n", "M996 OK")
+
+    def stop_motor(self) -> None:
+        """Stop motor movement."""
+        if self._simulating:
+            return
+        self._send_and_recv(f"M0\n")
 
     def get_limit_switch(self, axis: StackerAxis, direction: Direction) -> bool:
         """Get limit switch status.
@@ -243,4 +249,5 @@ class FlexStacker:
     def __del__(self) -> None:
         """Close serial port."""
         if not self._simulating:
+            self.stop_motor()
             self._serial.close()

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
@@ -159,7 +159,7 @@ class FlexStacker:
         """Stop motor movement."""
         if self._simulating:
             return
-        self._send_and_recv(f"M0\n")
+        self._send_and_recv("M0\n")
 
     def get_limit_switch(self, axis: StackerAxis, direction: Direction) -> bool:
         """Get limit switch status.

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
@@ -117,7 +117,7 @@ class FlexStacker:
         """Constructor."""
         self._simulating = simulating
         if not self._simulating:
-            self._serial = serial.Serial(port, baudrate=STACKER_FREQ)
+            self._serial = serial.Serial(port, baudrate=STACKER_FREQ, timeout=120)
 
     def _send_and_recv(self, msg: str, guard_ret: str = "") -> str:
         """Internal utility to send a command and receive the response."""

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/utils.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/utils.py
@@ -14,7 +14,7 @@ def test_limit_switches_per_direction(
     direction: Direction,
     report: CSVReport,
     section: str,
-    speed: float = 50.0,
+    speed: float = 10.0,
 ) -> None:
     """Sequence to test the limit switch for one direction."""
     ui.print_header(f"{axis} Limit Switch - {direction} direction")
@@ -26,7 +26,7 @@ def test_limit_switches_per_direction(
 
     # move until the limit switch is reached
     print(f"moving towards {direction} limit switch...\n")
-    driver.move_to_limit_switch(axis, direction, MoveParams(max_speed=speed))
+    driver.move_to_limit_switch(axis, direction, MoveParams(max_speed_discont=speed))
     result = driver.get_limit_switch(axis, direction)
     opposite_result = not driver.get_limit_switch(axis, direction.opposite())
     print(f"{direction} switch triggered: {result}")


### PR DESCRIPTION
# Overview
This PR makes sure we stop any motor movement if the qc script is exited prematurely for any reason, and adds a timeout when expecting a response.