### PR TITLE
fix(hardware-testing): add __init__.py to modules/ so it gets packed in the build + other Flex stacker QC fixes.

### DIFF
--- a/hardware-testing/hardware_testing/modules/__init__.py
+++ b/hardware-testing/hardware_testing/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Module QC Scripts."""

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
@@ -122,6 +122,7 @@ class FlexStacker:
     def _send_and_recv(self, msg: str, guard_ret: str = "") -> str:
         """Internal utility to send a command and receive the response."""
         assert not self._simulating
+        self._serial.flush()
         self._serial.write(msg.encode())
         ret = self._serial.readline()
         if guard_ret:

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
@@ -120,7 +120,7 @@ class FlexStacker:
             self._serial = serial.Serial(port, baudrate=STACKER_FREQ, timeout=60)
 
     def _send_and_recv(
-        self, msg: str, guard_ret: str = "", response_required=True
+        self, msg: str, guard_ret: str = "", response_required: bool = True
     ) -> str:
         """Internal utility to send a command and receive the response."""
         assert not self._simulating

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
@@ -119,11 +119,15 @@ class FlexStacker:
         if not self._simulating:
             self._serial = serial.Serial(port, baudrate=STACKER_FREQ, timeout=60)
 
-    def _send_and_recv(self, msg: str, guard_ret: str = "") -> str:
+    def _send_and_recv(
+        self, msg: str, guard_ret: str = "", response_required=True
+    ) -> str:
         """Internal utility to send a command and receive the response."""
         assert not self._simulating
         self._serial.reset_input_buffer()
         self._serial.write(msg.encode())
+        if not response_required:
+            return "OK\n"
         ret = self._serial.readline()
         if guard_ret:
             if not ret.startswith(guard_ret.encode()):
@@ -160,7 +164,7 @@ class FlexStacker:
         """Stop motor movement."""
         if self._simulating:
             return
-        self._send_and_recv("M0\n")
+        self._send_and_recv("M0\n", response_required=False)
 
     def get_limit_switch(self, axis: StackerAxis, direction: Direction) -> bool:
         """Get limit switch status.

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/driver.py
@@ -122,7 +122,7 @@ class FlexStacker:
     def _send_and_recv(self, msg: str, guard_ret: str = "") -> str:
         """Internal utility to send a command and receive the response."""
         assert not self._simulating
-        self._serial.flush()
+        self._serial.reset_input_buffer()
         self._serial.write(msg.encode())
         ret = self._serial.readline()
         if guard_ret:

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/test_estop.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/test_estop.py
@@ -62,7 +62,7 @@ def run(driver: FlexStacker, report: CSVReport, section: str) -> None:
     report(
         section,
         "x-move-disabled",
-        [CSVResult.from_bool(driver.get_limit_switch(StackerAxis.X, x_limit))],
+        [CSVResult.from_bool(not driver.get_limit_switch(StackerAxis.X, x_limit))],
     )
 
     print("try to move Z axis...")

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/test_estop.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/test_estop.py
@@ -1,6 +1,6 @@
 """Test E-Stop."""
 
-
+from time import sleep
 from typing import List, Union
 from hardware_testing.data import ui
 from hardware_testing.data.csv_report import (
@@ -48,6 +48,8 @@ def run(driver: FlexStacker, report: CSVReport, section: str) -> None:
     ui.print_header("Trigger E-Stop")
     if not driver._simulating:
         ui.get_user_ready("Trigger the E-Stop")
+        # wait a bit before requesting e-stop state
+        sleep(2)
 
         if not driver.get_estop():
             print("E-Stop is not triggered")

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/test_estop.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/test_estop.py
@@ -1,6 +1,6 @@
 """Test E-Stop."""
 
-from time import sleep
+
 from typing import List, Union
 from hardware_testing.data import ui
 from hardware_testing.data.csv_report import (
@@ -48,8 +48,6 @@ def run(driver: FlexStacker, report: CSVReport, section: str) -> None:
     ui.print_header("Trigger E-Stop")
     if not driver._simulating:
         ui.get_user_ready("Trigger the E-Stop")
-        # wait a bit before requesting e-stop state
-        sleep(2)
 
         if not driver.get_estop():
             print("E-Stop is not triggered")

--- a/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/test_estop.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_evt_qc/test_estop.py
@@ -56,14 +56,23 @@ def run(driver: FlexStacker, report: CSVReport, section: str) -> None:
 
     report(section, "trigger-estop", [CSVResult.PASS])
 
-    print("try to move X axis...")
-    driver.move_in_mm(StackerAxis.X, x_limit.opposite().distance(10))
-    print("X should not move")
-    report(
-        section,
-        "x-move-disabled",
-        [CSVResult.from_bool(not driver.get_limit_switch(StackerAxis.X, x_limit))],
-    )
+    print("Check X limit switch...")
+    limit_switch_triggered = driver.get_limit_switch(StackerAxis.X, x_limit)
+    if limit_switch_triggered:
+        report(
+            section,
+            "x-move-disabled",
+            [CSVResult.from_bool(False)],
+        )
+    else:
+        print("try to move X axis back to the limit switch...")
+        driver.move_in_mm(StackerAxis.X, x_limit.distance(3))
+        print("X should not move")
+        report(
+            section,
+            "x-move-disabled",
+            [CSVResult.from_bool(not driver.get_limit_switch(StackerAxis.X, x_limit))],
+        )
 
     print("try to move Z axis...")
     driver.move_in_mm(StackerAxis.Z, z_limit.opposite().distance(10))
@@ -74,14 +83,23 @@ def run(driver: FlexStacker, report: CSVReport, section: str) -> None:
         [CSVResult.from_bool(driver.get_limit_switch(StackerAxis.Z, z_limit))],
     )
 
-    print("try to move L axis...")
-    driver.move_in_mm(StackerAxis.L, l_limit.opposite().distance(10))
-    print("L should not move")
-    report(
-        section,
-        "l-move-disabled",
-        [CSVResult.from_bool(driver.get_limit_switch(StackerAxis.L, l_limit))],
-    )
+    print("Check L limit switch...")
+    limit_switch_triggered = driver.get_limit_switch(StackerAxis.L, l_limit)
+    if limit_switch_triggered:
+        report(
+            section,
+            "l-move-disabled",
+            [CSVResult.from_bool(False)],
+        )
+    else:
+        print("try to move L axis back to the limit switch...")
+        driver.move_in_mm(StackerAxis.L, l_limit.distance(1))
+        print("L should not move")
+        report(
+            section,
+            "l-move-disabled",
+            [CSVResult.from_bool(not driver.get_limit_switch(StackerAxis.L, l_limit))],
+        )
 
     if not driver._simulating:
         ui.get_user_ready("Untrigger the E-Stop")


### PR DESCRIPTION
# Overview

Sdist does not package non-module directories, so lets add an `__init__.py` so it does, this will make it so we can push to the robot. Fix some additional issues found while testing the Flex stacker QC script.

## Test Plan and Hands on Testing

- [x] Make sure we can use `push-ot3` and run the `flex_stacker_qc_script` from the flex robot.
- [x] Makes sure the `flex_stacker_qc_script` run successfully and on a real Flex-stacker

## Changelog

- add `__init__.py` to /modules dir
- change the way we validate no movement when in e-stop
- don't wait for ack from stop_motor `M0` command.

## Review requests
## Risk assessment