### PR TITLE
fix(protocol-designer): fix deck map flicker with ot-2 deckmap

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -40,7 +40,7 @@ import {
 } from '../../../file-data/selectors'
 import { TimelineAlerts } from '../../../organisms'
 
-const CONTENT_MAX_WIDTH = '46.9375rem'
+const CONTENT_MAX_WIDTH = '44.6704375rem'
 
 export function ProtocolSteps(): JSX.Element {
   const { i18n, t } = useTranslation('starting_deck_state')


### PR DESCRIPTION
closes RQA-3630

# Overview

Adjust the maxWidth of the protocol steps deck map to work with ot-2 and flex and remove the flicker

## Test Plan and Hands on Testing

Upload the attached protocol and see that it desnt flicker when hovering over the timeline steps

[untitled (1) (1).json](https://github.com/user-attachments/files/17978684/untitled.1.1.json)

then upload the 2nd attached protocol and confirm that it als odoesn't flicker when hovering over the timeline steps

[1.0 testing.json](https://github.com/user-attachments/files/17978688/1.0.testing.json)


additionally, introduce timeline errors with both protocols and see that the flickering doesn't occur



## Changelog

- adjust the maxWidth to work with the ot-2 and flex deck maps

## Risk assessment

low
