### PR TITLE
fix(protocol-designer): display correct z-value position in tip posit…

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
@@ -109,10 +109,6 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
       mmFromBottom ?? getDefaultMmFromBottom({ name: zName, wellDepthMm })
   }
 
-  console.log(
-    mmFromBottom,
-    getDefaultMmFromBottom({ name: zName, wellDepthMm })
-  )
   let modal = (
     <ZTipPositionModal
       name={zName}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
@@ -108,12 +108,17 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
     zValue =
       mmFromBottom ?? getDefaultMmFromBottom({ name: zName, wellDepthMm })
   }
+
+  console.log(
+    mmFromBottom,
+    getDefaultMmFromBottom({ name: zName, wellDepthMm })
+  )
   let modal = (
     <ZTipPositionModal
       name={zName}
       closeModal={handleClose}
       wellDepthMm={wellDepthMm}
-      zValue={mmFromBottom}
+      zValue={zValue as number}
       updateValue={zUpdateValue}
       isIndeterminate={isIndeterminate}
     />
@@ -133,7 +138,7 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
     const specs: PositionSpecs = {
       z: {
         name: zName,
-        value: mmFromBottom,
+        value: zValue as number,
         updateValue: zUpdateValue,
       },
       x: {
@@ -198,7 +203,7 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
                   propsForFields[yField].value != null
                     ? Number(propsForFields[yField].value)
                     : 0,
-                z: mmFromBottom ?? 0,
+                z: zValue,
               })}
             </StyledText>
           </ListButton>


### PR DESCRIPTION
…ion field

closes RQA-3723

# Overview

The tip position field didn't correctly display the default z-value if it is something other than 0 (which is always should be? lol)

## Test Plan and Hands on Testing

make a protocol with a tube rack and create a transfer. See that the default tip position shows 1 for the z value. There should also be a warning banner that appears by default for a tube rack.

test changing the values and it should be reflected correctly in the field

## Changelog

- use the zValue which gets the default value if the default was unchanged

## Risk assessment

low