### PR TITLE
build(components): publish all contents in components folder to npm

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -203,9 +203,6 @@ jobs:
           make setup-js
       - name: 'build typescript types'
         run: make -C components build-ts
-      - name: 'build js bundle'
-        run: |
-          make -C components lib
       # replace package.json stub version number with version from tag
       - name: 'set version number'
         run: |
@@ -221,4 +218,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          cd ./components && echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ./.npmrc && npm publish --access public
+          cd ./components
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ./.npmrc
+          ls -R # Debug: View contents of ./components
+          npm publish --access public

--- a/components/.npmignore
+++ b/components/.npmignore
@@ -1,3 +1,0 @@
-src
-dist
-*.tgz

--- a/components/package.json
+++ b/components/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "style": "src/index.module.css",
-  "main": "lib/index.mjs",
+  "main": "src/index.ts",
   "module": "src/index.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Overview
This PR publish all code in the components library to npm. This is because we are having [problems on the PL tooling side](https://opentrons.slack.com/archives/C6PF2M2LC/p1732723156162709).
