### PR TITLE
fix(protocol-designer): assign value instead of name from wellOrder f…

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
@@ -92,11 +92,11 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
               propsForFields.mix_wellOrder_second.updateValue
             }
             firstValue={
-              (propsForFields.mix_wellOrder_first.name ??
+              (propsForFields.mix_wellOrder_first?.value ??
                 't2b') as WellOrderOption
             }
             secondValue={
-              (propsForFields.mix_wellOrder_second.name ??
+              (propsForFields.mix_wellOrder_second?.value ??
                 'l2r') as WellOrderOption
             }
             firstName="mix_wellOrder_first"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -91,10 +91,10 @@ export function BatchEditMoveLiquidTools(
           propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
         }
         firstValue={
-          (propsForFields.wellOrder_first.name ?? 't2b') as WellOrderOption
+          (propsForFields.wellOrder_first.value ?? 't2b') as WellOrderOption
         }
         secondValue={
-          (propsForFields.wellOrder_second.name ?? 'l2r') as WellOrderOption
+          (propsForFields.wellOrder_second.value ?? 'l2r') as WellOrderOption
         }
         firstName={addFieldNamePrefix('wellOrder_first')}
         secondName={addFieldNamePrefix('wellOrder_second')}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -91,10 +91,10 @@ export function BatchEditMoveLiquidTools(
           propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
         }
         firstValue={
-          (propsForFields.wellOrder_first.value ?? 't2b') as WellOrderOption
+          (propsForFields.wellOrder_first?.value ?? 't2b') as WellOrderOption
         }
         secondValue={
-          (propsForFields.wellOrder_second.value ?? 'l2r') as WellOrderOption
+          (propsForFields.wellOrder_second?.value ?? 'l2r') as WellOrderOption
         }
         firstName={addFieldNamePrefix('wellOrder_first')}
         secondName={addFieldNamePrefix('wellOrder_second')}


### PR DESCRIPTION
…ields

closes RQA-3737

# Overview

The bugs in the ticket are due to assigning the `name` of the field instead of the `value` of the field when populating the well order values.

## Test Plan and Hands on Testing

Upload the 2 protocols and multi select transfer steps and mix steps and see that there is no white screen

for mix
[Mixing Troubles with batch edit.json](https://github.com/user-attachments/files/17997844/Mixing.Troubles.with.batch.edit.json)

for transfer
[Customizable Serial Dilution (1).json](https://github.com/user-attachments/files/17997845/Customizable.Serial.Dilution.1.json)



## Changelog

- return the field values instead of the field names

## Risk assessment

low
