### PR TITLE
fix(protocol-designer): fix error copy for heater-shaker latch open

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -141,7 +141,7 @@
       },
       "HEATER_SHAKER_LATCH_OPEN": {
         "title": "Heater-Shaker latch open",
-        "body": "Before the robot can interact with labware on the Heater-Shaker module, the labware latch must be closed. To resolve this error, please add a Heater-Shaker step ahead of the current step, and set the labware latch status to \"closed\"."
+        "body": "This step tries to pipette to labware on the Heater-Shaker Module, which requires the labware latch to be closed. Close the latch before this step."
       },
       "HEATER_SHAKER_IS_SHAKING": {
         "title": "Heater-Shaker is shaking",


### PR DESCRIPTION
closes rest of RQA-3678

# Overview

update error copy for heater-shaker latch open timeline error -- merging into edge since it isn't a critical bug

## Test Plan and Hands on Testing

check the json file copy 

## Changelog

fix error copy

## Risk assessment

low
