### PR TITLE
feat(protocol-designer): add protocol recovery to error boundary

### DIFF
--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -19,6 +19,7 @@
   "destination_well": "Destination Well",
   "developer_ff": "Developer Feature Flags",
   "done": "Done",
+  "download_protocol": "Download protocol",
   "edit_existing": "Edit existing protocol",
   "edit_instruments": "Edit Instruments",
   "edit_pipette": "Edit Pipette",

--- a/protocol-designer/src/resources/ProtocolDesignerAppFallback.tsx
+++ b/protocol-designer/src/resources/ProtocolDesignerAppFallback.tsx
@@ -4,15 +4,19 @@ import { useTranslation } from 'react-i18next'
 
 import type { FallbackProps } from 'react-error-boundary'
 
+import { actions } from '../load-file'
 import {
   AlertPrimaryButton,
   ALIGN_FLEX_END,
   DIRECTION_COLUMN,
   Flex,
   Modal,
+  SecondaryButton,
   SPACING,
   StyledText,
 } from '@opentrons/components'
+import { useDispatch } from 'react-redux'
+import type { ThunkDispatch } from '../types'
 
 export function ProtocolDesignerAppFallback({
   error,
@@ -20,8 +24,12 @@ export function ProtocolDesignerAppFallback({
 }: FallbackProps): JSX.Element {
   const { t } = useTranslation('shared')
 
+  const dispatch: ThunkDispatch<any> = useDispatch()
   const handleReloadClick = (): void => {
     resetErrorBoundary()
+  }
+  const handleDownloadProtocol = (): void => {
+    dispatch(actions.saveProtocolFile())
   }
 
   return (
@@ -35,12 +43,14 @@ export function ProtocolDesignerAppFallback({
             {error.message}
           </StyledText>
         </Flex>
-        <AlertPrimaryButton
-          alignSelf={ALIGN_FLEX_END}
-          onClick={handleReloadClick}
-        >
-          {t('reload_app')}
-        </AlertPrimaryButton>
+        <Flex alignSelf={ALIGN_FLEX_END} gridGap={SPACING.spacing8}>
+          <SecondaryButton onClick={handleDownloadProtocol}>
+            {t('download_protocol')}
+          </SecondaryButton>
+          <AlertPrimaryButton onClick={handleReloadClick}>
+            {t('reload_app')}
+          </AlertPrimaryButton>
+        </Flex>
       </Flex>
     </Modal>
   )


### PR DESCRIPTION
# Overview

In error boundary fallback modal, I add a new secondary button to allow the user to download the protocol after a whitescreen. No routing is implemented at this time, so impact should be low.

TODO: big routing refactor to avoid useEffects across routes

## Test Plan and Hands on Testing

- produce error boundary modal (example: reference unassigned variable in a stepform toolbox's code, and navigate to that step form
- verify that "Download protocol" button shows, and clicking downloads protocol file at current state
- verify that no routing occurs after click

https://github.com/user-attachments/assets/28810915-45a2-45dd-885f-135fb27ee653

## Changelog

- add download protocol action to error boundary fallback component
- add translation

## Review requests

see test plan

## Risk assessment

low