### PR TITLE
fix(protocol-designer): add duplicate tipracks off deck

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -318,12 +318,13 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       )
     }
     if (
-      selectedModuleModel == null &&
-      selectedLabwareDefUri != null &&
-      (createdLabwareForSlot?.labwareDefURI !== selectedLabwareDefUri ||
-        (selectedNestedLabwareDefUri != null &&
-          selectedNestedLabwareDefUri !==
-            createdNestedLabwareForSlot?.labwareDefURI))
+      (slot === 'offDeck' && selectedLabwareDefUri != null) ||
+      (selectedModuleModel == null &&
+        selectedLabwareDefUri != null &&
+        (createdLabwareForSlot?.labwareDefURI !== selectedLabwareDefUri ||
+          (selectedNestedLabwareDefUri != null &&
+            selectedNestedLabwareDefUri !==
+              createdNestedLabwareForSlot?.labwareDefURI)))
     ) {
       //  create adapter + labware on deck
       dispatch(


### PR DESCRIPTION
closes RQA-3744

# Overview

Fix bug where you couldn't add the same tiprack multiple times off deck

## Test Plan and Hands on Testing

Test that you can add multiple of the same labware and tipracks offdeck by selecting it and not pressing the duplicate button

## Changelog

- add logic for offdeck labware

## Risk assessment

low
