### PR TITLE
refactor(api): Port `AddressableAreaStore` to `StateUpdate`

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -27,7 +27,6 @@ from ..types import (
     ModuleDefinition,
     Liquid,
     DeckConfigurationType,
-    AddressableAreaLocation,
 )
 
 
@@ -235,12 +234,12 @@ class SetDeckConfigurationAction:
 class AddAddressableAreaAction:
     """Add a single addressable area to state.
 
-    This differs from the deck configuration in ProvideDeckConfigurationAction which
+    This differs from the deck configuration in SetDeckConfigurationAction which
     sends over a mapping of cutout fixtures. This action will only load one addressable
     area and that should be pre-validated before being sent via the action.
     """
 
-    addressable_area: AddressableAreaLocation
+    addressable_area_name: str
 
 
 @dataclasses.dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
@@ -95,7 +95,6 @@ class CloseLidImpl(AbstractCommandImpl[CloseLidParams, SuccessData[CloseLidResul
                     deck_slot=self._state_view.modules.get_location(
                         params.moduleId
                     ).slotName,
-                    deck_type=self._state_view.config.deck_type,
                     model=absorbance_model,
                 )
             )

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
@@ -91,7 +91,6 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult]]
                     deck_slot=self._state_view.modules.get_location(
                         params.moduleId
                     ).slotName,
-                    deck_type=self._state_view.config.deck_type,
                     model=absorbance_model,
                 )
             )

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -104,6 +104,8 @@ class LoadLabwareImplementation(
         self, params: LoadLabwareParams
     ) -> SuccessData[LoadLabwareResult]:
         """Load definition and calibration data necessary for a labware."""
+        state_update = StateUpdate()
+
         # TODO (tz, 8-15-2023): extend column validation to column 1 when working
         # on https://opentrons.atlassian.net/browse/RSS-258 and completing
         # https://opentrons.atlassian.net/browse/RSS-255
@@ -128,10 +130,12 @@ class LoadLabwareImplementation(
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 area_name
             )
+            state_update.set_addressable_area_used(area_name)
         elif isinstance(params.location, DeckSlotLocation):
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 params.location.slotName.id
             )
+            state_update.set_addressable_area_used(params.location.slotName.id)
 
         verified_location = self._state_view.geometry.ensure_location_not_occupied(
             params.location
@@ -143,8 +147,6 @@ class LoadLabwareImplementation(
             location=verified_location,
             labware_id=params.labwareId,
         )
-
-        state_update = StateUpdate()
 
         state_update.set_loaded_labware(
             labware_id=loaded_labware.labware_id,

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -130,25 +130,22 @@ class LoadModuleImplementation(
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 params.location.slotName.id
             )
-            state_update.set_addressable_area_used(
-                addressable_area_name=params.location.slotName.id
-            )
         else:
-            addressable_area = (
+            addressable_area_provided_by_module = (
                 self._state_view.modules.ensure_and_convert_module_fixture_location(
                     deck_slot=params.location.slotName,
                     model=params.model,
                 )
             )
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
-                addressable_area
-            )
-            state_update.set_addressable_area_used(
-                addressable_area_name=addressable_area
+                addressable_area_provided_by_module
             )
 
         verified_location = self._state_view.geometry.ensure_location_not_occupied(
             params.location
+        )
+        state_update.set_addressable_area_used(
+            addressable_area_name=params.location.slotName.id
         )
 
         if params.model == ModuleModel.MAGNETIC_BLOCK_V1:

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -124,12 +124,9 @@ class LoadModuleImplementation(
                 params.location.slotName.id
             )
         else:
-            addressable_area = (
-                self._state_view.modules.ensure_and_convert_module_fixture_location(
-                    deck_slot=params.location.slotName,
-                    deck_type=self._state_view.config.deck_type,
-                    model=params.model,
-                )
+            addressable_area = self._state_view.modules.ensure_and_convert_module_fixture_location(
+                deck_slot=params.location.slotName,
+                model=params.model,
             )
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 addressable_area

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -123,6 +123,9 @@ class LoadModuleImplementation(
         module_type = params.model.as_type()
         self._ensure_module_location(params.location.slotName, module_type)
 
+        # todo(mm, 2024-12-03): Theoretically, we should be able to deal with
+        # addressable areas and deck configurations the same way between OT-2 and Flex.
+        # Can this be simplified?
         if self._state_view.config.robot_type == "OT-2 Standard":
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 params.location.slotName.id
@@ -174,6 +177,9 @@ class LoadModuleImplementation(
     def _ensure_module_location(
         self, slot: DeckSlotName, module_type: ModuleType
     ) -> None:
+        # todo(mm, 2024-12-03): Theoretically, we should be able to deal with
+        # addressable areas and deck configurations the same way between OT-2 and Flex.
+        # Can this be simplified?
         if self._state_view.config.robot_type == "OT-2 Standard":
             slot_def = self._state_view.addressable_areas.get_slot_definition(slot.id)
             compatible_modules = slot_def["compatibleModuleTypes"]

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -124,10 +124,12 @@ class LoadModuleImplementation(
                 params.location.slotName.id
             )
         else:
-            addressable_area = self._state_view.geometry._modules.ensure_and_convert_module_fixture_location(
-                deck_slot=params.location.slotName,
-                deck_type=self._state_view.config.deck_type,
-                model=params.model,
+            addressable_area = (
+                self._state_view.modules.ensure_and_convert_module_fixture_location(
+                    deck_slot=params.location.slotName,
+                    deck_type=self._state_view.config.deck_type,
+                    model=params.model,
+                )
             )
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 addressable_area

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -156,6 +156,7 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 area_name
             )
+            state_update.set_addressable_area_used(addressable_area_name=area_name)
 
             if fixture_validation.is_gripper_waste_chute(area_name):
                 # When dropping off labware in the waste chute, some bigger pieces
@@ -200,6 +201,9 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
         elif isinstance(params.newLocation, DeckSlotLocation):
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 params.newLocation.slotName.id
+            )
+            state_update.set_addressable_area_used(
+                addressable_area_name=params.newLocation.slotName.id
             )
 
         available_new_location = self._state_view.geometry.ensure_location_not_occupied(

--- a/api/src/opentrons/protocol_engine/commands/movement_common.py
+++ b/api/src/opentrons/protocol_engine/commands/movement_common.py
@@ -265,17 +265,21 @@ async def move_to_addressable_area(
                     )
                 ],
             ),
-            state_update=StateUpdate().clear_all_pipette_locations(),
+            state_update=StateUpdate()
+            .clear_all_pipette_locations()
+            .set_addressable_area_used(addressable_area_name=addressable_area_name),
         )
     else:
         deck_point = DeckPoint.construct(x=x, y=y, z=z)
         return SuccessData(
             public=DestinationPositionResult(position=deck_point),
-            state_update=StateUpdate().set_pipette_location(
+            state_update=StateUpdate()
+            .set_pipette_location(
                 pipette_id=pipette_id,
                 new_addressable_area_name=addressable_area_name,
                 new_deck_point=deck_point,
-            ),
+            )
+            .set_addressable_area_used(addressable_area_name=addressable_area_name),
         )
 
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -30,7 +30,6 @@ from .types import (
     HexColor,
     PostRunHardwareState,
     DeckConfigurationType,
-    AddressableAreaLocation,
 )
 from .execution import (
     QueueWorker,
@@ -574,9 +573,8 @@ class ProtocolEngine:
 
     def add_addressable_area(self, addressable_area_name: str) -> None:
         """Add an addressable area to state."""
-        area = AddressableAreaLocation(addressableAreaName=addressable_area_name)
         self._action_dispatcher.dispatch(
-            AddAddressableAreaAction(addressable_area=area)
+            AddAddressableAreaAction(addressable_area_name)
         )
 
     def reset_tips(self, labware_id: str) -> None:

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -1,7 +1,7 @@
 """Basic addressable area data state and store."""
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set
 
 from opentrons_shared_data.robot.types import RobotType, RobotDefinition
 from opentrons_shared_data.deck.types import (
@@ -21,8 +21,6 @@ from ..errors import (
 )
 from ..resources import deck_configuration_provider
 from ..types import (
-    DeckSlotLocation,
-    AddressableAreaLocation,
     AddressableArea,
     PotentialCutoutFixture,
     DeckConfigurationType,
@@ -237,16 +235,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
                 )
         return {area.area_name: area for area in addressable_areas}
 
-    def _add_addressable_area(
-        self, location: Union[DeckSlotLocation, AddressableAreaLocation, str]
-    ) -> None:
-        if isinstance(location, DeckSlotLocation):
-            addressable_area_name = location.slotName.id
-        elif isinstance(location, AddressableAreaLocation):
-            addressable_area_name = location.addressableAreaName
-        else:
-            addressable_area_name = location
-
+    def _add_addressable_area(self, addressable_area_name: str) -> None:
         if addressable_area_name not in self._state.loaded_addressable_areas_by_name:
             cutout_id = self._validate_addressable_area_for_simulation(
                 addressable_area_name

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -36,12 +36,14 @@ from ..types import (
     DeckConfigurationType,
     Dimensions,
 )
+from ..actions.get_state_update import get_state_updates
 from ..actions import (
     Action,
     SucceedCommandAction,
     SetDeckConfigurationAction,
     AddAddressableAreaAction,
 )
+from . import update_types
 from .config import Config
 from ._abstract_store import HasState, HandlesActions
 
@@ -191,8 +193,16 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
             robot_definition=robot_definition,
         )
 
+    # TODO: Port loadLabware, moveLabware, loadModule, moveToAddressableArea, and moveToAddressableAreaForDropTip
+    # and their tests
     def handle_action(self, action: Action) -> None:
         """Modify state in reaction to an action."""
+        for state_update in get_state_updates(action):
+            if state_update.addressable_area_used != update_types.NO_CHANGE:
+                self._add_addressable_area(
+                    state_update.addressable_area_used.addressable_area_name
+                )
+
         if isinstance(action, SucceedCommandAction):
             self._handle_command(action.command)
         elif isinstance(action, AddAddressableAreaAction):

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -182,8 +182,6 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
             robot_definition=robot_definition,
         )
 
-    # TODO: Port loadLabware, moveLabware, loadModule, moveToAddressableArea, and moveToAddressableAreaForDropTip
-    # and their tests
     def handle_action(self, action: Action) -> None:
         """Modify state in reaction to an action."""
         for state_update in get_state_updates(action):

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -14,7 +14,6 @@ from opentrons.types import Point, DeckSlotName
 
 from ..commands import (
     Command,
-    LoadLabwareResult,
     LoadModuleResult,
     MoveLabwareResult,
     MoveToAddressableAreaResult,
@@ -223,12 +222,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
 
     def _handle_command(self, command: Command) -> None:
         """Modify state in reaction to a command."""
-        if isinstance(command.result, LoadLabwareResult):
-            location = command.params.location
-            if isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
-                self._add_addressable_area(location)
-
-        elif isinstance(command.result, MoveLabwareResult):
+        if isinstance(command.result, MoveLabwareResult):
             location = command.params.newLocation
             if isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
                 self._add_addressable_area(location)

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -196,7 +196,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
         if isinstance(action, SucceedCommandAction):
             self._handle_command(action.command)
         elif isinstance(action, AddAddressableAreaAction):
-            self._add_addressable_area(action.addressable_area)
+            self._add_addressable_area(action.addressable_area_name)
         elif isinstance(action, SetDeckConfigurationAction):
             current_state = self._state
             if (

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -14,7 +14,6 @@ from opentrons.types import Point, DeckSlotName
 
 from ..commands import (
     Command,
-    LoadModuleResult,
     MoveLabwareResult,
 )
 from ..errors import (
@@ -224,9 +223,6 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
             location = command.params.newLocation
             if isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
                 self._add_addressable_area(location)
-
-        elif isinstance(command.result, LoadModuleResult):
-            self._add_addressable_area(command.params.location)
 
     @staticmethod
     def _get_addressable_areas_from_deck_configuration(

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -196,7 +196,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
         if isinstance(action, SucceedCommandAction):
             self._handle_command(action.command)
         elif isinstance(action, AddAddressableAreaAction):
-            self._check_location_is_addressable_area(action.addressable_area)
+            self._add_addressable_area(action.addressable_area)
         elif isinstance(action, SetDeckConfigurationAction):
             current_state = self._state
             if (
@@ -216,22 +216,22 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
         if isinstance(command.result, LoadLabwareResult):
             location = command.params.location
             if isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
-                self._check_location_is_addressable_area(location)
+                self._add_addressable_area(location)
 
         elif isinstance(command.result, MoveLabwareResult):
             location = command.params.newLocation
             if isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
-                self._check_location_is_addressable_area(location)
+                self._add_addressable_area(location)
 
         elif isinstance(command.result, LoadModuleResult):
-            self._check_location_is_addressable_area(command.params.location)
+            self._add_addressable_area(command.params.location)
 
         elif isinstance(
             command.result,
             (MoveToAddressableAreaResult, MoveToAddressableAreaForDropTipResult),
         ):
             addressable_area_name = command.params.addressableAreaName
-            self._check_location_is_addressable_area(addressable_area_name)
+            self._add_addressable_area(addressable_area_name)
 
     @staticmethod
     def _get_addressable_areas_from_deck_configuration(
@@ -260,7 +260,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
                 )
         return {area.area_name: area for area in addressable_areas}
 
-    def _check_location_is_addressable_area(
+    def _add_addressable_area(
         self, location: Union[DeckSlotLocation, AddressableAreaLocation, str]
     ) -> None:
         if isinstance(location, DeckSlotLocation):

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -16,8 +16,6 @@ from ..commands import (
     Command,
     LoadModuleResult,
     MoveLabwareResult,
-    MoveToAddressableAreaResult,
-    MoveToAddressableAreaForDropTipResult,
 )
 from ..errors import (
     IncompatibleAddressableAreaError,
@@ -229,13 +227,6 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
 
         elif isinstance(command.result, LoadModuleResult):
             self._add_addressable_area(command.params.location)
-
-        elif isinstance(
-            command.result,
-            (MoveToAddressableAreaResult, MoveToAddressableAreaForDropTipResult),
-        ):
-            addressable_area_name = command.params.addressableAreaName
-            self._add_addressable_area(addressable_area_name)
 
     @staticmethod
     def _get_addressable_areas_from_deck_configuration(

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -12,10 +12,6 @@ from opentrons_shared_data.deck.types import (
 
 from opentrons.types import Point, DeckSlotName
 
-from ..commands import (
-    Command,
-    MoveLabwareResult,
-)
 from ..errors import (
     IncompatibleAddressableAreaError,
     AreaNotInDeckConfigurationError,
@@ -35,7 +31,6 @@ from ..types import (
 from ..actions.get_state_update import get_state_updates
 from ..actions import (
     Action,
-    SucceedCommandAction,
     SetDeckConfigurationAction,
     AddAddressableAreaAction,
 )
@@ -199,9 +194,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
                     state_update.addressable_area_used.addressable_area_name
                 )
 
-        if isinstance(action, SucceedCommandAction):
-            self._handle_command(action.command)
-        elif isinstance(action, AddAddressableAreaAction):
+        if isinstance(action, AddAddressableAreaAction):
             self._add_addressable_area(action.addressable_area_name)
         elif isinstance(action, SetDeckConfigurationAction):
             current_state = self._state
@@ -216,13 +209,6 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
                         deck_definition=current_state.deck_definition,
                     )
                 )
-
-    def _handle_command(self, command: Command) -> None:
-        """Modify state in reaction to a command."""
-        if isinstance(command.result, MoveLabwareResult):
-            location = command.params.newLocation
-            if isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
-                self._add_addressable_area(location)
 
     @staticmethod
     def _get_addressable_areas_from_deck_configuration(

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -908,7 +908,7 @@ class ModuleView:
                     "Module location invalid for nominal module offset calculation."
                 )
             module_addressable_area = self.ensure_and_convert_module_fixture_location(
-                location, self._state.deck_type, module.model
+                location, module.model
             )
             module_addressable_area_position = (
                 addressable_areas.get_addressable_area_offsets_from_cutout(
@@ -1281,13 +1281,14 @@ class ModuleView:
     def ensure_and_convert_module_fixture_location(
         self,
         deck_slot: DeckSlotName,
-        deck_type: DeckType,
         model: ModuleModel,
     ) -> str:
         """Ensure module fixture load location is valid.
 
         Also, convert the deck slot to a valid module fixture addressable area.
         """
+        deck_type = self._state.deck_type
+
         if deck_type == DeckType.OT2_STANDARD or deck_type == DeckType.OT2_SHORT_TRASH:
             raise ValueError(
                 f"Invalid Deck Type: {deck_type.name} - Does not support modules as fixtures."

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -269,6 +269,13 @@ class FilesAddedUpdate:
 
 
 @dataclasses.dataclass
+class AddressableAreaUsedUpdate:
+    """An update that says an addressable area has been used."""
+
+    addressable_area_name: str
+
+
+@dataclasses.dataclass
 class StateUpdate:
     """Represents an update to perform on engine state."""
 
@@ -308,6 +315,8 @@ class StateUpdate:
 
     files_added: FilesAddedUpdate | NoChangeType = NO_CHANGE
 
+    addressable_area_used: AddressableAreaUsedUpdate | NoChangeType = NO_CHANGE
+
     def append(self, other: Self) -> Self:
         """Apply another `StateUpdate` "on top of" this one.
 
@@ -334,7 +343,8 @@ class StateUpdate:
         return accumulator
 
     # These convenience functions let the caller avoid the boilerplate of constructing a
-    # complicated dataclass tree.
+    # complicated dataclass tree, and allow chaining.
+
     @typing.overload
     def set_pipette_location(
         self: Self, *, pipette_id: str, new_deck_point: DeckPoint
@@ -565,5 +575,12 @@ class StateUpdate:
         """Update an absorbance reader's lid location. See `AbsorbanceReaderLidUpdate`."""
         self.absorbance_reader_lid = AbsorbanceReaderLidUpdate(
             module_id=module_id, is_lid_on=is_lid_on
+        )
+        return self
+
+    def set_addressable_area_used(self: Self, addressable_area_name: str) -> Self:
+        """Mark that an addressable area has been used. See `AddressableAreaUsedUpdate`."""
+        self.addressable_area_used = AddressableAreaUsedUpdate(
+            addressable_area_name=addressable_area_name
         )
         return self

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -1,13 +1,9 @@
 """Test load labware commands."""
 import inspect
 from typing import Optional
-from opentrons.protocol_engine.state.update_types import (
-    AddressableAreaUsedUpdate,
-    LoadedLabwareUpdate,
-    StateUpdate,
-)
-import pytest
+from unittest.mock import sentinel
 
+import pytest
 from decoy import Decoy
 
 from opentrons.types import DeckSlotName
@@ -19,12 +15,19 @@ from opentrons.protocol_engine.errors import (
 )
 
 from opentrons.protocol_engine.types import (
+    AddressableAreaLocation,
     DeckSlotLocation,
+    LabwareLocation,
     OnLabwareLocation,
 )
 from opentrons.protocol_engine.execution import LoadedLabwareData, EquipmentHandler
 from opentrons.protocol_engine.resources import labware_validation
 from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.state.update_types import (
+    AddressableAreaUsedUpdate,
+    LoadedLabwareUpdate,
+    StateUpdate,
+)
 
 from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.load_labware import (
@@ -43,33 +46,40 @@ def patch_mock_labware_validation(
         monkeypatch.setattr(labware_validation, name, decoy.mock(func=func))
 
 
-@pytest.mark.parametrize("display_name", [("My custom display name"), (None)])
-async def test_load_labware_implementation(
+@pytest.mark.parametrize("display_name", ["My custom display name", None])
+@pytest.mark.parametrize(
+    ("location", "expected_addressable_area_name"),
+    [
+        (DeckSlotLocation(slotName=DeckSlotName.SLOT_3), "3"),
+        (AddressableAreaLocation(addressableAreaName="3"), "3"),
+    ],
+)
+async def test_load_labware_on_slot_or_addressable_area(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
     equipment: EquipmentHandler,
     state_view: StateView,
     display_name: Optional[str],
+    location: LabwareLocation,
+    expected_addressable_area_name: str,
 ) -> None:
     """A LoadLabware command should have an execution implementation."""
     subject = LoadLabwareImplementation(equipment=equipment, state_view=state_view)
 
     data = LoadLabwareParams(
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+        location=location,
         loadName="some-load-name",
         namespace="opentrons-test",
         version=1,
         displayName=display_name,
     )
 
-    decoy.when(
-        state_view.geometry.ensure_location_not_occupied(
-            DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
-        )
-    ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_4))
+    decoy.when(state_view.geometry.ensure_location_not_occupied(location)).then_return(
+        sentinel.validated_empty_location
+    )
     decoy.when(
         await equipment.load_labware(
-            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+            location=sentinel.validated_empty_location,
             load_name="some-load-name",
             namespace="opentrons-test",
             version=1,
@@ -100,10 +110,12 @@ async def test_load_labware_implementation(
                 labware_id="labware-id",
                 definition=well_plate_def,
                 offset_id="labware-offset-id",
-                new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+                new_location=sentinel.validated_empty_location,
                 display_name=display_name,
             ),
-            addressable_area_used=AddressableAreaUsedUpdate(addressable_area_name="3"),
+            addressable_area_used=AddressableAreaUsedUpdate(
+                addressable_area_name=expected_addressable_area_name
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -2,6 +2,7 @@
 import inspect
 from typing import Optional
 from opentrons.protocol_engine.state.update_types import (
+    AddressableAreaUsedUpdate,
     LoadedLabwareUpdate,
     StateUpdate,
 )
@@ -101,7 +102,8 @@ async def test_load_labware_implementation(
                 offset_id="labware-offset-id",
                 new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
                 display_name=display_name,
-            )
+            ),
+            addressable_area_used=AddressableAreaUsedUpdate(addressable_area_name="3"),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -78,7 +78,7 @@ async def test_load_module_implementation(
             deck_slot=data.location.slotName,
             model=data.model,
         )
-    ).then_return(sentinel.addressable_area_name)
+    ).then_return(sentinel.addressable_area_provided_by_module)
 
     decoy.when(
         await equipment.load_module(
@@ -95,6 +95,11 @@ async def test_load_module_implementation(
     )
 
     result = await subject.execute(data)
+    decoy.verify(
+        state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
+            sentinel.addressable_area_provided_by_module
+        )
+    )
     assert result == SuccessData(
         public=LoadModuleResult(
             moduleId="module-id",
@@ -104,7 +109,7 @@ async def test_load_module_implementation(
         ),
         state_update=update_types.StateUpdate(
             addressable_area_used=update_types.AddressableAreaUsedUpdate(
-                addressable_area_name=sentinel.addressable_area_name
+                addressable_area_name=data.location.slotName.id
             )
         ),
     )
@@ -145,7 +150,7 @@ async def test_load_module_implementation_mag_block(
             deck_slot=data.location.slotName,
             model=data.model,
         )
-    ).then_return(sentinel.addressable_area_name)
+    ).then_return(sentinel.addressable_area_provided_by_module)
 
     decoy.when(
         await equipment.load_magnetic_block(
@@ -162,6 +167,11 @@ async def test_load_module_implementation_mag_block(
     )
 
     result = await subject.execute(data)
+    decoy.verify(
+        state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
+            sentinel.addressable_area_provided_by_module
+        )
+    )
     assert result == SuccessData(
         public=LoadModuleResult(
             moduleId="module-id",
@@ -171,7 +181,7 @@ async def test_load_module_implementation_mag_block(
         ),
         state_update=update_types.StateUpdate(
             addressable_area_used=update_types.AddressableAreaUsedUpdate(
-                addressable_area_name=sentinel.addressable_area_name
+                addressable_area_name=data.location.slotName.id
             )
         ),
     )
@@ -238,7 +248,7 @@ async def test_load_module_implementation_abs_reader(
         ),
         state_update=update_types.StateUpdate(
             addressable_area_used=update_types.AddressableAreaUsedUpdate(
-                addressable_area_name=sentinel.addressable_area_name
+                addressable_area_name=data.location.slotName.id
             )
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -1,9 +1,12 @@
 """Test load module command."""
-import pytest
 from typing import cast
+from unittest.mock import sentinel
+
+import pytest
 from decoy import Decoy
 
 from opentrons.protocol_engine.errors import LocationIsOccupiedError
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons_shared_data.robot.types import RobotType
 from opentrons.types import DeckSlotName
@@ -71,6 +74,13 @@ async def test_load_module_implementation(
     ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_2))
 
     decoy.when(
+        state_view.modules.ensure_and_convert_module_fixture_location(
+            deck_slot=data.location.slotName,
+            model=data.model,
+        )
+    ).then_return(sentinel.addressable_area_name)
+
+    decoy.when(
         await equipment.load_module(
             model=ModuleModel.TEMPERATURE_MODULE_V2,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
@@ -91,6 +101,11 @@ async def test_load_module_implementation(
             serialNumber="mod-serial",
             model=ModuleModel.TEMPERATURE_MODULE_V2,
             definition=tempdeck_v2_def,
+        ),
+        state_update=update_types.StateUpdate(
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name=sentinel.addressable_area_name
+            )
         ),
     )
 
@@ -126,6 +141,13 @@ async def test_load_module_implementation_mag_block(
     ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_2))
 
     decoy.when(
+        state_view.modules.ensure_and_convert_module_fixture_location(
+            deck_slot=data.location.slotName,
+            model=data.model,
+        )
+    ).then_return(sentinel.addressable_area_name)
+
+    decoy.when(
         await equipment.load_magnetic_block(
             model=ModuleModel.MAGNETIC_BLOCK_V1,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
@@ -146,6 +168,11 @@ async def test_load_module_implementation_mag_block(
             serialNumber=None,
             model=ModuleModel.MAGNETIC_BLOCK_V1,
             definition=mag_block_v1_def,
+        ),
+        state_update=update_types.StateUpdate(
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name=sentinel.addressable_area_name
+            )
         ),
     )
 
@@ -181,6 +208,13 @@ async def test_load_module_implementation_abs_reader(
     ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_D3))
 
     decoy.when(
+        state_view.modules.ensure_and_convert_module_fixture_location(
+            deck_slot=data.location.slotName,
+            model=data.model,
+        )
+    ).then_return(sentinel.addressable_area_name)
+
+    decoy.when(
         await equipment.load_module(
             model=ModuleModel.ABSORBANCE_READER_V1,
             location=DeckSlotLocation(slotName=DeckSlotName.SLOT_D3),
@@ -201,6 +235,11 @@ async def test_load_module_implementation_abs_reader(
             serialNumber=None,
             model=ModuleModel.ABSORBANCE_READER_V1,
             definition=abs_reader_v1_def,
+        ),
+        state_update=update_types.StateUpdate(
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name=sentinel.addressable_area_name
+            )
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -1,6 +1,8 @@
 """Test the ``moveLabware`` command."""
 from datetime import datetime
 import inspect
+from unittest.mock import sentinel
+
 import pytest
 from decoy import Decoy, matchers
 
@@ -90,9 +92,10 @@ async def test_manual_move_labware_implementation(
     times_pause_called: int,
 ) -> None:
     """It should execute a pause and return the new offset."""
+    new_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_4)
     data = MoveLabwareParams(
         labwareId="my-cool-labware-id",
-        newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+        newLocation=new_location,
         strategy=strategy,
     )
 
@@ -131,7 +134,10 @@ async def test_manual_move_labware_implementation(
                 labware_id="my-cool-labware-id",
                 offset_id="wowzers-a-new-offset-id",
                 new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
-            )
+            ),
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name=new_location.slotName.id
+            ),
         ),
     )
 
@@ -211,20 +217,19 @@ async def test_gripper_move_labware_implementation(
     """It should delegate to the equipment handler and return the new offset."""
     from_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
     new_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_5)
+    pick_up_offset = LabwareOffsetVector(x=1, y=2, z=3)
 
     data = MoveLabwareParams(
         labwareId="my-cool-labware-id",
-        newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+        newLocation=new_location,
         strategy=LabwareMovementStrategy.USING_GRIPPER,
-        pickUpOffset=LabwareOffsetVector(x=1, y=2, z=3),
+        pickUpOffset=pick_up_offset,
         dropOffset=None,
     )
 
     decoy.when(
         state_view.labware.get_definition(labware_id="my-cool-labware-id")
-    ).then_return(
-        LabwareDefinition.construct(namespace="my-cool-namespace")  # type: ignore[call-arg]
-    )
+    ).then_return(sentinel.labware_definition)
     decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
         LoadedLabware(
             id="my-cool-labware-id",
@@ -235,29 +240,25 @@ async def test_gripper_move_labware_implementation(
         )
     )
     decoy.when(
-        state_view.geometry.ensure_location_not_occupied(
-            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
-        )
-    ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
+        state_view.geometry.ensure_location_not_occupied(location=new_location)
+    ).then_return(sentinel.new_location_validated_unoccupied)
     decoy.when(
         equipment.find_applicable_labware_offset_id(
             labware_definition_uri="opentrons-test/load-name/1",
-            labware_location=new_location,
+            labware_location=sentinel.new_location_validated_unoccupied,
         )
     ).then_return("wowzers-a-new-offset-id")
 
-    validated_from_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_6)
-    validated_new_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_7)
     decoy.when(
         state_view.geometry.ensure_valid_gripper_location(from_location)
-    ).then_return(validated_from_location)
+    ).then_return(sentinel.from_location_validated_for_gripper)
     decoy.when(
-        state_view.geometry.ensure_valid_gripper_location(new_location)
-    ).then_return(validated_new_location)
-    decoy.when(
-        labware_validation.validate_gripper_compatible(
-            LabwareDefinition.construct(namespace="my-cool-namespace")  # type: ignore[call-arg]
+        state_view.geometry.ensure_valid_gripper_location(
+            sentinel.new_location_validated_unoccupied
         )
+    ).then_return(sentinel.new_location_validated_for_gripper)
+    decoy.when(
+        labware_validation.validate_gripper_compatible(sentinel.labware_definition)
     ).then_return(True)
 
     result = await subject.execute(data)
@@ -265,10 +266,10 @@ async def test_gripper_move_labware_implementation(
         state_view.labware.raise_if_labware_has_labware_on_top("my-cool-labware-id"),
         await labware_movement.move_labware_with_gripper(
             labware_id="my-cool-labware-id",
-            current_location=validated_from_location,
-            new_location=validated_new_location,
+            current_location=sentinel.from_location_validated_for_gripper,
+            new_location=sentinel.new_location_validated_for_gripper,
             user_offset_data=LabwareMovementOffsetData(
-                pickUpOffset=LabwareOffsetVector(x=1, y=2, z=3),
+                pickUpOffset=pick_up_offset,
                 dropOffset=LabwareOffsetVector(x=0, y=0, z=0),
             ),
             post_drop_slide_offset=None,
@@ -282,8 +283,11 @@ async def test_gripper_move_labware_implementation(
             pipette_location=update_types.CLEAR,
             labware_location=update_types.LabwareLocationUpdate(
                 labware_id="my-cool-labware-id",
-                new_location=new_location,
+                new_location=sentinel.new_location_validated_unoccupied,
                 offset_id="wowzers-a-new-offset-id",
+            ),
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name=new_location.slotName.id
             ),
         ),
     )
@@ -380,6 +384,9 @@ async def test_gripper_error(
         state_update=update_types.StateUpdate(
             labware_location=update_types.NO_CHANGE,
             pipette_location=update_types.CLEAR,
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name=new_location.slotName.id
+            ),
         ),
     )
 
@@ -519,6 +526,9 @@ async def test_gripper_move_to_waste_chute_implementation(
                 labware_id="my-cool-labware-id",
                 new_location=new_location,
                 offset_id="wowzers-a-new-offset-id",
+            ),
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name=new_location.addressableAreaName
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
@@ -93,7 +93,10 @@ async def test_move_to_addressable_area_implementation_non_gen1(
                 pipette_id="abc",
                 new_location=update_types.AddressableArea(addressable_area_name="123"),
                 new_deck_point=DeckPoint(x=9, y=8, z=7),
-            )
+            ),
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name="123"
+            ),
         ),
     )
 
@@ -154,7 +157,10 @@ async def test_move_to_addressable_area_implementation_with_gen1(
                 pipette_id="abc",
                 new_location=update_types.AddressableArea(addressable_area_name="123"),
                 new_deck_point=DeckPoint(x=9, y=8, z=7),
-            )
+            ),
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name="123"
+            ),
         ),
     )
 
@@ -206,5 +212,10 @@ async def test_move_to_addressable_area_implementation_handles_stalls(
         public=StallOrCollisionError.construct(
             id=test_id, createdAt=timestamp, wrappedErrors=[matchers.Anything()]
         ),
-        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.CLEAR,
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name="123"
+            ),
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
@@ -79,7 +79,10 @@ async def test_move_to_addressable_area_for_drop_tip_implementation(
                 pipette_id="abc",
                 new_location=update_types.AddressableArea(addressable_area_name="123"),
                 new_deck_point=DeckPoint(x=9, y=8, z=7),
-            )
+            ),
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name="123"
+            ),
         ),
     )
 
@@ -133,5 +136,10 @@ async def test_move_to_addressable_area_for_drop_tip_handles_stalls(
         public=StallOrCollisionError.construct(
             id=test_id, createdAt=timestamp, wrappedErrors=[matchers.Anything()]
         ),
-        state_update=update_types.StateUpdate(pipette_location=update_types.CLEAR),
+        state_update=update_types.StateUpdate(
+            pipette_location=update_types.CLEAR,
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name="123"
+            ),
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
@@ -25,14 +25,12 @@ from opentrons.protocol_engine.state.addressable_areas import (
 from opentrons.protocol_engine.types import (
     DeckType,
     DeckConfigurationType,
-    ModuleModel,
     LabwareMovementStrategy,
     DeckSlotLocation,
     AddressableAreaLocation,
 )
 
 from .command_fixtures import (
-    create_load_module_command,
     create_move_labware_command,
 )
 
@@ -176,14 +174,6 @@ def test_initial_state(
     ("command", "expected_area"),
     (
         (
-            create_load_module_command(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
-                module_id="test-module-id",
-                model=ModuleModel.TEMPERATURE_MODULE_V2,
-            ),
-            "A1",
-        ),
-        (
             create_move_labware_command(
                 new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
                 strategy=LabwareMovementStrategy.USING_GRIPPER,
@@ -240,14 +230,6 @@ def test_addressable_area_usage_in_simulation(
 @pytest.mark.parametrize(
     ("command", "expected_area"),
     (
-        (
-            create_load_module_command(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
-                module_id="test-module-id",
-                model=ModuleModel.TEMPERATURE_MODULE_V2,
-            ),
-            "A1",
-        ),
         (
             create_move_labware_command(
                 new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
@@ -9,8 +9,6 @@ import pytest
 
 from opentrons_shared_data.deck.types import DeckDefinitionV5
 
-from opentrons.types import DeckSlotName
-
 from opentrons.protocol_engine.commands import Command, Comment
 from opentrons.protocol_engine.actions import (
     SucceedCommandAction,
@@ -25,13 +23,6 @@ from opentrons.protocol_engine.state.addressable_areas import (
 from opentrons.protocol_engine.types import (
     DeckType,
     DeckConfigurationType,
-    LabwareMovementStrategy,
-    DeckSlotLocation,
-    AddressableAreaLocation,
-)
-
-from .command_fixtures import (
-    create_move_labware_command,
 )
 
 
@@ -168,37 +159,6 @@ def test_initial_state(
     assert len(subject.state.loaded_addressable_areas_by_name) == 16
 
 
-# todo(mm, 2024-12-02): Delete in favor of test_addressable_area_usage_in_simulation()
-# when all of these commands have been ported to StateUpdate.
-@pytest.mark.parametrize(
-    ("command", "expected_area"),
-    (
-        (
-            create_move_labware_command(
-                new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
-                strategy=LabwareMovementStrategy.USING_GRIPPER,
-            ),
-            "A1",
-        ),
-        (
-            create_move_labware_command(
-                new_location=AddressableAreaLocation(addressableAreaName="A4"),
-                strategy=LabwareMovementStrategy.USING_GRIPPER,
-            ),
-            "A4",
-        ),
-    ),
-)
-def test_addressable_area_referencing_commands_load_on_simulated_deck(
-    command: Command,
-    expected_area: str,
-    simulated_subject: AddressableAreaStore,
-) -> None:
-    """It should check and store the addressable area when referenced in a command."""
-    simulated_subject.handle_action(SucceedCommandAction(command=command))
-    assert expected_area in simulated_subject.state.loaded_addressable_areas_by_name
-
-
 @pytest.mark.parametrize("addressable_area_name", ["A1", "A4", "gripperWasteChute"])
 def test_addressable_area_usage_in_simulation(
     simulated_subject: AddressableAreaStore,
@@ -223,37 +183,6 @@ def test_addressable_area_usage_in_simulation(
         addressable_area_name
         in simulated_subject.state.loaded_addressable_areas_by_name
     )
-
-
-# todo(mm, 2024-12-02): Delete in favor of test_addressable_area_usage()
-# when all of these commands have been ported to StateUpdate.
-@pytest.mark.parametrize(
-    ("command", "expected_area"),
-    (
-        (
-            create_move_labware_command(
-                new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
-                strategy=LabwareMovementStrategy.USING_GRIPPER,
-            ),
-            "A1",
-        ),
-        (
-            create_move_labware_command(
-                new_location=AddressableAreaLocation(addressableAreaName="C4"),
-                strategy=LabwareMovementStrategy.USING_GRIPPER,
-            ),
-            "C4",
-        ),
-    ),
-)
-def test_addressable_area_referencing_commands_load(
-    command: Command,
-    expected_area: str,
-    subject: AddressableAreaStore,
-) -> None:
-    """It should check that the addressable area is in the deck config."""
-    subject.handle_action(SucceedCommandAction(command=command))
-    assert expected_area in subject.state.loaded_addressable_areas_by_name
 
 
 @pytest.mark.parametrize("addressable_area_name", ["A1", "C4"])

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
@@ -185,37 +185,6 @@ def test_addressable_area_usage_in_simulation(
     )
 
 
-@pytest.mark.parametrize("addressable_area_name", ["A1", "C4"])
-def test_addressable_area_usage(
-    subject: AddressableAreaStore,
-    addressable_area_name: str,
-) -> None:
-    """Non-simulating stores should correctly handle `StateUpdate`s with addressable areas.
-
-    todo(mm, 2024-12-02): This is ported from an older test that said the
-    subject "should check that the addressable area is in the deck config." But
-    AddressableAreaStore does not do that--that is the job of AddressableAreaView--and
-    the original test did not cover that. Do we still need to test anything here, or
-    can this be deleted?
-    """
-    # The addressable area should have been added by the deck configuration.
-    # (Tested more explicitly elsewhere.)
-    assert addressable_area_name in subject.state.loaded_addressable_areas_by_name
-
-    subject.handle_action(
-        SucceedCommandAction(
-            command=_dummy_command(),
-            state_update=update_types.StateUpdate(
-                addressable_area_used=update_types.AddressableAreaUsedUpdate(
-                    addressable_area_name
-                )
-            ),
-        )
-    )
-    # The addressable area should still be there after handling the action.
-    assert addressable_area_name in subject.state.loaded_addressable_areas_by_name
-
-
 def test_add_addressable_area_action(
     simulated_subject: AddressableAreaStore,
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
@@ -8,9 +8,7 @@ tested together, treating AddressableAreaState as a private implementation detai
 import pytest
 
 from opentrons_shared_data.deck.types import DeckDefinitionV5
-from opentrons_shared_data.labware.labware_definition import Parameters
 
-from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName
 
 from opentrons.protocol_engine.commands import Command, Comment
@@ -34,7 +32,6 @@ from opentrons.protocol_engine.types import (
 )
 
 from .command_fixtures import (
-    create_load_labware_command,
     create_load_module_command,
     create_move_labware_command,
     create_move_to_addressable_area_command,
@@ -180,34 +177,6 @@ def test_initial_state(
     ("command", "expected_area"),
     (
         (
-            create_load_labware_command(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
-                labware_id="test-labware-id",
-                definition=LabwareDefinition.construct(  # type: ignore[call-arg]
-                    parameters=Parameters.construct(loadName="blah"),  # type: ignore[call-arg]
-                    namespace="bleh",
-                    version=123,
-                ),
-                offset_id="offset-id",
-                display_name="display-name",
-            ),
-            "A1",
-        ),
-        (
-            create_load_labware_command(
-                location=AddressableAreaLocation(addressableAreaName="A4"),
-                labware_id="test-labware-id",
-                definition=LabwareDefinition.construct(  # type: ignore[call-arg]
-                    parameters=Parameters.construct(loadName="blah"),  # type: ignore[call-arg]
-                    namespace="bleh",
-                    version=123,
-                ),
-                offset_id="offset-id",
-                display_name="display-name",
-            ),
-            "A4",
-        ),
-        (
             create_load_module_command(
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
                 module_id="test-module-id",
@@ -278,34 +247,6 @@ def test_addressable_area_usage_in_simulation(
 @pytest.mark.parametrize(
     ("command", "expected_area"),
     (
-        (
-            create_load_labware_command(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
-                labware_id="test-labware-id",
-                definition=LabwareDefinition.construct(  # type: ignore[call-arg]
-                    parameters=Parameters.construct(loadName="blah"),  # type: ignore[call-arg]
-                    namespace="bleh",
-                    version=123,
-                ),
-                offset_id="offset-id",
-                display_name="display-name",
-            ),
-            "A1",
-        ),
-        (
-            create_load_labware_command(
-                location=AddressableAreaLocation(addressableAreaName="C4"),
-                labware_id="test-labware-id",
-                definition=LabwareDefinition.construct(  # type: ignore[call-arg]
-                    parameters=Parameters.construct(loadName="blah"),  # type: ignore[call-arg]
-                    namespace="bleh",
-                    version=123,
-                ),
-                offset_id="offset-id",
-                display_name="display-name",
-            ),
-            "C4",
-        ),
         (
             create_load_module_command(
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
@@ -34,7 +34,6 @@ from opentrons.protocol_engine.types import (
 from .command_fixtures import (
     create_load_module_command,
     create_move_labware_command,
-    create_move_to_addressable_area_command,
 )
 
 
@@ -197,12 +196,6 @@ def test_initial_state(
                 strategy=LabwareMovementStrategy.USING_GRIPPER,
             ),
             "A4",
-        ),
-        (
-            create_move_to_addressable_area_command(
-                pipette_id="pipette-id", addressable_area_name="gripperWasteChute"
-            ),
-            "gripperWasteChute",
         ),
     ),
 )

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
@@ -308,10 +308,6 @@ def test_add_addressable_area_action(
 ) -> None:
     """It should add the addressable area to the store."""
     simulated_subject.handle_action(
-        AddAddressableAreaAction(
-            addressable_area=AddressableAreaLocation(
-                addressableAreaName="movableTrashA1"
-            )
-        )
+        AddAddressableAreaAction(addressable_area_name="movableTrashA1")
     )
     assert "movableTrashA1" in simulated_subject.state.loaded_addressable_areas_by_name

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -32,7 +32,6 @@ from opentrons.protocol_engine.types import (
     ModuleModel,
     Liquid,
     PostRunHardwareState,
-    AddressableAreaLocation,
 )
 from opentrons.protocol_engine.execution import (
     QueueWorker,
@@ -1119,11 +1118,7 @@ def test_add_addressable_area(
 
     decoy.verify(
         action_dispatcher.dispatch(
-            AddAddressableAreaAction(
-                addressable_area=AddressableAreaLocation(
-                    addressableAreaName="my_funky_area"
-                )
-            )
+            AddAddressableAreaAction(addressable_area_name="my_funky_area")
         )
     )
 


### PR DESCRIPTION
## Overview

Closes EXEC-755.

## Test Plan and Hands on Testing

* [x] Make sure all automated tests (in particular, the analysis snapshot tests) keep passing.
* [x] Run some random protocols on a Flex and OT-2 and make sure there aren't any unexpected errors related to addressable areas or deck configurations.

## Changelog

Following the usual pattern of EXEC-639, port:

* `AddressableAreaStore`
* `LoadLabwareImplementation`
* `MoveToAddressableAreaImplementation`
* `MoveToAddressableAreaForDropTipImplementation`
* `LoadModuleImplementation`

So that the command implementations use `StateUpdate` to tell `AddressableAreaStore` what addressable area they have used, instead of `AddressableAreaStore` trying to figure it out for itself.

## Review requests

See the risk assessment below and the comments on the diff.

## Risk assessment

Medium.

This needs careful code review to make sure that the end result on `AddressableAreaState` is unchanged; the code removed from `AddressableAreaStore` should be exactly compensated by the code added to the command implementations.

These command implementations did not have full unit test coverage of all the stuff they did with addressable areas and deck configurations, and even if they did, it's very possible for me to mess things up. I initially had one bug where I had `LoadModuleImplementation` load a completely wrong addressable area, and it was only caught by an analysis snapshot test that I guess happened to have a specific deck layout.

`LoadLabwareImplementation` and its tests in particular have grown to be difficult to verify.