### PR TITLE
docs(api): hide 2.22 features from 2.21 docs

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -28,7 +28,7 @@ Labware
 =======
 .. autoclass:: opentrons.protocol_api.Labware
    :members:
-   :exclude-members: next_tip, use_tips, previous_tip, return_tips
+   :exclude-members: next_tip, use_tips, previous_tip, return_tips, load_empty, load_liquid, load_liquid_by_well
 
 ..
    The trailing ()s at the end of TrashBin and WasteChute here hide the __init__()

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -763,8 +763,7 @@ class InstrumentContext(publisher.CommandPublisher):
             ``pipette.air_gap(height=2)``. If you call ``air_gap`` with a single,
             unnamed argument, it will always be interpreted as a volume.
 
-        .. note::
-
+        .. TODO: restore this as a note block for 2.22 docs
            Before API version 2.22, this function was implemented as an aspirate, and
            dispensing into a well would add the air gap volume to the liquid tracked in
            the well. At or above API version 2.22, air gap volume is not counted as liquid
@@ -1604,9 +1603,11 @@ class InstrumentContext(publisher.CommandPublisher):
             source=[well._core for well in flat_sources_list],
             dest=[well._core for well in flat_dests_list],
             new_tip=valid_new_tip,
-            trash_location=checked_trash_location._core
-            if isinstance(checked_trash_location, labware.Well)
-            else checked_trash_location,
+            trash_location=(
+                checked_trash_location._core
+                if isinstance(checked_trash_location, labware.Well)
+                else checked_trash_location
+            ),
         )
 
         return self

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -292,7 +292,7 @@ class Well:
         :param Liquid liquid: The liquid to load into the well.
         :param float volume: The volume of liquid to load, in µL.
 
-        .. deprecated:: 2.22
+        .. TODO: flag as deprecated in 2.22 docs
             In API version 2.22 and later, use :py:meth:`~Labware.load_liquid`, :py:meth:`~Labware.load_liquid_by_well`,
             or :py:meth:`~Labware.load_empty` to load liquid into a well.
         """


### PR DESCRIPTION

# Overview

We cut the `docs@2.21` tag from `edge` and it accidentally had some stuff _from the future_ 🔮 

This PR hides those things temporarily. We'll unhide them when writing docs for the 2.22 release.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-hide-future-2.22/v2/new_protocol_api.html)

## Changelog

- Exclude some methods in `new_protocol_api.rst`
- Turn some notes and deprecation notices in docstrings into invisible comments, with TODOs to change back.
- Ran `black` on code files.

## Review requests

Check that there are no other mentions of 2.22. I've searched the source (RST and Python) and can't think of anywhere they would pop up except the API Reference page, which is clean now. I suppose there could be some 2.22 stuff that wasn't tagged with a version and is still sneaking through.

## Risk assessment

v low, docs only except whatever black did