### PR TITLE
refactor(robot-server): use different pipette IDs for OT2 vs Flex dev servers

### DIFF
--- a/robot-server/robot_server/service/notifications/publisher_notifier.py
+++ b/robot-server/robot_server/service/notifications/publisher_notifier.py
@@ -52,9 +52,9 @@ class PublisherNotifier:
                             f'PublisherNotifier: exception in callback {getattr(callback, "__name__", "<unknown>")}'
                         )
         except asyncio.exceptions.CancelledError:
-            LOG.warning("PublisherNotifuer task cancelled.")
+            LOG.warning("PublisherNotifier task cancelled.")
         except BaseException:
-            LOG.exception("PublisherNotifer notify task failed")
+            LOG.exception("PublisherNotifier notify task failed")
 
 
 _pe_publisher_notifier_accessor: AppStateAccessor[PublisherNotifier] = AppStateAccessor[

--- a/robot-server/simulators/test-flex.json
+++ b/robot-server/simulators/test-flex.json
@@ -4,15 +4,15 @@
   "attached_instruments": {
     "right": {
       "model": "p1000_single_3.4",
-      "id": "321"
+      "id": "321_flex"
     },
     "left": {
       "model": "p50_single_3.4",
-      "id": "123"
+      "id": "123_flex"
     },
     "gripper":{
       "model": "gripper_1.3",
-      "id": "1234"
+      "id": "1234_flex_gripper"
     }
   },
   "attached_modules": {


### PR DESCRIPTION
# Overview

The OT2 and Flex pipette calibration data format is slightly different. In the simulator setup file, we have the OT2 & Flex pipette IDs the same so the calibration files get unintentionally shared between OT2 & Flex. When switching between OT2 and Flex dev servers, the difference in data format causes a validation error and we have to re-calibrate the pipettes (or update the files) each time. It's quite annoying to have to do this so I am changing the Flex's pipette ID so that we'll be able to use separate calibration files for flex & OT2 pipettes.

## Review requests

I don't think this should cause any problems for anyone but correct me if I'm wrong.

## Risk assessment

None. Dev server change only
