### PR TITLE
perf(protocol-designer): improve ProtocolOverview performance

### DIFF
--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -43,7 +43,7 @@
   "no_offdeck_labware": "No off-deck labware added",
   "off_deck_labware": "Off-deck Labware",
   "off_deck_title": "Off deck",
-  "offDeck": "Off-deck",
+  "offDeck": "Off deck",
   "onDeck": "On deck",
   "one_item": "No more than 1 {{hardware}} allowed on the deck at one time",
   "only_display_rec": "Only display recommended labware",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
@@ -91,7 +91,7 @@ describe('ProtocolSteps', () => {
   it('renders the toggle when formData is null', () => {
     render()
     screen.getByText('mock DeckSetupContainer')
-    fireEvent.click(screen.getByText('Off-deck'))
+    fireEvent.click(screen.getByText('Off deck'))
     screen.getByText('mock OffDeck')
   })
 

--- a/protocol-designer/src/pages/ProtocolOverview/StartingDeck.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/StartingDeck.tsx
@@ -1,102 +1,128 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 
 import {
   ALIGN_CENTER,
+  Box,
+  Btn,
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   StyledText,
-  Btn,
-  TYPOGRAPHY,
   ToggleGroup,
-  Box,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 
 import { BUTTON_LINK_STYLE } from '../../atoms'
+import { SlotDetailsContainer } from '../../organisms'
+import { getInitialDeckSetup } from '../../step-forms/selectors'
 import { DeckThumbnail } from './DeckThumbnail'
 import { OffDeckThumbnail } from './OffdeckThumbnail'
-import { SlotDetailsContainer } from '../../organisms'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { RobotType } from '@opentrons/shared-data'
+import type { DeckSlot } from '../../types'
 
 interface StartingDeckProps {
-  setShowMaterialsListModal: (showMaterialsListModal: boolean) => void
-  leftString: string
-  rightString: string
   robotType: RobotType
-  hover: string | null
-  setHover: Dispatch<SetStateAction<string | null>>
-  isOffDeckHover: boolean
+  setShowMaterialsListModal: Dispatch<SetStateAction<boolean>>
 }
 
 export function StartingDeck({
-  setShowMaterialsListModal,
-  leftString,
-  rightString,
   robotType,
-  hover,
-  setHover,
-  isOffDeckHover,
+  setShowMaterialsListModal,
 }: StartingDeckProps): JSX.Element {
-  const { t } = useTranslation('protocol_overview')
-
-  const [deckView, setDeckView] = useState<string>(leftString)
+  const [isOffDeck, setIsOFfDeck] = useState<boolean>(false)
 
   return (
-    <>
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
-        <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
-          <StyledText desktopStyle="headingSmallBold">
-            {t('starting_deck')}
-          </StyledText>
-          <Flex padding={SPACING.spacing4}>
-            <Btn
-              data-testid="Materials_list"
-              textDecoration={TYPOGRAPHY.textDecorationUnderline}
-              onClick={() => {
-                setShowMaterialsListModal(true)
-              }}
-              css={BUTTON_LINK_STYLE}
-            >
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {t('materials_list')}
-              </StyledText>
-            </Btn>
-          </Flex>
+    <Flex gridGap={SPACING.spacing12} flexDirection={DIRECTION_COLUMN}>
+      <StartingDeckHeader
+        isOffDeck={isOffDeck}
+        setIsOffDeck={setIsOFfDeck}
+        setShowMaterialsListModal={setShowMaterialsListModal}
+      />
+      <StartingDeckBody isOffDeck={isOffDeck} robotType={robotType} />
+    </Flex>
+  )
+}
+
+interface StartingDeckHeaderProps {
+  isOffDeck: boolean
+  setIsOffDeck: Dispatch<SetStateAction<boolean>>
+  setShowMaterialsListModal: Dispatch<SetStateAction<boolean>>
+}
+
+function StartingDeckHeader(props: StartingDeckHeaderProps): JSX.Element {
+  const { isOffDeck, setIsOffDeck, setShowMaterialsListModal } = props
+  const { t } = useTranslation(['protocol_overview', 'starting_deck_state'])
+  const onDeckString = t('starting_deck_state:onDeck')
+  const offDeckString = t('starting_deck_state:offDeck')
+  return (
+    <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
+      <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
+        <StyledText desktopStyle="headingSmallBold">
+          {t('starting_deck')}
+        </StyledText>
+        <Flex padding={SPACING.spacing4}>
+          <Btn
+            data-testid="Materials_list"
+            textDecoration={TYPOGRAPHY.textDecorationUnderline}
+            onClick={() => {
+              setShowMaterialsListModal(true)
+            }}
+            css={BUTTON_LINK_STYLE}
+          >
+            <StyledText desktopStyle="bodyDefaultRegular">
+              {t('protocol_overview:materials_list')}
+            </StyledText>
+          </Btn>
         </Flex>
-        <ToggleGroup
-          selectedValue={deckView}
-          leftText={leftString}
-          rightText={rightString}
-          leftClick={() => {
-            setDeckView(leftString)
-          }}
-          rightClick={() => {
-            setDeckView(rightString)
-          }}
+      </Flex>
+      <ToggleGroup
+        selectedValue={isOffDeck ? offDeckString : onDeckString}
+        leftText={onDeckString}
+        rightText={offDeckString}
+        leftClick={() => {
+          setIsOffDeck(false)
+        }}
+        rightClick={() => {
+          setIsOffDeck(true)
+        }}
+      />
+    </Flex>
+  )
+}
+
+interface StartingDeckBodyProps {
+  isOffDeck: boolean
+  robotType: RobotType
+}
+
+function StartingDeckBody(props: StartingDeckBodyProps): JSX.Element {
+  const { isOffDeck, robotType } = props
+  const [hover, setHover] = useState<DeckSlot | string | null>(null)
+  const { labware: labwaresOnDeck } = useSelector(getInitialDeckSetup)
+  const isOffDeckHover = hover != null && labwaresOnDeck[hover] != null
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing32}
+      alignItems={ALIGN_CENTER}
+    >
+      {isOffDeck ? (
+        <OffDeckThumbnail hover={hover} setHover={setHover} width="100%" />
+      ) : (
+        <DeckThumbnail hoverSlot={hover} setHoverSlot={setHover} />
+      )}
+      <Box width="100%" height="12.5rem">
+        <SlotDetailsContainer
+          robotType={robotType}
+          slot={isOffDeckHover ? 'offDeck' : hover}
+          offDeckLabwareId={isOffDeckHover ? hover : null}
         />
-      </Flex>
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        gridGap={SPACING.spacing32}
-        alignItems={ALIGN_CENTER}
-      >
-        {deckView === leftString ? (
-          <DeckThumbnail hoverSlot={hover} setHoverSlot={setHover} />
-        ) : (
-          <OffDeckThumbnail hover={hover} setHover={setHover} width="100%" />
-        )}
-        <Box width="100%" height="12.5rem">
-          <SlotDetailsContainer
-            robotType={robotType}
-            slot={isOffDeckHover ? 'offDeck' : hover}
-            offDeckLabwareId={isOffDeckHover ? hover : null}
-          />
-        </Box>
-      </Flex>
-    </>
+      </Box>
+    </Flex>
   )
 }

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/StartingDeck.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/StartingDeck.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, screen } from '@testing-library/react'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { i18n } from '../../../assets/localization'
+import { getInitialDeckSetup } from '../../../step-forms/selectors'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { SlotDetailsContainer } from '../../../organisms'
 import { StartingDeck } from '../StartingDeck'
@@ -13,6 +14,7 @@ import type { ComponentProps } from 'react'
 vi.mock('../DeckThumbnail')
 vi.mock('OffDeckThumbnail')
 vi.mock('../../../organisms')
+vi.mock('../../../step-forms/selectors')
 
 vi.mock('../DeckThumbnail', () => ({
   DeckThumbnail: vi.fn(() => <div>mock DeckThumbnail</div>),
@@ -22,7 +24,6 @@ vi.mock('../OffdeckThumbnail', () => ({
 }))
 
 const mockSetShowMaterialsListModal = vi.fn()
-const mockSetHover = vi.fn()
 
 const render = (props: ComponentProps<typeof StartingDeck>) => {
   return (
@@ -35,21 +36,23 @@ describe('StartingDeck', () => {
 
   beforeEach(() => {
     props = {
-      setShowMaterialsListModal: mockSetShowMaterialsListModal,
-      leftString: 'On deck',
-      rightString: 'Off deck',
       robotType: FLEX_ROBOT_TYPE,
-      hover: null,
-      setHover: mockSetHover,
-      isOffDeckHover: false,
+      setShowMaterialsListModal: mockSetShowMaterialsListModal,
     }
     vi.mocked(SlotDetailsContainer).mockReturnValue(
       <div>mock SlotDetailsContainer</div>
     )
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {},
+      pipettes: {},
+      additionalEquipmentOnDeck: {},
+      labware: {},
+    })
   })
 
   it('should render deck view, text and toggle', () => {
     render(props)
+
     screen.getByText('Protocol Starting Deck')
     screen.getByText('Materials list')
     screen.getByRole('button', { name: 'On deck' })
@@ -71,7 +74,7 @@ describe('StartingDeck', () => {
   })
 
   it('should render mock SlotDetailsContainer when hovering', () => {
-    render({ ...props, hover: 'D2' })
+    render({ ...props })
     screen.getByText('mock SlotDetailsContainer')
   })
 })

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -49,7 +49,6 @@ import { StepsInfo } from './StepsInfo'
 import { StartingDeck } from './StartingDeck'
 
 import type { CreateCommand } from '@opentrons/shared-data'
-import type { DeckSlot } from '@opentrons/step-generation'
 import type { ThunkDispatch } from '../../types'
 
 const DATE_ONLY_FORMAT = 'MMMM dd, yyyy'
@@ -94,7 +93,6 @@ export function ProtocolOverview(): JSX.Element {
     labwareIngredSelectors.allIngredientGroupFields
   )
   const dispatch: ThunkDispatch<any> = useDispatch()
-  const [hover, setHover] = useState<DeckSlot | string | null>(null)
   const [showMaterialsListModal, setShowMaterialsListModal] = useState<boolean>(
     false
   )
@@ -104,8 +102,6 @@ export function ProtocolOverview(): JSX.Element {
   const liquidsOnDeck = useSelector(
     labwareIngredSelectors.allIngredientNamesIds
   )
-  const leftString = t('starting_deck_state:onDeck')
-  const rightString = t('starting_deck_state:offDeck')
 
   useEffect(() => {
     if (formValues?.created == null) {
@@ -122,7 +118,6 @@ export function ProtocolOverview(): JSX.Element {
     additionalEquipmentOnDeck,
     pipettes,
   } = initialDeckSetup
-  const isOffDeckHover = hover != null && labwaresOnDeck[hover] != null
 
   const nonLoadCommands =
     fileData?.commands.filter(
@@ -326,13 +321,8 @@ export function ProtocolOverview(): JSX.Element {
             gridGap={SPACING.spacing12}
           >
             <StartingDeck
-              setShowMaterialsListModal={setShowMaterialsListModal}
-              leftString={leftString}
-              rightString={rightString}
               robotType={robotType}
-              isOffDeckHover={isOffDeckHover}
-              hover={hover}
-              setHover={setHover}
+              setShowMaterialsListModal={setShowMaterialsListModal}
             />
           </Flex>
         </Flex>


### PR DESCRIPTION
# Overview

This PR refactors ProtocolOverview to avoid unnecessary full rerenders and improve performance. Namely, I move logic for starting deck hover into the StartingDeck component. Further, I break this component into its comprising header and body to only maintain on/offdeck state at the StartingDeck level.

Closes RQA-3755


**Before:**

https://github.com/user-attachments/assets/4b7629e9-13db-41fe-a75e-ca51709b9eef



**After:**

https://github.com/user-attachments/assets/2c5cd0e9-ac48-4b6b-9074-88922e0a5d49


## Test Plan and Hands on Testing

- use [react-scan](https://github.com/aidenybai/react-scan?tab=readme-ov-file#install) to easily view component rendering (section for Vite/Create React App. is easiest)
- create or import Flex protocol and navigate to Protocol Overview page
- hover starting deck and verify that only the deck and SlotHover components rerender
- repeat with OT-2

## Changelog

- refactor hover logic into `StartingDeck` component to avoid unnecessary rendering of entire ProtocolOverview page
- separate `StartingDeck` into header and body to further reduce unnecessary rendering of header on hover

## Review requests

- see test plan

## Risk assessment

low