### PR TITLE
fix(app): no longer consider labware loaded late in protocol off-deck

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/index.tsx
@@ -270,7 +270,7 @@ export function ProtocolDetails(
     mostRecentAnalysis?.commands.filter(
       (command): command is LoadLabwareRunTimeCommand =>
         command.commandType === 'loadLabware' &&
-        command.result.definition.parameters.format !== 'trash'
+        command.result?.definition.parameters.format !== 'trash'
     ) ?? []
 
   const protocolDisplayName = getProtocolDisplayName(

--- a/app/src/organisms/Desktop/ProtocolDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/index.tsx
@@ -42,9 +42,6 @@ import {
   getGripperDisplayName,
   getModuleType,
   getSimplestDeckConfigForProtocol,
-  parseInitialLoadedLabwareByAdapter,
-  parseInitialLoadedLabwareByModuleId,
-  parseInitialLoadedLabwareBySlot,
   parseInitialLoadedModulesBySlot,
   parseInitialPipetteNamesByMount,
 } from '@opentrons/shared-data'
@@ -75,7 +72,11 @@ import { RobotConfigurationDetails } from './RobotConfigurationDetails'
 import { ProtocolParameters } from './ProtocolParameters'
 import { AnnotatedSteps } from './AnnotatedSteps'
 
-import type { JsonConfig, PythonConfig } from '@opentrons/shared-data'
+import type {
+  JsonConfig,
+  PythonConfig,
+  LoadLabwareRunTimeCommand,
+} from '@opentrons/shared-data'
 import type { StoredProtocolData } from '/app/redux/protocol-storage'
 import type { State, Dispatch } from '/app/redux/types'
 
@@ -265,28 +266,12 @@ export function ProtocolDetails(
       : null
   )
 
-  const requiredLabwareDetails =
-    mostRecentAnalysis != null
-      ? map({
-          ...parseInitialLoadedLabwareByModuleId(
-            mostRecentAnalysis.commands != null
-              ? mostRecentAnalysis.commands
-              : []
-          ),
-          ...parseInitialLoadedLabwareBySlot(
-            mostRecentAnalysis.commands != null
-              ? mostRecentAnalysis.commands
-              : []
-          ),
-          ...parseInitialLoadedLabwareByAdapter(
-            mostRecentAnalysis.commands != null
-              ? mostRecentAnalysis.commands
-              : []
-          ),
-        }).filter(
-          labware => labware.result?.definition?.parameters?.format !== 'trash'
-        )
-      : []
+  const loadLabwareCommands =
+    mostRecentAnalysis?.commands.filter(
+      (command): command is LoadLabwareRunTimeCommand =>
+        command.commandType === 'loadLabware' &&
+        command.result.definition.parameters.format !== 'trash'
+    ) ?? []
 
   const protocolDisplayName = getProtocolDisplayName(
     protocolKey,
@@ -323,7 +308,7 @@ export function ProtocolDetails(
 
   const contentsByTabName = {
     labware: (
-      <ProtocolLabwareDetails requiredLabwareDetails={requiredLabwareDetails} />
+      <ProtocolLabwareDetails requiredLabwareDetails={loadLabwareCommands} />
     ),
     robot_config: (
       <RobotConfigurationDetails

--- a/app/src/transformations/commands/transformations/getLabwareSetupItemGroups.ts
+++ b/app/src/transformations/commands/transformations/getLabwareSetupItemGroups.ts
@@ -27,18 +27,6 @@ export interface GroupedLabwareSetupItems {
 export function getLabwareSetupItemGroups(
   commands: RunTimeCommand[]
 ): GroupedLabwareSetupItems {
-  let beyondInitialLoadCommands = false
-
-  const LABWARE_ACCESS_COMMAND_TYPES = [
-    'moveToWell',
-    'aspirate',
-    'dispense',
-    'blowout',
-    'pickUpTip',
-    'dropTip',
-    'touchTip',
-  ]
-
   const [offDeckItems, onDeckItems] = partition(
     commands.reduce<LabwareSetupItem[]>((acc, c) => {
       if (
@@ -77,12 +65,7 @@ export function getLabwareSetupItemGroups(
         return [
           ...acc,
           {
-            // NOTE: for the purposes of the labware setup step, anything loaded after
-            // the initial load commands will be treated as "initially off deck"
-            // even if technically loaded directly onto the deck later in the protocol
-            initialLocation: beyondInitialLoadCommands
-              ? 'offDeck'
-              : c.params.location,
+            initialLocation: c.params.location,
             definition,
             moduleModel,
             moduleLocation,
@@ -90,17 +73,7 @@ export function getLabwareSetupItemGroups(
             labwareId: c.result?.labwareId,
           },
         ]
-      } else if (
-        !beyondInitialLoadCommands &&
-        LABWARE_ACCESS_COMMAND_TYPES.includes(c.commandType) &&
-        !(
-          c.commandType === 'moveLabware' &&
-          c.params.strategy === 'manualMoveWithoutPause'
-        )
-      ) {
-        beyondInitialLoadCommands = true
       }
-
       return acc
     }, []),
     ({ initialLocation }) => initialLocation === 'offDeck'


### PR DESCRIPTION
fix RQA-3732

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Logic in our util to determine required labware for a protocol was parsing protocol commands and considering everything loaded after a "non-prep" command to be loaded off-deck. While best practice is to load all labware at the beginning of a protocol, we should still show accurate locations for `loadLabware` commands issued at any point.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
1. Upload a protocol with stacked labware loaded after a non-prep command. In protocol setup, see that the labware is now displayed with correct load locations on ODD and desktop

_Before:_
<img width="1075" alt="ODD Before" src="https://github.com/user-attachments/assets/57a1ed1a-b241-47b0-9cc8-059ee3a59eec">
<img width="1079" alt="Screenshot 2024-12-02 at 6 42 49 PM" src="https://github.com/user-attachments/assets/2b8bcc22-969b-4d5a-87dd-1bffdd8263e9">

_After:_
<img width="1005" alt="ODD After" src="https://github.com/user-attachments/assets/07b259ed-d51c-4d2e-97fa-5f091289d20e">
<img width="902" alt="Desktop After" src="https://github.com/user-attachments/assets/8f0f672f-8f34-42f9-a5c1-1f506c7e1670">

2. Upload a protocol with labware loaded off-deck. See that off-deck labware is included in the list of labware required for desktop protocol details

_Before:_
<img width="933" alt="Off deck labware before" src="https://github.com/user-attachments/assets/4d44e6dc-ecdc-45af-89d9-f5d18daf232e">

_After:_
<img width="936" alt="Off deck labware after" src="https://github.com/user-attachments/assets/60b036b3-d50a-4c72-8270-64575743b6ba">
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
1. Refactor `getLabwareSetupItemGroups` to no longer have the concept of initial setup commands so that the accurate load location is returned for all labware
2. Remove specific parsing of commands that separates out labware loaded in each category in protocol details on ODD. Instead perform simple filtration to grab all load labware commands

## Review requests
Take a look at the changes and screenshots
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
