### PR TITLE
fix(protocol-designer): fix logic for showing AutoAddPauseUntilTempStepModal

### DIFF
--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -722,7 +722,7 @@ export const getUnsavedFormIsPristineSetTempForm: Selector<
   (unsavedForm, isPresaved) => {
     const isSetTempForm =
       unsavedForm?.stepType === 'temperature' &&
-      unsavedForm?.setTemperature === 'true'
+      unsavedForm?.targetTemperature != null
     return isPresaved && isSetTempForm
   }
 )
@@ -736,7 +736,7 @@ export const getUnsavedFormIsPristineHeaterShakerForm: Selector<
   (unsavedForm, isPresaved) => {
     const isSetHsTempForm =
       unsavedForm?.stepType === 'heaterShaker' &&
-      unsavedForm?.targetHeaterShakerTemperature !== null
+      unsavedForm?.targetHeaterShakerTemperature != null
 
     return isPresaved && isSetHsTempForm
   }

--- a/protocol-designer/src/step-forms/test/selectors.test.ts
+++ b/protocol-designer/src/step-forms/test/selectors.test.ts
@@ -160,7 +160,7 @@ describe('getUnsavedFormIsPristineSetTempForm', () => {
     // @ts-expect-error(jr, 4/8/22): missing module id
     const formData: FormData = {
       stepType: 'temperature',
-      setTemperature: 'true',
+      targetTemperature: 33,
     }
     const expected = true
     // @ts-expect-error(jr, 4/8/22): resultFunc (from reselect) is not part of their Selector interface


### PR DESCRIPTION
# Overview

The logic for `isPristineSetTempForm` passed to `StepForm` was performing a brittle check on the state of the temperature module form. Here, I change the logic to check for the presence of a non-null targetTemperature for safety, more closely mirroring the functioning logic of `isPristineSetHeaterShakerTempForm`. This fix correctly presents the modal to add a pause step after setting temperature for temperature modules.

Closes RQA-3763


## Test Plan and Hands on Testing

- create a temperature module set temperature form and save
- verify that modal to add pause is shown

## Changelog

- fix pristine check for temp form
- fix test

## Review requests

- see test plan

## Risk assessment

low. `isPristineSetTempForm` prop is only used in this instance