### PR TITLE
feat(api): RobotContext add opentrons_simulate outputs

### DIFF
--- a/api/src/opentrons/legacy_commands/robot_commands.py
+++ b/api/src/opentrons/legacy_commands/robot_commands.py
@@ -1,0 +1,51 @@
+from opentrons.types import Location, Mount, AxisMapType
+from .helpers import stringify_location
+from . import types as command_types
+from typing import Optional
+
+
+def move_to(
+    mount: Mount, location: Location, speed: Optional[float]
+) -> command_types.RobotMoveToCommand:
+    location_text = stringify_location(location)
+    text = f"Moving to {location_text} at {speed}"
+    return {
+        "name": command_types.ROBOT_MOVE_TO,
+        "payload": {"mount": mount, "location": location, "text": text},
+    }
+
+
+def move_axis_to(
+    axis_map: AxisMapType, speed: Optional[float]
+) -> command_types.RobotMoveAxisToCommand:
+    text = f"Moving to the provided absolute axis map {axis_map} at {speed}."
+    return {
+        "name": command_types.ROBOT_MOVE_AXES_TO,
+        "payload": {"absolute_axes": axis_map, "text": text},
+    }
+
+
+def move_axis_relative(
+    axis_map: AxisMapType, speed: Optional[float]
+) -> command_types.RobotMoveAxisRelativeCommand:
+    text = f"Moving to the provided relative axis map {axis_map} as {speed}"
+    return {
+        "name": command_types.ROBOT_MOVE_RELATIVE_TO,
+        "payload": {"relative_axes": axis_map, "text": text},
+    }
+
+
+def open_gripper() -> command_types.RobotOpenGripperJawCommand:
+    text = "Opening the gripper jaw."
+    return {
+        "name": command_types.ROBOT_OPEN_GRIPPER_JAW,
+        "payload": {"text": text},
+    }
+
+
+def close_gripper(force: Optional[float]) -> command_types.RobotCloseGripperJawCommand:
+    text = f"Closing the gripper jaw with force {force}."
+    return {
+        "name": command_types.ROBOT_CLOSE_GRIPPER_JAW,
+        "payload": {"text": text},
+    }

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
     from opentrons.protocol_api._liquid import LiquidClass
 
-from opentrons.types import Location
+from opentrons.types import Location, Mount, AxisMapType
 
 
 # type for subscriptions
@@ -85,6 +85,13 @@ THERMOCYCLER_WAIT_FOR_LID_TEMP: Final = "command.THERMOCYCLER_WAIT_FOR_LID_TEMP"
 THERMOCYCLER_SET_LID_TEMP: Final = "command.THERMOCYCLER_SET_LID_TEMP"
 THERMOCYCLER_DEACTIVATE_LID: Final = "command.THERMOCYCLER_DEACTIVATE_LID"
 THERMOCYCLER_DEACTIVATE_BLOCK: Final = "command.THERMOCYCLER_DEACTIVATE_BLOCK"
+
+# Robot #
+ROBOT_MOVE_TO: Final = "command.ROBOT_MOVE_TO"
+ROBOT_MOVE_AXES_TO: Final = "command.ROBOT_MOVE_AXES_TO"
+ROBOT_MOVE_RELATIVE_TO: Final = "command.ROBOT_MOVE_RELATIVE_TO"
+ROBOT_OPEN_GRIPPER_JAW: Final = "command.ROBOT_OPEN_GRIPPER_JAW"
+ROBOT_CLOSE_GRIPPER_JAW: Final = "command.ROBOT_CLOSE_GRIPPER_JAW"
 
 
 class TextOnlyPayload(TypedDict):
@@ -600,6 +607,49 @@ class PressurizeCommand(TypedDict):
     payload: PressurizeCommandPayload
 
 
+# Robot Commands and Payloads
+class GripperCommandPayload(TextOnlyPayload):
+    pass
+
+
+class RobotMoveToCommandPayload(TextOnlyPayload):
+    location: Location
+    mount: Mount
+
+
+class RobotMoveAxisToCommandPayload(TextOnlyPayload):
+    absolute_axes: AxisMapType
+
+
+class RobotMoveAxisRelativeCommandPayload(TextOnlyPayload):
+    relative_axes: AxisMapType
+
+
+class RobotMoveToCommand(TypedDict):
+    name: Literal["command.ROBOT_MOVE_TO"]
+    payload: RobotMoveToCommandPayload
+
+
+class RobotMoveAxisToCommand(TypedDict):
+    name: Literal["command.ROBOT_MOVE_AXES_TO"]
+    payload: RobotMoveAxisToCommandPayload
+
+
+class RobotMoveAxisRelativeCommand(TypedDict):
+    name: Literal["command.ROBOT_MOVE_RELATIVE_TO"]
+    payload: RobotMoveAxisRelativeCommandPayload
+
+
+class RobotOpenGripperJawCommand(TypedDict):
+    name: Literal["command.ROBOT_OPEN_GRIPPER_JAW"]
+    payload: GripperCommandPayload
+
+
+class RobotCloseGripperJawCommand(TypedDict):
+    name: Literal["command.ROBOT_CLOSE_GRIPPER_JAW"]
+    payload: GripperCommandPayload
+
+
 Command = Union[
     DropTipCommand,
     DropTipInDisposalLocationCommand,
@@ -654,6 +704,12 @@ Command = Union[
     SealCommand,
     UnsealCommand,
     PressurizeCommand,
+    # Robot commands
+    RobotMoveToCommand,
+    RobotMoveAxisToCommand,
+    RobotMoveAxisRelativeCommand,
+    RobotOpenGripperJawCommand,
+    RobotCloseGripperJawCommand,
 ]
 
 
@@ -707,6 +763,11 @@ CommandPayload = Union[
     SealCommandPayload,
     UnsealCommandPayload,
     PressurizeCommandPayload,
+    # Robot payloads
+    RobotMoveToCommandPayload,
+    RobotMoveAxisRelativeCommandPayload,
+    RobotMoveAxisToCommandPayload,
+    GripperCommandPayload,
 ]
 
 
@@ -947,6 +1008,26 @@ class MoveLabwareMessage(CommandMessageFields, MoveLabwareCommand):
     pass
 
 
+class RobotMoveToMessage(CommandMessageFields, RobotMoveToCommand):
+    pass
+
+
+class RobotMoveAxisToMessage(CommandMessageFields, RobotMoveAxisToCommand):
+    pass
+
+
+class RobotMoveAxisRelativeMessage(CommandMessageFields, RobotMoveAxisRelativeCommand):
+    pass
+
+
+class RobotOpenGripperJawMessage(CommandMessageFields, RobotOpenGripperJawCommand):
+    pass
+
+
+class RobotCloseGripperJawMessage(CommandMessageFields, RobotCloseGripperJawCommand):
+    pass
+
+
 CommandMessage = Union[
     DropTipMessage,
     DropTipInDisposalLocationMessage,
@@ -994,4 +1075,10 @@ CommandMessage = Union[
     MoveToMessage,
     MoveToDisposalLocationMessage,
     MoveLabwareMessage,
+    # Robot Messages
+    RobotMoveToMessage,
+    RobotMoveAxisToMessage,
+    RobotMoveAxisRelativeMessage,
+    RobotOpenGripperJawMessage,
+    RobotCloseGripperJawMessage,
 ]

--- a/api/src/opentrons/protocol_api/core/engine/robot.py
+++ b/api/src/opentrons/protocol_api/core/engine/robot.py
@@ -131,9 +131,9 @@ class RobotCore(AbstractRobot):
         )
 
     def release_grip(self) -> None:
-        self._engine_client.execute_command(cmd.robot.openGripperJawParams())
+        self._engine_client.execute_command(cmd.robot.OpenGripperJawParams())
 
     def close_gripper(self, force: Optional[float] = None) -> None:
         self._engine_client.execute_command(
-            cmd.robot.closeGripperJawParams(force=force)
+            cmd.robot.CloseGripperJawParams(force=force)
         )

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -196,6 +196,7 @@ class ProtocolContext(CommandPublisher):
                 core=self._core.load_robot(),
                 protocol_core=self._core,
                 api_version=self._api_version,
+                broker=broker,
             )
         except APIVersionError:
             self._robot = None

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -512,8 +512,8 @@ Command = Annotated[
         robot.MoveTo,
         robot.MoveAxesRelative,
         robot.MoveAxesTo,
-        robot.openGripperJaw,
-        robot.closeGripperJaw,
+        robot.OpenGripperJaw,
+        robot.CloseGripperJaw,
     ],
     Field(discriminator="commandType"),
 ]
@@ -615,8 +615,8 @@ CommandParams = Union[
     robot.MoveAxesRelativeParams,
     robot.MoveAxesToParams,
     robot.MoveToParams,
-    robot.openGripperJawParams,
-    robot.closeGripperJawParams,
+    robot.OpenGripperJawParams,
+    robot.CloseGripperJawParams,
 ]
 
 CommandType = Union[
@@ -716,8 +716,8 @@ CommandType = Union[
     robot.MoveAxesRelativeCommandType,
     robot.MoveAxesToCommandType,
     robot.MoveToCommandType,
-    robot.openGripperJawCommandType,
-    robot.closeGripperJawCommandType,
+    robot.OpenGripperJawCommandType,
+    robot.CloseGripperJawCommandType,
 ]
 
 CommandCreate = Annotated[
@@ -818,8 +818,8 @@ CommandCreate = Annotated[
         robot.MoveAxesRelativeCreate,
         robot.MoveAxesToCreate,
         robot.MoveToCreate,
-        robot.openGripperJawCreate,
-        robot.closeGripperJawCreate,
+        robot.OpenGripperJawCreate,
+        robot.CloseGripperJawCreate,
     ],
     Field(discriminator="commandType"),
 ]
@@ -928,8 +928,8 @@ CommandResult = Union[
     robot.MoveAxesRelativeResult,
     robot.MoveAxesToResult,
     robot.MoveToResult,
-    robot.openGripperJawResult,
-    robot.closeGripperJawResult,
+    robot.OpenGripperJawResult,
+    robot.CloseGripperJawResult,
 ]
 
 

--- a/api/src/opentrons/protocol_engine/commands/robot/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/__init__.py
@@ -22,18 +22,18 @@ from .move_axes_relative import (
     MoveAxesRelativeCommandType,
 )
 from .open_gripper_jaw import (
-    openGripperJaw,
-    openGripperJawCreate,
-    openGripperJawParams,
-    openGripperJawResult,
-    openGripperJawCommandType,
+    OpenGripperJaw,
+    OpenGripperJawCreate,
+    OpenGripperJawParams,
+    OpenGripperJawResult,
+    OpenGripperJawCommandType,
 )
 from .close_gripper_jaw import (
-    closeGripperJaw,
-    closeGripperJawCreate,
-    closeGripperJawParams,
-    closeGripperJawResult,
-    closeGripperJawCommandType,
+    CloseGripperJaw,
+    CloseGripperJawCreate,
+    CloseGripperJawParams,
+    CloseGripperJawResult,
+    CloseGripperJawCommandType,
 )
 
 __all__ = [
@@ -56,15 +56,15 @@ __all__ = [
     "MoveAxesRelativeResult",
     "MoveAxesRelativeCommandType",
     # robot/openGripperJaw
-    "openGripperJaw",
-    "openGripperJawCreate",
-    "openGripperJawParams",
-    "openGripperJawResult",
-    "openGripperJawCommandType",
+    "OpenGripperJaw",
+    "OpenGripperJawCreate",
+    "OpenGripperJawParams",
+    "OpenGripperJawResult",
+    "OpenGripperJawCommandType",
     # robot/closeGripperJaw
-    "closeGripperJaw",
-    "closeGripperJawCreate",
-    "closeGripperJawParams",
-    "closeGripperJawResult",
-    "closeGripperJawCommandType",
+    "CloseGripperJaw",
+    "CloseGripperJawCreate",
+    "CloseGripperJawParams",
+    "CloseGripperJawResult",
+    "CloseGripperJawCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/robot/close_gripper_jaw.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/close_gripper_jaw.py
@@ -21,14 +21,14 @@ if TYPE_CHECKING:
     from ...state.state import StateView
 
 
-closeGripperJawCommandType = Literal["robot/closeGripperJaw"]
+CloseGripperJawCommandType = Literal["robot/closeGripperJaw"]
 
 
 def _remove_default(s: dict[str, Any]) -> None:
     s.pop("default", None)
 
 
-class closeGripperJawParams(BaseModel):
+class CloseGripperJawParams(BaseModel):
     """Payload required to close a gripper."""
 
     force: float | SkipJsonSchema[None] = Field(
@@ -38,16 +38,16 @@ class closeGripperJawParams(BaseModel):
     )
 
 
-class closeGripperJawResult(BaseModel):
-    """Result data from the execution of a closeGripperJaw command."""
+class CloseGripperJawResult(BaseModel):
+    """Result data from the execution of a CloseGripperJaw command."""
 
     pass
 
 
-class closeGripperJawImplementation(
-    AbstractCommandImpl[closeGripperJawParams, SuccessData[closeGripperJawResult]]
+class CloseGripperJawImplementation(
+    AbstractCommandImpl[CloseGripperJawParams, SuccessData[CloseGripperJawResult]]
 ):
-    """closeGripperJaw command implementation."""
+    """CloseGripperJaw command implementation."""
 
     def __init__(
         self,
@@ -59,38 +59,38 @@ class closeGripperJawImplementation(
         self._state_view = state_view
 
     async def execute(
-        self, params: closeGripperJawParams
-    ) -> SuccessData[closeGripperJawResult]:
+        self, params: CloseGripperJawParams
+    ) -> SuccessData[CloseGripperJawResult]:
         """Release the gripper."""
         if self._state_view.config.use_virtual_gripper:
             return SuccessData(
-                public=closeGripperJawResult(),
+                public=CloseGripperJawResult(),
             )
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         await ot3_hardware_api.grip(force_newtons=params.force)
         return SuccessData(
-            public=closeGripperJawResult(),
+            public=CloseGripperJawResult(),
         )
 
 
-class closeGripperJaw(
-    BaseCommand[closeGripperJawParams, closeGripperJawResult, ErrorOccurrence]
+class CloseGripperJaw(
+    BaseCommand[CloseGripperJawParams, CloseGripperJawResult, ErrorOccurrence]
 ):
-    """closeGripperJaw command model."""
+    """CloseGripperJaw command model."""
 
-    commandType: closeGripperJawCommandType = "robot/closeGripperJaw"
-    params: closeGripperJawParams
-    result: Optional[closeGripperJawResult] = None
+    commandType: CloseGripperJawCommandType = "robot/closeGripperJaw"
+    params: CloseGripperJawParams
+    result: Optional[CloseGripperJawResult] = None
 
     _ImplementationCls: Type[
-        closeGripperJawImplementation
-    ] = closeGripperJawImplementation
+        CloseGripperJawImplementation
+    ] = CloseGripperJawImplementation
 
 
-class closeGripperJawCreate(BaseCommandCreate[closeGripperJawParams]):
-    """closeGripperJaw command request model."""
+class CloseGripperJawCreate(BaseCommandCreate[CloseGripperJawParams]):
+    """CloseGripperJaw command request model."""
 
-    commandType: closeGripperJawCommandType = "robot/closeGripperJaw"
-    params: closeGripperJawParams
+    commandType: CloseGripperJawCommandType = "robot/closeGripperJaw"
+    params: CloseGripperJawParams
 
-    _CommandCls: Type[closeGripperJaw] = closeGripperJaw
+    _CommandCls: Type[CloseGripperJaw] = CloseGripperJaw

--- a/api/src/opentrons/protocol_engine/commands/robot/close_gripper_jaw.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/close_gripper_jaw.py
@@ -1,6 +1,7 @@
 """Command models for opening a gripper jaw."""
+
 from __future__ import annotations
-from typing import Literal, Type, Optional, Any
+from typing import Literal, Type, Optional, Any, TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
@@ -15,6 +16,9 @@ from ..command import (
     SuccessData,
 )
 from opentrons.protocol_engine.errors.error_occurrence import ErrorOccurrence
+
+if TYPE_CHECKING:
+    from ...state.state import StateView
 
 
 closeGripperJawCommandType = Literal["robot/closeGripperJaw"]
@@ -48,14 +52,20 @@ class closeGripperJawImplementation(
     def __init__(
         self,
         hardware_api: HardwareControlAPI,
+        state_view: StateView,
         **kwargs: object,
     ) -> None:
         self._hardware_api = hardware_api
+        self._state_view = state_view
 
     async def execute(
         self, params: closeGripperJawParams
     ) -> SuccessData[closeGripperJawResult]:
         """Release the gripper."""
+        if self._state_view.config.use_virtual_gripper:
+            return SuccessData(
+                public=closeGripperJawResult(),
+            )
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         await ot3_hardware_api.grip(force_newtons=params.force)
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/robot/open_gripper_jaw.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/open_gripper_jaw.py
@@ -1,6 +1,7 @@
 """Command models for opening a gripper jaw."""
+
 from __future__ import annotations
-from typing import Literal, Type, Optional
+from typing import Literal, Type, Optional, TYPE_CHECKING
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.resources import ensure_ot3_hardware
 
@@ -13,6 +14,9 @@ from ..command import (
     SuccessData,
 )
 from opentrons.protocol_engine.errors.error_occurrence import ErrorOccurrence
+
+if TYPE_CHECKING:
+    from ...state.state import StateView
 
 
 openGripperJawCommandType = Literal["robot/openGripperJaw"]
@@ -38,14 +42,19 @@ class openGripperJawImplementation(
     def __init__(
         self,
         hardware_api: HardwareControlAPI,
+        state_view: StateView,
         **kwargs: object,
     ) -> None:
         self._hardware_api = hardware_api
+        self._state_view = state_view
 
     async def execute(
         self, params: openGripperJawParams
     ) -> SuccessData[openGripperJawResult]:
         """Release the gripper."""
+        if self._state_view.config.use_virtual_gripper:
+            return SuccessData(public=openGripperJawResult())
+
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
 
         await ot3_hardware_api.home_gripper_jaw()

--- a/api/src/opentrons/protocol_engine/commands/robot/open_gripper_jaw.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/open_gripper_jaw.py
@@ -19,23 +19,23 @@ if TYPE_CHECKING:
     from ...state.state import StateView
 
 
-openGripperJawCommandType = Literal["robot/openGripperJaw"]
+OpenGripperJawCommandType = Literal["robot/openGripperJaw"]
 
 
-class openGripperJawParams(BaseModel):
+class OpenGripperJawParams(BaseModel):
     """Payload required to release a gripper."""
 
     pass
 
 
-class openGripperJawResult(BaseModel):
+class OpenGripperJawResult(BaseModel):
     """Result data from the execution of a openGripperJaw command."""
 
     pass
 
 
-class openGripperJawImplementation(
-    AbstractCommandImpl[openGripperJawParams, SuccessData[openGripperJawResult]]
+class OpenGripperJawImplementation(
+    AbstractCommandImpl[OpenGripperJawParams, SuccessData[OpenGripperJawResult]]
 ):
     """openGripperJaw command implementation."""
 
@@ -49,38 +49,38 @@ class openGripperJawImplementation(
         self._state_view = state_view
 
     async def execute(
-        self, params: openGripperJawParams
-    ) -> SuccessData[openGripperJawResult]:
+        self, params: OpenGripperJawParams
+    ) -> SuccessData[OpenGripperJawResult]:
         """Release the gripper."""
         if self._state_view.config.use_virtual_gripper:
-            return SuccessData(public=openGripperJawResult())
+            return SuccessData(public=OpenGripperJawResult())
 
         ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
 
         await ot3_hardware_api.home_gripper_jaw()
         return SuccessData(
-            public=openGripperJawResult(),
+            public=OpenGripperJawResult(),
         )
 
 
-class openGripperJaw(
-    BaseCommand[openGripperJawParams, openGripperJawResult, ErrorOccurrence]
+class OpenGripperJaw(
+    BaseCommand[OpenGripperJawParams, OpenGripperJawResult, ErrorOccurrence]
 ):
     """openGripperJaw command model."""
 
-    commandType: openGripperJawCommandType = "robot/openGripperJaw"
-    params: openGripperJawParams
-    result: Optional[openGripperJawResult] = None
+    commandType: OpenGripperJawCommandType = "robot/openGripperJaw"
+    params: OpenGripperJawParams
+    result: Optional[OpenGripperJawResult] = None
 
     _ImplementationCls: Type[
-        openGripperJawImplementation
-    ] = openGripperJawImplementation
+        OpenGripperJawImplementation
+    ] = OpenGripperJawImplementation
 
 
-class openGripperJawCreate(BaseCommandCreate[openGripperJawParams]):
+class OpenGripperJawCreate(BaseCommandCreate[OpenGripperJawParams]):
     """openGripperJaw command request model."""
 
-    commandType: openGripperJawCommandType = "robot/openGripperJaw"
-    params: openGripperJawParams
+    commandType: OpenGripperJawCommandType = "robot/openGripperJaw"
+    params: OpenGripperJawParams
 
-    _CommandCls: Type[openGripperJaw] = openGripperJaw
+    _CommandCls: Type[OpenGripperJaw] = OpenGripperJaw

--- a/api/tests/opentrons/protocol_engine/commands/robot/test_close_gripper_jaw.py
+++ b/api/tests/opentrons/protocol_engine/commands/robot/test_close_gripper_jaw.py
@@ -6,9 +6,9 @@ from opentrons.hardware_control import OT3HardwareControlAPI
 
 from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.robot.close_gripper_jaw import (
-    closeGripperJawParams,
-    closeGripperJawResult,
-    closeGripperJawImplementation,
+    CloseGripperJawParams,
+    CloseGripperJawResult,
+    CloseGripperJawImplementation,
 )
 from opentrons.protocol_engine.state.state import StateView
 
@@ -19,14 +19,33 @@ async def test_close_gripper_jaw_implementation(
     ot3_hardware_api: OT3HardwareControlAPI,
 ) -> None:
     """Test the `robot.closeGripperJaw` implementation."""
-    subject = closeGripperJawImplementation(
+    subject = CloseGripperJawImplementation(
         hardware_api=ot3_hardware_api, state_view=state_view
     )
     decoy.when(state_view.config.use_virtual_gripper).then_return(False)
 
-    params = closeGripperJawParams(force=10)
+    params = CloseGripperJawParams(force=10)
 
     result = await subject.execute(params=params)
 
-    assert result == SuccessData(public=closeGripperJawResult())
+    assert result == SuccessData(public=CloseGripperJawResult())
     decoy.verify(await ot3_hardware_api.grip(force_newtons=10))
+
+
+async def test_close_gripper_jaw_analysis(
+    decoy: Decoy,
+    state_view: StateView,
+    ot3_hardware_api: OT3HardwareControlAPI,
+) -> None:
+    """Test that closeGripperJaw doesn't call the hardware controller in analysis."""
+    subject = CloseGripperJawImplementation(
+        hardware_api=ot3_hardware_api, state_view=state_view
+    )
+    decoy.when(state_view.config.use_virtual_gripper).then_return(True)
+
+    params = CloseGripperJawParams(force=10)
+
+    result = await subject.execute(params=params)
+
+    assert result == SuccessData(public=CloseGripperJawResult())
+    decoy.verify(await ot3_hardware_api.grip(force_newtons=10), times=0)

--- a/api/tests/opentrons/protocol_engine/commands/robot/test_close_gripper_jaw.py
+++ b/api/tests/opentrons/protocol_engine/commands/robot/test_close_gripper_jaw.py
@@ -1,4 +1,5 @@
 """Test robot.open-gripper-jaw commands."""
+
 from decoy import Decoy
 
 from opentrons.hardware_control import OT3HardwareControlAPI
@@ -9,16 +10,19 @@ from opentrons.protocol_engine.commands.robot.close_gripper_jaw import (
     closeGripperJawResult,
     closeGripperJawImplementation,
 )
+from opentrons.protocol_engine.state.state import StateView
 
 
 async def test_close_gripper_jaw_implementation(
     decoy: Decoy,
+    state_view: StateView,
     ot3_hardware_api: OT3HardwareControlAPI,
 ) -> None:
     """Test the `robot.closeGripperJaw` implementation."""
     subject = closeGripperJawImplementation(
-        hardware_api=ot3_hardware_api,
+        hardware_api=ot3_hardware_api, state_view=state_view
     )
+    decoy.when(state_view.config.use_virtual_gripper).then_return(False)
 
     params = closeGripperJawParams(force=10)
 

--- a/api/tests/opentrons/protocol_engine/commands/robot/test_open_gripper_jaw.py
+++ b/api/tests/opentrons/protocol_engine/commands/robot/test_open_gripper_jaw.py
@@ -6,9 +6,9 @@ from opentrons.hardware_control import OT3HardwareControlAPI
 
 from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.robot.open_gripper_jaw import (
-    openGripperJawParams,
-    openGripperJawResult,
-    openGripperJawImplementation,
+    OpenGripperJawParams,
+    OpenGripperJawResult,
+    OpenGripperJawImplementation,
 )
 from opentrons.protocol_engine.state.state import StateView
 
@@ -19,14 +19,33 @@ async def test_open_gripper_jaw_implementation(
     ot3_hardware_api: OT3HardwareControlAPI,
 ) -> None:
     """Test the `robot.openGripperJaw` implementation."""
-    subject = openGripperJawImplementation(
+    subject = OpenGripperJawImplementation(
         hardware_api=ot3_hardware_api, state_view=state_view
     )
     decoy.when(state_view.config.use_virtual_gripper).then_return(False)
 
-    params = openGripperJawParams()
+    params = OpenGripperJawParams()
 
     result = await subject.execute(params=params)
 
-    assert result == SuccessData(public=openGripperJawResult())
+    assert result == SuccessData(public=OpenGripperJawResult())
     decoy.verify(await ot3_hardware_api.home_gripper_jaw())
+
+
+async def test_open_gripper_jaw_analysis(
+    decoy: Decoy,
+    state_view: StateView,
+    ot3_hardware_api: OT3HardwareControlAPI,
+) -> None:
+    """Test the `robot.openGripperJaw` implementation doesn't call the hardware controller in analysis."""
+    subject = OpenGripperJawImplementation(
+        hardware_api=ot3_hardware_api, state_view=state_view
+    )
+    decoy.when(state_view.config.use_virtual_gripper).then_return(True)
+
+    params = OpenGripperJawParams()
+
+    result = await subject.execute(params=params)
+
+    assert result == SuccessData(public=OpenGripperJawResult())
+    decoy.verify(await ot3_hardware_api.home_gripper_jaw(), times=0)

--- a/api/tests/opentrons/protocol_engine/commands/robot/test_open_gripper_jaw.py
+++ b/api/tests/opentrons/protocol_engine/commands/robot/test_open_gripper_jaw.py
@@ -1,4 +1,5 @@
 """Test robot.open-gripper-jaw commands."""
+
 from decoy import Decoy
 
 from opentrons.hardware_control import OT3HardwareControlAPI
@@ -9,16 +10,19 @@ from opentrons.protocol_engine.commands.robot.open_gripper_jaw import (
     openGripperJawResult,
     openGripperJawImplementation,
 )
+from opentrons.protocol_engine.state.state import StateView
 
 
 async def test_open_gripper_jaw_implementation(
     decoy: Decoy,
+    state_view: StateView,
     ot3_hardware_api: OT3HardwareControlAPI,
 ) -> None:
     """Test the `robot.openGripperJaw` implementation."""
     subject = openGripperJawImplementation(
-        hardware_api=ot3_hardware_api,
+        hardware_api=ot3_hardware_api, state_view=state_view
     )
+    decoy.when(state_view.config.use_virtual_gripper).then_return(False)
 
     params = openGripperJawParams()
 

--- a/shared-data/command/schemas/13.json
+++ b/shared-data/command/schemas/13.json
@@ -749,6 +749,46 @@
       "title": "CalibratePipetteParams",
       "type": "object"
     },
+    "CloseGripperJawCreate": {
+      "description": "CloseGripperJaw command request model.",
+      "properties": {
+        "commandType": {
+          "const": "robot/closeGripperJaw",
+          "default": "robot/closeGripperJaw",
+          "enum": ["robot/closeGripperJaw"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CloseGripperJawParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CloseGripperJawCreate",
+      "type": "object"
+    },
+    "CloseGripperJawParams": {
+      "description": "Payload required to close a gripper.",
+      "properties": {
+        "force": {
+          "description": "The force the gripper should use to hold the jaws, falls to default if none is provided.",
+          "title": "Force",
+          "type": "number"
+        }
+      },
+      "title": "CloseGripperJawParams",
+      "type": "object"
+    },
     "CloseLabwareLatchCreate": {
       "description": "A request to create a Heater-Shaker's close latch command.",
       "properties": {
@@ -3859,6 +3899,40 @@
       "title": "OnLabwareLocation",
       "type": "object"
     },
+    "OpenGripperJawCreate": {
+      "description": "openGripperJaw command request model.",
+      "properties": {
+        "commandType": {
+          "const": "robot/openGripperJaw",
+          "default": "robot/openGripperJaw",
+          "enum": ["robot/openGripperJaw"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/OpenGripperJawParams"
+        }
+      },
+      "required": ["params"],
+      "title": "OpenGripperJawCreate",
+      "type": "object"
+    },
+    "OpenGripperJawParams": {
+      "description": "Payload required to release a gripper.",
+      "properties": {},
+      "title": "OpenGripperJawParams",
+      "type": "object"
+    },
     "OpenLabwareLatchCreate": {
       "description": "A request to create a Heater-Shaker's open labware latch command.",
       "properties": {
@@ -6379,80 +6453,6 @@
       "title": "WellOrigin",
       "type": "string"
     },
-    "closeGripperJawCreate": {
-      "description": "closeGripperJaw command request model.",
-      "properties": {
-        "commandType": {
-          "const": "robot/closeGripperJaw",
-          "default": "robot/closeGripperJaw",
-          "enum": ["robot/closeGripperJaw"],
-          "title": "Commandtype",
-          "type": "string"
-        },
-        "intent": {
-          "$ref": "#/$defs/CommandIntent",
-          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
-          "title": "Intent"
-        },
-        "key": {
-          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
-          "title": "Key",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/$defs/closeGripperJawParams"
-        }
-      },
-      "required": ["params"],
-      "title": "closeGripperJawCreate",
-      "type": "object"
-    },
-    "closeGripperJawParams": {
-      "description": "Payload required to close a gripper.",
-      "properties": {
-        "force": {
-          "description": "The force the gripper should use to hold the jaws, falls to default if none is provided.",
-          "title": "Force",
-          "type": "number"
-        }
-      },
-      "title": "closeGripperJawParams",
-      "type": "object"
-    },
-    "openGripperJawCreate": {
-      "description": "openGripperJaw command request model.",
-      "properties": {
-        "commandType": {
-          "const": "robot/openGripperJaw",
-          "default": "robot/openGripperJaw",
-          "enum": ["robot/openGripperJaw"],
-          "title": "Commandtype",
-          "type": "string"
-        },
-        "intent": {
-          "$ref": "#/$defs/CommandIntent",
-          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
-          "title": "Intent"
-        },
-        "key": {
-          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
-          "title": "Key",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/$defs/openGripperJawParams"
-        }
-      },
-      "required": ["params"],
-      "title": "openGripperJawCreate",
-      "type": "object"
-    },
-    "openGripperJawParams": {
-      "description": "Payload required to release a gripper.",
-      "properties": {},
-      "title": "openGripperJawParams",
-      "type": "object"
-    },
     "opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidCreate": {
       "description": "A request to execute an Absorbance Reader close lid command.",
       "properties": {
@@ -6870,11 +6870,11 @@
       "pressureDispense": "#/$defs/PressureDispenseCreate",
       "reloadLabware": "#/$defs/ReloadLabwareCreate",
       "retractAxis": "#/$defs/RetractAxisCreate",
-      "robot/closeGripperJaw": "#/$defs/closeGripperJawCreate",
+      "robot/closeGripperJaw": "#/$defs/CloseGripperJawCreate",
       "robot/moveAxesRelative": "#/$defs/MoveAxesRelativeCreate",
       "robot/moveAxesTo": "#/$defs/MoveAxesToCreate",
       "robot/moveTo": "#/$defs/MoveToCreate",
-      "robot/openGripperJaw": "#/$defs/openGripperJawCreate",
+      "robot/openGripperJaw": "#/$defs/OpenGripperJawCreate",
       "savePosition": "#/$defs/SavePositionCreate",
       "sealPipetteToTip": "#/$defs/SealPipetteToTipCreate",
       "setRailLights": "#/$defs/SetRailLightsCreate",
@@ -7198,10 +7198,10 @@
       "$ref": "#/$defs/MoveToCreate"
     },
     {
-      "$ref": "#/$defs/openGripperJawCreate"
+      "$ref": "#/$defs/OpenGripperJawCreate"
     },
     {
-      "$ref": "#/$defs/closeGripperJawCreate"
+      "$ref": "#/$defs/CloseGripperJawCreate"
     }
   ]
 }


### PR DESCRIPTION
# Overview

Any movement related commands in the robot context should have run logs associated with them.

## Test Plan and Hands on Testing

1. Check that run logs get generated for robot commands.

## Changelog

- Add run logs to robot context commands

## Review requests

Check that the run log messages make sense.

## Risk assessment

Low. Adding run logs to un-used API.