### PR TITLE
fix(protocol-designer): properly update moduleState for temperature form

### DIFF
--- a/protocol-designer/src/molecules/ToggleExpandStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/ToggleExpandStepFormField/index.tsx
@@ -62,7 +62,11 @@ export function ToggleExpandStepFormField(
         resetFieldValue()
       }
     } else if (toggleValue == null) {
-      toggleUpdateValue(name === 'targetTemperature' ? 'true' : true)
+      toggleUpdateValue(
+        name === 'targetTemperature' || name === 'heaterShakerTimer'
+          ? 'true'
+          : true
+      )
     } else {
       toggleUpdateValue(!toggleValue)
       if (toggleValue) {

--- a/protocol-designer/src/molecules/ToggleExpandStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/ToggleExpandStepFormField/index.tsx
@@ -42,6 +42,7 @@ export function ToggleExpandStepFormField(
     toggleValue,
     caption,
     toggleElement = 'toggle',
+    name,
     ...restProps
   } = props
 
@@ -49,17 +50,24 @@ export function ToggleExpandStepFormField(
     restProps.updateValue(null)
   }
 
+  //  TODO: refactor this, it is messy
   const onToggleUpdateValue = (): void => {
-    if (typeof toggleValue === 'boolean') {
+    if (toggleValue === 'engage' || toggleValue === 'disengage') {
+      const newValue = toggleValue === 'engage' ? 'disengage' : 'engage'
+      toggleUpdateValue(newValue)
+    } else if (toggleValue === 'true' || toggleValue === 'false') {
+      const newValue = toggleValue === 'true' ? 'false' : 'true'
+      toggleUpdateValue(newValue)
+      if (newValue === 'true') {
+        resetFieldValue()
+      }
+    } else if (toggleValue == null) {
+      toggleUpdateValue(name === 'targetTemperature' ? 'true' : true)
+    } else {
       toggleUpdateValue(!toggleValue)
       if (toggleValue) {
         resetFieldValue()
       }
-    } else if (toggleValue === 'engage' || toggleValue === 'disengage') {
-      const newToggleValue = toggleValue === 'engage' ? 'disengage' : 'engage'
-      toggleUpdateValue(newToggleValue)
-    } else if (toggleValue == null) {
-      toggleUpdateValue(true)
     }
   }
 
@@ -99,6 +107,7 @@ export function ToggleExpandStepFormField(
           {isSelected ? (
             <InputStepFormField
               {...restProps}
+              name={name}
               padding="0"
               showTooltip={false}
               title={fieldTitle}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/HeaterShakerTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/HeaterShakerTools/index.tsx
@@ -103,7 +103,7 @@ export function HeaterShakerTools(props: StepFormProps): JSX.Element {
             'form:step_edit_form.field.heaterShaker.timer.heaterShakerSetTimer'
           )}
           fieldTitle={t('form:step_edit_form.field.heaterShaker.duration')}
-          isSelected={formData.heaterShakerSetTimer === true}
+          isSelected={formData.heaterShakerSetTimer === 'true'}
           units={t('application:units.time')}
           toggleElement="checkbox"
           formLevelError={getFormLevelError(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
@@ -44,7 +44,7 @@ export function TemperatureTools(props: StepFormProps): JSX.Element {
           title={t('form:step_edit_form.moduleState')}
           fieldTitle={t('form:step_edit_form.field.temperature.setTemperature')}
           units={t('units.degrees')}
-          isSelected={formData.setTemperature === true}
+          isSelected={formData.setTemperature === 'true'}
           onLabel={t('form:step_edit_form.field.temperature.toggleOn')}
           offLabel={t('form:step_edit_form.field.temperature.toggleOff')}
           formLevelError={getFormLevelError(


### PR DESCRIPTION
closes RQA-3765

# Overview

fix updating module state for temperature form when you set a temperature. The error was because for some reason setTemperature type is `true` and `false` as strings instead of the boolean! that is some legacy code so maybe we should update it to be a true boolean after this release.

## Test Plan and Hands on Testing

test that you can add a heater-shaker and temperature module step with a built in pause with no timeline errors

test that magnetic module engage/disengage can properly be set as well

## Changelog

- expand code to include `true` and `false` as strings

## Risk assessment

low
