### PR TITLE
feat(modules): request reset reason on module connection

### DIFF
--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -177,7 +177,9 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         reset_reason = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.RESET_REASON
         )
-        await self._connection.send_command(command=reset_reason, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(
+            command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
+        )
 
         return utils.parse_hs_device_information(device_info_string=response)
 

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -23,7 +23,7 @@ class GCODE(str, Enum):
     CLOSE_LABWARE_LATCH = "M243"
     GET_LABWARE_LATCH_STATE = "M241"
     DEACTIVATE_HEATER = "M106"
-    RESET_REASON = "M114"
+    GET_RESET_REASON = "M114"
 
 
 HS_BAUDRATE = 115200
@@ -175,7 +175,7 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         )
 
         reset_reason = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
-            gcode=GCODE.RESET_REASON
+            gcode=GCODE.GET_RESET_REASON
         )
         await self._connection.send_command(
             command=reset_reason, retries=DEFAULT_COMMAND_RETRIES

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -31,6 +31,7 @@ class GCODE(str, Enum):
     GET_TEMP = "M105"
     SET_TEMP = "M104"
     DEVICE_INFO = "M115"
+    RESET_REASON = "M114"
     DISENGAGE = "M18"
     PROGRAMMING_MODE = "dfu"
 
@@ -154,10 +155,16 @@ class TempDeckDriver(AbstractTempDeckDriver):
         Example input from Temp-Deck's serial response:
             "serial:aa11bb22 model:aa11bb22 version:aa11bb22"
         """
-        c = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
+        device_info = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DEVICE_INFO
         )
-        response = await self._send_command(command=c)
+        response = await self._send_command(command=device_info)
+
+        reset_reason = CommandBuilder(
+            terminator=TEMP_DECK_COMMAND_TERMINATOR
+        ).add_gcode(gcode=GCODE.RESET_REASON)
+        await self._send_command(command=reset_reason)
+
         return utils.parse_device_information(device_info_string=response)
 
     async def enter_programming_mode(self) -> None:

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -31,7 +31,7 @@ class GCODE(str, Enum):
     GET_TEMP = "M105"
     SET_TEMP = "M104"
     DEVICE_INFO = "M115"
-    RESET_REASON = "M114"
+    GET_RESET_REASON = "M114"
     DISENGAGE = "M18"
     PROGRAMMING_MODE = "dfu"
 
@@ -162,7 +162,7 @@ class TempDeckDriver(AbstractTempDeckDriver):
 
         reset_reason = CommandBuilder(
             terminator=TEMP_DECK_COMMAND_TERMINATOR
-        ).add_gcode(gcode=GCODE.RESET_REASON)
+        ).add_gcode(gcode=GCODE.GET_RESET_REASON)
         await self._send_command(command=reset_reason)
 
         return utils.parse_device_information(device_info_string=response)

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -33,6 +33,7 @@ class GCODE(str, Enum):
     DEACTIVATE_LID = "M108"
     DEACTIVATE_BLOCK = "M14"
     DEVICE_INFO = "M115"
+    RESET_REASON = "M114"
     ENTER_PROGRAMMING = "dfu"
 
 
@@ -292,12 +293,18 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
 
     async def get_device_info(self) -> Dict[str, str]:
         """Send get device info command"""
-        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
+        device_info = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DEVICE_INFO
         )
         response = await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES
+            command=device_info, retries=DEFAULT_COMMAND_RETRIES
         )
+
+        reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
+            gcode=GCODE.RESET_REASON
+        )
+        await self._connection.send_command(command=reset_reason, retries=DEFAULT_COMMAND_RETRIES)
+
         return utils.parse_device_information(device_info_string=response)
 
     async def enter_programming_mode(self) -> None:
@@ -353,6 +360,12 @@ class ThermocyclerDriverV2(ThermocyclerDriver):
         response = await self._connection.send_command(
             command=c, retries=DEFAULT_COMMAND_RETRIES
         )
+
+        reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
+            gcode=GCODE.RESET_REASON
+        )
+        await self._connection.send_command(command=reset_reason, retries=DEFAULT_COMMAND_RETRIES)
+
         return utils.parse_hs_device_information(device_info_string=response)
 
     async def enter_programming_mode(self) -> None:

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -303,7 +303,9 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.RESET_REASON
         )
-        await self._connection.send_command(command=reset_reason, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(
+            command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
+        )
 
         return utils.parse_device_information(device_info_string=response)
 
@@ -364,7 +366,9 @@ class ThermocyclerDriverV2(ThermocyclerDriver):
         reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.RESET_REASON
         )
-        await self._connection.send_command(command=reset_reason, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(
+            command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
+        )
 
         return utils.parse_hs_device_information(device_info_string=response)
 

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -33,7 +33,7 @@ class GCODE(str, Enum):
     DEACTIVATE_LID = "M108"
     DEACTIVATE_BLOCK = "M14"
     DEVICE_INFO = "M115"
-    RESET_REASON = "M114"
+    GET_RESET_REASON = "M114"
     ENTER_PROGRAMMING = "dfu"
 
 
@@ -301,7 +301,7 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         )
 
         reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
-            gcode=GCODE.RESET_REASON
+            gcode=GCODE.GET_RESET_REASON
         )
         await self._connection.send_command(
             command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
@@ -364,7 +364,7 @@ class ThermocyclerDriverV2(ThermocyclerDriver):
         )
 
         reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
-            gcode=GCODE.RESET_REASON
+            gcode=GCODE.GET_RESET_REASON
         )
         await self._connection.send_command(
             command=reset_reason, retries=DEFAULT_COMMAND_RETRIES

--- a/api/src/opentrons/hardware_control/emulation/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/emulation/heater_shaker.py
@@ -45,6 +45,7 @@ class HeaterShakerEmulator(AbstractEmulator):
             GCODE.HOME.value: self._home,
             GCODE.ENTER_BOOTLOADER.value: self._enter_bootloader,
             GCODE.GET_VERSION.value: self._get_version,
+            GCODE.GET_RESET_REASON.value: self._get_reset_reason,
             GCODE.OPEN_LABWARE_LATCH.value: self._open_labware_latch,
             GCODE.CLOSE_LABWARE_LATCH.value: self._close_labware_latch,
             GCODE.GET_LABWARE_LATCH_STATE.value: self._get_labware_latch_state,
@@ -125,6 +126,9 @@ class HeaterShakerEmulator(AbstractEmulator):
             f"HW:{self._settings.model} "
             f"SerialNo:{self._settings.serial_number}"
         )
+
+    def _get_reset_reason(self, command: Command) -> str:
+        return "M114 Last Reset Reason: 01"
 
     def _open_labware_latch(self, command: Command) -> str:
         self._latch_status = HeaterShakerLabwareLatchStatus.IDLE_OPEN

--- a/api/tests/opentrons/drivers/heater_shaker/test_driver.py
+++ b/api/tests/opentrons/drivers/heater_shaker/test_driver.py
@@ -137,10 +137,14 @@ async def test_get_device_info(
     )
     response = await subject.get_device_info()
     assert response == {"serial": "TC2101010A2", "model": "A", "version": "21.2.1"}
-    expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
+    device_info = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M115"
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    reset_reason = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
+        gcode="M114"
+    )
+    connection.send_command.assert_any_call(command=device_info, retries=0)
+    connection.send_command.assert_called_with(command=reset_reason, retries=0)
 
 
 async def test_enter_bootloader(

--- a/api/tests/opentrons/drivers/temp_deck/test_driver.py
+++ b/api/tests/opentrons/drivers/temp_deck/test_driver.py
@@ -65,8 +65,12 @@ async def test_get_device_info(driver: TempDeckDriver, connection: AsyncMock) ->
 
     response = await driver.get_device_info()
 
-    device_info = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("M115")
-    reset_reason = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("M114")
+    device_info = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
+        "M115"
+    )
+    reset_reason = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
+        "M114"
+    )
 
     connection.send_command.assert_any_call(command=device_info, retries=3)
     connection.send_command.assert_called_with(command=reset_reason, retries=3)

--- a/api/tests/opentrons/drivers/temp_deck/test_driver.py
+++ b/api/tests/opentrons/drivers/temp_deck/test_driver.py
@@ -65,9 +65,11 @@ async def test_get_device_info(driver: TempDeckDriver, connection: AsyncMock) ->
 
     response = await driver.get_device_info()
 
-    expected = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("M115")
+    device_info = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("M115")
+    reset_reason = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("M114")
 
-    connection.send_command.assert_called_once_with(command=expected, retries=3)
+    connection.send_command.assert_any_call(command=device_info, retries=3)
+    connection.send_command.assert_called_with(command=reset_reason, retries=3)
 
     assert response == {"serial": "s", "model": "m", "version": "v"}
 

--- a/api/tests/opentrons/drivers/thermocycler/test_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_driver.py
@@ -237,10 +237,13 @@ async def test_device_info(
 
     device_info = await subject.get_device_info()
 
-    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+    get_device_info = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
         gcode="M115"
     )
+    reset_reason = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+        gcode="M114"
+    )
 
-    connection.send_command.assert_called_once_with(command=expected, retries=3)
-
+    connection.send_command.assert_any_call(command=get_device_info, retries=3)
+    connection.send_command.assert_called_with(command=reset_reason, retries=3)
     assert device_info == {"serial": "s", "model": "m", "version": "v"}

--- a/api/tests/opentrons/drivers/thermocycler/test_gen2_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_gen2_driver.py
@@ -225,11 +225,16 @@ async def test_device_info(
 
     device_info = await subject.get_device_info()
 
-    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+    get_device_info = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
         gcode="M115"
     )
+    reset_reason = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+        gcode="M114"
+    )
 
-    connection.send_command.assert_called_once_with(command=expected, retries=3)
+    connection.send_command.assert_any_call(command=get_device_info, retries=3)
+    connection.send_command.assert_any_call(command=reset_reason, retries=3)
+    # connection.send_command.assert_any_call(command=reset_reason, retries=3)
 
     assert device_info == {
         "serial": "EMPTYSN",

--- a/api/tests/opentrons/drivers/thermocycler/test_gen2_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_gen2_driver.py
@@ -233,8 +233,7 @@ async def test_device_info(
     )
 
     connection.send_command.assert_any_call(command=get_device_info, retries=3)
-    connection.send_command.assert_any_call(command=reset_reason, retries=3)
-    # connection.send_command.assert_any_call(command=reset_reason, retries=3)
+    connection.send_command.assert_called_with(command=reset_reason, retries=3)
 
     assert device_info == {
         "serial": "EMPTYSN",


### PR DESCRIPTION
## Overview
Python counterpart to https://github.com/Opentrons/opentrons-modules/pull/485 . Now that modules are able to report the reason for their last reset using the HAL's RCC flags, we should request it every time we find a new module connection.

## Changelog
For thermocycler, heater shaker, and temp deck drivers:
- add the `GET_RESET REASON` gcode message
- inside `get_device_info`, also send a request for the reset reason
- update tests