### PR TITLE
feat(robot-server): Implement the `/labwareOffsets` endpoints with an in-memory store

### DIFF
--- a/robot-server/robot_server/labware_offsets/fastapi_dependencies.py
+++ b/robot-server/robot_server/labware_offsets/fastapi_dependencies.py
@@ -1,0 +1,29 @@
+"""FastAPI dependencies for the `/labwareOffsets` endpoints."""
+
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+from .store import LabwareOffsetStore
+
+
+_labware_offset_store_accessor = AppStateAccessor[LabwareOffsetStore](
+    "labware_offset_store"
+)
+
+
+async def get_labware_offset_store(
+    app_state: Annotated[AppState, Depends(get_app_state)],
+) -> LabwareOffsetStore:
+    """Get the server's singleton LabwareOffsetStore."""
+    labware_offset_store = _labware_offset_store_accessor.get_from(app_state)
+    if labware_offset_store is None:
+        labware_offset_store = LabwareOffsetStore()
+        _labware_offset_store_accessor.set_on(app_state, labware_offset_store)
+    return labware_offset_store

--- a/robot-server/robot_server/labware_offsets/models.py
+++ b/robot-server/robot_server/labware_offsets/models.py
@@ -1,0 +1,19 @@
+"""Request/response models for the `/labwareOffsets` endpoints."""
+
+
+from typing import Literal, Type
+from typing_extensions import Self
+
+from robot_server.errors.error_responses import ErrorDetails
+
+
+class LabwareOffsetNotFound(ErrorDetails):
+    """An error returned when a requested labware offset does not exist."""
+
+    id: Literal["LabwareOffsetNotFound"] = "LabwareOffsetNotFound"
+    title: str = "Labware Offset Not Found"
+
+    @classmethod
+    def build(cls: Type[Self], bad_offset_id: str) -> Self:
+        """Return an error with a standard message."""
+        return cls.construct(detail=f'No offset found with ID "{bad_offset_id}".')

--- a/robot-server/robot_server/labware_offsets/router.py
+++ b/robot-server/robot_server/labware_offsets/router.py
@@ -90,21 +90,21 @@ async def get_labware_offsets(  # noqa: D103
     location_slot_name: Annotated[
         DeckSlotName | None,
         fastapi.Query(
-            alias="location.slotName",
+            alias="locationSlotName",
             description="Filter for exact matches on the `location.slotName` field.",
         ),
     ] = None,
     location_module_model: Annotated[
         ModuleModel | None,
         fastapi.Query(
-            alias="location.moduleModel",
+            alias="locationModuleModel",
             description="Filter for exact matches on the `location.moduleModel` field.",
         ),
     ] = None,
     location_definition_uri: Annotated[
         str | None,
         fastapi.Query(
-            alias="location.definitionUri",
+            alias="locationDefinitionUri",
             description=(
                 "Filter for exact matches on the `location.definitionUri` field."
                 " (Not to be confused with just `definitionUri`.)"

--- a/robot-server/robot_server/labware_offsets/store.py
+++ b/robot-server/robot_server/labware_offsets/store.py
@@ -1,0 +1,68 @@
+# noqa: D100
+
+from opentrons.protocol_engine import LabwareOffset, ModuleModel
+from opentrons.types import DeckSlotName
+
+
+# todo(mm, 2024-12-06): Convert to be SQL-based and persistent instead of in-memory.
+# https://opentrons.atlassian.net/browse/EXEC-1015
+class LabwareOffsetStore:
+    """A persistent store for labware offsets, to support the `/labwareOffsets` endpoints."""
+
+    def __init__(self) -> None:
+        self._offsets_by_id: dict[str, LabwareOffset] = {}
+
+    def add(self, offset: LabwareOffset) -> None:
+        """Store a new labware offset."""
+        assert offset.id not in self._offsets_by_id
+        self._offsets_by_id[offset.id] = offset
+
+    def search(
+        self,
+        id_filter: str | None,
+        definition_uri_filter: str | None,
+        location_slot_name_filter: DeckSlotName | None,
+        location_module_model_filter: ModuleModel | None,
+        location_definition_uri_filter: str | None,
+        # todo(mm, 2024-12-06): Support pagination (cursor & pageLength query params).
+        # The logic for that is currently duplicated across several places in
+        # robot-server and api. We should try to clean that up, or at least avoid
+        # making it worse.
+    ) -> list[LabwareOffset]:
+        """Return all matching labware offsets in order from oldest-added to newest."""
+
+        def is_match(candidate: LabwareOffset) -> bool:
+            return (
+                id_filter in (None, candidate.id)
+                and definition_uri_filter in (None, candidate.definitionUri)
+                and location_slot_name_filter in (None, candidate.location.slotName)
+                and location_module_model_filter
+                in (None, candidate.location.moduleModel)
+                and location_definition_uri_filter
+                in (None, candidate.location.definitionUri)
+            )
+
+        return [
+            candidate
+            for candidate in self._offsets_by_id.values()
+            if is_match(candidate)
+        ]
+
+    def delete(self, offset_id: str) -> LabwareOffset:
+        """Delete a labware offset by its ID. Return what was just deleted."""
+        try:
+            return self._offsets_by_id.pop(offset_id)
+        except KeyError:
+            raise LabwareOffsetNotFoundError(bad_offset_id=offset_id) from None
+
+    def delete_all(self) -> None:
+        """Delete all labware offsets."""
+        self._offsets_by_id.clear()
+
+
+class LabwareOffsetNotFoundError(KeyError):
+    """Raised when trying to access a labware offset that doesn't exist."""
+
+    def __init__(self, bad_offset_id: str) -> None:
+        super().__init__(bad_offset_id)
+        self.bad_offset_id = bad_offset_id

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -132,8 +132,8 @@ def _clean_server_state(base_url: str) -> None:
 
             await _reset_deck_configuration(robot_client)
             await _reset_error_recovery_settings(robot_client)
-
             await _delete_client_data(robot_client)
+            await _delete_labware_offsets(robot_client)
 
     asyncio.run(_clean_server_state_async())
 
@@ -179,3 +179,7 @@ async def _reset_deck_configuration(robot_client: RobotClient) -> None:
 
 async def _reset_error_recovery_settings(robot_client: RobotClient) -> None:
     await robot_client.delete_error_recovery_settings()
+
+
+async def _delete_labware_offsets(robot_client: RobotClient) -> None:
+    await robot_client.delete_all_labware_offsets()

--- a/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
@@ -83,7 +83,7 @@ stages:
   # Just a basic test here. More complicated tests for the filters belong in the unit tests.
   - name: Test getting labware offsets with a filter
     request:
-      url: '{ot3_server_base_url}/labwareOffsets?location.slotName=A2'
+      url: '{ot3_server_base_url}/labwareOffsets?locationSlotName=A2'
       method: GET
     response:
       json:

--- a/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
@@ -1,0 +1,131 @@
+test_name: Test /labwareOffsets CRUD operations.
+
+marks:
+  - usefixtures:
+      - ot3_server_base_url
+
+stages:
+  - name: Add a labware offset and check the response
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets'
+      method: POST
+      json:
+        data:
+          definitionUri: definitionUri1
+          location:
+            slotName: A1
+            definitionUri: testNamespace/testLoadName/123
+            moduleModel: thermocyclerModuleV2
+          vector: { x: 1, y: 1, z: 1 }
+    response:
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          createdAt: !anystr
+          definitionUri: definitionUri1
+          location:
+            slotName: A1
+            definitionUri: testNamespace/testLoadName/123
+            moduleModel: thermocyclerModuleV2
+          vector: { x: 1, y: 1, z: 1 }
+      save:
+        json:
+          offset_1_data: data
+          offset_1_id: data.id
+
+  - name: Add another labware offset to add more testing data
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets'
+      method: POST
+      json:
+        data:
+          definitionUri: definitionUri2
+          location:
+            slotName: A2
+          vector: { x: 2, y: 2, z: 2 }
+    response:
+      status_code: 201
+      save:
+        json:
+          offset_2_data: data
+
+  - name: Add another labware offset to add more testing data
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets'
+      method: POST
+      json:
+        data:
+          definitionUri: definitionUri3
+          location:
+            slotName: A3
+          vector: { x: 3, y: 3, z: 3 }
+    response:
+      status_code: 201
+      save:
+        json:
+          offset_3_data: data
+
+  - name: Test getting all labware offsets
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets'
+      method: GET
+    response:
+      json:
+        data:
+          - !force_format_include '{offset_1_data}'
+          - !force_format_include '{offset_2_data}'
+          - !force_format_include '{offset_3_data}'
+        meta:
+          cursor: 0
+          totalLength: 3
+
+  # Just a basic test here. More complicated tests for the filters belong in the unit tests.
+  - name: Test getting labware offsets with a filter
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets?location.slotName=A2'
+      method: GET
+    response:
+      json:
+        data:
+          - !force_format_include '{offset_2_data}'
+        meta:
+          cursor: 0
+          totalLength: 1
+
+  - name: Delete a labware offset
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets/{offset_1_id}'
+      method: DELETE
+    response:
+      json:
+        data: !force_format_include '{offset_1_data}'
+
+  - name: Make sure it got deleted
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets'
+    response:
+      json:
+        data:
+          - !force_format_include '{offset_2_data}'
+          - !force_format_include '{offset_3_data}'
+        meta:
+          cursor: 0
+          totalLength: 2
+
+  - name: Delete all labware offsets
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets'
+      method: DELETE
+    response:
+      json: {}
+
+  - name: Make sure they all got deleted
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets'
+    response:
+      json:
+        data: []
+        meta:
+          cursor: 0
+          totalLength: 0

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -127,9 +127,7 @@ class RobotClient:
         multipart_upload_name = "files"
 
         with contextlib.ExitStack() as file_exit_stack:
-            opened_files: List[
-                Union[BinaryIO, Tuple[str, bytes]],
-            ] = []
+            opened_files: List[Union[BinaryIO, Tuple[str, bytes]],] = []
 
             for file in files:
                 if isinstance(file, Path):
@@ -381,6 +379,11 @@ class RobotClient:
         response = await self.httpx_client.delete(
             url=f"{self.base_url}/errorRecovery/settings"
         )
+        response.raise_for_status()
+        return response
+
+    async def delete_all_labware_offsets(self) -> Response:
+        response = await self.httpx_client.delete(url=f"{self.base_url}/labwareOffsets")
         response.raise_for_status()
         return response
 

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -127,7 +127,9 @@ class RobotClient:
         multipart_upload_name = "files"
 
         with contextlib.ExitStack() as file_exit_stack:
-            opened_files: List[Union[BinaryIO, Tuple[str, bytes]],] = []
+            opened_files: List[
+                Union[BinaryIO, Tuple[str, bytes]],
+            ] = []
 
             for file in files:
                 if isinstance(file, Path):

--- a/robot-server/tests/labware_offsets/test_store.py
+++ b/robot-server/tests/labware_offsets/test_store.py
@@ -1,0 +1,124 @@
+# noqa: D100
+
+
+from datetime import datetime
+from opentrons.protocol_engine import (
+    LabwareOffset,
+    LabwareOffsetLocation,
+    LabwareOffsetVector,
+)
+from opentrons.types import DeckSlotName
+import pytest
+from robot_server.labware_offsets.store import (
+    LabwareOffsetStore,
+    LabwareOffsetNotFoundError,
+)
+
+
+def _get_all(store: LabwareOffsetStore) -> list[LabwareOffset]:
+    return store.search(
+        id_filter=None,
+        definition_uri_filter=None,
+        location_definition_uri_filter=None,
+        location_module_model_filter=None,
+        location_slot_name_filter=None,
+    )
+
+
+def test_filters() -> None:
+    """Test that the `.search()` method applies filters correctly."""
+    ids_and_definition_uris = [
+        ("id-1", "definition-uri-a"),
+        ("id-2", "definition-uri-b"),
+        ("id-3", "definition-uri-a"),
+        ("id-4", "definition-uri-b"),
+        ("id-5", "definition-uri-a"),
+        ("id-6", "definition-uri-b"),
+    ]
+    labware_offsets = [
+        LabwareOffset(
+            id=id,
+            createdAt=datetime.now(),
+            definitionUri=definition_uri,
+            location=LabwareOffsetLocation(slotName=DeckSlotName.SLOT_A1),
+            vector=LabwareOffsetVector(x=1, y=2, z=3),
+        )
+        for (id, definition_uri) in ids_and_definition_uris
+    ]
+
+    subject = LabwareOffsetStore()
+
+    for labware_offset in labware_offsets:
+        subject.add(labware_offset)
+
+    # No filters:
+    assert (
+        subject.search(
+            id_filter=None,
+            definition_uri_filter=None,
+            location_definition_uri_filter=None,
+            location_module_model_filter=None,
+            location_slot_name_filter=None,
+        )
+        == labware_offsets
+    )
+
+    # Filter on one thing:
+    result = subject.search(
+        id_filter=None,
+        definition_uri_filter="definition-uri-b",
+        location_definition_uri_filter=None,
+        location_module_model_filter=None,
+        location_slot_name_filter=None,
+    )
+    assert len(result) == 3
+    assert result == [
+        entry for entry in labware_offsets if entry.definitionUri == "definition-uri-b"
+    ]
+
+    # Filter on two things:
+    result = subject.search(
+        id_filter="id-2",
+        definition_uri_filter="definition-uri-b",
+        location_definition_uri_filter=None,
+        location_module_model_filter=None,
+        location_slot_name_filter=None,
+    )
+    assert result == [labware_offsets[1]]
+
+    # Filters should be ANDed, not ORed, together:
+    result = subject.search(
+        id_filter="id-1",
+        definition_uri_filter="definition-uri-b",
+        location_definition_uri_filter=None,
+        location_module_model_filter=None,
+        location_slot_name_filter=None,
+    )
+    assert result == []
+
+
+def test_delete() -> None:
+    """Test the `delete()` method."""
+    a, b, c = [
+        LabwareOffset(
+            id=id,
+            createdAt=datetime.now(),
+            definitionUri="",
+            location=LabwareOffsetLocation(slotName=DeckSlotName.SLOT_A1),
+            vector=LabwareOffsetVector(x=1, y=2, z=3),
+        )
+        for id in ["id-a", "id-b", "id-c"]
+    ]
+
+    subject = LabwareOffsetStore()
+
+    with pytest.raises(LabwareOffsetNotFoundError):
+        subject.delete("b")
+
+    subject.add(a)
+    subject.add(b)
+    subject.add(c)
+    assert subject.delete(b.id) == b
+    assert _get_all(subject) == [a, c]
+    with pytest.raises(LabwareOffsetNotFoundError):
+        subject.delete(b.id)


### PR DESCRIPTION
## Overview

This adds a temporary implementation of the `/labwareOffsets` endpoints so that we have something to play with and test the client against. Closes EXEC-1012.

Limitations:

* Does not persist across reboots yet (that's EXEC-1015)
* No pagination yet (that's just a bit of a mess right now; I'm working on it)

## Test Plan and Hands on Testing

We should be covered by automated tests added in this PR.

## Review requests

* Do the implemented semantics look right?
* Anything else we want the tests to cover?

## Risk assessment

No risk. All new and nothing uses this yet.
