### PR TITLE
fix(ai-client): use ai.opentrons.com

### DIFF
--- a/opentrons-ai-client/src/resources/constants.ts
+++ b/opentrons-ai-client/src/resources/constants.ts
@@ -9,7 +9,8 @@ export const STAGING_UPDATE_PROTOCOL_END_POINT =
   'https://staging.opentrons.ai/api/chat/updateProtocol'
 
 export const PROD_END_POINT = 'https://ai.opentrons.com/api/chat/completion'
-export const PROD_FEEDBACK_END_POINT = 'https://ai.opentrons.com/api/chat/feedback'
+export const PROD_FEEDBACK_END_POINT =
+  'https://ai.opentrons.com/api/chat/feedback'
 export const PROD_CREATE_PROTOCOL_END_POINT =
   'https://ai.opentrons.com/api/chat/createProtocol'
 export const PROD_UPDATE_PROTOCOL_END_POINT =

--- a/opentrons-ai-client/src/resources/constants.ts
+++ b/opentrons-ai-client/src/resources/constants.ts
@@ -8,12 +8,12 @@ export const STAGING_CREATE_PROTOCOL_END_POINT =
 export const STAGING_UPDATE_PROTOCOL_END_POINT =
   'https://staging.opentrons.ai/api/chat/updateProtocol'
 
-export const PROD_END_POINT = 'https://opentrons.ai/api/chat/completion'
-export const PROD_FEEDBACK_END_POINT = 'https://opentrons.ai/api/chat/feedback'
+export const PROD_END_POINT = 'https://ai.opentrons.com/api/chat/completion'
+export const PROD_FEEDBACK_END_POINT = 'https://ai.opentrons.com/api/chat/feedback'
 export const PROD_CREATE_PROTOCOL_END_POINT =
-  'https://opentrons.ai/api/chat/createProtocol'
+  'https://ai.opentrons.com/api/chat/createProtocol'
 export const PROD_UPDATE_PROTOCOL_END_POINT =
-  'https://opentrons.ai/api/chat/updateProtocol'
+  'https://ai.opentrons.com/api/chat/updateProtocol'
 
 // auth0 domain
 export const AUTH0_DOMAIN = 'identity.auth.opentrons.com'
@@ -24,7 +24,7 @@ export const STAGING_AUTH0_AUDIENCE = 'https://staging.opentrons.ai/api'
 
 // auth0 for production
 export const PROD_AUTH0_CLIENT_ID = 'b5oTRmfMY94tjYL8GyUaVYHhMTC28X8o'
-export const PROD_AUTH0_AUDIENCE = 'https://opentrons.ai/api'
+export const PROD_AUTH0_AUDIENCE = 'https://ai.opentrons.com/api'
 
 // auth0 for local
 export const LOCAL_AUTH0_CLIENT_ID = 'PcuD1wEutfijyglNeRBi41oxsKJ1HtKw'

--- a/opentrons-ai-server/README.md
+++ b/opentrons-ai-server/README.md
@@ -9,9 +9,7 @@ The Opentrons AI server is a FastAPI server that handles complex tasks like runn
 Currently we have 2 environments: `staging` and `prod`.
 
 - staging: <https://staging.opentrons.ai>
-- prod: <https://opentrons.ai>
-
-If your browser blocks cross site cookies, use <https://ai.opentrons.com> instead.
+- prod: <https://ai.opentrons.com>
 
 ### Environment Variables and Secrets
 


### PR DESCRIPTION
# Overview

We stopped using opentrons.ai and put in place a 301 redirect.

As soon as this is merged I will promote to prod.

## Test Plan and Hands on Testing

Get it to production as all API requests fail currently 