### PR TITLE
fix(ai-client): remove incorrect change of prod auth0 audience

### DIFF
--- a/opentrons-ai-client/src/resources/constants.ts
+++ b/opentrons-ai-client/src/resources/constants.ts
@@ -25,7 +25,7 @@ export const STAGING_AUTH0_AUDIENCE = 'https://staging.opentrons.ai/api'
 
 // auth0 for production
 export const PROD_AUTH0_CLIENT_ID = 'b5oTRmfMY94tjYL8GyUaVYHhMTC28X8o'
-export const PROD_AUTH0_AUDIENCE = 'https://ai.opentrons.com/api'
+export const PROD_AUTH0_AUDIENCE = 'https://opentrons.ai/api'
 
 // auth0 for local
 export const LOCAL_AUTH0_CLIENT_ID = 'PcuD1wEutfijyglNeRBi41oxsKJ1HtKw'


### PR DESCRIPTION
# Overview

I forgot that the audience is not a URL but a one time upon creation identified for the Auth0 api entity. Which should remain `https://opentrons.ai/api`
![image](https://github.com/user-attachments/assets/6e200ea3-e763-4887-a3cf-695afa7e73e2)

## Test Plan and Hands on Testing

Deploy to prod to get the API auth fixed.

## Note

There may still be one more problem in that I must create a new certificate that allows https from Cloudfront to the application Load balancer due to using ai.opentrons.com for the API.  The cert was created using the opentrons.ai zone. 
