### PR TITLE
feat(app): add LPC redesign feature flag

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -2,6 +2,7 @@
   "__dev_internal__enableLabwareCreator": "Enable App Labware Creator",
   "__dev_internal__enableRunNotes": "Display Notes During a Protocol Run",
   "__dev_internal__forceHttpPolling": "Poll all network requests instead of using MQTT",
+  "__dev_internal__lpcRedesign": "LPC Redesign",
   "__dev_internal__protocolStats": "Protocol Stats",
   "__dev_internal__protocolTimeline": "Protocol Timeline",
   "__dev_internal__reactQueryDevtools": "Enable React Query Devtools",

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -4,6 +4,7 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'forceHttpPolling',
   'protocolStats',
   'enableRunNotes',
+  'lpcRedesign',
   'protocolTimeline',
   'enableLabwareCreator',
   'reactQueryDevtools',

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -12,6 +12,7 @@ export type DevInternalFlag =
   | 'forceHttpPolling'
   | 'protocolStats'
   | 'enableRunNotes'
+  | 'lpcRedesign'
   | 'protocolTimeline'
   | 'enableLabwareCreator'
   | 'reactQueryDevtools'


### PR DESCRIPTION
Closes [EXEC-1040](https://opentrons.atlassian.net/browse/EXEC-1040)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Because LPC is such a critical flow, and because we expect a release before the LPC redesign release, we should hide all the LPC work behind a FF.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added the LPC redesign feature flag.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- For the sake of QA, I think it's probably best to hide all LPC refactors behind the feature flag, too. This will create some temporary grossness for the pre-LPC redesign release, since there will be code duplicity in the app (a "legacy" LPC and a "non-legacy LPC"), but doing so should create no risk when it comes to performing LPC (in the app). Does this seem reasonable?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
none
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1040]: https://opentrons.atlassian.net/browse/EXEC-1040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ