### PR TITLE
fix(api): tolerate unhandled module gcode

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/__init__.py
+++ b/api/src/opentrons/drivers/asyncio/communication/__init__.py
@@ -4,6 +4,7 @@ from opentrons.drivers.asyncio.communication.errors import (
     NoResponse,
     AlarmResponse,
     ErrorResponse,
+    UnhandledGcode
 )
 from .async_serial import AsyncSerial
 
@@ -15,4 +16,5 @@ __all__ = [
     "NoResponse",
     "AlarmResponse",
     "ErrorResponse",
+    "UnhandledGcode"
 ]

--- a/api/src/opentrons/drivers/asyncio/communication/__init__.py
+++ b/api/src/opentrons/drivers/asyncio/communication/__init__.py
@@ -4,7 +4,7 @@ from opentrons.drivers.asyncio.communication.errors import (
     NoResponse,
     AlarmResponse,
     ErrorResponse,
-    UnhandledGcode
+    UnhandledGcode,
 )
 from .async_serial import AsyncSerial
 
@@ -16,5 +16,5 @@ __all__ = [
     "NoResponse",
     "AlarmResponse",
     "ErrorResponse",
-    "UnhandledGcode"
+    "UnhandledGcode",
 ]

--- a/api/src/opentrons/drivers/asyncio/communication/errors.py
+++ b/api/src/opentrons/drivers/asyncio/communication/errors.py
@@ -1,23 +1,28 @@
 """Errors raised by serial connection."""
 
 
+from enum import Enum
+
+class ErrorCodes(Enum):
+    UNHANDLED_GCODE = 'ERR003'
+
 class SerialException(Exception):
     """Base serial exception"""
 
-    def __init__(self, port: str, description: str):
+    def __init__(self, port: str, description: str) -> None:
         super().__init__(f"{port}: {description}")
         self.port = port
         self.description = description
 
 
 class NoResponse(SerialException):
-    def __init__(self, port: str, command: str):
+    def __init__(self, port: str, command: str) -> None:
         super().__init__(port=port, description=f"No response to '{command}'")
         self.command = command
 
 
 class FailedCommand(SerialException):
-    def __init__(self, port: str, response: str):
+    def __init__(self, port: str, response: str) -> None:
         super().__init__(
             port=port, description=f"'Received error response '{response}'"
         )
@@ -30,3 +35,9 @@ class AlarmResponse(FailedCommand):
 
 class ErrorResponse(FailedCommand):
     pass
+
+
+class UnhandledGcode(ErrorResponse):
+    def __init__(self, port: str, response: str, command: str) -> None:
+        self.command = command
+        super().__init__(port, response)

--- a/api/src/opentrons/drivers/asyncio/communication/errors.py
+++ b/api/src/opentrons/drivers/asyncio/communication/errors.py
@@ -3,8 +3,10 @@
 
 from enum import Enum
 
+
 class ErrorCodes(Enum):
-    UNHANDLED_GCODE = 'ERR003'
+    UNHANDLED_GCODE = "ERR003"
+
 
 class SerialException(Exception):
     """Base serial exception"""

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -251,7 +251,9 @@ class SerialConnection:
 
         if self._error_keyword in lower:
             if ErrorCodes.UNHANDLED_GCODE.value in lower:
-                raise UnhandledGcode(port=self._port, response=response, command=request)
+                raise UnhandledGcode(
+                    port=self._port, response=response, command=request
+                )
             else:
                 raise ErrorResponse(port=self._port, response=response)
 

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -249,8 +249,8 @@ class SerialConnection:
         if self._alarm_keyword in lower:
             raise AlarmResponse(port=self._port, response=response)
 
-        if self._error_keyword in lower:
-            if ErrorCodes.UNHANDLED_GCODE.value in lower:
+        if self._error_keyword.lower() in lower:
+            if ErrorCodes.UNHANDLED_GCODE.value.lower() in lower:
                 raise UnhandledGcode(
                     port=self._port, response=response, command=request
                 )

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -6,7 +6,10 @@ import asyncio
 from typing import Optional, Dict
 from opentrons.drivers import utils
 from opentrons.drivers.command_builder import CommandBuilder
-from opentrons.drivers.asyncio.communication import AsyncResponseSerialConnection, UnhandledGcode
+from opentrons.drivers.asyncio.communication import (
+    AsyncResponseSerialConnection,
+    UnhandledGcode,
+)
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Optional, Dict
 from opentrons.drivers import utils
 from opentrons.drivers.command_builder import CommandBuilder
-from opentrons.drivers.asyncio.communication import AsyncResponseSerialConnection
+from opentrons.drivers.asyncio.communication import AsyncResponseSerialConnection, UnhandledGcode
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 
@@ -177,9 +177,12 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
         reset_reason = CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_RESET_REASON
         )
-        await self._connection.send_command(
-            command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
-        )
+        try:
+            await self._connection.send_command(
+                command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
+            )
+        except UnhandledGcode:
+            pass
 
         return utils.parse_hs_device_information(device_info_string=response)
 

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -17,7 +17,7 @@ from enum import Enum
 from opentrons.drivers import utils
 from opentrons.drivers.types import Temperature
 from opentrons.drivers.command_builder import CommandBuilder
-from opentrons.drivers.asyncio.communication import SerialConnection
+from opentrons.drivers.asyncio.communication import SerialConnection, UnhandledGcode
 from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver
 
 log = logging.getLogger(__name__)
@@ -163,7 +163,10 @@ class TempDeckDriver(AbstractTempDeckDriver):
         reset_reason = CommandBuilder(
             terminator=TEMP_DECK_COMMAND_TERMINATOR
         ).add_gcode(gcode=GCODE.GET_RESET_REASON)
-        await self._send_command(command=reset_reason)
+        try:
+            await self._send_command(command=reset_reason)
+        except UnhandledGcode:
+            pass
 
         return utils.parse_device_information(device_info_string=response)
 

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -11,7 +11,7 @@ from opentrons.drivers.asyncio.communication import (
     SerialConnection,
     AsyncResponseSerialConnection,
     AsyncSerial,
-    UnhandledGcode
+    UnhandledGcode,
 )
 from opentrons.drivers.thermocycler.abstract import AbstractThermocyclerDriver
 from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -96,7 +96,7 @@ class ThermocyclerDriverFactory:
             name=port,
             ack=TC_GEN2_SERIAL_ACK,
             retry_wait_time_seconds=0.1,
-            error_keyword="error",
+            error_keyword="err",
             alarm_keyword="alarm",
         )
 
@@ -300,16 +300,6 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         response = await self._connection.send_command(
             command=device_info, retries=DEFAULT_COMMAND_RETRIES
         )
-
-        reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
-            gcode=GCODE.GET_RESET_REASON
-        )
-        try:
-            await self._connection.send_command(
-                command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
-            )
-        except UnhandledGcode:
-            pass
 
         return utils.parse_device_information(device_info_string=response)
 

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -11,6 +11,7 @@ from opentrons.drivers.asyncio.communication import (
     SerialConnection,
     AsyncResponseSerialConnection,
     AsyncSerial,
+    UnhandledGcode
 )
 from opentrons.drivers.thermocycler.abstract import AbstractThermocyclerDriver
 from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus
@@ -303,9 +304,12 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_RESET_REASON
         )
-        await self._connection.send_command(
-            command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
-        )
+        try:
+            await self._connection.send_command(
+                command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
+            )
+        except UnhandledGcode:
+            pass
 
         return utils.parse_device_information(device_info_string=response)
 
@@ -366,9 +370,12 @@ class ThermocyclerDriverV2(ThermocyclerDriver):
         reset_reason = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_RESET_REASON
         )
-        await self._connection.send_command(
-            command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
-        )
+        try:
+            await self._connection.send_command(
+                command=reset_reason, retries=DEFAULT_COMMAND_RETRIES
+            )
+        except UnhandledGcode:
+            pass
 
         return utils.parse_hs_device_information(device_info_string=response)
 

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -13,7 +13,7 @@ from opentrons.drivers.asyncio.communication import (
     NoResponse,
     AlarmResponse,
     ErrorResponse,
-    UnhandledGcode
+    UnhandledGcode,
 )
 
 
@@ -161,17 +161,20 @@ async def test_send_command_response(
         ["error:Alarm lock", AlarmResponse, False],
         ["alarm:error", AlarmResponse, False],
         ["ALARM: Hard limit -X", AlarmResponse, False],
-        ['ERR003:unhandled gcode OK ', UnhandledGcode, True]
+        ["ERR003:unhandled gcode OK ", UnhandledGcode, True],
     ],
 )
 def test_raise_on_error(
-        subject: SerialKind, response: str, exception_type: Type[Exception], async_only: bool
+    subject: SerialKind,
+    response: str,
+    exception_type: Type[Exception],
+    async_only: bool,
 ) -> None:
     """It should raise an exception on error/alarm responses."""
     if isinstance(subject, SerialConnection) and async_only:
         pytest.skip()
     with pytest.raises(expected_exception=exception_type, match=response):
-        subject.raise_on_error(response, 'fake request')
+        subject.raise_on_error(response, "fake request")
 
 
 async def test_on_retry(mock_serial_port: AsyncMock, subject: SerialKind) -> None:
@@ -192,7 +195,7 @@ async def test_send_data_with_async_error_before(
     serial_error_response = f" {error_response}  {ack}"
     encoded_error_response = serial_error_response.encode()
     successful_response = "G28"
-    data = 'G28'
+    data = "G28"
     serial_successful_response = f" {successful_response}  {ack}"
     encoded_successful_response = serial_successful_response.encode()
     mock_serial_port.read_until.side_effect = [
@@ -211,8 +214,8 @@ async def test_send_data_with_async_error_before(
     )
     subject_raise_on_error_patched.raise_on_error.assert_has_calls(  # type: ignore[attr-defined]
         calls=[
-            call(response=error_response,request=data),
-            call(response=successful_response,request=data),
+            call(response=error_response, request=data),
+            call(response=successful_response, request=data),
         ]
     )
 
@@ -227,7 +230,7 @@ async def test_send_data_with_async_error_after(
     serial_error_response = f" {error_response}  {ack}"
     encoded_error_response = serial_error_response.encode()
     successful_response = "G28"
-    data = 'G28'
+    data = "G28"
     serial_successful_response = f" {successful_response}  {ack}"
     encoded_successful_response = serial_successful_response.encode()
     mock_serial_port.read_until.side_effect = [

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -13,6 +13,7 @@ from opentrons.drivers.asyncio.communication import (
     NoResponse,
     AlarmResponse,
     ErrorResponse,
+    UnhandledGcode
 )
 
 
@@ -149,25 +150,28 @@ async def test_send_command_response(
 
 
 @pytest.mark.parametrize(
-    argnames=["response", "exception_type"],
+    argnames=["response", "exception_type", "async_only"],
     argvalues=[
-        ["error", ErrorResponse],
-        ["Error", ErrorResponse],
-        ["Error: was found.", ErrorResponse],
-        ["alarm", AlarmResponse],
-        ["ALARM", AlarmResponse],
-        ["This is an Alarm", AlarmResponse],
-        ["error:Alarm lock", AlarmResponse],
-        ["alarm:error", AlarmResponse],
-        ["ALARM: Hard limit -X", AlarmResponse],
+        ["error", ErrorResponse, False],
+        ["Error", ErrorResponse, False],
+        ["Error: was found.", ErrorResponse, False],
+        ["alarm", AlarmResponse, False],
+        ["ALARM", AlarmResponse, False],
+        ["This is an Alarm", AlarmResponse, False],
+        ["error:Alarm lock", AlarmResponse, False],
+        ["alarm:error", AlarmResponse, False],
+        ["ALARM: Hard limit -X", AlarmResponse, False],
+        ['ERR003:unhandled gcode OK ', UnhandledGcode, True]
     ],
 )
 def test_raise_on_error(
-    subject: SerialKind, response: str, exception_type: Type[Exception]
+        subject: SerialKind, response: str, exception_type: Type[Exception], async_only: bool
 ) -> None:
     """It should raise an exception on error/alarm responses."""
+    if isinstance(subject, SerialConnection) and async_only:
+        pytest.skip()
     with pytest.raises(expected_exception=exception_type, match=response):
-        subject.raise_on_error(response)
+        subject.raise_on_error(response, 'fake request')
 
 
 async def test_on_retry(mock_serial_port: AsyncMock, subject: SerialKind) -> None:
@@ -188,6 +192,7 @@ async def test_send_data_with_async_error_before(
     serial_error_response = f" {error_response}  {ack}"
     encoded_error_response = serial_error_response.encode()
     successful_response = "G28"
+    data = 'G28'
     serial_successful_response = f" {successful_response}  {ack}"
     encoded_successful_response = serial_successful_response.encode()
     mock_serial_port.read_until.side_effect = [
@@ -195,7 +200,7 @@ async def test_send_data_with_async_error_before(
         encoded_successful_response,
     ]
 
-    response = await subject_raise_on_error_patched._send_data(data="G28")
+    response = await subject_raise_on_error_patched._send_data(data=data)
 
     assert response == successful_response
     mock_serial_port.read_until.assert_has_calls(
@@ -206,8 +211,8 @@ async def test_send_data_with_async_error_before(
     )
     subject_raise_on_error_patched.raise_on_error.assert_has_calls(  # type: ignore[attr-defined]
         calls=[
-            call(response=error_response),
-            call(response=successful_response),
+            call(response=error_response,request=data),
+            call(response=successful_response,request=data),
         ]
     )
 
@@ -222,6 +227,7 @@ async def test_send_data_with_async_error_after(
     serial_error_response = f" {error_response}  {ack}"
     encoded_error_response = serial_error_response.encode()
     successful_response = "G28"
+    data = 'G28'
     serial_successful_response = f" {successful_response}  {ack}"
     encoded_successful_response = serial_successful_response.encode()
     mock_serial_port.read_until.side_effect = [
@@ -229,7 +235,7 @@ async def test_send_data_with_async_error_after(
         encoded_error_response,
     ]
 
-    response = await subject_raise_on_error_patched._send_data(data="G28")
+    response = await subject_raise_on_error_patched._send_data(data=data)
 
     assert response == successful_response
     mock_serial_port.read_until.assert_has_calls(
@@ -239,6 +245,6 @@ async def test_send_data_with_async_error_after(
     )
     subject_raise_on_error_patched.raise_on_error.assert_has_calls(  # type: ignore[attr-defined]
         calls=[
-            call(response=successful_response),
+            call(response=successful_response, request=data),
         ]
     )

--- a/api/tests/opentrons/drivers/temp_deck/test_driver.py
+++ b/api/tests/opentrons/drivers/temp_deck/test_driver.py
@@ -1,7 +1,7 @@
 from mock import AsyncMock
 import pytest
 
-from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
+from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection, UnhandledGcode
 from opentrons.drivers.temp_deck.driver import (
     TempDeckDriver,
     TEMP_DECK_COMMAND_TERMINATOR,
@@ -59,7 +59,7 @@ async def test_get_temperature(driver: TempDeckDriver, connection: AsyncMock) ->
     assert response == Temperature(current=25, target=132)
 
 
-async def test_get_device_info(driver: TempDeckDriver, connection: AsyncMock) -> None:
+async def test_get_device_info_with_reset_reason(driver: TempDeckDriver, connection: AsyncMock) -> None:
     """It should send a get device info command and parse response"""
     connection.send_command.return_value = "serial:s model:m version:v"
 
@@ -76,6 +76,32 @@ async def test_get_device_info(driver: TempDeckDriver, connection: AsyncMock) ->
     connection.send_command.assert_called_with(command=reset_reason, retries=3)
 
     assert response == {"serial": "s", "model": "m", "version": "v"}
+
+
+async def test_get_device_info_no_reset_reason(driver: TempDeckDriver, connection: AsyncMock) -> None:
+    """It should send a get device info command and parse response"""
+
+    async def fake_send_command(command: CommandBuilder, retries: int = 0, timeout: float | None = None) -> str:
+        if command.build().startswith('M114'):
+            raise UnhandledGcode(port='fake port', response='ERR003: Unhandled Gcode', command=command.build(), )
+        else:
+            return "serial:s model:m version:v"
+    connection.send_command.side_effect = fake_send_command
+
+    response = await driver.get_device_info()
+
+    device_info = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
+        "M115"
+    )
+    reset_reason = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
+        "M114"
+    )
+
+    connection.send_command.assert_any_call(command=device_info, retries=3)
+    connection.send_command.assert_called_with(command=reset_reason, retries=3)
+
+    assert response == {"serial": "s", "model": "m", "version": "v"}
+
 
 
 async def test_enter_programming_mode(

--- a/api/tests/opentrons/drivers/thermocycler/test_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_driver.py
@@ -240,9 +240,6 @@ async def test_device_info(
     get_device_info = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
         gcode="M115"
     )
-    reset_reason = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
-        gcode="M114"
-    )
 
     connection.send_command.assert_any_call(command=get_device_info, retries=3)
     assert device_info == {"serial": "s", "model": "m", "version": "v"}

--- a/api/tests/opentrons/drivers/thermocycler/test_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_driver.py
@@ -245,5 +245,4 @@ async def test_device_info(
     )
 
     connection.send_command.assert_any_call(command=get_device_info, retries=3)
-    connection.send_command.assert_called_with(command=reset_reason, retries=3)
     assert device_info == {"serial": "s", "model": "m", "version": "v"}


### PR DESCRIPTION
These errors should not cause the system to fail in that way;.

https://github.com/Opentrons/opentrons/pull/17052 introduced using M114 to poll modules for their reset reason when they connect. But if the module doesn't know about that gcode because it hasn't been updated, it will fail, and if it fails while the server is starting (because the module is plugged in at boot), the server won't start.

## todo
- [x] fix lint
- [x] test on hw 

Closes RQA-3787