### PR TITLE
fix(protocols): re-add get_all_labware_definitions

### DIFF
--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -391,3 +391,13 @@ def requires_version(major: int, minor: int) -> Callable[[FuncT], FuncT]:
         return cast(FuncT, _check_version_wrapper)
 
     return _set_version
+
+
+class ModifiedList(list[str]):
+    def __contains__(self, item: object) -> bool:
+        if not isinstance(item, str):
+            return False
+        for name in self:
+            if name == item.replace("-", "_").lower():
+                return True
+        return False

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import logging
 import json
+import os
 
 from pathlib import Path
-from typing import Any, AnyStr, Dict, Optional, Union
+from typing import Any, AnyStr, Dict, Optional, Union, List
 
 import jsonschema  # type: ignore
 
 from opentrons_shared_data import load_shared_data, get_shared_data_root
+from opentrons.protocols.api_support.util import ModifiedList
 from opentrons.protocols.api_support.constants import (
     OPENTRONS_NAMESPACE,
     CUSTOM_NAMESPACE,
@@ -59,6 +61,27 @@ def get_labware_definition(
         pass
 
     return _get_standard_labware_definition(load_name, namespace, version)
+
+
+def get_all_labware_definitions() -> List[str]:
+    """
+    Return a list of standard and custom labware definitions with load_name +
+        name_space + version existing on the robot
+    """
+    labware_list = ModifiedList()
+
+    def _check_for_subdirectories(path: Union[str, Path, os.DirEntry[str]]) -> None:
+        with os.scandir(path) as top_path:
+            for sub_dir in top_path:
+                if sub_dir.is_dir():
+                    labware_list.append(sub_dir.name)
+
+    # check for standard labware
+    _check_for_subdirectories(get_shared_data_root() / STANDARD_DEFS_PATH)
+    # check for custom labware
+    for namespace in os.scandir(USER_DEFS_PATH):
+        _check_for_subdirectories(namespace)
+    return labware_list
 
 
 def save_definition(


### PR DESCRIPTION
## Overview
In https://github.com/Opentrons/opentrons/pull/16148 , we removed `get_all_labware_definitions` thinking it wouldn't be used outside of loading labware definitions from shared data. Turns out, there are some hardware testing scripts that use this. This just re-adds that function to un-break the harwdare testing code. 