### PR TITLE
fix(protocols): fix get_all_labware_defs

### DIFF
--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -63,7 +63,7 @@ def get_labware_definition(
     return _get_standard_labware_definition(load_name, namespace, version)
 
 
-def get_all_labware_definitions(schema_version: str = 2) -> List[str]:
+def get_all_labware_definitions(schema_version: str = "2") -> List[str]:
     """
     Return a list of standard and custom labware definitions with load_name +
         name_space + version existing on the robot
@@ -77,7 +77,9 @@ def get_all_labware_definitions(schema_version: str = 2) -> List[str]:
                     labware_list.append(sub_dir.name)
 
     # check for standard labware
-    _check_for_subdirectories(get_shared_data_root() / STANDARD_DEFS_PATH / schema_version)
+    _check_for_subdirectories(
+        get_shared_data_root() / STANDARD_DEFS_PATH / schema_version
+    )
     # check for custom labware
     for namespace in os.scandir(USER_DEFS_PATH):
         _check_for_subdirectories(namespace)

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -63,7 +63,7 @@ def get_labware_definition(
     return _get_standard_labware_definition(load_name, namespace, version)
 
 
-def get_all_labware_definitions() -> List[str]:
+def get_all_labware_definitions(schema_version: str = 2) -> List[str]:
     """
     Return a list of standard and custom labware definitions with load_name +
         name_space + version existing on the robot
@@ -77,7 +77,7 @@ def get_all_labware_definitions() -> List[str]:
                     labware_list.append(sub_dir.name)
 
     # check for standard labware
-    _check_for_subdirectories(get_shared_data_root() / STANDARD_DEFS_PATH)
+    _check_for_subdirectories(get_shared_data_root() / STANDARD_DEFS_PATH / schema_version)
     # check for custom labware
     for namespace in os.scandir(USER_DEFS_PATH):
         _check_for_subdirectories(namespace)


### PR DESCRIPTION
## Overview
https://github.com/Opentrons/opentrons/pull/17077 reintroduced `get_all_labware_defs`, but a change we'd made to accommodate labware schema 3 changed how it worked. This fixes that.