### PR TITLE
fix(protocol-designer): handle duplicate labware with a full deck

### DIFF
--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -22,6 +22,7 @@
   "custom": "Custom labware definitions",
   "customize_slot": "Customize slot",
   "deck_hardware": "Deck hardware",
+  "deck_slots_full": "Deck slots are full",
   "define_liquid": "Define a liquid",
   "done": "Done",
   "double_click_to_edit": "Double-click to edit",

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -115,8 +115,6 @@ export function SlotOverflowMenu(
 
   const { makeSnackbar } = useKitchen()
 
-  const isSpace = getNextAvailableDeckSlot(deckSetup, robotType) != null
-
   const {
     labware: deckSetupLabware,
     modules: deckSetupModules,
@@ -133,6 +131,9 @@ export function SlotOverflowMenu(
       ? lw.id === location
       : lw.slot === location || lw.slot === moduleOnSlot?.id
   )
+  const isSpace =
+    getNextAvailableDeckSlot(deckSetup, robotType, labwareOnSlot?.def) != null
+
   const isLabwareTiprack = labwareOnSlot?.def.parameters.isTiprack ?? false
   const isLabwareAnAdapter =
     labwareOnSlot?.def.allowedRoles?.includes('adapter') ?? false
@@ -171,10 +172,8 @@ export function SlotOverflowMenu(
     location as AddressableAreaName
   )
 
-  function handleDuplicate(): void {
-    console.log('test')
+  const handleDuplicate = (): void => {
     if (!isSpace) {
-      console.log('test')
       makeSnackbar(t('deck_slots_full') as string)
       return
     }

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -117,8 +117,6 @@ export function SlotOverflowMenu(
 
   const isSpace = getNextAvailableDeckSlot(deckSetup, robotType) != null
 
-  console.log(isSpace)
-
   const {
     labware: deckSetupLabware,
     modules: deckSetupModules,

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SlotOverflowMenu.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SlotOverflowMenu.test.tsx
@@ -11,6 +11,7 @@ import {
   openIngredientSelector,
 } from '../../../../labware-ingred/actions'
 import { EditNickNameModal } from '../../../../organisms'
+import { useKitchen } from '../../../../organisms/Kitchen/hooks'
 import { deleteModule } from '../../../../step-forms/actions'
 import { deleteDeckFixture } from '../../../../step-forms/actions/additionalItems'
 import { getDeckSetupForActiveItem } from '../../../../top-selectors/labware-locations'
@@ -20,7 +21,6 @@ import { SlotOverflowMenu } from '../SlotOverflowMenu'
 
 import type { NavigateFunction } from 'react-router-dom'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import { useKitchen } from '../../../../organisms/Kitchen/hooks'
 
 const mockNavigate = vi.fn()
 


### PR DESCRIPTION
# Overview

If a slot overflow is opened and duplicate labware is clicked, the action will fail silently if no room is left on the robot deck. Here, we use the `getNextAvailableDeckSlot` util to determine whether or not we can dispatch a labware duplication on the deck. If not, we keep the menu open, but render a snackbar letting the user know the reason for the failure. Note that according to new design paradigms, the button remains enabled in every case.

https://github.com/user-attachments/assets/2441bf87-a039-440f-bfe9-5861189b6c0b

Closes AUTH-1146

## Test Plan and Hands on Testing

- fill a robot deck with any combination of modules, adapters, and labware
- select any labware and click "Duplicate labware"
- verify taht menu remains open, no labware addition is dispatched, and snackbar renders stating that the deck is full

## Changelog

- get whether deck is full in SlotOverflowMenu and handle logic in `handleDuplicate` function
- add test and translation

## Review requests

see test plan

## Risk assessment

low-medium. relying on `getNextAvailableDeckSlot` to handle full deck logic