### PR TITLE
feat(protocol-designer): indent generated JSON file to make it readable

### DIFF
--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -1,7 +1,7 @@
 import { saveAs } from 'file-saver'
 import type { ProtocolFile } from '@opentrons/shared-data'
 export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
-  const blob = new Blob([JSON.stringify(fileData)], {
+  const blob = new Blob([JSON.stringify(fileData, null, 2)], {
     type: 'application/json',
   })
   saveAs(blob, fileName)


### PR DESCRIPTION
# Overview

I have to stare at JSON protocols a lot. Indenting them makes them easier to read, and saves me the trouble of using a separate tool just to reformat the JSON.

`JSON.stringify()` has a built-in option for indentation; we just have to call it.

## Test Plan and Hands on Testing

I edited a protocol in PD and examined the generated JSON file by hand.

I confirmed that the indented JSON files can be successfully re-imported.

All the CI tests pass.

## Risk assessment

Low risk. The indented JSON files should be entirely semantically equivalent to the unindented ones.