### PR TITLE
fix(protocol-designer): fix logic for terminal step icon

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TerminalItemStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TerminalItemStep.tsx
@@ -83,7 +83,7 @@ export function TerminalItemStep(props: TerminalItemStepProps): JSX.Element {
       <StepContainer
         {...{
           stepId: `TerminalItem_${id}`,
-          iconName: title === 'Starting deck state' ? 'ot-start' : 'ot-end',
+          iconName: id === '__initial_setup__' ? 'ot-start' : 'ot-end',
           hovered,
           selected,
           title,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TerminalItemStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TerminalItemStep.tsx
@@ -28,14 +28,15 @@ import type {
 } from '../../../../ui/steps'
 import type { TerminalItemId } from '../../../../steplist'
 import type { ThunkDispatch } from '../../../../types'
+import { useTranslation } from 'react-i18next'
 
 export interface TerminalItemStepProps {
   id: TerminalItemId
-  title: string
 }
 
 export function TerminalItemStep(props: TerminalItemStepProps): JSX.Element {
-  const { id, title } = props
+  const { id } = props
+  const { t } = useTranslation('protocol_steps')
   const hovered = useSelector(getHoveredTerminalItemId) === id
   const selected = useSelector(getSelectedTerminalItemId) === id
   const currentFormIsPresaved = useSelector(getCurrentFormIsPresaved)
@@ -86,7 +87,8 @@ export function TerminalItemStep(props: TerminalItemStepProps): JSX.Element {
           iconName: id === '__initial_setup__' ? 'ot-start' : 'ot-end',
           hovered,
           selected,
-          title,
+          title:
+            id === '__initial_setup__' ? t('starting_deck') : t('ending_deck'),
           onClick,
           onMouseEnter,
           onMouseLeave,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -78,10 +78,7 @@ export const TimelineToolbox = (): JSX.Element => {
         gridGap={SPACING.spacing4}
         width="100%"
       >
-        <TerminalItemStep
-          id={START_TERMINAL_ITEM_ID}
-          title={t('starting_deck')}
-        />
+        <TerminalItemStep id={START_TERMINAL_ITEM_ID} />
         <DraggableSteps
           orderedStepIds={orderedStepIds}
           reorderSteps={(stepIds: StepIdType[]) => {
@@ -89,7 +86,7 @@ export const TimelineToolbox = (): JSX.Element => {
           }}
         />
         <PresavedStep />
-        <TerminalItemStep id={END_TERMINAL_ITEM_ID} title={t('ending_deck')} />
+        <TerminalItemStep id={END_TERMINAL_ITEM_ID} />
       </Flex>
     </Toolbox>
   )


### PR DESCRIPTION
# Overview

This fixes a bug where the starting deck terminal step icon was being incorrectly determined as the end icon, because we were checking the title text of the step, which is subject to change. To fix this, we determine the icon based on step ID.
<img width="296" alt="Screenshot 2024-12-11 at 5 51 34 PM" src="https://github.com/user-attachments/assets/6def1d5e-dc41-4f0c-91ab-1fd31299f757" />

close RQA-3791

## Test Plan and Hands on Testing

- on any protocol, navigate to protocol timeline toolbox and verify correct icons for starting deck and ending deck steps

## Changelog

- fix logic for icon

## Review requests

see test plan

## Risk assessment

low