### PR TITLE
test(app): start of a test to validate translation mappings

### DIFF
--- a/app/src/assets/localization/__tests__/translationConsistency.test.ts
+++ b/app/src/assets/localization/__tests__/translationConsistency.test.ts
@@ -1,0 +1,88 @@
+import { resources } from '..'
+import { describe, it, expect } from 'vitest'
+
+describe('Translation consistency between en and zh', () => {
+  const enTranslations = resources['en']
+  const zhTranslations = resources['zh']
+
+  const checkKeys = (
+    base: { [key: string]: any },
+    compare: { [key: string]: any },
+    baseLang: string,
+    compareLang: string
+  ) => {
+    const missingKeys: string[] = []
+
+    const traverseKeys = (obj: object, path = '') => {
+      Object.entries(obj).forEach(([key, value]) => {
+        const fullPath = path ? `${path}.${key}` : key
+
+        if (typeof value === 'object' && value !== null) {
+          // Recursively check nested objects
+          traverseKeys(value, fullPath)
+        } else {
+          // Check if key exists and has same type
+          const compareObj = path
+            .split('.')
+            .reduce((acc, curr) => acc?.[curr], compare)
+          if (!compareObj?.[key] || typeof compareObj[key] !== typeof value) {
+            missingKeys.push(fullPath)
+          }
+        }
+      })
+    }
+
+    traverseKeys(base)
+
+    if (missingKeys.length > 0) {
+      throw new Error(
+        `Missing ${compareLang} translations for the following ${baseLang} keys:\n${missingKeys.join(
+          '\n'
+        )}`
+      )
+    }
+  }
+
+  it('should have all keys in zh that are in en', () => {
+    checkKeys(enTranslations, zhTranslations, 'en', 'zh')
+  })
+
+  it('should have all keys in en that are in zh', () => {
+    checkKeys(zhTranslations, enTranslations, 'zh', 'en')
+  })
+
+  it('should have matching value types', () => {
+    const checkValueTypes = (
+      obj1: { [key: string]: any },
+      obj2: { [key: string]: any },
+      path = ''
+    ) => {
+      const typeMismatches: string[] = []
+
+      Object.entries(obj1).forEach(([key, value]) => {
+        const fullPath = path ? `${path}.${key}` : key
+        const value2 = path
+          .split('.')
+          .reduce((acc, curr) => acc?.[curr], obj2)?.[key]
+
+        if (value2 !== undefined && typeof value !== typeof value2) {
+          typeMismatches.push(
+            `${fullPath}: en(${typeof value}) vs zh(${typeof value2})`
+          )
+        }
+
+        if (typeof value === 'object' && value !== null) {
+          checkValueTypes(value, value2, fullPath)
+        }
+      })
+
+      return typeMismatches
+    }
+
+    const typeMismatches = checkValueTypes(enTranslations, zhTranslations)
+
+    if (typeMismatches.length > 0) {
+      throw new Error(`Type mismatches found:\n${typeMismatches.join('\n')}`)
+    }
+  })
+})


### PR DESCRIPTION
# Overview

Not sure if this is exactly what we want but trying to get started...

## Current output

`make test tests=src/assets/localization/__tests__/translationConsistency.test.ts`

```shell
 FAIL  app/src/assets/localization/__tests__/translationConsistency.test.ts > Translation consistency between en and zh > should have all keys in zh that are in en
Error: Missing zh translations for the following en keys:
shared.closed
anonymous.language_preference_description
anonymous.system_language_preferences_update_description
anonymous.unexpected_error
app_settings.__dev_internal__lpcRedesign
app_settings.__dev_internal__reactQueryDevtools
app_settings.__dev_internal__reactScan
app_settings.app_language_description
app_settings.app_language_preferences
app_settings.choose_your_language
app_settings.dont_change
app_settings.error_recovery_mode
app_settings.error_recovery_mode_description
app_settings.language
app_settings.language_preference
app_settings.select_a_language
app_settings.select_language
app_settings.system_language_preferences_update
app_settings.use_system_language
branded.language_preference_description
branded.system_language_preferences_update_description
branded.unexpected_error
protocol_command_text.absorbance_reader_close_lid
protocol_command_text.absorbance_reader_initialize
protocol_command_text.absorbance_reader_open_lid
protocol_command_text.absorbance_reader_read
protocol_command_text.air_gap_in_place
protocol_command_text.dropping_tip_in_trash
protocol_command_text.in_location
protocol_command_text.load_labware_to_display_location
protocol_command_text.multiple
protocol_command_text.on_location
protocol_command_text.single
protocol_command_text.tc_starting_extended_profile
protocol_command_text.tc_starting_extended_profile_cycle
protocol_command_text.trash_bin
protocol_command_text.with_reference_of
device_details.abs_reader_lid_status
device_settings.no_calibration_required
drop_tip_wizard.fixed_trash_in_12
protocol_info.date_added_date
protocol_info.last_run_time
protocol_setup.labware_quantity
protocol_setup.module_instructions_manual
quick_transfer.air_gap_after_aspirating
quick_transfer.delay_after_aspirating
quick_transfer.touch_tip_after_aspirating
run_details.device_details
run_details.files_available_robot_details
run_details.load_labware_info_protocol_setup_plural
run_details.na
run_details.step_na
error_recovery.carefully_move_labware
error_recovery.do_you_need_to_blowout
error_recovery.door_open_robot_home
error_recovery.home_and_retry
error_recovery.home_gantry
error_recovery.home_now
error_recovery.inspect_the_robot
error_recovery.na
error_recovery.prepare_deck_for_homing
error_recovery.proceed_to_home
error_recovery.replace_tips_and_select_loc_partial_tip
error_recovery.retry_dropping_tip
error_recovery.retry_picking_up_tip
error_recovery.retrying_step_succeeded_na
error_recovery.skipping_to_step_succeeded_na
error_recovery.stall_or_collision_detected_when
error_recovery.stall_or_collision_error
error_recovery.take_necessary_actions_failed_tip_drop
error_recovery.take_necessary_actions_home
error_recovery.the_robot_must_return_to_home_position
 ❯ checkKeys app/src/assets/localization/__tests__/translationConsistency.test.ts:38:13

 ❯ app/src/assets/localization/__tests__/translationConsistency.test.ts:47:5

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  app/src/assets/localization/__tests__/translationConsistency.test.ts > Translation consistency between en and zh > should have all keys in en that are in zh
Error: Missing en translations for the following zh keys:
drop_tip_wizard.exit_screen_title
drop_tip_wizard.remove_the_tips
protocol_details.csv_required
protocol_setup.offsets_applied_plural
run_details.load_liquids_info_protocol_setup
run_details.load_module_protocol_setup
run_details.load_pipette_protocol_setup
run_details.run_complete_splash
top_navigation.all_protocols
error_recovery.preserve_aspirated_liquid
error_recovery.you_may_want_to_remove
 ❯ checkKeys app/src/assets/localization/__tests__/translationConsistency.test.ts:38:13

 ❯ app/src/assets/localization/__tests__/translationConsistency.test.ts:51:5

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
   Start at  09:34:23
   Duration  1.04s (transform 155ms, setup 191ms, collect 178ms, tests 7ms, environment 320ms, prepare 46ms)


 FAIL  Tests failed. Watching for file changes...
       press h to show help, press q to quit
```
