### PR TITLE
fix(protocol-designer): blowout field checkbox properly populating

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -137,13 +137,6 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
 
   const mappedErrorsToField = getFormErrorsMappedToField(visibleFormErrors)
 
-  // auto-collapse blowout field if disposal volume is not null
-  // useEffect(() => {
-  //   if (formData.disposalVolume_checkbox) {
-  //     propsForFields.blowout_checkbox.updateValue(false)
-  //   }
-  // }, [formData.disposalVolume_checkbox])
-
   return toolboxStep === 0 ? (
     <Flex
       flexDirection={DIRECTION_COLUMN}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -71,7 +71,6 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
   const labwares = useSelector(getLabwareEntities)
   const pipettes = useSelector(getPipetteEntities)
   const addFieldNamePrefix = makeAddFieldNamePrefix(tab)
-
   const isWasteChuteSelected =
     propsForFields.dispense_labware?.value != null
       ? additionalEquipmentEntities[
@@ -98,11 +97,15 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
     additionalEquipmentEntities[String(propsForFields.dispense_labware.value)]
       ?.name === 'trashBin'
 
-  const destinationLabwareType = getTrashOrLabware(
-    labwares,
-    additionalEquipmentEntities,
-    formData.dispense_labware as string
-  )
+  const destinationLabwareType =
+    formData.dispense_labware != null
+      ? getTrashOrLabware(
+          labwares,
+          additionalEquipmentEntities,
+          formData.dispense_labware as string
+        )
+      : null
+
   const isDestinationTrash =
     destinationLabwareType != null
       ? ['trashBin', 'wasteChute'].includes(destinationLabwareType)
@@ -134,12 +137,12 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
 
   const mappedErrorsToField = getFormErrorsMappedToField(visibleFormErrors)
 
-  // auto-collapse blowout field if disposal volume is checked
-  useEffect(() => {
-    if (formData.disposalVolume_checkbox) {
-      propsForFields.blowout_checkbox.updateValue(false)
-    }
-  }, [formData.disposalVolume_checkbox])
+  // auto-collapse blowout field if disposal volume is not null
+  // useEffect(() => {
+  //   if (formData.disposalVolume_checkbox) {
+  //     propsForFields.blowout_checkbox.updateValue(false)
+  //   }
+  // }, [formData.disposalVolume_checkbox])
 
   return toolboxStep === 0 ? (
     <Flex

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -428,6 +428,7 @@ const updatePatchDisposalVolumeFields = (
       ...patch,
       disposalVolume_checkbox: true,
       disposalVolume_volume: recommendedMinimumDisposalVol,
+      blowout_checkbox: false,
     }
   }
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
@@ -313,6 +313,7 @@ describe('disposal volume should update...', () => {
         dispense_mix_checkbox: false,
         dispense_mix_times: null,
         dispense_mix_volume: null,
+        blowout_checkbox: false,
       })
     })
 


### PR DESCRIPTION
# Overview

This was a weird bug only affecting the UI and not any commands being generated. Basically, the blowout checkbox was incorrectly not being selected because there was logic in place (a useEffect) to hardcode it to false due to the disposal volume checkbox being true. IDK why the disposal volume checkbox is true -- seems like something we allowed for all move liquid steps back in the day. So in order to prevent a migration and possible changing old protocol behaviors, I added the field to be dependent on the disposal volume fields and removed the useEffect in place.

## Test Plan and Hands on Testing

Upload the attached protocol and make sure the blowout checkbox is checked for the dispense advanced settings

[BCA_Assay_2Dilutions.json](https://github.com/user-attachments/files/18113994/BCA_Assay_2Dilutions.json)


## Changelog

- remove useEffect that was causing issues since we can't rely on the disposal volume checkbox behavior
- add some null protection to remove console errors
- add `blowout_checkbox` to `updatePatchDisposalVolumeFields` so that it is dependent on the disposal volume

## Risk assessment

low