### PR TITLE
fix(protocol-designer): blowout field checkbox properly populating

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import {
@@ -133,13 +132,6 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
     tab === 'dispense' && (isWasteChuteSelected || isTrashBinSelected)
 
   const mappedErrorsToField = getFormErrorsMappedToField(visibleFormErrors)
-
-  // auto-collapse blowout field if disposal volume is checked
-  useEffect(() => {
-    if (formData.disposalVolume_checkbox) {
-      propsForFields.blowout_checkbox.updateValue(false)
-    }
-  }, [formData.disposalVolume_checkbox])
 
   return toolboxStep === 0 ? (
     <Flex

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -428,6 +428,7 @@ const updatePatchDisposalVolumeFields = (
       ...patch,
       disposalVolume_checkbox: true,
       disposalVolume_volume: recommendedMinimumDisposalVol,
+      blowout_checkbox: false,
     }
   }
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
@@ -313,6 +313,7 @@ describe('disposal volume should update...', () => {
         dispense_mix_checkbox: false,
         dispense_mix_times: null,
         dispense_mix_volume: null,
+        blowout_checkbox: false,
       })
     })
 


### PR DESCRIPTION
closes RQA-3792

# Overview

This was a weird bug only affecting the UI and not any commands being generated. Basically, the blowout checkbox was incorrectly not being selected because there was logic in place (a useEffect) to hardcode it to false due to the disposal volume checkbox being true. IDK why the disposal volume checkbox is true -- seems like something we allowed for all move liquid steps back in the day. So for a UI fix, I added the field to be dependent on the disposal volume fields and removed the useEffect in place. 

For a followup, we are looking into removing `disposal volume checkbox is true` and possibly adding it to the migration only if the disposal volume volume is also null (that _shouldn't_ change old protocol behavior)

## Test Plan and Hands on Testing

Upload the attached protocol and make sure the blowout checkbox is checked for the dispense advanced settings

[BCA_Assay_2Dilutions.json](https://github.com/user-attachments/files/18113994/BCA_Assay_2Dilutions.json)


## Changelog

- remove useEffect that was causing issues since we can't rely on the disposal volume checkbox behavior
- add `blowout_checkbox` to `updatePatchDisposalVolumeFields` so that it is dependent on the disposal volume

## Risk assessment

low