### PR TITLE
fix(protocol-designer): resolve console error by adding null protection

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -98,11 +98,14 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
     additionalEquipmentEntities[String(propsForFields.dispense_labware.value)]
       ?.name === 'trashBin'
 
-  const destinationLabwareType = getTrashOrLabware(
-    labwares,
-    additionalEquipmentEntities,
-    formData.dispense_labware as string
-  )
+  const destinationLabwareType =
+    formData.dispense_labware != null
+      ? getTrashOrLabware(
+          labwares,
+          additionalEquipmentEntities,
+          formData.dispense_labware as string
+        )
+      : null
   const isDestinationTrash =
     destinationLabwareType != null
       ? ['trashBin', 'wasteChute'].includes(destinationLabwareType)


### PR DESCRIPTION
# Overview

resolve a console error

## Test Plan and Hands on Testing

create a transfer step and make sure there is no error in the console that says: `expected to determine if dest labware is a labware or waste chute with destLabware ${destinationId} but could not`

## Changelog

null protection

## Risk assessment

low