### PR TITLE
fix(protocol-designer): analytics opt in modal fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,6 +12,7 @@
 **/CHANGELOG.md
 !api/release-notes.md
 !app-shell/build/release-notes.md
+**/.yarn-cache/**
 
 # components library
 storybook-static

--- a/components/src/modals/Modal.tsx
+++ b/components/src/modals/Modal.tsx
@@ -24,6 +24,7 @@ export interface ModalProps extends StyleProps {
   zIndexOverlay?: number
   showOverlay?: boolean
   position?: Position
+  hasHeader?: boolean
 }
 
 /**
@@ -43,6 +44,7 @@ export const Modal = (props: ModalProps): JSX.Element => {
     zIndexOverlay,
     position,
     showOverlay,
+    hasHeader = true,
     ...styleProps
   } = props
 
@@ -83,7 +85,7 @@ export const Modal = (props: ModalProps): JSX.Element => {
       showOverlay={showOverlay}
       zIndexOverlay={zIndexOverlay}
       width={styleProps.width ?? '31.25rem'}
-      header={modalHeader}
+      header={hasHeader ? modalHeader : undefined}
       onOutsideClick={closeOnOutsideClick ?? false ? onClose : undefined}
       // center within viewport aside from nav
       marginLeft={styleProps.marginLeft ?? '5.656rem'}

--- a/protocol-designer/cypress/e2e/createNew.cy.ts
+++ b/protocol-designer/cypress/e2e/createNew.cy.ts
@@ -12,6 +12,7 @@ describe('The Redesigned Create Protocol Landing Page', () => {
   })
 
   it('content and step 1 flow works', () => {
+    cy.closeAnalyticsModal()
     cy.clickCreateNew()
     cy.verifyCreateNewHeader()
     verifyCreateProtocolPage()

--- a/protocol-designer/cypress/e2e/import.cy.ts
+++ b/protocol-designer/cypress/e2e/import.cy.ts
@@ -7,6 +7,7 @@ import {
 describe('The Import Page', () => {
   beforeEach(() => {
     cy.visit('/')
+    cy.closeAnalyticsModal()
   })
 
   it('successfully loads a protocol exported on a previous version', () => {

--- a/protocol-designer/cypress/e2e/migrations.cy.ts
+++ b/protocol-designer/cypress/e2e/migrations.cy.ts
@@ -6,6 +6,7 @@ import { TestFilePath } from '../support/testFiles'
 describe('Protocol fixtures migrate and match snapshots', () => {
   beforeEach(() => {
     cy.visit('/')
+    cy.closeAnalyticsModal()
   })
 
   const testCases: MigrateTestCase[] = [

--- a/protocol-designer/cypress/e2e/settings.cy.ts
+++ b/protocol-designer/cypress/e2e/settings.cy.ts
@@ -1,6 +1,7 @@
 describe('The Settings Page', () => {
   before(() => {
     cy.visit('/')
+    cy.closeAnalyticsModal()
   })
 
   it('content and toggle state', () => {
@@ -19,19 +20,19 @@ describe('The Settings Page', () => {
     cy.getByTestId('analyticsToggle')
       .should('exist')
       .should('be.visible')
-      .find('path[aria-roledescription="ot-toggle-input-off"]')
+      .find('path[aria-roledescription="ot-toggle-input-on"]')
       .should('exist')
     // Toggle the share sessions with Opentrons setting
     cy.getByTestId('analyticsToggle').click()
     cy.getByTestId('analyticsToggle')
-      .find('path[aria-roledescription="ot-toggle-input-on"]')
+      .find('path[aria-roledescription="ot-toggle-input-off"]')
       .should('exist')
     // Navigate away from the settings page
     // Then return to see privacy toggle remains toggled on
     cy.visit('/')
     cy.openSettingsPage()
     cy.getByTestId('analyticsToggle').find(
-      'path[aria-roledescription="ot-toggle-input-on"]'
+      'path[aria-roledescription="ot-toggle-input-off"]'
     )
     // Toggle off editing timeline tips
     // Navigate away from the settings page

--- a/protocol-designer/cypress/support/commands.ts
+++ b/protocol-designer/cypress/support/commands.ts
@@ -62,7 +62,7 @@ export const locators = {
   eula: 'a[href="https://opentrons.com/eula"]',
   privacyToggle: 'Settings_hotKeys',
   analyticsToggleTestId: 'analyticsToggle',
-  confirm: 'Confirm'
+  confirm: 'Confirm',
 }
 
 // General Custom Commands
@@ -115,11 +115,10 @@ Cypress.Commands.add('clickCreateNew', () => {
 
 Cypress.Commands.add('closeAnalyticsModal', () => {
   cy.get('button')
-  .contains(locators.confirm)
-  .should('be.visible')
-  .click({ force: true })
+    .contains(locators.confirm)
+    .should('be.visible')
+    .click({ force: true })
 })
-
 
 // Header Import
 Cypress.Commands.add('importProtocol', (protocolFilePath: string) => {

--- a/protocol-designer/cypress/support/commands.ts
+++ b/protocol-designer/cypress/support/commands.ts
@@ -9,6 +9,7 @@ declare global {
       verifyFullHeader: () => Cypress.Chainable<void>
       verifyCreateNewHeader: () => Cypress.Chainable<void>
       clickCreateNew: () => Cypress.Chainable<void>
+      closeAnalyticsModal: () => Cypress.Chainable<void>
       closeAnnouncementModal: () => Cypress.Chainable<void>
       verifyHomePage: () => Cypress.Chainable<void>
       importProtocol: (protocolFile: string) => Cypress.Chainable<void>
@@ -61,6 +62,7 @@ export const locators = {
   eula: 'a[href="https://opentrons.com/eula"]',
   privacyToggle: 'Settings_hotKeys',
   analyticsToggleTestId: 'analyticsToggle',
+  confirm: 'Confirm'
 }
 
 // General Custom Commands
@@ -110,6 +112,14 @@ Cypress.Commands.add('verifyHomePage', () => {
 Cypress.Commands.add('clickCreateNew', () => {
   cy.contains(locators.createProtocol).click()
 })
+
+Cypress.Commands.add('closeAnalyticsModal', () => {
+  cy.get('button')
+  .contains(locators.confirm)
+  .should('be.visible')
+  .click({ force: true })
+})
+
 
 // Header Import
 Cypress.Commands.add('importProtocol', (protocolFilePath: string) => {

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -59,7 +59,8 @@ export function ProtocolRoutes(): JSX.Element {
     path: '/',
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
-
+  const showGateModal =
+    process.env.NODE_ENV === 'production' || process.env.OT_PD_SHOW_GATE
   const navigate = useNavigate()
   const handleReset = (): void => {
     navigate('/', { replace: true })
@@ -73,7 +74,7 @@ export function ProtocolRoutes(): JSX.Element {
       <NavigationBar />
       <Kitchen>
         <Box width="100%">
-          <GateModal />
+          {showGateModal ? <GateModal /> : null}
           <LabwareUploadModal />
           <FileUploadMessagesModal />
           <Routes>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -59,8 +59,6 @@ export function ProtocolRoutes(): JSX.Element {
     path: '/',
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
-  const showGateModal =
-    process.env.NODE_ENV === 'production' || process.env.OT_PD_SHOW_GATE
   const navigate = useNavigate()
   const handleReset = (): void => {
     navigate('/', { replace: true })
@@ -74,7 +72,7 @@ export function ProtocolRoutes(): JSX.Element {
       <NavigationBar />
       <Kitchen>
         <Box width="100%">
-          {showGateModal ? <GateModal /> : null}
+          <GateModal />
           <LabwareUploadModal />
           <FileUploadMessagesModal />
           <Routes>

--- a/protocol-designer/src/ProtocolRoutes.tsx
+++ b/protocol-designer/src/ProtocolRoutes.tsx
@@ -59,8 +59,6 @@ export function ProtocolRoutes(): JSX.Element {
     path: '/',
   }
   const allRoutes: RouteProps[] = [...pdRoutes, landingPage]
-  const showGateModal =
-    process.env.NODE_ENV === 'production' || process.env.OT_PD_SHOW_GATE
 
   const navigate = useNavigate()
   const handleReset = (): void => {
@@ -75,7 +73,7 @@ export function ProtocolRoutes(): JSX.Element {
       <NavigationBar />
       <Kitchen>
         <Box width="100%">
-          {showGateModal ? <GateModal /> : null}
+          <GateModal />
           <LabwareUploadModal />
           <FileUploadMessagesModal />
           <Routes>

--- a/protocol-designer/src/analytics/actions.ts
+++ b/protocol-designer/src/analytics/actions.ts
@@ -1,3 +1,4 @@
+import { OLDEST_MIGRATEABLE_VERSION } from '../load-file/migration'
 import { setMixpanelTracking } from './mixpanel'
 import type { AnalyticsEvent } from './mixpanel'
 
@@ -16,14 +17,20 @@ const _setOptIn = (payload: SetOptIn['payload']): SetOptIn => {
 
   return {
     type: 'SET_OPT_IN',
-    payload,
+    payload: { hasOptedIn: payload.hasOptedIn, appVersion: payload.appVersion },
   }
 }
 
-export const optIn = (appVersion: string): SetOptIn =>
-  _setOptIn({ hasOptedIn: true, appVersion: appVersion })
-export const optOut = (appVersion: string): SetOptIn =>
-  _setOptIn({ hasOptedIn: false, appVersion: appVersion })
+export const optIn = (): SetOptIn =>
+  _setOptIn({
+    hasOptedIn: true,
+    appVersion: process.env.OT_PD_VERSION || OLDEST_MIGRATEABLE_VERSION,
+  })
+export const optOut = (): SetOptIn =>
+  _setOptIn({
+    hasOptedIn: false,
+    appVersion: process.env.OT_PD_VERSION || OLDEST_MIGRATEABLE_VERSION,
+  })
 export interface AnalyticsEventAction {
   type: 'ANALYTICS_EVENT'
   payload: AnalyticsEvent

--- a/protocol-designer/src/analytics/actions.ts
+++ b/protocol-designer/src/analytics/actions.ts
@@ -3,7 +3,7 @@ import type { AnalyticsEvent } from './mixpanel'
 
 export interface SetOptIn {
   type: 'SET_OPT_IN'
-  payload: boolean
+  payload: { hasOptedIn: boolean; appVersion: string }
 }
 
 const _setOptIn = (payload: SetOptIn['payload']): SetOptIn => {
@@ -20,8 +20,10 @@ const _setOptIn = (payload: SetOptIn['payload']): SetOptIn => {
   }
 }
 
-export const optIn = (): SetOptIn => _setOptIn(true)
-export const optOut = (): SetOptIn => _setOptIn(false)
+export const optIn = (appVersion: string): SetOptIn =>
+  _setOptIn({ hasOptedIn: true, appVersion: appVersion })
+export const optOut = (appVersion: string): SetOptIn =>
+  _setOptIn({ hasOptedIn: false, appVersion: appVersion })
 export interface AnalyticsEventAction {
   type: 'ANALYTICS_EVENT'
   payload: AnalyticsEvent

--- a/protocol-designer/src/analytics/middleware.ts
+++ b/protocol-designer/src/analytics/middleware.ts
@@ -499,7 +499,7 @@ export const trackEventMiddleware: Middleware<BaseState, any> = ({
   // NOTE: this is the Redux state AFTER the action has been fully dispatched
   const state = getState()
 
-  const optedIn = getHasOptedIn(state as BaseState) ?? false
+  const optedIn = getHasOptedIn(state as BaseState)?.hasOptedIn ?? false
   const event = reduxActionToAnalyticsEvent(state as BaseState, action)
 
   if (event != null) {

--- a/protocol-designer/src/analytics/mixpanel.ts
+++ b/protocol-designer/src/analytics/mixpanel.ts
@@ -1,10 +1,8 @@
-// TODO(IL, 2020-09-09): reconcile with app/src/analytics/mixpanel.js, which this is derived from
 import mixpanel from 'mixpanel-browser'
 import { getIsProduction } from '../networking/opentronsWebApi'
 import { getHasOptedIn } from './selectors'
 import type { BaseState } from '../types'
 
-// TODO(IL, 2020-09-09): AnalyticsEvent type copied from app/src/analytics/types.js, consider merging
 export type AnalyticsEvent =
   | {
       name: string
@@ -19,18 +17,20 @@ const MIXPANEL_ID = getIsProduction()
   : process.env.OT_PD_MIXPANEL_DEV_ID
 
 const MIXPANEL_OPTS = {
-  // opt out by default
   opt_out_tracking_by_default: true,
 }
 
 export function initializeMixpanel(state: BaseState): void {
   const optedIn = getHasOptedIn(state)?.hasOptedIn ?? false
   if (MIXPANEL_ID != null) {
-    console.debug('Initializing Mixpanel', { optedIn })
-
-    mixpanel.init(MIXPANEL_ID, MIXPANEL_OPTS)
-    setMixpanelTracking(optedIn)
-    trackEvent({ name: 'appOpen', properties: {} }, optedIn) // TODO IMMEDIATELY: do we want this?
+    try {
+      console.debug('Initializing Mixpanel', { optedIn })
+      mixpanel.init(MIXPANEL_ID, MIXPANEL_OPTS)
+      setMixpanelTracking(optedIn)
+      trackEvent({ name: 'appOpen', properties: {} }, optedIn)
+    } catch (error) {
+      console.error('Error initializing Mixpanel:', error)
+    }
   } else {
     console.warn('MIXPANEL_ID not found; this is a bug if build is production')
   }
@@ -40,32 +40,38 @@ export function initializeMixpanel(state: BaseState): void {
 export function trackEvent(event: AnalyticsEvent, optedIn: boolean): void {
   console.debug('Trackable event', { event, optedIn })
   if (MIXPANEL_ID != null && optedIn) {
-    if ('superProperties' in event && event.superProperties != null) {
-      mixpanel.register(event.superProperties)
-    }
-    if ('name' in event && event.name != null) {
-      mixpanel.track(event.name, event.properties)
+    try {
+      if ('superProperties' in event && event.superProperties != null) {
+        mixpanel.register(event.superProperties)
+      }
+      if ('name' in event && event.name != null) {
+        mixpanel.track(event.name, event.properties)
+      }
+    } catch (error) {
+      console.error('Error tracking event:', error)
     }
   }
 }
 
 export function setMixpanelTracking(optedIn: boolean): void {
   if (MIXPANEL_ID != null) {
-    if (optedIn) {
-      console.debug('User has opted into analytics; tracking with Mixpanel')
-      mixpanel.opt_in_tracking()
-      // Register "super properties" which are included with all events
-      mixpanel.register({
-        appVersion: process.env.OT_PD_VERSION,
-        // NOTE(IL, 2020): Since PD may be in the same Mixpanel project as other OT web apps, this 'appName' property is intended to distinguish it
-        appName: 'protocolDesigner',
-      })
-    } else {
-      console.debug(
-        'User has opted out of analytics; stopping Mixpanel tracking'
-      )
-      mixpanel.opt_out_tracking()
-      mixpanel.reset()
+    try {
+      if (optedIn) {
+        console.debug('User has opted into analytics; tracking with Mixpanel')
+        mixpanel.opt_in_tracking()
+        mixpanel.register({
+          appVersion: process.env.OT_PD_VERSION,
+          appName: 'protocolDesigner',
+        })
+      } else {
+        console.debug(
+          'User has opted out of analytics; stopping Mixpanel tracking'
+        )
+        mixpanel.opt_out_tracking()
+        mixpanel.reset()
+      }
+    } catch (error) {
+      console.error('Error setting Mixpanel tracking:', error)
     }
   }
 }

--- a/protocol-designer/src/analytics/mixpanel.ts
+++ b/protocol-designer/src/analytics/mixpanel.ts
@@ -24,7 +24,7 @@ const MIXPANEL_OPTS = {
 }
 
 export function initializeMixpanel(state: BaseState): void {
-  const optedIn = getHasOptedIn(state) ?? false
+  const optedIn = getHasOptedIn(state)?.hasOptedIn ?? false
   if (MIXPANEL_ID != null) {
     console.debug('Initializing Mixpanel', { optedIn })
 

--- a/protocol-designer/src/analytics/reducers.ts
+++ b/protocol-designer/src/analytics/reducers.ts
@@ -4,8 +4,14 @@ import type { Reducer } from 'redux'
 import type { Action } from '../types'
 import type { SetOptIn } from './actions'
 import type { RehydratePersistedAction } from '../persist'
-type OptInState = boolean | null
-const optInInitialState = null
+export interface OptInState {
+  hasOptedIn: boolean | null
+  appVersion?: string
+}
+const optInInitialState = {
+  hasOptedIn: null,
+}
+
 // @ts-expect-error(sb, 2021-6-17): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 const hasOptedIn: Reducer<OptInState, any> = handleActions(
@@ -17,7 +23,9 @@ const hasOptedIn: Reducer<OptInState, any> = handleActions(
       action: RehydratePersistedAction
     ) => {
       const persistedState = action.payload?.['analytics.hasOptedIn']
-      return persistedState !== undefined ? persistedState : optInInitialState
+      return persistedState !== undefined && state.appVersion != null
+        ? persistedState
+        : optInInitialState
     },
   },
   optInInitialState

--- a/protocol-designer/src/analytics/reducers.ts
+++ b/protocol-designer/src/analytics/reducers.ts
@@ -23,9 +23,7 @@ const hasOptedIn: Reducer<OptInState, any> = handleActions(
       action: RehydratePersistedAction
     ) => {
       const persistedState = action.payload?.['analytics.hasOptedIn']
-      return persistedState !== undefined && state.appVersion != null
-        ? persistedState
-        : optInInitialState
+      return persistedState !== undefined ? persistedState : optInInitialState
     },
   },
   optInInitialState

--- a/protocol-designer/src/analytics/selectors.ts
+++ b/protocol-designer/src/analytics/selectors.ts
@@ -1,3 +1,4 @@
 import type { BaseState } from '../types'
-export const getHasOptedIn = (state: BaseState): boolean | null =>
+import type { OptInState } from './reducers'
+export const getHasOptedIn = (state: BaseState): OptInState =>
   state.analytics.hasOptedIn

--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -102,7 +102,7 @@
   "only_tiprack": "Incompatible file type",
   "opentrons_flex": "Opentrons Flex",
   "opentrons": "Opentrons",
-  "opentrons_collects_data": "In order to improve our products, Opentrons would like to collect data related to your use of Protocol Designer. With your consent, Opentrons will collect and store analytics and session data, including through the use of cookies and similar technologies, solely for the purpose enhancing our products.",
+  "opentrons_collects_data": "In order to improve our products, Opentrons would like to collect data related to your use of Protocol Designer. Opentrons will collect and store analytics and session data, including through the use of cookies and similar technologies, solely for the purpose enhancing our products.",
   "ot2": "Opentrons OT-2",
   "overwrite_labware": "Overwrite labware",
   "overwrite": "Click Overwrite to replace the existing labware with the new labware.",

--- a/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
+++ b/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
@@ -24,9 +24,6 @@ export function SettingsApp(): JSX.Element {
   const canClearHintDismissals = useSelector(
     tutorialSelectors.getCanClearHintDismissals
   )
-  const _toggleOptedIn = analytics.hasOptedIn
-    ? analyticsActions.optOut
-    : analyticsActions.optIn
 
   const { t } = useTranslation(['card', 'application', 'button'])
   return (
@@ -75,9 +72,9 @@ export function SettingsApp(): JSX.Element {
                 toggledOn={Boolean(analytics.hasOptedIn)}
                 onClick={() =>
                   dispatch(
-                    _toggleOptedIn(
-                      process.env.OT_PD_VERSION || OLDEST_MIGRATEABLE_VERSION
-                    )
+                    analytics.hasOptedIn
+                      ? analyticsActions.optOut
+                      : analyticsActions.optIn
                   )
                 }
               />

--- a/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
+++ b/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
@@ -20,7 +20,7 @@ import { FeatureFlagCard } from './FeatureFlagCard/FeatureFlagCard'
 
 export function SettingsApp(): JSX.Element {
   const dispatch = useDispatch()
-  const analytics = useSelector(analyticsSelectors.getHasOptedIn)
+  const { hasOptedIn } = useSelector(analyticsSelectors.getHasOptedIn)
   const canClearHintDismissals = useSelector(
     tutorialSelectors.getCanClearHintDismissals
   )
@@ -72,9 +72,9 @@ export function SettingsApp(): JSX.Element {
                 toggledOn={Boolean(analytics.hasOptedIn)}
                 onClick={() =>
                   dispatch(
-                    analytics.hasOptedIn
-                      ? analyticsActions.optOut
-                      : analyticsActions.optIn
+                    hasOptedIn
+                      ? analyticsActions.optOut()
+                      : analyticsActions.optIn()
                   )
                 }
               />

--- a/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
+++ b/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
@@ -69,7 +69,7 @@ export function SettingsApp(): JSX.Element {
               <p className={styles.toggle_label}>{t('toggle.share_session')}</p>
               <ToggleButton
                 className={styles.toggle_button}
-                toggledOn={Boolean(analytics.hasOptedIn)}
+                toggledOn={Boolean(hasOptedIn)}
                 onClick={() =>
                   dispatch(
                     hasOptedIn

--- a/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
+++ b/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
@@ -20,11 +20,11 @@ import { FeatureFlagCard } from './FeatureFlagCard/FeatureFlagCard'
 
 export function SettingsApp(): JSX.Element {
   const dispatch = useDispatch()
-  const hasOptedIn = useSelector(analyticsSelectors.getHasOptedIn)
+  const analytics = useSelector(analyticsSelectors.getHasOptedIn)
   const canClearHintDismissals = useSelector(
     tutorialSelectors.getCanClearHintDismissals
   )
-  const _toggleOptedIn = hasOptedIn
+  const _toggleOptedIn = analytics.hasOptedIn
     ? analyticsActions.optOut
     : analyticsActions.optIn
 
@@ -72,8 +72,14 @@ export function SettingsApp(): JSX.Element {
               <p className={styles.toggle_label}>{t('toggle.share_session')}</p>
               <ToggleButton
                 className={styles.toggle_button}
-                toggledOn={Boolean(hasOptedIn)}
-                onClick={() => dispatch(_toggleOptedIn())}
+                toggledOn={Boolean(analytics.hasOptedIn)}
+                onClick={() =>
+                  dispatch(
+                    _toggleOptedIn(
+                      process.env.OT_PD_VERSION || OLDEST_MIGRATEABLE_VERSION
+                    )
+                  )
+                }
               />
             </div>
 

--- a/protocol-designer/src/organisms/GateModal/index.tsx
+++ b/protocol-designer/src/organisms/GateModal/index.tsx
@@ -21,10 +21,12 @@ const EULA_URL = 'https://opentrons.com/eula'
 
 export function GateModal(): JSX.Element | null {
   const { t } = useTranslation('shared')
-  const analytics = useSelector(analyticsSelectors.getHasOptedIn)
+  const { appVersion, hasOptedIn } = useSelector(
+    analyticsSelectors.getHasOptedIn
+  )
   const dispatch = useDispatch()
 
-  if (analytics.appVersion == null || analytics.hasOptedIn == null) {
+  if (appVersion == null || hasOptedIn == null) {
     return (
       <Modal
         position="bottomRight"

--- a/protocol-designer/src/organisms/GateModal/index.tsx
+++ b/protocol-designer/src/organisms/GateModal/index.tsx
@@ -29,6 +29,7 @@ export function GateModal(): JSX.Element | null {
   if (appVersion == null || hasOptedIn == null) {
     return (
       <Modal
+        hasHeader={false}
         position="bottomRight"
         showOverlay={false}
         footer={

--- a/protocol-designer/src/organisms/GateModal/index.tsx
+++ b/protocol-designer/src/organisms/GateModal/index.tsx
@@ -9,23 +9,23 @@ import {
   Modal,
   PrimaryButton,
   SPACING,
-  SecondaryButton,
   StyledText,
 } from '@opentrons/components'
 import {
   actions as analyticsActions,
   selectors as analyticsSelectors,
 } from '../../analytics'
+import { OLDEST_MIGRATEABLE_VERSION } from '../../load-file/migration'
 
 const PRIVACY_POLICY_URL = 'https://opentrons.com/privacy-policy'
 const EULA_URL = 'https://opentrons.com/eula'
 
 export function GateModal(): JSX.Element | null {
   const { t } = useTranslation('shared')
-  const hasOptedIn = useSelector(analyticsSelectors.getHasOptedIn)
+  const analytics = useSelector(analyticsSelectors.getHasOptedIn)
   const dispatch = useDispatch()
 
-  if (hasOptedIn == null) {
+  if (analytics.appVersion == null || analytics.hasOptedIn == null) {
     return (
       <Modal
         position="bottomRight"
@@ -36,16 +36,17 @@ export function GateModal(): JSX.Element | null {
             gridGap={SPACING.spacing8}
             padding={SPACING.spacing24}
           >
-            <SecondaryButton
-              onClick={() => dispatch(analyticsActions.optOut())}
+            <PrimaryButton
+              onClick={() =>
+                dispatch(
+                  analyticsActions.optIn(
+                    process.env.OT_PD_VERSION || OLDEST_MIGRATEABLE_VERSION
+                  )
+                )
+              }
             >
               <StyledText desktopStyle="bodyDefaultRegular">
-                {t('reject')}
-              </StyledText>
-            </SecondaryButton>
-            <PrimaryButton onClick={() => dispatch(analyticsActions.optIn())}>
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {t('agree')}
+                {t('confirm')}
               </StyledText>
             </PrimaryButton>
           </Flex>

--- a/protocol-designer/src/organisms/GateModal/index.tsx
+++ b/protocol-designer/src/organisms/GateModal/index.tsx
@@ -15,7 +15,6 @@ import {
   actions as analyticsActions,
   selectors as analyticsSelectors,
 } from '../../analytics'
-import { OLDEST_MIGRATEABLE_VERSION } from '../../load-file/migration'
 
 const PRIVACY_POLICY_URL = 'https://opentrons.com/privacy-policy'
 const EULA_URL = 'https://opentrons.com/eula'
@@ -36,15 +35,7 @@ export function GateModal(): JSX.Element | null {
             gridGap={SPACING.spacing8}
             padding={SPACING.spacing24}
           >
-            <PrimaryButton
-              onClick={() =>
-                dispatch(
-                  analyticsActions.optIn(
-                    process.env.OT_PD_VERSION || OLDEST_MIGRATEABLE_VERSION
-                  )
-                )
-              }
-            >
+            <PrimaryButton onClick={() => dispatch(analyticsActions.optIn())}>
               <StyledText desktopStyle="bodyDefaultRegular">
                 {t('confirm')}
               </StyledText>

--- a/protocol-designer/src/organisms/GateModal/index.tsx
+++ b/protocol-designer/src/organisms/GateModal/index.tsx
@@ -86,9 +86,6 @@ export function GateModal(): JSX.Element | null {
               }}
             />
           </StyledText>
-          <StyledText desktopStyle="bodyDefaultRegular">
-            {t('analytics_tracking')}
-          </StyledText>
         </Flex>
       </Modal>
     )

--- a/protocol-designer/src/pages/Landing/__tests__/Landing.test.tsx
+++ b/protocol-designer/src/pages/Landing/__tests__/Landing.test.tsx
@@ -35,7 +35,10 @@ const render = () => {
 
 describe('Landing', () => {
   beforeEach(() => {
-    vi.mocked(getHasOptedIn).mockReturnValue(false)
+    vi.mocked(getHasOptedIn).mockReturnValue({
+      hasOptedIn: false,
+      appVersion: '8.2.1',
+    })
     vi.mocked(getFileMetadata).mockReturnValue({})
     vi.mocked(loadProtocolFile).mockReturnValue(vi.fn())
     vi.mocked(useAnnouncements).mockReturnValue({} as any)

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -38,7 +38,7 @@ export function Landing(): JSX.Element {
   const [showAnnouncementModal, setShowAnnouncementModal] = useState<boolean>(
     false
   )
-  const hasOptedIn = useSelector(getHasOptedIn)
+  const { hasOptedIn } = useSelector(getHasOptedIn)
   const { bakeToast, eatToast } = useKitchen()
   const announcements = useAnnouncements()
   const lastAnnouncement = announcements[announcements.length - 1]

--- a/protocol-designer/src/pages/Settings/__tests__/Settings.test.tsx
+++ b/protocol-designer/src/pages/Settings/__tests__/Settings.test.tsx
@@ -32,7 +32,10 @@ const render = () => {
 
 describe('Settings', () => {
   beforeEach(() => {
-    vi.mocked(getHasOptedIn).mockReturnValue(false)
+    vi.mocked(getHasOptedIn).mockReturnValue({
+      hasOptedIn: false,
+      appVersion: '8.2.1',
+    })
     vi.mocked(getFeatureFlagData).mockReturnValue({})
     vi.mocked(getCanClearHintDismissals).mockReturnValue(true)
   })

--- a/protocol-designer/src/pages/Settings/index.tsx
+++ b/protocol-designer/src/pages/Settings/index.tsx
@@ -31,6 +31,7 @@ import { BUTTON_LINK_STYLE } from '../../atoms'
 import { actions as featureFlagActions } from '../../feature-flags'
 import { getFeatureFlagData } from '../../feature-flags/selectors'
 import type { FlagTypes } from '../../feature-flags'
+import { OLDEST_MIGRATEABLE_VERSION } from '../../load-file/migration'
 
 const HOT_KEY_FLAG = 'OT_PD_ENABLE_HOT_KEYS_DISPLAY'
 const PRIVACY_POLICY_URL = 'https://opentrons.com/privacy-policy'
@@ -42,12 +43,12 @@ export function Settings(): JSX.Element {
   const [showAnnouncementModal, setShowAnnouncementModal] = useState<boolean>(
     false
   )
-  const hasOptedIn = useSelector(analyticsSelectors.getHasOptedIn)
+  const analytics = useSelector(analyticsSelectors.getHasOptedIn)
   const flags = useSelector(getFeatureFlagData)
   const canClearHintDismissals = useSelector(
     tutorialSelectors.getCanClearHintDismissals
   )
-  const _toggleOptedIn = hasOptedIn
+  const _toggleOptedIn = analytics.hasOptedIn
     ? analyticsActions.optOut
     : analyticsActions.optIn
 
@@ -276,15 +277,21 @@ export function Settings(): JSX.Element {
                   data-testid="analyticsToggle"
                   size="2rem"
                   css={
-                    Boolean(hasOptedIn)
+                    Boolean(analytics.hasOptedIn)
                       ? TOGGLE_ENABLED_STYLES
                       : TOGGLE_DISABLED_STYLES
                   }
-                  onClick={() => dispatch(_toggleOptedIn())}
+                  onClick={() =>
+                    dispatch(
+                      _toggleOptedIn(pdVersion || OLDEST_MIGRATEABLE_VERSION)
+                    )
+                  }
                 >
                   <Icon
                     name={
-                      hasOptedIn ? 'ot-toggle-input-on' : 'ot-toggle-input-off'
+                      analytics.hasOptedIn
+                        ? 'ot-toggle-input-on'
+                        : 'ot-toggle-input-off'
                     }
                     height="1rem"
                   />

--- a/protocol-designer/src/pages/Settings/index.tsx
+++ b/protocol-designer/src/pages/Settings/index.tsx
@@ -31,7 +31,6 @@ import { BUTTON_LINK_STYLE } from '../../atoms'
 import { actions as featureFlagActions } from '../../feature-flags'
 import { getFeatureFlagData } from '../../feature-flags/selectors'
 import type { FlagTypes } from '../../feature-flags'
-import { OLDEST_MIGRATEABLE_VERSION } from '../../load-file/migration'
 
 const HOT_KEY_FLAG = 'OT_PD_ENABLE_HOT_KEYS_DISPLAY'
 const PRIVACY_POLICY_URL = 'https://opentrons.com/privacy-policy'

--- a/protocol-designer/src/pages/Settings/index.tsx
+++ b/protocol-designer/src/pages/Settings/index.tsx
@@ -48,12 +48,10 @@ export function Settings(): JSX.Element {
   const canClearHintDismissals = useSelector(
     tutorialSelectors.getCanClearHintDismissals
   )
-  const _toggleOptedIn = analytics.hasOptedIn
-    ? analyticsActions.optOut
-    : analyticsActions.optIn
+
+  const pdVersion = process.env.OT_PD_VERSION
 
   const prereleaseModeEnabled = flags.PRERELEASE_MODE === true
-  const pdVersion = process.env.OT_PD_VERSION
 
   const allFlags = Object.keys(flags) as FlagTypes[]
 
@@ -283,7 +281,9 @@ export function Settings(): JSX.Element {
                   }
                   onClick={() =>
                     dispatch(
-                      _toggleOptedIn(pdVersion || OLDEST_MIGRATEABLE_VERSION)
+                      analytics.hasOptedIn
+                        ? analyticsActions.optOut()
+                        : analyticsActions.optIn()
                     )
                   }
                 >

--- a/protocol-designer/src/persist.ts
+++ b/protocol-designer/src/persist.ts
@@ -8,7 +8,10 @@ export interface RehydratePersistedAction {
   payload: {
     'tutorial.dismissedHints'?: Record<string, any>
     'featureFlags.flags'?: Record<string, any>
-    'analytics.hasOptedIn'?: boolean | null
+    'analytics.hasOptedIn'?: {
+      hasOptedIn: boolean | null
+      appVersion?: string
+    }
   }
 }
 export const getLocalStorageItem = (path: string): unknown => {


### PR DESCRIPTION
closes AUTH-1142

# Overview

Fix when the opt in modal shows up and also adjust the copy and CTAs.

## Test Plan and Hands on Testing

Test that this works in your dev env with the gate modal ff turned on like so: `make -C protocol-designer dev OT_PD_SHOW_GATE=true`. Test that if you select to accept and then go to the settings to toggle it off, it doesn't show up again unless you clear local cache.

## Changelog

update modal to match designs

code wise, i added an appVersion prop to the opt_in action. If the appVersion is undefined, it will trigger the modal. also if the opt_in is null, it will trigger the modal. i believe this should force the user to see the modal even if they previously selected false.

## Risk assessment

low