### PR TITLE
fix(app): Fix run start/finish protocol analytics

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/useRunHeaderModalContainer.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/useRunHeaderModalContainer.ts
@@ -16,9 +16,15 @@ import { useProtocolDetailsForRun } from '/app/resources/runs'
 import { getFallbackRobotSerialNumber } from '../utils'
 import {
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
+  ANALYTICS_PROTOCOL_RUN_ACTION,
   useTrackEvent,
 } from '/app/redux/analytics'
+import {
+  useRobotAnalyticsData,
+  useTrackProtocolRunEvent,
+} from '/app/redux-resources/analytics'
 import { useRobot, useRobotType } from '/app/redux-resources/robots'
+
 import type { AttachedModule, RunStatus, Run } from '@opentrons/api-client'
 import type { UseErrorRecoveryResult } from '/app/organisms/ErrorRecoveryFlows'
 import type {
@@ -71,13 +77,19 @@ export function useRunHeaderModalContainer({
   const robot = useRobot(robotName)
   const robotSerialNumber = getFallbackRobotSerialNumber(robot)
   const trackEvent = useTrackEvent()
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const robotType = useRobotType(robotName)
+  const robotAnalyticsData = useRobotAnalyticsData(robotName)
 
   function handleProceedToRunClick(): void {
     navigate(`/devices/${robotName}/protocol-runs/${runId}/run-preview`)
     trackEvent({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
       properties: { robotSerialNumber },
+    })
+    trackProtocolRunEvent({
+      name: ANALYTICS_PROTOCOL_RUN_ACTION.START,
+      properties: robotAnalyticsData ?? {},
     })
     protocolRunControls.play()
   }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/hooks/useRunAnalytics.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/hooks/useRunAnalytics.ts
@@ -28,15 +28,12 @@ export function useRunAnalytics({
 
   useEffect(() => {
     const areReportConditionsValid =
-      isRunCurrent &&
-      runId != null &&
-      robotAnalyticsData != null &&
-      isTerminalRunStatus(runStatus)
+      isRunCurrent && runId != null && isTerminalRunStatus(runStatus)
 
     if (areReportConditionsValid) {
       trackProtocolRunEvent({
         name: ANALYTICS_PROTOCOL_RUN_ACTION.FINISH,
-        properties: robotAnalyticsData,
+        properties: robotAnalyticsData ?? undefined,
       })
     }
   }, [runStatus, isRunCurrent, runId, robotAnalyticsData])

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -576,7 +576,6 @@ describe('ProtocolSetup', () => {
     render(`/runs/${RUN_ID}/setup/`)
 
     fireEvent.click(screen.getByRole('button', { name: 'play' }))
-    expect(mockTrackProtocolRunEvent).toBeCalledTimes(1)
     expect(mockTrackProtocolRunEvent).toHaveBeenCalledWith({
       name: ANALYTICS_PROTOCOL_RUN_ACTION.START,
       properties: {},

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -741,10 +741,18 @@ export function ProtocolSetup(): JSX.Element {
     robotType,
     protocolName
   )
+
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
+  const robotAnalyticsData = useRobotAnalyticsData(robotName)
+
   const handleProceedToRunClick = (): void => {
     trackEvent({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
       properties: { robotSerialNumber },
+    })
+    trackProtocolRunEvent({
+      name: ANALYTICS_PROTOCOL_RUN_ACTION.START,
+      properties: robotAnalyticsData ?? {},
     })
     play()
   }

--- a/app/src/redux-resources/analytics/hooks/__tests__/useTrackProtocolRunEvent.test.tsx
+++ b/app/src/redux-resources/analytics/hooks/__tests__/useTrackProtocolRunEvent.test.tsx
@@ -2,7 +2,7 @@ import type * as React from 'react'
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 import { QueryClient, QueryClientProvider } from 'react-query'
-import { vi, it, expect, describe, beforeEach, afterEach } from 'vitest'
+import { vi, it, expect, describe, beforeEach } from 'vitest'
 import { when } from 'vitest-when'
 import { waitFor, renderHook } from '@testing-library/react'
 
@@ -63,10 +63,6 @@ describe('useTrackProtocolRunEvent hook', () => {
       })
   })
 
-  afterEach(() => {
-    vi.resetAllMocks()
-  })
-
   it('returns trackProtocolRunEvent function', () => {
     const { result } = renderHook(
       () => useTrackProtocolRunEvent(RUN_ID, ROBOT_NAME),
@@ -92,7 +88,7 @@ describe('useTrackProtocolRunEvent hook', () => {
     )
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: ANALYTICS_PROTOCOL_RUN_ACTION.START,
-      properties: PROTOCOL_PROPERTIES,
+      properties: { ...PROTOCOL_PROPERTIES, transactionId: RUN_ID },
     })
   })
 

--- a/app/src/redux-resources/analytics/hooks/useTrackProtocolRunEvent.ts
+++ b/app/src/redux-resources/analytics/hooks/useTrackProtocolRunEvent.ts
@@ -34,6 +34,9 @@ export function useTrackProtocolRunEvent(
             ...properties,
             ...protocolRunAnalyticsData,
             runTime,
+            // It's sometimes unavoidable (namely on the desktop app) to prevent sending an event multiple times.
+            // In these circumstances, we need an idempotency key to accurately filter events in Mixpanel.
+            transactionId: runId,
           },
         })
       })


### PR DESCRIPTION
Closes [EXEC-850](https://opentrons.atlassian.net/browse/EXEC-850) and [EXEC-805](https://opentrons.atlassian.net/browse/EXEC-805)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR addresses a couple issues with run-based analytics.

a1b47b7fe90030c0f04c7adffd7306dfb37a31cb - On the desktop app, we do not tie analytic reporting directly to CTAs, since users can navigate away/back to a specific robot over the course of a run. Because run-based analytics are coupled to certain side-effects, it's possible for a side effect to occur, triggering an analytic, then a user navigates away and back to the same run, causing the same analytic event to fire again, resulting in overreporting certain events. Unfortunately, the Mixpanel API does not provide any built-in idempotency key solution, but it is possible to filter events by any property to display "one time by that property only", effectively acting as an idempotency key of sorts. After talking with Product, they were comfortable filtering by a specific property. For run time events, the idempotency key is simple: just use the `runId`. 

ec5a32f3d61d57831793c6dbcfc3eb0f13d44319 & e836661d832012dc9e93eeead6e85f53388d6688- Woops, if a user was prompted that they hadn't completed run setup and they decided to start the run anyway, we weren't capturing this event. 

3c81fe53d13d6dae2665029c903da65d5195d85d - Minor cleanup. Just harmonize the conditional behavior on the desktop/ODD.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Hard to test because it's analytics. Hope to look at analytics in the 8.3 alphas to confirm it's working as expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Improved run start and finished analytics reporting.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-850]: https://opentrons.atlassian.net/browse/EXEC-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-805]: https://opentrons.atlassian.net/browse/EXEC-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ