### PR TITLE
fix(protocol-designer): heater shaker timer field is a boolean instea…

### DIFF
--- a/protocol-designer/src/molecules/ToggleExpandStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/ToggleExpandStepFormField/index.tsx
@@ -62,11 +62,7 @@ export function ToggleExpandStepFormField(
         resetFieldValue()
       }
     } else if (toggleValue == null) {
-      toggleUpdateValue(
-        name === 'targetTemperature' || name === 'heaterShakerTimer'
-          ? 'true'
-          : true
-      )
+      toggleUpdateValue(name === 'targetTemperature' ? 'true' : true)
     } else {
       toggleUpdateValue(!toggleValue)
       if (toggleValue) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/HeaterShakerTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/HeaterShakerTools/index.tsx
@@ -103,7 +103,7 @@ export function HeaterShakerTools(props: StepFormProps): JSX.Element {
             'form:step_edit_form.field.heaterShaker.timer.heaterShakerSetTimer'
           )}
           fieldTitle={t('form:step_edit_form.field.heaterShaker.duration')}
-          isSelected={formData.heaterShakerSetTimer === 'true'}
+          isSelected={formData.heaterShakerSetTimer === true}
           units={t('application:units.time')}
           toggleElement="checkbox"
           formLevelError={getFormLevelError(


### PR DESCRIPTION
…d of boolean string

closes RQA-3794

# Overview

the heater shaker set timer is a true boolean instead of a boolean string. fix it in the checkbox.

## Test Plan and Hands on Testing

Import the attached protocol and see that the heater-shaker step checks the timer box. Create another heater-shaker step and see that the checkbox is checkable

[RQA-3794 with Older OldeR PD .json](https://github.com/user-attachments/files/18156600/RQA-3794.with.Older.OldeR.PD.json)


## Changelog

fix field type

## Risk assessment

low