### PR TITLE
fix(app): fix back to back manual move commands on desktop app

### DIFF
--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -191,7 +191,6 @@ export function MoveLabwareInterventionContent({
         <Flex width="50%">
           <Box margin="0 auto" width="100%">
             <MoveLabwareOnDeck
-              key={command.id} // important so that back to back move labware commands bust the cache
               robotType={robotType}
               deckFill={isOnDevice ? COLORS.grey35 : '#e6e6e6'}
               initialLabwareLocation={oldLabwareLocation}

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -191,7 +191,10 @@ export function MoveLabwareOnDeck(
       loadedLabware,
     }) ?? offDeckPosition
 
+  const shouldReset = usePositionChangeReset(initialPosition, finalPosition)
+
   const springProps = useSpring({
+    reset: shouldReset,
     config: { duration: 1000, easing: easings.easeInOutSine },
     from: {
       ...initialPosition,
@@ -245,6 +248,37 @@ export function MoveLabwareOnDeck(
   )
 }
 
+function usePositionChangeReset(
+  initialPosition: { x: number; y: number },
+  finalPosition: { x: number; y: number }
+): boolean {
+  const [shouldReset, setShouldReset] = React.useState(false)
+
+  React.useLayoutEffect(() => {
+    if (shouldReset) {
+      setShouldReset(false)
+      return
+    }
+
+    const isNewPosition =
+      previousInitialRef.current?.x !== initialPosition.x ||
+      previousInitialRef.current?.y !== initialPosition.y ||
+      previousFinalRef.current?.x !== finalPosition.x ||
+      previousFinalRef.current?.y !== finalPosition.y
+
+    if (isNewPosition) {
+      setShouldReset(true)
+    }
+
+    previousInitialRef.current = initialPosition
+    previousFinalRef.current = finalPosition
+  }, [initialPosition, finalPosition])
+
+  const previousInitialRef = React.useRef(initialPosition)
+  const previousFinalRef = React.useRef(finalPosition)
+
+  return shouldReset
+}
 /**
  * These animated components needs to be split out because react-spring and styled-components don't play nice
  * @see https://github.com/pmndrs/react-spring/issues/1515 */


### PR DESCRIPTION
Closes [RQA-3728](https://opentrons.atlassian.net/browse/RQA-3728)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Since the introduction of the move labware intervention deck map, chaining back to back move interventions has posed a challenge, see comments in https://github.com/Opentrons/opentrons/pull/13005. 

The `setTimeout` solution proposed in the linked PR effectively worked, and this code looks like it got dropped at some point. However, there are other ways of doing the same thing that are more React Spring-esque, using the API's `reset` property.


### Current Behavior

https://github.com/user-attachments/assets/24284a3b-d116-4132-be90-7ed568798dd8

### Fixed Behavior

https://github.com/user-attachments/assets/cc121efb-eaf4-42dc-b2a9-94eeb8d7088c



<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video. Verified using QA's protocol probably like 20 times.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed back-to-back intervention modals sometimes moving labware to interesting places.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3728]: https://opentrons.atlassian.net/browse/RQA-3728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ