### PR TITLE
feat(api): add execution of dispense steps for liquid class based transfer

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1013,7 +1013,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
                 liquid=0,
                 air_gap=0,
             )
-        components_executer = tx_comps_executor.TransferComponentsExecutor(
+        components_executor = tx_comps_executor.TransferComponentsExecutor(
             instrument_core=self,
             transfer_properties=transfer_properties,
             target_location=aspirate_location,
@@ -1040,10 +1040,10 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         self,
         volume: float,
         dest: Tuple[Location, WellCore],
+        source: Optional[Tuple[Location, WellCore]],
         transfer_properties: TransferProperties,
         transfer_type: tx_comps_executor.TransferType,
         tip_contents: List[tx_comps_executor.LiquidAndAirGapPair],
-        source: Optional[Tuple[Location, WellCore]],
         trash_location: Union[Location, TrashBin, WasteChute],
     ) -> tx_comps_executor.LiquidAndAirGapPair:
         """Execute single-dispense steps.
@@ -1092,7 +1092,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
                 liquid=0,
                 air_gap=0,
             )
-        components_executor = tx_comps_executor.get_transfer_components_executor(
+        components_executor = tx_comps_executor.TransferComponentsExecutor(
             instrument_core=self,
             transfer_properties=transfer_properties,
             target_location=dispense_location,

--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -333,7 +333,7 @@ class TransferComponentsExecutor:
             )
         )
 
-    def retract_after_dispensing(
+    def retract_after_dispensing(  # noqa: C901
         self,
         trash_location: Union[Location, TrashBin, WasteChute],
         source_location: Optional[Location],

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -319,7 +319,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         dest: List[Tuple[types.Location, WellCoreType]],
         new_tip: TransferTipPolicyV2,
         tiprack_uri: str,
-        trash_location: Union[WellCoreType, types.Location, TrashBin, WasteChute],
+        trash_location: Union[types.Location, TrashBin, WasteChute],
     ) -> None:
         """Transfer a liquid from source to dest according to liquid class properties."""
         ...

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -564,7 +564,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
         dest: List[Tuple[types.Location, LegacyWellCore]],
         new_tip: TransferTipPolicyV2,
         tiprack_uri: str,
-        trash_location: Union[LegacyWellCore, types.Location, TrashBin, WasteChute],
+        trash_location: Union[types.Location, TrashBin, WasteChute],
     ) -> None:
         """This will never be called because it was added in .."""
         # TODO(spp, 2024-11-20): update the docstring and error to include API version

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -482,7 +482,7 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
         dest: List[Tuple[types.Location, LegacyWellCore]],
         new_tip: TransferTipPolicyV2,
         tiprack_uri: str,
-        trash_location: Union[LegacyWellCore, types.Location, TrashBin, WasteChute],
+        trash_location: Union[types.Location, TrashBin, WasteChute],
     ) -> None:
         """Transfer a liquid from source to dest according to liquid class properties."""
         # TODO(spp, 2024-11-20): update the docstring and error to include API version

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1520,7 +1520,7 @@ class InstrumentContext(publisher.CommandPublisher):
             labware.Well, Sequence[labware.Well], Sequence[Sequence[labware.Well]]
         ],
         new_tip: TransferTipPolicyV2Type = "once",
-        tip_drop_location: Optional[
+        trash_location: Optional[
             Union[types.Location, labware.Well, TrashBin, WasteChute]
         ] = None,
     ) -> InstrumentContext:
@@ -1578,19 +1578,17 @@ class InstrumentContext(publisher.CommandPublisher):
             )
 
         _trash_location: Union[types.Location, labware.Well, TrashBin, WasteChute]
-        if tip_drop_location is None:
+        if trash_location is None:
             saved_trash = self.trash_container
             if isinstance(saved_trash, labware.Labware):
                 _trash_location = saved_trash.wells()[0]
             else:
                 _trash_location = saved_trash
         else:
-            _trash_location = tip_drop_location
+            _trash_location = trash_location
 
-        checked_trash_location = (
-            validation.ensure_valid_tip_drop_location_for_transfer_v2(
-                tip_drop_location=_trash_location
-            )
+        checked_trash_location = validation.ensure_valid_trash_location_for_transfer_v2(
+            trash_location=_trash_location
         )
         self._core.transfer_liquid(
             liquid_class=liquid_class,
@@ -1605,11 +1603,7 @@ class InstrumentContext(publisher.CommandPublisher):
             ],
             new_tip=valid_new_tip,
             tiprack_uri=tiprack.uri,
-            trash_location=(
-                checked_trash_location._core
-                if isinstance(checked_trash_location, labware.Well)
-                else checked_trash_location
-            ),
+            trash_location=checked_trash_location,
         )
         return self
 

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -32,6 +32,7 @@ from opentrons.types import (
     AxisType,
     AxisMapType,
     StringAxisMap,
+    Point,
 )
 from opentrons.hardware_control.modules.types import (
     ModuleModel,
@@ -713,20 +714,18 @@ def ensure_valid_flat_wells_list_for_transfer_v2(
         )
 
 
-def ensure_valid_tip_drop_location_for_transfer_v2(
-    tip_drop_location: Union[Location, Well, TrashBin, WasteChute]
-) -> Union[Location, Well, TrashBin, WasteChute]:
-    """Ensure that the tip drop location is valid for v2 transfer."""
+def ensure_valid_trash_location_for_transfer_v2(
+    trash_location: Union[Location, Well, TrashBin, WasteChute]
+) -> Union[Location, TrashBin, WasteChute]:
+    """Ensure that the trash location is valid for v2 transfer."""
     from .labware import Well
 
-    if (
-        isinstance(tip_drop_location, Well)
-        or isinstance(tip_drop_location, TrashBin)
-        or isinstance(tip_drop_location, WasteChute)
-    ):
-        return tip_drop_location
-    elif isinstance(tip_drop_location, Location):
-        _, maybe_well = tip_drop_location.labware.get_parent_labware_and_well()
+    if isinstance(trash_location, TrashBin) or isinstance(trash_location, WasteChute):
+        return trash_location
+    elif isinstance(trash_location, Well):
+        return Location(Point(), labware=trash_location)
+    elif isinstance(trash_location, Location):
+        _, maybe_well = trash_location.labware.get_parent_labware_and_well()
 
         if maybe_well is None:
             raise TypeError(
@@ -736,11 +735,11 @@ def ensure_valid_tip_drop_location_for_transfer_v2(
                 " since that is where a tip is dropped."
                 " However, the given location doesn't refer to any well."
             )
-        return tip_drop_location
+        return trash_location
     else:
         raise TypeError(
             f"If specified, location should be an instance of"
             f" `types.Location` (e.g. the return value from `Well.top()`)"
             f" or `Well` (e.g. `reservoir.wells()[0]`) or an instance of `TrashBin` or `WasteChute`."
-            f" However, it is '{tip_drop_location}'."
+            f" However, it is '{trash_location}'."
         )

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -951,7 +951,7 @@ def maximal_liquid_class_def() -> LiquidClassSchemaV1:
                                     ),
                                 ),
                                 delay=DelayProperties(
-                                    enable=False, params=DelayParams(duration=0)
+                                    enable=True, params=DelayParams(duration=10)
                                 ),
                             ),
                             positionReference=PositionReference.WELL_BOTTOM,

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -22,7 +22,6 @@ from opentrons.protocol_api.core.engine.transfer_components_executor import (
     TransferComponentsExecutor,
     TransferType,
     TipState,
-    LiquidAndAirGapPair,
 )
 from opentrons.protocol_engine import (
     DeckPoint,

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -20,6 +20,9 @@ from opentrons.protocol_api._liquid_properties import TransferProperties
 from opentrons.protocol_api.core.engine import transfer_components_executor
 from opentrons.protocol_api.core.engine.transfer_components_executor import (
     TransferComponentsExecutor,
+    TransferType,
+    TipState,
+    LiquidAndAirGapPair,
 )
 from opentrons.protocol_engine import (
     DeckPoint,
@@ -1621,6 +1624,8 @@ def test_aspirate_liquid_class(
             transfer_properties=test_transfer_properties,
             target_location=Location(Point(1, 2, 3), labware=None),
             target_well=source_well,
+            transfer_type=TransferType.ONE_TO_ONE,
+            tip_state=TipState(),
         )
     ).then_return(mock_transfer_components_executor)
     decoy.when(
@@ -1630,14 +1635,16 @@ def test_aspirate_liquid_class(
         volume=123,
         source=(source_location, source_well),
         transfer_properties=test_transfer_properties,
+        transfer_type=TransferType.ONE_TO_ONE,
+        tip_contents=[],
     )
     decoy.verify(
         mock_transfer_components_executor.submerge(
             submerge_properties=test_transfer_properties.aspirate.submerge,
-            air_gap_volume=111,
         ),
         mock_transfer_components_executor.mix(
-            mix_properties=test_transfer_properties.aspirate.mix
+            mix_properties=test_transfer_properties.aspirate.mix,
+            last_dispense_push_out=False,
         ),
         mock_transfer_components_executor.pre_wet(volume=123),
         mock_transfer_components_executor.aspirate_and_wait(volume=123),

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -22,6 +22,7 @@ from opentrons.protocol_api.core.engine.transfer_components_executor import (
     TransferComponentsExecutor,
     TransferType,
     TipState,
+    LiquidAndAirGapPair,
 )
 from opentrons.protocol_engine import (
     DeckPoint,
@@ -1628,9 +1629,9 @@ def test_aspirate_liquid_class(
         )
     ).then_return(mock_transfer_components_executor)
     decoy.when(
-        mock_engine_client.state.pipettes.get_aspirated_volume("abc123")
-    ).then_return(111)
-    subject.aspirate_liquid_class(
+        mock_transfer_components_executor.tip_state.last_liquid_and_air_gap_in_tip
+    ).then_return(LiquidAndAirGapPair(liquid=111, air_gap=222))
+    result = subject.aspirate_liquid_class(
         volume=123,
         source=(source_location, source_well),
         transfer_properties=test_transfer_properties,
@@ -1649,3 +1650,73 @@ def test_aspirate_liquid_class(
         mock_transfer_components_executor.aspirate_and_wait(volume=123),
         mock_transfer_components_executor.retract_after_aspiration(volume=123),
     )
+    assert result == LiquidAndAirGapPair(air_gap=222, liquid=111)
+
+
+def test_dispense_liquid_class(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: InstrumentCore,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+    mock_transfer_components_executor: TransferComponentsExecutor,
+) -> None:
+    """It should call dispense sub-steps execution based on liquid class."""
+    source_well = decoy.mock(cls=WellCore)
+    source_location = Location(Point(1, 2, 3), labware=None)
+    dest_well = decoy.mock(cls=WellCore)
+    dest_location = Location(Point(3, 2, 1), labware=None)
+    test_liquid_class = LiquidClass.create(minimal_liquid_class_def2)
+    test_transfer_properties = test_liquid_class.get_for(
+        "flex_1channel_50", "opentrons_flex_96_tiprack_50ul"
+    )
+    push_out_vol = test_transfer_properties.dispense.push_out_by_volume.get_for_volume(
+        123
+    )
+    decoy.when(
+        transfer_components_executor.absolute_point_from_position_reference_and_offset(
+            well=dest_well,
+            position_reference=PositionReference.WELL_BOTTOM,
+            offset=Coordinate(x=0, y=0, z=-5),
+        )
+    ).then_return(Point(1, 2, 3))
+    decoy.when(
+        transfer_components_executor.TransferComponentsExecutor(
+            instrument_core=subject,
+            transfer_properties=test_transfer_properties,
+            target_location=Location(Point(1, 2, 3), labware=None),
+            target_well=dest_well,
+            transfer_type=TransferType.ONE_TO_ONE,
+            tip_state=TipState(),
+        )
+    ).then_return(mock_transfer_components_executor)
+    decoy.when(
+        mock_transfer_components_executor.tip_state.last_liquid_and_air_gap_in_tip
+    ).then_return(LiquidAndAirGapPair(liquid=333, air_gap=444))
+    result = subject.dispense_liquid_class(
+        volume=123,
+        dest=(dest_location, dest_well),
+        source=(source_location, source_well),
+        transfer_properties=test_transfer_properties,
+        transfer_type=TransferType.ONE_TO_ONE,
+        tip_contents=[],
+        trash_location=Location(Point(1, 2, 3), labware=None),
+    )
+    decoy.verify(
+        mock_transfer_components_executor.submerge(
+            submerge_properties=test_transfer_properties.dispense.submerge,
+        ),
+        mock_transfer_components_executor.dispense_and_wait(
+            volume=123,
+            push_out_override=push_out_vol,
+        ),
+        mock_transfer_components_executor.mix(
+            mix_properties=test_transfer_properties.dispense.mix,
+            last_dispense_push_out=True,
+        ),
+        mock_transfer_components_executor.retract_after_dispensing(
+            trash_location=Location(Point(1, 2, 3), labware=None),
+            source_location=source_location,
+            source_well=source_well,
+        ),
+    )
+    assert result == LiquidAndAirGapPair(air_gap=444, liquid=333)

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -16,7 +16,6 @@ from opentrons.protocol_api.core.engine.transfer_components_executor import (
     absolute_point_from_position_reference_and_offset,
     TipState,
     TransferType,
-    LiquidAndAirGapPair,
 )
 from opentrons.types import Location, Point
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -14,6 +14,9 @@ from opentrons.protocol_api.core.engine.instrument import InstrumentCore
 from opentrons.protocol_api.core.engine.transfer_components_executor import (
     TransferComponentsExecutor,
     absolute_point_from_position_reference_and_offset,
+    TipState,
+    TransferType,
+    LiquidAndAirGapPair,
 )
 from opentrons.types import Location, Point
 
@@ -75,14 +78,13 @@ def test_submerge(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
     decoy.when(source_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(source_well.get_top(0)).then_return(well_top_point)
 
-    subject.submerge(
-        submerge_properties=sample_transfer_props.aspirate.submerge,
-        air_gap_volume=123,
-    )
+    subject.submerge(submerge_properties=sample_transfer_props.aspirate.submerge)
 
     decoy.verify(
         mock_instrument_core.move_to(
@@ -130,6 +132,8 @@ def test_aspirate_and_wait(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 2, 3), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
     subject.aspirate_and_wait(volume=10)
     decoy.verify(
@@ -160,6 +164,8 @@ def test_aspirate_and_wait_skips_delay(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 2, 3), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
     subject.aspirate_and_wait(volume=10)
     decoy.verify(
@@ -184,8 +190,10 @@ def test_dispense_and_wait(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 2, 3), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
-    subject.dispense_and_wait(volume=10, push_out=123)
+    subject.dispense_and_wait(volume=10, push_out_override=123)
     decoy.verify(
         mock_instrument_core.dispense(
             location=Location(Point(1, 2, 3), labware=None),
@@ -215,8 +223,10 @@ def test_dispense_and_wait_skips_delay(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 2, 3), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
-    subject.dispense_and_wait(volume=10, push_out=123)
+    subject.dispense_and_wait(volume=10, push_out_override=123)
     decoy.verify(
         mock_instrument_core.delay(0.2),
         times=0,
@@ -241,8 +251,13 @@ def test_mix(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 2, 3), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
-    subject.mix(mix_properties=sample_transfer_props.aspirate.mix)
+    subject.mix(
+        mix_properties=sample_transfer_props.aspirate.mix,
+        last_dispense_push_out=True,
+    )
 
     decoy.verify(
         mock_instrument_core.aspirate(
@@ -262,7 +277,7 @@ def test_mix(
             rate=1,
             flow_rate=dispense_flow_rate,
             in_place=True,
-            push_out=0,
+            push_out=2.0,
             is_meniscus=None,
         ),
         mock_instrument_core.delay(0.5),
@@ -285,8 +300,13 @@ def test_mix_disabled(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 2, 3), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
-    subject.mix(mix_properties=sample_transfer_props.aspirate.mix)
+    subject.mix(
+        mix_properties=sample_transfer_props.aspirate.mix,
+        last_dispense_push_out=True,
+    )
     decoy.verify(
         mock_instrument_core.aspirate(
             location=Location(Point(1, 2, 3), labware=None),
@@ -319,6 +339,8 @@ def test_pre_wet(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 2, 3), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
     subject.pre_wet(volume=40)
 
@@ -363,6 +385,8 @@ def test_pre_wet_disabled(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 2, 3), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
     subject.pre_wet(volume=40)
 
@@ -399,6 +423,8 @@ def test_retract_after_aspiration(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 1, 1), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
     decoy.when(source_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(source_well.get_top(0)).then_return(well_top_point)
@@ -458,6 +484,8 @@ def test_retract_after_aspiration_without_touch_tip_and_delay(
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 1, 1), labware=None),
         target_well=source_well,
+        tip_state=TipState(),
+        transfer_type=TransferType.ONE_TO_ONE,
     )
     decoy.when(source_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(source_well.get_top(0)).then_return(well_top_point)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1974,7 +1974,7 @@ def test_transfer_liquid_delegates_to_engine_core(
     ).then_return((next_tiprack, decoy.mock(cls=Well)))
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(
-        mock_validation.ensure_valid_tip_drop_location_for_transfer_v2(trash_location)
+        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
     ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
@@ -1984,7 +1984,7 @@ def test_transfer_liquid_delegates_to_engine_core(
         source=[mock_well],
         dest=[mock_well],
         new_tip="never",
-        tip_drop_location=trash_location,
+        trash_location=trash_location,
     )
     decoy.verify(
         mock_instrument_core.transfer_liquid(

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -842,19 +842,17 @@ def test_ensure_valid_tip_drop_location_for_transfer_v2(
     mock_location = Location(point=Point(x=1, y=1, z=1), labware=mock_well)
     mock_trash_bin = decoy.mock(cls=TrashBin)
     mock_waste_chute = decoy.mock(cls=WasteChute)
+    assert subject.ensure_valid_trash_location_for_transfer_v2(mock_well) == mock_well
     assert (
-        subject.ensure_valid_tip_drop_location_for_transfer_v2(mock_well) == mock_well
-    )
-    assert (
-        subject.ensure_valid_tip_drop_location_for_transfer_v2(mock_location)
+        subject.ensure_valid_trash_location_for_transfer_v2(mock_location)
         == mock_location
     )
     assert (
-        subject.ensure_valid_tip_drop_location_for_transfer_v2(mock_trash_bin)
+        subject.ensure_valid_trash_location_for_transfer_v2(mock_trash_bin)
         == mock_trash_bin
     )
     assert (
-        subject.ensure_valid_tip_drop_location_for_transfer_v2(mock_waste_chute)
+        subject.ensure_valid_trash_location_for_transfer_v2(mock_waste_chute)
         == mock_waste_chute
     )
 
@@ -862,15 +860,19 @@ def test_ensure_valid_tip_drop_location_for_transfer_v2(
 def test_ensure_valid_tip_drop_location_for_transfer_v2_raises(decoy: Decoy) -> None:
     """It should raise an error for invalid tip drop locations."""
     with pytest.raises(TypeError, match="However, it is '\\['a'\\]'"):
-        subject.ensure_valid_tip_drop_location_for_transfer_v2(["a"])  # type: ignore[arg-type]
+        subject.ensure_valid_trash_location_for_transfer_v2(
+            ["a"]  # type: ignore[arg-type]
+        )
 
     mock_labware = decoy.mock(cls=Labware)
     with pytest.raises(TypeError, match=f"However, it is '{mock_labware}'"):
-        subject.ensure_valid_tip_drop_location_for_transfer_v2(mock_labware)  # type: ignore[arg-type]
+        subject.ensure_valid_trash_location_for_transfer_v2(
+            mock_labware  # type: ignore[arg-type]
+        )
 
     with pytest.raises(
         TypeError, match="However, the given location doesn't refer to any well."
     ):
-        subject.ensure_valid_tip_drop_location_for_transfer_v2(
+        subject.ensure_valid_trash_location_for_transfer_v2(
             Location(point=Point(x=1, y=1, z=1), labware=None)
         )

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -834,15 +834,17 @@ def test_ensure_valid_flat_wells_list(decoy: Decoy) -> None:
     ) == [target1, target1, target2, target2]
 
 
-def test_ensure_valid_tip_drop_location_for_transfer_v2(
+def test_ensure_valid_trash_location_for_transfer_v2(
     decoy: Decoy,
 ) -> None:
-    """It should check that the tip drop location is valid."""
+    """It should check that the trash location is valid."""
     mock_well = decoy.mock(cls=Well)
     mock_location = Location(point=Point(x=1, y=1, z=1), labware=mock_well)
     mock_trash_bin = decoy.mock(cls=TrashBin)
     mock_waste_chute = decoy.mock(cls=WasteChute)
-    assert subject.ensure_valid_trash_location_for_transfer_v2(mock_well) == mock_well
+    assert subject.ensure_valid_trash_location_for_transfer_v2(mock_well) == Location(
+        Point(0, 0, 0), labware=mock_well
+    )
     assert (
         subject.ensure_valid_trash_location_for_transfer_v2(mock_location)
         == mock_location
@@ -857,8 +859,8 @@ def test_ensure_valid_tip_drop_location_for_transfer_v2(
     )
 
 
-def test_ensure_valid_tip_drop_location_for_transfer_v2_raises(decoy: Decoy) -> None:
-    """It should raise an error for invalid tip drop locations."""
+def test_ensure_valid_trash_location_for_transfer_v2_raises(decoy: Decoy) -> None:
+    """It should raise an error for invalid trash locations."""
     with pytest.raises(TypeError, match="However, it is '\\['a'\\]'"):
         subject.ensure_valid_trash_location_for_transfer_v2(
             ["a"]  # type: ignore[arg-type]


### PR DESCRIPTION
Closes AUTH-1246. Requirement for AUTH-866

# Overview

Part 2 of the three-part series of implementing transfer function.

This PR adds `InstrumentCore.dispense_liquid_class()` which utilizes the `TransferComponentsExecutor` to execute the dispense steps in specific order. `dispense_liquid_class()` will then be utilized by the `InstrumentCore.transfer_liquid()` method to perform dispense during each transfer step. This method can also be accessed in the protocol by using private API accessors for testing purposes. 

Changes to `TransferComponentsExecutor`:

1. adds `retract_after_dispensing()` to execute post-dispense retraction steps
2. adds a tip state tracker to the class in order to keep track of whether the pipette is 'ready to aspirate' and also track the liquid and air gap in the tip that either the single aspirate or dispense steps will be handling.

## Test Plan and Hands on Testing

- Integrated and on-robot testing will have to wait until this implementation is wired up to the public API
- Added unit tests for all new functions and classes

## Review requests

- Some suggestions from the aspirate PR will still hold to this PR- eg, naming of `TransferComponentsExecutor`. Those will be addressed in the final PR. But let me know if there are any critical changes that should be made here.
- Usual code review stuff

## Risk assessment

Low. Makes no changes to the existing code.
