### PR TITLE
refactor(robot-server): Delete obsolete workarounds for discriminated unions in Pydantic v1

### DIFF
--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -28,17 +28,6 @@ _DEFAULT_COMMAND_LIST_LENGTH: Final = 20
 commands_router = APIRouter()
 
 
-class RequestModelWithStatelessCommandCreate(RequestModel[StatelessCommandCreate]):
-    """Equivalent to RequestModel[StatelessCommandCreate].
-
-    This works around a Pydantic v<2 bug where RequestModel[StatelessCommandCreate]
-    doesn't parse using the StatelessCommandCreate union discriminator.
-    https://github.com/pydantic/pydantic/issues/3782
-    """
-
-    data: StatelessCommandCreate
-
-
 class CommandNotFound(ErrorDetails):
     """An error returned if the given command cannot be found."""
 
@@ -63,7 +52,7 @@ class CommandNotFound(ErrorDetails):
     },
 )
 async def create_command(
-    request_body: RequestModelWithStatelessCommandCreate,
+    request_body: RequestModel[StatelessCommandCreate],
     orchestrator: Annotated[RunOrchestrator, Depends(get_default_orchestrator)],
     waitUntilComplete: Annotated[
         bool,

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -17,10 +17,10 @@ from robot_server.service.json_api import (
     MultiBody,
     MultiBodyMeta,
     PydanticResponse,
+    RequestModel,
 )
 from robot_server.robot.control.dependencies import require_estop_in_good_state
 from robot_server.runs.command_models import (
-    RequestModelWithCommandCreate,
     CommandCollectionLinks,
     CommandLink,
     CommandLinkMeta,
@@ -99,7 +99,7 @@ async def get_current_run_from_url(
     },
 )
 async def create_run_command(
-    request_body: RequestModelWithCommandCreate,
+    request_body: RequestModel[pe_commands.CommandCreate],
     run_orchestrator_store: Annotated[
         MaintenanceRunOrchestratorStore, Depends(get_maintenance_run_orchestrator_store)
     ],

--- a/robot-server/robot_server/runs/command_models.py
+++ b/robot-server/robot_server/runs/command_models.py
@@ -8,21 +8,6 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from opentrons.protocol_engine import commands as pe_commands
-
-from robot_server.service.json_api.request import RequestModel
-
-
-class RequestModelWithCommandCreate(RequestModel[pe_commands.CommandCreate]):
-    """Equivalent to RequestModel[CommandCreate].
-
-    This works around a Pydantic v<2 bug where RequestModel[CommandCreate]
-    doesn't parse using the CommandCreate union discriminator.
-    https://github.com/pydantic/pydantic/issues/3782
-    """
-
-    data: pe_commands.CommandCreate
-
 
 class CommandLinkMeta(BaseModel):
     """Metadata about a command resource referenced in `links`."""

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -17,11 +17,11 @@ from robot_server.service.json_api import (
     MultiBodyMeta,
     PydanticResponse,
     SimpleMultiBody,
+    RequestModel,
 )
 from robot_server.robot.control.dependencies import require_estop_in_good_state
 
 from ..command_models import (
-    RequestModelWithCommandCreate,
     CommandCollectionLinks,
     CommandLink,
     CommandLinkMeta,
@@ -155,7 +155,7 @@ async def get_current_run_from_url(
     },
 )
 async def create_run_command(
-    request_body: RequestModelWithCommandCreate,
+    request_body: RequestModel[pe_commands.CommandCreate],
     run_orchestrator_store: Annotated[
         RunOrchestratorStore, Depends(get_run_orchestrator_store)
     ],

--- a/robot-server/tests/commands/test_router.py
+++ b/robot-server/tests/commands/test_router.py
@@ -11,10 +11,9 @@ from opentrons.protocol_engine import (
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
 from opentrons.protocol_runner import RunOrchestrator
 
-from robot_server.service.json_api import MultiBodyMeta
+from robot_server.service.json_api import MultiBodyMeta, RequestModel
 from robot_server.errors.error_responses import ApiError
 from robot_server.commands.router import (
-    RequestModelWithStatelessCommandCreate,
     create_command,
     get_commands_list,
     get_command,
@@ -58,7 +57,7 @@ async def test_create_command(
     ).then_do(_stub_queued_command_state)
 
     result = await create_command(
-        RequestModelWithStatelessCommandCreate(data=command_create),
+        RequestModel(data=command_create),
         waitUntilComplete=False,
         timeout=42,
         orchestrator=run_orchestrator,
@@ -99,7 +98,7 @@ async def test_create_command_wait_for_complete(
     decoy.when(run_orchestrator.get_command("abc123")).then_return(completed_command)
 
     result = await create_command(
-        RequestModelWithStatelessCommandCreate(data=command_create),
+        RequestModel(data=command_create),
         waitUntilComplete=True,
         timeout=42,
         orchestrator=run_orchestrator,

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -13,7 +13,7 @@ from opentrons.protocol_engine import (
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
 
 from robot_server.errors.error_responses import ApiError
-from robot_server.service.json_api import MultiBodyMeta
+from robot_server.service.json_api import MultiBodyMeta, RequestModel
 
 from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
     MaintenanceRunOrchestratorStore,
@@ -31,7 +31,6 @@ from robot_server.maintenance_runs.router.commands_router import (
     get_current_run_from_url,
 )
 from robot_server.runs.command_models import (
-    RequestModelWithCommandCreate,
     CommandCollectionLinks,
     CommandLink,
     CommandLinkMeta,
@@ -109,7 +108,7 @@ async def test_create_run_command(
 
     result = await create_run_command(
         run_id="run-id",
-        request_body=RequestModelWithCommandCreate(data=command_request),
+        request_body=RequestModel(data=command_request),
         waitUntilComplete=False,
         run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         timeout=None,
@@ -151,7 +150,7 @@ async def test_create_run_command_blocking_completion(
 
     result = await create_run_command(
         run_id="run-id",
-        request_body=RequestModelWithCommandCreate(data=command_request),
+        request_body=RequestModel(data=command_request),
         waitUntilComplete=True,
         timeout=999,
         run_orchestrator_store=mock_maintenance_run_orchestrator_store,

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -13,10 +13,9 @@ from opentrons.protocol_engine import (
 )
 
 from robot_server.errors.error_responses import ApiError
-from robot_server.service.json_api import MultiBodyMeta
+from robot_server.service.json_api import MultiBodyMeta, RequestModel
 
 from robot_server.runs.command_models import (
-    RequestModelWithCommandCreate,
     CommandCollectionLinks,
     CommandLink,
     CommandLinkMeta,
@@ -129,7 +128,7 @@ async def test_create_run_command(
 
     result = await create_run_command(
         run_id="run-id",
-        request_body=RequestModelWithCommandCreate(data=command_request),
+        request_body=RequestModel(data=command_request),
         waitUntilComplete=False,
         run_orchestrator_store=mock_run_orchestrator_store,
         failedCommandId=None,
@@ -163,7 +162,7 @@ async def test_create_command_with_failed_command_raises(
     with pytest.raises(ApiError):
         await create_run_command(
             run_id="run-id",
-            request_body=RequestModelWithCommandCreate(data=command_create),
+            request_body=RequestModel(data=command_create),
             run_orchestrator_store=mock_run_orchestrator_store,
             failedCommandId="123",
             check_estop=True,
@@ -204,7 +203,7 @@ async def test_create_run_command_blocking_completion(
 
     result = await create_run_command(
         run_id="run-id",
-        request_body=RequestModelWithCommandCreate(data=command_request),
+        request_body=RequestModel(data=command_request),
         waitUntilComplete=True,
         timeout=999,
         run_orchestrator_store=mock_run_orchestrator_store,
@@ -238,7 +237,7 @@ async def test_add_conflicting_setup_command(
     with pytest.raises(ApiError) as exc_info:
         await create_run_command(
             run_id="run-id",
-            request_body=RequestModelWithCommandCreate(data=command_request),
+            request_body=RequestModel(data=command_request),
             run_orchestrator_store=mock_run_orchestrator_store,
             failedCommandId=None,
             check_estop=True,
@@ -273,7 +272,7 @@ async def test_add_command_to_stopped_engine(
     with pytest.raises(ApiError) as exc_info:
         await create_run_command(
             run_id="run-id",
-            request_body=RequestModelWithCommandCreate(data=command_request),
+            request_body=RequestModel(data=command_request),
             run_orchestrator_store=mock_run_orchestrator_store,
             failedCommandId=None,
             check_estop=True,


### PR DESCRIPTION
## Overview

Now that we're on Pydantic v2, we can delete these old workarounds for https://github.com/pydantic/pydantic/issues/3782. Closes EXEC-1065.

## Test Plan and Hands on Testing

* [x] Run a dev server, try sending a command to these endpoints, and make sure the errors reflect that the union discriminator is being used. In other words, Pydantic should only try parsing the input as the command you specified by `commandType`, not all possible commands. You'll know if this isn't working properly because the error message will be the length of the novel if you forget a param.

## Review requests

None.

## Risk assessment

Low if the manual test plan is done.