### PR TITLE
feat(shared-data,-protocol-designer): add foundation for plate reader support in PD

### DIFF
--- a/components/src/molecules/Tabs/index.tsx
+++ b/components/src/molecules/Tabs/index.tsx
@@ -1,8 +1,10 @@
 import { css } from 'styled-components'
-import { TYPOGRAPHY, SPACING, RESPONSIVENESS } from '../../ui-style-constants'
+import { Tooltip } from '../../atoms'
 import { COLORS, BORDERS } from '../../helix-design-system'
-import { POSITION_RELATIVE, DIRECTION_ROW } from '../../styles'
 import { Btn, Flex } from '../../primitives'
+import { POSITION_RELATIVE, DIRECTION_ROW } from '../../styles'
+import { useHoverTooltip } from '../../tooltips'
+import { TYPOGRAPHY, SPACING, RESPONSIVENESS } from '../../ui-style-constants'
 
 const DEFAULT_TAB_STYLE = css`
   ${TYPOGRAPHY.pSemiBold}
@@ -65,6 +67,7 @@ export interface TabProps {
   onClick: () => void
   isActive?: boolean
   disabled?: boolean
+  disabledReasonForTooltip?: string
 }
 
 export interface TabsProps {
@@ -77,18 +80,36 @@ export function Tabs(props: TabsProps): JSX.Element {
   return (
     <Flex flexDirection={DIRECTION_ROW} css={DEFAULT_CONTAINER_STYLE}>
       {tabs.map((tab, index) => (
-        <Btn
-          data-testid={`tab_${index}_${tab.text}`}
-          key={index}
-          onClick={() => {
-            tab.onClick()
-          }}
-          css={tab.isActive === true ? CURRENT_TAB_STYLE : DEFAULT_TAB_STYLE}
-          disabled={tab.disabled}
-        >
-          {tab.text}
-        </Btn>
+        <Tab {...tab} data-testid={`tab_${index}_${tab.text}`} key={index} />
       ))}
     </Flex>
+  )
+}
+
+function Tab(props: TabProps): JSX.Element {
+  const {
+    text,
+    onClick,
+    isActive,
+    disabled = false,
+    disabledReasonForTooltip,
+  } = props
+  const [targetProps, tooltipProps] = useHoverTooltip()
+  return (
+    <>
+      <Btn
+        onClick={onClick}
+        css={isActive === true ? CURRENT_TAB_STYLE : DEFAULT_TAB_STYLE}
+        disabled={disabled}
+        {...targetProps}
+      >
+        {text}
+      </Btn>
+      {disabled && disabledReasonForTooltip != null ? (
+        <Tooltip tooltipProps={tooltipProps}>
+          {disabledReasonForTooltip}
+        </Tooltip>
+      ) : null}
+    </>
   )
 }

--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -48,6 +48,7 @@
   "onDeck": "On deck",
   "one_item": "No more than 1 {{hardware}} allowed on the deck at one time",
   "only_display_rec": "Only display recommended labware",
+  "plate_reader_no_labware": "Labware cannot be loaded onto a plate reader. You can move labware onto the plate reader when building your protocol",
   "protocol_starting_deck": "Protocol starting deck",
   "read_more_gen1_gen2": "Read more about the differences between GEN1 and GEN2 Magnetic Modules",
   "rename_lab": "Rename labware",

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -18,6 +18,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
+  ABSORBANCE_READER_V1,
   FLEX_ROBOT_TYPE,
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   getModuleDisplayName,
@@ -228,7 +229,9 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     disabled:
       selectedFixture === 'wasteChute' ||
       selectedFixture === 'wasteChuteAndStagingArea' ||
-      selectedFixture === 'trashBin',
+      selectedFixture === 'trashBin' ||
+      selectedModuleModel === ABSORBANCE_READER_V1,
+    disabledReasonForTooltip: t('plate_reader_no_labware'),
     isActive: tab === 'labware',
     onClick: () => {
       setTab('labware')

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -191,6 +191,7 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
                 ? hoveredItem.text ?? ''
                 : selectedItemModule.text ?? ''
             }
+            slot={moduleOnDeck.slot}
           />
         )
       }

--- a/protocol-designer/src/pages/Designer/DeckSetup/HoveredItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HoveredItems.tsx
@@ -109,6 +109,7 @@ export const HoveredItems = (
               orientation={orientation}
               isSelected={false}
               isLast={true}
+              slot={selectedSlot.slot}
             />
           ) : null}
         </>

--- a/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
@@ -38,6 +38,7 @@ import { getOnlyLatestDefs } from '../../../labware-defs'
 import {
   ADAPTER_96_CHANNEL,
   getLabwareIsCompatible as _getLabwareIsCompatible,
+  getLabwareCompatibleWithAbsorbanceReader,
 } from '../../../utils/labwareModuleCompatibility'
 import { getHas96Channel } from '../../../utils'
 import { createCustomLabwareDef } from '../../../labware-defs/actions'
@@ -49,6 +50,7 @@ import {
   selectLabware,
   selectNestedLabware,
 } from '../../../labware-ingred/actions'
+import { getEnableAbsorbanceReader } from '../../../feature-flags/selectors'
 import {
   ALL_ORDERED_CATEGORIES,
   CUSTOM_CATEGORY,
@@ -132,13 +134,17 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
     robotType === OT2_ROBOT_TYPE ? isNextToHeaterShaker : false
   )
 
+  const enablePlateReader = useSelector(getEnableAbsorbanceReader)
+
   const getLabwareCompatible = useCallback(
     (def: LabwareDefinition2) => {
       // assume that custom (non-standard) labware is (potentially) compatible
       if (moduleType == null || !getLabwareDefIsStandard(def)) {
         return true
       }
-      return _getLabwareIsCompatible(def, moduleType)
+      return moduleType === ABSORBANCE_READER_TYPE
+        ? getLabwareCompatibleWithAbsorbanceReader(def)
+        : _getLabwareIsCompatible(def, moduleType)
     },
     [moduleType]
   )
@@ -167,7 +173,8 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
           moduleType !== HEATERSHAKER_MODULE_TYPE) ||
         (isAdapter96Channel && !has96Channel) ||
         (slot === 'offDeck' && isAdapter) ||
-        (PLATE_READER_LOADNAME === parameters.loadName &&
+        (!enablePlateReader &&
+          PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE)
       )
     },

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedHoveredItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedHoveredItems.tsx
@@ -188,6 +188,7 @@ export const SelectedHoveredItems = (
               orientation={orientation}
               isSelected={true}
               labwareInfos={labwareInfos}
+              slot={selectedSlot.slot}
             />
           ) : null}
         </>

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/LabwareTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/LabwareTools.test.tsx
@@ -25,6 +25,7 @@ import type { LabwareDefinition2, PipetteV2Specs } from '@opentrons/shared-data'
 
 vi.mock('../../../../utils')
 vi.mock('../../../../step-forms/selectors')
+vi.mock('../../../../feature-flags/selectors')
 vi.mock('../../../../file-data/selectors')
 vi.mock('../../../../labware-defs/selectors')
 vi.mock('../../../../labware-defs/actions')

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  ABSORBANCE_READER_V1,
   FLEX_ROBOT_TYPE,
   HEATERSHAKER_MODULE_TYPE,
   HEATERSHAKER_MODULE_V1,
@@ -45,12 +46,13 @@ describe('getModuleModelsBySlot', () => {
   })
   it('renders all flex modules for B1', () => {
     expect(getModuleModelsBySlot(true, FLEX_ROBOT_TYPE, 'B1')).toEqual(
-      FLEX_MODULE_MODELS
+      FLEX_MODULE_MODELS.filter(model => model !== ABSORBANCE_READER_V1)
     )
   })
   it('renders all flex modules for C1', () => {
     const noTC = FLEX_MODULE_MODELS.filter(
-      model => model !== THERMOCYCLER_MODULE_V2
+      model =>
+        model !== THERMOCYCLER_MODULE_V2 && model !== ABSORBANCE_READER_V1
     )
     expect(getModuleModelsBySlot(true, FLEX_ROBOT_TYPE, 'C1')).toEqual(noTC)
   })

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -13,6 +13,7 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_BLOCK_TYPE,
   ABSORBANCE_READER_TYPE,
+  ABSORBANCE_READER_V1,
 } from '@opentrons/shared-data'
 
 import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
@@ -103,6 +104,7 @@ export const MOAM_MODELS: ModuleModel[] = [
   TEMPERATURE_MODULE_V2,
   HEATERSHAKER_MODULE_V1,
   MAGNETIC_BLOCK_V1,
+  ABSORBANCE_READER_V1,
 ]
 
 export const MAX_MOAM_MODULES = 7

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -94,6 +94,7 @@ export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
   ],
   [ABSORBANCE_READER_TYPE]: [
     'opentrons_flex_lid_absorbance_plate_reader_module',
+    'nest_96_wellplate_200ul_flat',
   ],
 }
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -93,10 +93,7 @@ export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'nest_96_wellplate_2ml_deep',
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
-  [ABSORBANCE_READER_TYPE]: [
-    'opentrons_flex_lid_absorbance_plate_reader_module',
-    'nest_96_wellplate_200ul_flat',
-  ],
+  [ABSORBANCE_READER_TYPE]: ['nest_96_wellplate_200ul_flat'],
 }
 
 export const MOAM_MODELS_WITH_FF: ModuleModel[] = [TEMPERATURE_MODULE_V2]

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -5,8 +5,9 @@ import {
   FLEX_ROBOT_TYPE,
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   HEATERSHAKER_MODULE_TYPE,
-  MAGNETIC_BLOCK_V1,
+  HEATERSHAKER_MODULE_V1,
   OT2_ROBOT_TYPE,
+  TEMPERATURE_MODULE_V2,
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_MODULE_V2,
   getAreSlotsAdjacent,
@@ -61,33 +62,32 @@ export function getModuleModelsBySlot(
   robotType: RobotType,
   slot: DeckSlotId
 ): ModuleModel[] {
-  const FLEX_MIDDLE_SLOTS = ['B2', 'C2', 'A2', 'D2']
+  const FLEX_MIDDLE_SLOTS = new Set(['B2', 'C2', 'A2', 'D2'])
   const OT2_MIDDLE_SLOTS = ['2', '5', '8', '11']
-  const FILTERED_MODULES = enableAbsorbanceReader
-    ? FLEX_MODULE_MODELS
-    : FLEX_MODULE_MODELS.filter(model => model !== ABSORBANCE_READER_V1)
 
-  let moduleModels: ModuleModel[] = FILTERED_MODULES
+  const FLEX_RIGHT_SLOTS = new Set(['A3', 'B3', 'C3', 'D3'])
+
+  let moduleModels: ModuleModel[] = FLEX_MODULE_MODELS
 
   switch (robotType) {
     case FLEX_ROBOT_TYPE: {
-      if (slot !== 'B1' && !FLEX_MIDDLE_SLOTS.includes(slot)) {
-        moduleModels = FILTERED_MODULES.filter(
-          model => model !== THERMOCYCLER_MODULE_V2
-        )
-      }
-      if (FLEX_MIDDLE_SLOTS.includes(slot)) {
-        moduleModels = FILTERED_MODULES.filter(
-          model => model === MAGNETIC_BLOCK_V1
-        )
-      }
-      if (
-        FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS.includes(
-          slot as AddressableAreaName
-        )
-      ) {
-        moduleModels = []
-      }
+      moduleModels = FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS.includes(
+        slot as AddressableAreaName
+      )
+        ? []
+        : FLEX_MODULE_MODELS.filter(model => {
+            if (model === THERMOCYCLER_MODULE_V2) {
+              return slot === 'B1'
+            } else if (model === ABSORBANCE_READER_V1) {
+              return FLEX_RIGHT_SLOTS.has(slot) && enableAbsorbanceReader
+            } else if (
+              model === TEMPERATURE_MODULE_V2 ||
+              model === HEATERSHAKER_MODULE_V1
+            ) {
+              return !FLEX_MIDDLE_SLOTS.has(slot)
+            }
+            return true
+          })
       break
     }
     case OT2_ROBOT_TYPE: {

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -11,6 +11,9 @@ import type { LabwareDefByDefURI } from '../labware-defs'
 import type { LabwareOnDeck } from '../step-forms'
 import type { LabwareDefinition2, ModuleType } from '@opentrons/shared-data'
 // NOTE: this does not distinguish btw versions. Standard labware only (assumes namespace is 'opentrons')
+
+const PLATE_READER_MAX_LABWARE_Z_MM = 16
+
 export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
   ModuleType,
   Readonly<string[]>
@@ -153,6 +156,18 @@ export const getLabwareIsCustom = (
   labwareOnDeck: LabwareOnDeck
 ): boolean => {
   return labwareOnDeck.labwareDefURI in customLabwares
+}
+
+// This breaks pattern with other module compatibility checks, but it more exactly mirrors Protocol Engine's logic
+// See api/src/opentrons/protocol_engine/state/labware.py for details
+export const getLabwareCompatibleWithAbsorbanceReader = (
+  def: LabwareDefinition2
+): boolean => {
+  return (
+    Object.entries(def.wells).length === 96 &&
+    !def.parameters.isTiprack &&
+    def.dimensions.zDimension <= PLATE_READER_MAX_LABWARE_Z_MM
+  )
 }
 
 export const getAdapterLabwareIsAMatch = (

--- a/shared-data/module/definitions/3/absorbanceReaderV1.json
+++ b/shared-data/module/definitions/3/absorbanceReaderV1.json
@@ -11,8 +11,8 @@
     "bareOverallHeight": 18.5,
     "overLabwareHeight": 0.0,
     "lidHeight": 60.0,
-    "xDimension": 95.5,
-    "yDimension": 155.3,
+    "xDimension": 155.3,
+    "yDimension": 95.5,
     "labwareInterfaceXDimension": 127.8,
     "labwareInterfaceYDimension": 85.5
   },


### PR DESCRIPTION
# Overview

This PR introduces plate reader to PD, still hidden behind a feature flag. Namely, it adds the ability to add plate reader to the initial deck state and fixes logic for ModuleLabel rendering for all modules. Of note, in this dev work, I discovered a bug in the plate reader's shared-data definition, in which the top-level x and y dimensions were flipped, so those values are swapped here as well.

Closes AUTH-1077

## Test Plan and Hands on Testing

- create or import a Flex protocol ([example](https://github.com/user-attachments/files/18190895/platereader.json.zip))
- select slot B1 to edit hardware/labware
- verify correct modules populate, and hovering each module option produces the correctly positioned ModuleLabel on the deck
- repeat with center and right column slots, verifying that plate reader option displays properly on the right column slot
- with modules added, navigate to protocol timeline and click various module steps
- verify that ModuleLabel is correctly positioned

https://github.com/user-attachments/assets/71df6c54-b2cd-41f2-a32e-87a5da1519db


## Changelog

- add logic for handling plate reader addition to deck and adding compatible labware
- add logic for correct positioning of ModuleLabel for all modules in any slot position. An implication here is passing a slot prop to determine slot-specific corner offset from slot from a module's definition
- improve time complexity of DeckSetup util `getModuleModelsBySlot`
- fix plate reader x and y dimensions (spoke with plate reader devs to ensure this was correct)
- fix tests

## Review requests

see test plan

## Risk assessment

low. behind feature flag and major changes only affect UI for module labels