### PR TITLE
fix(protocol-designer): dropdown option text refinement

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -38,6 +38,8 @@ import { MagneticBlockFixture } from './MagneticBlockFixture'
 import { ThermocyclerFixture } from './ThermocyclerFixture'
 import { AbsorbanceReaderFixture } from './AbsorbanceReaderFixture'
 
+export * from './constants'
+
 interface DeckConfiguratorProps {
   deckConfig: DeckConfiguration
   handleClickAdd: (cutoutId: CutoutId) => void

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -38,8 +38,6 @@ import { MagneticBlockFixture } from './MagneticBlockFixture'
 import { ThermocyclerFixture } from './ThermocyclerFixture'
 import { AbsorbanceReaderFixture } from './AbsorbanceReaderFixture'
 
-export * from './constants'
-
 interface DeckConfiguratorProps {
   deckConfig: DeckConfiguration
   handleClickAdd: (cutoutId: CutoutId) => void

--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -24,6 +24,7 @@ import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { Tooltip } from '../../atoms/Tooltip'
 import { StyledText } from '../../atoms/StyledText'
 import { LiquidIcon } from '../LiquidIcon'
+import { DeckInfoLabel } from '..'
 
 export interface DropdownOption {
   name: string
@@ -32,6 +33,8 @@ export interface DropdownOption {
   liquidColor?: string
   /** optional dropdown option for adding the deck label */
   deckLabel?: string
+  /** subtext below the name */
+  subtext?: string
   disabled?: boolean
   tooltipText?: string
 }
@@ -250,7 +253,11 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
             {currentOption.liquidColor != null ? (
               <LiquidIcon color={currentOption.liquidColor} />
             ) : null}
+            {currentOption.deckLabel != null ? (
+              <DeckInfoLabel deckLabel={currentOption.deckLabel} svgSize={13} />
+            ) : null}
             <Flex
+              flexDirection={DIRECTION_COLUMN}
               css={css`
                 font-weight: ${dropdownType === 'rounded'
                   ? TYPOGRAPHY.pSemiBold
@@ -307,7 +314,26 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
                     {option.liquidColor != null ? (
                       <LiquidIcon color={option.liquidColor} />
                     ) : null}
-                    {option.name}
+                    {option.deckLabel != null ? (
+                      <DeckInfoLabel
+                        deckLabel={option.deckLabel}
+                        svgSize={13}
+                      />
+                    ) : null}
+                    <Flex
+                      flexDirection={DIRECTION_COLUMN}
+                      gridGap={option.subtext != null ? SPACING.spacing4 : '0'}
+                    >
+                      <StyledText desktopStyle="captionRegular">
+                        {option.name}
+                      </StyledText>
+                      <StyledText
+                        desktopStyle="captionRegular"
+                        color={COLORS.black70}
+                      >
+                        {option.subtext}
+                      </StyledText>
+                    </Flex>
                   </Flex>
                 </MenuItem>
                 {option.tooltipText != null ? (

--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -24,7 +24,7 @@ import { MenuItem } from '../../atoms/MenuList/MenuItem'
 import { Tooltip } from '../../atoms/Tooltip'
 import { StyledText } from '../../atoms/StyledText'
 import { LiquidIcon } from '../LiquidIcon'
-import { DeckInfoLabel } from '..'
+import { DeckInfoLabel } from '../DeckInfoLabel'
 
 export interface DropdownOption {
   name: string

--- a/protocol-designer/src/assets/localization/en/application.json
+++ b/protocol-designer/src/assets/localization/en/application.json
@@ -16,7 +16,6 @@
   "magnet_height_caption": "Must be between {{low}} to {{high}}.",
   "magnet_recommended": "The recommended height is {{default}}",
   "manually": "Manually",
-  "mix": "Mix",
   "module_and_slot": "{{moduleLongName}} in Slot {{slotName}}",
   "n_steps_selected": "{{n}} steps selected",
   "networking": {

--- a/protocol-designer/src/assets/localization/en/application.json
+++ b/protocol-designer/src/assets/localization/en/application.json
@@ -16,6 +16,7 @@
   "magnet_height_caption": "Must be between {{low}} to {{high}}.",
   "magnet_recommended": "The recommended height is {{default}}",
   "manually": "Manually",
+  "mix": "Mix",
   "module_and_slot": "{{moduleLongName}} in Slot {{slotName}}",
   "n_steps_selected": "{{n}} steps selected",
   "networking": {

--- a/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
@@ -1,8 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import {
+  ALIGN_CENTER,
   COLORS,
   DIRECTION_COLUMN,
+  DeckInfoLabel,
   DropdownMenu,
   Flex,
   ListItem,
@@ -108,10 +110,28 @@ export function DropdownStepFormField(
             {title}
           </StyledText>
           <ListItem type="noActive">
-            <Flex padding={SPACING.spacing12}>
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {options[0].name}
-              </StyledText>
+            <Flex
+              gridGap={SPACING.spacing8}
+              alignItems={ALIGN_CENTER}
+              padding={SPACING.spacing12}
+            >
+              {options[0].deckLabel != null ? (
+                <DeckInfoLabel deckLabel={options[0].deckLabel} svgSize={13} />
+              ) : null}
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                gridGap={options[0].subtext != null ? SPACING.spacing4 : '0'}
+              >
+                <StyledText desktopStyle="captionRegular">
+                  {options[0].name}
+                </StyledText>
+                <StyledText
+                  desktopStyle="captionRegular"
+                  color={COLORS.black70}
+                >
+                  {options[0].subtext}
+                </StyledText>
+              </Flex>
             </Flex>
           </ListItem>
         </Flex>

--- a/protocol-designer/src/organisms/MaterialsListModal/__tests__/MaterialsListModal.test.tsx
+++ b/protocol-designer/src/organisms/MaterialsListModal/__tests__/MaterialsListModal.test.tsx
@@ -137,7 +137,7 @@ describe('MaterialsListModal', () => {
           lidTargetTemp: null,
           lidOpen: false,
         },
-        slot: 'span7_8_10_11',
+        slot: '7',
         type: 'thermocyclerModuleType',
       },
     ] as ModuleOnDeck[]

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -166,8 +166,8 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
               {
                 name:
                   modIdWithAdapter != null
-                    ? `${adapterDisplayName} on top of ${moduleUnderAdapter} in slot ${moduleSlotInfo}`
-                    : `${adapterDisplayName} on slot ${adapterSlotInfo}`,
+                    ? `${moduleSlotInfo} on ${moduleUnderAdapter} with ${adapterDisplayName}`
+                    : `${adapterSlotInfo} with ${adapterDisplayName}`,
                 value: labwareId,
               },
             ]
@@ -186,13 +186,9 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
           : [
               ...acc,
               {
-                name: `${getModuleDisplayName(
+                name: `${modOnDeck.slot} on ${getModuleDisplayName(
                   moduleEntities[modId].model
-                )} in slot ${
-                  modOnDeck.slot === 'span7_8_10_11'
-                    ? '7, 8, 10, 11'
-                    : modOnDeck.slot
-                }`,
+                )}`,
                 value: modId,
               },
             ]
@@ -234,7 +230,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
         )
       })
       .map(slotId => ({ name: slotId, value: slotId }))
-    const offDeck = { name: 'Off-Deck', value: 'offDeck' }
+    const offDeck = { name: 'Off-deck', value: 'offDeck' }
     const wasteChuteSlot = {
       name: 'Waste Chute in D3',
       value: WASTE_CHUTE_CUTOUT,

--- a/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
+++ b/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@opentrons/shared-data/labware/fixtures/2'
 
 import type { LabwareEntities } from '@opentrons/step-generation'
+import type { InitialDeckSetup } from '../../../step-forms'
 
 describe('labware selectors', () => {
   let names: Record<string, string>
@@ -102,7 +103,7 @@ describe('labware selectors', () => {
       expect(
         // @ts-expect-error(sa, 2021-6-15): resultFunc
         getDisposalOptions.resultFunc(additionalEquipmentEntities)
-      ).toEqual([{ name: 'Trash Bin', value: mockTrashId }])
+      ).toEqual([{ name: 'Trash bin', value: mockTrashId }])
     })
     it('filters out additional equipment that is NOT trash when multiple trash bins present', () => {
       const mockTrashId = 'mockTrashId'
@@ -129,8 +130,8 @@ describe('labware selectors', () => {
         // @ts-expect-error(sa, 2021-6-15): resultFunc
         getDisposalOptions.resultFunc(additionalEquipmentEntities)
       ).toEqual([
-        { name: 'Trash Bin', value: mockTrashId },
-        { name: 'Trash Bin', value: mockTrashId2 },
+        { name: 'Trash bin', value: mockTrashId },
+        { name: 'Trash bin', value: mockTrashId2 },
       ])
     })
   })
@@ -142,7 +143,12 @@ describe('labware selectors', () => {
         getLabwareOptions.resultFunc(
           {},
           {},
-          { labware: {}, modules: {}, pipettes: {} },
+          {
+            labware: {},
+            modules: {},
+            pipettes: {},
+            additionalEquipmentOnDeck: {},
+          },
           {},
           {},
           {}
@@ -153,13 +159,13 @@ describe('labware selectors', () => {
     it('should return labware options when no modules are present, with no tipracks', () => {
       const labwareEntities = {
         ...tipracks,
-        ...trash,
         ...otherLabware,
       }
-      const initialDeckSetup = {
+      const initialDeckSetup: InitialDeckSetup = {
         labware: labwareEntities,
         modules: {},
         pipettes: {},
+        additionalEquipmentOnDeck: {},
       }
       expect(
         // @ts-expect-error(sa, 2021-6-15): resultFunc
@@ -171,13 +177,10 @@ describe('labware selectors', () => {
           {},
           {}
         )
-      ).toEqual([
-        { name: 'Source Plate', value: 'wellPlateId' },
-        { name: 'Trash', value: mockTrash },
-      ])
+      ).toEqual([{ name: 'Source Plate', value: 'wellPlateId' }])
     })
 
-    it('should return labware options with module prefixes when a labware is on module', () => {
+    it('should return labware options with no module prefixes even when a labware is on module', () => {
       const labware = {
         wellPlateId: {
           ...otherLabware.wellPlateId,
@@ -200,11 +203,14 @@ describe('labware selectors', () => {
         },
       }
       const labwareEntities = { ...trash, ...labware }
-      const initialDeckSetup = {
+      const initialDeckSetup: InitialDeckSetup = {
         pipettes: {},
         labware: {
           ...trash,
           ...labware,
+        },
+        additionalEquipmentOnDeck: {
+          trash: { id: 'trash', location: 'cutout12', name: 'trashBin' },
         },
         modules: {
           magModuleId: {
@@ -223,7 +229,7 @@ describe('labware selectors', () => {
             id: 'thermocyclerId',
             type: THERMOCYCLER_MODULE_TYPE,
             model: THERMOCYCLER_MODULE_V1,
-            slot: SPAN7_8_10_11_SLOT,
+            slot: '8',
           },
           heaterShakerId: {
             id: 'heaterShakerId',
@@ -253,11 +259,11 @@ describe('labware selectors', () => {
           {}
         )
       ).toEqual([
-        { name: 'HS Plate in Heater-Shaker', value: 'hsPlateId' },
-        { name: 'TC Plate in Thermocycler', value: 'tcPlateId' },
-        { name: 'Temp Plate in Temperature Module', value: 'tempPlateId' },
+        { name: 'HS Plate in 6', value: 'hsPlateId' },
+        { name: 'TC Plate in A1+B1', value: 'tcPlateId' },
+        { name: 'Temp Plate in 3', value: 'tempPlateId' },
         { name: 'Trash', value: mockTrash },
-        { name: 'Well Plate in Magnetic Module', value: 'wellPlateId' },
+        { name: 'Well Plate in 1', value: 'wellPlateId' },
       ])
     })
 
@@ -269,10 +275,9 @@ describe('labware selectors', () => {
         },
       }
       const labwareEntities = { ...trash, ...labware }
-      const initialDeckSetup = {
+      const initialDeckSetup: InitialDeckSetup = {
         pipettes: {},
         labware: {
-          ...trash,
           ...labware,
         },
         modules: {
@@ -282,6 +287,9 @@ describe('labware selectors', () => {
             model: MAGNETIC_MODULE_V1,
             slot: '1',
           },
+        },
+        additionalEquipmentOnDeck: {
+          trash: { id: 'trash', name: 'trashBin', location: 'cutout12' },
         },
       }
 
@@ -312,14 +320,14 @@ describe('labware selectors', () => {
         )
       ).toEqual([
         { name: 'Trash', value: mockTrash },
-        { name: 'Well Plate in Magnetic Module', value: 'wellPlateId' },
+        { name: 'Well Plate in 1', value: 'wellPlateId' },
       ])
     })
   })
 
   describe('_sortLabwareDropdownOptions', () => {
     const trashOption = {
-      name: 'Trash Bin',
+      name: 'Trash bin',
       value: mockTrash,
     }
     const zzzPlateOption = { name: 'Zzz Plate', value: 'zzz' }

--- a/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
+++ b/protocol-designer/src/ui/labware/__tests__/selectors.test.ts
@@ -9,7 +9,6 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
-import { SPAN7_8_10_11_SLOT } from '../../../constants'
 import {
   getDisposalOptions,
   getLabwareOptions,
@@ -23,7 +22,6 @@ import {
 } from '@opentrons/shared-data/labware/fixtures/2'
 
 import type { LabwareEntities } from '@opentrons/step-generation'
-import type { InitialDeckSetup } from '../../../step-forms'
 
 describe('labware selectors', () => {
   let names: Record<string, string>
@@ -161,7 +159,7 @@ describe('labware selectors', () => {
         ...tipracks,
         ...otherLabware,
       }
-      const initialDeckSetup: InitialDeckSetup = {
+      const initialDeckSetup = {
         labware: labwareEntities,
         modules: {},
         pipettes: {},
@@ -203,7 +201,7 @@ describe('labware selectors', () => {
         },
       }
       const labwareEntities = { ...trash, ...labware }
-      const initialDeckSetup: InitialDeckSetup = {
+      const initialDeckSetup = {
         pipettes: {},
         labware: {
           ...trash,
@@ -275,7 +273,7 @@ describe('labware selectors', () => {
         },
       }
       const labwareEntities = { ...trash, ...labware }
-      const initialDeckSetup: InitialDeckSetup = {
+      const initialDeckSetup = {
         pipettes: {},
         labware: {
           ...labware,

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -8,7 +8,6 @@ import {
 import {
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
-  RobotType,
   getIsTiprack,
   getLabwareDisplayName,
 } from '@opentrons/shared-data'
@@ -21,6 +20,7 @@ import type {
   AdditionalEquipmentEntity,
 } from '@opentrons/step-generation'
 import type { DropdownOption } from '@opentrons/components'
+import type { RobotType } from '@opentrons/shared-data'
 import type { Selector } from '../../types'
 import type {
   AllTemporalPropertiesForTimelineFrame,

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -2,10 +2,6 @@ import { createSelector } from 'reselect'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 import {
-  WASTE_CHUTE_DISPLAY_NAME,
-  TRASH_BIN_DISPLAY_NAME,
-} from '@opentrons/components'
-import {
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
   RobotType,
@@ -27,6 +23,8 @@ import type {
   SavedStepFormState,
 } from '../../step-forms'
 
+const TRASH_BIN = 'Trash bin'
+
 export const getLabwareNicknamesById: Selector<
   Record<string, string>
 > = createSelector(
@@ -44,8 +42,8 @@ export const _sortLabwareDropdownOptions = (
 ): DropdownOption[] =>
   options.sort((a, b) => {
     // special case for trash (always at the bottom of the list)
-    if (a.name === TRASH_BIN_DISPLAY_NAME) return 1
-    if (b.name === TRASH_BIN_DISPLAY_NAME) return -1
+    if (a.name === TRASH_BIN) return 1
+    if (b.name === TRASH_BIN) return -1
     // sort by name everything else by name
     return a.name.localeCompare(b.name)
   })
@@ -228,7 +226,7 @@ export const getWasteChuteOption: Selector<DropdownOption | null> = createSelect
     const wasteChuteOption: DropdownOption | null =
       wasteChuteEntity != null
         ? {
-            name: WASTE_CHUTE_DISPLAY_NAME,
+            name: 'Waste chute',
             value: wasteChuteEntity.id,
           }
         : null
@@ -252,7 +250,7 @@ export const getDisposalOptions = createSelector(
           ? [
               ...acc,
               {
-                name: TRASH_BIN_DISPLAY_NAME,
+                name: TRASH_BIN,
                 value: additionalEquipment.id ?? '',
               },
             ]

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -2,6 +2,10 @@ import { createSelector } from 'reselect'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 import {
+  TRASH_BIN_DISPLAY_NAME,
+  WASTE_CHUTE_DISPLAY_NAME,
+} from '@opentrons/components'
+import {
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
   RobotType,
@@ -23,8 +27,6 @@ import type {
   SavedStepFormState,
 } from '../../step-forms'
 
-const TRASH_BIN = 'Trash bin'
-
 export const getLabwareNicknamesById: Selector<
   Record<string, string>
 > = createSelector(
@@ -42,8 +44,8 @@ export const _sortLabwareDropdownOptions = (
 ): DropdownOption[] =>
   options.sort((a, b) => {
     // special case for trash (always at the bottom of the list)
-    if (a.name === TRASH_BIN) return 1
-    if (b.name === TRASH_BIN) return -1
+    if (a.name === TRASH_BIN_DISPLAY_NAME) return 1
+    if (b.name === TRASH_BIN_DISPLAY_NAME) return -1
     // sort by name everything else by name
     return a.name.localeCompare(b.name)
   })
@@ -106,6 +108,7 @@ export const getMoveLabwareOptions: Selector<DropdownOption[]> = createSelector(
     )?.location
     const robotType =
       trashBinLocation === 'cutout12' ? OT2_ROBOT_TYPE : FLEX_ROBOT_TYPE
+
     const moveLabwareOptions = reduce(
       labwareEntities,
       (
@@ -226,7 +229,7 @@ export const getWasteChuteOption: Selector<DropdownOption | null> = createSelect
     const wasteChuteOption: DropdownOption | null =
       wasteChuteEntity != null
         ? {
-            name: 'Waste chute',
+            name: WASTE_CHUTE_DISPLAY_NAME,
             value: wasteChuteEntity.id,
           }
         : null
@@ -250,7 +253,7 @@ export const getDisposalOptions = createSelector(
           ? [
               ...acc,
               {
-                name: TRASH_BIN,
+                name: TRASH_BIN_DISPLAY_NAME,
                 value: additionalEquipment.id ?? '',
               },
             ]

--- a/protocol-designer/src/ui/labware/utils.ts
+++ b/protocol-designer/src/ui/labware/utils.ts
@@ -1,4 +1,5 @@
 import { getHasWasteChute } from '@opentrons/step-generation'
+import { WASTE_CHUTE_DISPLAY_NAME } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
   RobotType,
@@ -57,7 +58,7 @@ export function getLabwareLatestSlot(
     hasWasteChute &&
     (initialSlot === 'D3' || moveLabwareStep?.newLocation === 'D3')
   ) {
-    return 'Waste chute'
+    return WASTE_CHUTE_DISPLAY_NAME
   }
 
   if (moveLabwareStep?.newLocation != null) {

--- a/protocol-designer/src/ui/labware/utils.ts
+++ b/protocol-designer/src/ui/labware/utils.ts
@@ -4,7 +4,6 @@ import {
   RobotType,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { WASTE_CHUTE_DISPLAY_NAME } from '@opentrons/components'
 import type { InitialDeckSetup, SavedStepFormState } from '../../step-forms'
 
 function resolveSlotLocation(
@@ -58,7 +57,7 @@ export function getLabwareLatestSlot(
     hasWasteChute &&
     (initialSlot === 'D3' || moveLabwareStep?.newLocation === 'D3')
   ) {
-    return WASTE_CHUTE_DISPLAY_NAME
+    return 'Waste chute'
   }
 
   if (moveLabwareStep?.newLocation != null) {

--- a/protocol-designer/src/ui/labware/utils.ts
+++ b/protocol-designer/src/ui/labware/utils.ts
@@ -2,6 +2,8 @@ import { getHasWasteChute } from '@opentrons/step-generation'
 import { WASTE_CHUTE_DISPLAY_NAME } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import type { RobotType } from '@opentrons/shared-data'
@@ -13,7 +15,10 @@ function resolveSlotLocation(
   location: string,
   robotType: RobotType
 ): string {
-  const TCSlot = robotType === FLEX_ROBOT_TYPE ? 'A1+B1' : '8,9,10,11'
+  const TCSlot =
+    robotType === FLEX_ROBOT_TYPE
+      ? TC_MODULE_LOCATION_OT3
+      : TC_MODULE_LOCATION_OT2
   if (location === 'offDeck') {
     return 'offDeck'
   } else if (modules[location] != null) {

--- a/protocol-designer/src/ui/labware/utils.ts
+++ b/protocol-designer/src/ui/labware/utils.ts
@@ -2,9 +2,9 @@ import { getHasWasteChute } from '@opentrons/step-generation'
 import { WASTE_CHUTE_DISPLAY_NAME } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
-  RobotType,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
+import type { RobotType } from '@opentrons/shared-data'
 import type { InitialDeckSetup, SavedStepFormState } from '../../step-forms'
 
 function resolveSlotLocation(
@@ -65,7 +65,7 @@ export function getLabwareLatestSlot(
     return resolveSlotLocation(
       modules,
       labware,
-      moveLabwareStep.newLocation,
+      moveLabwareStep.newLocation as string,
       robotType
     )
   } else if (moveLabwareStep == null) {

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -77,7 +77,7 @@ export function getModuleUnderLabware(
 export const getModuleShortNames = (type: ModuleType): string => {
   switch (type) {
     case 'heaterShakerModuleType':
-      return 'Heater-Shaker'
+      return 'Heater-Shaker Module'
     case 'magneticBlockType':
       return 'Magnetic Block'
     case 'magneticModuleType':
@@ -110,22 +110,25 @@ export function getModuleLabwareOptions(
         )?.id
         if (labwareOnAdapterId != null) {
           return {
-            name: `${nicknamesById[labwareOnAdapterId]} in ${
-              nicknamesById[labware.id]
-            } in ${module} in slot ${moduleOnDeck.slot}`,
+            name: `${nicknamesById[labware.id]} with ${
+              nicknamesById[labwareOnAdapterId]
+            }`,
+            deckLabel: moduleOnDeck.slot,
+            subtext: module,
             value: moduleOnDeck.id,
           }
         } else {
           return {
-            name: `${nicknamesById[labware.id]} in ${module} in slot ${
-              moduleOnDeck.slot
-            }`,
+            name: nicknamesById[labware.id],
+            deckLabel: moduleOnDeck.slot,
+            subtext: module,
             value: moduleOnDeck.id,
           }
         }
       } else {
         return {
-          name: `No labware in ${module} in slot ${moduleOnDeck.slot}`,
+          name: module,
+          deckLabel: moduleOnDeck.slot,
           value: moduleOnDeck.id,
         }
       }

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -1,7 +1,13 @@
 import values from 'lodash/values'
 import {
-  MAGNETIC_MODULE_V1,
+  ABSORBANCE_READER_TYPE,
   getLabwareDefaultEngageHeight,
+  HEATERSHAKER_MODULE_TYPE,
+  MAGNETIC_BLOCK_TYPE,
+  MAGNETIC_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import type { DropdownOption } from '@opentrons/components'
 import type { ModuleType } from '@opentrons/shared-data'
@@ -76,17 +82,17 @@ export function getModuleUnderLabware(
 
 export const getModuleShortNames = (type: ModuleType): string => {
   switch (type) {
-    case 'heaterShakerModuleType':
+    case HEATERSHAKER_MODULE_TYPE:
       return 'Heater-Shaker Module'
-    case 'magneticBlockType':
+    case MAGNETIC_BLOCK_TYPE:
       return 'Magnetic Block'
-    case 'magneticModuleType':
+    case MAGNETIC_MODULE_TYPE:
       return 'Magnetic Module'
-    case 'temperatureModuleType':
+    case TEMPERATURE_MODULE_TYPE:
       return 'Temperature Module'
-    case 'thermocyclerModuleType':
+    case THERMOCYCLER_MODULE_TYPE:
       return 'Thermocycler'
-    case 'absorbanceReaderType':
+    case ABSORBANCE_READER_TYPE:
       return 'Absorbance Reader'
   }
 }


### PR DESCRIPTION
closes RQA-3773 and RQA-3774

# Overview

Refine the dropdown option text for module, labware, and new location.

## Test Plan and Hands on Testing

Review the text for module steps, transfer/mix, and move labware

<img width="314" alt="Screenshot 2024-12-19 at 13 10 28" src="https://github.com/user-attachments/assets/28be32c2-4b4a-4d36-8796-4a747727fe0e" />
<img width="322" alt="Screenshot 2024-12-19 at 13 10 47" src="https://github.com/user-attachments/assets/181d3b21-5a56-48ce-bded-e9f7d7fdf8a9" />
<img width="322" alt="Screenshot 2024-12-19 at 13 11 03" src="https://github.com/user-attachments/assets/c9726475-8fec-4af8-adbf-51c5b116280b" />

## Changelog

- add prop to DropdownMenu to include a subtext and the deck label 
- plug in new text for the selectors

## Risk assessment

low