### PR TITLE
feat(protocol-designer): prevent user from adding plate reader without gripper

### DIFF
--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -34,6 +34,7 @@
   "edit_slot": "Edit slot",
   "edit": "Edit",
   "gen1_gen2_different_units": "Switching between GEN1 and GEN2 Magnetic Modules will clear all non-default engage heights from existing magnet steps in your protocol. GEN1 and GEN2 Magnetic Modules do not use the same units.",
+  "gripper_required_for_plate_reader": "Gripper required to add absorbance reader",
   "heater_shaker_adjacent_to": "A module is adjacent to this slot. The Heater-Shaker cannot be placed next to a module",
   "heater_shaker_adjacent": "A Heater-Shaker is adjacent to this slot. Modules cannot be placed next to a Heater-Shaker",
   "heater_shaker_trash": "The heater-shaker cannot be next to the trash bin",

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
@@ -14,6 +14,7 @@ import {
   WRAP,
 } from '@opentrons/components'
 import {
+  ABSORBANCE_READER_TYPE,
   ABSORBANCE_READER_V1,
   FLEX_ROBOT_TYPE,
   getModuleDisplayName,
@@ -70,6 +71,7 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
     TEMPERATURE_MODULE_TYPE,
     HEATERSHAKER_MODULE_TYPE,
     MAGNETIC_BLOCK_TYPE,
+    ABSORBANCE_READER_TYPE,
   ]
 
   const handleAddModule = (

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -329,17 +329,16 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       const moduleType = getModuleType(selectedModuleModel)
       // enforce gripper present in order to add plate reader
       if (moduleType === ABSORBANCE_READER_TYPE && !isGripperAttached) {
-        makeSnackbar('Gripper required to add absorbance reader')
+        makeSnackbar(t('gripper_required_for_plate_reader') as string)
         return
-      } else {
-        dispatch(
-          createModule({
-            slot,
-            type: moduleType,
-            model: selectedModuleModel,
-          })
-        )
       }
+      dispatch(
+        createModule({
+          slot,
+          type: moduleType,
+          model: selectedModuleModel,
+        })
+      )
     }
     if (
       (slot === 'offDeck' && selectedLabwareDefUri != null) ||

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { fireEvent, screen } from '@testing-library/react'
 import {
+  ABSORBANCE_READER_V1,
   FLEX_ROBOT_TYPE,
   HEATERSHAKER_MODULE_V1,
   fixture96Plate,
@@ -9,7 +10,9 @@ import {
 import { i18n } from '../../../../assets/localization'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { deleteContainer } from '../../../../labware-ingred/actions'
+import { useKitchen } from '../../../../organisms/Kitchen/hooks'
 import { deleteModule } from '../../../../step-forms/actions'
+import { getAdditionalEquipment } from '../../../../step-forms/selectors'
 import { getRobotType } from '../../../../file-data/selectors'
 import { getEnableAbsorbanceReader } from '../../../../feature-flags/selectors'
 import { deleteDeckFixture } from '../../../../step-forms/actions/additionalItems'
@@ -31,11 +34,15 @@ vi.mock('../../../../step-forms/actions')
 vi.mock('../../../../step-forms/actions/additionalItems')
 vi.mock('../../../../labware-ingred/selectors')
 vi.mock('../../../../tutorial/selectors')
+vi.mock('../../../../step-forms/selectors')
+vi.mock('../../../../organisms/Kitchen/hooks')
 const render = (props: React.ComponentProps<typeof DeckSetupTools>) => {
   return renderWithProviders(<DeckSetupTools {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
+
+const mockMakeSnackbar = vi.fn()
 
 describe('DeckSetupTools', () => {
   let props: React.ComponentProps<typeof DeckSetupTools>
@@ -66,6 +73,12 @@ describe('DeckSetupTools', () => {
       pipettes: {},
     })
     vi.mocked(getDismissedHints).mockReturnValue([])
+    vi.mocked(getAdditionalEquipment).mockReturnValue({})
+    vi.mocked(useKitchen).mockReturnValue({
+      makeSnackbar: mockMakeSnackbar,
+      bakeToast: vi.fn(),
+      eatToast: vi.fn(),
+    })
   })
   afterEach(() => {
     vi.resetAllMocks()
@@ -163,5 +176,33 @@ describe('DeckSetupTools', () => {
     fireEvent.click(screen.getByText('Waste chute and staging area slot'))
     fireEvent.click(screen.getByText('Done'))
     expect(props.onCloseClick).toHaveBeenCalled()
+  })
+  it('should save plate reader if gripper configured', () => {
+    vi.mocked(getAdditionalEquipment).mockReturnValue({
+      gripperUri: { name: 'gripper', id: 'gripperId' },
+    })
+    vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
+      selectedLabwareDefUri: null,
+      selectedNestedLabwareDefUri: null,
+      selectedFixture: null,
+      selectedModuleModel: ABSORBANCE_READER_V1,
+      selectedSlot: { slot: 'D3', cutout: 'cutoutD3' },
+    })
+    render(props)
+    fireEvent.click(screen.getByText('Done'))
+    expect(props.onCloseClick).toHaveBeenCalled()
+  })
+  it('should prevent saving plate reader and make toast if gripper not configured', () => {
+    vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
+      selectedLabwareDefUri: null,
+      selectedNestedLabwareDefUri: null,
+      selectedFixture: null,
+      selectedModuleModel: ABSORBANCE_READER_V1,
+      selectedSlot: { slot: 'D3', cutout: 'cutoutD3' },
+    })
+    render(props)
+    fireEvent.click(screen.getByText('Done'))
+    expect(props.onCloseClick).not.toHaveBeenCalled()
+    expect(mockMakeSnackbar).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
# Overview

Here, I prevent saving adding a plate reader in DeckSetupTools if a gripper has not already been added. In a followup, we will enforce a timeline error at for plate reader stepforms that modify the lid state of the reader.

TODO: update snackbar copy/confirm that behavior with Design

Closes AUTH-1195
## Test Plan and Hands on Testing

- open or create a flex protocol and ensure a gripper is **_not_** configured
- navigate to edit > protocol starting deck
- select a right column slot and select absorbance reader
- select "done" and verify that the toolbox does not save, and a snackbar renders informing you to setup gripper first

https://github.com/user-attachments/assets/182bbf0e-1e8c-42f4-ad9c-aeeeb8ada4bd

## Changelog

- update logic for `handleConfirm` in `DeckSetupTools` to check for presence of a gripper when saving absorbance reader
- fix tests

## Review requests

- see test plan

## Risk assessment

low