### PR TITLE
fix(protocol-designer): properly delete and generate adapter/labware …

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -36,8 +36,11 @@ import {
   createDeckFixture,
   deleteDeckFixture,
 } from '../../../step-forms/actions/additionalItems'
-import { createModule, deleteModule } from '../../../step-forms/actions'
-import { getAdditionalEquipment } from '../../../step-forms/selectors'
+import { deleteModule } from '../../../step-forms/actions'
+import {
+  getAdditionalEquipment,
+  getSavedStepForms,
+} from '../../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import {
   createContainer,
@@ -54,7 +57,10 @@ import { useBlockingHint } from '../../../organisms/BlockingHintModal/useBlockin
 import { selectors } from '../../../labware-ingred/selectors'
 import { useKitchen } from '../../../organisms/Kitchen/hooks'
 import { getDismissedHints } from '../../../tutorial/selectors'
-import { createContainerAboveModule } from '../../../step-forms/actions/thunks'
+import {
+  createContainerAboveModule,
+  createModuleEntityAndChangeForm,
+} from '../../../step-forms/actions/thunks'
 import { BUTTON_LINK_STYLE, NAV_BAR_HEIGHT_REM } from '../../../atoms'
 import { ConfirmDeleteStagingAreaModal } from '../../../organisms'
 import { getSlotInformation } from '../utils'
@@ -66,6 +72,13 @@ import { getModuleModelsBySlot, getDeckErrors } from './utils'
 import type { AddressableAreaName, ModuleModel } from '@opentrons/shared-data'
 import type { ThunkDispatch } from '../../../types'
 import type { Fixture } from './constants'
+
+const mapModTypeToStepType: Record<string, string> = {
+  heaterShakerModuleType: 'heaterShaker',
+  magneticModuleType: 'magnet',
+  temperatureModuleType: 'temperature',
+  thermocyclerModuleType: 'thermocycler',
+}
 
 interface DeckSetupToolsProps {
   onCloseClick: () => void
@@ -91,6 +104,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   const { makeSnackbar } = useKitchen()
   const selectedSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
   const robotType = useSelector(getRobotType)
+  const savedSteps = useSelector(getSavedStepForms)
   const [showDeleteLabwareModal, setShowDeleteLabwareModal] = useState<
     ModuleModel | 'clear' | null
   >(null)
@@ -336,11 +350,32 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
         makeSnackbar(t('gripper_required_for_plate_reader') as string)
         return
       }
+
+      const moduleSteps = Object.values(savedSteps).filter(step => {
+        return (
+          step.stepType === mapModTypeToStepType[moduleType] &&
+          //  only update module steps that match the old moduleId
+          //  to accommodate instances of MoaM
+          step.moduleId === createdModuleForSlot?.id
+        )
+      })
+
+      const pauseSteps = Object.values(savedSteps).filter(step => {
+        return (
+          step.stepType === 'pause' &&
+          //  only update module steps that match the old moduleId
+          //  to accommodate instances of MoaM
+          step.moduleId === createdModuleForSlot?.id
+        )
+      })
+
       dispatch(
-        createModule({
+        createModuleEntityAndChangeForm({
           slot,
           type: moduleType,
           model: selectedModuleModel,
+          moduleSteps,
+          pauseSteps,
         })
       )
     }

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -272,7 +272,11 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       if (
         createdLabwareForSlot != null &&
         (!keepExistingLabware ||
-          createdLabwareForSlot.labwareDefURI !== selectedLabwareDefUri)
+          createdLabwareForSlot.labwareDefURI !== selectedLabwareDefUri ||
+          //  if nested labware changes but labware doesn't, still delete both
+          (createdLabwareForSlot.labwareDefURI === selectedLabwareDefUri &&
+            createdNestedLabwareForSlot?.labwareDefURI !==
+              selectedNestedLabwareDefUri))
       ) {
         dispatch(deleteContainer({ labwareId: createdLabwareForSlot.id }))
       }
@@ -364,7 +368,11 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     if (
       selectedModuleModel != null &&
       selectedLabwareDefUri != null &&
-      createdLabwareForSlot?.labwareDefURI !== selectedLabwareDefUri
+      (createdLabwareForSlot?.labwareDefURI !== selectedLabwareDefUri ||
+        //  if nested labware changes but labware doesn't, still create both both
+        (createdLabwareForSlot.labwareDefURI === selectedLabwareDefUri &&
+          createdNestedLabwareForSlot?.labwareDefURI !==
+            selectedNestedLabwareDefUri))
     ) {
       //   create adapter + labware on module
       dispatch(

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -12,7 +12,10 @@ import { renderWithProviders } from '../../../../__testing-utils__'
 import { deleteContainer } from '../../../../labware-ingred/actions'
 import { useKitchen } from '../../../../organisms/Kitchen/hooks'
 import { deleteModule } from '../../../../step-forms/actions'
-import { getAdditionalEquipment } from '../../../../step-forms/selectors'
+import {
+  getAdditionalEquipment,
+  getSavedStepForms,
+} from '../../../../step-forms/selectors'
 import { getRobotType } from '../../../../file-data/selectors'
 import { getEnableAbsorbanceReader } from '../../../../feature-flags/selectors'
 import { deleteDeckFixture } from '../../../../step-forms/actions/additionalItems'
@@ -72,6 +75,7 @@ describe('DeckSetupTools', () => {
       additionalEquipmentOnDeck: {},
       pipettes: {},
     })
+    vi.mocked(getSavedStepForms).mockReturnValue({})
     vi.mocked(getDismissedHints).mockReturnValue([])
     vi.mocked(getAdditionalEquipment).mockReturnValue({})
     vi.mocked(useKitchen).mockReturnValue({

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -12,12 +12,18 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
-import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  HEATERSHAKER_MODULE_V1,
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  getModuleDisplayName,
+} from '@opentrons/shared-data'
 import {
   getAdditionalEquipmentEntities,
   getLabwareEntities,
   getModuleEntities,
 } from '../../../step-forms/selectors'
+import { getModuleShortNames } from '../../../ui/modules/utils'
 import { getLabwareNicknamesById } from '../../../ui/labware/selectors'
 import { LINE_CLAMP_TEXT_STYLE } from '../../../atoms'
 import type { FormData } from '../../../form-types'
@@ -124,9 +130,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         engageHeight,
         magnetAction,
       } = currentStep
-      const magneticModuleDisplayName = getModuleDisplayName(
-        modules[magneticModuleId].model
-      )
+      const magneticModuleDisplayName =
+        getModuleDisplayName(modules[magneticModuleId]?.model) ??
+        getModuleShortNames(MAGNETIC_MODULE_TYPE)
       stepSummaryContent =
         magnetAction === 'engage' ? (
           <StyledTrans
@@ -259,9 +265,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         targetTemperature,
       } = currentStep
       const isDeactivating = setTemperature === 'false'
-      const tempModuleDisplayName = getModuleDisplayName(
-        modules[tempModuleId].model
-      )
+      const tempModuleDisplayName =
+        getModuleDisplayName(modules[tempModuleId]?.model) ??
+        getModuleShortNames(TEMPERATURE_MODULE_TYPE)
       stepSummaryContent = isDeactivating ? (
         <StyledTrans
           i18nKey={'protocol_steps:temperature_module.deactivated'}
@@ -362,7 +368,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         targetSpeed,
       } = currentStep
       const moduleDisplayName = getModuleDisplayName(
-        modules[heaterShakerModuleId].model
+        modules[heaterShakerModuleId]?.model ?? HEATERSHAKER_MODULE_V1
       )
       stepSummaryContent = (
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -12,18 +12,12 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
-import {
-  HEATERSHAKER_MODULE_V1,
-  MAGNETIC_MODULE_TYPE,
-  TEMPERATURE_MODULE_TYPE,
-  getModuleDisplayName,
-} from '@opentrons/shared-data'
+import { getModuleDisplayName } from '@opentrons/shared-data'
 import {
   getAdditionalEquipmentEntities,
   getLabwareEntities,
   getModuleEntities,
 } from '../../../step-forms/selectors'
-import { getModuleShortNames } from '../../../ui/modules/utils'
 import { getLabwareNicknamesById } from '../../../ui/labware/selectors'
 import { LINE_CLAMP_TEXT_STYLE } from '../../../atoms'
 import type { FormData } from '../../../form-types'
@@ -132,7 +126,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       } = currentStep
       const magneticModuleDisplayName =
         getModuleDisplayName(modules[magneticModuleId]?.model) ??
-        getModuleShortNames(MAGNETIC_MODULE_TYPE)
+        'Unknown module'
       stepSummaryContent =
         magnetAction === 'engage' ? (
           <StyledTrans
@@ -237,9 +231,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           )
           break
         case 'untilTemperature':
-          const pauseModuleDisplayName = getModuleDisplayName(
-            modules[pauseModuleId].model
-          )
+          const pauseModuleDisplayName =
+            getModuleDisplayName(modules[pauseModuleId]?.model) ??
+            'Unknown module'
           stepSummaryContent = (
             <StyledTrans
               i18nKey="protocol_steps:pause.untilTemperature"
@@ -266,8 +260,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       } = currentStep
       const isDeactivating = setTemperature === 'false'
       const tempModuleDisplayName =
-        getModuleDisplayName(modules[tempModuleId]?.model) ??
-        getModuleShortNames(TEMPERATURE_MODULE_TYPE)
+        getModuleDisplayName(modules[tempModuleId]?.model) ?? 'Unknown module'
       stepSummaryContent = isDeactivating ? (
         <StyledTrans
           i18nKey={'protocol_steps:temperature_module.deactivated'}
@@ -367,9 +360,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         targetHeaterShakerTemperature,
         targetSpeed,
       } = currentStep
-      const moduleDisplayName = getModuleDisplayName(
-        modules[heaterShakerModuleId]?.model ?? HEATERSHAKER_MODULE_V1
-      )
+      const moduleDisplayName =
+        getModuleDisplayName(modules[heaterShakerModuleId]?.model) ??
+        'Unknown module'
       stepSummaryContent = (
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
           <Flex gridGap={SPACING.spacing20} alignItems={ALIGN_CENTER}>


### PR DESCRIPTION
…combo when editing

closes RQA-3777 RQA-3804

# Overview

Wowza this was a very annoying bug haha, took me about 4 hours to figure out what to do to handle all cases. basically, we weren't properly regenerating labware if you edit the labware on top of the adapter but not the adapter. this PR fixes that

## Test Plan and Hands on Testing

Look at the ticket and test the example, then test editing labware in general on the deck, on an adapter and on a module and make sure it all works as expected

For the 2nd bug fix, upload the attached protocol, edit the labware on top of the heater-shaker module and go back to the protocol steps and see that the heater-shaker steps don't error. The transfer steps error and that's because we no longer have the dispense labware

[1.0 testing (18).json](https://github.com/user-attachments/files/18211837/1.0.testing.18.json)

## Changelog

refine logic for when to delete and create labware
create thunk for creating module and migrating the saved step forms module id

## Risk assessment

low