### PR TITLE
fix(protocol-designer): editing labware on top of a module and adapter fixes

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -143,5 +143,6 @@
   "volume_per_well": "Volume per well",
   "well_name": "Well {{wellName}}",
   "well_order_title": "{{prefix}} well order",
-  "well_position": "Well position: X {{x}} Y {{y}} Z {{z}} (mm)"
+  "well_position": "Well position: X {{x}} Y {{y}} Z {{z}} (mm)",
+  "unknown_module": "Unknown module"
 }

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -339,7 +339,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       const pauseSteps = Object.values(savedSteps).filter(step => {
         return (
           step.stepType === 'pause' &&
-          //  only update module steps that match the old moduleId
+          //  only update pause steps that match the old moduleId
           //  to accommodate instances of MoaM
           step.moduleId === createdModuleForSlot?.id
         )
@@ -348,7 +348,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       dispatch(
         createModuleEntityAndChangeForm({
           slot,
-          type: getModuleType(selectedModuleModel),
+          type: moduleType,
           model: selectedModuleModel,
           moduleSteps,
           pauseSteps,

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -255,7 +255,11 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       if (
         createdLabwareForSlot != null &&
         (!keepExistingLabware ||
-          createdLabwareForSlot.labwareDefURI !== selectedLabwareDefUri)
+          createdLabwareForSlot.labwareDefURI !== selectedLabwareDefUri ||
+          //  if nested labware changes but labware doesn't, still delete both
+          (createdLabwareForSlot.labwareDefURI === selectedLabwareDefUri &&
+            createdNestedLabwareForSlot?.labwareDefURI !==
+              selectedNestedLabwareDefUri))
       ) {
         dispatch(deleteContainer({ labwareId: createdLabwareForSlot.id }))
       }
@@ -344,7 +348,11 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     if (
       selectedModuleModel != null &&
       selectedLabwareDefUri != null &&
-      createdLabwareForSlot?.labwareDefURI !== selectedLabwareDefUri
+      (createdLabwareForSlot?.labwareDefURI !== selectedLabwareDefUri ||
+        //  if nested labware changes but labware doesn't, still create both both
+        (createdLabwareForSlot.labwareDefURI === selectedLabwareDefUri &&
+          createdNestedLabwareForSlot?.labwareDefURI !==
+            selectedNestedLabwareDefUri))
     ) {
       //   create adapter + labware on module
       dispatch(

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -33,7 +33,8 @@ import {
   createDeckFixture,
   deleteDeckFixture,
 } from '../../../step-forms/actions/additionalItems'
-import { createModule, deleteModule } from '../../../step-forms/actions'
+import { deleteModule } from '../../../step-forms/actions'
+import { getSavedStepForms } from '../../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import {
   createContainer,
@@ -50,9 +51,12 @@ import { useBlockingHint } from '../../../organisms/BlockingHintModal/useBlockin
 import { selectors } from '../../../labware-ingred/selectors'
 import { useKitchen } from '../../../organisms/Kitchen/hooks'
 import { getDismissedHints } from '../../../tutorial/selectors'
-import { createContainerAboveModule } from '../../../step-forms/actions/thunks'
-import { ConfirmDeleteStagingAreaModal } from '../../../organisms'
+import {
+  createContainerAboveModule,
+  createModuleEntityAndChangeForm,
+} from '../../../step-forms/actions/thunks'
 import { BUTTON_LINK_STYLE } from '../../../atoms'
+import { ConfirmDeleteStagingAreaModal } from '../../../organisms'
 import { getSlotInformation } from '../utils'
 import { ALL_ORDERED_CATEGORIES, FIXTURES, MOAM_MODELS } from './constants'
 import { LabwareTools } from './LabwareTools'
@@ -62,6 +66,13 @@ import { getModuleModelsBySlot, getDeckErrors } from './utils'
 import type { AddressableAreaName, ModuleModel } from '@opentrons/shared-data'
 import type { ThunkDispatch } from '../../../types'
 import type { Fixture } from './constants'
+
+const mapModTypeToStepType: Record<string, string> = {
+  heaterShakerModuleType: 'heaterShaker',
+  magneticModuleType: 'magnet',
+  temperatureModuleType: 'temperature',
+  thermocyclerModuleType: 'thermocycler',
+}
 
 interface DeckSetupToolsProps {
   onCloseClick: () => void
@@ -80,6 +91,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
   const { makeSnackbar } = useKitchen()
   const selectedSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
   const robotType = useSelector(getRobotType)
+  const savedSteps = useSelector(getSavedStepForms)
   const [showDeleteLabwareModal, setShowDeleteLabwareModal] = useState<
     ModuleModel | 'clear' | null
   >(null)
@@ -313,11 +325,38 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     }
     if (selectedModuleModel != null) {
       //  create module
+      const moduleType = getModuleType(selectedModuleModel)
+      // enforce gripper present in order to add plate reader
+      if (moduleType === ABSORBANCE_READER_TYPE && !isGripperAttached) {
+        makeSnackbar(t('gripper_required_for_plate_reader') as string)
+        return
+      }
+
+      const moduleSteps = Object.values(savedSteps).filter(step => {
+        return (
+          step.stepType === mapModTypeToStepType[moduleType] &&
+          //  only update module steps that match the old moduleId
+          //  to accommodate instances of MoaM
+          step.moduleId === createdModuleForSlot?.id
+        )
+      })
+
+      const pauseSteps = Object.values(savedSteps).filter(step => {
+        return (
+          step.stepType === 'pause' &&
+          //  only update module steps that match the old moduleId
+          //  to accommodate instances of MoaM
+          step.moduleId === createdModuleForSlot?.id
+        )
+      })
+
       dispatch(
-        createModule({
+        createModuleEntityAndChangeForm({
           slot,
           type: getModuleType(selectedModuleModel),
           model: selectedModuleModel,
+          moduleSteps,
+          pauseSteps,
         })
       )
     }

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -326,11 +326,6 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     if (selectedModuleModel != null) {
       //  create module
       const moduleType = getModuleType(selectedModuleModel)
-      // enforce gripper present in order to add plate reader
-      if (moduleType === ABSORBANCE_READER_TYPE && !isGripperAttached) {
-        makeSnackbar(t('gripper_required_for_plate_reader') as string)
-        return
-      }
 
       const moduleSteps = Object.values(savedSteps).filter(step => {
         return (

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -10,6 +10,7 @@ import { i18n } from '../../../../assets/localization'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { deleteContainer } from '../../../../labware-ingred/actions'
 import { deleteModule } from '../../../../step-forms/actions'
+import { getSavedStepForms } from '../../../../step-forms/selectors'
 import { getRobotType } from '../../../../file-data/selectors'
 import { getEnableAbsorbanceReader } from '../../../../feature-flags/selectors'
 import { deleteDeckFixture } from '../../../../step-forms/actions/additionalItems'
@@ -65,6 +66,7 @@ describe('DeckSetupTools', () => {
       additionalEquipmentOnDeck: {},
       pipettes: {},
     })
+    vi.mocked(getSavedStepForms).mockReturnValue({})
     vi.mocked(getDismissedHints).mockReturnValue([])
   })
   afterEach(() => {

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -20,7 +20,6 @@ import { getDeckSetupForActiveItem } from '../../../../top-selectors/labware-loc
 import { DeckSetupTools } from '../DeckSetupTools'
 import { LabwareTools } from '../LabwareTools'
 
-import type * as React from 'react'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 vi.mock('../LabwareTools')
@@ -32,6 +31,7 @@ vi.mock('../../../../step-forms/actions')
 vi.mock('../../../../step-forms/actions/additionalItems')
 vi.mock('../../../../labware-ingred/selectors')
 vi.mock('../../../../tutorial/selectors')
+vi.mock('../../../../step-forms/selectors')
 const render = (props: React.ComponentProps<typeof DeckSetupTools>) => {
   return renderWithProviders(<DeckSetupTools {...props} />, {
     i18nInstance: i18n,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -79,6 +79,7 @@ interface StepSummaryProps {
 export function StepSummary(props: StepSummaryProps): JSX.Element | null {
   const { currentStep, stepDetails } = props
   const { t } = useTranslation(['protocol_steps', 'application'])
+  const unknownModule = t('unkonwn_module')
   const labwareNicknamesById = useSelector(getLabwareNicknamesById)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
@@ -125,8 +126,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         magnetAction,
       } = currentStep
       const magneticModuleDisplayName =
-        getModuleDisplayName(modules[magneticModuleId]?.model) ??
-        'Unknown module'
+        getModuleDisplayName(modules[magneticModuleId]?.model) ?? unknownModule
       stepSummaryContent =
         magnetAction === 'engage' ? (
           <StyledTrans
@@ -232,8 +232,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           break
         case 'untilTemperature':
           const pauseModuleDisplayName =
-            getModuleDisplayName(modules[pauseModuleId]?.model) ??
-            'Unknown module'
+            getModuleDisplayName(modules[pauseModuleId]?.model) ?? unknownModule
           stepSummaryContent = (
             <StyledTrans
               i18nKey="protocol_steps:pause.untilTemperature"
@@ -260,7 +259,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       } = currentStep
       const isDeactivating = setTemperature === 'false'
       const tempModuleDisplayName =
-        getModuleDisplayName(modules[tempModuleId]?.model) ?? 'Unknown module'
+        getModuleDisplayName(modules[tempModuleId]?.model) ?? unknownModule
       stepSummaryContent = isDeactivating ? (
         <StyledTrans
           i18nKey={'protocol_steps:temperature_module.deactivated'}
@@ -362,7 +361,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       } = currentStep
       const moduleDisplayName =
         getModuleDisplayName(modules[heaterShakerModuleId]?.model) ??
-        'Unknown module'
+        unknownModule
       stepSummaryContent = (
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
           <Flex gridGap={SPACING.spacing20} alignItems={ALIGN_CENTER}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -12,12 +12,18 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
-import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  HEATERSHAKER_MODULE_V1,
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  getModuleDisplayName,
+} from '@opentrons/shared-data'
 import {
   getAdditionalEquipmentEntities,
   getLabwareEntities,
   getModuleEntities,
 } from '../../../step-forms/selectors'
+import { getModuleShortNames } from '../../../ui/modules/utils'
 import { getLabwareNicknamesById } from '../../../ui/labware/selectors'
 import { LINE_CLAMP_TEXT_STYLE } from '../../../atoms'
 import type { FormData } from '../../../form-types'
@@ -124,9 +130,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         engageHeight,
         magnetAction,
       } = currentStep
-      const magneticModuleDisplayName = getModuleDisplayName(
-        modules[magneticModuleId].model
-      )
+      const magneticModuleDisplayName =
+        getModuleDisplayName(modules[magneticModuleId]?.model) ??
+        getModuleShortNames(MAGNETIC_MODULE_TYPE)
       stepSummaryContent =
         magnetAction === 'engage' ? (
           <StyledTrans
@@ -259,9 +265,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         targetTemperature,
       } = currentStep
       const isDeactivating = setTemperature === 'false'
-      const tempModuleDisplayName = getModuleDisplayName(
-        modules[tempModuleId].model
-      )
+      const tempModuleDisplayName =
+        getModuleDisplayName(modules[tempModuleId]?.model) ??
+        getModuleShortNames(TEMPERATURE_MODULE_TYPE)
       stepSummaryContent = isDeactivating ? (
         <StyledTrans
           i18nKey={'protocol_steps:temperature_module.deactivated'}
@@ -362,7 +368,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         targetSpeed,
       } = currentStep
       const moduleDisplayName = getModuleDisplayName(
-        modules[heaterShakerModuleId].model
+        modules[heaterShakerModuleId]?.model ?? HEATERSHAKER_MODULE_V1
       )
       stepSummaryContent = (
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -12,18 +12,12 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
-import {
-  HEATERSHAKER_MODULE_V1,
-  MAGNETIC_MODULE_TYPE,
-  TEMPERATURE_MODULE_TYPE,
-  getModuleDisplayName,
-} from '@opentrons/shared-data'
+import { getModuleDisplayName } from '@opentrons/shared-data'
 import {
   getAdditionalEquipmentEntities,
   getLabwareEntities,
   getModuleEntities,
 } from '../../../step-forms/selectors'
-import { getModuleShortNames } from '../../../ui/modules/utils'
 import { getLabwareNicknamesById } from '../../../ui/labware/selectors'
 import { LINE_CLAMP_TEXT_STYLE } from '../../../atoms'
 import type { FormData } from '../../../form-types'
@@ -132,7 +126,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       } = currentStep
       const magneticModuleDisplayName =
         getModuleDisplayName(modules[magneticModuleId]?.model) ??
-        getModuleShortNames(MAGNETIC_MODULE_TYPE)
+        'Unknown module'
       stepSummaryContent =
         magnetAction === 'engage' ? (
           <StyledTrans
@@ -237,9 +231,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           )
           break
         case 'untilTemperature':
-          const pauseModuleDisplayName = getModuleDisplayName(
-            modules[pauseModuleId].model
-          )
+          const pauseModuleDisplayName =
+            getModuleDisplayName(modules[pauseModuleId]?.model) ??
+            'Unknown module'
           stepSummaryContent = (
             <StyledTrans
               i18nKey="protocol_steps:pause.untilTemperature"
@@ -266,8 +260,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       } = currentStep
       const isDeactivating = setTemperature === 'false'
       const tempModuleDisplayName =
-        getModuleDisplayName(modules[tempModuleId]?.model) ??
-        getModuleShortNames(TEMPERATURE_MODULE_TYPE)
+        getModuleDisplayName(modules[tempModuleId]?.model) ?? 'Unknown module'
       stepSummaryContent = isDeactivating ? (
         <StyledTrans
           i18nKey={'protocol_steps:temperature_module.deactivated'}
@@ -367,9 +360,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         targetHeaterShakerTemperature,
         targetSpeed,
       } = currentStep
-      const moduleDisplayName = getModuleDisplayName(
-        modules[heaterShakerModuleId]?.model ?? HEATERSHAKER_MODULE_V1
-      )
+      const moduleDisplayName =
+        getModuleDisplayName(modules[heaterShakerModuleId]?.model) ??
+        'Unknown module'
       stepSummaryContent = (
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
           <Flex gridGap={SPACING.spacing20} alignItems={ALIGN_CENTER}>


### PR DESCRIPTION
address RQA-3777 RQA-3804

# Overview

2 bugs were addressed here and they're related. 

1. we weren't properly regenerating labware if you edit the labware on top of the adapter but not the adapter. this PR fixes that (bug outlined in RQA-3777)
2. if you have a protocol with module steps and you edit the labware on top of the module, the steps error because the moduleId is the old moduleId that was deleted. this PR migrates those steps to using the right moduleId

## Test Plan and Hands on Testing

1. Look at the ticket and test the example, then test editing labware in general on the deck, on an adapter and on a module and make sure it all works as expected

2. For the 2nd bug fix, upload the attached protocol, edit the labware on top of the heater-shaker module and go back to the protocol steps and see that the heater-shaker steps don't error. The transfer steps error and that's because we no longer have the dispense labware

[1.0 testing (18).json](https://github.com/user-attachments/files/18211837/1.0.testing.18.json)

## Changelog

refine logic for when to delete and create labware
create thunk for creating module and migrating the saved step forms module id

## Risk assessment

isolated fix, low
