### PR TITLE
fix(protocol-designer): allow custom labware on adapters

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
@@ -437,10 +437,15 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
                                             )
                                           }
                                         )
-                                      : getLabwareCompatibleWithAdapter(
-                                          loadName
-                                        ).map(nestedDefUri => {
-                                          const nestedDef = defs[nestedDefUri]
+                                      : [
+                                          ...getLabwareCompatibleWithAdapter(
+                                            loadName
+                                          ),
+                                          ...Object.keys(customLabwareDefs),
+                                        ].map(nestedDefUri => {
+                                          const nestedDef =
+                                            defs[nestedDefUri] ??
+                                            customLabwareDefs[nestedDefUri]
 
                                           return (
                                             <ListButtonRadioButton


### PR DESCRIPTION
closes RQA-3779

# Overview

Allow custom labware on top of adapters

## Test Plan and Hands on Testing

Add the attached custom labware to your protocol. Then try to add it on to an adapter and see that its selectable and when you press save, it is correctly saved

[Thermo Scientific 96 Well Plate V Bottom 450 uL_with offset.json](https://github.com/user-attachments/files/18212603/Thermo.Scientific.96.Well.Plate.V.Bottom.450.uL_with.offset.json)


## Changelog

- extend adapter labware to include custom labwares

## Risk assessment

low
