### PR TITLE
fix(protocol-designer): timeline errors/warnings show up in mixpanel

### DIFF
--- a/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.ts
+++ b/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.ts
@@ -154,9 +154,10 @@ describe('reduxActionToAnalyticsEvent', () => {
         id: 'stepId',
         pipette: 'pipetteId',
         otherField: 123,
-        aspirateFlowRate: undefined,
-        dispenseFlowRate: undefined,
-        aspirateAirGap: undefined,
+        aspirateFlowRate: 'default',
+        dispenseFlowRate: 'default',
+        aspirateAirGap: 'default',
+        dispenseAirGap: 'default',
         nested: { inner: true },
         // de-nested fields
         __nested__inner: true,

--- a/protocol-designer/src/analytics/middleware.ts
+++ b/protocol-designer/src/analytics/middleware.ts
@@ -158,9 +158,14 @@ export const reduxActionToAnalyticsEvent = (
             name: `${modifiedStepName}Step`,
             properties: {
               ...stepArgModified,
-              aspirateAirGap: stepArgModified.aspirateAirGapVolume,
-              aspirateFlowRate: stepArgModified.aspirateFlowRateUlSec,
-              dispenseFlowRate: stepArgModified.dispenseFlowRateUlSec,
+              aspirateAirGap:
+                stepArgModified.aspirateAirGapVolume ?? DEFAULT_VALUE,
+              aspirateFlowRate:
+                stepArgModified.aspirateFlowRateUlSec ?? DEFAULT_VALUE,
+              dispenseFlowRate:
+                stepArgModified.dispenseFlowRateUlSec ?? DEFAULT_VALUE,
+              dispenseAirGap:
+                stepArgModified.dispenseAirGapVolume ?? DEFAULT_VALUE,
               blowoutFlowRate: stepArgModified.blowoutFlowRateUlSec,
               aspirateOffsetFromBottomMm:
                 stepArgModified.aspirateOffsetFromBottomMm ===
@@ -202,9 +207,10 @@ export const reduxActionToAnalyticsEvent = (
             name: `mixStep`,
             properties: {
               ...stepArgModified,
-              aspirateFlowRate: stepArgModified.aspirateFlowRateUlSec,
-              dispenseFlowRate: stepArgModified.dispenseFlowRateUlSec,
-              blowoutFlowRate: stepArgModified.blowoutFlowRateUlSec,
+              aspirateFlowRate:
+                stepArgModified.aspirateFlowRateUlSec ?? DEFAULT_VALUE,
+              dispenseFlowRate:
+                stepArgModified.dispenseFlowRateUlSec ?? DEFAULT_VALUE,
               aspirateOffsetFromBottomMm:
                 stepArgModified.aspirateOffsetFromBottomMm ===
                 DEFAULT_MM_FROM_BOTTOM_ASPIRATE
@@ -246,7 +252,6 @@ export const reduxActionToAnalyticsEvent = (
 
   if (action.type === 'COMPUTE_ROBOT_STATE_TIMELINE_SUCCESS') {
     const robotTimeline = getRobotStateTimeline(state)
-    console.log('hit here with robotTimeline as', robotTimeline?.timeline)
     const { errors, timeline } = robotTimeline
     const commandAndRobotState = timeline.filter(t => t.warnings != null)
     const warnings =

--- a/protocol-designer/src/analytics/middleware.ts
+++ b/protocol-designer/src/analytics/middleware.ts
@@ -158,12 +158,9 @@ export const reduxActionToAnalyticsEvent = (
             name: `${modifiedStepName}Step`,
             properties: {
               ...stepArgModified,
-              aspirateAirGap:
-                stepArgModified.aspirateAirGapVolume ?? DEFAULT_VALUE,
-              aspirateFlowRate:
-                stepArgModified.aspirateFlowRateUlSec ?? DEFAULT_VALUE,
-              dispenseFlowRate:
-                stepArgModified.dispenseFlowRateUlSec ?? DEFAULT_VALUE,
+              aspirateAirGap: stepArgModified.aspirateAirGapVolume,
+              aspirateFlowRate: stepArgModified.aspirateFlowRateUlSec,
+              dispenseFlowRate: stepArgModified.dispenseFlowRateUlSec,
               blowoutFlowRate: stepArgModified.blowoutFlowRateUlSec,
               aspirateOffsetFromBottomMm:
                 stepArgModified.aspirateOffsetFromBottomMm ===

--- a/protocol-designer/src/analytics/middleware.ts
+++ b/protocol-designer/src/analytics/middleware.ts
@@ -211,6 +211,7 @@ export const reduxActionToAnalyticsEvent = (
                 stepArgModified.aspirateFlowRateUlSec ?? DEFAULT_VALUE,
               dispenseFlowRate:
                 stepArgModified.dispenseFlowRateUlSec ?? DEFAULT_VALUE,
+              blowoutFlowRate: stepArgModified.blowoutFlowRateUlSec,
               aspirateOffsetFromBottomMm:
                 stepArgModified.aspirateOffsetFromBottomMm ===
                 DEFAULT_MM_FROM_BOTTOM_ASPIRATE

--- a/protocol-designer/src/analytics/middleware.ts
+++ b/protocol-designer/src/analytics/middleware.ts
@@ -158,9 +158,12 @@ export const reduxActionToAnalyticsEvent = (
             name: `${modifiedStepName}Step`,
             properties: {
               ...stepArgModified,
-              aspirateAirGap: stepArgModified.aspirateAirGapVolume,
-              aspirateFlowRate: stepArgModified.aspirateFlowRateUlSec,
-              dispenseFlowRate: stepArgModified.dispenseFlowRateUlSec,
+              aspirateAirGap:
+                stepArgModified.aspirateAirGapVolume ?? DEFAULT_VALUE,
+              aspirateFlowRate:
+                stepArgModified.aspirateFlowRateUlSec ?? DEFAULT_VALUE,
+              dispenseFlowRate:
+                stepArgModified.dispenseFlowRateUlSec ?? DEFAULT_VALUE,
               blowoutFlowRate: stepArgModified.blowoutFlowRateUlSec,
               aspirateOffsetFromBottomMm:
                 stepArgModified.aspirateOffsetFromBottomMm ===
@@ -246,6 +249,7 @@ export const reduxActionToAnalyticsEvent = (
 
   if (action.type === 'COMPUTE_ROBOT_STATE_TIMELINE_SUCCESS') {
     const robotTimeline = getRobotStateTimeline(state)
+    console.log('hit here with robotTimeline as', robotTimeline?.timeline)
     const { errors, timeline } = robotTimeline
     const commandAndRobotState = timeline.filter(t => t.warnings != null)
     const warnings =

--- a/protocol-designer/src/configureStore.ts
+++ b/protocol-designer/src/configureStore.ts
@@ -89,8 +89,8 @@ export function configureStore(): StoreType {
     /* preloadedState, */
     composeEnhancers(
       applyMiddleware(
-        trackEventMiddleware as Middleware<BaseState, Record<string, any>, any>,
         timelineMiddleware as Middleware<BaseState, Record<string, any>, any>,
+        trackEventMiddleware as Middleware<BaseState, Record<string, any>, any>,
         thunk
       )
     ) as StoreEnhancer<unknown, unknown>

--- a/protocol-designer/src/configureStore.ts
+++ b/protocol-designer/src/configureStore.ts
@@ -89,9 +89,9 @@ export function configureStore(): StoreType {
     /* preloadedState, */
     composeEnhancers(
       applyMiddleware(
+        thunk,
         timelineMiddleware as Middleware<BaseState, Record<string, any>, any>,
-        trackEventMiddleware as Middleware<BaseState, Record<string, any>, any>,
-        thunk
+        trackEventMiddleware as Middleware<BaseState, Record<string, any>, any>
       )
     ) as StoreEnhancer<unknown, unknown>
   )


### PR DESCRIPTION
closes RQA-3778

# Overview

Added a few missing args to `moveLiquid` and `mix` and then swapped the middleware order so the timeline errors/warnings analytics event gets recorded

## Test Plan and Hands on Testing

Test in the sandbox making a timeline error/warning and see that it gets properly populated into the mixpanel web dev project

## Changelog

- swapped middleware order
- add 'default' if the args are not populated

## Risk assessment

low
