### PR TITLE
fix(protocol-designer): fix save behavior for bad liquid form

### DIFF
--- a/protocol-designer/src/assets/localization/en/form.json
+++ b/protocol-designer/src/assets/localization/en/form.json
@@ -23,7 +23,11 @@
   "liquid_placement": {
     "liquid": "Liquid",
     "volume": "Volume",
-    "volume_exceeded": "Warning: exceeded max volume per well: {{volume}}µL"
+    "errors": {
+      "liquid_required": "Define a liquid",
+      "volume_exceeded": "Warning: exceeded max volume per well: {{volume}}µL",
+      "volume_required": "Define a volume"
+    }
   },
   "pipette_mount_label": {
     "left": "(L)",

--- a/protocol-designer/src/organisms/AssignLiquidsModal/LiquidCard.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/LiquidCard.tsx
@@ -166,7 +166,7 @@ export function LiquidCard(props: LiquidCardProps): JSX.Element {
       </Flex>
       {isExpanded ? (
         <>
-          <Divider borderBottom={`1px solid ${String(COLORS.grey35)}`} />
+          <Divider borderBottom={`1px solid ${COLORS.grey40}`} />
           <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
             <Flex gridGap={SPACING.spacing4} color={COLORS.grey60}>
               <StyledText width="50%" desktopStyle="bodyDefaultRegular">
@@ -178,7 +178,7 @@ export function LiquidCard(props: LiquidCardProps): JSX.Element {
                 </StyledText>
               </Flex>
             </Flex>
-            <Divider borderColor={COLORS.grey35} />
+            <Divider borderBottom={`1px solid ${COLORS.grey40}`} />
             {info.liquidIndex != null
               ? fullWellsByLiquid[info.liquidIndex]
                   .sort((a, b) =>
@@ -194,7 +194,9 @@ export function LiquidCard(props: LiquidCardProps): JSX.Element {
                         <WellContents wellName={wellName} volume={volume} />
                         {wellliquidIndex <
                         fullWellsByLiquid[liquidIndex].length - 1 ? (
-                          <Divider borderColor={COLORS.grey35} />
+                          <Divider
+                            borderBottom={`1px solid ${COLORS.grey40}`}
+                          />
                         ) : null}
                       </>
                     )

--- a/protocol-designer/src/organisms/AssignLiquidsModal/LiquidCard.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/LiquidCard.tsx
@@ -12,7 +12,7 @@ import {
   Flex,
   Icon,
   LiquidIcon,
-  ListItem,
+  ListButton,
   SPACING,
   StyledText,
   TEXT_DECORATION_UNDERLINE,
@@ -98,7 +98,15 @@ export function LiquidCard(props: LiquidCardProps): JSX.Element {
   }
 
   return (
-    <ListItem type="noActive" flexDirection={DIRECTION_COLUMN} key={name}>
+    <ListButton
+      type="noActive"
+      flexDirection={DIRECTION_COLUMN}
+      key={name}
+      onClick={() => {
+        setIsExpanded(prev => !prev)
+      }}
+      padding="0"
+    >
       <Flex
         flexDirection={DIRECTION_COLUMN}
         padding={SPACING.spacing12}
@@ -133,12 +141,7 @@ export function LiquidCard(props: LiquidCardProps): JSX.Element {
                 : null}
             </StyledText>
           </Flex>
-          <Flex
-            cursor={CURSOR_POINTER}
-            onClick={() => {
-              setIsExpanded(prev => !prev)
-            }}
-          >
+          <Flex cursor={CURSOR_POINTER}>
             <Icon
               name={isExpanded ? 'chevron-up' : 'chevron-down'}
               size="2rem"
@@ -162,42 +165,45 @@ export function LiquidCard(props: LiquidCardProps): JSX.Element {
         </Btn>
       </Flex>
       {isExpanded ? (
-        <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
-          <Flex gridGap={SPACING.spacing4} color={COLORS.grey60}>
-            <StyledText width="50%" desktopStyle="bodyDefaultRegular">
-              {t('well')}
-            </StyledText>
-            <Flex width="50%">
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {t('microliters')}
+        <>
+          <Divider borderBottom={`1px solid ${String(COLORS.grey35)}`} />
+          <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
+            <Flex gridGap={SPACING.spacing4} color={COLORS.grey60}>
+              <StyledText width="50%" desktopStyle="bodyDefaultRegular">
+                {t('well')}
               </StyledText>
+              <Flex width="50%">
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {t('microliters')}
+                </StyledText>
+              </Flex>
             </Flex>
-          </Flex>
-          <Divider borderColor={COLORS.grey35} />
-          {info.liquidIndex != null
-            ? fullWellsByLiquid[info.liquidIndex]
-                .sort((a, b) =>
-                  orderedWells.indexOf(b) > orderedWells.indexOf(a) ? -1 : 1
-                )
-                .map((wellName, wellliquidIndex) => {
-                  const volume =
-                    wellContents != null
-                      ? wellContents[wellName].ingreds[liquidIndex].volume
-                      : 0
-                  return (
-                    <>
-                      <WellContents wellName={wellName} volume={volume} />
-                      {wellliquidIndex <
-                      fullWellsByLiquid[liquidIndex].length - 1 ? (
-                        <Divider borderColor={COLORS.grey35} />
-                      ) : null}
-                    </>
+            <Divider borderColor={COLORS.grey35} />
+            {info.liquidIndex != null
+              ? fullWellsByLiquid[info.liquidIndex]
+                  .sort((a, b) =>
+                    orderedWells.indexOf(b) > orderedWells.indexOf(a) ? -1 : 1
                   )
-                })
-            : null}
-        </Flex>
+                  .map((wellName, wellliquidIndex) => {
+                    const volume =
+                      wellContents != null
+                        ? wellContents[wellName].ingreds[liquidIndex].volume
+                        : 0
+                    return (
+                      <>
+                        <WellContents wellName={wellName} volume={volume} />
+                        {wellliquidIndex <
+                        fullWellsByLiquid[liquidIndex].length - 1 ? (
+                          <Divider borderColor={COLORS.grey35} />
+                        ) : null}
+                      </>
+                    )
+                  })
+              : null}
+          </Flex>
+        </>
       ) : null}
-    </ListItem>
+    </ListButton>
   )
 }
 

--- a/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -106,11 +106,12 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
     control,
     setValue,
     reset,
-    formState: { touchedFields },
+    formState,
   } = useForm<ToolboxFormValues>({
     defaultValues: getInitialValues(),
   })
 
+  const { errors } = formState
   const selectedLiquidId = watch('selectedLiquidId')
   const volume = watch('volume')
 
@@ -184,15 +185,22 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
     reset()
   }
 
-  let volumeErrors: string | null = null
-  if (Boolean(touchedFields.volume)) {
-    if (volume == null || volume === '0') {
-      volumeErrors = t('generic.error.more_than_zero')
-    } else if (parseInt(volume) > selectedWellsMaxVolume) {
-      volumeErrors = t('form:liquid_placement.volume_exceeded', {
+  const validateVolume = (
+    volume: string | null | undefined
+  ): string | undefined => {
+    if (volume == null || volume === '') {
+      return t('form:liquid_placement.errors.volume_required')
+    }
+    const volumeNumber = parseFloat(volume)
+    if (volumeNumber === 0) {
+      return t('form:generic.error.more_than_zero')
+    }
+    if (volumeNumber > selectedWellsMaxVolume) {
+      return t('form:liquid_placement.errors.volume_exceeded', {
         volume: selectedWellsMaxVolume,
       })
     }
+    return undefined
   }
 
   let wellContents: ContentsByWell | null = null
@@ -301,7 +309,12 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
                         name="selectedLiquidId"
                         control={control}
                         rules={{
-                          required: true,
+                          required: {
+                            value: true,
+                            message: t(
+                              'form:liquid_placement.errors.liquid_required'
+                            ),
+                          },
                         }}
                         render={({ field }) => {
                           const fullOptions: DropdownOption[] = liquidSelectionOptions.map(
@@ -337,6 +350,7 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
                               }}
                               onClick={field.onChange}
                               menuPlacement="bottom"
+                              error={errors.selectedLiquidId?.message}
                             />
                           )
                         }}
@@ -354,14 +368,14 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
                         name="volume"
                         control={control}
                         rules={{
-                          required: true,
+                          validate: validateVolume,
                         }}
                         render={({ field }) => (
                           <InputField
                             name="volume"
                             units={t('application:units.microliter')}
                             value={volume}
-                            error={volumeErrors}
+                            error={errors.volume?.message}
                             onBlur={field.onBlur}
                             onChange={handleChangeVolume}
                           />
@@ -377,18 +391,7 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
                           {t('shared:cancel')}
                         </StyledText>
                       </Btn>
-                      <PrimaryButton
-                        disabled={
-                          volumeErrors != null ||
-                          volume == null ||
-                          volume === '' ||
-                          selectedLiquidId == null ||
-                          selectedLiquidId === ''
-                        }
-                        type="submit"
-                      >
-                        {t('save')}
-                      </PrimaryButton>
+                      <PrimaryButton type="submit">{t('save')}</PrimaryButton>
                     </Flex>
                   </Flex>
                 </ListItem>


### PR DESCRIPTION
# Overview

In liquids toolbox, we should never disable "save" when adding a liquid to wells. Rather, errors should show when save is clicked, surfacing to the user fields that need to be resolved. Here, I modify our logic for Controller rules in our form used to added liquids, and implement a volume validation function.

Closes RQA-3497

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/8dc4b184-8765-46b6-bb57-bd2bc4259a4c
- open "add/edit liquid" from a labware on starting deck
- select wells to open add liquid form
- verify behavior for various error states (empty and invalid volumes)

## Changelog

- update form logic
- add translations

## Review requests

see test plan

## Risk assessment

low