### PR TITLE
perf(robot-server): Avoid creating process pools that won't do anything

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/up_to_3.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_3.py
@@ -191,6 +191,12 @@ def _migrate_db_commands(
     the work across subprocesses. Each subprocess extracts, migrates, and inserts
     all of the commands for a single run.
     """
+    # Performance optimization: If we have nothing to migrate, don't even create the
+    # process pool. This avoids the heavy imports in the preload.
+    # On my laptop, this shaves ~1.5s off of each of our integration tests.
+    if not run_ids:
+        return
+
     mp = multiprocessing.get_context("forkserver")
     mp.set_forkserver_preload(_up_to_3_worker.imports)
 


### PR DESCRIPTION
## Overview

This optimizes a specific case of robot-server startup. 

## Details

One of our persistence directory migrations delegates some work to a process pool, for parallelization. But there is a lot of overhead to spawning that process pool (chiefly because of [heavy, intertwined imports in the `opentrons` package](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3997401136/Imports+and+module+structure#Don%E2%80%99t-re-export-things-from-__init__.py) that we have not yet been able to untangle). The optimization is that if we know we won't have any work to feed that process pool, we can avoid creating it in the first place.

The most common practical scenario where this applies is first-time server startup. That happens dozens of times in our integration tests, so this helps developer experience.

## Performance testing

On my laptop, this saves ~30 seconds when running `make -C robot-server test`. In CI, it saves about a minute.

## Correctness testing

We're well-covered by existing integration tests.

## Review requests

Does the comment make sense?

## Risk assessment

Low.