### PR TITLE
refactor(robot-server): Fix more Pydantic warnings

### DIFF
--- a/robot-server/robot_server/client_data/router.py
+++ b/robot-server/robot_server/client_data/router.py
@@ -24,7 +24,7 @@ router = fastapi.APIRouter()
 Key = Annotated[
     str,
     fastapi.Path(
-        regex="^[a-zA-Z0-9-_]*$",
+        pattern="^[a-zA-Z0-9-_]*$",
         description=(
             "A key for storing and retrieving the piece of data."
             " This should be chosen to avoid colliding with other clients,"

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -3,7 +3,6 @@
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Type
-from warnings import filterwarnings
 import warnings
 
 import pytest


### PR DESCRIPTION
## Changelog

* There was a scary-looking warning coming out of robot-server's tests, but it turns out to be a harmless side effect of the way that one of the tests was working. This silences the warning. Closes EXEC-1071.
* Rename an instance of `regex` -> `pattern` per FastAPI+Pydantic deprecation notices.

## Test Plan and Hands on Testing

None needed.

## Review requests

None.

## Risk assessment

No risk.