### PR TITLE
fix(protocol-designer): allow minutesSeconds timer fields to add more…

### DIFF
--- a/protocol-designer/src/steplist/fieldLevel/errors.ts
+++ b/protocol-designer/src/steplist/fieldLevel/errors.ts
@@ -34,7 +34,7 @@ export type ErrorChecker = (value: unknown) => string | null
 export const requiredField: ErrorChecker = (value: unknown) =>
   !value ? FIELD_ERRORS.REQUIRED : null
 export const isTimeFormat: ErrorChecker = (value: unknown): string | null => {
-  const timeRegex = new RegExp(/^\d{1,2}:(?:[0-5]\d):(?:[0-5]\d)$/g)
+  const timeRegex = new RegExp(/^\d{1,2}:(?:[0-5]?\d):(?:[0-5]?\d)$/g)
   return (typeof value === 'string' && timeRegex.test(value)) || !value
     ? null
     : FIELD_ERRORS.BAD_TIME_HMS

--- a/protocol-designer/src/steplist/fieldLevel/errors.ts
+++ b/protocol-designer/src/steplist/fieldLevel/errors.ts
@@ -34,7 +34,7 @@ export type ErrorChecker = (value: unknown) => string | null
 export const requiredField: ErrorChecker = (value: unknown) =>
   !value ? FIELD_ERRORS.REQUIRED : null
 export const isTimeFormat: ErrorChecker = (value: unknown): string | null => {
-  const timeRegex = new RegExp(/^\d{1,2}:\d{1,2}:\d{1,2}$/g)
+  const timeRegex = new RegExp(/^\d{1,2}:(?:[0-5]\d):(?:[0-5]\d)$/g)
   return (typeof value === 'string' && timeRegex.test(value)) || !value
     ? null
     : FIELD_ERRORS.BAD_TIME_HMS
@@ -42,7 +42,7 @@ export const isTimeFormat: ErrorChecker = (value: unknown): string | null => {
 export const isTimeFormatMinutesSeconds: ErrorChecker = (
   value: unknown
 ): string | null => {
-  const timeRegex = new RegExp(/^\d+:\d{1,2}$/g)
+  const timeRegex = new RegExp(/^\d+:[0-5]?\d$/g)
   return (typeof value === 'string' && timeRegex.test(value)) || !value
     ? null
     : FIELD_ERRORS.BAD_TIME_MS

--- a/protocol-designer/src/steplist/fieldLevel/errors.ts
+++ b/protocol-designer/src/steplist/fieldLevel/errors.ts
@@ -42,7 +42,7 @@ export const isTimeFormat: ErrorChecker = (value: unknown): string | null => {
 export const isTimeFormatMinutesSeconds: ErrorChecker = (
   value: unknown
 ): string | null => {
-  const timeRegex = new RegExp(/^\d{1,2}:\d{1,2}$/g)
+  const timeRegex = new RegExp(/^\d+:\d{1,2}$/g)
   return (typeof value === 'string' && timeRegex.test(value)) || !value
     ? null
     : FIELD_ERRORS.BAD_TIME_MS


### PR DESCRIPTION
… than 99 minutes

closes RQA-3817

# Overview

So initially i thought this needed a migration to add an hour field. But quickly realized that doing that would require a migration for the heater-shaker timer field and 2 thermocycler timer fields. I think this approach is fine because the chances of someone adding a heater-shaker timer field greater than 99 minutes is low (that's why we didn't catch this for awhile). But please let me know if you have concerns with this fix and we can consider adding a migration.

## Test Plan and Hands on Testing

upload the attached protocol and see that the heater-shaker timer field doesn't error
[fds (2).json](https://github.com/user-attachments/files/18320089/fds.2.json)


## Changelog

adjut regex to allow more than 2 digits for minutes

## Risk assessment

low
