### PR TITLE
fix(step-generation): configureForVolume volume correctly set to am…

### DIFF
--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -3624,7 +3624,7 @@
       "key": "dd1b37d6-eb8c-4616-bc8a-e1f17556234a",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
-        "volume": 1
+        "volume": 10
       }
     },
     {

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -192,12 +192,6 @@ export const transfer: CommandCreator<TransferArgs> = (
   //  account for minVolume for lowVolume pipettes
   const pipetteMinVol = Math.min(...liquidMinVolumes)
   const chunksPerSubTransfer = Math.ceil(args.volume / effectiveTransferVol)
-  console.log(
-    chunksPerSubTransfer,
-    args.volume,
-    effectiveTransferVol,
-    getPipetteWithTipMaxVol(args.pipette, invariantContext, tipRack)
-  )
   const lastSubTransferVol =
     args.volume - (chunksPerSubTransfer - 1) * effectiveTransferVol
   // volume of each chunk in a sub-transfer

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -192,6 +192,12 @@ export const transfer: CommandCreator<TransferArgs> = (
   //  account for minVolume for lowVolume pipettes
   const pipetteMinVol = Math.min(...liquidMinVolumes)
   const chunksPerSubTransfer = Math.ceil(args.volume / effectiveTransferVol)
+  console.log(
+    chunksPerSubTransfer,
+    args.volume,
+    effectiveTransferVol,
+    getPipetteWithTipMaxVol(args.pipette, invariantContext, tipRack)
+  )
   const lastSubTransferVol =
     args.volume - (chunksPerSubTransfer - 1) * effectiveTransferVol
   // volume of each chunk in a sub-transfer
@@ -263,7 +269,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             ? [
                 curryCommandCreator(configureForVolume, {
                   pipetteId: args.pipette,
-                  volume: chunksPerSubTransfer,
+                  volume: subTransferVol,
                 }),
               ]
             : []


### PR DESCRIPTION
…ount

closes RESC-366

# Overview

Whoops, this error is from https://github.com/Opentrons/opentrons/pull/16666 👻. previously, the configure for volume volume was set to the transfer's total volume and not the chunk's volume. But this pr changed it so the volume was set to the chunk number! This pr fixes it so the volume is set to the actual volume

## Test Plan and Hands on Testing

upload attached protocol into the app. it should fail analysis.
upload the attached protocol into PD and upload that into the app. it should pass analysis now.

## Changelog

volume should be transfer amount not number of chunks

## Risk assessment

med