### PR TITLE
chore: fix canbus test warnings

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1397,7 +1397,11 @@ class OT3Controller(FlexBackend):
             return
 
         if hasattr(self, "_event_watcher"):
-            if loop.is_running() and self._event_watcher:
+            if (
+                loop.is_running()
+                and self._event_watcher
+                and not self._event_watcher.closed
+            ):
                 self._event_watcher.close()
 
         messenger = getattr(self, "_messenger", None)

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -145,7 +145,18 @@ def mock_messenger(can_message_notifier: MockCanMessageNotifier) -> mock.AsyncMo
 
 @pytest.fixture
 def mock_can_driver(mock_messenger: mock.AsyncMock) -> AbstractCanDriver:
-    return mock.AsyncMock(spec=AbstractCanDriver)
+    driver = mock.AsyncMock(spec=AbstractCanDriver)
+
+    # ignoring this type error because this is a very weird function that will in fact
+    # do nothing, but has to have the yield in there for the compiler to make it a
+    # generator function
+    async def _fake_message_retrieve(d):  # type: ignore[no-untyped-def]
+        while True:
+            await asyncio.sleep(1)
+        yield
+
+    driver.__aiter__ = _fake_message_retrieve
+    return driver
 
 
 @pytest.fixture
@@ -160,15 +171,19 @@ def mock_eeprom_driver() -> EEPROMDriver:
 
 
 @pytest.fixture
-def controller(
+async def controller(
     mock_config: OT3Config,
     mock_can_driver: AbstractCanDriver,
     mock_eeprom_driver: EEPROMDriver,
-) -> OT3Controller:
-    with (mock.patch("opentrons.hardware_control.backends.ot3controller.OT3GPIO")):
-        return OT3Controller(
+) -> AsyncIterator[OT3Controller]:
+    with mock.patch("opentrons.hardware_control.backends.ot3controller.OT3GPIO"):
+        controller = OT3Controller(
             mock_config, mock_can_driver, eeprom_driver=mock_eeprom_driver
         )
+        try:
+            yield controller
+        finally:
+            await controller.clean_up()
 
 
 @pytest.fixture

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -1,4 +1,5 @@
 """Can messenger class."""
+
 from __future__ import annotations
 import asyncio
 from inspect import Traceback
@@ -361,7 +362,11 @@ class CanMessenger:
                 return
             except BaseException:
                 log.exception("Exception in read")
+                await asyncio.sleep(0)
                 continue
+            else:
+                log.error("read task finished, this should not happen")
+                await asyncio.sleep(0)
 
     async def _read_task(self) -> None:
         """Read task."""


### PR DESCRIPTION
Removes 40 or so warnings from tests on edge. Should be no functional change.