### PR TITLE
fix(protocol-designer): moving labware into waste chute step summary …

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -12,7 +12,10 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
-import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  WASTE_CHUTE_CUTOUT,
+  getModuleDisplayName,
+} from '@opentrons/shared-data'
 import {
   getAdditionalEquipmentEntities,
   getLabwareEntities,
@@ -285,6 +288,8 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         newLocationName = labwareNicknamesById[newLocation]
       } else if (newLocation === 'offDeck') {
         newLocationName = t('off_deck')
+      } else if (newLocation === WASTE_CHUTE_CUTOUT) {
+        newLocationName = t('shared:wasteChute')
       }
       stepSummaryContent = (
         <StyledTrans


### PR DESCRIPTION
…copy fix

closes RQA-3769

# Overview

special case for moving labware into the waste chute and grab the waste chute display name instead of the cutout id

## Test Plan and Hands on Testing

Create a flex protocol with a waste chute and gripper. move the tiprack into the waste chute using the gripper. see that the step summary text says "waste chute" instead of "cutout d3"

## Changelog

update the const to display wasteChute instead of cutout D3

## Risk assessment

low
