### PR TITLE
fix(shared-data): Add back missing parent labwares for auto sealing lids

### DIFF
--- a/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/1.json
+++ b/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/1.json
@@ -81,7 +81,9 @@
   "compatibleParentLabware": [
     "armadillo_96_wellplate_200ul_pcr_full_skirt",
     "opentrons_96_wellplate_200ul_pcr_full_skirt",
-    "opentrons_tough_pcr_auto_sealing_lid"
+    "opentrons_tough_pcr_auto_sealing_lid",
+    "biorad_96_wellplate_200ul_pcr",
+    "opentrons_flex_deck_riser"
   ],
   "gripForce": 15,
   "gripHeightFromLabwareBottom": 7.91,


### PR DESCRIPTION
# Overview
Covers RQA-3819

With the improved lid architecture labware definitions we need to provide compatible parent labwares rather than generally accepting any labware as a potential parent. Some were missed when updating the auto-sealing lids definition, leading to this bug being found. 


## Test Plan and Hands on Testing

- [x] Ensure the protocol file from the RQA-3819 ticket pass analysis

## Changelog


## Review requests
Question for reviewers: Should we just ignore a parent "labware" all together if it's an adapter when checking the "compatible parent labwares" list? Would that cause us a headache later?


## Risk assessment
Low - enforces existing 8.2 behavior.