### PR TITLE
fix(protocol-designer): importing a protocol from the settings naviga…

### DIFF
--- a/protocol-designer/src/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/organisms/Navigation/index.tsx
@@ -30,6 +30,7 @@ export function Navigation(): JSX.Element | null {
   const loadFile = (fileChangeEvent: ChangeEvent<HTMLInputElement>): void => {
     dispatch(loadFileActions.loadProtocolFile(fileChangeEvent))
     dispatch(toggleNewProtocolModal(false))
+    navigate('/')
   }
   const hasUnsavedChanges = useSelector(getHasUnsavedChanges)
 


### PR DESCRIPTION
…tes to overview

closes AUTH-1198

# Overview

Previously, if you uploaded a protocol from the settings page, you stay on the settings page instead of navigating to the overview page. this Pr fixes that issue. seems like a straightforward fix so hopefully i fixed it correctly.

## Test Plan and Hands on Testing

Go to the settings page, upload a protocol, see that it navigates to the overview page

## Changelog

add navigation when loading a file

## Risk assessment

low
