### PR TITLE
fix(protocol-designer): release notes banner dismisses upon clicking x

### DIFF
--- a/protocol-designer/src/organisms/AnnouncementModal/index.tsx
+++ b/protocol-designer/src/organisms/AnnouncementModal/index.tsx
@@ -40,7 +40,9 @@ export const AnnouncementModal = (
   )
 
   const handleClick = (): void => {
-    if (onClose != null) onClose()
+    if (onClose != null) {
+      onClose()
+    }
     setLocalStorageItem(localStorageAnnouncementKey, announcementKey)
     setShowAnnouncementModal(false)
   }

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -25,7 +25,11 @@ import { toggleNewProtocolModal } from '../../navigation/actions'
 import { useKitchen } from '../../organisms/Kitchen/hooks'
 import { getHasOptedIn } from '../../analytics/selectors'
 import { useAnnouncements } from '../../organisms/AnnouncementModal/announcements'
-import { getLocalStorageItem, localStorageAnnouncementKey } from '../../persist'
+import {
+  getLocalStorageItem,
+  localStorageAnnouncementKey,
+  setLocalStorageItem,
+} from '../../persist'
 import welcomeImage from '../../assets/images/welcome_page.png'
 
 import type { ChangeEvent, ComponentProps } from 'react'
@@ -39,7 +43,7 @@ export function Landing(): JSX.Element {
   const [showAnnouncementModal, setShowAnnouncementModal] = useState<boolean>(
     false
   )
-  const { hasOptedIn } = useSelector(getHasOptedIn)
+  const { hasOptedIn, appVersion } = useSelector(getHasOptedIn)
   const { bakeToast, eatToast } = useKitchen()
   const announcements = useAnnouncements()
   const lastAnnouncement = announcements[announcements.length - 1]
@@ -52,7 +56,11 @@ export function Landing(): JSX.Element {
     hasOptedIn != null
 
   useEffect(() => {
-    if (userHasNotSeenAnnouncement) {
+    if (
+      userHasNotSeenAnnouncement &&
+      appVersion != null &&
+      hasOptedIn != null
+    ) {
       const toastId = bakeToast(
         t('learn_more', { version: process.env.OT_PD_VERSION }) as string,
         INFO_TOAST,
@@ -60,6 +68,9 @@ export function Landing(): JSX.Element {
           heading: t('updated_protocol_designer'),
           closeButton: true,
           linkText: t('view_release_notes'),
+          onClose: () => {
+            setLocalStorageItem(localStorageAnnouncementKey, announcementKey)
+          },
           onLinkClick: () => {
             eatToast(toastId)
             setShowAnnouncementModal(true)
@@ -69,7 +80,7 @@ export function Landing(): JSX.Element {
         }
       )
     }
-  }, [userHasNotSeenAnnouncement])
+  }, [userHasNotSeenAnnouncement, appVersion, hasOptedIn])
 
   useEffect(() => {
     if (metadata?.created != null) {


### PR DESCRIPTION
closes RQA-3821

# Overview

As outlined in the loom attached in the ticket, the release notes banner wouldn't properly dismiss even when the user clicks the "x". this Pr now dismisses it when X is selected and when the release notes modal is opened. Additionally, the release notes banner now only shows up after you have dismissed the analytics modal

## Test Plan and Hands on Testing

Clear your local storage (in console type in `localStorage.clear()` and then refresh the page)
Dismiss the analytics modal and then see that the release notes banner pops up afterwards
Do not dismiss the release notes banner, upload a protocol instead and see that the banner persists. Then refresh the browser and see that the banner persists. Then, dismiss the banner via the X. navigate to different parts of the app and see that the banner stays dismissed

## Changelog

- fix when the release notes toast shows up and clicking on the X dismisses it properly

## Risk assessment

low