### PR TITLE
fix(app): Fix gantry not homing when no labware in gripper jaws during Error Recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/shared/GripperIsHoldingLabware.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/GripperIsHoldingLabware.tsx
@@ -29,12 +29,15 @@ export const HOLDING_LABWARE_OPTIONS: HoldingLabwareOption[] = [
 export function GripperIsHoldingLabware({
   routeUpdateActions,
   currentRecoveryOptionUtils,
+  recoveryCommands,
 }: RecoveryContentProps): JSX.Element {
   const {
     proceedNextStep,
     proceedToRouteAndStep,
     goBackPrevStep,
+    handleMotionRouting,
   } = routeUpdateActions
+  const { homeExceptPlungers } = recoveryCommands
   const { selectedRecoveryOption } = currentRecoveryOptionUtils
   const {
     MANUAL_MOVE_AND_SKIP,
@@ -48,24 +51,29 @@ export function GripperIsHoldingLabware({
   const { t } = useTranslation(['error_recovery', 'shared'])
 
   const handleNoOption = (): void => {
-    switch (selectedRecoveryOption) {
-      case MANUAL_MOVE_AND_SKIP.ROUTE:
-        void proceedToRouteAndStep(
-          MANUAL_MOVE_AND_SKIP.ROUTE,
-          MANUAL_MOVE_AND_SKIP.STEPS.MANUAL_MOVE
-        )
-        break
-      case MANUAL_REPLACE_AND_RETRY.ROUTE:
-        void proceedToRouteAndStep(
-          MANUAL_REPLACE_AND_RETRY.ROUTE,
-          MANUAL_REPLACE_AND_RETRY.STEPS.MANUAL_REPLACE
-        )
-        break
-      default: {
-        console.error('Unexpected recovery option for gripper routing.')
-        void proceedToRouteAndStep(OPTION_SELECTION.ROUTE)
-      }
-    }
+    // The "yes" option also contains a home, but it occurs later in the control flow,
+    // after the user has extricated the labware from the gripper jaws.
+    void handleMotionRouting(true)
+      .then(() => homeExceptPlungers())
+      .then(() => {
+        switch (selectedRecoveryOption) {
+          case MANUAL_MOVE_AND_SKIP.ROUTE:
+            return proceedToRouteAndStep(
+              MANUAL_MOVE_AND_SKIP.ROUTE,
+              MANUAL_MOVE_AND_SKIP.STEPS.MANUAL_MOVE
+            )
+          case MANUAL_REPLACE_AND_RETRY.ROUTE:
+            return proceedToRouteAndStep(
+              MANUAL_REPLACE_AND_RETRY.ROUTE,
+              MANUAL_REPLACE_AND_RETRY.STEPS.MANUAL_REPLACE
+            )
+          default: {
+            console.error('Unexpected recovery option for gripper routing.')
+            return proceedToRouteAndStep(OPTION_SELECTION.ROUTE)
+          }
+        }
+      })
+      .finally(() => handleMotionRouting(false))
   }
 
   const primaryOnClick = (): void => {

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/GripperIsHoldingLabware.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/GripperIsHoldingLabware.test.tsx
@@ -23,19 +23,25 @@ const render = (props: ComponentProps<typeof GripperIsHoldingLabware>) => {
 
 let mockProceedToRouteAndStep: Mock
 let mockProceedNextStep: Mock
+let mockHandleMotionRouting: Mock
+let mockHomeExceptPlungers: Mock
 
 describe('GripperIsHoldingLabware', () => {
   let props: ComponentProps<typeof GripperIsHoldingLabware>
   beforeEach(() => {
     mockProceedToRouteAndStep = vi.fn(() => Promise.resolve())
     mockProceedNextStep = vi.fn(() => Promise.resolve())
+    mockHandleMotionRouting = vi.fn(() => Promise.resolve())
+    mockHomeExceptPlungers = vi.fn(() => Promise.resolve())
 
     props = {
       ...mockRecoveryContentProps,
       routeUpdateActions: {
         proceedToRouteAndStep: mockProceedToRouteAndStep,
         proceedNextStep: mockProceedNextStep,
+        handleMotionRouting: mockHandleMotionRouting,
       } as any,
+      recoveryCommands: { homeExceptPlungers: mockHomeExceptPlungers } as any,
     }
   })
 
@@ -83,10 +89,22 @@ describe('GripperIsHoldingLabware', () => {
     clickButtonLabeled('Continue')
 
     await waitFor(() => {
+      expect(mockHandleMotionRouting).toHaveBeenCalledWith(true)
+    })
+
+    await waitFor(() => {
+      expect(mockHomeExceptPlungers).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
       expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
         RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE,
         RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.STEPS.MANUAL_MOVE
       )
+    })
+
+    await waitFor(() => {
+      expect(mockHandleMotionRouting).toHaveBeenCalledWith(false)
     })
   })
 


### PR DESCRIPTION
Closes [RQA-3822](https://opentrons.atlassian.net/browse/RQA-3822)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

After the 8.2 release and some subsequent refactors, we were able to tie the gripper command sequencing directly to CTAs instead of utilizing an implicit execution sequence via a `useEffect`. Part of that command sequencing includes gripper homing, which occurs roughly when the user is prompted to confirm whether [labware is currently in the gripper jaws.](https://www.figma.com/design/OGssKRmCOvuXSqUpK2qXrV/Feature%3A-Error-Recovery-November-Release?node-id=9752-53711&t=rF9nBvPCXHmLcO1X-4) We (aka me) forgot to add the home command for the "no labware in jaws" case, as the homing should occur regardless of whether or not labware is in the jaws. 

This PR just adds the explicit homing command to the "no labware in jaws" option, preventing fatal errors that occur after gripper recovery involving axes with unknown positioning.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Go through the gripper error flow, selecting "no labware in jaws". On edge, there won't be any homing behavior that occurs. On this branch, there should be a home.
- Verified the run does not terminally fail after completing gripper recovery.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed gripper recovery sometimes resulting in the run terminally failing after completing recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3822]: https://opentrons.atlassian.net/browse/RQA-3822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ