### PR TITLE
fix(step-generation): only aspirate disposal volume in first chunk

### DIFF
--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -483,7 +483,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
             }),
           ]
         : []
-
+      const aspirateDisposalVolumeOnce = chunkIndex === 0 ? disposalVolume : 0
       return [
         ...tipCommands,
         ...configureForVolumeCommand,
@@ -492,8 +492,11 @@ export const distribute: CommandCreator<DistributeArgs> = (
           pipette,
           volume:
             args.volume * destWellChunk.length +
-            //  only add disposal volume if its the 1st chunk
-            (chunkIndex === 0 ? disposalVolume : 0),
+            //  only add disposal volume if its the 1st chunk and changing tip once
+            //  and not blowing out after dispenses
+            (args.changeTip === 'once' && blowoutLocation == null
+              ? aspirateDisposalVolumeOnce
+              : disposalVolume),
           labware: args.sourceLabware,
           well: args.sourceWell,
           flowRate: aspirateFlowRateUlSec,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -490,7 +490,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
         ...mixBeforeAspirateCommands,
         curryCommandCreator(aspirate, {
           pipette,
-          volume: args.volume * destWellChunk.length + disposalVolume,
+          volume:
+            args.volume * destWellChunk.length +
+            //  only add disposal volume if its the 1st chunk
+            (chunkIndex === 0 ? disposalVolume : 0),
           labware: args.sourceLabware,
           well: args.sourceWell,
           flowRate: aspirateFlowRateUlSec,


### PR DESCRIPTION
closes RQA-3807

# Overview

This is not a regression and the bug has existed at least since 8.1.0. It is regarding the disposal volume for distribute steps. 

**Background info**: The disposal volume is the volume left over at the end of a distribute sequence that gets disposed of when you drop your tip. We recommend users to add a disposal volume and select it by default. But they can choose not to add a disposal volume if they please. Typically what happens is a user will make a distribute, use the default disposal volume and use the default tip handling option of "Before every aspirate". 

**The bug**: Alex has a protocol made by a customer where they have a distribute over 34 wells with p20 tip and 4ul per well and 1ul for the disposal volume. they also changed tip handling to occur "once at the start of the step" and no blow out location. The protocol errors not in PD but when uploading to the app because eventually the tip can't handle the amount of liquid it needs to aspirate. This happens because since the user selected to change their tip "once at the start of the step" with no blow out, PD never removes that 1uL of disposal volume and instead keeps adding more with every aspirate.

**The fix**:  to fix this, I modified step-generation so that it only aspirates the disposal volume during the first chunk if the change tip is set to "once at the start of the step" and the blowout location is null. That way it doesn't keep adding more and more disposal volume to the tip and overloading it if there is no space

## Test Plan and Hands on Testing

Upload the attached protocol into the app, see that it fails analysis. Then upload it into PD and export and upload that new json file into the app and see that it passes analysis.

[qPCR BioRAD 384-12 samples-16 gene fixy Fixy.json](https://github.com/user-attachments/files/18337622/qPCR.BioRAD.384-12.samples-16.gene.fixy.Fixy.json)


## Changelog

only add disposal volume to aspirate for the first chunk

## Risk assessment

low-ish/med-ish