### PR TITLE
feat(shared-data): add flex stacker addressable area to deck definition

### DIFF
--- a/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
@@ -203,6 +203,11 @@ def test_get_provided_addressable_area_names(
                     cutout_fixture_id="stagingAreaRightSlot",
                     provided_addressable_areas=frozenset({"D3", "D4"}),
                 ),
+                PotentialCutoutFixture(
+                    cutout_id="cutoutD3",
+                    cutout_fixture_id="flexStackerV1",
+                    provided_addressable_areas=frozenset({"D3", "flexStackerV1D4"}),
+                ),
             },
             lazy_fixture("ot3_standard_deck_def"),
         ),

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -228,6 +228,9 @@ def test_unrecognized_cutout_fixture() -> None:
                     "magneticBlockV1",
                     "absorbanceReaderV1",
                     "stagingAreaSlotWithMagneticBlockV1",
+                    "flexStackerV1",
+                    "flexStackerV1WithWasteChuteRightAdapterCovered",
+                    "flexStackerV1WithWasteChuteRightAdapterNoCover",
                 ]
             ),
         )

--- a/shared-data/deck/definitions/5/ot3_standard.json
+++ b/shared-data/deck/definitions/5/ot3_standard.json
@@ -760,6 +760,50 @@
           "zDimension": 0
         },
         "displayName": "Absorbance Reader Lid Dock in A4"
+      },
+      {
+        "id": "flexStackerV1D4",
+        "areaType": "flexStacker",
+        "offsetFromCutoutFixture": [161.0, 0.0, 31.0],
+        "boundingBox": {
+          "xDimension": 128.0,
+          "yDimension": 86.0,
+          "zDimension": 0
+        },
+        "displayName": "Flex Stacker in D4"
+      },
+      {
+        "id": "flexStackerV1C4",
+        "areaType": "flexStacker",
+        "offsetFromCutoutFixture": [161.0, 0.0, 31.0],
+        "boundingBox": {
+          "xDimension": 128.0,
+          "yDimension": 86.0,
+          "zDimension": 0
+        },
+        "displayName": "Flex Stacker in C4"
+      },
+      {
+        "id": "flexStackerV1B4",
+        "areaType": "flexStacker",
+        "offsetFromCutoutFixture": [161.0, 0.0, 31.0],
+        "boundingBox": {
+          "xDimension": 128.0,
+          "yDimension": 86.0,
+          "zDimension": 0
+        },
+        "displayName": "Flex Stacker in B4"
+      },
+      {
+        "id": "flexStackerV1A4",
+        "areaType": "flexStacker",
+        "offsetFromCutoutFixture": [161.0, 0.0, 31.0],
+        "boundingBox": {
+          "xDimension": 128.0,
+          "yDimension": 86.0,
+          "zDimension": 0
+        },
+        "displayName": "Flex Stacker in A4"
       }
     ],
     "cutouts": [
@@ -974,6 +1018,34 @@
       "height": 124.5
     },
     {
+      "id": "flexStackerV1WithWasteChuteRightAdapterCovered",
+      "expectOpentronsModuleSerialNumber": true,
+      "mayMountTo": ["cutoutD3"],
+      "displayName": "Flex Stacker With Waste Chute Adapter for 96 Channel Pipette or Gripper",
+      "providesAddressableAreas": {
+        "cutoutD3": ["1ChannelWasteChute", "8ChannelWasteChute", "D4"]
+      },
+      "fixtureGroup": {},
+      "height": 124.5
+    },
+    {
+      "id": "flexStackerV1WithWasteChuteRightAdapterNoCover",
+      "expectOpentronsModuleSerialNumber": true,
+      "mayMountTo": ["cutoutD3"],
+      "displayName": "Flex Stacker With Waste Chute Adapter",
+      "providesAddressableAreas": {
+        "cutoutD3": [
+          "1ChannelWasteChute",
+          "8ChannelWasteChute",
+          "96ChannelWasteChute",
+          "gripperWasteChute",
+          "flexStackerV1D4"
+        ]
+      },
+      "fixtureGroup": {},
+      "height": 124.5
+    },
+    {
       "id": "thermocyclerModuleV2Rear",
       "expectOpentronsModuleSerialNumber": true,
       "mayMountTo": ["cutoutA1"],
@@ -1122,6 +1194,20 @@
         "cutoutC3": ["absorbanceReaderV1C3", "absorbanceReaderV1LidDockC4"],
         "cutoutB3": ["absorbanceReaderV1B3", "absorbanceReaderV1LidDockB4"],
         "cutoutA3": ["absorbanceReaderV1A3", "absorbanceReaderV1LidDockA4"]
+      },
+      "fixtureGroup": {},
+      "height": 10.65
+    },
+    {
+      "id": "flexStackerV1",
+      "expectOpentronsModuleSerialNumber": true,
+      "mayMountTo": ["cutoutD3", "cutoutC3", "cutoutB3", "cutoutA3"],
+      "displayName": "Slot With a Flex Stacker",
+      "providesAddressableAreas": {
+        "cutoutD3": ["flexStackerV1D4", "D3"],
+        "cutoutC3": ["flexStackerV1C4", "C3"],
+        "cutoutB3": ["flexStackerV1B4", "B3"],
+        "cutoutA3": ["flexStackerV1A4", "A3"]
       },
       "fixtureGroup": {},
       "height": 10.65

--- a/shared-data/deck/schemas/5.json
+++ b/shared-data/deck/schemas/5.json
@@ -142,7 +142,13 @@
                   "movableTrash",
                   "fixedTrash",
                   "wasteChute",
-                  "lidDock"
+                  "lidDock",
+                  "heaterShaker",
+                  "magneticBlock",
+                  "temperatureModule",
+                  "thermocycler",
+                  "absorbanceReader",
+                  "flexStacker"
                 ]
               },
               "offsetFromCutoutFixture": {

--- a/shared-data/deck/types/schemaV5.ts
+++ b/shared-data/deck/types/schemaV5.ts
@@ -64,6 +64,10 @@ export type FlexAddressableAreaName =
   | 'absorbanceReaderV1LidDockB4'
   | 'absorbanceReaderV1LidDockC4'
   | 'absorbanceReaderV1LidDockD4'
+  | 'flexStackerV1A4'
+  | 'flexStackerV1B4'
+  | 'flexStackerV1C4'
+  | 'flexStackerV1D4'
 
 export type OT2AddressableAreaName =
   | '1'
@@ -126,6 +130,8 @@ export type WasteChuteCutoutFixtureId =
   | 'wasteChuteRightAdapterNoCover'
   | 'stagingAreaSlotWithWasteChuteRightAdapterCovered'
   | 'stagingAreaSlotWithWasteChuteRightAdapterNoCover'
+  | 'flexStackerV1WithWasteChuteRightAdapterCovered'
+  | 'flexStackerV1WithWasteChuteRightAdapterNoCover'
 
 export type FlexModuleCutoutFixtureId =
   | 'heaterShakerModuleV1'
@@ -135,6 +141,7 @@ export type FlexModuleCutoutFixtureId =
   | 'thermocyclerModuleV2Rear'
   | 'thermocyclerModuleV2Front'
   | 'absorbanceReaderV1'
+  | 'flexStackerV1'
 
 export type OT2SingleStandardSlot = 'singleStandardSlot'
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds the addressable areas for the stacker to the deck definition. This also includes adding the most delightful fixtures that are the `flexStackerV1WithWasteChuteRightAdapterNoCover` and `flexStackerV1WithWasteChuteRightAdapterNoCover` so we can use the stacker next to a trash chute. 

#### Side note
I found out that the deck definition hasn't been matching the schema. Specifically, the `areaType` enums for the modules are all missing... So i added them here. 
Though this means the `areaType` field doesn't really do much of anything, it raises the question if we should validate our definitions against the schemas more diligently. Like, adding CI checks? 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->