### PR TITLE
fix(protocol-designer): tooltip under path animation copy update

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
@@ -135,14 +135,21 @@ export function getDisabledPathMap(
     airGapVolume,
   })
 
-  if (!withinCapacityForMultiDispense && (values.volume != null && values.volume !== '')) {
+  if (
+    !withinCapacityForMultiDispense &&
+    values.volume != null &&
+    values.volume !== ''
+  ) {
     disabledPathMap = {
       ...disabledPathMap,
       multiDispense: t('step_edit_form.field.path.subtitle.volume_too_high'),
     }
   }
-console.log(values.volume == null, values.volume === '')
-  if (!withinCapacityForMultiAspirate && (values.volume != null && values.volume !== '')) {
+  if (
+    !withinCapacityForMultiAspirate &&
+    values.volume != null &&
+    values.volume !== ''
+  ) {
     disabledPathMap = {
       ...disabledPathMap,
       multiAspirate: t('step_edit_form.field.path.subtitle.volume_too_high'),

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
@@ -135,14 +135,14 @@ export function getDisabledPathMap(
     airGapVolume,
   })
 
-  if (!withinCapacityForMultiDispense) {
+  if (!withinCapacityForMultiDispense && (values.volume != null && values.volume !== '')) {
     disabledPathMap = {
       ...disabledPathMap,
       multiDispense: t('step_edit_form.field.path.subtitle.volume_too_high'),
     }
   }
-
-  if (!withinCapacityForMultiAspirate) {
+console.log(values.volume == null, values.volume === '')
+  if (!withinCapacityForMultiAspirate && (values.volume != null && values.volume !== '')) {
     disabledPathMap = {
       ...disabledPathMap,
       multiAspirate: t('step_edit_form.field.path.subtitle.volume_too_high'),


### PR DESCRIPTION
closes RQA-3806

# Overview

Don't show the "volume too high" copy if the volume field was not yet filled out

## Test Plan and Hands on Testing

Create a protocol and enable the multi-dispense or multi-aspirate options in a transfer step. make sure the volume is not filled out and see that the copy under the animation tooltip is empty. then if you add the volume to something too high, see that the tooltip animation copy says that the volume is too high.

## Changelog

only show volume too high if volume field is not empty or null

## Risk assessment

low
