### PR TITLE
chore(app-shell): pass team id via env var only

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -1,11 +1,7 @@
 'use strict'
 const path = require('path')
 
-const {
-  OT_APP_DEPLOY_BUCKET,
-  OT_APP_DEPLOY_FOLDER,
-  APPLE_TEAM_ID,
-} = process.env
+const { OT_APP_DEPLOY_BUCKET, OT_APP_DEPLOY_FOLDER } = process.env
 const DEV_MODE = process.env.NODE_ENV !== 'production'
 const USE_PYTHON = process.env.NO_PYTHON !== 'true'
 const WINDOWS_SIGN = process.env.WINDOWS_SIGN === 'true'
@@ -62,9 +58,7 @@ module.exports = async () => ({
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',
     forceCodeSigning: !DEV_MODE,
     gatekeeperAssess: true,
-    notarize: {
-      teamId: APPLE_TEAM_ID,
-    },
+    // note: notarize.teamId is passed by implicitly sending through the APPLE_TEAM_ID env var
   },
   dmg: {
     icon: null,


### PR DESCRIPTION
This is very odd and I'm not sure when it would have changed but this is the thing the error message says to do.

## Testing
- [x] does the apple build work
- [x] does the apple build run