### PR TITLE
fix(app): Fix gripper calibration copy during exit

### DIFF
--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -145,6 +145,8 @@ export function GripperWizardFlows(
   })
 
   const handleCleanUpAndClose = (): void => {
+    setIsExiting(true)
+
     if (maintenanceRunData?.data.id == null) {
       handleClose()
     } else {


### PR DESCRIPTION
Closes [RQA-3832](https://opentrons.atlassian.net/browse/RQA-3832)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The `MovePin` step of gripper (re)calibration flows has extra special movement copy logic, since we must account for the robot being in motion due to calibration and due to homing the gantry during an exit event. However, as far as I can tell, never at any point have we ever set the robot to `isExiting` when we start exiting. Woops. 

The reason this doesn't impact other steps in the calibration flow is instead of checking `isExiting` when we exit, we check `isRobotMoving` to show the exit modal, since there aren't any other competing movement commands...?

Anyway, there's a lot of refactoring we should do for these flows, and the amount of work required to polish them is definitely a sustaining task, see [EXEC-1081](https://opentrons.atlassian.net/browse/EXEC-1081).

### Current Behavior

https://github.com/user-attachments/assets/b22f2f3a-4a97-4407-8770-620e4b7e2e84

### Fixed Behavior

https://github.com/user-attachments/assets/7eca1621-5f0a-485d-842f-9082edb582ac

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed incorrect copy appearing when exiting the gripper calibration flows during the "move pin" step.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3832]: https://opentrons.atlassian.net/browse/RQA-3832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-1081]: https://opentrons.atlassian.net/browse/EXEC-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ