### PR TITLE
feat(protocol-designer, step-generation): single channel partial tip support for 'default' primaryNozzle only

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -39,7 +39,7 @@ export interface DropdownOption {
   /** subtext below the name */
   subtext?: string
   disabled?: boolean
-  tooltipText?: string
+  tooltipText?: string | null
 }
 
 export type DropdownBorder = 'rounded' | 'neutral'

--- a/protocol-designer/src/assets/localization/en/feature_flags.json
+++ b/protocol-designer/src/assets/localization/en/feature_flags.json
@@ -42,5 +42,9 @@
   "OT_PD_ENABLE_MULTIPLE_TEMPS_OT2": {
     "title": "Allow two temperature modules on OT-2",
     "description": "This experimental setting may cause collisions, and Opentrons will not be responsible for any damage resulting from its use."
+  },
+  "OT_PD_ENABLE_PARTIAL_TIP_SUPPORT": {
+    "title": "Enable partial tip support",
+    "description": "Partial tip configurations that are not released yet"
   }
 }

--- a/protocol-designer/src/assets/localization/en/form.json
+++ b/protocol-designer/src/assets/localization/en/form.json
@@ -198,7 +198,7 @@
           "COLUMN": "Column"
         },
         "option_tooltip": {
-          "partial": "To use partial tip pickup, a tiprack without an adapter must be placed on the deck.",
+          "partial": "To use partial tip pickup, a tiprack without an adapter must be placed on the deck."
         }
       },
       "path": {

--- a/protocol-designer/src/assets/localization/en/form.json
+++ b/protocol-designer/src/assets/localization/en/form.json
@@ -198,7 +198,7 @@
           "COLUMN": "Column"
         },
         "option_tooltip": {
-          "COLUMN": "To use column partial tip pickup, a tiprack without an adapter must be placed on the deck."
+          "partial": "To use partial tip pickup, a tiprack without an adapter must be placed on the deck.",
         }
       },
       "path": {

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -106,6 +106,7 @@
   "select_volume": "Select a volume",
   "shake": "Shake",
   "single": "Single path",
+  "single_nozzle": "Single",
   "speed": "Speed",
   "starting_deck": "Starting deck",
   "step_substeps": "{{stepType}} details",

--- a/protocol-designer/src/components/organisms/Labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/organisms/Labware/SelectableLabware.tsx
@@ -67,7 +67,7 @@ export const SelectableLabware = (
     selectedWells: WellGroup
   ) => WellGroup = selectedWells => {
     // Returns PRIMARY WELLS from the selection.
-    if (nozzleType != null && nozzleType !== SINGLE) {
+    if (nozzleType !== null && nozzleType !== SINGLE) {
       const channels = getChannelsFromNozzleType(nozzleType)
       // for the wells that have been highlighted,
       // get all 8-well well sets and merge them
@@ -101,7 +101,7 @@ export const SelectableLabware = (
     rect
   ) => {
     if (!e.shiftKey) {
-      if (nozzleType != null && nozzleType !== SINGLE) {
+      if (nozzleType !== null && nozzleType !== SINGLE) {
         const channels = getChannelsFromNozzleType(nozzleType)
         const selectedWells = _getWellsFromRect(rect)
         const allWellsForMulti: WellGroup = reduce(
@@ -142,7 +142,7 @@ export const SelectableLabware = (
   }
 
   const handleMouseEnterWell: (args: WellMouseEvent) => void = args => {
-    if (nozzleType != null && nozzleType !== SINGLE) {
+    if (nozzleType !== null && nozzleType !== SINGLE) {
       const channels = getChannelsFromNozzleType(nozzleType)
       const wellSet = getWellSetForMultichannel({
         labwareDef,
@@ -158,7 +158,7 @@ export const SelectableLabware = (
 
   // For rendering, show all wells not just primary wells
   const allSelectedWells =
-    nozzleType != null && nozzleType !== SINGLE
+    nozzleType !== null && nozzleType !== SINGLE
       ? reduce<WellGroup, WellGroup>(
           selectedPrimaryWells,
           (acc, _, wellName): WellGroup => {

--- a/protocol-designer/src/components/organisms/Labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/organisms/Labware/SelectableLabware.tsx
@@ -1,6 +1,6 @@
 import reduce from 'lodash/reduce'
 
-import { COLUMN } from '@opentrons/shared-data'
+import { COLUMN, SINGLE } from '@opentrons/shared-data'
 import { COLORS } from '@opentrons/components'
 
 import {
@@ -39,7 +39,7 @@ export interface SelectableLabwareProps {
 
 type ChannelType = 8 | 96
 
-const getChannelsFromNozleType = (nozzleType: NozzleType): ChannelType => {
+const getChannelsFromNozzleType = (nozzleType: NozzleType): ChannelType => {
   if (nozzleType === '8-channel' || nozzleType === COLUMN) {
     return 8
   } else {
@@ -67,8 +67,8 @@ export const SelectableLabware = (
     selectedWells: WellGroup
   ) => WellGroup = selectedWells => {
     // Returns PRIMARY WELLS from the selection.
-    if (nozzleType != null) {
-      const channels = getChannelsFromNozleType(nozzleType)
+    if (nozzleType != null && nozzleType !== SINGLE) {
+      const channels = getChannelsFromNozzleType(nozzleType)
       // for the wells that have been highlighted,
       // get all 8-well well sets and merge them
       const primaryWells: WellGroup = reduce(
@@ -101,8 +101,8 @@ export const SelectableLabware = (
     rect
   ) => {
     if (!e.shiftKey) {
-      if (nozzleType != null) {
-        const channels = getChannelsFromNozleType(nozzleType)
+      if (nozzleType != null && nozzleType !== SINGLE) {
+        const channels = getChannelsFromNozzleType(nozzleType)
         const selectedWells = _getWellsFromRect(rect)
         const allWellsForMulti: WellGroup = reduce(
           selectedWells,
@@ -142,8 +142,8 @@ export const SelectableLabware = (
   }
 
   const handleMouseEnterWell: (args: WellMouseEvent) => void = args => {
-    if (nozzleType != null) {
-      const channels = getChannelsFromNozleType(nozzleType)
+    if (nozzleType != null && nozzleType !== SINGLE) {
+      const channels = getChannelsFromNozzleType(nozzleType)
       const wellSet = getWellSetForMultichannel({
         labwareDef,
         wellName: args.wellName,
@@ -158,11 +158,11 @@ export const SelectableLabware = (
 
   // For rendering, show all wells not just primary wells
   const allSelectedWells =
-    nozzleType != null
+    nozzleType != null && nozzleType !== SINGLE
       ? reduce<WellGroup, WellGroup>(
           selectedPrimaryWells,
           (acc, _, wellName): WellGroup => {
-            const channels = getChannelsFromNozleType(nozzleType)
+            const channels = getChannelsFromNozzleType(nozzleType)
             const wellSet = getWellSetForMultichannel({
               labwareDef,
               wellName,

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -36,6 +36,8 @@ const initialFlags: Flags = {
     process.env.OT_PD_ENABLE_TIMELINE_SCRUBBER === '1' || false,
   OT_PD_ENABLE_PYTHON_EXPORT:
     process.env.OT_PD_ENABLE_PYTHON_EXPORT === '1' || false,
+  OT_PD_ENABLE_PARTIAL_TIP_SUPPORT:
+    process.env.OT_PD_ENABLE_PARTIAL_TIP_SUPPORT === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -57,3 +57,7 @@ export const getEnablePythonExport: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_PYTHON_EXPORT ?? false
 )
+export const getEnablePartialTipSupport: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_PARTIAL_TIP_SUPPORT ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -40,6 +40,7 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_MULTIPLE_TEMPS_OT2'
   | 'OT_PD_ENABLE_TIMELINE_SCRUBBER'
   | 'OT_PD_ENABLE_PYTHON_EXPORT'
+  | 'OT_PD_ENABLE_PARTIAL_TIP_SUPPORT'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',
@@ -56,5 +57,6 @@ export const allFlags: FlagTypes[] = [
   'OT_PD_ENABLE_LIQUID_CLASSES',
   'OT_PD_ENABLE_TIMELINE_SCRUBBER',
   'OT_PD_ENABLE_PYTHON_EXPORT',
+  'OT_PD_ENABLE_PARTIAL_TIP_SUPPORT',
 ]
 export type Flags = Partial<Record<FlagTypes, boolean | null | undefined>>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
@@ -1,50 +1,79 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { ALL, COLUMN } from '@opentrons/shared-data'
-import { Flex, DropdownMenu, SPACING } from '@opentrons/components'
+import { ALL, COLUMN, SINGLE } from '@opentrons/shared-data'
+import {
+  Flex,
+  DropdownMenu,
+  SPACING,
+  DropdownOption,
+} from '@opentrons/components'
+import { getEnablePartialTipSupport } from '../../../../../feature-flags/selectors'
 import { getInitialDeckSetup } from '../../../../../step-forms/selectors'
+import type { PipetteV2Specs } from '@opentrons/shared-data'
+
 import type { FieldProps } from '../types'
 
-export function PartialTipField(props: FieldProps): JSX.Element {
+interface PartialTipFieldProps extends FieldProps {
+  pipetteSpecs: PipetteV2Specs
+}
+export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
   const {
     value: dropdownItem,
     updateValue,
     errorToShow,
     padding = `0 ${SPACING.spacing16}`,
     tooltipContent,
+    pipetteSpecs,
   } = props
   const { t } = useTranslation('protocol_steps')
   const deckSetup = useSelector(getInitialDeckSetup)
+  const enablePartialTip = useSelector(getEnablePartialTipSupport)
+  const is96Channel = pipetteSpecs.channels === 96
+
   const tipracks = Object.values(deckSetup.labware).filter(
     labware => labware.def.parameters.isTiprack
   )
   const tipracksNotOnAdapter = tipracks.filter(
     tiprack => deckSetup.labware[tiprack.slot] == null
   )
+  const noTipracksOnAdapter = tipracksNotOnAdapter.length === 0
 
-  const options = [
+  let options: DropdownOption[] = [
     {
       name: t('all'),
       value: ALL,
     },
-    {
+  ]
+  if (is96Channel) {
+    options.push({
       name: t('column'),
       value: COLUMN,
-      disabled: tipracksNotOnAdapter.length === 0,
-      tooltipText:
-        tipracksNotOnAdapter.length === 0
-          ? t('form:step_edit_form.field.nozzles.option_tooltip.COLUMN')
+      disabled: noTipracksOnAdapter,
+      tooltipText: noTipracksOnAdapter
+        ? t('form:step_edit_form.field.nozzles.option_tooltip.partial')
+        : undefined,
+    })
+    if (enablePartialTip) {
+      options.push({
+        name: t('single_nozzle'),
+        value: SINGLE,
+        disabled: noTipracksOnAdapter,
+        tooltipText: noTipracksOnAdapter
+          ? t('form:step_edit_form.field.nozzles.option_tooltip.partial')
           : undefined,
-    },
-  ]
+      })
+    }
+  } else {
+    options.push({
+      name: t('single_nozzle'),
+      value: SINGLE,
+    })
+  }
 
   const [selectedValue, setSelectedValue] = useState(
     dropdownItem || options[0].value
   )
-  useEffect(() => {
-    updateValue(selectedValue)
-  }, [selectedValue])
 
   return (
     <Flex padding={padding}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
@@ -2,16 +2,11 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { ALL, COLUMN, SINGLE } from '@opentrons/shared-data'
-import {
-  Flex,
-  DropdownMenu,
-  SPACING,
-  DropdownOption,
-} from '@opentrons/components'
+import { Flex, DropdownMenu, SPACING } from '@opentrons/components'
 import { getEnablePartialTipSupport } from '../../../../../feature-flags/selectors'
 import { getInitialDeckSetup } from '../../../../../step-forms/selectors'
 import type { PipetteV2Specs } from '@opentrons/shared-data'
-
+import type { DropdownOption } from '@opentrons/components'
 import type { FieldProps } from '../types'
 
 interface PartialTipFieldProps extends FieldProps {
@@ -39,7 +34,7 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
   )
   const noTipracksOnAdapter = tipracksNotOnAdapter.length === 0
 
-  let options: DropdownOption[] = [
+  const options: DropdownOption[] = [
     {
       name: t('all'),
       value: ALL,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
@@ -47,7 +47,7 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
       disabled: noTipracksOnAdapter,
       tooltipText: noTipracksOnAdapter
         ? t('form:step_edit_form.field.nozzles.option_tooltip.partial')
-        : undefined,
+        : null,
     })
     if (enablePartialTip) {
       options.push({
@@ -56,7 +56,7 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
         disabled: noTipracksOnAdapter,
         tooltipText: noTipracksOnAdapter
           ? t('form:step_edit_form.field.nozzles.option_tooltip.partial')
-          : undefined,
+          : null,
       })
     }
   } else {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
@@ -16,7 +16,10 @@ import {
   getLabwareEntities,
   getPipetteEntities,
 } from '../../../../../../step-forms/selectors'
-import { getEnableReturnTip } from '../../../../../../feature-flags/selectors'
+import {
+  getEnablePartialTipSupport,
+  getEnableReturnTip,
+} from '../../../../../../feature-flags/selectors'
 import {
   BlowoutLocationField,
   BlowoutOffsetField,
@@ -53,6 +56,7 @@ export function MixTools(props: StepFormProps): JSX.Element {
   } = props
   const pipettes = useSelector(getPipetteEntities)
   const enableReturnTip = useSelector(getEnableReturnTip)
+  const enablePartialTip = useSelector(getEnablePartialTipSupport)
   const labwares = useSelector(getLabwareEntities)
   const { t, i18n } = useTranslation(['application', 'form'])
   const aspirateTab = {
@@ -74,6 +78,9 @@ export function MixTools(props: StepFormProps): JSX.Element {
   const is96Channel =
     propsForFields.pipette.value != null &&
     pipettes[String(propsForFields.pipette.value)].name === 'p1000_96'
+  const is8Channel =
+    propsForFields.pipette.value != null &&
+    pipettes[String(propsForFields.pipette.value)].spec.channels === 8
   const userSelectedPickUpTipLocation =
     labwares[String(propsForFields.pickUpTip_location.value)] != null
   const userSelectedDropTipLocation =
@@ -88,7 +95,13 @@ export function MixTools(props: StepFormProps): JSX.Element {
       paddingY={SPACING.spacing16}
     >
       <PipetteField {...propsForFields.pipette} />
-      {is96Channel ? <PartialTipField {...propsForFields.nozzles} /> : null}
+      {propsForFields.pipette.value != null &&
+      (is96Channel || (is8Channel && enablePartialTip)) ? (
+        <PartialTipField
+          {...propsForFields.nozzles}
+          pipetteSpecs={pipettes[String(propsForFields.pipette.value)]?.spec}
+        />
+      ) : null}
       <Divider marginY="0" />
       <TiprackField
         {...propsForFields.tipRack}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
@@ -77,7 +77,7 @@ export function MixTools(props: StepFormProps): JSX.Element {
 
   const is96Channel =
     propsForFields.pipette.value != null &&
-    pipettes[String(propsForFields.pipette.value)].name === 'p1000_96'
+    pipettes[String(propsForFields.pipette.value)].spec.channels === 96
   const is8Channel =
     propsForFields.pipette.value != null &&
     pipettes[String(propsForFields.pipette.value)].spec.channels === 8

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
@@ -8,7 +8,10 @@ import {
   getPipetteEntities,
 } from '../../../../../../step-forms/selectors'
 import { getFormErrorsMappedToField, getFormLevelError } from '../../utils'
-import { getEnableReturnTip } from '../../../../../../feature-flags/selectors'
+import {
+  getEnablePartialTipSupport,
+  getEnableReturnTip,
+} from '../../../../../../feature-flags/selectors'
 
 import {
   ChangeTipField,
@@ -42,6 +45,7 @@ export function FirstStepMoveLiquidTools({
   const { t } = useTranslation('protocol_steps')
   const labwares = useSelector(getLabwareEntities)
   const pipettes = useSelector(getPipetteEntities)
+  const enablePartialTip = useSelector(getEnablePartialTipSupport)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
@@ -50,6 +54,9 @@ export function FirstStepMoveLiquidTools({
   const { pipette, tipRack } = propsForFields
   const is96Channel =
     pipette.value != null && pipettes[String(pipette.value)].name === 'p1000_96'
+  const is8Channel =
+    propsForFields.pipette.value != null &&
+    pipettes[String(propsForFields.pipette.value)].spec.channels === 8
   const userSelectedDropTipLocation =
     labwares[String(propsForFields.dropTip_location.value)] != null
   const userSelectedPickUpTipLocation =
@@ -68,10 +75,14 @@ export function FirstStepMoveLiquidTools({
       paddingY={SPACING.spacing16}
     >
       <PipetteField {...propsForFields.pipette} />
-      {is96Channel ? (
+      {propsForFields.pipette.value != null &&
+      (is96Channel || (is8Channel && enablePartialTip)) ? (
         <>
           <Divider marginY="0" />
-          <PartialTipField {...propsForFields.nozzles} />
+          <PartialTipField
+            {...propsForFields.nozzles}
+            pipetteSpecs={pipettes[String(propsForFields.pipette.value)]?.spec}
+          />
         </>
       ) : null}
       <Divider marginY="0" />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
@@ -6,7 +6,7 @@ import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
   DEST_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
-import { ALL, COLUMN } from '@opentrons/shared-data'
+import { ALL, COLUMN, SINGLE } from '@opentrons/shared-data'
 import { getFieldErrors } from '../../../../steplist/fieldLevel'
 import {
   getDisabledFields,
@@ -231,12 +231,14 @@ export const getNozzleType = (
   nozzles: string | null
 ): NozzleType | null => {
   const is8Channel = pipette != null && pipette.spec.channels === 8
-  if (is8Channel) {
+  if (is8Channel && nozzles !== SINGLE) {
     return '8-channel'
   } else if (nozzles === COLUMN) {
     return COLUMN
   } else if (nozzles === ALL) {
     return ALL
+  } else if (nozzles === SINGLE) {
+    return SINGLE
   } else {
     return null
   }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
@@ -6,7 +6,7 @@ import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
   DEST_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
-import { ALL, COLUMN, SINGLE } from '@opentrons/shared-data'
+import { SINGLE } from '@opentrons/shared-data'
 import { getFieldErrors } from '../../../../steplist/fieldLevel'
 import {
   getDisabledFields,
@@ -233,12 +233,8 @@ export const getNozzleType = (
   const is8Channel = pipette != null && pipette.spec.channels === 8
   if (is8Channel && nozzles !== SINGLE) {
     return '8-channel'
-  } else if (nozzles === COLUMN) {
-    return COLUMN
-  } else if (nozzles === ALL) {
-    return ALL
-  } else if (nozzles === SINGLE) {
-    return SINGLE
+  } else if (nozzles != null) {
+    return nozzles as NozzleType
   } else {
     return null
   }

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -98,10 +98,15 @@ const _patchDefaultNozzle = (args: {
   pipetteEntities: PipetteEntities
 }): FormUpdater => formData => {
   const { labwareEntities, pipetteEntities } = args
+  const hasPartialTipSupportedChannel = Object.values(pipetteEntities).find(
+    pip => pip.spec.channels === 96
+    // || pip.spec.channels === 8
+    // TODO: add this in once we remove enablePartialTip feature flag
+  )
 
   const formHasNozzlesField = formData && 'nozzles' in formData
 
-  if (formHasNozzlesField) {
+  if (formHasNozzlesField && hasPartialTipSupportedChannel) {
     const updatedFields = handleFormChange(
       {
         nozzles: ALL,

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -99,9 +99,7 @@ const _patchDefaultNozzle = (args: {
 }): FormUpdater => formData => {
   const { labwareEntities, pipetteEntities } = args
   const hasPartialTipSupportedChannel = Object.values(pipetteEntities).find(
-    pip => pip.spec.channels === 96
-    // || pip.spec.channels === 8
-    // TODO: add this in once we remove enablePartialTip feature flag
+    pip => pip.spec.channels === 96 || pip.spec.channels === 8
   )
 
   const formHasNozzlesField = formData && 'nozzles' in formData

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -1,6 +1,7 @@
 import last from 'lodash/last'
 import {
   ABSORBANCE_READER_TYPE,
+  ALL,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
@@ -81,6 +82,29 @@ const _patchDefaultPipette = (args: {
     const updatedFields = handleFormChange(
       {
         pipette: defaultPipetteId,
+      },
+      formData,
+      pipetteEntities,
+      labwareEntities
+    )
+    return updatedFields
+  }
+
+  return null
+}
+
+const _patchDefaultNozzle = (args: {
+  labwareEntities: LabwareEntities
+  pipetteEntities: PipetteEntities
+}): FormUpdater => formData => {
+  const { labwareEntities, pipetteEntities } = args
+
+  const formHasNozzlesField = formData && 'nozzles' in formData
+
+  if (formHasNozzlesField) {
+    const updatedFields = handleFormChange(
+      {
+        nozzles: ALL,
       },
       formData,
       pipetteEntities,
@@ -409,6 +433,11 @@ export const createPresavedStepForm = ({
     stepType,
   })
 
+  const updateDefaultNozzles = _patchDefaultNozzle({
+    labwareEntities,
+    pipetteEntities,
+  })
+
   const updateDefaultDropTip = _patchDefaultDropTipLocation({
     labwareEntities,
     pipetteEntities,
@@ -481,6 +510,7 @@ export const createPresavedStepForm = ({
     updateAbsorbanceReaderModuleId,
     updateDefaultLabwareLocations,
     updateMoveLabwareFields,
+    updateDefaultNozzles,
   ].reduce<FormData>(
     (acc, updater: FormUpdater) => {
       const updates = updater(acc)

--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -10,6 +10,7 @@ import {
   ALL,
   COLUMN,
   OT2_ROBOT_TYPE,
+  SINGLE,
 } from '@opentrons/shared-data'
 
 import type { Channels } from '@opentrons/components'
@@ -261,10 +262,12 @@ export const substepTimelineMultiChannel = (
             : null
 
         let numChannels = channels
-        if (nozzles === ALL) {
+        if (nozzles === ALL && channels !== 8) {
           numChannels = 96
         } else if (nozzles === COLUMN) {
           numChannels = 8
+        } else if (nozzles === SINGLE) {
+          numChannels = 1
         }
         const wellsForTips =
           numChannels &&

--- a/protocol-designer/src/top-selectors/substep-highlight.ts
+++ b/protocol-designer/src/top-selectors/substep-highlight.ts
@@ -34,7 +34,7 @@ function _wellsForPipette(
 
   // `wells` is all the wells that pipette's channel 1 interacts with.
   if ((pipChannels === 8 || pipChannels === 96) && nozzles !== SINGLE) {
-    let channels: 8 | 96 = pipChannels
+    let channels = pipChannels
     if (nozzles === ALL && pipChannels === 8) {
       channels = 96
     } else if (

--- a/step-generation/src/__tests__/configureNozzleLayout.test.ts
+++ b/step-generation/src/__tests__/configureNozzleLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ALL, COLUMN } from '@opentrons/shared-data'
+import { ALL, COLUMN, fixtureP100096V2Specs } from '@opentrons/shared-data'
 import { getSuccessResult } from '../fixtures'
 import { configureNozzleLayout } from '../commandCreators/atomic/configureNozzleLayout'
 
@@ -14,6 +14,7 @@ const invariantContext: any = {
       name: 'p1000_96',
       id: mockPipette,
       pythonName: 'mock_pipette',
+      spec: fixtureP100096V2Specs,
     },
   },
 }

--- a/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
+++ b/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it, beforeEach } from 'vitest'
 import { getIsSafePipetteMovement } from '../utils'
 import {
+  COLUMN,
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V2,
   fixture96Plate,
@@ -82,6 +83,7 @@ describe('getIsSafePipetteMovement', () => {
 
   it('returns true when the labware id is a trash bin', () => {
     const result = getIsSafePipetteMovement(
+      COLUMN,
       {
         labware: {},
         pipettes: {},
@@ -108,6 +110,7 @@ describe('getIsSafePipetteMovement', () => {
   })
   it('returns false when within pipette extents is false', () => {
     const result = getIsSafePipetteMovement(
+      COLUMN,
       mockRobotState,
       mockInvariantProperties,
       mockPipId,
@@ -131,6 +134,7 @@ describe('getIsSafePipetteMovement', () => {
       },
     }
     const result = getIsSafePipetteMovement(
+      COLUMN,
       mockRobotState,
       mockInvariantProperties,
       mockPipId,
@@ -148,6 +152,7 @@ describe('getIsSafePipetteMovement', () => {
       [mockAdapter]: { slot: 'D1' },
     }
     const result = getIsSafePipetteMovement(
+      COLUMN,
       mockRobotState,
       mockInvariantProperties,
       mockPipId,
@@ -180,6 +185,7 @@ describe('getIsSafePipetteMovement', () => {
       },
     }
     const result = getIsSafePipetteMovement(
+      COLUMN,
       mockRobotState,
       mockInvariantProperties,
       mockPipId,

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -1,4 +1,9 @@
-import { COLUMN, FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import {
+  ALL,
+  FLEX_ROBOT_TYPE,
+  OT2_ROBOT_TYPE,
+  SINGLE,
+} from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import {
@@ -114,13 +119,14 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
     )
   }
 
-  const is96Channel =
-    invariantContext.pipetteEntities[pipetteId]?.spec.channels === 96
+  const pipChannels = invariantContext.pipetteEntities[pipetteId]?.spec.channels
+  const is96Channel = pipChannels === 96
+  const is8Channel = pipChannels === 8
 
   if (
-    is96Channel &&
-    nozzles === COLUMN &&
+    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
     !getIsSafePipetteMovement(
+      nozzles,
       prevRobotState,
       invariantContext,
       pipetteId,

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -1,9 +1,4 @@
-import {
-  ALL,
-  FLEX_ROBOT_TYPE,
-  OT2_ROBOT_TYPE,
-  SINGLE,
-} from '@opentrons/shared-data'
+import { ALL, FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import {
@@ -119,12 +114,12 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
     )
   }
 
-  const pipChannels = invariantContext.pipetteEntities[pipetteId]?.spec.channels
-  const is96Channel = pipChannels === 96
-  const is8Channel = pipChannels === 8
+  const isMultiChannelPipette =
+    invariantContext.pipetteEntities[pipetteId]?.spec.channels !== 1
 
   if (
-    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
+    isMultiChannelPipette &&
+    nozzles !== ALL &&
     !getIsSafePipetteMovement(
       nozzles,
       prevRobotState,

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -1,9 +1,4 @@
-import {
-  ALL,
-  FLEX_ROBOT_TYPE,
-  OT2_ROBOT_TYPE,
-  SINGLE,
-} from '@opentrons/shared-data'
+import { ALL, FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import {
   absorbanceReaderCollision,
@@ -118,12 +113,12 @@ export const dispense: CommandCreator<DispenseAtomicCommandParams> = (
     }
   }
 
-  const pipChannels = invariantContext.pipetteEntities[pipetteId]?.spec.channels
-  const is96Channel = pipChannels === 96
-  const is8Channel = pipChannels === 8
+  const isMultiChannelPipette =
+    invariantContext.pipetteEntities[pipetteId]?.spec.channels !== 1
 
   if (
-    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
+    isMultiChannelPipette &&
+    nozzles !== ALL &&
     !getIsSafePipetteMovement(
       nozzles,
       prevRobotState,

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -1,4 +1,9 @@
-import { COLUMN, FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import {
+  ALL,
+  FLEX_ROBOT_TYPE,
+  OT2_ROBOT_TYPE,
+  SINGLE,
+} from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import {
   absorbanceReaderCollision,
@@ -112,14 +117,21 @@ export const dispense: CommandCreator<DispenseAtomicCommandParams> = (
       )
     }
   }
+<<<<<<< HEAD
 
   const is96Channel =
     invariantContext.pipetteEntities[pipetteId]?.spec.channels === 96
+=======
+  const pipChannels =
+    invariantContext.pipetteEntities[args.pipette]?.spec.channels
+  const is96Channel = pipChannels === 96
+  const is8Channel = pipChannels === 8
+>>>>>>> b54ac77286 (add full support for single partial tip with the primary nozzle being the default)
 
   if (
-    is96Channel &&
-    nozzles === COLUMN &&
+    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
     !getIsSafePipetteMovement(
+      nozzles,
       prevRobotState,
       invariantContext,
       pipetteId,

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -117,16 +117,10 @@ export const dispense: CommandCreator<DispenseAtomicCommandParams> = (
       )
     }
   }
-<<<<<<< HEAD
 
-  const is96Channel =
-    invariantContext.pipetteEntities[pipetteId]?.spec.channels === 96
-=======
-  const pipChannels =
-    invariantContext.pipetteEntities[args.pipette]?.spec.channels
+  const pipChannels = invariantContext.pipetteEntities[pipetteId]?.spec.channels
   const is96Channel = pipChannels === 96
   const is8Channel = pipChannels === 8
->>>>>>> b54ac77286 (add full support for single partial tip with the primary nozzle being the default)
 
   if (
     ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&

--- a/step-generation/src/commandCreators/atomic/pickUpTip.ts
+++ b/step-generation/src/commandCreators/atomic/pickUpTip.ts
@@ -1,4 +1,4 @@
-import { COLUMN } from '@opentrons/shared-data'
+import { ALL, SINGLE } from '@opentrons/shared-data'
 import {
   pipettingIntoColumn4,
   possiblePipetteCollision,
@@ -23,13 +23,14 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
   const { pipetteId, labwareId, wellName, nozzles } = args
   const errors: CommandCreatorError[] = []
 
-  const is96Channel =
-    invariantContext.pipetteEntities[pipetteId]?.spec.channels === 96
+  const pipChannels = invariantContext.pipetteEntities[pipetteId]?.spec.channels
+  const is96Channel = pipChannels === 96
+  const is8Channel = pipChannels === 8
 
   if (
-    is96Channel &&
-    nozzles === COLUMN &&
+    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
     !getIsSafePipetteMovement(
+      args.nozzles ?? null,
       prevRobotState,
       invariantContext,
       pipetteId,

--- a/step-generation/src/commandCreators/atomic/pickUpTip.ts
+++ b/step-generation/src/commandCreators/atomic/pickUpTip.ts
@@ -1,4 +1,4 @@
-import { ALL, SINGLE } from '@opentrons/shared-data'
+import { ALL } from '@opentrons/shared-data'
 import {
   pipettingIntoColumn4,
   possiblePipetteCollision,
@@ -23,12 +23,12 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
   const { pipetteId, labwareId, wellName, nozzles } = args
   const errors: CommandCreatorError[] = []
 
-  const pipChannels = invariantContext.pipetteEntities[pipetteId]?.spec.channels
-  const is96Channel = pipChannels === 96
-  const is8Channel = pipChannels === 8
+  const isMultiChannelPipette =
+    invariantContext.pipetteEntities[pipetteId]?.spec.channels !== 1
 
   if (
-    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
+    isMultiChannelPipette &&
+    nozzles !== ALL &&
     !getIsSafePipetteMovement(
       args.nozzles ?? null,
       prevRobotState,

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -1,10 +1,11 @@
 import chunk from 'lodash/chunk'
 import flatMap from 'lodash/flatMap'
 import {
-  COLUMN,
   getWellDepth,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  ALL,
+  SINGLE,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -86,8 +87,10 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   } = args
 
   const pipetteData = prevRobotState.pipettes[args.pipette]
-  const is96Channel =
-    invariantContext.pipetteEntities[args.pipette]?.spec.channels === 96
+  const pipChannels =
+    invariantContext.pipetteEntities[args.pipette]?.spec.channels
+  const is96Channel = pipChannels === 96
+  const is8Channel = pipChannels === 8
 
   if (!pipetteData) {
     // bail out before doing anything else
@@ -130,9 +133,9 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   }
 
   if (
-    is96Channel &&
-    args.nozzles === COLUMN &&
+    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
     !getIsSafePipetteMovement(
+      nozzles,
       prevRobotState,
       invariantContext,
       args.pipette,
@@ -147,9 +150,9 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   }
 
   if (
-    is96Channel &&
-    args.nozzles === COLUMN &&
+    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
     !getIsSafePipetteMovement(
+      nozzles,
       prevRobotState,
       invariantContext,
       args.pipette,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -2,10 +2,11 @@ import chunk from 'lodash/chunk'
 import flatMap from 'lodash/flatMap'
 import last from 'lodash/last'
 import {
-  COLUMN,
   getWellDepth,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  ALL,
+  SINGLE,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -80,8 +81,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
   // TODO Ian 2018-05-03 next ~20 lines match consolidate.js
   const actionName = 'distribute'
   const errors: CommandCreatorError[] = []
-  const is96Channel =
-    invariantContext.pipetteEntities[args.pipette]?.spec.channels === 96
+  const pipChannels =
+    invariantContext.pipetteEntities[args.pipette]?.spec.channels
+  const is96Channel = pipChannels === 96
+  const is8Channel = pipChannels === 8
 
   // TODO: Ian 2019-04-19 revisit these pipetteDoesNotExist errors, how to do it DRY?
   if (
@@ -127,9 +130,9 @@ export const distribute: CommandCreator<DistributeArgs> = (
   }
 
   if (
-    is96Channel &&
-    args.nozzles === COLUMN &&
+    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
     !getIsSafePipetteMovement(
+      args.nozzles,
       prevRobotState,
       invariantContext,
       args.pipette,
@@ -142,9 +145,9 @@ export const distribute: CommandCreator<DistributeArgs> = (
   }
 
   if (
-    is96Channel &&
-    args.nozzles === COLUMN &&
+    ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) &&
     !getIsSafePipetteMovement(
+      args.nozzles,
       prevRobotState,
       invariantContext,
       args.pipette,

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -3,7 +3,6 @@ import {
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   ALL,
-  SINGLE,
 } from '@opentrons/shared-data'
 import {
   repeatArray,
@@ -150,9 +149,8 @@ export const mix: CommandCreator<MixArgs> = (
     nozzles,
   } = data
 
-  const pipChannels = invariantContext.pipetteEntities[pipette]?.spec.channels
-  const is96Channel = pipChannels === 96
-  const is8Channel = pipChannels === 8
+  const isMultiChannelPipette =
+    invariantContext.pipetteEntities[pipette]?.spec.channels !== 1
 
   // Errors
   if (
@@ -199,7 +197,7 @@ export const mix: CommandCreator<MixArgs> = (
     return { errors: [errorCreators.dropTipLocationDoesNotExist()] }
   }
 
-  if ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) {
+  if (isMultiChannelPipette && nozzles !== ALL) {
     const isAspirateSafePipetteMovement = getIsSafePipetteMovement(
       data.nozzles,
       prevRobotState,

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -1,8 +1,9 @@
 import flatMap from 'lodash/flatMap'
 import {
   LOW_VOLUME_PIPETTES,
-  COLUMN,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  ALL,
+  SINGLE,
 } from '@opentrons/shared-data'
 import {
   repeatArray,
@@ -149,8 +150,9 @@ export const mix: CommandCreator<MixArgs> = (
     nozzles,
   } = data
 
-  const is96Channel =
-    invariantContext.pipetteEntities[pipette]?.spec.channels === 96
+  const pipChannels = invariantContext.pipetteEntities[pipette]?.spec.channels
+  const is96Channel = pipChannels === 96
+  const is8Channel = pipChannels === 8
 
   // Errors
   if (
@@ -197,8 +199,9 @@ export const mix: CommandCreator<MixArgs> = (
     return { errors: [errorCreators.dropTipLocationDoesNotExist()] }
   }
 
-  if (is96Channel && data.nozzles === COLUMN) {
+  if ((is96Channel && nozzles !== ALL) || (is8Channel && nozzles === SINGLE)) {
     const isAspirateSafePipetteMovement = getIsSafePipetteMovement(
+      data.nozzles,
       prevRobotState,
       invariantContext,
       pipette,
@@ -207,6 +210,7 @@ export const mix: CommandCreator<MixArgs> = (
       { x: xOffset, y: yOffset }
     )
     const isDispenseSafePipetteMovement = getIsSafePipetteMovement(
+      data.nozzles,
       prevRobotState,
       invariantContext,
       pipette,

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -3,6 +3,7 @@ import {
   COLUMN,
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
+  SINGLE,
 } from '@opentrons/shared-data'
 import { getNextTiprack } from '../../robotStateSelectors'
 import * as errorCreators from '../../errorCreators'
@@ -173,14 +174,24 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     }
   }
 
+  let primaryNozzle
+  if (nozzles === COLUMN) {
+    primaryNozzle = PRIMARY_NOZZLE
+  } else if (nozzles === SINGLE && channels === 96) {
+    primaryNozzle = 'H12'
+  } else if (nozzles === SINGLE && channels === 8) {
+    primaryNozzle = 'H1'
+  }
+
   const configureNozzleLayoutCommand: CurriedCommandCreator[] =
     //  only emit the command if previous nozzle state is different
-    channels === 96 && args.nozzles != null && args.nozzles !== stateNozzles
+    (channels === 96 || channels === 8) &&
+    args.nozzles != null &&
+    args.nozzles !== stateNozzles
       ? [
           curryCommandCreator(configureNozzleLayout, {
             configurationParams: {
-              primaryNozzle:
-                args.nozzles === COLUMN ? PRIMARY_NOZZLE : undefined,
+              primaryNozzle,
               style: args.nozzles,
             },
             pipetteId: args.pipette,

--- a/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
@@ -1,6 +1,6 @@
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
-import { COLUMN } from '@opentrons/shared-data'
+import { COLUMN, SINGLE } from '@opentrons/shared-data'
 import {
   splitLiquid,
   mergeLiquid,
@@ -44,7 +44,12 @@ export function dispenseUpdateLiquidState(
   } = args
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const nozzles = robotStateAndWarnings.robotState.pipettes[pipetteId].nozzles
-  const channels = nozzles === COLUMN ? 8 : pipetteSpec.channels
+  let channels = pipetteSpec.channels
+  if (nozzles === COLUMN) {
+    channels = 8
+  } else if (nozzles === SINGLE) {
+    channels = 1
+  }
   const trashId = Object.values(
     invariantContext.additionalEquipmentEntities
   ).find(aE => aE.name === 'wasteChute' || aE.name === 'trashBin')?.id

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -1,7 +1,7 @@
 import range from 'lodash/range'
 import isEmpty from 'lodash/isEmpty'
 import uniq from 'lodash/uniq'
-import { COLUMN } from '@opentrons/shared-data'
+import { COLUMN, SINGLE } from '@opentrons/shared-data'
 import {
   AIR,
   mergeLiquid,
@@ -24,8 +24,13 @@ export function forAspirate(
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const labwareDef = invariantContext.labwareEntities[labwareId].def
   const isReservoir = labwareDef.metadata.displayCategory === 'reservoir'
-  const channels = nozzles === COLUMN ? 8 : pipetteSpec.channels
-
+  let channels = pipetteSpec.channels
+  if (nozzles === COLUMN) {
+    channels = 8
+  } else if (nozzles === SINGLE) {
+    channels = 1
+  }
+  console.log('for aspirate nozzles', nozzles)
   const { allWellsShared, wellsForTips } = getWellsForTips(
     channels,
     labwareDef,

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -30,7 +30,7 @@ export function forAspirate(
   } else if (nozzles === SINGLE) {
     channels = 1
   }
-  console.log('for aspirate nozzles', nozzles)
+
   const { allWellsShared, wellsForTips } = getWellsForTips(
     channels,
     labwareDef,

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -19,9 +19,7 @@ export function forPickUpTip(
   // pipette now has tip(s)
   tipState.pipettes[pipetteId] = true
   // remove tips from tiprack
-  console.log('nozzles', nozzles)
   if (pipetteSpec.channels === 1 || nozzles === SINGLE) {
-    console.log('hit here')
     tipState.tipracks[labwareId][wellName] = false
   } else if (pipetteSpec.channels === 8 || nozzles === COLUMN) {
     const allWells = tiprackDef.ordering.find(col => col[0] === wellName)

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { ALL, COLUMN, getIsTiprack } from '@opentrons/shared-data'
+import { ALL, COLUMN, SINGLE, getIsTiprack } from '@opentrons/shared-data'
 import type { PickUpTipParams } from '@opentrons/shared-data'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 export function forPickUpTip(
@@ -19,7 +19,9 @@ export function forPickUpTip(
   // pipette now has tip(s)
   tipState.pipettes[pipetteId] = true
   // remove tips from tiprack
-  if (pipetteSpec.channels === 1) {
+  console.log('nozzles', nozzles)
+  if (pipetteSpec.channels === 1 || nozzles === SINGLE) {
+    console.log('hit here')
     tipState.tipracks[labwareId][wellName] = false
   } else if (pipetteSpec.channels === 8 || nozzles === COLUMN) {
     const allWells = tiprackDef.ordering.find(col => col[0] === wellName)

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -61,7 +61,7 @@ export function _getNextTip(args: {
   const tiprackDef = invariantContext.labwareEntities[tiprackId]?.def
 
   const hasTip = (wellName: string): boolean => tiprackWellsState[wellName]
-  console.log(nozzles)
+
   const orderedWells = orderWells(tiprackDef.ordering, 't2b', 'l2r')
   if (pipetteChannels === 1 || nozzles === SINGLE) {
     const well = orderedWells.find(hasTip)

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -8,6 +8,7 @@ import {
   getTiprackVolume,
   orderWells,
   THERMOCYCLER_MODULE_TYPE,
+  SINGLE,
 } from '@opentrons/shared-data'
 import { COLUMN_4_SLOTS } from './constants'
 import type {
@@ -60,9 +61,9 @@ export function _getNextTip(args: {
   const tiprackDef = invariantContext.labwareEntities[tiprackId]?.def
 
   const hasTip = (wellName: string): boolean => tiprackWellsState[wellName]
-
+  console.log(nozzles)
   const orderedWells = orderWells(tiprackDef.ordering, 't2b', 'l2r')
-  if (pipetteChannels === 1) {
+  if (pipetteChannels === 1 || nozzles === SINGLE) {
     const well = orderedWells.find(hasTip)
     return well || null
   }

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -298,7 +298,7 @@ export function getWellsForTips(
   // Array of wells corresponding to the tip at each position.
   const wellsForTips =
     channels === 1 ? [well] : getWellNamePerMultiTip(labwareDef, well, channels)
-  console.log('channels from getWellsForTips', channels)
+
   if (!wellsForTips) {
     console.warn(
       channels === 1

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -298,7 +298,7 @@ export function getWellsForTips(
   // Array of wells corresponding to the tip at each position.
   const wellsForTips =
     channels === 1 ? [well] : getWellNamePerMultiTip(labwareDef, well, channels)
-
+  console.log('channels from getWellsForTips', channels)
   if (!wellsForTips) {
     console.warn(
       channels === 1

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -1,5 +1,6 @@
 import {
   FLEX_ROBOT_TYPE,
+  SINGLE,
   THERMOCYCLER_MODULE_TYPE,
   getAddressableAreaFromSlotId,
   getDeckDefFromRobotType,
@@ -23,7 +24,6 @@ import type {
 const A12_column_front_left_bound = { x: -11.03, y: 2 }
 const A12_column_back_right_bound = { x: 526.77, y: 506.2 }
 export const PRIMARY_NOZZLE = 'A12'
-const NOZZLE_CONFIGURATION = 'COLUMN'
 const FLEX_TC_LID_COLLISION_ZONE = {
   back_left: { x: -43.25, y: 454.9, z: 211.91 },
   front_right: { x: 128.75, y: 402, z: 211.91 },
@@ -78,7 +78,7 @@ const getPipetteBoundsAtSpecifiedMoveToPosition = (
   pipetteEntity: PipetteEntity,
   tipLength: number,
   wellTargetPoint: Point,
-  primaryNozzle: string = 'A12' // hardcoding A12 becasue only column pick up supported currently
+  primaryNozzle: string // hardcoding A12 becasue only column pick up supported currently
 ): Point[] => {
   const {
     nozzleMap,
@@ -293,6 +293,7 @@ const getWellPosition = (
 
 //  util to use in step-generation for if the pipette movement is safe
 export const getIsSafePipetteMovement = (
+  nozzleConfiguation: NozzleConfigurationStyle | null,
   robotState: RobotState,
   invariantContext: InvariantContext,
   pipetteId: string,
@@ -310,8 +311,12 @@ export const getIsSafePipetteMovement = (
   } = invariantContext
   const { labware: labwareState, tipState } = robotState
 
-  //  early exit if labwareId is a trashBin or wasteChute
-  if (labwareEntities[labwareId] == null || wellTargetName == null) {
+  //  early exit if labwareId is a trashBin or wasteChute or if no nozzle is provided
+  if (
+    labwareEntities[labwareId] == null ||
+    wellTargetName == null ||
+    nozzleConfiguation == null
+  ) {
     return true
   }
 
@@ -341,13 +346,20 @@ export const getIsSafePipetteMovement = (
     addressableAreaOffset,
     pipetteHasTip
   )
+  let primaryNozzle = 'A12'
+  if (nozzleConfiguation === SINGLE && pipetteEntity.spec.channels === 96) {
+    primaryNozzle = 'H12'
+  } else if (
+    nozzleConfiguation === SINGLE &&
+    pipetteEntity.spec.channels === 8
+  ) {
+    primaryNozzle = 'H1'
+  }
 
   const isWithinPipetteExtents = getIsWithinPipetteExtents(
     wellTargetPoint,
-    //  TODO(jr, 4/22/24): PD only supports A12 as a primary nozzle for now
-    //  and only for 96-channel column pick up
-    NOZZLE_CONFIGURATION,
-    PRIMARY_NOZZLE
+    nozzleConfiguation,
+    primaryNozzle
   )
   if (!isWithinPipetteExtents) {
     return false
@@ -355,7 +367,8 @@ export const getIsSafePipetteMovement = (
     const pipetteBoundsAtWellLocation = getPipetteBoundsAtSpecifiedMoveToPosition(
       pipetteEntity,
       tipLength,
-      wellTargetPoint
+      wellTargetPoint,
+      primaryNozzle
     )
     const surroundingSlots = getFlexSurroundingSlots(
       labwareSlot,

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -78,7 +78,7 @@ const getPipetteBoundsAtSpecifiedMoveToPosition = (
   pipetteEntity: PipetteEntity,
   tipLength: number,
   wellTargetPoint: Point,
-  primaryNozzle: string // hardcoding A12 becasue only column pick up supported currently
+  primaryNozzle: string
 ): Point[] => {
   const {
     nozzleMap,


### PR DESCRIPTION
closes AUTH-594 AUTH-596 AUTH-597 AUTH-598 AUTH-599

# Overview

This is behind a ff so shouldn't affect anything in 8.4.0, 8.5.0, etc until we want to finish & release this feature

This PR adds single tip partial tip support for 96-channel and 8-channel, only starting at the 'default' primary nozzles which are `H1` for 8-channel and `H12` for 96-channel.

Note that collision warnings for deck extents, ot-2 and 8-channel are not fully supported yet.

## Test Plan and Hands on Testing

Turn on the partial tip FF
- create an 8-channel protocol for the Flex or OT-2, add 2 transfer steps, one with all nozzles and one with 1 nozzle. see that it looks correct and it passes analysis on the app
- create a 96-channel protocol for the Flex, add  3 transfer steps, one with all nozzles, one with 1 nozzle, and one with 1 column. see that it looks correct and passes analysis on the app
- turn off the FF, see that the single option is not found

Here are some test protocols you can upload:

[96-channel partial tip.json](https://github.com/user-attachments/files/19234611/96-channel.partial.tip.json)
[8-channel partial tip.json](https://github.com/user-attachments/files/19234619/8-channel.partial.tip.json)


## Changelog

- add support for single nozzle pick up for the default primary nozzle
- extend support to the partial tip field, utils, and step-generation
- create ff for partial tip work

## Risk assessment

low, behind ff