### PR TITLE
fix(shared-data): find latest definition if version not specified 

### DIFF
--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -240,7 +240,7 @@ def _get_standard_labware_definition(
         )
 
     namespace = namespace.lower()
-    def_path = _get_path_to_labware(load_name, namespace, checked_version)
+    def_path = _get_path_to_labware(load_name, namespace, version)
 
     try:
         with open(def_path, "rb") as f:
@@ -254,26 +254,31 @@ def _get_standard_labware_definition(
 
 
 def _get_path_to_labware(
-    load_name: str, namespace: str, version: int, base_path: Optional[Path] = None
+    load_name: str,
+    namespace: str,
+    version: Optional[int] = None,
+    base_path: Optional[Path] = None,
 ) -> Path:
     if namespace == OPENTRONS_NAMESPACE:
         # all labware in OPENTRONS_NAMESPACE is stored in shared data
-        schema_3_path = (
-            get_shared_data_root()
-            / STANDARD_DEFS_PATH
-            / "3"
-            / load_name
-            / f"{version}.json"
-        )
-        schema_2_path = (
-            get_shared_data_root()
-            / STANDARD_DEFS_PATH
-            / "2"
-            / load_name
-            / f"{version}.json"
-        )
-        return schema_3_path if schema_3_path.exists() else schema_2_path
+        schema_3_dir = get_shared_data_root() / STANDARD_DEFS_PATH / "3" / load_name
+        if schema_3_dir.exists():
+            schema_3_files = os.listdir(schema_3_dir)
+            version_filename = f"{version}.json" if version else max(schema_3_files)
+            schema_3_path = schema_3_dir / version_filename
+            return schema_3_path
+        else:
+            version_filename = f"{version}.json" if version else "1.json"
+            schema_2_path = (
+                get_shared_data_root()
+                / STANDARD_DEFS_PATH
+                / "2"
+                / load_name
+                / f"{version_filename}.json"
+            )
+        return schema_2_path
     if not base_path:
         base_path = USER_DEFS_PATH
-    def_path = base_path / namespace / load_name / f"{version}.json"
+    version_filename = f"{version}.json" if version else "1.json"
+    def_path = base_path / namespace / load_name / f"{version_filename}.json"
     return def_path

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -258,6 +258,7 @@ def _get_path_to_labware(
     version: Optional[int] = None,
     base_path: Optional[Path] = None,
 ) -> Path:
+    version_filename = f"{version}.json" if version else "1.json"
     if namespace == OPENTRONS_NAMESPACE:
         # all labware in OPENTRONS_NAMESPACE is stored in shared data
         schema_3_dir = get_shared_data_root() / STANDARD_DEFS_PATH / "3" / load_name
@@ -267,7 +268,6 @@ def _get_path_to_labware(
             schema_3_path = schema_3_dir / version_filename
             if schema_3_path.exists():
                 return schema_3_path
-        version_filename = f"{version}.json" if version else "1.json"
         schema_2_path = (
             get_shared_data_root()
             / STANDARD_DEFS_PATH
@@ -279,6 +279,5 @@ def _get_path_to_labware(
             return schema_2_path
     if not base_path:
         base_path = USER_DEFS_PATH
-    version_filename = f"{version}.json" if version else "1.json"
-    def_path = base_path / namespace / load_name / f"{version_filename}.json"
+    def_path = base_path / namespace / load_name / version_filename
     return def_path

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -238,7 +238,6 @@ def _get_standard_labware_definition(
         raise FileNotFoundError(
             error_msg_string.format(load_name, checked_version, OPENTRONS_NAMESPACE)
         )
-
     namespace = namespace.lower()
     def_path = _get_path_to_labware(load_name, namespace, version)
 
@@ -266,17 +265,18 @@ def _get_path_to_labware(
             schema_3_files = os.listdir(schema_3_dir)
             version_filename = f"{version}.json" if version else max(schema_3_files)
             schema_3_path = schema_3_dir / version_filename
-            return schema_3_path
-        else:
-            version_filename = f"{version}.json" if version else "1.json"
-            schema_2_path = (
-                get_shared_data_root()
-                / STANDARD_DEFS_PATH
-                / "2"
-                / load_name
-                / f"{version_filename}.json"
-            )
-        return schema_2_path
+            if schema_3_path.exists():
+                return schema_3_path
+        version_filename = f"{version}.json" if version else "1.json"
+        schema_2_path = (
+            get_shared_data_root()
+            / STANDARD_DEFS_PATH
+            / "2"
+            / load_name
+            / version_filename
+        )
+        if schema_2_path.exists():
+            return schema_2_path
     if not base_path:
         base_path = USER_DEFS_PATH
     version_filename = f"{version}.json" if version else "1.json"


### PR DESCRIPTION
## Overview
When grabbing a labware definition, if a version is not specified, we default the file version to `1.json` and check whether that file exists. This was done under the impression that all labware definitions in schema 3 would start at `1.json`, but since that isn't the case, if no version is specified, we should just find the latest available labware def version that exists and load that.