### PR TITLE
fix(protocol-designer): padding adjustments with forms

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -36,9 +36,11 @@ import {
   createDeckFixture,
   deleteDeckFixture,
 } from '../../../step-forms/actions/additionalItems'
-import { getAdditionalEquipment } from '../../../step-forms/selectors'
+import {
+  getAdditionalEquipment,
+  getSavedStepForms,
+} from '../../../step-forms/selectors'
 import { deleteModule } from '../../../step-forms/actions'
-import { getSavedStepForms } from '../../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import {
   createContainer,

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -12,8 +12,10 @@ import { renderWithProviders } from '../../../../__testing-utils__'
 import { deleteContainer } from '../../../../labware-ingred/actions'
 import { useKitchen } from '../../../../organisms/Kitchen/hooks'
 import { deleteModule } from '../../../../step-forms/actions'
-import { getAdditionalEquipment } from '../../../../step-forms/selectors'
-import { getSavedStepForms } from '../../../../step-forms/selectors'
+import {
+  getAdditionalEquipment,
+  getSavedStepForms,
+} from '../../../../step-forms/selectors'
 import { getRobotType } from '../../../../file-data/selectors'
 import { getEnableAbsorbanceReader } from '../../../../feature-flags/selectors'
 import { deleteDeckFixture } from '../../../../step-forms/actions/additionalItems'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
@@ -220,7 +220,6 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
           isIndeterminate={isIndeterminate}
           units={t('units.millimeter')}
           id={`TipPositionField_${zName}`}
-          padding={padding}
         />
       )}
     </>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerState.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerState.tsx
@@ -65,7 +65,6 @@ export function ThermocyclerState(props: ThermocyclerStateProps): JSX.Element {
       flexDirection={DIRECTION_COLUMN}
       gridGap={SPACING.spacing4}
       paddingX={SPACING.spacing16}
-      paddingTop={SPACING.spacing16}
     >
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         <StyledText desktopStyle="bodyDefaultSemiBold">


### PR DESCRIPTION
closes RQA-3700 RQA-3693

# Overview

Adjust padding in 2 places in the forms

## Test Plan and Hands on Testing

Look at the areas in thermocycler form and transfer form, see that the padding looks correct now

<img width="319" alt="Screenshot 2025-01-09 at 08 57 38" src="https://github.com/user-attachments/assets/9c39cfd2-826c-4100-8f39-ec42b121fcdc" />

<img width="323" alt="Screenshot 2025-01-09 at 08 57 54" src="https://github.com/user-attachments/assets/e904e248-390b-4fa9-88fb-7383709917a8" />



## Changelog

- adjust padding

## Risk assessment

low