### PR TITLE
feat(protocol-designer): yaml upload and download artifact version to 4

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -164,7 +164,7 @@ jobs:
         run: |
           make -C protocol-designer NODE_ENV=development
       - name: 'upload github artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'pd-artifact'
           path: protocol-designer/dist
@@ -197,7 +197,7 @@ jobs:
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
             buildComplexEnvVars(core, context)
       - name: 'download PD build'
-        uses: 'actions/download-artifact@v3'
+        uses: 'actions/download-artifact@v4'
         with:
           name: pd-artifact
           path: ./dist


### PR DESCRIPTION
# Overview

github actions upload-artifact and download-artifact v3 was deprecated so this updates to v4.

## Test Plan and Hands on Testing

Review yaml and make sure the artifact is correctly built

## Changelog

update the download and upload artifact version from 3 to 4

## Risk assessment

low