### PR TITLE
feat(robot-server): Persist `/labwareOffsets` storage across reboots

### DIFF
--- a/robot-server/robot_server/labware_offsets/fastapi_dependencies.py
+++ b/robot-server/robot_server/labware_offsets/fastapi_dependencies.py
@@ -10,6 +10,9 @@ from server_utils.fastapi_utils.app_state import (
     AppStateAccessor,
     get_app_state,
 )
+import sqlalchemy
+
+from robot_server.persistence.fastapi_dependencies import get_sql_engine
 from .store import LabwareOffsetStore
 
 
@@ -20,10 +23,11 @@ _labware_offset_store_accessor = AppStateAccessor[LabwareOffsetStore](
 
 async def get_labware_offset_store(
     app_state: Annotated[AppState, Depends(get_app_state)],
+    sql_engine: Annotated[sqlalchemy.engine.Engine, Depends(get_sql_engine)],
 ) -> LabwareOffsetStore:
     """Get the server's singleton LabwareOffsetStore."""
     labware_offset_store = _labware_offset_store_accessor.get_from(app_state)
     if labware_offset_store is None:
-        labware_offset_store = LabwareOffsetStore()
+        labware_offset_store = LabwareOffsetStore(sql_engine)
         _labware_offset_store_accessor.set_on(app_state, labware_offset_store)
     return labware_offset_store

--- a/robot-server/robot_server/labware_offsets/router.py
+++ b/robot-server/robot_server/labware_offsets/router.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime
 import textwrap
-from typing import Annotated, Literal, Type
+from typing import Annotated, Literal
 
 import fastapi
 from pydantic import Json
@@ -24,7 +24,12 @@ from robot_server.service.json_api.response import (
     SimpleMultiBody,
 )
 
-from .store import DO_NOT_FILTER, LabwareOffsetNotFoundError, LabwareOffsetStore
+from .store import (
+    DO_NOT_FILTER,
+    DoNotFilterType,
+    LabwareOffsetNotFoundError,
+    LabwareOffsetStore,
+)
 from .fastapi_dependencies import get_labware_offset_store
 
 
@@ -78,11 +83,11 @@ async def post_labware_offset(  # noqa: D103
 async def get_labware_offsets(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],
     id: Annotated[
-        Json[str] | SkipJsonSchema[Type[DO_NOT_FILTER]],
+        Json[str] | SkipJsonSchema[DoNotFilterType],
         fastapi.Query(description="Filter for exact matches on the `id` field."),
     ] = DO_NOT_FILTER,
     definition_uri: Annotated[
-        Json[str] | SkipJsonSchema[Type[DO_NOT_FILTER]],
+        Json[str] | SkipJsonSchema[DoNotFilterType],
         fastapi.Query(
             alias="definitionUri",
             description=(
@@ -92,21 +97,21 @@ async def get_labware_offsets(  # noqa: D103
         ),
     ] = DO_NOT_FILTER,
     location_slot_name: Annotated[
-        Json[DeckSlotName] | SkipJsonSchema[Type[DO_NOT_FILTER]],
+        Json[DeckSlotName] | SkipJsonSchema[DoNotFilterType],
         fastapi.Query(
             alias="locationSlotName",
             description="Filter for exact matches on the `location.slotName` field.",
         ),
     ] = DO_NOT_FILTER,
     location_module_model: Annotated[
-        Json[ModuleModel | None] | SkipJsonSchema[Type[DO_NOT_FILTER]],
+        Json[ModuleModel | None] | SkipJsonSchema[DoNotFilterType],
         fastapi.Query(
             alias="locationModuleModel",
             description="Filter for exact matches on the `location.moduleModel` field.",
         ),
     ] = DO_NOT_FILTER,
     location_definition_uri: Annotated[
-        Json[str | None] | SkipJsonSchema[Type[DO_NOT_FILTER]],
+        Json[str | None] | SkipJsonSchema[DoNotFilterType],
         fastapi.Query(
             alias="locationDefinitionUri",
             description=(

--- a/robot-server/robot_server/labware_offsets/store.py
+++ b/robot-server/robot_server/labware_offsets/store.py
@@ -1,10 +1,20 @@
 # noqa: D100
 
 import enum
-from typing import Final, Literal, Type, TypeAlias
+from typing import Final, Literal, TypeAlias
 
-from opentrons.protocol_engine import LabwareOffset, ModuleModel
+from opentrons.protocol_engine.types import (
+    LabwareOffset,
+    LabwareOffsetLocation,
+    LabwareOffsetVector,
+    ModuleModel,
+)
 from opentrons.types import DeckSlotName
+
+from robot_server.persistence.tables import labware_offset_table
+
+import sqlalchemy
+import sqlalchemy.exc
 
 
 class _DoNotFilter(enum.Enum):
@@ -31,13 +41,21 @@ Unfortunately, mypy doesn't let us write `Literal[DO_NOT_FILTER]`. Use this inst
 class LabwareOffsetStore:
     """A persistent store for labware offsets, to support the `/labwareOffsets` endpoints."""
 
-    def __init__(self) -> None:
-        self._offsets_by_id: dict[str, LabwareOffset] = {}
+    def __init__(self, sql_engine: sqlalchemy.engine.Engine) -> None:
+        """Initialize the store.
+
+        Params:
+            sql_engine: The SQL database to use as backing storage. Assumed to already
+                have all the proper tables set up.
+        """
+        self._sql_engine = sql_engine
 
     def add(self, offset: LabwareOffset) -> None:
         """Store a new labware offset."""
-        assert offset.id not in self._offsets_by_id
-        self._offsets_by_id[offset.id] = offset
+        with self._sql_engine.begin() as transaction:
+            transaction.execute(
+                sqlalchemy.insert(labware_offset_table).values(_pydantic_to_sql(offset))
+            )
 
     def search(
         self,
@@ -54,35 +72,66 @@ class LabwareOffsetStore:
         # making it worse.
     ) -> list[LabwareOffset]:
         """Return all matching labware offsets in order from oldest-added to newest."""
+        statement = sqlalchemy.select(labware_offset_table).order_by(
+            labware_offset_table.c.row_id
+        )
 
-        def is_match(candidate: LabwareOffset) -> bool:
-            return (
-                id_filter in (DO_NOT_FILTER, candidate.id)
-                and definition_uri_filter in (DO_NOT_FILTER, candidate.definitionUri)
-                and location_slot_name_filter
-                in (DO_NOT_FILTER, candidate.location.slotName)
-                and location_module_model_filter
-                in (DO_NOT_FILTER, candidate.location.moduleModel)
-                and location_definition_uri_filter
-                in (DO_NOT_FILTER, candidate.location.definitionUri)
+        if id_filter is not DO_NOT_FILTER:
+            statement = statement.where(labware_offset_table.c.offset_id == id_filter)
+        if definition_uri_filter is not DO_NOT_FILTER:
+            statement = statement.where(
+                labware_offset_table.c.definition_uri == definition_uri_filter
+            )
+        if location_slot_name_filter is not DO_NOT_FILTER:
+            statement = statement.where(
+                labware_offset_table.c.location_slot_name
+                == location_slot_name_filter.value
+            )
+        if location_module_model_filter is not DO_NOT_FILTER:
+            location_module_model_filter_value = (
+                location_module_model_filter.value
+                if location_module_model_filter is not None
+                else None
+            )
+            statement = statement.where(
+                labware_offset_table.c.location_module_model
+                == location_module_model_filter_value
+            )
+        if location_definition_uri_filter is not DO_NOT_FILTER:
+            statement = statement.where(
+                labware_offset_table.c.location_definition_uri
+                == location_definition_uri_filter
             )
 
-        return [
-            candidate
-            for candidate in self._offsets_by_id.values()
-            if is_match(candidate)
-        ]
+        with self._sql_engine.begin() as transaction:
+            result = transaction.execute(statement).all()
+
+        return [_sql_to_pydantic(row) for row in result]
 
     def delete(self, offset_id: str) -> LabwareOffset:
         """Delete a labware offset by its ID. Return what was just deleted."""
-        try:
-            return self._offsets_by_id.pop(offset_id)
-        except KeyError:
-            raise LabwareOffsetNotFoundError(bad_offset_id=offset_id) from None
+        with self._sql_engine.begin() as transaction:
+            try:
+                row_to_delete = transaction.execute(
+                    sqlalchemy.select(labware_offset_table).where(
+                        labware_offset_table.c.offset_id == offset_id
+                    )
+                ).one()
+            except sqlalchemy.exc.NoResultFound:
+                raise LabwareOffsetNotFoundError(bad_offset_id=offset_id) from None
+
+            transaction.execute(
+                sqlalchemy.delete(labware_offset_table).where(
+                    labware_offset_table.c.offset_id == offset_id
+                )
+            )
+
+        return _sql_to_pydantic(row_to_delete)
 
     def delete_all(self) -> None:
         """Delete all labware offsets."""
-        self._offsets_by_id.clear()
+        with self._sql_engine.begin() as transaction:
+            transaction.execute(sqlalchemy.delete(labware_offset_table))
 
 
 class LabwareOffsetNotFoundError(KeyError):
@@ -91,3 +140,38 @@ class LabwareOffsetNotFoundError(KeyError):
     def __init__(self, bad_offset_id: str) -> None:
         super().__init__(bad_offset_id)
         self.bad_offset_id = bad_offset_id
+
+
+def _sql_to_pydantic(row: sqlalchemy.engine.Row) -> LabwareOffset:
+    return LabwareOffset(
+        id=row.offset_id,
+        createdAt=row.created_at,
+        definitionUri=row.definition_uri,
+        location=LabwareOffsetLocation(
+            slotName=DeckSlotName(row.location_slot_name),
+            moduleModel=row.location_module_model,
+            definitionUri=row.location_definition_uri,
+        ),
+        vector=LabwareOffsetVector(
+            x=row.vector_x,
+            y=row.vector_y,
+            z=row.vector_z,
+        ),
+    )
+
+
+def _pydantic_to_sql(labware_offset: LabwareOffset) -> dict[str, object]:
+    return dict(
+        offset_id=labware_offset.id,
+        definition_uri=labware_offset.definitionUri,
+        location_slot_name=labware_offset.location.slotName.value,
+        location_module_model=labware_offset.location.moduleModel.value
+        if labware_offset.location.moduleModel is not None
+        else None,
+        location_definition_uri=labware_offset.location.definitionUri,
+        vector_x=labware_offset.vector.x,
+        vector_y=labware_offset.vector.y,
+        vector_z=labware_offset.vector.z,
+        created_at=labware_offset.createdAt,
+        active=True,
+    )

--- a/robot-server/robot_server/labware_offsets/store.py
+++ b/robot-server/robot_server/labware_offsets/store.py
@@ -1,19 +1,29 @@
 # noqa: D100
 
-from typing import Type
+import enum
+from typing import Final, Literal, Type, TypeAlias
 
 from opentrons.protocol_engine import LabwareOffset, ModuleModel
 from opentrons.types import DeckSlotName
 
 
-class DO_NOT_FILTER:
-    """A sentinel value for when a filter should not be applied.
+class _DoNotFilter(enum.Enum):
+    DO_NOT_FILTER = enum.auto()
 
-    This is different from filtering on `None`, which returns only entries where the
-    value is equal to `None`.
-    """
 
-    pass
+DO_NOT_FILTER: Final = _DoNotFilter.DO_NOT_FILTER
+"""A sentinel value for when a filter should not be applied.
+
+This is different from filtering on `None`, which returns only entries where the
+value is equal to `None`.
+"""
+
+
+DoNotFilterType: TypeAlias = Literal[_DoNotFilter.DO_NOT_FILTER]
+"""The type of `DO_NOT_FILTER`, as `NoneType` is to `None`.
+
+Unfortunately, mypy doesn't let us write `Literal[DO_NOT_FILTER]`. Use this instead.
+"""
 
 
 # todo(mm, 2024-12-06): Convert to be SQL-based and persistent instead of in-memory.
@@ -31,15 +41,13 @@ class LabwareOffsetStore:
 
     def search(
         self,
-        id_filter: str | Type[DO_NOT_FILTER] = DO_NOT_FILTER,
-        definition_uri_filter: str | Type[DO_NOT_FILTER] = DO_NOT_FILTER,
-        location_slot_name_filter: DeckSlotName | Type[DO_NOT_FILTER] = DO_NOT_FILTER,
+        id_filter: str | DoNotFilterType = DO_NOT_FILTER,
+        definition_uri_filter: str | DoNotFilterType = DO_NOT_FILTER,
+        location_slot_name_filter: DeckSlotName | DoNotFilterType = DO_NOT_FILTER,
         location_module_model_filter: ModuleModel
         | None
-        | Type[DO_NOT_FILTER] = DO_NOT_FILTER,
-        location_definition_uri_filter: str
-        | None
-        | Type[DO_NOT_FILTER] = DO_NOT_FILTER,
+        | DoNotFilterType = DO_NOT_FILTER,
+        location_definition_uri_filter: str | None | DoNotFilterType = DO_NOT_FILTER,
         # todo(mm, 2024-12-06): Support pagination (cursor & pageLength query params).
         # The logic for that is currently duplicated across several places in
         # robot-server and api. We should try to clean that up, or at least avoid

--- a/robot-server/robot_server/persistence/_migrations/_util.py
+++ b/robot-server/robot_server/persistence/_migrations/_util.py
@@ -41,6 +41,15 @@ def copy_rows_unmodified(
         dest_connection.execute(insert, row)
 
 
+def copy_contents(source_dir: Path, dest_dir: Path) -> None:
+    """Copy the contents of one directory to another (assumed to be empty)."""
+    for item in source_dir.iterdir():
+        if item.is_dir():
+            shutil.copytree(src=item, dst=dest_dir / item.name)
+        else:
+            shutil.copy(src=item, dst=dest_dir / item.name)
+
+
 def copy_if_exists(src: Path, dst: Path) -> None:
     """Like `shutil.copy()`, but no-op if `src` doesn't exist."""
     try:

--- a/robot-server/robot_server/persistence/_migrations/v3_to_v4.py
+++ b/robot-server/robot_server/persistence/_migrations/v3_to_v4.py
@@ -8,9 +8,8 @@ Summary of changes from schema 3:
 
 from pathlib import Path
 from contextlib import ExitStack
-import shutil
 
-from ._util import add_column
+from ._util import add_column, copy_contents
 from ..database import sql_engine_ctx
 from ..file_and_directory_names import DB_FILE
 from ..tables import schema_4
@@ -21,11 +20,8 @@ class Migration3to4(Migration):  # noqa: D101
     def migrate(self, source_dir: Path, dest_dir: Path) -> None:
         """Migrate the persistence directory from schema 3 to 4."""
         # Copy over all existing directories and files to new version
-        for item in source_dir.iterdir():
-            if item.is_dir():
-                shutil.copytree(src=item, dst=dest_dir / item.name)
-            else:
-                shutil.copy(src=item, dst=dest_dir / item.name)
+        copy_contents(source_dir=source_dir, dest_dir=dest_dir)
+
         dest_db_file = dest_dir / DB_FILE
 
         # Append the new column to existing analyses in v4 database

--- a/robot-server/robot_server/persistence/_migrations/v4_to_v5.py
+++ b/robot-server/robot_server/persistence/_migrations/v4_to_v5.py
@@ -8,9 +8,8 @@ Summary of changes from schema 4:
 
 from pathlib import Path
 from contextlib import ExitStack
-import shutil
 
-from ._util import add_column
+from ._util import add_column, copy_contents
 from ..database import sql_engine_ctx
 from ..file_and_directory_names import DB_FILE
 from ..tables import schema_5
@@ -21,11 +20,8 @@ class Migration4to5(Migration):  # noqa: D101
     def migrate(self, source_dir: Path, dest_dir: Path) -> None:
         """Migrate the persistence directory from schema 4 to 5."""
         # Copy over all existing directories and files to new version
-        for item in source_dir.iterdir():
-            if item.is_dir():
-                shutil.copytree(src=item, dst=dest_dir / item.name)
-            else:
-                shutil.copy(src=item, dst=dest_dir / item.name)
+        copy_contents(source_dir=source_dir, dest_dir=dest_dir)
+
         dest_db_file = dest_dir / DB_FILE
 
         # Append the new column to existing protocols in v4 database

--- a/robot-server/robot_server/persistence/_migrations/v6_to_v7.py
+++ b/robot-server/robot_server/persistence/_migrations/v6_to_v7.py
@@ -10,11 +10,10 @@ Summary of changes from schema 6:
 import json
 from pathlib import Path
 from contextlib import ExitStack
-import shutil
 
 import sqlalchemy
 
-from ._util import add_column
+from ._util import add_column, copy_contents
 from ..database import sql_engine_ctx, sqlite_rowid
 from ..tables import schema_7
 from .._folder_migrator import Migration
@@ -28,11 +27,7 @@ class Migration6to7(Migration):  # noqa: D101
     def migrate(self, source_dir: Path, dest_dir: Path) -> None:
         """Migrate the persistence directory from schema 6 to 7."""
         # Copy over all existing directories and files to new version
-        for item in source_dir.iterdir():
-            if item.is_dir():
-                shutil.copytree(src=item, dst=dest_dir / item.name)
-            else:
-                shutil.copy(src=item, dst=dest_dir / item.name)
+        copy_contents(source_dir=source_dir, dest_dir=dest_dir)
 
         dest_db_file = dest_dir / DB_FILE
 

--- a/robot-server/robot_server/persistence/_migrations/v7_to_v8.py
+++ b/robot-server/robot_server/persistence/_migrations/v7_to_v8.py
@@ -9,11 +9,10 @@ Summary of changes from schema 7:
 import json
 from pathlib import Path
 from contextlib import ExitStack
-import shutil
 
 import sqlalchemy
 
-from ._util import add_column
+from ._util import add_column, copy_contents
 from ..database import sql_engine_ctx
 from ..tables import schema_8
 from .._folder_migrator import Migration
@@ -28,11 +27,7 @@ class Migration7to8(Migration):  # noqa: D101
     def migrate(self, source_dir: Path, dest_dir: Path) -> None:
         """Migrate the persistence directory from schema 6 to 7."""
         # Copy over all existing directories and files to new version
-        for item in source_dir.iterdir():
-            if item.is_dir():
-                shutil.copytree(src=item, dst=dest_dir / item.name)
-            else:
-                shutil.copy(src=item, dst=dest_dir / item.name)
+        copy_contents(source_dir=source_dir, dest_dir=dest_dir)
 
         dest_db_file = dest_dir / DB_FILE
 

--- a/robot-server/robot_server/persistence/_migrations/v8_to_v9.py
+++ b/robot-server/robot_server/persistence/_migrations/v8_to_v9.py
@@ -11,12 +11,14 @@ from robot_server.persistence.database import sql_engine_ctx
 from robot_server.persistence.file_and_directory_names import DB_FILE
 from robot_server.persistence.tables import schema_9
 
+from ._util import copy_contents
 from .._folder_migrator import Migration
 
 
 class Migration8to9(Migration):  # noqa: D101
     def migrate(self, source_dir: Path, dest_dir: Path) -> None:
         """Migrate the persistence directory from schema 8 to 9."""
-        # FIX BEFORE MERGE: Put an actual migration here.
+        copy_contents(source_dir=source_dir, dest_dir=dest_dir)
+
         with sql_engine_ctx(dest_dir / DB_FILE) as engine:
-            schema_9.metadata.create_all(engine)
+            schema_9.labware_offset_table.create(engine)

--- a/robot-server/robot_server/persistence/_migrations/v8_to_v9.py
+++ b/robot-server/robot_server/persistence/_migrations/v8_to_v9.py
@@ -1,0 +1,22 @@
+"""Migrate the persistence directory from schema 8 to 9.
+
+Summary of changes from schema 8:
+
+- Adds a new `labware_offset` table.
+"""
+
+from pathlib import Path
+
+from robot_server.persistence.database import sql_engine_ctx
+from robot_server.persistence.file_and_directory_names import DB_FILE
+from robot_server.persistence.tables import schema_9
+
+from .._folder_migrator import Migration
+
+
+class Migration8to9(Migration):  # noqa: D101
+    def migrate(self, source_dir: Path, dest_dir: Path) -> None:
+        """Migrate the persistence directory from schema 8 to 9."""
+        # FIX BEFORE MERGE: Put an actual migration here.
+        with sql_engine_ctx(dest_dir / DB_FILE) as engine:
+            schema_9.metadata.create_all(engine)

--- a/robot-server/robot_server/persistence/file_and_directory_names.py
+++ b/robot-server/robot_server/persistence/file_and_directory_names.py
@@ -8,7 +8,7 @@ v2/deck_configuration.json, etc.
 
 from typing import Final
 
-LATEST_VERSION_DIRECTORY: Final = "8"
+LATEST_VERSION_DIRECTORY: Final = "9"
 
 DECK_CONFIGURATION_FILE: Final = "deck_configuration.json"
 PROTOCOLS_DIRECTORY: Final = "protocols"

--- a/robot-server/robot_server/persistence/persistence_directory.py
+++ b/robot-server/robot_server/persistence/persistence_directory.py
@@ -11,7 +11,15 @@ from typing_extensions import Final
 from anyio import Path as AsyncPath, to_thread
 
 from ._folder_migrator import MigrationOrchestrator
-from ._migrations import up_to_3, v3_to_v4, v4_to_v5, v5_to_v6, v6_to_v7, v7_to_v8
+from ._migrations import (
+    up_to_3,
+    v3_to_v4,
+    v4_to_v5,
+    v5_to_v6,
+    v6_to_v7,
+    v7_to_v8,
+    v8_to_v9,
+)
 from .file_and_directory_names import LATEST_VERSION_DIRECTORY
 
 _TEMP_PERSISTENCE_DIR_PREFIX: Final = "opentrons-robot-server-"
@@ -46,7 +54,7 @@ class PersistenceResetter:
 def make_migration_orchestrator(prepared_root: Path) -> MigrationOrchestrator:
     """Return a `MigrationOrchestrator` configured for robot-server production use.
 
-    Production code should not use this directly.
+    Production code should not use this directly. Use `prepare_active_subdirectory()` instead.
     This is currently exposed only for tests.
     """
     return MigrationOrchestrator(
@@ -60,7 +68,8 @@ def make_migration_orchestrator(prepared_root: Path) -> MigrationOrchestrator:
             # schema that was never released to the public. It may be present on
             # internal robots.
             v6_to_v7.Migration6to7(subdirectory="7.1"),
-            v7_to_v8.Migration7to8(subdirectory=LATEST_VERSION_DIRECTORY),
+            v7_to_v8.Migration7to8(subdirectory="8"),
+            v8_to_v9.Migration8to9(subdirectory=LATEST_VERSION_DIRECTORY),
         ],
         temp_file_prefix="temp-",
     )

--- a/robot-server/robot_server/persistence/tables/__init__.py
+++ b/robot-server/robot_server/persistence/tables/__init__.py
@@ -1,7 +1,7 @@
 """SQL database schemas."""
 
 # Re-export the latest schema.
-from .schema_8 import (
+from .schema_9 import (
     metadata,
     protocol_table,
     analysis_table,
@@ -13,6 +13,7 @@ from .schema_8 import (
     run_csv_rtp_table,
     data_files_table,
     boolean_setting_table,
+    labware_offset_table,
     PrimitiveParamSQLEnum,
     ProtocolKindSQLEnum,
     BooleanSettingKey,
@@ -33,6 +34,7 @@ __all__ = [
     "run_csv_rtp_table",
     "data_files_table",
     "boolean_setting_table",
+    "labware_offset_table",
     "PrimitiveParamSQLEnum",
     "ProtocolKindSQLEnum",
     "BooleanSettingKey",

--- a/robot-server/robot_server/persistence/tables/schema_9.py
+++ b/robot-server/robot_server/persistence/tables/schema_9.py
@@ -1,0 +1,395 @@
+"""v9 of our SQLite schema."""
+
+import enum
+import sqlalchemy
+
+from robot_server.persistence._utc_datetime import UTCDateTime
+
+
+metadata = sqlalchemy.MetaData()
+
+
+class PrimitiveParamSQLEnum(enum.Enum):
+    """Enum type to store primitive param type."""
+
+    INT = "int"
+    FLOAT = "float"
+    BOOL = "bool"
+    STR = "str"
+
+
+class ProtocolKindSQLEnum(enum.Enum):
+    """What kind a stored protocol is."""
+
+    STANDARD = "standard"
+    QUICK_TRANSFER = "quick-transfer"
+
+
+class DataFileSourceSQLEnum(enum.Enum):
+    """The source this data file is from."""
+
+    UPLOADED = "uploaded"
+    GENERATED = "generated"
+
+
+class CommandStatusSQLEnum(enum.Enum):
+    """Command status sql enum."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+protocol_table = sqlalchemy.Table(
+    "protocol",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        UTCDateTime,
+        nullable=False,
+    ),
+    sqlalchemy.Column("protocol_key", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column(
+        "protocol_kind",
+        sqlalchemy.Enum(
+            ProtocolKindSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+            create_constraint=True,
+        ),
+        index=True,
+        nullable=False,
+    ),
+)
+
+
+analysis_table = sqlalchemy.Table(
+    "analysis",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "protocol_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("protocol.id"),
+        index=True,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "analyzer_version",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "completed_analysis",
+        # Stores a JSON string. See CompletedAnalysisStore.
+        sqlalchemy.String,
+        nullable=False,
+    ),
+)
+
+
+analysis_primitive_type_rtp_table = sqlalchemy.Table(
+    "analysis_primitive_rtp_table",
+    metadata,
+    sqlalchemy.Column(
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "analysis_id",
+        sqlalchemy.ForeignKey("analysis.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_type",
+        sqlalchemy.Enum(
+            PrimitiveParamSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            create_constraint=True,
+            # todo(mm, 2024-09-24): Can we add validate_strings=True here?
+        ),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_value",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+)
+
+
+analysis_csv_rtp_table = sqlalchemy.Table(
+    "analysis_csv_rtp_table",
+    metadata,
+    sqlalchemy.Column(
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "analysis_id",
+        sqlalchemy.ForeignKey("analysis.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "file_id",
+        sqlalchemy.ForeignKey("data_files.id"),
+        nullable=True,
+    ),
+)
+
+
+run_table = sqlalchemy.Table(
+    "run",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        UTCDateTime,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "protocol_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("protocol.id"),
+        nullable=True,
+    ),
+    sqlalchemy.Column(
+        "state_summary",
+        sqlalchemy.String,
+        nullable=True,
+    ),
+    sqlalchemy.Column("engine_status", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column("_updated_at", UTCDateTime, nullable=True),
+    sqlalchemy.Column(
+        "run_time_parameters",
+        # Stores a JSON string. See RunStore.
+        sqlalchemy.String,
+        nullable=True,
+    ),
+)
+
+
+action_table = sqlalchemy.Table(
+    "action",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
+    sqlalchemy.Column("action_type", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+    ),
+)
+
+
+run_command_table = sqlalchemy.Table(
+    "run_command",
+    metadata,
+    sqlalchemy.Column("row_id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "run_id", sqlalchemy.String, sqlalchemy.ForeignKey("run.id"), nullable=False
+    ),
+    # command_index in commands enumeration
+    sqlalchemy.Column("index_in_run", sqlalchemy.Integer, nullable=False),
+    sqlalchemy.Column("command_id", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column("command", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column(
+        "command_intent",
+        sqlalchemy.String,
+        # nullable=True to match the underlying SQL, which is nullable because of a bug
+        # in the migration that introduced this column. This is not intended to ever be
+        # null in practice.
+        nullable=True,
+    ),
+    sqlalchemy.Column("command_error", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column(
+        "command_status",
+        sqlalchemy.Enum(
+            CommandStatusSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+            # nullable=True because it was easier for the migration to add the column
+            # this way. This is not intended to ever be null in practice.
+            nullable=True,
+            # todo(mm, 2024-11-20): We want create_constraint=True here. Something
+            # about the way we compare SQL in test_tables.py is making that difficult--
+            # even when we correctly add the constraint in the migration, the SQL
+            # doesn't compare equal to what create_constraint=True here would emit.
+            create_constraint=False,
+        ),
+    ),
+    sqlalchemy.Index(
+        "ix_run_run_id_command_id",  # An arbitrary name for the index.
+        "run_id",
+        "command_id",
+        unique=True,
+    ),
+    sqlalchemy.Index(
+        "ix_run_run_id_index_in_run",  # An arbitrary name for the index.
+        "run_id",
+        "index_in_run",
+        unique=True,
+    ),
+    sqlalchemy.Index(
+        "ix_run_run_id_command_status_index_in_run",  # An arbitrary name for the index.
+        "run_id",
+        "command_status",
+        "index_in_run",
+        unique=True,
+    ),
+)
+
+
+data_files_table = sqlalchemy.Table(
+    "data_files",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "file_hash",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        UTCDateTime,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "source",
+        sqlalchemy.Enum(
+            DataFileSourceSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+            # create_constraint=False to match the underlying SQL, which omits
+            # the constraint because of a bug in the migration that introduced this
+            # column. This is not intended to ever have values other than those in
+            # DataFileSourceSQLEnum.
+            create_constraint=False,
+        ),
+        # nullable=True to match the underlying SQL, which is nullable because of a bug
+        # in the migration that introduced this column. This is not intended to ever be
+        # null in practice.
+        nullable=True,
+    ),
+)
+
+
+run_csv_rtp_table = sqlalchemy.Table(
+    "run_csv_rtp_table",
+    metadata,
+    sqlalchemy.Column(
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "file_id",
+        sqlalchemy.ForeignKey("data_files.id"),
+        nullable=True,
+    ),
+)
+
+
+class BooleanSettingKey(enum.Enum):
+    """Keys for boolean settings."""
+
+    ENABLE_ERROR_RECOVERY = "enable_error_recovery"
+
+
+boolean_setting_table = sqlalchemy.Table(
+    "boolean_setting",
+    metadata,
+    sqlalchemy.Column(
+        "key",
+        sqlalchemy.Enum(
+            BooleanSettingKey,
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+            create_constraint=True,
+        ),
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "value",
+        sqlalchemy.Boolean,
+        nullable=False,
+    ),
+)
+
+
+labware_offset_table = sqlalchemy.Table(
+    "labware_offset",
+    metadata,
+    # Numeric row ID for ordering:
+    sqlalchemy.Column("row_id", sqlalchemy.Integer, primary_key=True),
+    # String UUID for exposing over HTTP:
+    sqlalchemy.Column(
+        "offset_id", sqlalchemy.String, nullable=False, unique=True, index=True
+    ),
+    # The URI identifying the labware definition that this offset applies to.
+    sqlalchemy.Column("definition_uri", sqlalchemy.String, nullable=False),
+    # Information about where the target labware needs to be placed, for the offset to apply:
+    sqlalchemy.Column("location_slot_name", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column("location_module_model", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column("location_definition_uri", sqlalchemy.String, nullable=True),
+    # The offset itself:
+    sqlalchemy.Column("vector_x", sqlalchemy.Float, nullable=False),
+    sqlalchemy.Column("vector_y", sqlalchemy.Float, nullable=False),
+    sqlalchemy.Column("vector_z", sqlalchemy.Float, nullable=False),
+    # Whether this record is "active", i.e. whether it should be considered as a
+    # candidate to apply to runs and affect actual robot motion:
+    sqlalchemy.Column("active", sqlalchemy.Boolean, nullable=False),
+    # When this record was created:
+    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
+)

--- a/robot-server/tests/labware_offsets/test_store.py
+++ b/robot-server/tests/labware_offsets/test_store.py
@@ -71,7 +71,7 @@ def test_filters() -> None:
 
 
 def test_delete() -> None:
-    """Test the `delete()` method."""
+    """Test the `delete()` and `delete_all()` methods."""
     a, b, c = [
         LabwareOffset(
             id=id,
@@ -95,3 +95,6 @@ def test_delete() -> None:
     assert _get_all(subject) == [a, c]
     with pytest.raises(LabwareOffsetNotFoundError):
         subject.delete(b.id)
+
+    subject.delete_all()
+    assert _get_all(subject) == []

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -19,6 +19,7 @@ from robot_server.persistence.tables import (
     schema_6,
     schema_7,
     schema_8,
+    schema_9,
 )
 
 # The statements that we expect to emit when we create a fresh database.
@@ -158,10 +159,157 @@ EXPECTED_STATEMENTS_LATEST = [
         CONSTRAINT booleansettingkey CHECK ("key" IN ('enable_error_recovery'))
     )
     """,
+    """
+    CREATE TABLE labware_offset (
+        row_id INTEGER NOT NULL,
+        offset_id VARCHAR NOT NULL,
+        definition_uri VARCHAR NOT NULL,
+        location_slot_name VARCHAR NOT NULL,
+        location_module_model VARCHAR,
+        location_definition_uri VARCHAR,
+        vector_x FLOAT NOT NULL,
+        vector_y FLOAT NOT NULL,
+        vector_z FLOAT NOT NULL,
+        active BOOLEAN NOT NULL,
+        created_at DATETIME NOT NULL,
+        PRIMARY KEY (row_id)
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX ix_labware_offset_offset_id ON labware_offset (offset_id)
+    """,
 ]
 
 
-EXPECTED_STATEMENTS_V8 = EXPECTED_STATEMENTS_LATEST
+EXPECTED_STATEMENTS_V9 = EXPECTED_STATEMENTS_LATEST
+
+
+EXPECTED_STATEMENTS_V8 = [
+    """
+    CREATE TABLE protocol (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        protocol_key VARCHAR,
+        protocol_kind VARCHAR(14) NOT NULL,
+        PRIMARY KEY (id),
+        CONSTRAINT protocolkindsqlenum CHECK (protocol_kind IN ('standard', 'quick-transfer'))
+    )
+    """,
+    """
+    CREATE TABLE analysis (
+        id VARCHAR NOT NULL,
+        protocol_id VARCHAR NOT NULL,
+        analyzer_version VARCHAR NOT NULL,
+        completed_analysis VARCHAR NOT NULL,
+        PRIMARY KEY (id),
+        FOREIGN KEY(protocol_id) REFERENCES protocol (id)
+    )
+    """,
+    """
+    CREATE TABLE analysis_primitive_rtp_table (
+        row_id INTEGER NOT NULL,
+        analysis_id VARCHAR NOT NULL,
+        parameter_variable_name VARCHAR NOT NULL,
+        parameter_type VARCHAR(5) NOT NULL,
+        parameter_value VARCHAR NOT NULL,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(analysis_id) REFERENCES analysis (id),
+        CONSTRAINT primitiveparamsqlenum CHECK (parameter_type IN ('int', 'float', 'bool', 'str'))
+    )
+    """,
+    """
+    CREATE TABLE analysis_csv_rtp_table (
+        row_id INTEGER NOT NULL,
+        analysis_id VARCHAR NOT NULL,
+        parameter_variable_name VARCHAR NOT NULL,
+        file_id VARCHAR,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(analysis_id) REFERENCES analysis (id),
+        FOREIGN KEY(file_id) REFERENCES data_files (id)
+    )
+    """,
+    """
+    CREATE INDEX ix_analysis_protocol_id ON analysis (protocol_id)
+    """,
+    """
+    CREATE TABLE run (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        protocol_id VARCHAR,
+        state_summary VARCHAR,
+        engine_status VARCHAR,
+        _updated_at DATETIME,
+        run_time_parameters VARCHAR,
+        PRIMARY KEY (id),
+        FOREIGN KEY(protocol_id) REFERENCES protocol (id)
+    )
+    """,
+    """
+    CREATE TABLE action (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        action_type VARCHAR NOT NULL,
+        run_id VARCHAR NOT NULL,
+        PRIMARY KEY (id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+    """
+    CREATE TABLE run_command (
+        row_id INTEGER NOT NULL,
+        run_id VARCHAR NOT NULL,
+        index_in_run INTEGER NOT NULL,
+        command_id VARCHAR NOT NULL,
+        command VARCHAR NOT NULL,
+        command_intent VARCHAR,
+        command_error VARCHAR,
+        command_status VARCHAR(9),
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_command_id ON run_command (run_id, command_id)
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_index_in_run ON run_command (run_id, index_in_run)
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_command_status_index_in_run ON run_command (run_id, command_status, index_in_run)
+    """,
+    """
+    CREATE INDEX ix_protocol_protocol_kind ON protocol (protocol_kind)
+    """,
+    """
+    CREATE TABLE data_files (
+        id VARCHAR NOT NULL,
+        name VARCHAR NOT NULL,
+        file_hash VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        source VARCHAR(9),
+        PRIMARY KEY (id)
+    )
+    """,
+    """
+    CREATE TABLE run_csv_rtp_table (
+        row_id INTEGER NOT NULL,
+        run_id VARCHAR NOT NULL,
+        parameter_variable_name VARCHAR NOT NULL,
+        file_id VARCHAR,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(run_id) REFERENCES run (id),
+        FOREIGN KEY(file_id) REFERENCES data_files (id)
+    )
+    """,
+    """
+    CREATE TABLE boolean_setting (
+        "key" VARCHAR(21) NOT NULL,
+        value BOOLEAN NOT NULL,
+        PRIMARY KEY ("key"),
+        CONSTRAINT booleansettingkey CHECK ("key" IN ('enable_error_recovery'))
+    )
+    """,
+]
 
 
 EXPECTED_STATEMENTS_V7 = [
@@ -683,6 +831,7 @@ def _normalize_statement(statement: str) -> str:
     ("metadata", "expected_statements"),
     [
         (latest_metadata, EXPECTED_STATEMENTS_LATEST),
+        (schema_9.metadata, EXPECTED_STATEMENTS_V9),
         (schema_8.metadata, EXPECTED_STATEMENTS_V8),
         (schema_7.metadata, EXPECTED_STATEMENTS_V7),
         (schema_6.metadata, EXPECTED_STATEMENTS_V6),


### PR DESCRIPTION
## Overview

Closes EXEC-1015.

## Test plan and Hands on testing

We're covered by automated tests.

## Changelog

* Add a new `labware_offset` SQL table.
* Make `LabwareOffsetStore` to use it.

## Review requests

EXEC-1015 has a guideline:

> Follow database archival practices and have a validity marking rather than an expectation of deletion when a row becomes invalid (this should allow persistent reference to IDs)

The way I'm implementing that here is:

* HTTP `DELETE` requests do an actual SQL `DELETE`.
* There is a SQL boolean column, `active`, to represent the validity marking.
    * It is currently always set to `TRUE`, and there is currently no way of reading it.
    * I'm imagining that future work could add HTTP APIs like `PATCH /labwareOffsets/{id}  { "active": false }` and `GET /labwareOffsets?active=true`.

Does all of that sound right?

## Risk assessment

Low. This code is currently unused.

If we need to make any changes to the SQL schema, it's possible to do later but kind of annoying, so we should scrutinize it here, to the extent that we can.