### PR TITLE
fix(app): fix terminal banner render state

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/TerminalRunBannerContainer.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/TerminalRunBannerContainer.tsx
@@ -40,12 +40,15 @@ export function useTerminalRunBannerContainer({
   const completedWithErrors =
     (commandErrorList != null && commandErrorList.length > 0) ||
     highestPriorityError != null
+  // TODO(jh, 01-10-25): Adding /commandErrors to notifications accomplishes the below with reduced latency.
+  const completedWithNoErrors =
+    commandErrorList != null && commandErrorList.length === 0
 
   const showSuccessBanner =
     runStatus === RUN_STATUS_SUCCEEDED &&
     isRunCurrent &&
     !isResetRunLoading &&
-    !completedWithErrors
+    completedWithNoErrors
 
   // TODO(jh, 08-14-24): Ideally, the backend never returns the "user cancelled a run" error and
   //  cancelledWithoutRecovery becomes unnecessary.


### PR DESCRIPTION
Closes [RQA-3840](https://opentrons.atlassian.net/browse/RQA-3840)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes conditional logic that causes the "run succeeded" banner to render momentarily when in actuality, an error banner should render. Checking if the `commandErrorList` is `null` is not sufficient to render the success banner appropriately, because the `commandErrorList` is `null` when the network request has not yet completed. Instead, we should check if the length of the list is 0.

A lower-latency solution would be to add the `/runs/:runId/commandErrors` resource to notifications, which would also simplify the conditional logic, see [EXEC-1083](https://opentrons.atlassian.net/browse/EXEC-1083). 

### Current Behavior

https://github.com/user-attachments/assets/2ddd3dcf-0500-42da-953e-bd42dca7bd2f

### Fixed Behavior

https://github.com/user-attachments/assets/d1feb707-4d61-4e9f-8058-530e622f53d0


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the success banner sometimes flickering when a run fails on the desktop app.  
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low - easy to validate.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3840]: https://opentrons.atlassian.net/browse/RQA-3840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-1083]: https://opentrons.atlassian.net/browse/EXEC-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ