### PR TITLE
fix(app): Fix gripper recovery loop

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/shared/GripperIsHoldingLabware.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/GripperIsHoldingLabware.tsx
@@ -55,6 +55,7 @@ export function GripperIsHoldingLabware({
     // after the user has extricated the labware from the gripper jaws.
     void handleMotionRouting(true)
       .then(() => homeExceptPlungers())
+      .finally(() => handleMotionRouting(false))
       .then(() => {
         switch (selectedRecoveryOption) {
           case MANUAL_MOVE_AND_SKIP.ROUTE:
@@ -73,7 +74,6 @@ export function GripperIsHoldingLabware({
           }
         }
       })
-      .finally(() => handleMotionRouting(false))
   }
 
   const primaryOnClick = (): void => {

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/GripperIsHoldingLabware.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/GripperIsHoldingLabware.test.tsx
@@ -97,14 +97,14 @@ describe('GripperIsHoldingLabware', () => {
     })
 
     await waitFor(() => {
+      expect(mockHandleMotionRouting).toHaveBeenCalledWith(false)
+    })
+
+    await waitFor(() => {
       expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
         RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE,
         RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.STEPS.MANUAL_MOVE
       )
-    })
-
-    await waitFor(() => {
-      expect(mockHandleMotionRouting).toHaveBeenCalledWith(false)
     })
   })
 


### PR DESCRIPTION
Closes [RQA-3841](https://opentrons.atlassian.net/browse/RQA-3841)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a bug when selecting the "no" option during the "is gripper holding labware" prompt. The command sequencing was slightly off, causing routing issues. Terminating an "in motion" view restores the previous view before the "in motion" view, which causes the loop.

### Current Behavior

https://github.com/user-attachments/assets/00db1f48-e2be-4522-805d-0dfa150e93d8

### Fixed Behavior

https://github.com/user-attachments/assets/d8061f41-f0b7-4454-9feb-8b792bfd4330

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a bug during gripper recovery in which selecting "no labware in jaws" causes a loop.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3841]: https://opentrons.atlassian.net/browse/RQA-3841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ