### PR TITLE
feat(api): add dispense_labware and store_labware methods to FlexStacker module.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -335,8 +335,8 @@ class FlexStacker(mod_abc.AbstractModule):
         await self.close_latch()
 
         # Move platform along the Z then X axis
-        offset = (labware_height / 2 + OFFSET_MD)
-        await self._move_and_home_axis( StackerAxis.Z, Direction.RETRACT, offset)
+        offset = labware_height / 2 + OFFSET_MD
+        await self._move_and_home_axis(StackerAxis.Z, Direction.RETRACT, offset)
         await self._move_and_home_axis(StackerAxis.X, Direction.EXTENT, OFFSET_SM)
         return True
 


### PR DESCRIPTION
# Overview

Adds functionality to the FlexStacker hardware controller module to store and dispense labware

Closes: [EXEC-1082](https://opentrons.atlassian.net/browse/EXEC-1082)

## Test Plan and Hands on Testing

From a Flex robot use asyncio REPL to create an instance of the OT3API to interact with the FlexStacker module, like so.
```
root@platypus:~# python3 -m asyncio

asyncio REPL 3.10.9 (main, Dec  6 2022, 18:44:57) [GCC 11.3.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.

>>> import asyncio
>>> from opentrons.drivers.flex_stacker.types import StackerAxis, Direction
>>> from opentrons.hardware_control.ot3api import OT3API
>>> api = await OT3API.build_hardware_controller(loop=asyncio.get_running_loop())
>>>
>>> await api.attached_modules[0].store_labware(16)
>>> await api.attached_modules[0].store_labware(16)
>>> await api.attached_modules[0].dispense_labware(16)
>>>
>>> await api.attached_modules[1].store_labware(100)
>>> await api.attached_modules[1].store_labware(100)
>>> await api.attached_modules[1].dispense_labware(100)
```

- [x] Dispense and store multiple 200ml tipracks (100mm height) with the `dispense_labware` and `store_labware` methods
- [x] Dispense and store multiple PCR plates (16mm height) with the `dispense_labware` and `store_labware` methods
- [x] Make sure the `open_latch` and `close_latch` methods still work as expected

## Changelog

- Added `dispense_labware` and `store_labware` methods to the FlexStacker module
- Added MAX_TRAVEL dict to keep track of the maximum distance all axes can travel
- Changed the `open_latch` method to use the `home_axis` instead of `move_axis` since we can detect a limit switch on the RETRACT side of the axis.

## Review requests

need anything else?

## Risk assessment

low, unreleased 

[EXEC-1082]: https://opentrons.atlassian.net/browse/EXEC-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ