### PR TITLE
fix(app): Inject labware definitions into Error Recovery

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/RunHeaderModalContainer.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/RunHeaderModalContainer.tsx
@@ -52,6 +52,7 @@ export function RunHeaderModalContainer(
           runStatus={runStatus}
           runId={runId}
           unvalidatedFailedCommand={recoveryModalUtils.failedCommand}
+          runLwDefsByUri={recoveryModalUtils.runLwDefsByUri}
           protocolAnalysis={robotProtocolAnalysis}
         />
       ) : null}

--- a/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
@@ -58,6 +58,7 @@ export const mockRecoveryContentProps: RecoveryContentProps = {
     byRunRecord: mockFailedCommand,
     byAnalysis: mockFailedCommand,
   },
+  runLwDefsByUri: {} as any,
   errorKind: 'GENERAL_ERROR',
   robotType: FLEX_ROBOT_TYPE,
   runId: 'MOCK_RUN_ID',

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
@@ -198,17 +198,7 @@ describe('getRunCurrentModulesInfo', () => {
     const result = getRunCurrentModulesInfo({
       runRecord: null as any,
       deckDef: mockDeckDef,
-      labwareDefinitionsByUri: {},
-    })
-
-    expect(result).toEqual([])
-  })
-
-  it('should return an empty array if protocolAnalysis is null', () => {
-    const result = getRunCurrentModulesInfo({
-      runRecord: mockRunRecord,
-      deckDef: mockDeckDef,
-      labwareDefinitionsByUri: null,
+      runLwDefsByUri: {},
     })
 
     expect(result).toEqual([])
@@ -219,7 +209,7 @@ describe('getRunCurrentModulesInfo', () => {
     const result = getRunCurrentModulesInfo({
       runRecord: mockRunRecord,
       deckDef: mockDeckDef,
-      labwareDefinitionsByUri: {
+      runLwDefsByUri: {
         'opentrons/opentrons_96_pcr_adapter/1': 'MOCK_LW_DEF',
       } as any,
     })
@@ -242,7 +232,7 @@ describe('getRunCurrentModulesInfo', () => {
         data: { modules: [mockModule], labware: [] },
       },
       deckDef: mockDeckDef,
-      labwareDefinitionsByUri: {},
+      runLwDefsByUri: {},
     })
     expect(result).toEqual([
       {
@@ -261,7 +251,7 @@ describe('getRunCurrentModulesInfo', () => {
     const result = getRunCurrentModulesInfo({
       runRecord: mockRunRecord,
       deckDef: mockDeckDef,
-      labwareDefinitionsByUri: null,
+      runLwDefsByUri: {},
     })
     expect(result).toEqual([])
   })
@@ -286,7 +276,7 @@ describe('getRunCurrentLabwareInfo', () => {
   it('should return an empty array if runRecord is null', () => {
     const result = getRunCurrentLabwareInfo({
       runRecord: undefined,
-      labwareDefinitionsByUri: {} as any,
+      runLwDefsByUri: {} as any,
     })
 
     expect(result).toEqual([])
@@ -295,7 +285,7 @@ describe('getRunCurrentLabwareInfo', () => {
   it('should return an empty array if protocolAnalysis is null', () => {
     const result = getRunCurrentLabwareInfo({
       runRecord: { data: { labware: [] } } as any,
-      labwareDefinitionsByUri: null,
+      runLwDefsByUri: {},
     })
 
     expect(result).toEqual([])
@@ -309,7 +299,7 @@ describe('getRunCurrentLabwareInfo', () => {
 
     const result = getRunCurrentLabwareInfo({
       runRecord: { data: { labware: [mockPickUpTipLwSlotName] } } as any,
-      labwareDefinitionsByUri: {
+      runLwDefsByUri: {
         [mockPickUpTipLabware.definitionUri]: mockLabwareDef,
       },
     })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -22,11 +22,7 @@ import { useCleanupRecoveryState } from './useCleanupRecoveryState'
 import { useFailedPipetteUtils } from './useFailedPipetteUtils'
 import { getRunningStepCountsFrom } from '/app/resources/protocols'
 
-import type {
-  LabwareDefinition2,
-  LabwareDefinitionsByUri,
-  RobotType,
-} from '@opentrons/shared-data'
+import type { LabwareDefinition2, RobotType } from '@opentrons/shared-data'
 import type { IRecoveryMap, RouteStep, RecoveryRoute } from '../types'
 import type { ErrorRecoveryFlowsProps } from '..'
 import type { UseRouteUpdateActionsResult } from './useRouteUpdateActions'
@@ -54,7 +50,6 @@ export type ERUtilsProps = Omit<ErrorRecoveryFlowsProps, 'failedCommand'> & {
   failedCommand: ReturnType<typeof useRetainedFailedCommandBySource>
   isActiveUser: UseRecoveryTakeoverResult['isActiveUser']
   allRunDefs: LabwareDefinition2[]
-  labwareDefinitionsByUri: LabwareDefinitionsByUri | null
 }
 
 export interface ERUtilsResults {
@@ -90,7 +85,7 @@ export function useERUtils({
   isActiveUser,
   allRunDefs,
   unvalidatedFailedCommand,
-  labwareDefinitionsByUri,
+  runLwDefsByUri,
 }: ERUtilsProps): ERUtilsResults {
   const { data: attachedInstruments } = useInstrumentsQuery()
   const { data: runRecord } = useNotifyRunQuery(runId)
@@ -185,7 +180,7 @@ export function useERUtils({
     runRecord,
     protocolAnalysis,
     failedLabwareUtils,
-    labwareDefinitionsByUri,
+    runLwDefsByUri,
   })
 
   const recoveryActionMutationUtils = useRecoveryActionMutation(

--- a/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
+++ b/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
@@ -161,6 +161,7 @@ describe('RunningProtocol', () => {
     vi.mocked(useErrorRecoveryFlows).mockReturnValue({
       isERActive: false,
       failedCommand: {} as any,
+      runLwDefsByUri: {} as any,
     })
     vi.mocked(useInterventionModal).mockReturnValue({
       showModal: false,
@@ -224,6 +225,7 @@ describe('RunningProtocol', () => {
     vi.mocked(useErrorRecoveryFlows).mockReturnValue({
       isERActive: true,
       failedCommand: {} as any,
+      runLwDefsByUri: {} as any,
     })
     render(`/runs/${RUN_ID}/run`)
     screen.getByText('MOCK ERROR RECOVERY')

--- a/app/src/pages/ODD/RunningProtocol/index.tsx
+++ b/app/src/pages/ODD/RunningProtocol/index.tsx
@@ -122,7 +122,10 @@ export function RunningProtocol(): JSX.Element {
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
   const robotType = useRobotType(robotName)
-  const { isERActive, failedCommand } = useErrorRecoveryFlows(runId, runStatus)
+  const { isERActive, failedCommand, runLwDefsByUri } = useErrorRecoveryFlows(
+    runId,
+    runStatus
+  )
   const {
     showModal: showIntervention,
     modalProps: interventionProps,
@@ -169,6 +172,7 @@ export function RunningProtocol(): JSX.Element {
           runStatus={runStatus}
           runId={runId}
           unvalidatedFailedCommand={failedCommand}
+          runLwDefsByUri={runLwDefsByUri}
           protocolAnalysis={robotSideAnalysis}
         />
       ) : null}

--- a/app/src/resources/runs/useRunLoadedLabwareDefinitionsByUri.ts
+++ b/app/src/resources/runs/useRunLoadedLabwareDefinitionsByUri.ts
@@ -18,23 +18,29 @@ export type RunLoadedLabwareDefinitionsByUri = Record<
 
 // Returns a record of labware definitions keyed by URI for the labware that
 // has been loaded with a "loadLabware" command. Errors if the run is not the current run.
+// Returns null if the network request is pending.
 export function useRunLoadedLabwareDefinitionsByUri(
   runId: string | null,
   options: UseQueryOptions<RunLoadedLabwareDefinitions, AxiosError> = {},
   hostOverride?: HostConfig
-): RunLoadedLabwareDefinitionsByUri {
+): RunLoadedLabwareDefinitionsByUri | null {
   const { data } = useRunLoadedLabwareDefinitions(runId, options, hostOverride)
 
   return useMemo(() => {
     const result: Record<string, LabwareDefinition2> = {}
-    // @ts-expect-error TODO(jh, 10-12-24): Update the app's typing to support LabwareDefinition3.
-    data?.data.forEach((def: LabwareDefinition2) => {
-      if ('schemaVersion' in def) {
-        const lwUri = getLabwareDefURI(def)
-        result[lwUri] = def
-      }
-    })
 
-    return result
+    if (data == null) {
+      return null
+    } else {
+      // @ts-expect-error TODO(jh, 10-12-24): Update the app's typing to support LabwareDefinition3.
+      data?.data.forEach((def: LabwareDefinition2) => {
+        if ('schemaVersion' in def) {
+          const lwUri = getLabwareDefURI(def)
+          result[lwUri] = def
+        }
+      })
+
+      return result
+    }
   }, [data])
 }


### PR DESCRIPTION
Closes [RQA-3814](https://opentrons.atlassian.net/browse/RQA-3814)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Not too long ago, we implemented the `/runs/runId/labware_definitions` resource on the FE and started using it in Error Recovery. Because we now get labware definitions asynchronously (instead of the old command scanning synchronous behavior), we get blippy UX while the request is still loading.

This PR injects the labware definitions into Error Recovery, gating ER rendering while the request is ongoing.

Like 90% of the diff is type/variable name refactoring. See `app/src/organisms/ErrorRecoveryFlows/index.tsx` for the functional changes.

### Current Behavior

https://github.com/user-attachments/assets/4f8a9049-c1f1-495b-af02-7d3dececf819

### Fixed Behavior

https://github.com/user-attachments/assets/9141eddb-85e0-4b42-be6d-bc8695dd825f

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed Error Recovery splash copy rendering while the recovery splash page is visible.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low - mainly type stuff
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3814]: https://opentrons.atlassian.net/browse/RQA-3814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ