### PR TITLE
feat(robot-server): Harvest offset data from existing runs

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v8_to_v9.py
+++ b/robot-server/robot_server/persistence/_migrations/v8_to_v9.py
@@ -7,8 +7,13 @@ Summary of changes from schema 8:
 
 from pathlib import Path
 
-from robot_server.persistence.database import sql_engine_ctx
+import sqlalchemy
+
+from opentrons.protocol_engine import LabwareOffset, StateSummary
+
+from robot_server.persistence.database import sqlite_rowid, sql_engine_ctx
 from robot_server.persistence.file_and_directory_names import DB_FILE
+from robot_server.persistence.pydantic import json_to_pydantic
 from robot_server.persistence.tables import schema_9
 
 from ._util import copy_contents
@@ -20,5 +25,50 @@ class Migration8to9(Migration):  # noqa: D101
         """Migrate the persistence directory from schema 8 to 9."""
         copy_contents(source_dir=source_dir, dest_dir=dest_dir)
 
-        with sql_engine_ctx(dest_dir / DB_FILE) as engine:
-            schema_9.labware_offset_table.create(engine)
+        with sql_engine_ctx(
+            dest_dir / DB_FILE
+        ) as engine, engine.begin() as transaction:
+            schema_9.labware_offset_table.create(transaction)
+            _import_labware_offsets_from_runs(transaction)
+
+
+def _import_labware_offsets_from_runs(connection: sqlalchemy.engine.Connection) -> None:
+    """Seed the new labware_offset table with records scraped from existing runs."""
+    raw_state_summaries = (
+        connection.execute(
+            sqlalchemy.select(schema_9.run_table.c.state_summary)
+            .where(schema_9.run_table.c.state_summary.is_not(None))
+            .order_by(sqlite_rowid)
+        )
+        .scalars()
+        .all()
+    )
+
+    state_summaries = (
+        json_to_pydantic(StateSummary, raw_state_summary)
+        for raw_state_summary in raw_state_summaries
+    )
+
+    for state_summary in state_summaries:
+        for labware_offset in state_summary.labwareOffsets:
+            converted = _pydantic_labware_offset_to_sql(labware_offset)
+            connection.execute(
+                sqlalchemy.insert(schema_9.labware_offset_table).values(converted)
+            )
+
+
+def _pydantic_labware_offset_to_sql(labware_offset: LabwareOffset) -> dict[str, object]:
+    return dict(
+        offset_id=labware_offset.id,
+        definition_uri=labware_offset.definitionUri,
+        location_slot_name=labware_offset.location.slotName.value,
+        location_module_model=labware_offset.location.moduleModel.value
+        if labware_offset.location.moduleModel is not None
+        else None,
+        location_definition_uri=labware_offset.location.definitionUri,
+        vector_x=labware_offset.vector.x,
+        vector_y=labware_offset.vector.y,
+        vector_z=labware_offset.vector.z,
+        created_at=labware_offset.createdAt,
+        active=True,
+    )

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -49,6 +49,7 @@ class Snapshot:
 
     version: str
     expected_protocol_count: int
+    expected_labware_offset_count: int
     expected_runs: List[Union[Run, BadRun]]
     protocols_with_no_analyses: List[str] = field(default_factory=list)
 
@@ -67,6 +68,7 @@ class Snapshot:
 flex_dev_compat_snapshot = Snapshot(
     version="ot3_v0.14.0_python_validation",
     expected_protocol_count=1,
+    expected_labware_offset_count=0,
     expected_runs=[Run("305b0cca-fc78-4853-b113-40ac4c30cd8f", 1)],
 )
 
@@ -76,6 +78,7 @@ snapshots: List[ParameterSet] = [
         Snapshot(
             version="v6.0.1",
             expected_protocol_count=4,
+            expected_labware_offset_count=0,
             expected_runs=[
                 Run("7bc1f20d-3925-4aa2-b200-82906112816f", 23),
                 Run("1b00190c-013f-463d-b371-5bf49b6ad61f", 16),
@@ -90,6 +93,7 @@ snapshots: List[ParameterSet] = [
         Snapshot(
             version="v6.1.0",
             expected_protocol_count=2,
+            expected_labware_offset_count=13,
             expected_runs=[
                 Run("a4338d46-96af-4e23-877d-1d79227a0946", 147),
                 Run("efc7374f-2e64-45ea-83fe-bd7a55f2699e", 205),
@@ -101,6 +105,7 @@ snapshots: List[ParameterSet] = [
         Snapshot(
             version="v6.2.0",
             expected_protocol_count=2,
+            expected_labware_offset_count=0,
             expected_runs=[
                 Run("199b991d-db3c-49ff-9b4f-905118c10685", 125),
                 Run("25a66ec6-2137-4680-8a94-d53c0e2a7488", 87),
@@ -112,6 +117,7 @@ snapshots: List[ParameterSet] = [
         Snapshot(
             version="v6.2.0_large",
             expected_protocol_count=17,
+            expected_labware_offset_count=15,
             expected_runs=[
                 Run("eeb17dc0-1878-432a-bf3f-33e7d3023b8d", 218),
                 Run("917cf0f8-8b79-47ab-a407-918c182eb6df", 125),
@@ -144,6 +150,7 @@ snapshots: List[ParameterSet] = [
         Snapshot(
             version="v7.1.1",
             expected_protocol_count=10,
+            expected_labware_offset_count=146,
             expected_runs=[
                 Run("69fe2d6f-3bda-4dfb-800b-cd93017d1cbd", 4634),
                 BadRun("04ec9eda-19b2-4850-9148-d28112565b37", 0),
@@ -245,6 +252,11 @@ async def test_protocols_analyses_and_runs_available_from_older_persistence_dir(
             # Ideally, we would also fetch full commands via
             # `GET /runs/{run_id}/commands/{command_id}`.
             # We skip it for performance. Adds ~10+ seconds
+
+            all_labware_offsets = (await robot_client.get_labware_offsets()).json()[
+                "data"
+            ]
+            assert len(all_labware_offsets) == snapshot.expected_labware_offset_count
 
 
 # TODO(mm, 2023-08-12): We can remove this test when we remove special handling for these

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -384,6 +384,12 @@ class RobotClient:
         response.raise_for_status()
         return response
 
+    async def get_labware_offsets(self) -> Response:
+        # Filter query parameters omitted for simplicity. This currently returns all offsets.
+        response = await self.httpx_client.get(url=f"{self.base_url}/labwareOffsets")
+        response.raise_for_status()
+        return response
+
     async def delete_all_labware_offsets(self) -> Response:
         response = await self.httpx_client.delete(url=f"{self.base_url}/labwareOffsets")
         response.raise_for_status()


### PR DESCRIPTION
## Overview

Closes EXEC-1013.

## Test Plan and Hands on Testing

* [ ] Launch a server with a populated persistence directory. Check `/labwareOffsets` to make sure there's stuff there, and that the `createdAt` timestamps etc. look like they were correctly preserved.
    * There may be some floating point rounding going on. Looking into it.

## Changelog

* When the server migrates to schema 9, adding the `labware_offset` table for the first time, seed it with data scraped from the `run` table.
* Add a very basic smoke test for this in `test_compatibility.py`.

## Review requests

* Do we want something more sophisticated in `test_compatibility.py`?
* EXEC-1013 suggests making a `run -> labware_offset` relation. I think that's a good idea for a few reasons, like helping us track offset provenance, and bringing unbounded data out of a monolithic JSON blob. I haven't done that here because I think we should first figure out how provenance will be exposed in the HTTP API. Does that seem right?

## Risk assessment

Medium because it's a migration and if something goes wrong here it can stop the server from starting up. For example, I initially had a bug where I forgot to filter out `NULL` state summaries. 