### PR TITLE
feat(app): Block evotips labware from appearing in labware tab

### DIFF
--- a/app/src/local-resources/labware/hooks/useAllLabware.ts
+++ b/app/src/local-resources/labware/hooks/useAllLabware.ts
@@ -4,6 +4,7 @@ import { getAllDefinitions } from '../utils'
 import type { LabwareSort, LabwareFilter, LabwareDefAndDate } from '../types'
 
 // labware to filter out from the labware tab of the desktop app
+// TODO (sb:1/14/25) remove evotips from blocklist before public launch
 const LABWARE_LOADNAME_BLOCKLIST = [
   'evotips_flex_96_tiprack_adapter',
   'evotips_opentrons_96_labware',

--- a/app/src/local-resources/labware/hooks/useAllLabware.ts
+++ b/app/src/local-resources/labware/hooks/useAllLabware.ts
@@ -3,12 +3,20 @@ import { getValidCustomLabware } from '/app/redux/custom-labware'
 import { getAllDefinitions } from '../utils'
 import type { LabwareSort, LabwareFilter, LabwareDefAndDate } from '../types'
 
+// labware to filter out from the labware tab of the desktop app
+const LABWARE_LOADNAME_BLOCKLIST = [
+  'evotips_flex_96_tiprack_adapter',
+  'evotips_opentrons_96_labware',
+]
+
 export function useAllLabware(
   sortBy: LabwareSort,
   filterBy: LabwareFilter
 ): LabwareDefAndDate[] {
   const fullLabwareList: LabwareDefAndDate[] = []
-  const labwareDefinitions = getAllDefinitions()
+  const labwareDefinitions = getAllDefinitions().filter(
+    def => !LABWARE_LOADNAME_BLOCKLIST.includes(def.parameters.loadName)
+  )
   labwareDefinitions.forEach(def => fullLabwareList.push({ definition: def }))
   const customLabwareList = useSelector(getValidCustomLabware)
   customLabwareList.forEach(customLabware =>


### PR DESCRIPTION
fix EXEC-1085
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We want to hide the evotips labware and adapter from the labware tab of the app. This PR adds the load names to a block list that will filter them out from this view
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Once https://github.com/Opentrons/opentrons/pull/17237 merges, evotips labware and adapter should be visible in the labware tab of the app
This PR should hide those labware
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Added a blocklist to `useAllLabware` so that we don't show evotips labware in the labware tab of the app

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Verify these are the correct loadnames, test it out
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
