### PR TITLE
fix(protocol-designer): ot-2 TC labware highlight in protocol steps

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -5,7 +5,6 @@ import {
   STANDARD_FLEX_SLOTS,
   STANDARD_OT2_SLOTS,
   THERMOCYCLER_MODULE_TYPE,
-  THERMOCYCLER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
   WASTE_CHUTE_CUTOUT,
   getAddressableAreaFromSlotId,
@@ -37,6 +36,7 @@ interface HighlightItemsProps {
   deckDef: DeckDefinition
   robotType: RobotType
 }
+//  TODO(ja, 1/13/25): get actual coordinates from thermocycler and deck definitions
 const FLEX_TC_POSITION: CoordinateTuple = [-20, 282, 0]
 const OT2_TC_GEN_1_POSITION: CoordinateTuple = [0, 264, 0]
 const OT2_TC_GEN_2_POSITION: CoordinateTuple = [0, 250, 0]
@@ -140,13 +140,11 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
         const position = getPositionFromSlotId(labwareSlot, deckDef)
         if (position != null) {
           let tcPosition: CoordinateTuple = FLEX_TC_POSITION
-          if (tcModel === THERMOCYCLER_MODULE_V1 && labwareSlot === '7') {
-            tcPosition = OT2_TC_GEN_1_POSITION
-          } else if (
-            tcModel === THERMOCYCLER_MODULE_V2 &&
-            labwareSlot === '7'
-          ) {
-            tcPosition = OT2_TC_GEN_2_POSITION
+          if (labwareSlot === '7') {
+            tcPosition =
+              tcModel === THERMOCYCLER_MODULE_V2
+                ? OT2_TC_GEN_2_POSITION
+                : OT2_TC_GEN_1_POSITION
           }
 
           items.push(

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -5,6 +5,8 @@ import {
   STANDARD_FLEX_SLOTS,
   STANDARD_OT2_SLOTS,
   THERMOCYCLER_MODULE_TYPE,
+  THERMOCYCLER_MODULE_V1,
+  THERMOCYCLER_MODULE_V2,
   WASTE_CHUTE_CUTOUT,
   getAddressableAreaFromSlotId,
   getPositionFromSlotId,
@@ -26,6 +28,7 @@ import type {
   DeckDefinition,
   CutoutId,
   AddressableAreaName,
+  CoordinateTuple,
 } from '@opentrons/shared-data'
 import type { LabwareOnDeck, ModuleOnDeck } from '../../../step-forms'
 import type { Fixture } from './constants'
@@ -34,6 +37,9 @@ interface HighlightItemsProps {
   deckDef: DeckDefinition
   robotType: RobotType
 }
+const FLEX_TC_POSITION: CoordinateTuple = [-20, 282, 0]
+const OT2_TC_GEN_1_POSITION: CoordinateTuple = [0, 264, 0]
+const OT2_TC_GEN_2_POSITION: CoordinateTuple = [0, 250, 0]
 
 const SLOTS = [
   ...STANDARD_FLEX_SLOTS,
@@ -120,9 +126,9 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
         }
 
         let labwareSlot = labwareOnDeck.slot
-        const hasTC = Object.values(modules).some(
+        const tcModel = Object.values(modules).find(
           module => module.type === THERMOCYCLER_MODULE_TYPE
-        )
+        )?.model
 
         if (modules[labwareSlot]) {
           labwareSlot = modules[labwareSlot].slot
@@ -133,6 +139,16 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
 
         const position = getPositionFromSlotId(labwareSlot, deckDef)
         if (position != null) {
+          let tcPosition: CoordinateTuple = FLEX_TC_POSITION
+          if (tcModel === THERMOCYCLER_MODULE_V1 && labwareSlot === '7') {
+            tcPosition = OT2_TC_GEN_1_POSITION
+          } else if (
+            tcModel === THERMOCYCLER_MODULE_V2 &&
+            labwareSlot === '7'
+          ) {
+            tcPosition = OT2_TC_GEN_2_POSITION
+          }
+
           items.push(
             <LabwareLabel
               key={`${labwareOnDeck.id}_${index}`}
@@ -140,9 +156,7 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
                 selected => selected.id === labwareOnDeck.id
               )}
               isLast={true}
-              position={
-                hasTC && labwareSlot === 'B1' ? [-20, 282, 0] : position
-              }
+              position={tcModel != null ? tcPosition : position}
               labwareDef={labwareOnDeck.def}
               labelText={
                 hoveredItemLabware == null


### PR DESCRIPTION
closes RQA-3849

# Overview

For the labware highlights in protocol steps, adjust the position logic to take into account the OT-2 and the thermocycler

## Test Plan and Hands on Testing

Create a protocol with a GEN1 and GEN2 thermocycler for the ot-2 and add a labware on to it. create a protocol with a TC step to open the lid then create a transfer and see that the labware is properly highlighted

## Changelog

adjust the position for highlighting the labware for TC GEN1, TC GEN2, and ot-2 vs flex

## Risk assessment

low
