### PR TITLE
fix(api): prevent protocols from passing with mistyped property setting for liquid classes

### DIFF
--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from numpy import interp
-from typing import Optional, Dict, Sequence, Tuple, List
+from typing import Optional, Dict, Sequence, Tuple, List, Any
 
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     AspirateProperties as SharedDataAspirateProperties,
@@ -84,7 +84,20 @@ class LiquidHandlingPropertyByVolume:
 
 
 @dataclass
-class DelayProperties:
+class _BaseProperties:
+    def __setattr__(self, key: str, value: Any) -> None:
+        # This is very hacky but since the purpose of this check is to prevent user errors when setting properties and
+        # not block random attribute setting all-together, this is the most straightforward way of accomplishing this.
+        # If we don't include the `startswith` check this breaks init.
+        if not key.startswith("_") and not hasattr(self, key):
+            # Since we already know we don't have this attribute, calling this will raise an attribute error but will
+            # helpfully use Python's built in "Did you mean:" for variables closely misspelled properties
+            getattr(self, key)
+        super().__setattr__(key, value)
+
+
+@dataclass
+class DelayProperties(_BaseProperties):
 
     _enabled: bool
     _duration: Optional[float]
@@ -119,7 +132,7 @@ class DelayProperties:
 
 
 @dataclass
-class TouchTipProperties:
+class TouchTipProperties(_BaseProperties):
 
     _enabled: bool
     _z_offset: Optional[float]
@@ -191,7 +204,7 @@ class TouchTipProperties:
 
 
 @dataclass
-class MixProperties:
+class MixProperties(_BaseProperties):
 
     _enabled: bool
     _repetitions: Optional[int]
@@ -244,7 +257,7 @@ class MixProperties:
 
 
 @dataclass
-class BlowoutProperties:
+class BlowoutProperties(_BaseProperties):
 
     _enabled: bool
     _location: Optional[BlowoutLocation]
@@ -298,7 +311,7 @@ class BlowoutProperties:
 
 
 @dataclass
-class SubmergeRetractCommon:
+class SubmergeRetractCommon(_BaseProperties):
 
     _position_reference: PositionReference
     _offset: Coordinate
@@ -406,7 +419,7 @@ class RetractDispense(SubmergeRetractCommon):
 
 
 @dataclass
-class BaseLiquidHandlingProperties:
+class BaseLiquidHandlingProperties(_BaseProperties):
 
     _submerge: Submerge
     _position_reference: PositionReference

--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from numpy import interp
-from typing import Optional, Dict, Sequence, Tuple, List, Any
+from typing import Optional, Dict, Sequence, Tuple, List
 
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     AspirateProperties as SharedDataAspirateProperties,
@@ -83,20 +83,8 @@ class LiquidHandlingPropertyByVolume:
         )
 
 
-@dataclass
-class _BaseProperties:
-    def __setattr__(self, key: str, value: Any) -> None:
-        # This is very hacky but since the purpose of this check is to prevent user errors when setting properties and
-        # not block random attribute setting all-together, this is the most straightforward way of accomplishing this.
-        # If we don't include the `startswith` check this breaks init.
-        if not key.startswith("_") and not hasattr(self, key):
-            # Since we already know we don't have this attribute, this will raise the appropriate attribute error
-            getattr(self, key)
-        super().__setattr__(key, value)
-
-
-@dataclass
-class DelayProperties(_BaseProperties):
+@dataclass(slots=True)
+class DelayProperties:
 
     _enabled: bool
     _duration: Optional[float]
@@ -130,8 +118,8 @@ class DelayProperties(_BaseProperties):
         )
 
 
-@dataclass
-class TouchTipProperties(_BaseProperties):
+@dataclass(slots=True)
+class TouchTipProperties:
 
     _enabled: bool
     _z_offset: Optional[float]
@@ -202,8 +190,8 @@ class TouchTipProperties(_BaseProperties):
         )
 
 
-@dataclass
-class MixProperties(_BaseProperties):
+@dataclass(slots=True)
+class MixProperties:
 
     _enabled: bool
     _repetitions: Optional[int]
@@ -255,8 +243,8 @@ class MixProperties(_BaseProperties):
         )
 
 
-@dataclass
-class BlowoutProperties(_BaseProperties):
+@dataclass(slots=True)
+class BlowoutProperties:
 
     _enabled: bool
     _location: Optional[BlowoutLocation]
@@ -309,8 +297,8 @@ class BlowoutProperties(_BaseProperties):
         )
 
 
-@dataclass
-class SubmergeRetractCommon(_BaseProperties):
+@dataclass(slots=True)
+class SubmergeRetractCommon:
 
     _position_reference: PositionReference
     _offset: Coordinate
@@ -348,10 +336,8 @@ class SubmergeRetractCommon(_BaseProperties):
         return self._delay
 
 
-@dataclass
+@dataclass(slots=True)
 class Submerge(SubmergeRetractCommon):
-    ...
-
     def as_shared_data_model(self) -> SharedDataSubmerge:
         return SharedDataSubmerge(
             positionReference=self._position_reference,
@@ -361,7 +347,7 @@ class Submerge(SubmergeRetractCommon):
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class RetractAspirate(SubmergeRetractCommon):
 
     _air_gap_by_volume: LiquidHandlingPropertyByVolume
@@ -386,7 +372,7 @@ class RetractAspirate(SubmergeRetractCommon):
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class RetractDispense(SubmergeRetractCommon):
 
     _air_gap_by_volume: LiquidHandlingPropertyByVolume
@@ -417,8 +403,8 @@ class RetractDispense(SubmergeRetractCommon):
         )
 
 
-@dataclass
-class BaseLiquidHandlingProperties(_BaseProperties):
+@dataclass(slots=True)
+class BaseLiquidHandlingProperties:
 
     _submerge: Submerge
     _position_reference: PositionReference
@@ -461,7 +447,7 @@ class BaseLiquidHandlingProperties(_BaseProperties):
         return self._delay
 
 
-@dataclass
+@dataclass(slots=True)
 class AspirateProperties(BaseLiquidHandlingProperties):
 
     _retract: RetractAspirate
@@ -499,7 +485,7 @@ class AspirateProperties(BaseLiquidHandlingProperties):
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class SingleDispenseProperties(BaseLiquidHandlingProperties):
 
     _retract: RetractDispense
@@ -532,7 +518,7 @@ class SingleDispenseProperties(BaseLiquidHandlingProperties):
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class MultiDispenseProperties(BaseLiquidHandlingProperties):
 
     _retract: RetractDispense
@@ -565,7 +551,7 @@ class MultiDispenseProperties(BaseLiquidHandlingProperties):
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class TransferProperties:
     _aspirate: AspirateProperties
     _dispense: SingleDispenseProperties

--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -90,8 +90,7 @@ class _BaseProperties:
         # not block random attribute setting all-together, this is the most straightforward way of accomplishing this.
         # If we don't include the `startswith` check this breaks init.
         if not key.startswith("_") and not hasattr(self, key):
-            # Since we already know we don't have this attribute, calling this will raise an attribute error but will
-            # helpfully use Python's built in "Did you mean:" for variables closely misspelled properties
+            # Since we already know we don't have this attribute, this will raise the appropriate attribute error
             getattr(self, key)
         super().__setattr__(key, value)
 

--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -83,6 +83,9 @@ class LiquidHandlingPropertyByVolume:
         )
 
 
+# We use slots for this dataclass (and the rest of liquid properties) to prevent dynamic creation of attributes
+# not defined in the class, not for any performance reasons. This is so that mistyping properties when overriding
+# values will cause the protocol to fail analysis, rather than silently passing.
 @dataclass(slots=True)
 class DelayProperties:
 
@@ -157,7 +160,7 @@ class TouchTipProperties:
     @mm_to_edge.setter
     def mm_to_edge(self, new_mm: float) -> None:
         validated_mm = validation.ensure_float(new_mm)
-        self._z_offset = validated_mm
+        self._mm_to_edge = validated_mm
 
     @property
     def speed(self) -> Optional[float]:

--- a/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
@@ -215,4 +215,4 @@ def test_non_existent_property_raises_error() -> None:
     aspirate_properties = build_aspirate_properties(aspirate_data)
 
     with pytest.raises(AttributeError):
-        aspirate_properties.mix.enable = True
+        aspirate_properties.mix.enable = True  # type: ignore[attr-defined]

--- a/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
@@ -204,3 +204,15 @@ def test_liquid_handling_property_by_volume() -> None:
     # Test bounds
     assert subject.get_for_volume(1) == 50.0
     assert subject.get_for_volume(1000) == 250.0
+
+
+def test_non_existent_property_raises_error() -> None:
+    """It should raise an attribute error if the set property does not exist."""
+    fixture_data = load_shared_data("liquid-class/fixtures/1/fixture_glycerol50.json")
+    liquid_class_model = LiquidClassSchemaV1.model_validate_json(fixture_data)
+    aspirate_data = liquid_class_model.byPipette[0].byTipType[0].aspirate
+
+    aspirate_properties = build_aspirate_properties(aspirate_data)
+
+    with pytest.raises(AttributeError):
+        aspirate_properties.mix.enable = True

--- a/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
@@ -58,6 +58,62 @@ def test_build_aspirate_settings() -> None:
     assert aspirate_properties.as_shared_data_model() == aspirate_data
 
 
+def test_aspirate_settings_overrides() -> None:
+    """It should allow aspirate properties to be overridden with new values."""
+    fixture_data = load_shared_data("liquid-class/fixtures/1/fixture_glycerol50.json")
+    liquid_class_model = LiquidClassSchemaV1.model_validate_json(fixture_data)
+    aspirate_data = liquid_class_model.byPipette[0].byTipType[0].aspirate
+
+    aspirate_properties = build_aspirate_properties(aspirate_data)
+
+    aspirate_properties.submerge.position_reference = "well-bottom"  # type: ignore[assignment]
+    assert aspirate_properties.submerge.position_reference.value == "well-bottom"
+    aspirate_properties.submerge.offset = 5, 0, 0  # type: ignore[assignment]
+    assert aspirate_properties.submerge.offset == Coordinate(x=5, y=0, z=0)
+    aspirate_properties.submerge.speed = 123
+    assert aspirate_properties.submerge.speed == 123
+    aspirate_properties.submerge.delay.enabled = False
+    assert aspirate_properties.submerge.delay.enabled is False
+    aspirate_properties.submerge.delay.duration = 5.1
+    assert aspirate_properties.submerge.delay.duration == 5.1
+
+    aspirate_properties.retract.position_reference = "well-center"  # type: ignore[assignment]
+    assert aspirate_properties.retract.position_reference.value == "well-center"
+    aspirate_properties.retract.offset = 0, 50, 0  # type: ignore[assignment]
+    assert aspirate_properties.retract.offset == Coordinate(x=0, y=50, z=0)
+    aspirate_properties.retract.speed = 987
+    assert aspirate_properties.retract.speed == 987
+    aspirate_properties.retract.touch_tip.enabled = False
+    assert aspirate_properties.retract.touch_tip.enabled is False
+    aspirate_properties.retract.touch_tip.z_offset = 2.34
+    assert aspirate_properties.retract.touch_tip.z_offset == 2.34
+    aspirate_properties.retract.touch_tip.mm_to_edge = 4.56
+    assert aspirate_properties.retract.touch_tip.mm_to_edge == 4.56
+    aspirate_properties.retract.touch_tip.speed = 501
+    assert aspirate_properties.retract.touch_tip.speed == 501
+    aspirate_properties.retract.delay.enabled = False
+    assert aspirate_properties.retract.delay.enabled is False
+    aspirate_properties.retract.delay.duration = 0.5
+    assert aspirate_properties.retract.delay.duration == 0.5
+
+    aspirate_properties.position_reference = "liquid-meniscus"  # type: ignore[assignment]
+    assert aspirate_properties.position_reference.value == "liquid-meniscus"
+    aspirate_properties.offset = -1, -2, -3  # type: ignore[assignment]
+    assert aspirate_properties.offset == Coordinate(x=-1, y=-2, z=-3)
+    aspirate_properties.pre_wet = False
+    assert aspirate_properties.pre_wet is False
+    aspirate_properties.mix.enabled = False
+    assert aspirate_properties.mix.enabled is False
+    aspirate_properties.mix.repetitions = 33
+    assert aspirate_properties.mix.repetitions == 33
+    aspirate_properties.mix.volume = 51
+    assert aspirate_properties.mix.volume == 51
+    aspirate_properties.delay.enabled = False
+    assert aspirate_properties.delay.enabled is False
+    aspirate_properties.delay.duration = 2.3
+    assert aspirate_properties.delay.duration == 2.3
+
+
 def test_build_single_dispense_settings() -> None:
     """It should convert the shared data single dispense settings to the PAPI type."""
     fixture_data = load_shared_data("liquid-class/fixtures/1/fixture_glycerol50.json")
@@ -115,6 +171,67 @@ def test_build_single_dispense_settings() -> None:
     assert single_dispense_properties.as_shared_data_model() == single_dispense_data
 
 
+def test_single_dispense_settings_override() -> None:
+    """It should allow single dispense properties to be overridden with new values."""
+    fixture_data = load_shared_data("liquid-class/fixtures/1/fixture_glycerol50.json")
+    liquid_class_model = LiquidClassSchemaV1.model_validate_json(fixture_data)
+    single_dispense_data = liquid_class_model.byPipette[0].byTipType[0].singleDispense
+
+    single_dispense_properties = build_single_dispense_properties(single_dispense_data)
+
+    single_dispense_properties.submerge.position_reference = "well-bottom"  # type: ignore[assignment]
+    assert single_dispense_properties.submerge.position_reference.value == "well-bottom"
+    single_dispense_properties.submerge.offset = 3, -2, 1  # type: ignore[assignment]
+    assert single_dispense_properties.submerge.offset == Coordinate(x=3, y=-2, z=1)
+    single_dispense_properties.submerge.speed = 111
+    assert single_dispense_properties.submerge.speed == 111
+    single_dispense_properties.submerge.delay.enabled = False
+    assert single_dispense_properties.submerge.delay.enabled is False
+    single_dispense_properties.submerge.delay.duration = 5.1
+    assert single_dispense_properties.submerge.delay.duration == 5.1
+
+    single_dispense_properties.retract.position_reference = "well-center"  # type: ignore[assignment]
+    assert single_dispense_properties.retract.position_reference.value == "well-center"
+    single_dispense_properties.retract.offset = -9, -8, -7  # type: ignore[assignment]
+    assert single_dispense_properties.retract.offset == Coordinate(x=-9, y=-8, z=-7)
+    single_dispense_properties.retract.speed = 222
+    assert single_dispense_properties.retract.speed == 222
+    single_dispense_properties.retract.touch_tip.enabled = False
+    assert single_dispense_properties.retract.touch_tip.enabled is False
+    single_dispense_properties.retract.touch_tip.z_offset = 2.34
+    assert single_dispense_properties.retract.touch_tip.z_offset == 2.34
+    single_dispense_properties.retract.touch_tip.mm_to_edge = 1.11
+    assert single_dispense_properties.retract.touch_tip.mm_to_edge == 1.11
+    single_dispense_properties.retract.touch_tip.speed = 543
+    assert single_dispense_properties.retract.touch_tip.speed == 543
+    single_dispense_properties.retract.blowout.enabled = False
+    assert single_dispense_properties.retract.blowout.enabled is False
+    single_dispense_properties.retract.blowout.location = "destination"  # type: ignore[assignment]
+    assert single_dispense_properties.retract.blowout.location
+    assert single_dispense_properties.retract.blowout.location.value == "destination"
+    single_dispense_properties.retract.blowout.flow_rate = 3.21
+    assert single_dispense_properties.retract.blowout.flow_rate == 3.21
+    single_dispense_properties.retract.delay.enabled = False
+    assert single_dispense_properties.retract.delay.enabled is False
+    single_dispense_properties.retract.delay.duration = 0.1
+    assert single_dispense_properties.retract.delay.duration == 0.1
+
+    single_dispense_properties.position_reference = "liquid-meniscus"  # type: ignore[assignment]
+    assert single_dispense_properties.position_reference.value == "liquid-meniscus"
+    single_dispense_properties.offset = 11, 22, -33  # type: ignore[assignment]
+    assert single_dispense_properties.offset == Coordinate(x=11, y=22, z=-33)
+    single_dispense_properties.mix.enabled = False
+    assert single_dispense_properties.mix.enabled is False
+    single_dispense_properties.mix.repetitions = 15
+    assert single_dispense_properties.mix.repetitions == 15
+    single_dispense_properties.mix.volume = 3
+    assert single_dispense_properties.mix.volume == 3
+    single_dispense_properties.delay.enabled = False
+    assert single_dispense_properties.delay.enabled is False
+    single_dispense_properties.delay.duration = 25.25
+    assert single_dispense_properties.delay.duration == 25.25
+
+
 def test_build_multi_dispense_settings() -> None:
     """It should convert the shared data multi dispense settings to the PAPI type."""
     fixture_data = load_shared_data("liquid-class/fixtures/1/fixture_glycerol50.json")
@@ -169,6 +286,62 @@ def test_build_multi_dispense_settings() -> None:
     assert multi_dispense_properties.delay.enabled is True
     assert multi_dispense_properties.delay.duration == 1
     assert multi_dispense_properties.as_shared_data_model() == multi_dispense_data
+
+
+def test_multi_dispense_settings_override() -> None:
+    """It should allow multi dispense properties to be overridden with new values."""
+    fixture_data = load_shared_data("liquid-class/fixtures/1/fixture_glycerol50.json")
+    liquid_class_model = LiquidClassSchemaV1.model_validate_json(fixture_data)
+    multi_dispense_data = liquid_class_model.byPipette[0].byTipType[0].multiDispense
+    assert multi_dispense_data is not None
+    multi_dispense_properties = build_multi_dispense_properties(multi_dispense_data)
+    assert multi_dispense_properties is not None
+
+    multi_dispense_properties.submerge.position_reference = "well-bottom"  # type: ignore[assignment]
+    assert multi_dispense_properties.submerge.position_reference.value == "well-bottom"
+    multi_dispense_properties.submerge.offset = 3, -2, 1  # type: ignore[assignment]
+    assert multi_dispense_properties.submerge.offset == Coordinate(x=3, y=-2, z=1)
+    multi_dispense_properties.submerge.speed = 111
+    assert multi_dispense_properties.submerge.speed == 111
+    multi_dispense_properties.submerge.delay.enabled = False
+    assert multi_dispense_properties.submerge.delay.enabled is False
+    multi_dispense_properties.submerge.delay.duration = 5.1
+    assert multi_dispense_properties.submerge.delay.duration == 5.1
+
+    multi_dispense_properties.retract.position_reference = "well-center"  # type: ignore[assignment]
+    assert multi_dispense_properties.retract.position_reference.value == "well-center"
+    multi_dispense_properties.retract.offset = -9, -8, -7  # type: ignore[assignment]
+    assert multi_dispense_properties.retract.offset == Coordinate(x=-9, y=-8, z=-7)
+    multi_dispense_properties.retract.speed = 222
+    assert multi_dispense_properties.retract.speed == 222
+    multi_dispense_properties.retract.touch_tip.enabled = False
+    assert multi_dispense_properties.retract.touch_tip.enabled is False
+    multi_dispense_properties.retract.touch_tip.z_offset = 2.34
+    assert multi_dispense_properties.retract.touch_tip.z_offset == 2.34
+    multi_dispense_properties.retract.touch_tip.mm_to_edge = 1.11
+    assert multi_dispense_properties.retract.touch_tip.mm_to_edge == 1.11
+    multi_dispense_properties.retract.touch_tip.speed = 543
+    assert multi_dispense_properties.retract.touch_tip.speed == 543
+    multi_dispense_properties.retract.blowout.enabled = False
+    assert multi_dispense_properties.retract.blowout.enabled is False
+    multi_dispense_properties.retract.blowout.location = "destination"  # type: ignore[assignment]
+    assert multi_dispense_properties.retract.blowout.location
+    assert multi_dispense_properties.retract.blowout.location.value == "destination"
+    multi_dispense_properties.retract.blowout.flow_rate = 3.21
+    assert multi_dispense_properties.retract.blowout.flow_rate == 3.21
+    multi_dispense_properties.retract.delay.enabled = False
+    assert multi_dispense_properties.retract.delay.enabled is False
+    multi_dispense_properties.retract.delay.duration = 0.1
+    assert multi_dispense_properties.retract.delay.duration == 0.1
+
+    multi_dispense_properties.position_reference = "liquid-meniscus"  # type: ignore[assignment]
+    assert multi_dispense_properties.position_reference.value == "liquid-meniscus"
+    multi_dispense_properties.offset = 11, 22, -33  # type: ignore[assignment]
+    assert multi_dispense_properties.offset == Coordinate(x=11, y=22, z=-33)
+    multi_dispense_properties.delay.enabled = False
+    assert multi_dispense_properties.delay.enabled is False
+    multi_dispense_properties.delay.duration = 25.25
+    assert multi_dispense_properties.delay.duration == 25.25
 
 
 def test_build_multi_dispense_settings_none(


### PR DESCRIPTION
# Overview

This PR addresses an issue found while testing liquid classes. The API for changing individual liquid class properties uses the `@property.setter` decorator to allow easy one line changes of properties while validating the values that the properties are being set to. A consequence of this is because Python allows dynamic setting of variables, a typo (e.g putting `water_p50_props.aspirate.mix.enable = True` instead of `water_p50_props.aspirate.mix.enabled = True`) did **not** cause the protocol to fail analysis. This means that a multi-hour protocol could not behave as expected due to a typo somewhere in the protocol.

Since this would be a huge pain point for customers, the liquid class properties now use the `slots=True` argument of dataclass to automatically generate the `__slots__` attribute, preventing instances from being assigned new variables while giving a small, though negligible, performance boost.

## Test Plan and Hands on Testing

This protocol now fails analysis with a `AttributeError [line 16]: 'MixProperties' object has no attribute 'enable'` error. Fixing line 16 to be enable**d** causes the protocol to correctly pass.

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.22"
}

def run(protocol_context):
	tiprack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C1")
	trash = protocol_context.load_trash_bin('A3')
	pipette_50 = protocol_context.load_instrument("flex_1channel_1000", "right", tip_racks=[tiprack1])

	nest_plate = protocol_context.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", "D3")
	arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "D2")

	water_class = protocol_context.define_liquid_class("water")
	water_p50_props = water_class.get_for("flex_1channel_1000", "opentrons_flex_96_tiprack_50ul")
	water_p50_props.aspirate.mix.enable = True  # This is a typo
```

## Changelog

- Disallow setting non-existent properties for liquid class property dataclasses


## Risk assessment

Low