### PR TITLE
fix(protocol-designer): deck flickering at smaller viewport sizes

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -101,7 +101,7 @@ export function ProtocolSteps(): JSX.Element {
         <Flex
           flexDirection={DIRECTION_COLUMN}
           gridGap={SPACING.spacing16}
-          maxWidth={CONTENT_MAX_WIDTH}
+          width={CONTENT_MAX_WIDTH}
         >
           {showTimelineAlerts ? (
             <TimelineAlerts justifyContent={JUSTIFY_CENTER} width="100%" />


### PR DESCRIPTION
closes RQA-3630, AUTH-1266

# Overview

There was still some deck flickering experienced with the step summary at a smaller viewport - Alex saw it when QAing and Mike saw it when presenting his screen during a meeting. Hopefully this fixes that issue

## Test Plan and Hands on Testing

Upload a protocol with steps and then hover over the steps to see the step summary. make sure there is no deck flickering at your default viewport size and also when you shrink the viewport size down

## Changelog

width should be all the time, not max-width

## Risk assessment

low