### PR TITLE
refactor(app): refactor ODD protocol card copy when run data is not "ok"

### DIFF
--- a/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCard.tsx
@@ -158,15 +158,22 @@ export function ProtocolWithLastRun({
     [RUN_STATUS_SUCCEEDED]: t('completed'),
     [RUN_STATUS_FAILED]: t('failed'),
   }
-  // TODO(BC, 2023-06-05): see if addSuffix false allow can remove usage of .replace here
-  const formattedLastRunTime = formatDistance(
-    // Fallback to current date if completedAt is null, though this should never happen since runs must be completed to appear in dashboard
-    new Date(runData.completedAt ?? new Date()),
-    new Date(),
-    {
-      addSuffix: true,
+  const formattedLastRunTime =
+    runData.completedAt != null
+      ? formatDistance(new Date(runData.completedAt), new Date(), {
+          addSuffix: true,
+        }).replace('about ', '')
+      : null
+  const buildLastRunCopy = (): string => {
+    if (formattedLastRunTime != null) {
+      return i18n.format(
+        `${terminationTypeMap[runData.status] ?? ''} ${formattedLastRunTime}`,
+        'capitalize'
+      )
+    } else {
+      return ''
     }
-  ).replace('about ', '')
+  }
 
   return isProtocolFetching || isLookingForHardware ? (
     <Skeleton
@@ -227,10 +234,7 @@ export function ProtocolWithLastRun({
         lineHeight={TYPOGRAPHY.lineHeight28}
         color={COLORS.grey60}
       >
-        {i18n.format(
-          `${terminationTypeMap[runData.status] ?? ''} ${formattedLastRunTime}`,
-          'capitalize'
-        )}
+        {buildLastRunCopy()}
       </LegacyStyledText>
     </Flex>
   )


### PR DESCRIPTION
Closes [RQA-3851](https://opentrons.atlassian.net/browse/RQA-3851)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When protocol cards have not ok run data, we can't retrieve the `completedAt` timestamp, and the fallback has been the current date, which is confusing copy. After speaking with Design, the plan is to remove copy if we can't retrieve the `completedAt` timestamp.

As an aside, I did investigate the `suffix` comment left in the code. After playing around with it a bit and reading the docs, turns out we do need to keep `suffix: true`. 

<img width="1283" alt="Screenshot 2025-01-14 at 10 09 21 AM" src="https://github.com/user-attachments/assets/fff7950b-40fe-4b4e-a39b-45f1c8adee9c" />

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See pic.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- ODD recently run protocol cards no longer show the current time when the last run completed time is unknown.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3851]: https://opentrons.atlassian.net/browse/RQA-3851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ