### PR TITLE
fix(api): Fix Pydantic error when parsing commands that did not succeed

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
@@ -132,7 +132,7 @@ class CloseLid(BaseCommand[CloseLidParams, CloseLidResult, ErrorOccurrence]):
 
     commandType: CloseLidCommandType = "absorbanceReader/closeLid"
     params: CloseLidParams
-    result: Optional[CloseLidResult]
+    result: Optional[CloseLidResult] = None
 
     _ImplementationCls: Type[CloseLidImpl] = CloseLidImpl
 

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/initialize.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/initialize.py
@@ -137,7 +137,7 @@ class Initialize(BaseCommand[InitializeParams, InitializeResult, ErrorOccurrence
 
     commandType: InitializeCommandType = "absorbanceReader/initialize"
     params: InitializeParams
-    result: Optional[InitializeResult]
+    result: Optional[InitializeResult] = None
 
     _ImplementationCls: Type[InitializeImpl] = InitializeImpl
 

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
@@ -133,7 +133,7 @@ class OpenLid(BaseCommand[OpenLidParams, OpenLidResult, ErrorOccurrence]):
 
     commandType: OpenLidCommandType = "absorbanceReader/openLid"
     params: OpenLidParams
-    result: Optional[OpenLidResult]
+    result: Optional[OpenLidResult] = None
 
     _ImplementationCls: Type[OpenLidImpl] = OpenLidImpl
 

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -209,7 +209,7 @@ class ReadAbsorbance(
 
     commandType: ReadAbsorbanceCommandType = "absorbanceReader/read"
     params: ReadAbsorbanceParams
-    result: Optional[ReadAbsorbanceResult]
+    result: Optional[ReadAbsorbanceResult] = None
 
     _ImplementationCls: Type[ReadAbsorbanceImpl] = ReadAbsorbanceImpl
 

--- a/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
@@ -146,7 +146,7 @@ class AirGapInPlace(
 
     commandType: AirGapInPlaceCommandType = "airGapInPlace"
     params: AirGapInPlaceParams
-    result: Optional[AirGapInPlaceResult]
+    result: Optional[AirGapInPlaceResult] = None
 
     _ImplementationCls: Type[AirGapInPlaceImplementation] = AirGapInPlaceImplementation
 

--- a/api/src/opentrons/protocol_engine/commands/get_next_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/get_next_tip.py
@@ -120,7 +120,7 @@ class GetNextTip(BaseCommand[GetNextTipParams, GetNextTipResult, ErrorOccurrence
 
     commandType: GetNextTipCommandType = "getNextTip"
     params: GetNextTipParams
-    result: Optional[GetNextTipResult]
+    result: Optional[GetNextTipResult] = None
 
     _ImplementationCls: Type[GetNextTipImplementation] = GetNextTipImplementation
 

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -361,7 +361,7 @@ class LiquidProbe(
 
     commandType: LiquidProbeCommandType = "liquidProbe"
     params: LiquidProbeParams
-    result: Optional[LiquidProbeResult]
+    result: Optional[LiquidProbeResult] = None
 
     _ImplementationCls: Type[LiquidProbeImplementation] = LiquidProbeImplementation
 
@@ -373,7 +373,7 @@ class TryLiquidProbe(
 
     commandType: TryLiquidProbeCommandType = "tryLiquidProbe"
     params: TryLiquidProbeParams
-    result: Optional[TryLiquidProbeResult]
+    result: Optional[TryLiquidProbeResult] = None
 
     _ImplementationCls: Type[
         TryLiquidProbeImplementation

--- a/api/src/opentrons/protocol_engine/commands/load_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_lid.py
@@ -132,7 +132,7 @@ class LoadLid(BaseCommand[LoadLidParams, LoadLidResult, ErrorOccurrence]):
 
     commandType: LoadLidCommandType = "loadLid"
     params: LoadLidParams
-    result: Optional[LoadLidResult]
+    result: Optional[LoadLidResult] = None
 
     _ImplementationCls: Type[LoadLidImplementation] = LoadLidImplementation
 

--- a/api/src/opentrons/protocol_engine/commands/load_lid_stack.py
+++ b/api/src/opentrons/protocol_engine/commands/load_lid_stack.py
@@ -175,7 +175,7 @@ class LoadLidStack(
 
     commandType: LoadLidStackCommandType = "loadLidStack"
     params: LoadLidStackParams
-    result: Optional[LoadLidStackResult]
+    result: Optional[LoadLidStackResult] = None
 
     _ImplementationCls: Type[LoadLidStackImplementation] = LoadLidStackImplementation
 

--- a/api/src/opentrons/protocol_engine/commands/load_liquid_class.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid_class.py
@@ -128,7 +128,7 @@ class LoadLiquidClass(
 
     commandType: LoadLiquidClassCommandType = "loadLiquidClass"
     params: LoadLiquidClassParams
-    result: Optional[LoadLiquidClassResult]
+    result: Optional[LoadLiquidClassResult] = None
 
     _ImplementationCls: Type[
         LoadLiquidClassImplementation

--- a/api/src/opentrons/protocol_engine/commands/robot/close_gripper_jaw.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/close_gripper_jaw.py
@@ -70,7 +70,7 @@ class closeGripperJaw(
 
     commandType: closeGripperJawCommandType = "robot/closeGripperJaw"
     params: closeGripperJawParams
-    result: Optional[closeGripperJawResult]
+    result: Optional[closeGripperJawResult] = None
 
     _ImplementationCls: Type[
         closeGripperJawImplementation

--- a/api/src/opentrons/protocol_engine/commands/robot/move_axes_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/move_axes_relative.py
@@ -85,7 +85,7 @@ class MoveAxesRelative(
 
     commandType: MoveAxesRelativeCommandType = "robot/moveAxesRelative"
     params: MoveAxesRelativeParams
-    result: Optional[MoveAxesRelativeResult]
+    result: Optional[MoveAxesRelativeResult] = None
 
     _ImplementationCls: Type[
         MoveAxesRelativeImplementation

--- a/api/src/opentrons/protocol_engine/commands/robot/move_axes_to.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/move_axes_to.py
@@ -86,7 +86,7 @@ class MoveAxesTo(BaseCommand[MoveAxesToParams, MoveAxesToResult, ErrorOccurrence
 
     commandType: MoveAxesToCommandType = "robot/moveAxesTo"
     params: MoveAxesToParams
-    result: Optional[MoveAxesToResult]
+    result: Optional[MoveAxesToResult] = None
 
     _ImplementationCls: Type[MoveAxesToImplementation] = MoveAxesToImplementation
 

--- a/api/src/opentrons/protocol_engine/commands/robot/move_to.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/move_to.py
@@ -80,7 +80,7 @@ class MoveTo(BaseCommand[MoveToParams, MoveToResult, ErrorOccurrence]):
 
     commandType: MoveToCommandType = "robot/moveTo"
     params: MoveToParams
-    result: Optional[MoveToResult]
+    result: Optional[MoveToResult] = None
 
     _ImplementationCls: Type[MoveToImplementation] = MoveToImplementation
 

--- a/api/src/opentrons/protocol_engine/commands/robot/open_gripper_jaw.py
+++ b/api/src/opentrons/protocol_engine/commands/robot/open_gripper_jaw.py
@@ -61,7 +61,7 @@ class openGripperJaw(
 
     commandType: openGripperJawCommandType = "robot/openGripperJaw"
     params: openGripperJawParams
-    result: Optional[openGripperJawResult]
+    result: Optional[openGripperJawResult] = None
 
     _ImplementationCls: Type[
         openGripperJawImplementation

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_extended_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_extended_profile.py
@@ -157,7 +157,7 @@ class RunExtendedProfile(
 
     commandType: RunExtendedProfileCommandType = "thermocycler/runExtendedProfile"
     params: RunExtendedProfileParams
-    result: Optional[RunExtendedProfileResult]
+    result: Optional[RunExtendedProfileResult] = None
 
     _ImplementationCls: Type[RunExtendedProfileImpl] = RunExtendedProfileImpl
 

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
@@ -82,7 +82,7 @@ class UnsafeBlowOutInPlace(
 
     commandType: UnsafeBlowOutInPlaceCommandType = "unsafe/blowOutInPlace"
     params: UnsafeBlowOutInPlaceParams
-    result: Optional[UnsafeBlowOutInPlaceResult]
+    result: Optional[UnsafeBlowOutInPlaceResult] = None
 
     _ImplementationCls: Type[
         UnsafeBlowOutInPlaceImplementation

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -99,7 +99,7 @@ class UnsafeDropTipInPlace(
 
     commandType: UnsafeDropTipInPlaceCommandType = "unsafe/dropTipInPlace"
     params: UnsafeDropTipInPlaceParams
-    result: Optional[UnsafeDropTipInPlaceResult]
+    result: Optional[UnsafeDropTipInPlaceResult] = None
 
     _ImplementationCls: Type[
         UnsafeDropTipInPlaceImplementation

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_engage_axes.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_engage_axes.py
@@ -66,7 +66,7 @@ class UnsafeEngageAxes(
 
     commandType: UnsafeEngageAxesCommandType = "unsafe/engageAxes"
     params: UnsafeEngageAxesParams
-    result: Optional[UnsafeEngageAxesResult]
+    result: Optional[UnsafeEngageAxesResult] = None
 
     _ImplementationCls: Type[
         UnsafeEngageAxesImplementation

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
@@ -192,7 +192,7 @@ class UnsafePlaceLabware(
 
     commandType: UnsafePlaceLabwareCommandType = "unsafe/placeLabware"
     params: UnsafePlaceLabwareParams
-    result: Optional[UnsafePlaceLabwareResult]
+    result: Optional[UnsafePlaceLabwareResult] = None
 
     _ImplementationCls: Type[
         UnsafePlaceLabwareImplementation

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_ungrip_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_ungrip_labware.py
@@ -61,7 +61,7 @@ class UnsafeUngripLabware(
 
     commandType: UnsafeUngripLabwareCommandType = "unsafe/ungripLabware"
     params: UnsafeUngripLabwareParams
-    result: Optional[UnsafeUngripLabwareResult]
+    result: Optional[UnsafeUngripLabwareResult] = None
 
     _ImplementationCls: Type[
         UnsafeUngripLabwareImplementation

--- a/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
@@ -74,7 +74,7 @@ class UpdatePositionEstimators(
 
     commandType: UpdatePositionEstimatorsCommandType = "unsafe/updatePositionEstimators"
     params: UpdatePositionEstimatorsParams
-    result: Optional[UpdatePositionEstimatorsResult]
+    result: Optional[UpdatePositionEstimatorsResult] = None
 
     _ImplementationCls: Type[
         UpdatePositionEstimatorsImplementation


### PR DESCRIPTION
## Overview

robot-server sometimes stores, in its database, run commands that do not have a `result`. For example, if a command failed, it has an `error` instead of a `result`.

After the recent Pydantic v1->v2 upgrade, parsing these commands was broken for about 1/3rd of our command types. The server would raise a 500 error. Their Pydantic models were defined like:

```
result: Optional[FooResult]
```

In Pydantic v1, that parses JSON where `result` is `null` or omitted, but in Pydantic v2, it only parses JSON where `result` is `null`. We need to change it to:

```
result: Optional[FooResult] = None
```

Addresses RQA-3853, I think.

## Test Plan and Hands on Testing

* [x] Find a `GET /runs/.../commands/...` request that fails with a 500 error without this PR, and make sure it succeeds with this PR.

## Review requests

I made this change by running `bump-pydantic` on `api/src/opentrons/protocol_engine`. Double-check my work to make sure no changes snuck in outside of what I've described above.

## Risk assessment

Low.