### PR TITLE
fix(protocol-designer): custom labware <> adapter combos

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
@@ -385,7 +385,7 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
                             />
 
                             {uri === selectedLabwareDefUri &&
-                              getLabwareCompatibleWithAdapter(loadName)
+                              getLabwareCompatibleWithAdapter(defs, loadName)
                                 ?.length > 0 && (
                                 <ListButtonAccordionContainer
                                   id={`nestedAccordionContainer_${loadName}`}
@@ -435,12 +435,10 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
                                             )
                                           }
                                         )
-                                      : [
-                                          ...getLabwareCompatibleWithAdapter(
-                                            loadName
-                                          ),
-                                          ...Object.keys(customLabwareDefs),
-                                        ].map(nestedDefUri => {
+                                      : getLabwareCompatibleWithAdapter(
+                                          { ...defs, ...customLabwareDefs },
+                                          loadName
+                                        ).map(nestedDefUri => {
                                           const nestedDef =
                                             defs[nestedDefUri] ??
                                             customLabwareDefs[nestedDefUri]

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -14,7 +14,6 @@ import {
   getModuleType,
 } from '@opentrons/shared-data'
 
-import { getOnlyLatestDefs } from '../../../labware-defs'
 import { getStagingAreaAddressableAreas } from '../../../utils'
 import {
   FLEX_MODULE_MODELS,
@@ -33,6 +32,7 @@ import type {
   ModuleModel,
   RobotType,
 } from '@opentrons/shared-data'
+import type { LabwareDefByDefURI } from '../../../labware-defs'
 import type {
   AllTemporalPropertiesForTimelineFrame,
   InitialDeckSetup,
@@ -132,14 +132,12 @@ export const getLabwareIsRecommended = (
 }
 
 export const getLabwareCompatibleWithAdapter = (
+  defs: LabwareDefByDefURI,
   adapterLoadName?: string
 ): string[] => {
-  const defs = getOnlyLatestDefs()
-
   if (adapterLoadName == null) {
     return []
   }
-
   return Object.entries(defs)
     .filter(
       ([, { stackingOffsetWithLabware }]) =>


### PR DESCRIPTION
closes RQA-3855

# Overview

Custom labware should only be compatible with an adapter if its included in the stacking offset info

## Test Plan and Hands on Testing

Upload the attached custom labware. see that it is listed to add directly to the deck and to add to the `opentrons_aluminum_flat_bottom_plate` adapter/aluminum block. Otherwise, it should not be selectable for other adapters

[Thermo Scientific 96 Well Plate V Bottom 450 uL_with offset (1).json](https://github.com/user-attachments/files/18414337/Thermo.Scientific.96.Well.Plate.V.Bottom.450.uL_with.offset.1.json)



## Changelog

filter custom labware based on the stacking offset info

## Risk assessment

low
