### PR TITLE
chore(robot-server): Lint and typecheck robot-server scripts

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -8,6 +8,8 @@ REDOC := npx @redocly/cli
 
 # Path of source package
 SRC_PATH = robot_server
+SCRIPTS_PATH = scripts
+TESTS_PATH = tests
 
 # Project to get the version for
 ot_project := $(OPENTRONS_PROJECT)
@@ -125,9 +127,9 @@ test-cov:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy $(SRC_PATH) $(tests)
+	$(python) -m mypy $(SRC_PATH) $(SCRIPTS_PATH) $(TESTS_PATH)
 	$(python) -m black $(black_opts) --check .
-	$(python) -m flake8 $(SRC_PATH) $(tests) setup.py
+	$(python) -m flake8 $(SRC_PATH) $(SCRIPTS_PATH) $(TESTS_PATH) setup.py
 
 .PHONY: format
 format:

--- a/robot-server/scripts/settings_schema.py
+++ b/robot-server/scripts/settings_schema.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+"""Generate a JSON schema representing the server's settings."""
+
 from sys import argv
 from robot_server.settings import RobotServerSettings
 

--- a/robot-server/scripts/spec_generator.py
+++ b/robot-server/scripts/spec_generator.py
@@ -7,18 +7,16 @@ a machine handy.
 """
 
 from argparse import ArgumentParser, FileType
-from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 import json
 from io import TextIOBase
-import os
 import sys
 
 from robot_server.app_setup import app
 from robot_server.versioning import API_VERSION
 
 
-def write_api_spec(output: TextIOBase) -> None:
+def _write_api_spec(output: TextIOBase) -> None:
     spec_dict = get_openapi(
         title="Opentrons HTTP API Spec",
         version=str(API_VERSION),
@@ -45,7 +43,7 @@ def _run_cmdline() -> int:
         help="Where to write the file (will be json)",
     )
     args = parser.parse_args()
-    write_api_spec(args.output)
+    _write_api_spec(args.output)
     return 0
 
 


### PR DESCRIPTION
## Overview

This includes robot-server's `scripts/` directory in lints and typechecks. This code is only run on our laptops and is not included in production builds.

## Test Plan and Hands on Testing

Just make sure CI passes.

## Review requests

None.

## Risk assessment

No risk.