### PR TITLE
feat(shared-data): Enable stacking of up to 4 Opentrons PCR well plates

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_96_wellplate_200ul_pcr_full_skirt/2.json
+++ b/shared-data/labware/definitions/2/opentrons_96_wellplate_200ul_pcr_full_skirt/2.json
@@ -31,8 +31,6 @@
     "y": 0,
     "z": 0
   },
-  "stackLimit": 4,
-  "compatibleParentLabware": ["opentrons_96_wellplate_200ul_pcr_full_skirt"],
   "stackingOffsetWithLabware": {
     "opentrons_96_pcr_adapter": {
       "x": 0,
@@ -43,11 +41,6 @@
       "x": 0,
       "y": 0,
       "z": 11.91
-    },
-    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
-      "x": 0,
-      "y": 0,
-      "z": 3.0
     }
   },
   "stackingOffsetWithModule": {

--- a/shared-data/labware/definitions/2/opentrons_96_wellplate_200ul_pcr_full_skirt/2.json
+++ b/shared-data/labware/definitions/2/opentrons_96_wellplate_200ul_pcr_full_skirt/2.json
@@ -31,6 +31,8 @@
     "y": 0,
     "z": 0
   },
+  "stackLimit": 4,
+  "compatibleParentLabware": ["opentrons_96_wellplate_200ul_pcr_full_skirt"],
   "stackingOffsetWithLabware": {
     "opentrons_96_pcr_adapter": {
       "x": 0,
@@ -41,6 +43,11 @@
       "x": 0,
       "y": 0,
       "z": 11.91
+    },
+    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
+      "x": 0,
+      "y": 0,
+      "z": 3.0
     }
   },
   "stackingOffsetWithModule": {

--- a/shared-data/labware/definitions/3/opentrons_96_wellplate_200ul_pcr_full_skirt/3.json
+++ b/shared-data/labware/definitions/3/opentrons_96_wellplate_200ul_pcr_full_skirt/3.json
@@ -31,6 +31,8 @@
     "y": 0,
     "z": 0
   },
+  "stackLimit": 4,
+  "compatibleParentLabware": ["opentrons_96_wellplate_200ul_pcr_full_skirt"],
   "stackingOffsetWithLabware": {
     "opentrons_96_pcr_adapter": {
       "x": 0,
@@ -41,6 +43,11 @@
       "x": 0,
       "y": 0,
       "z": 11.91
+    },
+    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
+      "x": 0,
+      "y": 0,
+      "z": 3.0
     }
   },
   "stackingOffsetWithModule": {


### PR DESCRIPTION
# Overview
Covers EXEC-957

Enables the `opentrons_96_wellplate_200ul_pcr_full_skirt` labware to stack onto itself up to 4 labwares high. 

Stacking offset of 3.0mm identified on labware utilizing calipers.

## Test Plan and Hands on Testing

- [x] Run the following protocol with the labware moving between two stacks:

```
from typing import List, Dict, Any, Optional
from opentrons.protocol_api import ProtocolContext, Labware

metadata = {"protocolName": "Plate_stack Test"}
requirements = {"robotType": "Flex", "apiLevel": "2.22"}


def run(protocol: ProtocolContext):
    plates: List[Labware] = [protocol.load_labware(load_name="opentrons_96_wellplate_200ul_pcr_full_skirt", location="A2", version=3)]
    for i in range(3):
        plates.append(plates[-1].load_labware(name="opentrons_96_wellplate_200ul_pcr_full_skirt", version=3))
    plates.reverse()

    destination = "B2"
    for i in range(4):
        protocol.move_labware(plates[i], destination, True)
        destination = plates[i]
```

## Changelog
Updated labware definition to include stacking limit and stacking offsets with itself.

## Review requests
Do we think we need to check to see if this labware has liquid in it before stacking? How helicopter-parenty do we want to be about this kind of stacking in the future?

## Risk assessment
Low-mid, this is enabling some stacking behavior needed by science and ABR for flex stacker protocols, but in theory you could fill these labwares with liquid and stack them, potentially making a mess.