### PR TITLE
fix(protocol-designer): clean-up usage of css/styled-components with …

### DIFF
--- a/protocol-designer/src/organisms/Labware/WellTooltip.tsx
+++ b/protocol-designer/src/organisms/Labware/WellTooltip.tsx
@@ -1,13 +1,27 @@
-import { Fragment, useState } from 'react'
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import map from 'lodash/map'
 import reduce from 'lodash/reduce'
-import { css } from 'styled-components'
+import styled from 'styled-components'
 import { createPortal } from 'react-dom'
 import { Popper, Reference, Manager } from 'react-popper'
+import {
+  BORDERS,
+  COLORS,
+  CURSOR_POINTER,
+  DISPLAY_FLEX,
+  JUSTIFY_SPACE_BETWEEN,
+  POSITION_ABSOLUTE,
+  SPACING,
+  StyledText,
+  TYPOGRAPHY,
+} from '@opentrons/components'
 import { getMainPagePortalEl } from '../../organisms'
 import { selectors } from '../../labware-ingred/selectors'
-import { formatVolume } from '../../pages/Designer/ProtocolSteps/Timeline/utils'
+import {
+  formatPercentage,
+  formatVolume,
+} from '../../pages/Designer/ProtocolSteps/Timeline/utils'
 import { swatchColors } from '../DefineLiquidsModal/swatchColors'
 
 import type { MouseEvent, ReactNode } from 'react'
@@ -31,14 +45,15 @@ interface WellTooltipProps {
   ingredNames: WellIngredientNames
 }
 
-interface State {
+interface TooltipState {
   tooltipX?: number | null
   tooltipY?: number | null
   tooltipWellName?: string | null
   tooltipWellIngreds?: LocationLiquidState | null
   tooltipOffset?: number | null
 }
-const initialTooltipState: State = {
+
+const initialTooltipState: TooltipState = {
   tooltipX: null,
   tooltipY: null,
   tooltipWellName: null,
@@ -46,18 +61,23 @@ const initialTooltipState: State = {
   tooltipOffset: DEFAULT_TOOLTIP_OFFSET,
 }
 
-export const WellTooltip = (props: WellTooltipProps): JSX.Element => {
-  const { children } = props
-  const [tooltipState, setTooltipState] = useState<State>(initialTooltipState)
+//  TODO(ja, 1/15/25): this is the only component where react-popper is being used
+//  we should refactor and reevaluate removing its usage in the future
+export const WellTooltip = ({
+  children,
+  ingredNames,
+}: WellTooltipProps): JSX.Element => {
+  const [tooltipState, setTooltipState] = useState<TooltipState>(
+    initialTooltipState
+  )
 
-  const makeHandleMouseEnterWell: (
+  const makeHandleMouseEnterWell = (
     wellName: string,
     wellIngreds: LocationLiquidState
-  ) => (e: MouseEvent) => void = (wellName, wellIngreds) => e => {
-    const { target } = e
-    if (target instanceof Element) {
-      const wellBoundingRect = target.getBoundingClientRect()
-      const { left, top, height, width } = wellBoundingRect
+  ) => (e: MouseEvent) => {
+    const target = e.target as Element
+    if (target) {
+      const { left, top, height, width } = target.getBoundingClientRect()
       if (Object.keys(wellIngreds).length > 0 && left && top) {
         setTooltipState({
           tooltipX: left + width / 2,
@@ -96,173 +116,139 @@ export const WellTooltip = (props: WellTooltipProps): JSX.Element => {
         <Reference>
           {({ ref }) =>
             createPortal(
-              <div
-                ref={ref}
-                css={css`
-                  position: absolute;
-                `}
-                // @ts-expect-error(sa, 2021-6-21): can't use null as top and left, default to undefined
-                style={{ top: tooltipY, left: tooltipX }}
-              />,
+              //  @ts-expect-error
+              <TooltipContainer ref={ref} x={tooltipX} y={tooltipY} />,
               getMainPagePortalEl()
             )
           }
         </Reference>
         {children({
-          makeHandleMouseEnterWell: makeHandleMouseEnterWell,
-          handleMouseLeaveWell: handleMouseLeaveWell,
-          tooltipWellName: tooltipWellName,
+          makeHandleMouseEnterWell,
+          handleMouseLeaveWell,
+          tooltipWellName,
         })}
-        {tooltipWellName && (
+        {tooltipWellName != null ? (
           <Popper
             modifiers={{
               offset: {
-                // @ts-expect-error(sa, 2021-6-21): tooltipOffset might be null or undefined
-                offset: `0, ${tooltipOffset + WELL_BORDER_WIDTH * 2}`,
+                offset: `0, ${(tooltipOffset ?? 0) + WELL_BORDER_WIDTH * 2}`,
               },
             }}
           >
-            {({ ref, style, placement, arrowProps }) => {
-              return createPortal(
-                <div
-                  style={style}
+            {({ ref, style, placement }) =>
+              createPortal(
+                <PopperContent
                   ref={ref}
+                  style={style}
                   data-placement={placement}
-                  css={css`
-                    font-size: var(
-                      --fs-body-1
-                    ); /* from legacy --font-body-1-light */
-                    font-weight: var(
-                      --fw-regular
-                    ); /* from legacy --font-body-1-light */
-                    color: var(
-                      --c-font-light
-                    ); /* from legacy --font-body-1-light */
-                    background-color: var(--c-bg-dark);
-                    box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.13),
-                      0 3px 6px 0 rgba(0, 0, 0, 0.23);
-                    padding: 8px;
-                    cursor: pointer;
-                    z-index: 10001;
-                    position: absolute;
-                  `}
                 >
-                  <div
-                    css={css`
-                      margin: 0.5em;
-                      max-width: 20rem;
-                    `}
-                  >
-                    <table>
-                      <tbody>
-                        {map(tooltipWellIngreds || {}, (ingred, groupId) => (
-                          <tr
-                            key={groupId}
-                            css={css`
-                              min-width: 180px;
-                            `}
-                          >
+                  <TooltipTable>
+                    <tbody>
+                      {map(tooltipWellIngreds || {}, (ingred, groupId) => (
+                        <TooltipRow key={groupId}>
+                          <td>
+                            <ColorCircle
+                              color={
+                                liquidDisplayColors[Number(groupId)] ??
+                                swatchColors(groupId)
+                              }
+                            />
+                          </td>
+                          <td>
+                            <StyledText desktopStyle="captionRegular">
+                              {ingredNames[groupId]}
+                            </StyledText>
+                          </td>
+                          {hasMultipleIngreds && (
                             <td>
-                              <div
-                                css={css`
-                                  height: 2em;
-                                  width: 2em;
-                                  border-radius: 50%;
-                                  margin-right: 1em;
-                                `}
-                                style={{
-                                  backgroundColor:
-                                    liquidDisplayColors[Number(groupId)] ??
-                                    swatchColors(groupId),
-                                }}
-                              />
-                            </td>
-                            <td
-                              css={css`
-                                text-align: left;
-                                padding-right: 1em;
-                              `}
-                            >
-                              {props.ingredNames[groupId]}
-                            </td>
-                            {hasMultipleIngreds && (
-                              <td
-                                css={css`
-                                  text-align: right;
-                                  padding-right: 1em;
-                                `}
-                              >
-                                {/* @ts-expect-error(sa, 2021-6-20): TODO IMMEDIATELY, this could either be single channel OR multi channel volume data */}
+                              <StyledText desktopStyle="captionRegular">
                                 {formatPercentage(
                                   ingred.volume,
                                   totalLiquidVolume
                                 )}
-                              </td>
-                            )}
-                            <td
-                              css={css`
-                                text-align: right;
-                              `}
-                            >
-                              {formatVolume(ingred.volume, 2)}µl
+                              </StyledText>
                             </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                    {hasMultipleIngreds && (
-                      <Fragment>
-                        <div
-                          css={css`
-                            height: 1px;
-                            width: 100%;
-                            background-color: var(--c-light-gray);
-                            margin: 1em 0;
-                          `}
-                        />
-                        <div
-                          css={css`
-                            display: flex;
-                            justify-content: space-between;
-                          `}
-                        >
-                          <span>{`${tooltipWellName} Total Volume`}</span>
-                          <span>{formatVolume(totalLiquidVolume, 2)}µl</span>
-                        </div>
-                      </Fragment>
-                    )}
-                  </div>
-                  <div
-                    css={css`
-                      position: absolute;
-                      bottom: 0;
-                      left: 0;
-                      margin-bottom: -0.5em;
-                      width: 1em;
-                      height: 0.5em;
-
-                      &::before {
-                        border-width: 0.5em 0.5em 0 0.5em;
-                        content: '';
-                        margin: auto;
-                        display: block;
-                        width: 0;
-                        height: 0;
-                        border-style: solid;
-                        border-color: var(--c-bg-dark) transparent transparent
-                          transparent;
-                      }
-                    `}
-                    ref={arrowProps.ref}
-                    style={arrowProps.style}
-                  />
-                </div>,
+                          )}
+                          <td>
+                            <StyledText desktopStyle="captionRegular">
+                              {formatVolume(ingred.volume, 2)}µl
+                            </StyledText>
+                          </td>
+                        </TooltipRow>
+                      ))}
+                    </tbody>
+                  </TooltipTable>
+                  {hasMultipleIngreds && (
+                    <>
+                      <Divider />
+                      <Footer>
+                        <StyledText desktopStyle="captionRegular">{`${tooltipWellName} Total Volume`}</StyledText>
+                        <StyledText desktopStyle="captionRegular">
+                          {formatVolume(totalLiquidVolume, 2)}µl
+                        </StyledText>
+                      </Footer>
+                    </>
+                  )}
+                </PopperContent>,
                 getMainPagePortalEl()
               )
-            }}
+            }
           </Popper>
-        )}
+        ) : null}
       </Manager>
     </>
   )
 }
+
+const TooltipContainer = styled.div.attrs<{
+  x: number | null
+  y: number | null
+}>(({ x, y }) => ({
+  style: {
+    top: y || undefined,
+    left: x || undefined,
+  },
+}))`
+  position: ${POSITION_ABSOLUTE};
+`
+
+const PopperContent = styled.div`
+  font-size: ${TYPOGRAPHY.fontSizeCaption};
+  font-weight: ${TYPOGRAPHY.fontWeightRegular};
+  color: ${COLORS.white};
+  background-color: ${COLORS.black90};
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.13), 0 3px 6px rgba(0, 0, 0, 0.23);
+  padding: ${SPACING.spacing8};
+  cursor: ${CURSOR_POINTER};
+  z-index: 10001;
+  border-radius: ${BORDERS.borderRadius8};
+`
+
+const TooltipTable = styled.table`
+  margin: 0.5em;
+  max-width: 20rem;
+`
+
+const TooltipRow = styled.tr`
+  min-width: 11.25rem;
+`
+
+const ColorCircle = styled.div<{ color: string }>`
+  height: 2em;
+  width: 2em;
+  border-radius: 50%;
+  margin-right: 1em;
+  background-color: ${({ color }) => color};
+`
+
+const Divider = styled.div`
+  height: 1px;
+  width: 100%;
+  background-color: ${COLORS.grey60};
+  margin: 1em 0;
+`
+
+const Footer = styled.div`
+  display: ${DISPLAY_FLEX};
+  justify-content: ${JUSTIFY_SPACE_BETWEEN};
+`

--- a/protocol-designer/src/organisms/Labware/WellTooltip.tsx
+++ b/protocol-designer/src/organisms/Labware/WellTooltip.tsx
@@ -220,7 +220,7 @@ const PopperContent = styled.div`
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.13), 0 3px 6px rgba(0, 0, 0, 0.23);
   padding: ${SPACING.spacing8};
   cursor: ${CURSOR_POINTER};
-  z-index: 10001;
+  z-index: 10000;
   border-radius: ${BORDERS.borderRadius8};
 `
 


### PR DESCRIPTION
…react-popper for wellTooltip

closes AUTH-1275

# Overview

The bug only exists in production and not in a dev-env and upon investigating, i believe it is because of the usage of css and styled-components mixed in with react-popper.

## Test Plan and Hands on Testing

Test this in the sandbox build from this branch

Upload the protocol and see that the tooltip when editing the liquids in the labware is not transparent. NOTE: can't find this tooltip in designs so i opted to keep it more or less like other tooltips but i didn't follow any specific designs

[untitled (32).json](https://github.com/user-attachments/files/18428279/untitled.32.json)


## Changelog

clean up `wellTooltip` component

## Risk assessment

low