### PR TITLE
fix(protocol-designer): propagate mix form's name/description to args

### DIFF
--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -89,10 +89,8 @@ export const mixFormToArgs = (
   )
   return {
     commandCreatorFnName: 'mix',
-    name: `Mix ${hydratedFormData.id}`,
-    // TODO real name for steps
-    description: 'description would be here 2018-03-01',
-    // TODO get from form
+    name: hydratedFormData.stepName,
+    description: hydratedFormData.stepDetails,
     labware: labware.id,
     wells: orderedWells,
     volume,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
@@ -76,18 +76,18 @@ describe('mix step form -> command creator args', () => {
     const args = mixFormToArgs(hydratedForm)
     expect(args).toMatchObject({
       commandCreatorFnName: 'mix',
-      name: 'Cool Mix Step',  // make sure name and description are present
+      name: 'Cool Mix Step', // make sure name and description are present
       description: 'Here we mix 2 wells',
       labware: 'labwareId',
-      wells: [ 'A1', 'A2' ],
+      wells: ['A1', 'A2'],
       volume: '12',
       times: '2',
       touchTip: false,
-      touchTipMmFromBottom: 9.54,  // where does this number come from?
+      touchTipMmFromBottom: 9.54, // where does this number come from?
       changeTip: 'always',
       blowoutLocation: null,
       pipette: 'pipetteId',
-      aspirateFlowRateUlSec: 5,  // make sure flow rates are numbers instead of strings
+      aspirateFlowRateUlSec: 5, // make sure flow rates are numbers instead of strings
       dispenseFlowRateUlSec: 4,
       blowoutFlowRateUlSec: 1000,
       aspirateOffsetFromBottomMm: 0.5,
@@ -101,7 +101,7 @@ describe('mix step form -> command creator args', () => {
       aspirateXOffset: 0,
       dispenseXOffset: 0,
       aspirateYOffset: 0,
-      dispenseYOffset: 0    
+      dispenseYOffset: 0,
     })
   })
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
@@ -83,7 +83,7 @@ describe('mix step form -> command creator args', () => {
       volume: '12',
       times: '2',
       touchTip: false,
-      touchTipMmFromBottom: 9.54, // where does this number come from?
+      touchTipMmFromBottom: 9.54,
       changeTip: 'always',
       blowoutLocation: null,
       pipette: 'pipetteId',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
@@ -22,8 +22,8 @@ beforeEach(() => {
   hydratedForm = {
     id: 'stepId',
     stepType: 'mix',
-    stepName: 'mix',
-    stepDetails: '',
+    stepName: 'Cool Mix Step',
+    stepDetails: 'Here we mix 2 wells',
     changeTip: 'always',
     labware: {
       id: 'labwareId',
@@ -72,6 +72,39 @@ afterEach(() => {
 })
 
 describe('mix step form -> command creator args', () => {
+  it('mixFormToArgs propagates form fields to MixStepArgs', () => {
+    const args = mixFormToArgs(hydratedForm)
+    expect(args).toMatchObject({
+      commandCreatorFnName: 'mix',
+      name: 'Cool Mix Step',  // make sure name and description are present
+      description: 'Here we mix 2 wells',
+      labware: 'labwareId',
+      wells: [ 'A1', 'A2' ],
+      volume: '12',
+      times: '2',
+      touchTip: false,
+      touchTipMmFromBottom: 9.54,  // where does this number come from?
+      changeTip: 'always',
+      blowoutLocation: null,
+      pipette: 'pipetteId',
+      aspirateFlowRateUlSec: 5,  // make sure flow rates are numbers instead of strings
+      dispenseFlowRateUlSec: 4,
+      blowoutFlowRateUlSec: 1000,
+      aspirateOffsetFromBottomMm: 0.5,
+      dispenseOffsetFromBottomMm: 0.5,
+      blowoutOffsetFromTopMm: 0,
+      aspirateDelaySeconds: null,
+      tipRack: 'mockTiprack',
+      dispenseDelaySeconds: null,
+      dropTipLocation: undefined,
+      nozzles: undefined,
+      aspirateXOffset: 0,
+      dispenseXOffset: 0,
+      aspirateYOffset: 0,
+      dispenseYOffset: 0    
+    })
+  })
+
   it('mixFormToArgs calls getOrderedWells correctly', () => {
     mixFormToArgs(hydratedForm)
 


### PR DESCRIPTION
# Overview

We were not filling in the `name` and `description` in the `MixStepArgs` with the data from the form, putting the dummy value `'description would be here 2018-03-01'` there instead. This was apparently a TODO left over from 2018.

Python generation is going to work off of the StepArgs, so I want all the data I need to be in the StepArgs.

## Test Plan and Hands on Testing

I added a unit test.

## Review requests

Could you look at the other `MixStepArgs` values in the unit test and see if they make sense? The other values are outside the scope of this PR, but I'm not sure where values like `touchTipMmFromBottom: 9.54` are coming from.

## Risk assessment

Should be low. I assume no one was using the `name` and `description` before, because they would notice the blatant placeholder values if they were.