### PR TITLE
feat(api,robot-server): use deck def v6 

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,4 +1,5 @@
 """ProtocolEngine-based Protocol API core implementation."""
+
 from __future__ import annotations
 from typing import Dict, Optional, Type, Union, List, Tuple, TYPE_CHECKING
 
@@ -7,7 +8,7 @@ from opentrons_shared_data.liquid_classes import LiquidClassDefinitionDoesNotExi
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine.commands import LoadModuleResult
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
+from opentrons_shared_data.deck.types import DeckDefinitionV6, SlotDefV3
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 from opentrons_shared_data import liquid_classes
@@ -759,7 +760,7 @@ class ProtocolCore(
 
         return labware_core
 
-    def get_deck_definition(self) -> DeckDefinitionV5:
+    def get_deck_definition(self) -> DeckDefinitionV6:
         """Get the geometry definition of the robot's deck."""
         return self._engine_client.state.labware.get_deck_definition()
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, List, Optional, Set, Union, cast, Tuple
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
+from opentrons_shared_data.deck.types import DeckDefinitionV6, SlotDefV3
 from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.robot.types import RobotType
@@ -525,7 +525,7 @@ class LegacyProtocolCore(
     ) -> Optional[LegacyLabwareCore]:
         assert False, "get_labware_on_labware only supported on engine core"
 
-    def get_deck_definition(self) -> DeckDefinitionV5:
+    def get_deck_definition(self) -> DeckDefinitionV6:
         """Get the geometry definition of the robot's deck."""
         assert False, "get_deck_definition only supported on engine core"
 

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 from typing import Generic, List, Optional, Union, Tuple, Dict, TYPE_CHECKING
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
+from opentrons_shared_data.deck.types import DeckDefinitionV6, SlotDefV3
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons_shared_data.robot.types import RobotType
@@ -220,7 +220,7 @@ class AbstractProtocol(
         ...
 
     @abstractmethod
-    def get_deck_definition(self) -> DeckDefinitionV5:
+    def get_deck_definition(self) -> DeckDefinitionV6:
         """Get the geometry definition of the robot's deck."""
 
     @abstractmethod

--- a/api/src/opentrons/protocol_engine/resources/deck_configuration_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_configuration_provider.py
@@ -1,7 +1,8 @@
 """Deck configuration resource provider."""
+
 from typing import List, Set, Tuple
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5, CutoutFixture
+from opentrons_shared_data.deck.types import DeckDefinitionV6, CutoutFixture
 
 from opentrons.types import DeckSlotName
 
@@ -20,7 +21,7 @@ from ..errors import (
 )
 
 
-def get_cutout_position(cutout_id: str, deck_definition: DeckDefinitionV5) -> DeckPoint:
+def get_cutout_position(cutout_id: str, deck_definition: DeckDefinitionV6) -> DeckPoint:
     """Get the base position of a cutout on the deck."""
     for cutout in deck_definition["locations"]["cutouts"]:
         if cutout_id == cutout["id"]:
@@ -31,7 +32,7 @@ def get_cutout_position(cutout_id: str, deck_definition: DeckDefinitionV5) -> De
 
 
 def get_cutout_fixture(
-    cutout_fixture_id: str, deck_definition: DeckDefinitionV5
+    cutout_fixture_id: str, deck_definition: DeckDefinitionV6
 ) -> CutoutFixture:
     """Gets cutout fixture from deck that matches the cutout fixture ID provided."""
     for cutout_fixture in deck_definition["cutoutFixtures"]:
@@ -43,7 +44,7 @@ def get_cutout_fixture(
 
 
 def get_provided_addressable_area_names(
-    cutout_fixture_id: str, cutout_id: str, deck_definition: DeckDefinitionV5
+    cutout_fixture_id: str, cutout_id: str, deck_definition: DeckDefinitionV6
 ) -> List[str]:
     """Gets a list of the addressable areas provided by the cutout fixture on the cutout."""
     cutout_fixture = get_cutout_fixture(cutout_fixture_id, deck_definition)
@@ -54,7 +55,7 @@ def get_provided_addressable_area_names(
 
 
 def get_addressable_area_display_name(
-    addressable_area_name: str, deck_definition: DeckDefinitionV5
+    addressable_area_name: str, deck_definition: DeckDefinitionV6
 ) -> str:
     """Get the display name for an addressable area name."""
     for addressable_area in deck_definition["locations"]["addressableAreas"]:
@@ -66,7 +67,7 @@ def get_addressable_area_display_name(
 
 
 def get_potential_cutout_fixtures(
-    addressable_area_name: str, deck_definition: DeckDefinitionV5
+    addressable_area_name: str, deck_definition: DeckDefinitionV6
 ) -> Tuple[str, Set[PotentialCutoutFixture]]:
     """Given an addressable area name, gets the cutout ID associated with it and a set of potential fixtures."""
     potential_fixtures = []
@@ -99,7 +100,7 @@ def get_addressable_area_from_name(
     addressable_area_name: str,
     cutout_position: DeckPoint,
     base_slot: DeckSlotName,
-    deck_definition: DeckDefinitionV5,
+    deck_definition: DeckDefinitionV6,
 ) -> AddressableArea:
     """Given a name and a cutout position, get an addressable area on the deck."""
     for addressable_area in deck_definition["locations"]["addressableAreas"]:

--- a/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
@@ -1,4 +1,5 @@
 """Deck data resource provider."""
+
 from dataclasses import dataclass
 from typing import List, Optional, cast
 from typing_extensions import final
@@ -9,7 +10,7 @@ from opentrons_shared_data.deck import (
     load as load_deck,
     DEFAULT_DECK_DEFINITION_VERSION,
 )
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons.types import DeckSlotName
 
@@ -44,10 +45,10 @@ class DeckDataProvider:
         self._deck_type = deck_type
         self._labware_data = labware_data or LabwareDataProvider()
 
-    async def get_deck_definition(self) -> DeckDefinitionV5:
+    async def get_deck_definition(self) -> DeckDefinitionV6:
         """Get a labware definition given the labware's identification."""
 
-        def sync() -> DeckDefinitionV5:
+        def sync() -> DeckDefinitionV6:
             return load_deck(
                 name=self._deck_type.value, version=DEFAULT_DECK_DEFINITION_VERSION
             )
@@ -57,7 +58,7 @@ class DeckDataProvider:
     async def get_deck_fixed_labware(
         self,
         load_fixed_trash: bool,
-        deck_definition: DeckDefinitionV5,
+        deck_definition: DeckDefinitionV6,
         deck_configuration: Optional[DeckConfigurationType] = None,
     ) -> List[DeckFixedLabware]:
         """Get a list of all labware fixtures from a given deck definition."""

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -1,11 +1,12 @@
 """Basic addressable area data state and store."""
+
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Dict, List, Optional, Set
 
 from opentrons_shared_data.robot.types import RobotType, RobotDefinition
 from opentrons_shared_data.deck.types import (
-    DeckDefinitionV5,
+    DeckDefinitionV6,
     SlotDefV3,
     CutoutFixture,
 )
@@ -53,7 +54,7 @@ class AddressableAreaState:
 
     potential_cutout_fixtures_by_cutout_id: Dict[str, Set[PotentialCutoutFixture]]
 
-    deck_definition: DeckDefinitionV5
+    deck_definition: DeckDefinitionV6
 
     deck_configuration: Optional[DeckConfigurationType]
     """The host robot's full deck configuration.
@@ -94,7 +95,7 @@ _FLEX_ORDERED_STAGING_SLOTS = ["D4", "C4", "B4", "A4"]
 def _get_conflicting_addressable_areas_error_string(
     potential_cutout_fixtures: Set[PotentialCutoutFixture],
     loaded_addressable_areas: Dict[str, AddressableArea],
-    deck_definition: DeckDefinitionV5,
+    deck_definition: DeckDefinitionV6,
 ) -> str:
     loaded_areas_on_cutout = set()
     for fixture in potential_cutout_fixtures:
@@ -158,7 +159,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
         self,
         deck_configuration: DeckConfigurationType,
         config: Config,
-        deck_definition: DeckDefinitionV5,
+        deck_definition: DeckDefinitionV6,
         robot_definition: RobotDefinition,
     ) -> None:
         """Initialize an addressable area store and its state."""
@@ -208,7 +209,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
 
     @staticmethod
     def _get_addressable_areas_from_deck_configuration(
-        deck_config: DeckConfigurationType, deck_definition: DeckDefinitionV5
+        deck_config: DeckConfigurationType, deck_definition: DeckDefinitionV6
     ) -> Dict[str, AddressableArea]:
         """Return all addressable areas provided by the given deck configuration."""
         addressable_areas = []

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1,4 +1,5 @@
 """Basic labware data state and store."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -17,7 +18,7 @@ from typing import (
 )
 
 from opentrons.protocol_engine.state import update_types
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.gripper.constants import LABWARE_GRIP_FORCE
 from opentrons_shared_data.labware.labware_definition import (
     InnerWellGeometry,
@@ -109,7 +110,7 @@ class LabwareState:
     labware_offsets_by_id: Dict[str, LabwareOffset]
 
     definitions_by_uri: Dict[str, LabwareDefinition]
-    deck_definition: DeckDefinitionV5
+    deck_definition: DeckDefinitionV6
 
 
 class LabwareStore(HasState[LabwareState], HandlesActions):
@@ -119,7 +120,7 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
 
     def __init__(
         self,
-        deck_definition: DeckDefinitionV5,
+        deck_definition: DeckDefinitionV6,
         deck_fixed_labware: Sequence[DeckFixedLabware],
     ) -> None:
         """Initialize a labware store and its state."""
@@ -418,7 +419,7 @@ class LabwareView:
             or self.get_definition(labware_id).metadata.displayName
         )
 
-    def get_deck_definition(self) -> DeckDefinitionV5:
+    def get_deck_definition(self) -> DeckDefinitionV6:
         """Get the current deck definition."""
         return self._state.deck_definition
 

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -1,11 +1,12 @@
 """Protocol engine state management."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Sequence, TypeVar
 from typing_extensions import ParamSpec
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.robot.types import RobotDefinition
 
 from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
@@ -177,7 +178,7 @@ class StateStore(StateView, ActionHandler):
         self,
         *,
         config: Config,
-        deck_definition: DeckDefinitionV5,
+        deck_definition: DeckDefinitionV6,
         deck_fixed_labware: Sequence[DeckFixedLabware],
         robot_definition: RobotDefinition,
         is_door_open: bool,

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -58,7 +58,7 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
 from opentrons_shared_data.deck.types import (
     RobotModel,
     DeckDefinitionV3,
-    DeckDefinitionV5,
+    DeckDefinitionV6,
 )
 from opentrons_shared_data.deck import (
     load as load_deck,
@@ -277,7 +277,7 @@ def deck_definition_name(robot_model: RobotModel) -> str:
 
 
 @pytest.fixture
-def deck_definition(deck_definition_name: str) -> DeckDefinitionV5:
+def deck_definition(deck_definition_name: str) -> DeckDefinitionV6:
     return load_deck(deck_definition_name, DEFAULT_DECK_DEFINITION_VERSION)
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -12,7 +12,7 @@ from decoy import Decoy
 
 from opentrons_shared_data.deck import load as load_deck
 from opentrons_shared_data.deck.types import (
-    DeckDefinitionV5,
+    DeckDefinitionV6,
     SlotDefV3,
 )
 from opentrons_shared_data.pipette.types import PipetteNameType
@@ -95,15 +95,15 @@ from ... import versions_below, versions_at_or_above
 
 
 @pytest.fixture(scope="session")
-def ot2_standard_deck_def() -> DeckDefinitionV5:
+def ot2_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT2_DECK, 5)
+    return load_deck(STANDARD_OT2_DECK, 6)
 
 
 @pytest.fixture(scope="session")
-def ot3_standard_deck_def() -> DeckDefinitionV5:
+def ot3_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT3_DECK, 5)
+    return load_deck(STANDARD_OT3_DECK, 6)
 
 
 @pytest.fixture(autouse=True)
@@ -199,7 +199,7 @@ def test_api_version(
 
 
 def test_get_slot_definition(
-    ot2_standard_deck_def: DeckDefinitionV5, subject: ProtocolCore, decoy: Decoy
+    ot2_standard_deck_def: DeckDefinitionV6, subject: ProtocolCore, decoy: Decoy
 ) -> None:
     """It should return a deck slot's definition."""
     expected_slot_def = cast(
@@ -1026,9 +1026,9 @@ def test_move_labware(
                 labwareId="labware-id",
                 newLocation=DeckSlotLocation(slotName=DeckSlotName.SLOT_5),
                 strategy=expected_strategy,
-                pickUpOffset=LabwareOffsetVector(x=4, y=5, z=6)
-                if pick_up_offset
-                else None,
+                pickUpOffset=(
+                    LabwareOffsetVector(x=4, y=5, z=6) if pick_up_offset else None
+                ),
                 dropOffset=LabwareOffsetVector(x=4, y=5, z=6) if drop_offset else None,
             )
         ),
@@ -1712,7 +1712,7 @@ def test_get_deck_definition(
     decoy: Decoy, mock_engine_client: EngineClient, subject: ProtocolCore
 ) -> None:
     """It should return the loaded deck definition from engine state."""
-    deck_definition = cast(DeckDefinitionV5, {"schemaVersion": "5"})
+    deck_definition = cast(DeckDefinitionV6, {"schemaVersion": "6"})
 
     decoy.when(mock_engine_client.state.labware.get_deck_definition()).then_return(
         deck_definition

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -1,11 +1,12 @@
 """Tests for opentrons.legacy.Deck."""
+
 import inspect
 from typing import cast, Dict
 
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
+from opentrons_shared_data.deck.types import DeckDefinitionV6, SlotDefV3
 
 from opentrons.motion_planning import adjacent_slots_getters as mock_adjacent_slots
 from opentrons.protocols.api_support.types import APIVersion
@@ -23,10 +24,10 @@ from opentrons.types import DeckSlotName, Point
 
 
 @pytest.fixture
-def deck_definition() -> DeckDefinitionV5:
+def deck_definition() -> DeckDefinitionV6:
     """Get a deck definition value object."""
     return cast(
-        DeckDefinitionV5,
+        DeckDefinitionV6,
         {
             "locations": {"addressableAreas": [], "calibrationPoints": []},
             "cutoutFixtures": {},
@@ -81,7 +82,7 @@ def staging_slot_definitions_by_name() -> Dict[str, SlotDefV3]:
 @pytest.fixture
 def subject(
     decoy: Decoy,
-    deck_definition: DeckDefinitionV5,
+    deck_definition: DeckDefinitionV6,
     mock_protocol_core: ProtocolCore,
     mock_core_map: LoadedCoreMap,
     api_version: APIVersion,

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -1,4 +1,5 @@
 """Test load module command."""
+
 from typing import cast
 from unittest.mock import sentinel
 
@@ -33,7 +34,7 @@ from opentrons.hardware_control.modules.types import (
     HeaterShakerModuleModel,
 )
 from opentrons_shared_data.deck.types import (
-    DeckDefinitionV5,
+    DeckDefinitionV6,
     SlotDefV3,
 )
 from opentrons_shared_data.deck import load as load_deck
@@ -58,7 +59,7 @@ async def test_load_module_implementation(
         moduleId="some-id",
     )
 
-    deck_def = load_deck(STANDARD_OT3_DECK, 5)
+    deck_def = load_deck(STANDARD_OT3_DECK, 6)
 
     decoy.when(state_view.labware.get_deck_definition()).then_return(deck_def)
     decoy.when(
@@ -130,7 +131,7 @@ async def test_load_module_implementation_mag_block(
         moduleId="some-id",
     )
 
-    deck_def = load_deck(STANDARD_OT3_DECK, 5)
+    deck_def = load_deck(STANDARD_OT3_DECK, 6)
 
     decoy.when(state_view.labware.get_deck_definition()).then_return(deck_def)
     decoy.when(
@@ -202,7 +203,7 @@ async def test_load_module_implementation_abs_reader(
         moduleId="some-id",
     )
 
-    deck_def = load_deck(STANDARD_OT3_DECK, 5)
+    deck_def = load_deck(STANDARD_OT3_DECK, 6)
 
     decoy.when(state_view.labware.get_deck_definition()).then_return(deck_def)
     decoy.when(
@@ -268,7 +269,7 @@ async def test_load_module_raises_if_location_occupied(
         moduleId="some-id",
     )
 
-    deck_def = load_deck(STANDARD_OT3_DECK, 5)
+    deck_def = load_deck(STANDARD_OT3_DECK, 6)
 
     decoy.when(state_view.labware.get_deck_definition()).then_return(deck_def)
     decoy.when(
@@ -299,28 +300,28 @@ async def test_load_module_raises_if_location_occupied(
         (
             TemperatureModuleModel.TEMPERATURE_V2,
             EngineModuleModel.TEMPERATURE_MODULE_V2,
-            load_deck(STANDARD_OT3_DECK, 5),
+            load_deck(STANDARD_OT3_DECK, 6),
             DeckSlotName.SLOT_D2,
             "OT-3 Standard",
         ),
         (
             ThermocyclerModuleModel.THERMOCYCLER_V1,
             EngineModuleModel.THERMOCYCLER_MODULE_V1,
-            load_deck(STANDARD_OT2_DECK, 5),
+            load_deck(STANDARD_OT2_DECK, 6),
             DeckSlotName.SLOT_1,
             "OT-2 Standard",
         ),
         (
             ThermocyclerModuleModel.THERMOCYCLER_V2,
             EngineModuleModel.THERMOCYCLER_MODULE_V2,
-            load_deck(STANDARD_OT3_DECK, 5),
+            load_deck(STANDARD_OT3_DECK, 6),
             DeckSlotName.SLOT_A2,
             "OT-3 Standard",
         ),
         (
             HeaterShakerModuleModel.HEATER_SHAKER_V1,
             EngineModuleModel.HEATER_SHAKER_MODULE_V1,
-            load_deck(STANDARD_OT3_DECK, 5),
+            load_deck(STANDARD_OT3_DECK, 6),
             DeckSlotName.SLOT_A2,
             "OT-3 Standard",
         ),
@@ -332,7 +333,7 @@ async def test_load_module_raises_wrong_location(
     state_view: StateView,
     requested_model: HardwareModuleModel,
     engine_model: EngineModuleModel,
-    deck_def: DeckDefinitionV5,
+    deck_def: DeckDefinitionV6,
     slot_name: DeckSlotName,
     robot_type: RobotType,
 ) -> None:
@@ -376,7 +377,7 @@ async def test_load_module_raises_wrong_location(
         (
             MagneticModuleModel.MAGNETIC_V2,
             EngineModuleModel.MAGNETIC_MODULE_V2,
-            load_deck(STANDARD_OT3_DECK, 5),
+            load_deck(STANDARD_OT3_DECK, 6),
             DeckSlotName.SLOT_A2,
             "OT-3 Standard",
         ),
@@ -388,7 +389,7 @@ async def test_load_module_raises_module_fixture_id_does_not_exist(
     state_view: StateView,
     requested_model: HardwareModuleModel,
     engine_model: EngineModuleModel,
-    deck_def: DeckDefinitionV5,
+    deck_def: DeckDefinitionV6,
     slot_name: DeckSlotName,
     robot_type: RobotType,
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -1,4 +1,5 @@
 """ProtocolEngine shared test fixtures."""
+
 from __future__ import annotations
 
 import pytest
@@ -7,7 +8,7 @@ from decoy import Decoy
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.labware import load_definition
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.pipette import pipette_definition
@@ -58,21 +59,21 @@ def ot3_hardware_api(decoy: Decoy) -> OT3API:
 
 
 @pytest.fixture(scope="session")
-def ot2_standard_deck_def() -> DeckDefinitionV5:
+def ot2_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT2_DECK, 5)
+    return load_deck(STANDARD_OT2_DECK, 6)
 
 
 @pytest.fixture(scope="session")
-def ot2_short_trash_deck_def() -> DeckDefinitionV5:
+def ot2_short_trash_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 short-trash deck definition."""
-    return load_deck(SHORT_TRASH_DECK, 5)
+    return load_deck(SHORT_TRASH_DECK, 6)
 
 
 @pytest.fixture(scope="session")
-def ot3_standard_deck_def() -> DeckDefinitionV5:
+def ot3_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT3_DECK, 5)
+    return load_deck(STANDARD_OT3_DECK, 6)
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
@@ -1,11 +1,12 @@
 """Test deck configuration provider."""
+
 from typing import List, Set
 
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 
 from opentrons.types import DeckSlotName
 
@@ -32,21 +33,21 @@ from opentrons.protocol_engine.resources import deck_configuration_provider as s
 
 
 @pytest.fixture(scope="session")
-def ot2_standard_deck_def() -> DeckDefinitionV5:
+def ot2_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT2_DECK, 5)
+    return load_deck(STANDARD_OT2_DECK, 6)
 
 
 @pytest.fixture(scope="session")
-def ot2_short_trash_deck_def() -> DeckDefinitionV5:
+def ot2_short_trash_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(SHORT_TRASH_DECK, 5)
+    return load_deck(SHORT_TRASH_DECK, 6)
 
 
 @pytest.fixture(scope="session")
-def ot3_standard_deck_def() -> DeckDefinitionV5:
+def ot3_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT3_DECK, 5)
+    return load_deck(STANDARD_OT3_DECK, 6)
 
 
 @pytest.mark.parametrize(
@@ -72,7 +73,7 @@ def ot3_standard_deck_def() -> DeckDefinitionV5:
 def test_get_cutout_position(
     cutout_id: str,
     expected_deck_point: DeckPoint,
-    deck_def: DeckDefinitionV5,
+    deck_def: DeckDefinitionV6,
 ) -> None:
     """It should get the deck position for the requested cutout id."""
     cutout_position = subject.get_cutout_position(cutout_id, deck_def)
@@ -80,7 +81,7 @@ def test_get_cutout_position(
 
 
 def test_get_cutout_position_raises(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
 ) -> None:
     """It should raise if there is no cutout with that ID in the deck definition."""
     with pytest.raises(CutoutDoesNotExistError):
@@ -106,7 +107,7 @@ def test_get_cutout_position_raises(
 def test_get_cutout_fixture(
     cutout_fixture_id: str,
     expected_display_name: str,
-    deck_def: DeckDefinitionV5,
+    deck_def: DeckDefinitionV6,
 ) -> None:
     """It should get the cutout fixture given the cutout fixture id."""
     cutout_fixture = subject.get_cutout_fixture(cutout_fixture_id, deck_def)
@@ -114,7 +115,7 @@ def test_get_cutout_fixture(
 
 
 def test_get_cutout_fixture_raises(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
 ) -> None:
     """It should raise if the given cutout fixture id does not exist."""
     with pytest.raises(FixtureDoesNotExistError):
@@ -148,7 +149,7 @@ def test_get_provided_addressable_area_names(
     cutout_fixture_id: str,
     cutout_id: str,
     expected_areas: List[str],
-    deck_def: DeckDefinitionV5,
+    deck_def: DeckDefinitionV6,
 ) -> None:
     """It should get the provided addressable area for the cutout fixture and cutout."""
     provided_addressable_areas = subject.get_provided_addressable_area_names(
@@ -217,7 +218,7 @@ def test_get_potential_cutout_fixtures(
     addressable_area_name: str,
     expected_cutout_id: str,
     expected_potential_fixtures: Set[PotentialCutoutFixture],
-    deck_def: DeckDefinitionV5,
+    deck_def: DeckDefinitionV6,
 ) -> None:
     """It should get a cutout id and a set of potential cutout fixtures for an addressable area name."""
     cutout_id, potential_fixtures = subject.get_potential_cutout_fixtures(
@@ -228,7 +229,7 @@ def test_get_potential_cutout_fixtures(
 
 
 def test_get_potential_cutout_fixtures_raises(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
 ) -> None:
     """It should raise if there is no fixtures that provide the requested area."""
     with pytest.raises(AddressableAreaDoesNotExistError):
@@ -317,7 +318,7 @@ def test_get_potential_cutout_fixtures_raises(
 def test_get_addressable_area_from_name(
     addressable_area_name: str,
     expected_addressable_area: AddressableArea,
-    deck_def: DeckDefinitionV5,
+    deck_def: DeckDefinitionV6,
 ) -> None:
     """It should get the deck position for the requested cutout id."""
     addressable_area = subject.get_addressable_area_from_name(
@@ -327,7 +328,7 @@ def test_get_addressable_area_from_name(
 
 
 def test_get_addressable_area_from_name_raises(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
 ) -> None:
     """It should raise if there is no addressable area by that name in the deck."""
     with pytest.raises(AddressableAreaDoesNotExistError):

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
@@ -1,9 +1,10 @@
 """Test deck data provider."""
+
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from decoy import Decoy
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons.types import DeckSlotName
 
@@ -34,7 +35,7 @@ def mock_labware_data_provider(decoy: Decoy) -> LabwareDataProvider:
 )
 async def test_get_deck_definition(
     deck_type: DeckType,
-    expected_definition: DeckDefinitionV5,
+    expected_definition: DeckDefinitionV6,
     mock_labware_data_provider: LabwareDataProvider,
 ) -> None:
     """It should be able to load the correct deck definition."""
@@ -47,7 +48,7 @@ async def test_get_deck_definition(
 
 async def test_get_deck_labware_fixtures_ot2_standard(
     decoy: Decoy,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     ot2_fixed_trash_def: LabwareDefinition,
     mock_labware_data_provider: LabwareDataProvider,
 ) -> None:
@@ -77,7 +78,7 @@ async def test_get_deck_labware_fixtures_ot2_standard(
 
 async def test_get_deck_labware_fixtures_ot2_short_trash(
     decoy: Decoy,
-    ot2_short_trash_deck_def: DeckDefinitionV5,
+    ot2_short_trash_deck_def: DeckDefinitionV6,
     ot2_short_fixed_trash_def: LabwareDefinition,
     mock_labware_data_provider: LabwareDataProvider,
 ) -> None:
@@ -107,7 +108,7 @@ async def test_get_deck_labware_fixtures_ot2_short_trash(
 
 async def test_get_deck_labware_fixtures_ot3_standard(
     decoy: Decoy,
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
     ot3_fixed_trash_def: LabwareDefinition,
     mock_labware_data_provider: LabwareDataProvider,
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_state.py
@@ -4,7 +4,7 @@ The trifecta is tested here as a single unit, treating AddressableAreaState as a
 implementation detail.
 """
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 
 from opentrons.protocol_engine.actions.actions import SetDeckConfigurationAction
 from opentrons.protocol_engine.state.addressable_areas import (
@@ -16,7 +16,7 @@ from opentrons.protocol_engine.types import DeckType
 
 
 def test_deck_configuration_setting(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
 ) -> None:
     """You should be able to set the deck configuration with a SetDeckConfigurationAction."""
     subject = AddressableAreaStore(

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store_old.py
@@ -7,7 +7,7 @@ tested together, treating AddressableAreaState as a private implementation detai
 
 import pytest
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 
 from opentrons.protocol_engine.commands import Command, Comment
 from opentrons.protocol_engine.actions import (
@@ -50,7 +50,7 @@ def _dummy_command() -> Command:
 
 @pytest.fixture
 def simulated_subject(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
 ) -> AddressableAreaStore:
     """Get an AddressableAreaStore test subject, under simulated deck conditions."""
     return AddressableAreaStore(
@@ -83,7 +83,7 @@ def simulated_subject(
 
 @pytest.fixture
 def subject(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
 ) -> AddressableAreaStore:
     """Get an AddressableAreaStore test subject."""
     return AddressableAreaStore(
@@ -115,7 +115,7 @@ def subject(
 
 
 def test_initial_state_simulated(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
     simulated_subject: AddressableAreaStore,
 ) -> None:
     """It should create the Addressable Area store with no loaded addressable areas."""
@@ -147,7 +147,7 @@ def test_initial_state_simulated(
 
 
 def test_initial_state(
-    ot3_standard_deck_def: DeckDefinitionV5,
+    ot3_standard_deck_def: DeckDefinitionV6,
     subject: AddressableAreaStore,
 ) -> None:
     """It should create the Addressable Area store with loaded addressable areas."""

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_view_old.py
@@ -13,7 +13,7 @@ from decoy import Decoy
 from typing import Dict, Set, Optional, cast
 
 from opentrons_shared_data.robot.types import RobotType
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons.types import Point, DeckSlotName
 
 from opentrons.protocol_engine.errors import (
@@ -54,7 +54,7 @@ def get_addressable_area_view(
     potential_cutout_fixtures_by_cutout_id: Optional[
         Dict[str, Set[PotentialCutoutFixture]]
     ] = None,
-    deck_definition: Optional[DeckDefinitionV5] = None,
+    deck_definition: Optional[DeckDefinitionV6] = None,
     deck_configuration: Optional[DeckConfigurationType] = None,
     robot_type: RobotType = "OT-3 Standard",
     use_simulated_deck_config: bool = False,
@@ -64,7 +64,7 @@ def get_addressable_area_view(
         loaded_addressable_areas_by_name=loaded_addressable_areas_by_name or {},
         potential_cutout_fixtures_by_cutout_id=potential_cutout_fixtures_by_cutout_id
         or {},
-        deck_definition=deck_definition or cast(DeckDefinitionV5, {"otId": "fake"}),
+        deck_definition=deck_definition or cast(DeckDefinitionV6, {"otId": "fake"}),
         robot_definition={
             "displayName": "OT-3",
             "robotType": "OT-3 Standard",
@@ -399,7 +399,7 @@ def test_get_slot_definition() -> None:
 
 def test_get_slot_definition_raises_with_bad_slot_name(decoy: Decoy) -> None:
     """It should raise a SlotDoesNotExistError if a bad slot name is given."""
-    deck_definition = cast(DeckDefinitionV5, {"otId": "fake"})
+    deck_definition = cast(DeckDefinitionV6, {"otId": "fake"})
     subject = get_addressable_area_view(
         deck_definition=deck_definition,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -17,7 +17,7 @@ from opentrons.protocol_engine.state.update_types import (
 )
 
 from opentrons_shared_data import get_shared_data_root, load_shared_data
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.deck import load as load_deck
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.types import LabwareUri
@@ -157,9 +157,9 @@ def use_mocks() -> bool:
 
 
 @pytest.fixture
-def deck_definition(state_config: Config) -> DeckDefinitionV5:
+def deck_definition(state_config: Config) -> DeckDefinitionV6:
     """Override as parameter to use a non-flex deck def."""
-    return load_deck(name=state_config.deck_type.value, version=5)
+    return load_deck(name=state_config.deck_type.value, version=6)
 
 
 @pytest.fixture
@@ -172,7 +172,7 @@ def state_config() -> Config:
 
 
 @pytest.fixture
-def labware_store(deck_definition: DeckDefinitionV5) -> LabwareStore:
+def labware_store(deck_definition: DeckDefinitionV6) -> LabwareStore:
     """Get a labware store that can accept actions."""
     return LabwareStore(deck_definition=deck_definition, deck_fixed_labware=[])
 
@@ -223,7 +223,7 @@ def pipette_view(pipette_store: PipetteStore) -> PipetteView:
 
 @pytest.fixture
 def addressable_area_store(
-    state_config: Config, deck_definition: DeckDefinitionV5
+    state_config: Config, deck_definition: DeckDefinitionV6
 ) -> AddressableAreaStore:
     """Get an addressable area store that can accept actions."""
     return AddressableAreaStore(
@@ -315,9 +315,9 @@ def subject(
         well_view=mock_well_view if use_mocks else well_view,
         module_view=mock_module_view if use_mocks else module_view,
         pipette_view=mock_pipette_view if use_mocks else pipette_view,
-        addressable_area_view=mock_addressable_area_view
-        if use_mocks
-        else addressable_area_view,
+        addressable_area_view=(
+            mock_addressable_area_view if use_mocks else addressable_area_view
+        ),
     )
 
 
@@ -368,7 +368,7 @@ def test_get_labware_parent_position_on_module(
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     subject: GeometryView,
 ) -> None:
     """It should return a module position for labware on a module."""
@@ -427,7 +427,7 @@ def test_get_labware_parent_position_on_labware(
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     subject: GeometryView,
 ) -> None:
     """It should return a labware position for labware on a labware on a module."""
@@ -504,7 +504,7 @@ def test_module_calibration_offset_rotation(
     decoy: Decoy,
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     subject: GeometryView,
 ) -> None:
     """Return the rotated module calibration offset if the module was moved from one side of the deck to the other."""
@@ -633,7 +633,7 @@ def test_get_module_labware_highest_z(
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     subject: GeometryView,
 ) -> None:
     """It should get the absolute location of a labware's highest Z point."""
@@ -939,7 +939,7 @@ def test_get_highest_z_in_slot_with_single_module(
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
     subject: GeometryView,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
 ) -> None:
     """It should get the highest Z in slot with just a single module."""
     # Case: Slot has a module that doesn't have any labware on it. Highest z is equal to module height.
@@ -1078,7 +1078,7 @@ def test_get_highest_z_in_slot_with_labware_stack_on_module(
     mock_addressable_area_view: AddressableAreaView,
     subject: GeometryView,
     well_plate_def: LabwareDefinition,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
 ) -> None:
     """It should get the highest z in slot of labware on module.
 
@@ -1333,7 +1333,7 @@ def test_get_module_labware_well_position(
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     subject: GeometryView,
 ) -> None:
     """It should be able to get the position of a well top in a labware on module."""
@@ -2356,7 +2356,7 @@ def test_get_labware_grip_point_for_labware_on_module(
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     subject: GeometryView,
 ) -> None:
     """It should return the grip point for labware directly on a module."""

--- a/api/tests/opentrons/protocol_engine/state/test_labware_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_store_old.py
@@ -4,6 +4,7 @@ DEPRECATED: Testing LabwareStore independently of LabwareView is no
 longer helpful. Try to add new tests to test_labware_state.py, where they can be
 tested together, treating LabwareState as a private implementation detail.
 """
+
 from typing import Optional
 from opentrons.protocol_engine.state import update_types
 import pytest
@@ -11,7 +12,7 @@ import pytest
 from datetime import datetime
 
 from opentrons.calibration_storage.helpers import uri_from_details
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons.types import DeckSlotName
 
@@ -38,7 +39,7 @@ from .command_fixtures import (
 
 @pytest.fixture
 def subject(
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
 ) -> LabwareStore:
     """Get a LabwareStore test subject."""
     return LabwareStore(
@@ -48,7 +49,7 @@ def subject(
 
 
 def test_initial_state(
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     subject: LabwareStore,
 ) -> None:
     """It should create the labware store with preloaded fixed labware."""

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -4,13 +4,14 @@ DEPRECATED: Testing LabwareView independently of LabwareStore is no
 longer helpful. Try to add new tests to test_labware_state.py, where they can be
 tested together, treating LabwareState as a private implementation detail.
 """
+
 import pytest
 from datetime import datetime
 from typing import Dict, Optional, cast, ContextManager, Any, Union, NamedTuple, List
 from contextlib import nullcontext as does_not_raise
 
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.pipette.types import LabwareUri
 from opentrons_shared_data.labware import load_definition
 from opentrons_shared_data.labware.labware_definition import (
@@ -115,14 +116,14 @@ def get_labware_view(
     labware_by_id: Optional[Dict[str, LoadedLabware]] = None,
     labware_offsets_by_id: Optional[Dict[str, LabwareOffset]] = None,
     definitions_by_uri: Optional[Dict[str, LabwareDefinition]] = None,
-    deck_definition: Optional[DeckDefinitionV5] = None,
+    deck_definition: Optional[DeckDefinitionV6] = None,
 ) -> LabwareView:
     """Get a labware view test subject."""
     state = LabwareState(
         labware_by_id=labware_by_id or {},
         labware_offsets_by_id=labware_offsets_by_id or {},
         definitions_by_uri=definitions_by_uri or {},
-        deck_definition=deck_definition or cast(DeckDefinitionV5, {"fake": True}),
+        deck_definition=deck_definition or cast(DeckDefinitionV6, {"fake": True}),
     )
 
     return LabwareView(state=state)
@@ -707,7 +708,7 @@ def test_get_labware_overlap_offsets() -> None:
 class ModuleOverlapSpec(NamedTuple):
     """Spec data to test LabwareView.get_module_overlap_offsets."""
 
-    spec_deck_definition: DeckDefinitionV5
+    spec_deck_definition: DeckDefinitionV6
     module_model: ModuleModel
     stacking_offset_with_module: Dict[str, SharedDataOverlapOffset]
     expected_offset: OverlapOffset
@@ -716,7 +717,7 @@ class ModuleOverlapSpec(NamedTuple):
 module_overlap_specs: List[ModuleOverlapSpec] = [
     ModuleOverlapSpec(
         # Labware on temp module on OT2, with stacking overlap for temp module
-        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
+        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 6),
         module_model=ModuleModel.TEMPERATURE_MODULE_V2,
         stacking_offset_with_module={
             str(ModuleModel.TEMPERATURE_MODULE_V2.value): SharedDataOverlapOffset(
@@ -727,7 +728,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
     ),
     ModuleOverlapSpec(
         # Labware on TC Gen1 on OT2, with stacking overlap for TC Gen1
-        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
+        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 6),
         module_model=ModuleModel.THERMOCYCLER_MODULE_V1,
         stacking_offset_with_module={
             str(ModuleModel.THERMOCYCLER_MODULE_V1.value): SharedDataOverlapOffset(
@@ -738,21 +739,21 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
     ),
     ModuleOverlapSpec(
         # Labware on TC Gen2 on OT2, with no stacking overlap
-        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
+        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 6),
         module_model=ModuleModel.THERMOCYCLER_MODULE_V2,
         stacking_offset_with_module={},
         expected_offset=OverlapOffset(x=0, y=0, z=10.7),
     ),
     ModuleOverlapSpec(
         # Labware on TC Gen2 on Flex, with no stacking overlap
-        spec_deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        spec_deck_definition=load_deck(STANDARD_OT3_DECK, 6),
         module_model=ModuleModel.THERMOCYCLER_MODULE_V2,
         stacking_offset_with_module={},
         expected_offset=OverlapOffset(x=0, y=0, z=0),
     ),
     ModuleOverlapSpec(
         # Labware on TC Gen2 on Flex, with stacking overlap for TC Gen2
-        spec_deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        spec_deck_definition=load_deck(STANDARD_OT3_DECK, 6),
         module_model=ModuleModel.THERMOCYCLER_MODULE_V2,
         stacking_offset_with_module={
             str(ModuleModel.THERMOCYCLER_MODULE_V2.value): SharedDataOverlapOffset(
@@ -769,7 +770,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
     argvalues=module_overlap_specs,
 )
 def test_get_module_overlap_offsets(
-    spec_deck_definition: DeckDefinitionV5,
+    spec_deck_definition: DeckDefinitionV6,
     module_model: ModuleModel,
     stacking_offset_with_module: Dict[str, SharedDataOverlapOffset],
     expected_offset: OverlapOffset,
@@ -808,7 +809,7 @@ def test_get_default_magnet_height(
     assert subject.get_default_magnet_height(module_id="module-id", offset=2) == 12.0
 
 
-def test_get_deck_definition(ot2_standard_deck_def: DeckDefinitionV5) -> None:
+def test_get_deck_definition(ot2_standard_deck_def: DeckDefinitionV6) -> None:
     """It should get the deck definition from the state."""
     subject = get_labware_view(deck_definition=ot2_standard_deck_def)
 
@@ -1495,7 +1496,7 @@ def test_labware_stacking_height_passes_or_raises(
         )
 
 
-def test_get_deck_gripper_offsets(ot3_standard_deck_def: DeckDefinitionV5) -> None:
+def test_get_deck_gripper_offsets(ot3_standard_deck_def: DeckDefinitionV6) -> None:
     """It should get the deck's gripper offsets."""
     subject = get_labware_view(deck_definition=ot3_standard_deck_def)
 

--- a/api/tests/opentrons/protocol_engine/state/test_module_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store_old.py
@@ -4,13 +4,14 @@ DEPRECATED: Testing ModuleStore independently of ModuleView is no longer helpful
 Try to add new tests to test_module_state.py, where they can be tested together,
 treating ModuleState as a private implementation detail.
 """
+
 from typing import List, Set, cast, Dict, Optional
 
 import pytest
 
 from opentrons.protocol_engine.state import update_types
 from opentrons_shared_data.robot.types import RobotType
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
 from opentrons.types import DeckSlotName
@@ -71,7 +72,7 @@ def get_addressable_area_view(
     potential_cutout_fixtures_by_cutout_id: Optional[
         Dict[str, Set[PotentialCutoutFixture]]
     ] = None,
-    deck_definition: Optional[DeckDefinitionV5] = None,
+    deck_definition: Optional[DeckDefinitionV6] = None,
     deck_configuration: Optional[DeckConfigurationType] = None,
     robot_type: RobotType = "OT-3 Standard",
     use_simulated_deck_config: bool = False,
@@ -81,7 +82,7 @@ def get_addressable_area_view(
         loaded_addressable_areas_by_name=loaded_addressable_areas_by_name or {},
         potential_cutout_fixtures_by_cutout_id=potential_cutout_fixtures_by_cutout_id
         or {},
-        deck_definition=deck_definition or cast(DeckDefinitionV5, {"otId": "fake"}),
+        deck_definition=deck_definition or cast(DeckDefinitionV6, {"otId": "fake"}),
         deck_configuration=deck_configuration or [],
         robot_definition={
             "displayName": "OT-3",

--- a/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
@@ -4,6 +4,7 @@ DEPRECATED: Testing ModuleView independently of ModuleView is no longer helpful.
 Try to add new tests to test_module_state.py, where they can be tested together,
 treating ModuleState as a private implementation detail.
 """
+
 import pytest
 from math import isclose
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
@@ -23,7 +24,7 @@ from typing import (
 )
 
 from opentrons_shared_data.robot.types import RobotType
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 
 from opentrons_shared_data import load_shared_data
 from opentrons.types import DeckSlotName, MountType
@@ -70,9 +71,9 @@ from opentrons.protocols.api_support.deck_type import (
 
 
 @pytest.fixture(scope="session")
-def ot3_standard_deck_def() -> DeckDefinitionV5:
+def ot3_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT3_DECK, 5)
+    return load_deck(STANDARD_OT3_DECK, 6)
 
 
 def get_addressable_area_view(
@@ -80,7 +81,7 @@ def get_addressable_area_view(
     potential_cutout_fixtures_by_cutout_id: Optional[
         Dict[str, Set[PotentialCutoutFixture]]
     ] = None,
-    deck_definition: Optional[DeckDefinitionV5] = None,
+    deck_definition: Optional[DeckDefinitionV6] = None,
     deck_configuration: Optional[DeckConfigurationType] = None,
     robot_type: RobotType = "OT-3 Standard",
     use_simulated_deck_config: bool = False,
@@ -90,7 +91,7 @@ def get_addressable_area_view(
         loaded_addressable_areas_by_name=loaded_addressable_areas_by_name or {},
         potential_cutout_fixtures_by_cutout_id=potential_cutout_fixtures_by_cutout_id
         or {},
-        deck_definition=deck_definition or cast(DeckDefinitionV5, {"otId": "fake"}),
+        deck_definition=deck_definition or cast(DeckDefinitionV6, {"otId": "fake"}),
         deck_configuration=deck_configuration or [],
         robot_definition={
             "displayName": "OT-3",
@@ -461,7 +462,7 @@ def test_get_module_offset_for_ot3_standard(
     module_def: ModuleDefinition,
     slot: DeckSlotName,
     expected_offset: LabwareOffsetVector,
-    deck_definition: DeckDefinitionV5,
+    deck_definition: DeckDefinitionV6,
 ) -> None:
     """It should return the correct labware offset for module in specified slot."""
     subject = make_module_view(
@@ -1885,7 +1886,7 @@ def test_get_module_highest_z(
     deck_type: DeckType,
     slot_name: DeckSlotName,
     expected_highest_z: float,
-    deck_definition: DeckDefinitionV5,
+    deck_definition: DeckDefinitionV6,
 ) -> None:
     """It should get the highest z point of the module."""
     subject = make_module_view(

--- a/api/tests/opentrons/protocol_engine/state/test_state_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_state_store.py
@@ -1,11 +1,12 @@
 """Tests for the top-level StateStore/StateView."""
+
 from typing import Any, Callable, Union
 from datetime import datetime
 
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons.util.change_notifier import ChangeNotifier
 
 from opentrons.protocol_engine.actions import PlayAction
@@ -33,7 +34,7 @@ def engine_config() -> Config:
 @pytest.fixture
 def subject(
     change_notifier: ChangeNotifier,
-    ot2_standard_deck_def: DeckDefinitionV5,
+    ot2_standard_deck_def: DeckDefinitionV6,
     engine_config: Config,
 ) -> StateStore:
     """Get a StateStore test subject."""

--- a/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
@@ -1,9 +1,10 @@
 """Smoke tests for the ProtocolEngine creation factory."""
+
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.robot.types import RobotType
 
@@ -29,21 +30,21 @@ from opentrons.protocols.api_support.deck_type import (
 
 
 @pytest.fixture(scope="session")
-def ot2_standard_deck_def() -> DeckDefinitionV5:
+def ot2_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT2_DECK, 5)
+    return load_deck(STANDARD_OT2_DECK, 6)
 
 
 @pytest.fixture(scope="session")
-def ot2_short_trash_deck_def() -> DeckDefinitionV5:
+def ot2_short_trash_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 with short trash standard deck definition."""
-    return load_deck(SHORT_TRASH_DECK, 5)
+    return load_deck(SHORT_TRASH_DECK, 6)
 
 
 @pytest.fixture(scope="session")
-def ot3_standard_deck_def() -> DeckDefinitionV5:
+def ot3_standard_deck_def() -> DeckDefinitionV6:
     """Get the OT-2 standard deck definition."""
-    return load_deck(STANDARD_OT3_DECK, 5)
+    return load_deck(STANDARD_OT3_DECK, 6)
 
 
 @pytest.mark.parametrize(
@@ -74,7 +75,7 @@ async def test_create_engine_initializes_state_with_no_fixed_trash(
     hardware_api: HardwareAPI,
     robot_type: RobotType,
     deck_type: DeckType,
-    expected_deck_def: DeckDefinitionV5,
+    expected_deck_def: DeckDefinitionV6,
 ) -> None:
     """It should load deck geometry data into the store on create."""
     engine = await create_protocol_engine(
@@ -130,7 +131,7 @@ async def test_create_engine_initializes_state_with_fixed_trash(
     hardware_api: HardwareAPI,
     robot_type: RobotType,
     deck_type: DeckType,
-    expected_deck_def: DeckDefinitionV5,
+    expected_deck_def: DeckDefinitionV6,
     expected_fixed_trash_def: LabwareDefinition,
     expected_fixed_trash_slot: DeckSlotName,
 ) -> None:

--- a/robot-server/robot_server/deck_configuration/router.py
+++ b/robot-server/robot_server/deck_configuration/router.py
@@ -1,6 +1,5 @@
 """The HTTP API for getting and setting the robot's current deck configuration."""
 
-
 from datetime import datetime
 from typing import Annotated, Union
 
@@ -8,7 +7,7 @@ import fastapi
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 from server_utils.fastapi_utils.light_router import LightRouter
 
-from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV6
 
 from robot_server.errors.error_responses import ErrorBody
 from robot_server.hardware import get_deck_definition
@@ -67,7 +66,7 @@ async def put_deck_configuration(  # noqa: D103
         DeckConfigurationStore, fastapi.Depends(get_deck_configuration_store)
     ],
     now: Annotated[datetime, fastapi.Depends(get_current_time)],
-    deck_definition: Annotated[DeckDefinitionV5, fastapi.Depends(get_deck_definition)],
+    deck_definition: Annotated[DeckDefinitionV6, fastapi.Depends(get_deck_definition)],
 ) -> PydanticResponse[
     Union[
         SimpleBody[models.DeckConfigurationResponse],

--- a/robot-server/robot_server/deck_configuration/validation.py
+++ b/robot-server/robot_server/deck_configuration/validation.py
@@ -1,6 +1,5 @@
 """Validate a deck configuration."""
 
-
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import DefaultDict, FrozenSet, List, Set, Tuple, Union, Optional
@@ -88,7 +87,7 @@ ConfigurationError = Union[
 
 
 def get_configuration_errors(  # noqa: C901
-    deck_definition: deck_types.DeckDefinitionV5,
+    deck_definition: deck_types.DeckDefinitionV6,
     placements: List[Placement],
 ) -> Set[ConfigurationError]:
     """Return all the problems with the given deck configration.
@@ -176,7 +175,7 @@ def get_configuration_errors(  # noqa: C901
 
 
 def _find_cutout_fixture(
-    deck_definition: deck_types.DeckDefinitionV5, cutout_fixture_id: str
+    deck_definition: deck_types.DeckDefinitionV6, cutout_fixture_id: str
 ) -> Union[deck_types.CutoutFixture, UnrecognizedCutoutFixtureError]:
     cutout_fixtures = deck_definition["cutoutFixtures"]
     try:

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -1,4 +1,5 @@
 """Hardware API wrapper module for initialization and management."""
+
 import asyncio
 import logging
 from pathlib import Path
@@ -349,9 +350,9 @@ async def get_deck_type() -> DeckType:
 
 async def get_deck_definition(
     deck_type: Annotated[DeckType, Depends(get_deck_type)],
-) -> deck.types.DeckDefinitionV5:
+) -> deck.types.DeckDefinitionV6:
     """Return this robot's deck definition."""
-    return deck.load(deck_type, version=5)
+    return deck.load(deck_type, version=6)
 
 
 async def _postinit_ot2_tasks(

--- a/robot-server/tests/deck_configuration/test_defaults.py
+++ b/robot-server/tests/deck_configuration/test_defaults.py
@@ -1,6 +1,5 @@
 """Unit tests for robot_server.deck_configuration.defaults."""
 
-
 from typing_extensions import Final
 
 import pytest
@@ -12,7 +11,7 @@ from robot_server.deck_configuration import validation
 from robot_server.deck_configuration import validation_mapping
 
 
-DECK_DEFINITION_VERSION: Final = 5
+DECK_DEFINITION_VERSION: Final = 6
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -7,7 +7,7 @@ from robot_server.deck_configuration import validation as subject
 
 def test_valid() -> None:
     """It should return an empty error list if the input is valid."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,
@@ -34,7 +34,7 @@ def test_valid() -> None:
 
 def test_invalid_empty_cutouts() -> None:
     """It should enforce that every cutout is occupied."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,
@@ -65,7 +65,7 @@ def test_invalid_empty_cutouts() -> None:
 
 def test_invalid_overcrowded_cutouts() -> None:
     """It should prevent you from putting multiple things into a single cutout."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,
@@ -105,7 +105,7 @@ def test_invalid_overcrowded_cutouts() -> None:
 
 def test_invalid_cutout_for_fixture() -> None:
     """Each fixture must be placed in a location that's valid for that particular fixture."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,
@@ -147,7 +147,7 @@ def test_invalid_cutout_for_fixture() -> None:
 
 def test_unrecognized_cutout() -> None:
     """It should raise a sensible error if you pass a totally nonexistent cutout."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,
@@ -184,7 +184,7 @@ def test_unrecognized_cutout() -> None:
 
 def test_unrecognized_cutout_fixture() -> None:
     """It should raise a sensible error if you pass a totally nonexistent cutout fixture."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,
@@ -239,7 +239,7 @@ def test_unrecognized_cutout_fixture() -> None:
 
 def test_invalid_serial_number() -> None:
     """It should raise a sensible error if you fail to provide a serial number for a fixture that requires one."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,
@@ -272,7 +272,7 @@ def test_invalid_serial_number() -> None:
 
 def test_unexpected_serial_number() -> None:
     """It should raise a sensible error if you provide a serial number for a fixture that DOES NOT require one."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,
@@ -307,7 +307,7 @@ def test_unexpected_serial_number() -> None:
 # new test to raise error if not all members of a fixture group are loaded into the deck config
 def test_missing_group_fixture() -> None:
     """It should raise a sensible error if you fail to provide all members of a fixture group in a deck configuration."""
-    deck_definition = load_deck_definition("ot3_standard", version=5)
+    deck_definition = load_deck_definition("ot3_standard", version=6)
     cutout_fixtures = [
         subject.Placement(
             cutout_fixture_id=cutout_fixture_id,

--- a/shared-data/python/opentrons_shared_data/deck/__init__.py
+++ b/shared-data/python/opentrons_shared_data/deck/__init__.py
@@ -44,19 +44,23 @@ CALIBRATION_SQUARE_EDGES: Dict[str, Offset] = {
 
 
 @overload
-def load(name: str, version: "DeckSchemaVersion6") -> "DeckDefinitionV6": ...
+def load(name: str, version: "DeckSchemaVersion6") -> "DeckDefinitionV6":
+    ...
 
 
 @overload
-def load(name: str, version: "DeckSchemaVersion5") -> "DeckDefinitionV5": ...
+def load(name: str, version: "DeckSchemaVersion5") -> "DeckDefinitionV5":
+    ...
 
 
 @overload
-def load(name: str, version: "DeckSchemaVersion4") -> "DeckDefinitionV4": ...
+def load(name: str, version: "DeckSchemaVersion4") -> "DeckDefinitionV4":
+    ...
 
 
 @overload
-def load(name: str, version: "DeckSchemaVersion3") -> "DeckDefinitionV3": ...
+def load(name: str, version: "DeckSchemaVersion3") -> "DeckDefinitionV3":
+    ...
 
 
 def load(name: str, version: int = DEFAULT_DECK_DEFINITION_VERSION) -> "DeckDefinition":

--- a/shared-data/python/opentrons_shared_data/deck/__init__.py
+++ b/shared-data/python/opentrons_shared_data/deck/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
         DeckSchemaVersion6,
     )
 
-DEFAULT_DECK_DEFINITION_VERSION: Final = 5
+DEFAULT_DECK_DEFINITION_VERSION: Final = 6
 
 
 class Offset(NamedTuple):
@@ -44,23 +44,19 @@ CALIBRATION_SQUARE_EDGES: Dict[str, Offset] = {
 
 
 @overload
-def load(name: str, version: "DeckSchemaVersion6") -> "DeckDefinitionV6":
-    ...
+def load(name: str, version: "DeckSchemaVersion6") -> "DeckDefinitionV6": ...
 
 
 @overload
-def load(name: str, version: "DeckSchemaVersion5") -> "DeckDefinitionV5":
-    ...
+def load(name: str, version: "DeckSchemaVersion5") -> "DeckDefinitionV5": ...
 
 
 @overload
-def load(name: str, version: "DeckSchemaVersion4") -> "DeckDefinitionV4":
-    ...
+def load(name: str, version: "DeckSchemaVersion4") -> "DeckDefinitionV4": ...
 
 
 @overload
-def load(name: str, version: "DeckSchemaVersion3") -> "DeckDefinitionV3":
-    ...
+def load(name: str, version: "DeckSchemaVersion3") -> "DeckDefinitionV3": ...
 
 
 def load(name: str, version: int = DEFAULT_DECK_DEFINITION_VERSION) -> "DeckDefinition":


### PR DESCRIPTION
Change the robot server and API to use deck definitions from schema v6 for loading labware. Because schema v6 contains all information from schema V5, this does not require changes beyond import paths.

Closes EXEC-80