### PR TITLE
feat(protocol-designer): initial absorbance reader stepform UI

### DIFF
--- a/protocol-designer/src/assets/localization/en/application.json
+++ b/protocol-designer/src/assets/localization/en/application.json
@@ -31,6 +31,7 @@
   "protocol_name": "Protocol Name",
   "save": "save",
   "stepType": {
+    "absorbanceReader": "absorbance plate reader",
     "comment": "comment",
     "ending_hold": "ending hold",
     "heaterShaker": "heater-shaker",
@@ -39,7 +40,6 @@
     "moveLabware": "move",
     "moveLiquid": "transfer",
     "pause": "pause",
-    "plateReader": "absorbance reader",
     "profile_settings": "profile settings",
     "profile_steps": "profile steps",
     "temperature": "temperature",
@@ -57,6 +57,7 @@
     "microliter": "μL",
     "microliterPerSec": "μL/s",
     "millimeter": "mm",
+    "nanometer": "nm",
     "minutes": "m",
     "rpm": "rpm",
     "seconds": "s",

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -177,6 +177,9 @@ export const STAGING_AREA_CUTOUTS_ORDERED: CutoutId[] = [
 ]
 export const ABSORBANCE_READER_INITIALIZE_MODE_SINGLE = 'single'
 export const ABSORBANCE_READER_INITIALIZE_MODE_MULTI = 'multi'
-export const ABSORBANCE_READER_INITIALIZE: 'initialize' = 'initialize'
-export const ABSORBANCE_READER_READ: 'read' = 'read'
-export const ABSORBANCE_READER_LID: 'lid' = 'lid'
+export const ABSORBANCE_READER_INITIALIZE: 'absorbanceReaderInitialize' =
+  'absorbanceReaderInitialize'
+export const ABSORBANCE_READER_READ: 'absorbanceReaderRead' =
+  'absorbanceReaderRead'
+export const ABSORBANCE_READER_LID: 'absorbanceReaderLid' =
+  'absorbanceReaderLid'

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -379,11 +379,14 @@ export interface HydratedHeaterShakerFormData {
   targetHeaterShakerTemperature: string | null
   targetSpeed: string | null
 }
+
+export type AbsorbanceReaderFormType =
+  | typeof ABSORBANCE_READER_INITIALIZE
+  | typeof ABSORBANCE_READER_READ
+  | typeof ABSORBANCE_READER_LID
+
 export interface HydratedAbsorbanceReaderFormData {
-  absorbanceReaderFormType:
-    | typeof ABSORBANCE_READER_INITIALIZE
-    | typeof ABSORBANCE_READER_READ
-    | typeof ABSORBANCE_READER_LID
+  absorbanceReaderFormType: AbsorbanceReaderFormType | null
   filePath: string | null
   lidOpen: boolean | null
   mode:

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -205,6 +205,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   }
 
   const isMultiStepToolbox =
+    formData.stepType === 'absorbanceReader' ||
     formData.stepType === 'moveLiquid' ||
     formData.stepType === 'mix' ||
     formData.stepType === 'thermocycler'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/InitializationEditor.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/InitializationEditor.tsx
@@ -1,0 +1,18 @@
+import { DIRECTION_COLUMN, Flex, SPACING } from '@opentrons/components'
+import type { FormData } from '../../../../../../form-types'
+import type { FieldPropsByName } from '../../types'
+
+interface InitializationEditorProps {
+  formData: FormData
+  propsForFields: FieldPropsByName
+}
+
+export function InitializationEditor(
+  props: InitializationEditorProps
+): JSX.Element {
+  return (
+    <Flex gridGap={SPACING.spacing4} flexDirection={DIRECTION_COLUMN}>
+      <>TODO add wavelength component </>
+    </Flex>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/InitializationSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/InitializationSettings.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next'
+import {
+  Flex,
+  DIRECTION_COLUMN,
+  SPACING,
+  ListItem,
+  StyledText,
+  InfoScreen,
+} from '@opentrons/components'
+import type { Initialization } from '../../../../../../step-forms/types'
+
+interface InitializationSettingsProps {
+  initialization: Initialization | null
+}
+
+export function InitializationSettings(
+  props: InitializationSettingsProps
+): JSX.Element {
+  const { initialization } = props
+  const { t } = useTranslation('form')
+  const content =
+    initialization == null ? (
+      <InfoScreen height="12.75rem" content={t('no_settings_defined')} />
+    ) : (
+      initialization.wavelengths.map(wavelength => (
+        <ListItem
+          type="noActive"
+          key={`listItem_${wavelength}`}
+          padding={SPACING.spacing12}
+        >
+          <StyledText desktopStyle="bodyDefaultRegular">{`${wavelength} ${t(
+            'application:units.nanometer'
+          )}`}</StyledText>
+        </ListItem>
+      ))
+    )
+
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing4}
+      width="100%"
+    >
+      <StyledText desktopStyle="bodyDefaultSemiBold">
+        {t('current_initialization_settings')}
+      </StyledText>
+      {content}
+    </Flex>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/LidControls.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/LidControls.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next'
+import {
+  DIRECTION_COLUMN,
+  Flex,
+  SPACING,
+  StyledText,
+} from '@opentrons/components'
+import { ToggleStepFormField } from '../../../../../../molecules'
+
+import type { FieldProps } from '../../types'
+
+interface LidControlsProps {
+  fieldProps: FieldProps
+  label?: string
+  paddingX?: string
+}
+
+export function LidControls(props: LidControlsProps): JSX.Element {
+  const { fieldProps, label, paddingX = '0' } = props
+  const { t } = useTranslation('form')
+  return (
+    <Flex
+      width="100%"
+      paddingX={paddingX}
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing4}
+    >
+      {label != null ? (
+        <StyledText desktopStyle="bodyDefaultSemiBold">{label}</StyledText>
+      ) : null}
+      <ToggleStepFormField
+        title={t('lid_position')}
+        isSelected={fieldProps.value === true}
+        onLabel={t('open')}
+        offLabel={t('closed')}
+        toggleUpdateValue={() => {
+          fieldProps.updateValue(!fieldProps.value)
+        }}
+        toggleValue={fieldProps.value}
+        isDisabled={false}
+        tooltipContent={null}
+      />
+    </Flex>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/ReadSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/ReadSettings.tsx
@@ -14,7 +14,7 @@ interface ReadSettingsProps {
 
 export function ReadSettings(props: ReadSettingsProps): JSX.Element {
   const { propsForFields } = props
-  const { t } = useTranslation()
+  const { t } = useTranslation('form')
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/ReadSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/ReadSettings.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next'
+import {
+  DIRECTION_COLUMN,
+  Flex,
+  SPACING,
+  StyledText,
+} from '@opentrons/components'
+import { InputStepFormField } from '../../../../../../molecules'
+import type { FieldPropsByName } from '../../types'
+
+interface ReadSettingsProps {
+  propsForFields: FieldPropsByName
+}
+
+export function ReadSettings(props: ReadSettingsProps): JSX.Element {
+  const { propsForFields } = props
+  const { t } = useTranslation()
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      paddingX={SPACING.spacing16}
+      gridGap={SPACING.spacing12}
+      width="100%"
+    >
+      <Flex flexDirection={DIRECTION_COLUMN}>
+        <StyledText desktopStyle="bodyDefaultSemiBold">
+          {t('export_settings')}
+        </StyledText>
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('export_detail')}
+        </StyledText>
+      </Flex>
+      <InputStepFormField
+        padding="0"
+        {...propsForFields.filePath}
+        title={t('exported_file_name')}
+      />
+    </Flex>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
@@ -31,7 +31,7 @@ export function AbsorbanceReaderTools(props: StepFormProps): JSX.Element {
   const { formData, propsForFields, toolboxStep } = props
   const { moduleId } = formData
   const dispatch = useDispatch()
-  const { t } = useTranslation()
+  const { t } = useTranslation('form')
   const robotState = useSelector(getRobotStateAtActiveItem)
   const absorbanceReaderOptions = useSelector(getAbsorbanceReaderLabwareOptions)
   const { labware = {}, modules = {} } = robotState ?? {}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
@@ -1,5 +1,154 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
+import {
+  DIRECTION_COLUMN,
+  Divider,
+  Flex,
+  RadioButton,
+  SPACING,
+  StyledText,
+} from '@opentrons/components'
+import {
+  ABSORBANCE_READER_INITIALIZE,
+  ABSORBANCE_READER_LID,
+  ABSORBANCE_READER_READ,
+} from '../../../../../../constants'
+import { DropdownStepFormField } from '../../../../../../molecules'
+import { getRobotStateAtActiveItem } from '../../../../../../top-selectors/labware-locations'
+import { getAbsorbanceReaderLabwareOptions } from '../../../../../../ui/modules/selectors'
+import { hoverSelection } from '../../../../../../ui/steps/actions/actions'
+import { InitializationSettings } from './InitializationSettings'
+import { InitializationEditor } from './InitializationEditor'
+import { LidControls } from './LidControls'
+import { ReadSettings } from './ReadSettings'
+
+import type { AbsorbanceReaderState } from '@opentrons/step-generation'
+import type { AbsorbanceReaderFormType } from '../../../../../../form-types'
 import type { StepFormProps } from '../../types'
 
 export function AbsorbanceReaderTools(props: StepFormProps): JSX.Element {
-  return <div>TODO: ADD PLATE READER TOOLS</div>
+  const { formData, propsForFields, toolboxStep } = props
+  const { moduleId } = formData
+  const dispatch = useDispatch()
+  const { t } = useTranslation()
+  const robotState = useSelector(getRobotStateAtActiveItem)
+  const absorbanceReaderOptions = useSelector(getAbsorbanceReaderLabwareOptions)
+  const { labware = {}, modules = {} } = robotState ?? {}
+  const isLabwareOnAbsorbanceReader = Object.values(labware).some(
+    lw => lw.slot === propsForFields.moduleId.value
+  )
+  const absorbanceReaderFormType = formData.absorbanceReaderFormType as AbsorbanceReaderFormType
+  const absorbanceReaderState = modules[moduleId]
+    ?.moduleState as AbsorbanceReaderState | null
+  const initialization = absorbanceReaderState?.initialization ?? null
+
+  const enableReadOrInitialization =
+    !isLabwareOnAbsorbanceReader || initialization != null
+  const compoundCommandType = isLabwareOnAbsorbanceReader
+    ? ABSORBANCE_READER_READ
+    : ABSORBANCE_READER_INITIALIZE
+
+  // pre-select radio button on mount and module change if not previously set
+  useEffect(() => {
+    if (formData.absorbanceReaderFormType == null) {
+      if (enableReadOrInitialization) {
+        propsForFields.absorbanceReaderFormType.updateValue(compoundCommandType)
+        return
+      }
+      propsForFields.absorbanceReaderFormType.updateValue(ABSORBANCE_READER_LID)
+    }
+  }, [formData.moduleId])
+
+  const lidRadioButton = (
+    <RadioButton
+      onChange={() => {
+        propsForFields.absorbanceReaderFormType.updateValue(
+          ABSORBANCE_READER_LID
+        )
+      }}
+      isSelected={absorbanceReaderFormType === ABSORBANCE_READER_LID}
+      buttonLabel={t('change_lid_position')}
+      buttonValue={ABSORBANCE_READER_LID}
+      largeDesktopBorderRadius
+    />
+  )
+  const compoundCommandButton = (
+    <RadioButton
+      onChange={() => {
+        propsForFields.absorbanceReaderFormType.updateValue(compoundCommandType)
+      }}
+      isSelected={absorbanceReaderFormType === compoundCommandType}
+      buttonLabel={t(compoundCommandType)}
+      buttonValue={compoundCommandType}
+      largeDesktopBorderRadius
+    />
+  )
+
+  const page1Content = (
+    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
+      <DropdownStepFormField
+        options={absorbanceReaderOptions}
+        title={t('module')}
+        {...propsForFields.moduleId}
+        tooltipContent={null}
+        onEnter={(id: string) => {
+          dispatch(hoverSelection({ id, text: t('select') }))
+        }}
+        onExit={() => {
+          dispatch(hoverSelection({ id: null, text: null }))
+        }}
+      />
+      {moduleId != null ? (
+        <>
+          <Divider marginY="0" />
+          <Flex paddingX={SPACING.spacing16}>
+            <InitializationSettings initialization={initialization} />
+          </Flex>
+          <Divider marginY="0" />
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            gridGap={SPACING.spacing4}
+            paddingX={SPACING.spacing16}
+          >
+            <StyledText desktopStyle="bodyDefaultSemiBold">
+              {t('module_controls')}
+            </StyledText>
+            {enableReadOrInitialization ? (
+              <>
+                {compoundCommandButton}
+                {lidRadioButton}
+              </>
+            ) : (
+              <LidControls fieldProps={propsForFields.lidOpen} />
+            )}
+          </Flex>
+        </>
+      ) : null}
+    </Flex>
+  )
+
+  const page2ContentMap = {
+    [ABSORBANCE_READER_READ]: <ReadSettings propsForFields={propsForFields} />,
+    [ABSORBANCE_READER_INITIALIZE]: (
+      <InitializationEditor
+        formData={formData}
+        propsForFields={propsForFields}
+      />
+    ),
+    [ABSORBANCE_READER_LID]: (
+      <LidControls
+        fieldProps={propsForFields.lidOpen}
+        label={t('change_lid_position')}
+        paddingX={SPACING.spacing16}
+      />
+    ),
+  }
+
+  const contentByPage: JSX.Element[] = [
+    page1Content,
+    page2ContentMap[absorbanceReaderFormType],
+  ]
+
+  return <Flex paddingY={SPACING.spacing16}>{contentByPage[toolboxStep]}</Flex>
 }

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -1,5 +1,6 @@
 import last from 'lodash/last'
 import {
+  ABSORBANCE_READER_TYPE,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
@@ -284,6 +285,33 @@ const _patchHeaterShakerModuleId = (args: {
   return null
 }
 
+const _patchAbsorbanceReaderModuleId = (args: {
+  initialDeckSetup: InitialDeckSetup
+  orderedStepIds: OrderedStepIdsState
+  savedStepForms: SavedStepFormState
+  stepType: StepType
+}): FormUpdater => () => {
+  const { initialDeckSetup, stepType } = args
+  const numOfModules =
+    Object.values(initialDeckSetup.modules).filter(
+      module => module.type === ABSORBANCE_READER_TYPE
+    )?.length ?? 1
+  const hasAbsorbanceReaderModuleId = stepType === 'absorbanceReader'
+
+  if (hasAbsorbanceReaderModuleId && numOfModules === 1) {
+    const moduleId =
+      getModuleOnDeckByType(initialDeckSetup, ABSORBANCE_READER_TYPE)?.id ??
+      null
+    if (moduleId != null) {
+      return {
+        moduleId,
+      }
+    }
+  }
+
+  return null
+}
+
 const _patchThermocyclerFields = (args: {
   initialDeckSetup: InitialDeckSetup
   stepType: StepType
@@ -376,6 +404,13 @@ export const createPresavedStepForm = ({
     stepType,
   })
 
+  const updateAbsorbanceReaderModuleId = _patchAbsorbanceReaderModuleId({
+    initialDeckSetup,
+    orderedStepIds,
+    savedStepForms,
+    stepType,
+  })
+
   const updateThermocyclerFields = _patchThermocyclerFields({
     initialDeckSetup,
     stepType,
@@ -391,6 +426,7 @@ export const createPresavedStepForm = ({
     updateThermocyclerFields,
     updateHeaterShakerModuleId,
     updateMagneticModuleId,
+    updateAbsorbanceReaderModuleId,
     updateDefaultLabwareLocations,
   ].reduce<FormData>(
     (acc, updater: FormUpdater) => {

--- a/protocol-designer/src/steplist/formLevel/createBlankForm.ts
+++ b/protocol-designer/src/steplist/formLevel/createBlankForm.ts
@@ -13,6 +13,9 @@ interface NewFormArgs {
 //  TODO(jr, 1/17/24): add to i18n
 const getStepType = (stepType: StepType): string => {
   switch (stepType) {
+    case 'absorbanceReader': {
+      return 'absorbance plate reader'
+    }
     case 'heaterShaker': {
       return 'heater-shaker'
     }

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -177,7 +177,7 @@ export function getDefaultsForStepType(
       }
     case 'absorbanceReader':
       return {
-        absorbanceReaderFormType: 'initialize',
+        absorbanceReaderFormType: null,
         filePath: null,
         lidOpen: null,
         mode: null,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateAbsorbanceReader.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateAbsorbanceReader.ts
@@ -30,35 +30,11 @@ const updatePatchOnAbsorbanceReaderFormType = (
   return patch
 }
 
-const updatePatchOnAbsorbanceReaderModuleId = (
-  patch: FormPatch,
-  rawForm: FormData
-): FormPatch => {
-  if (
-    rawForm.absorbanceReaderFormType !== null &&
-    fieldHasChanged(rawForm, patch, 'moduleId')
-  ) {
-    return {
-      ...patch,
-      ...getDefaultFields(
-        'absorbanceReaderFormType',
-        'wavelengths',
-        'referenceWavelength',
-        'lidOpen',
-        'mode',
-        'filePath'
-      ),
-    }
-  }
-  return patch
-}
-
-export function dependentFieldsUpdateAbsorbanceReader(
+export const dependentFieldsUpdateAbsorbanceReader = (
   originalPatch: FormPatch,
   rawForm: FormData
-): FormPatch {
+): FormPatch => {
   return chainPatchUpdaters(originalPatch, [
     chainPatch => updatePatchOnAbsorbanceReaderFormType(chainPatch, rawForm),
-    chainPatch => updatePatchOnAbsorbanceReaderModuleId(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateAbsorbanceReader.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateAbsorbanceReader.ts
@@ -1,0 +1,64 @@
+import pick from 'lodash/pick'
+import { chainPatchUpdaters, fieldHasChanged } from './utils'
+import { getDefaultsForStepType } from '../getDefaultsForStepType'
+import type { FormData, StepFieldName } from '../../../form-types'
+import type { FormPatch } from '../../actions/types'
+
+const getDefaultFields = (...fields: StepFieldName[]): FormPatch =>
+  pick(getDefaultsForStepType('absorbanceReader'), fields)
+
+const updatePatchOnAbsorbanceReaderFormType = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (
+    rawForm.absorbanceReaderFormType !== null &&
+    fieldHasChanged(rawForm, patch, 'absorbanceReaderFormType')
+  ) {
+    return {
+      ...patch,
+      ...getDefaultFields(
+        'wavelengths',
+        'referenceWavelength',
+        'lidOpen',
+        'mode',
+        'filePath'
+      ),
+    }
+  }
+
+  return patch
+}
+
+const updatePatchOnAbsorbanceReaderModuleId = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (
+    rawForm.absorbanceReaderFormType !== null &&
+    fieldHasChanged(rawForm, patch, 'moduleId')
+  ) {
+    return {
+      ...patch,
+      ...getDefaultFields(
+        'absorbanceReaderFormType',
+        'wavelengths',
+        'referenceWavelength',
+        'lidOpen',
+        'mode',
+        'filePath'
+      ),
+    }
+  }
+  return patch
+}
+
+export function dependentFieldsUpdateAbsorbanceReader(
+  originalPatch: FormPatch,
+  rawForm: FormData
+): FormPatch {
+  return chainPatchUpdaters(originalPatch, [
+    chainPatch => updatePatchOnAbsorbanceReaderFormType(chainPatch, rawForm),
+    chainPatch => updatePatchOnAbsorbanceReaderModuleId(chainPatch, rawForm),
+  ])
+}

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.ts
@@ -1,3 +1,4 @@
+import { dependentFieldsUpdateAbsorbanceReader } from './dependentFieldsUpdateAbsorbanceReader'
 import { dependentFieldsUpdateMoveLiquid } from './dependentFieldsUpdateMoveLiquid'
 import { dependentFieldsUpdateMix } from './dependentFieldsUpdateMix'
 import { dependentFieldsUpdateMagnet } from './dependentFieldsUpdateMagnet'
@@ -70,6 +71,14 @@ export function handleFormChange(
 
   if (rawForm.stepType === 'pause') {
     const dependentFieldsPatch = dependentFieldsUpdatePause(patch, rawForm)
+    return { ...patch, ...dependentFieldsPatch }
+  }
+
+  if (rawForm.stepType === 'absorbanceReader') {
+    const dependentFieldsPatch = dependentFieldsUpdateAbsorbanceReader(
+      patch,
+      rawForm
+    )
     return { ...patch, ...dependentFieldsPatch }
   }
 

--- a/protocol-designer/src/ui/modules/selectors.ts
+++ b/protocol-designer/src/ui/modules/selectors.ts
@@ -1,10 +1,11 @@
 import { createSelector } from 'reselect'
 import mapValues from 'lodash/mapValues'
 import {
+  ABSORBANCE_READER_TYPE,
   getLabwareDisplayName,
+  HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
-  HEATERSHAKER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { getInitialDeckSetup } from '../../step-forms/selectors'
 import { getLabwareNicknamesById } from '../labware/selectors'
@@ -78,6 +79,22 @@ export const getHeaterShakerLabwareOptions: Selector<
       HEATERSHAKER_MODULE_TYPE
     )
     return heaterShakerModuleOptions
+  }
+)
+
+/** Returns dropdown option for labware placed on absorbance reader module */
+export const getAbsorbanceReaderLabwareOptions: Selector<
+  DropdownOption[]
+> = createSelector(
+  getInitialDeckSetup,
+  getLabwareNicknamesById,
+  (initialDeckSetup, nicknamesById) => {
+    const absorbanceReaderModuleOptions = getModuleLabwareOptions(
+      initialDeckSetup,
+      nicknamesById,
+      ABSORBANCE_READER_TYPE
+    )
+    return absorbanceReaderModuleOptions
   }
 )
 

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -93,7 +93,7 @@ export const getModuleShortNames = (type: ModuleType): string => {
     case THERMOCYCLER_MODULE_TYPE:
       return 'Thermocycler'
     case ABSORBANCE_READER_TYPE:
-      return 'Absorbance Reader'
+      return 'Absorbance Plate Reader'
   }
 }
 


### PR DESCRIPTION
# Overview

This PR adds the initial UI for absorbance reader steps. It creates the new AbsorbanceReaderTools component in line with our other step form toolbox components, and modularizes its children components for cleanliness. The content of both pages 1 and 2 of the form are determined by:
1) module initialization state, and
2) labware presence or lack thereof.

According to designs, the UI will funnel the user into the correct step form type (lid, initializaton, or reading) based on those 2 inputs. Also implicated here are creation and wiring up of the following methods:
- patch to pre-select an absorbance reader module if only one is available
- form change handlers for absorbance reader dependent fields
- absorbance reader module option getter

Closes AUTH-1264

## Test Plan and Hands on Testing

- create or open a protocol on this branch
- on starting deck, add an absorbance reader to any of right column of slots; also ensure a gripper is added
- navigate to timeline and add an absorbance reader step
- navigate through form and ensure UI looks correct (translations pending)
- changing the module ID or form type (lid, read, initialize) should reset other field values to default

Because of the conditional nature of this step form content, it is slightly difficult to test the UI thoroughly at present. Functionality will be able to be thoroughly tested in a fast-follow PR that wires up step generation and allows for module controls to be manipulated.

## Changelog

- add UI components for absorbance reader tools
- implement in StepFormToolbox
- add utilities for form handling

## Review requests

- see test plan

## Risk assessment

low