### PR TITLE
fix(shared-data): flex a3 needs mating surface

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -1,4 +1,5 @@
 """Protocol engine commands sub-state."""
+
 from __future__ import annotations
 
 import enum
@@ -304,7 +305,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
         # TODO(mc, 2021-06-22): mypy has trouble with this automatic
         # request > command mapping, figure out how to type precisely
         # (or wait for a future mypy version that can figure it out).
-        queued_command = action.request._CommandCls.model_construct(  # type: ignore[call-arg]
+        queued_command = action.request._CommandCls.model_construct(
             id=action.command_id,
             key=(
                 action.request.key
@@ -506,7 +507,10 @@ class CommandStore(HasState[CommandState], HandlesActions):
                         pass
                     case QueueStatus.RUNNING | QueueStatus.PAUSED:
                         self._state.queue_status = QueueStatus.PAUSED
-                    case QueueStatus.AWAITING_RECOVERY | QueueStatus.AWAITING_RECOVERY_PAUSED:
+                    case (
+                        QueueStatus.AWAITING_RECOVERY
+                        | QueueStatus.AWAITING_RECOVERY_PAUSED
+                    ):
                         self._state.queue_status = QueueStatus.AWAITING_RECOVERY_PAUSED
             elif action.door_state == DoorState.CLOSED:
                 self._state.is_door_blocking = False

--- a/shared-data/deck/definitions/5/ot3_standard.json
+++ b/shared-data/deck/definitions/5/ot3_standard.json
@@ -149,6 +149,7 @@
         "id": "A3",
         "areaType": "slot",
         "offsetFromCutoutFixture": [0.0, 0.0, 0.0],
+        "matingSurfaceUnitVector": [-1, 1, -1],
         "boundingBox": {
           "xDimension": 128.0,
           "yDimension": 86.0,


### PR DESCRIPTION
This is used by the client to decide whether something is a lot when it's rendering destinations, and if this doesn't exist then intervention modals will show the labware moving off deck.

Closes RQA-3839
