### PR TITLE
fix(app): fix manual move to location with module

### DIFF
--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -38,7 +38,7 @@ const getModulePosition = (
   )
   if (modSlot == null) return null
 
-  const modPosition = getPositionFromSlotId(loadedModule.id, deckDef)
+  const modPosition = getPositionFromSlotId(modSlot.id, deckDef)
   if (modPosition == null) return null
   const [modX, modY] = modPosition
 

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -116,6 +116,7 @@ export const FLEX_SINGLE_SLOT_BY_CUTOUT_ID: { [CutoutId: string]: string } = {
   cutoutD3: 'D3',
 }
 
+// TODO(jh 01-15-25): Instead of typing slotId as `string`, type it as `AddressableAreaName`.
 // returns the position associated with a slot id
 export function getPositionFromSlotId(
   slotId: string,


### PR DESCRIPTION
Closes [RQA-3839](https://opentrons.atlassian.net/browse/RQA-3839)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a bug in which manually moving labware to a module was moving the labware off-deck. Turns out that one of the lower level utils was specifying an invalid param to `getPositionFromSlotId`: the `moduleId` instead of the `AddressableAreaName`, ex. "A3". 

Unfortunately, it's we can't really update the interface for this util to require an `AddressableAreaName`, because the util is utilized in so many places that pass in `string`s and not `AddressableAreaNames` that this quickly becomes unmanageable for a quick bug fix. I've left a TODO here in the meantime. 

### Current Behavior

https://github.com/user-attachments/assets/412fc56d-3634-478d-b7a1-a664eafa14c5

### Fixed Behavior

https://github.com/user-attachments/assets/bf0f6811-1484-4956-8de3-c03044c3316b

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed manual move commands moving labware off deck instead of on top of modules.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3839]: https://opentrons.atlassian.net/browse/RQA-3839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ