### PR TITLE
fix(api): Fix liquid getting homed into pipette after certain protocols end

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
+++ b/api/src/opentrons/protocol_engine/execution/hardware_stopper.py
@@ -65,7 +65,7 @@ class HardwareStopper:
             axes=[MotorAxis.X, MotorAxis.Y, MotorAxis.LEFT_Z, MotorAxis.RIGHT_Z]
         )
 
-    async def _drop_tip(self) -> None:
+    async def _try_to_drop_tips(self) -> None:
         """Drop currently attached tip, if any, into trash after a run cancel."""
         attached_tips = self._state_store.pipettes.get_all_attached_tips()
 
@@ -134,9 +134,9 @@ class HardwareStopper:
             PostRunHardwareState.HOME_THEN_DISENGAGE,
         )
         if drop_tips_after_run:
-            await self._drop_tip()
-            await self._hardware_api.stop(home_after=home_after_stop)
-        else:
-            await self._hardware_api.stop(home_after=False)
-            if home_after_stop:
-                await self._home_everything_except_plungers()
+            await self._try_to_drop_tips()
+
+        await self._hardware_api.stop(home_after=False)
+
+        if home_after_stop:
+            await self._home_everything_except_plungers()


### PR DESCRIPTION
## Overview

Closes RESC-345.

## Test Plan and Hands on Testing

Run a PAPIv≥2.16 protocol on a Flex. Cancel it at a point when tips are attached and contain liquid. Without this PR, the pipette should accidentally aspirate when it homes, as shown in [this video](https://opentrons.atlassian.net/browse/RESC-345?focusedCommentId=111504). With this PR, it should not do that; the liquid should remain in place. Ideally, use food dye to confirm this, because it can be difficult to notice.

## Changelog

See comments.

## Review requests

See comments.

## Risk assessment

Medium.
