### PR TITLE
feat(protocol-designer,-step-generation): wire up absorbance reader in step-generation

### DIFF
--- a/protocol-designer/src/file-data/helpers/index.ts
+++ b/protocol-designer/src/file-data/helpers/index.ts
@@ -79,6 +79,26 @@ export const commandCreatorFromStepArgs = (
       )
     case 'comment':
       return StepGeneration.curryCommandCreator(StepGeneration.comment, args)
+    case 'absorbanceReaderOpenLid':
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.absorbanceReaderOpenLid,
+        args
+      )
+    case 'absorbanceReaderCloseLid':
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.absorbanceReaderCloseLid,
+        args
+      )
+    case 'absorbanceReaderRead':
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.absorbanceReaderCloseRead,
+        args
+      )
+    case 'absorbanceReaderInitialize':
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.absorbanceReaderCloseInitialize,
+        args
+      )
   }
   // @ts-expect-error we've exhausted all command creators, but keeping this console warn
   // for when we impelement the next command creator

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -387,7 +387,7 @@ export type AbsorbanceReaderFormType =
 
 export interface HydratedAbsorbanceReaderFormData {
   absorbanceReaderFormType: AbsorbanceReaderFormType | null
-  filePath: string | null
+  fileName: string | null
   lidOpen: boolean | null
   mode:
     | typeof ABSORBANCE_READER_INITIALIZE_MODE_MULTI

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/ReadSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/ReadSettings.tsx
@@ -32,7 +32,7 @@ export function ReadSettings(props: ReadSettingsProps): JSX.Element {
       </Flex>
       <InputStepFormField
         padding="0"
-        {...propsForFields.filePath}
+        {...propsForFields.fileName}
         title={t('exported_file_name')}
       />
     </Flex>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
@@ -87,7 +87,11 @@ export function AbsorbanceReaderTools(props: StepFormProps): JSX.Element {
   )
 
   const page1Content = (
-    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing12}
+      width="100%"
+    >
       <DropdownStepFormField
         options={absorbanceReaderOptions}
         title={t('module')}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import {
@@ -35,8 +35,9 @@ export function AbsorbanceReaderTools(props: StepFormProps): JSX.Element {
   const robotState = useSelector(getRobotStateAtActiveItem)
   const absorbanceReaderOptions = useSelector(getAbsorbanceReaderLabwareOptions)
   const { labware = {}, modules = {} } = robotState ?? {}
-  const isLabwareOnAbsorbanceReader = Object.values(labware).some(
-    lw => lw.slot === propsForFields.moduleId.value
+  const isLabwareOnAbsorbanceReader = useMemo(
+    () => Object.values(labware).some(lw => lw.slot === moduleId),
+    [moduleId]
   )
   const absorbanceReaderFormType = formData.absorbanceReaderFormType as AbsorbanceReaderFormType
   const absorbanceReaderState = modules[moduleId]

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -178,7 +178,7 @@ export function getDefaultsForStepType(
     case 'absorbanceReader':
       return {
         absorbanceReaderFormType: null,
-        filePath: null,
+        fileName: null,
         lidOpen: null,
         mode: null,
         moduleId: null,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateAbsorbanceReader.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateAbsorbanceReader.ts
@@ -22,7 +22,7 @@ const updatePatchOnAbsorbanceReaderFormType = (
         'referenceWavelength',
         'lidOpen',
         'mode',
-        'filePath'
+        'fileName'
       ),
     }
   }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
@@ -31,7 +31,7 @@ export const absorbanceReaderFormToArgs = (
     case ABSORBANCE_READER_INITIALIZE:
       return {
         module: moduleId,
-        mode: 'multi',
+        mode: 'multi', // TODO (nd: 1/16/2025): reflect actual `mode` form field
         commandCreatorFnName: 'absorbanceReaderInitialize',
         ...DUMMY_INITIALIZATION,
       }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
@@ -1,0 +1,52 @@
+import {
+  ABSORBANCE_READER_INITIALIZE,
+  ABSORBANCE_READER_LID,
+  ABSORBANCE_READER_READ,
+} from '../../../constants'
+import type { AbsorbanceReaderArgs } from '@opentrons/step-generation'
+import type { HydratedAbsorbanceReaderFormData } from '../../../form-types'
+
+// TODO (nd: 1/15/2025) replace with actual form data once UI is
+const DUMMY_INITIALIZATION = {
+  wavelengths: [420, 600],
+  referenceWavelength: 200,
+}
+
+export const absorbanceReaderFormToArgs = (
+  hydratedFormData: HydratedAbsorbanceReaderFormData
+): AbsorbanceReaderArgs | null => {
+  const {
+    absorbanceReaderFormType,
+    filePath,
+    lidOpen,
+    moduleId,
+    // mode,
+    // referenceWavelength,
+    // wavelengths,
+  } = hydratedFormData
+  const lidAction = lidOpen
+    ? 'absorbanceReaderOpenLid'
+    : 'absorbanceReaderCloseLid'
+  switch (absorbanceReaderFormType) {
+    case ABSORBANCE_READER_INITIALIZE:
+      return {
+        module: moduleId,
+        mode: 'multi',
+        commandCreatorFnName: 'absorbanceReaderInitialize',
+        ...DUMMY_INITIALIZATION,
+      }
+    case ABSORBANCE_READER_READ:
+      return {
+        module: moduleId,
+        commandCreatorFnName: 'absorbanceReaderRead',
+        filePath,
+      }
+    case ABSORBANCE_READER_LID:
+      return {
+        module: moduleId,
+        commandCreatorFnName: lidAction,
+      }
+    default:
+      return null
+  }
+}

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
@@ -17,7 +17,7 @@ export const absorbanceReaderFormToArgs = (
 ): AbsorbanceReaderArgs | null => {
   const {
     absorbanceReaderFormType,
-    filePath,
+    fileName,
     lidOpen,
     moduleId,
     // mode,
@@ -39,7 +39,7 @@ export const absorbanceReaderFormToArgs = (
       return {
         module: moduleId,
         commandCreatorFnName: 'absorbanceReaderRead',
-        filePath,
+        fileName,
       }
     case ABSORBANCE_READER_LID:
       return {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
@@ -9,9 +9,11 @@ import { heaterShakerFormToArgs } from './heaterShakerFormToArgs'
 import { moveLiquidFormToArgs } from './moveLiquidFormToArgs'
 import { moveLabwareFormToArgs } from './moveLabwareFormToArgs'
 import { commentFormToArgs } from './commentFormToArgs'
+import { absorbanceReaderFormToArgs } from './absorbanceReaderFormToArgs'
 import type { CommandCreatorArgs } from '@opentrons/step-generation'
 import type {
   FormData,
+  HydratedAbsorbanceReaderFormData,
   HydratedCommentFormData,
   HydratedHeaterShakerFormData,
   HydratedMagnetFormData,
@@ -72,6 +74,12 @@ export const stepFormToArgs = (hydratedForm: FormData): StepArgs => {
         fields: castForm,
       }
       return commentFormToArgs(commentFormData)
+    }
+
+    case 'absorbanceReader': {
+      return absorbanceReaderFormToArgs(
+        castForm as HydratedAbsorbanceReaderFormData
+      )
     }
 
     default:

--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -492,7 +492,6 @@ export function generateSubstepItem(
 
   console.warn(
     "generateSubsteps doesn't support commandCreatorFnName: ",
-    // @ts-expect-error(sa, 2021-6-14): I don't think this case can ever happen, so stepArgs.commandCreatorFnName gets never typed
     stepArgs.commandCreatorFnName,
     stepId
   )

--- a/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest'
+import { absorbanceReaderCloseInitialize } from '../commandCreators'
+import {
+  absorbanceReaderStateGetter,
+  getModuleState,
+} from '../robotStateSelectors'
+import { getInitialRobotStateStandard, makeContext } from '../fixtures'
+import { getErrorResult, getSuccessResult } from '../fixtures/commandFixtures'
+
+import type {
+  AbsorbanceReaderInitializeArgs,
+  AbsorbanceReaderState,
+  InvariantContext,
+  RobotState,
+} from '../types'
+import {
+  ABSORBANCE_READER_TYPE,
+  ABSORBANCE_READER_V1,
+} from '@opentrons/shared-data'
+
+vi.mock('../robotStateSelectors')
+
+describe('absorbanceReaderCloseInitialize compound command creator', () => {
+  let absorbanceReaderCloseInitializeArgs: AbsorbanceReaderInitializeArgs
+  const ABSORBANCE_READER_MODULE_ID = 'absorbanceReaderModuleId'
+  const ABSORBANCE_READER_MODULE_SLOT = 'D3'
+  let robotState: RobotState
+  let invariantContext: InvariantContext
+  beforeEach(() => {
+    absorbanceReaderCloseInitializeArgs = {
+      commandCreatorFnName: 'absorbanceReaderInitialize',
+      module: ABSORBANCE_READER_MODULE_ID,
+      mode: 'single',
+      wavelengths: [450],
+    }
+    invariantContext = {
+      ...makeContext(),
+      moduleEntities: {
+        [ABSORBANCE_READER_MODULE_ID]: {
+          id: ABSORBANCE_READER_MODULE_ID,
+          type: ABSORBANCE_READER_TYPE,
+          model: ABSORBANCE_READER_V1,
+        },
+      },
+    }
+    const state = getInitialRobotStateStandard(invariantContext)
+
+    robotState = {
+      ...state,
+      modules: {
+        ...state.modules,
+        [ABSORBANCE_READER_MODULE_ID]: {
+          slot: ABSORBANCE_READER_MODULE_SLOT,
+        } as any,
+      },
+    }
+    vi.mocked(getModuleState).mockReturnValue({
+      type: ABSORBANCE_READER_TYPE,
+    } as any)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+  it('should return an error when module is not found', () => {
+    const result = absorbanceReaderCloseInitialize(
+      absorbanceReaderCloseInitializeArgs,
+      invariantContext,
+      robotState
+    )
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue(null)
+
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'MISSING_MODULE',
+    })
+  })
+  it('should emit close and intalize commands if single mode', () => {
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue(
+      {} as AbsorbanceReaderState
+    )
+
+    const result = absorbanceReaderCloseInitialize(
+      absorbanceReaderCloseInitializeArgs,
+      invariantContext,
+      robotState
+    )
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'absorbanceReader/closeLid',
+        key: expect.any(String),
+        params: {
+          moduleId: 'absorbanceReaderModuleId',
+        },
+      },
+      {
+        commandType: 'absorbanceReader/initialize',
+        key: expect.any(String),
+        params: {
+          moduleId: 'absorbanceReaderModuleId',
+          sampleWavelengths: [450],
+          measureMode: 'single',
+        },
+      },
+    ])
+  })
+  it('should emit close and intalize commands if multi mode', () => {
+    absorbanceReaderCloseInitializeArgs = {
+      ...absorbanceReaderCloseInitializeArgs,
+      mode: 'multi',
+      wavelengths: [450, 600],
+    }
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue(
+      {} as AbsorbanceReaderState
+    )
+
+    const result = absorbanceReaderCloseInitialize(
+      absorbanceReaderCloseInitializeArgs,
+      invariantContext,
+      robotState
+    )
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'absorbanceReader/closeLid',
+        key: expect.any(String),
+        params: {
+          moduleId: 'absorbanceReaderModuleId',
+        },
+      },
+      {
+        commandType: 'absorbanceReader/initialize',
+        key: expect.any(String),
+        params: {
+          moduleId: 'absorbanceReaderModuleId',
+          sampleWavelengths: [450, 600],
+          measureMode: 'multi',
+        },
+      },
+    ])
+  })
+})

--- a/step-generation/src/__tests__/absorbanceReaderCloseLid.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseLid.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import {
+  ABSORBANCE_READER_TYPE,
+  ABSORBANCE_READER_V1,
+} from '@opentrons/shared-data'
+import {
+  getErrorResult,
+  makeContext,
+  getInitialRobotStateStandard,
+} from '../fixtures'
+import { absorbanceReaderCloseLid } from '../commandCreators/atomic/absorbanceReaderCloseLid'
+import { absorbanceReaderStateGetter } from '../robotStateSelectors'
+import type {
+  AbsorbanceReaderState,
+  InvariantContext,
+  RobotState,
+} from '../types'
+
+const moduleId = 'absorbanceReaderId'
+vi.mock('../robotStateSelectors')
+
+describe('absorbanceReaderCloseLid', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+  beforeEach(() => {
+    invariantContext = makeContext()
+    invariantContext.moduleEntities[moduleId] = {
+      id: moduleId,
+      type: ABSORBANCE_READER_TYPE,
+      model: ABSORBANCE_READER_V1,
+    }
+    robotState = getInitialRobotStateStandard(invariantContext)
+    robotState.modules[moduleId] = {
+      slot: 'D3',
+      moduleState: {
+        type: ABSORBANCE_READER_TYPE,
+        initialization: null,
+        lidOpen: false,
+      },
+    }
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue(
+      {} as AbsorbanceReaderState
+    )
+  })
+  it.only('creates absorbance reader close lid command', () => {
+    const module = moduleId
+    const result = absorbanceReaderCloseLid(
+      {
+        module,
+        commandCreatorFnName: 'absorbanceReaderCloseLid',
+      },
+      invariantContext,
+      robotState
+    )
+    expect(result).toEqual({
+      commands: [
+        {
+          commandType: 'absorbanceReader/closeLid',
+          key: expect.any(String),
+          params: {
+            moduleId: module,
+          },
+        },
+      ],
+    })
+  })
+  it('creates returns error if bad module state', () => {
+    const module = moduleId
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue(null)
+    const result = absorbanceReaderCloseLid(
+      {
+        module,
+        commandCreatorFnName: 'absorbanceReaderCloseLid',
+      },
+      invariantContext,
+      robotState
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'MISSING_MODULE',
+    })
+  })
+})

--- a/step-generation/src/__tests__/absorbanceReaderCloseRead.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseRead.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest'
+import { absorbanceReaderCloseRead } from '../commandCreators'
+import {
+  absorbanceReaderStateGetter,
+  getModuleState,
+} from '../robotStateSelectors'
+import { getInitialRobotStateStandard, makeContext } from '../fixtures'
+import { getErrorResult, getSuccessResult } from '../fixtures/commandFixtures'
+
+import type {
+  AbsorbanceReaderReadArgs,
+  AbsorbanceReaderState,
+  InvariantContext,
+  RobotState,
+} from '../types'
+import {
+  ABSORBANCE_READER_TYPE,
+  ABSORBANCE_READER_V1,
+} from '@opentrons/shared-data'
+
+vi.mock('../robotStateSelectors')
+
+describe('absorbanceReaderCloseRead compound command creator', () => {
+  let absorbanceReaderCloseReadArgs: AbsorbanceReaderReadArgs
+  const ABSORBANCE_READER_MODULE_ID = 'absorbanceReaderModuleId'
+  const ABSORBANCE_READER_OUTPUT_PATH = 'outputPath.csv'
+  const ABSORBANCE_READER_MODULE_SLOT = 'D3'
+  let robotState: RobotState
+  let invariantContext: InvariantContext
+  beforeEach(() => {
+    absorbanceReaderCloseReadArgs = {
+      commandCreatorFnName: 'absorbanceReaderRead',
+      module: ABSORBANCE_READER_MODULE_ID,
+      fileName: null,
+    }
+    invariantContext = {
+      ...makeContext(),
+      moduleEntities: {
+        [ABSORBANCE_READER_MODULE_ID]: {
+          id: ABSORBANCE_READER_MODULE_ID,
+          type: ABSORBANCE_READER_TYPE,
+          model: ABSORBANCE_READER_V1,
+        },
+      },
+    }
+    const state = getInitialRobotStateStandard(invariantContext)
+
+    robotState = {
+      ...state,
+      modules: {
+        ...state.modules,
+        [ABSORBANCE_READER_MODULE_ID]: {
+          slot: ABSORBANCE_READER_MODULE_SLOT,
+        } as any,
+      },
+    }
+    vi.mocked(getModuleState).mockReturnValue({
+      type: ABSORBANCE_READER_TYPE,
+    } as any)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+  it('should return an error when module is not found', () => {
+    const result = absorbanceReaderCloseRead(
+      absorbanceReaderCloseReadArgs,
+      invariantContext,
+      robotState
+    )
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue(null)
+
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'MISSING_MODULE',
+    })
+  })
+  it.only('should emit close and read commands without fileName param', () => {
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue({
+      initialization: {},
+    } as AbsorbanceReaderState)
+    const result = absorbanceReaderCloseRead(
+      absorbanceReaderCloseReadArgs,
+      invariantContext,
+      robotState
+    )
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'absorbanceReader/closeLid',
+        key: expect.any(String),
+        params: {
+          moduleId: 'absorbanceReaderModuleId',
+        },
+      },
+      {
+        commandType: 'absorbanceReader/read',
+        key: expect.any(String),
+        params: {
+          moduleId: 'absorbanceReaderModuleId',
+        },
+      },
+    ])
+  })
+  it.only('should emit close and read commands with fileName param', () => {
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue({
+      initialization: {},
+    } as AbsorbanceReaderState)
+    absorbanceReaderCloseReadArgs = {
+      ...absorbanceReaderCloseReadArgs,
+      fileName: ABSORBANCE_READER_OUTPUT_PATH,
+    }
+    const result = absorbanceReaderCloseRead(
+      absorbanceReaderCloseReadArgs,
+      invariantContext,
+      robotState
+    )
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'absorbanceReader/closeLid',
+        key: expect.any(String),
+        params: {
+          moduleId: 'absorbanceReaderModuleId',
+        },
+      },
+      {
+        commandType: 'absorbanceReader/read',
+        key: expect.any(String),
+        params: {
+          moduleId: 'absorbanceReaderModuleId',
+          fileName: ABSORBANCE_READER_OUTPUT_PATH,
+        },
+      },
+    ])
+  })
+})

--- a/step-generation/src/__tests__/absorbanceReaderOpenLid.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderOpenLid.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import {
+  ABSORBANCE_READER_TYPE,
+  ABSORBANCE_READER_V1,
+} from '@opentrons/shared-data'
+import {
+  getErrorResult,
+  makeContext,
+  getInitialRobotStateStandard,
+} from '../fixtures'
+import { absorbanceReaderOpenLid } from '../commandCreators/atomic/absorbanceReaderOpenLid'
+import { absorbanceReaderStateGetter } from '../robotStateSelectors'
+import type {
+  AbsorbanceReaderState,
+  InvariantContext,
+  RobotState,
+} from '../types'
+
+const moduleId = 'absorbanceReaderId'
+vi.mock('../robotStateSelectors')
+
+describe('absorbanceReaderOpenLid', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+  beforeEach(() => {
+    invariantContext = makeContext()
+    invariantContext.moduleEntities[moduleId] = {
+      id: moduleId,
+      type: ABSORBANCE_READER_TYPE,
+      model: ABSORBANCE_READER_V1,
+    }
+    robotState = getInitialRobotStateStandard(invariantContext)
+    robotState.modules[moduleId] = {
+      slot: 'D3',
+      moduleState: {
+        type: ABSORBANCE_READER_TYPE,
+        initialization: null,
+        lidOpen: false,
+      },
+    }
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue(
+      {} as AbsorbanceReaderState
+    )
+  })
+  it('creates absorbance reader open lid command', () => {
+    const module = moduleId
+    const result = absorbanceReaderOpenLid(
+      {
+        module,
+        commandCreatorFnName: 'absorbanceReaderOpenLid',
+      },
+      invariantContext,
+      robotState
+    )
+    expect(result).toEqual({
+      commands: [
+        {
+          commandType: 'absorbanceReader/openLid',
+          key: expect.any(String),
+          params: {
+            moduleId: module,
+          },
+        },
+      ],
+    })
+  })
+  it('creates returns error if bad module state', () => {
+    const module = moduleId
+    vi.mocked(absorbanceReaderStateGetter).mockReturnValue(null)
+    const result = absorbanceReaderOpenLid(
+      {
+        module,
+        commandCreatorFnName: 'absorbanceReaderOpenLid',
+      },
+      invariantContext,
+      robotState
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'MISSING_MODULE',
+    })
+  })
+})

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
@@ -1,0 +1,20 @@
+import { uuid } from '../../utils'
+import type { AbsorbanceReaderLidArgs, CommandCreator } from '../../types'
+
+export const absorbanceReaderCloseLid: CommandCreator<AbsorbanceReaderLidArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        commandType: 'absorbanceReader/closeLid',
+        key: uuid(),
+        params: {
+          moduleId: args.module,
+        },
+      },
+    ],
+  }
+}

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
@@ -1,4 +1,6 @@
 import { uuid } from '../../utils'
+import { missingModuleError } from '../../errorCreators'
+import { getModuleState } from '../../robotStateSelectors'
 import type { AbsorbanceReaderLidArgs, CommandCreator } from '../../types'
 
 export const absorbanceReaderCloseLid: CommandCreator<AbsorbanceReaderLidArgs> = (
@@ -6,6 +8,13 @@ export const absorbanceReaderCloseLid: CommandCreator<AbsorbanceReaderLidArgs> =
   invariantContext,
   prevRobotState
 ) => {
+  const absorbanceReaderState = getModuleState(prevRobotState, args.module)
+  if (args.module == null || absorbanceReaderState == null) {
+    return {
+      errors: [missingModuleError()],
+    }
+  }
+
   return {
     commands: [
       {

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
@@ -1,6 +1,6 @@
 import { uuid } from '../../utils'
 import { missingModuleError } from '../../errorCreators'
-import { getModuleState } from '../../robotStateSelectors'
+import { absorbanceReaderStateGetter } from '../../robotStateSelectors'
 import type { AbsorbanceReaderLidArgs, CommandCreator } from '../../types'
 
 export const absorbanceReaderCloseLid: CommandCreator<AbsorbanceReaderLidArgs> = (
@@ -8,7 +8,10 @@ export const absorbanceReaderCloseLid: CommandCreator<AbsorbanceReaderLidArgs> =
   invariantContext,
   prevRobotState
 ) => {
-  const absorbanceReaderState = getModuleState(prevRobotState, args.module)
+  const absorbanceReaderState = absorbanceReaderStateGetter(
+    prevRobotState,
+    args.module
+  )
   if (args.module == null || absorbanceReaderState == null) {
     return {
       errors: [missingModuleError()],

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderInitialize.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderInitialize.ts
@@ -1,0 +1,27 @@
+import { uuid } from '../../utils'
+import type {
+  AbsorbanceReaderInitializeArgs,
+  CommandCreator,
+} from '../../types'
+
+export const absorbanceReaderInitialize: CommandCreator<AbsorbanceReaderInitializeArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { module: moduleId, mode, wavelengths, referenceWavelength } = args
+  return {
+    commands: [
+      {
+        commandType: 'absorbanceReader/initialize',
+        key: uuid(),
+        params: {
+          moduleId,
+          measureMode: mode,
+          sampleWavelengths: wavelengths,
+          ...(referenceWavelength != null ? { referenceWavelength } : {}),
+        },
+      },
+    ],
+  }
+}

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderOpenLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderOpenLid.ts
@@ -1,16 +1,18 @@
 import { uuid } from '../../utils'
 import { missingModuleError } from '../../errorCreators'
-import { getModuleState } from '../../robotStateSelectors'
+import { absorbanceReaderStateGetter } from '../../robotStateSelectors'
 
-import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/types/schemaV4'
-import type { CommandCreator } from '../../types'
+import type { AbsorbanceReaderLidArgs, CommandCreator } from '../../types'
 
-export const absorbanceReaderOpenLid: CommandCreator<ModuleOnlyParams> = (
+export const absorbanceReaderOpenLid: CommandCreator<AbsorbanceReaderLidArgs> = (
   args,
   invariantContext,
   prevRobotState
 ) => {
-  const absorbanceReaderState = getModuleState(prevRobotState, args.module)
+  const absorbanceReaderState = absorbanceReaderStateGetter(
+    prevRobotState,
+    args.module
+  )
   if (args.module == null || absorbanceReaderState == null) {
     return {
       errors: [missingModuleError()],

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderOpenLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderOpenLid.ts
@@ -1,4 +1,7 @@
 import { uuid } from '../../utils'
+import { missingModuleError } from '../../errorCreators'
+import { getModuleState } from '../../robotStateSelectors'
+
 import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/types/schemaV4'
 import type { CommandCreator } from '../../types'
 
@@ -7,6 +10,13 @@ export const absorbanceReaderOpenLid: CommandCreator<ModuleOnlyParams> = (
   invariantContext,
   prevRobotState
 ) => {
+  const absorbanceReaderState = getModuleState(prevRobotState, args.module)
+  if (args.module == null || absorbanceReaderState == null) {
+    return {
+      errors: [missingModuleError()],
+    }
+  }
+
   return {
     commands: [
       {

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderOpenLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderOpenLid.ts
@@ -1,0 +1,21 @@
+import { uuid } from '../../utils'
+import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/types/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const absorbanceReaderOpenLid: CommandCreator<ModuleOnlyParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        commandType: 'absorbanceReader/openLid',
+        key: uuid(),
+        params: {
+          moduleId: args.module,
+        },
+      },
+    ],
+  }
+}

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderRead.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderRead.ts
@@ -12,7 +12,7 @@ export const absorbanceReaderRead: CommandCreator<AbsorbanceReaderReadArgs> = (
   invariantContext,
   prevRobotState
 ) => {
-  const { module, filePath } = args
+  const { module, fileName } = args
   const errors: CommandCreatorError[] = []
   const absorbanceReaderState = absorbanceReaderStateGetter(
     prevRobotState,
@@ -37,7 +37,7 @@ export const absorbanceReaderRead: CommandCreator<AbsorbanceReaderReadArgs> = (
             key: uuid(),
             params: {
               moduleId: module,
-              ...(filePath != null ? { filePath } : {}),
+              ...(fileName != null ? { fileName } : {}),
             },
           },
         ],

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderRead.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderRead.ts
@@ -1,0 +1,45 @@
+import * as errorCreators from '../../errorCreators'
+import { absorbanceReaderStateGetter } from '../../robotStateSelectors'
+import { uuid } from '../../utils'
+import type {
+  AbsorbanceReaderReadArgs,
+  CommandCreator,
+  CommandCreatorError,
+} from '../../types'
+
+export const absorbanceReaderRead: CommandCreator<AbsorbanceReaderReadArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { module, filePath } = args
+  const errors: CommandCreatorError[] = []
+  const absorbanceReaderState = absorbanceReaderStateGetter(
+    prevRobotState,
+    module
+  )
+  if (absorbanceReaderState == null) {
+    return {
+      errors: [errorCreators.missingModuleError()],
+    }
+  }
+
+  if (absorbanceReaderState.initialization === null) {
+    errors.push(errorCreators.absorbanceReaderLidClosed())
+  }
+
+  return errors.length > 0
+    ? { errors }
+    : {
+        commands: [
+          {
+            commandType: 'absorbanceReader/read',
+            key: uuid(),
+            params: {
+              moduleId: module,
+              ...(filePath != null ? { filePath } : {}),
+            },
+          },
+        ],
+      }
+}

--- a/step-generation/src/commandCreators/atomic/index.ts
+++ b/step-generation/src/commandCreators/atomic/index.ts
@@ -1,3 +1,7 @@
+import { absorbanceReaderCloseLid } from './absorbanceReaderCloseLid'
+import { absorbanceReaderInitialize } from './absorbanceReaderInitialize'
+import { absorbanceReaderOpenLid } from './absorbanceReaderOpenLid'
+import { absorbanceReaderRead } from './absorbanceReaderRead'
 import { aspirate } from './aspirate'
 import { aspirateInPlace } from './aspirateInPlace'
 import { blowout } from './blowout'
@@ -22,6 +26,10 @@ import { setTemperature } from './setTemperature'
 import { touchTip } from './touchTip'
 import { waitForTemperature } from './waitForTemperature'
 export {
+  absorbanceReaderCloseLid,
+  absorbanceReaderInitialize,
+  absorbanceReaderOpenLid,
+  absorbanceReaderRead,
   aspirate,
   aspirateInPlace,
   blowout,

--- a/step-generation/src/commandCreators/compound/absorbanceReaderCloseInitialize.ts
+++ b/step-generation/src/commandCreators/compound/absorbanceReaderCloseInitialize.ts
@@ -1,0 +1,40 @@
+import { absorbanceReaderCloseLid, absorbanceReaderInitialize } from '../atomic'
+import * as errorCreators from '../../errorCreators'
+import { curryCommandCreator, reduceCommandCreators } from '../../utils'
+
+import type {
+  AbsorbanceReaderInitializeArgs,
+  CommandCreator,
+  CurriedCommandCreator,
+} from '../../types'
+
+export const absorbanceReaderCloseInitialize: CommandCreator<AbsorbanceReaderInitializeArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  if (args.module == null) {
+    return {
+      errors: [errorCreators.missingModuleError()],
+    }
+  }
+  const { module, mode, wavelengths, referenceWavelength } = args
+  const commandCreators: CurriedCommandCreator[] = [
+    curryCommandCreator(absorbanceReaderCloseLid, {
+      commandCreatorFnName: 'absorbanceReaderCloseLid',
+      module,
+    }),
+    curryCommandCreator(absorbanceReaderInitialize, {
+      commandCreatorFnName: 'absorbanceReaderInitialize',
+      module,
+      mode,
+      wavelengths,
+      referenceWavelength,
+    }),
+  ]
+  return reduceCommandCreators(
+    commandCreators,
+    invariantContext,
+    prevRobotState
+  )
+}

--- a/step-generation/src/commandCreators/compound/absorbanceReaderCloseInitialize.ts
+++ b/step-generation/src/commandCreators/compound/absorbanceReaderCloseInitialize.ts
@@ -1,5 +1,6 @@
 import { absorbanceReaderCloseLid, absorbanceReaderInitialize } from '../atomic'
 import * as errorCreators from '../../errorCreators'
+import { absorbanceReaderStateGetter } from '../../robotStateSelectors'
 import { curryCommandCreator, reduceCommandCreators } from '../../utils'
 
 import type {
@@ -13,7 +14,12 @@ export const absorbanceReaderCloseInitialize: CommandCreator<AbsorbanceReaderIni
   invariantContext,
   prevRobotState
 ) => {
-  if (args.module == null) {
+  const absorbanceReaderState = absorbanceReaderStateGetter(
+    prevRobotState,
+    args.module
+  )
+
+  if (args.module == null || absorbanceReaderState == null) {
     return {
       errors: [errorCreators.missingModuleError()],
     }

--- a/step-generation/src/commandCreators/compound/absorbanceReaderCloseRead.ts
+++ b/step-generation/src/commandCreators/compound/absorbanceReaderCloseRead.ts
@@ -39,7 +39,7 @@ export const absorbanceReaderCloseRead: CommandCreator<AbsorbanceReaderReadArgs>
     curryCommandCreator(absorbanceReaderRead, {
       commandCreatorFnName: 'absorbanceReaderRead',
       module,
-      filePath,
+      fileName,
     }),
   ]
   return reduceCommandCreators(

--- a/step-generation/src/commandCreators/compound/absorbanceReaderCloseRead.ts
+++ b/step-generation/src/commandCreators/compound/absorbanceReaderCloseRead.ts
@@ -29,7 +29,6 @@ export const absorbanceReaderCloseRead: CommandCreator<AbsorbanceReaderReadArgs>
   if (errors.length > 0) {
     return { errors }
   }
-
   const { module, fileName } = args
   const commandCreators: CurriedCommandCreator[] = [
     curryCommandCreator(absorbanceReaderCloseLid, {

--- a/step-generation/src/commandCreators/compound/absorbanceReaderCloseRead.ts
+++ b/step-generation/src/commandCreators/compound/absorbanceReaderCloseRead.ts
@@ -1,0 +1,38 @@
+import * as errorCreators from '../../errorCreators'
+import { curryCommandCreator, reduceCommandCreators } from '../../utils'
+import { absorbanceReaderCloseLid, absorbanceReaderRead } from '../atomic'
+
+import type {
+  AbsorbanceReaderReadArgs,
+  CommandCreator,
+  CurriedCommandCreator,
+} from '../../types'
+
+export const absorbanceReaderCloseRead: CommandCreator<AbsorbanceReaderReadArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  if (args.module == null) {
+    return {
+      errors: [errorCreators.missingModuleError()],
+    }
+  }
+  const { module, filePath } = args
+  const commandCreators: CurriedCommandCreator[] = [
+    curryCommandCreator(absorbanceReaderCloseLid, {
+      commandCreatorFnName: 'absorbanceReaderCloseLid',
+      module,
+    }),
+    curryCommandCreator(absorbanceReaderRead, {
+      commandCreatorFnName: 'absorbanceReaderRead',
+      module,
+      filePath,
+    }),
+  ]
+  return reduceCommandCreators(
+    commandCreators,
+    invariantContext,
+    prevRobotState
+  )
+}

--- a/step-generation/src/commandCreators/compound/index.ts
+++ b/step-generation/src/commandCreators/compound/index.ts
@@ -1,3 +1,5 @@
+export { absorbanceReaderCloseInitialize } from './absorbanceReaderCloseInitialize'
+export { absorbanceReaderCloseRead } from './absorbanceReaderCloseRead'
 export { consolidate } from './consolidate'
 export { distribute } from './distribute'
 export { mix } from './mix'

--- a/step-generation/src/commandCreators/index.ts
+++ b/step-generation/src/commandCreators/index.ts
@@ -6,9 +6,15 @@ export {
   thermocyclerProfileStep,
   thermocyclerStateStep,
   heaterShaker,
+  absorbanceReaderCloseInitialize,
+  absorbanceReaderCloseRead,
 } from './compound'
 
 export {
+  absorbanceReaderCloseLid,
+  absorbanceReaderInitialize,
+  absorbanceReaderOpenLid,
+  absorbanceReaderRead,
   aspirate,
   waitForTemperature,
   blowout,

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -161,7 +161,15 @@ export const absorbanceReaderLidClosed = (): CommandCreatorError => {
   return {
     type: 'ABSORBANCE_READER_LID_CLOSED',
     message:
-      'Attempted to interact with contents of an absorbance reader with the lid closed.',
+      'Attempted to interact with contents of an absorbance plate reader with the lid closed.',
+  }
+}
+
+export const absorbanceReaderNoInitialization = (): CommandCreatorError => {
+  return {
+    type: 'ABSORBANCE_READER_NO_INITIALIZATION',
+    message:
+      'This step tries to read labware without initializing the Plate Reader first. Initialize the Plate Reader module or remove this step in order to proceed.',
   }
 }
 

--- a/step-generation/src/getNextRobotStateAndWarnings/absorbanceReaderUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/absorbanceReaderUpdates.ts
@@ -1,0 +1,76 @@
+import { ABSORBANCE_READER_TYPE } from '@opentrons/shared-data'
+import { getModuleState } from '../robotStateSelectors'
+import type {
+  AbsorbanceReaderInitializeParams,
+  ModuleOnlyParams,
+} from '@opentrons/shared-data'
+import type {
+  AbsorbanceReaderState,
+  InvariantContext,
+  RobotState,
+  RobotStateAndWarnings,
+} from '../types'
+
+const _getAbsorbanceReaderState = (
+  robotState: RobotState,
+  module: string
+): AbsorbanceReaderState => {
+  const moduleState = getModuleState(robotState, module)
+
+  if (moduleState.type === ABSORBANCE_READER_TYPE) {
+    return moduleState
+  } else {
+    console.error(
+      `Absorbance reader state updater expected ${module} moduleState to be absorbanceReader, but it was ${moduleState.type}`
+    )
+    // return some object instead of an error :/
+    const fallback: any = {}
+    return fallback
+  }
+}
+
+export const forAbsorbanceReaderOpenLid = (
+  params: ModuleOnlyParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { robotState } = robotStateAndWarnings
+  const { moduleId } = params
+  const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
+
+  moduleState.lidOpen = true
+}
+
+export const forAbsorbanceReaderCloseLid = (
+  params: ModuleOnlyParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { robotState } = robotStateAndWarnings
+  const { moduleId } = params
+  const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
+
+  moduleState.lidOpen = false
+}
+
+export const forAbsorbanceReaderInitialize = (
+  params: AbsorbanceReaderInitializeParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { robotState } = robotStateAndWarnings
+  const {
+    moduleId,
+    measureMode,
+    sampleWavelengths,
+    referenceWavelength,
+  } = params
+
+  const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
+  moduleState.initialization = {
+    mode: measureMode,
+    wavelengths: sampleWavelengths,
+    referenceWavelength,
+  }
+  moduleState.lidOpen = false
+}

--- a/step-generation/src/getNextRobotStateAndWarnings/absorbanceReaderUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/absorbanceReaderUpdates.ts
@@ -14,7 +14,7 @@ import type {
 const _getAbsorbanceReaderState = (
   robotState: RobotState,
   module: string
-): AbsorbanceReaderState => {
+): AbsorbanceReaderState | null => {
   const moduleState = getModuleState(robotState, module)
 
   if (moduleState.type === ABSORBANCE_READER_TYPE) {
@@ -23,9 +23,7 @@ const _getAbsorbanceReaderState = (
     console.error(
       `Absorbance reader state updater expected ${module} moduleState to be absorbanceReader, but it was ${moduleState.type}`
     )
-    // return some object instead of an error :/
-    const fallback: any = {}
-    return fallback
+    return null
   }
 }
 
@@ -38,7 +36,9 @@ export const forAbsorbanceReaderOpenLid = (
   const { moduleId } = params
   const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
 
+  if (moduleState != null) {
   moduleState.lidOpen = true
+}
 }
 
 export const forAbsorbanceReaderCloseLid = (
@@ -50,7 +50,9 @@ export const forAbsorbanceReaderCloseLid = (
   const { moduleId } = params
   const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
 
+  if (moduleState != null) {
   moduleState.lidOpen = false
+}
 }
 
 export const forAbsorbanceReaderInitialize = (
@@ -67,10 +69,12 @@ export const forAbsorbanceReaderInitialize = (
   } = params
 
   const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
+  if (moduleState != null) {
   moduleState.initialization = {
     mode: measureMode,
     wavelengths: sampleWavelengths,
     referenceWavelength,
   }
   moduleState.lidOpen = false
+}
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/absorbanceReaderUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/absorbanceReaderUpdates.ts
@@ -37,8 +37,8 @@ export const forAbsorbanceReaderOpenLid = (
   const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
 
   if (moduleState != null) {
-  moduleState.lidOpen = true
-}
+    moduleState.lidOpen = true
+  }
 }
 
 export const forAbsorbanceReaderCloseLid = (
@@ -51,8 +51,8 @@ export const forAbsorbanceReaderCloseLid = (
   const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
 
   if (moduleState != null) {
-  moduleState.lidOpen = false
-}
+    moduleState.lidOpen = false
+  }
 }
 
 export const forAbsorbanceReaderInitialize = (
@@ -70,11 +70,11 @@ export const forAbsorbanceReaderInitialize = (
 
   const moduleState = _getAbsorbanceReaderState(robotState, moduleId)
   if (moduleState != null) {
-  moduleState.initialization = {
-    mode: measureMode,
-    wavelengths: sampleWavelengths,
-    referenceWavelength,
+    moduleState.initialization = {
+      mode: measureMode,
+      wavelengths: sampleWavelengths,
+      referenceWavelength,
+    }
+    moduleState.lidOpen = false
   }
-  moduleState.lidOpen = false
-}
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -315,7 +315,6 @@ function _getNextRobotStateAndWarningsSingleCommand(
         robotStateAndWarnings
       )
       break
-    case 'absorbanceReader/read':
     case 'absorbanceReader/closeLid':
       forAbsorbanceReaderCloseLid(
         command.params,
@@ -329,6 +328,8 @@ function _getNextRobotStateAndWarningsSingleCommand(
         invariantContext,
         robotStateAndWarnings
       )
+      break
+    case 'absorbanceReader/read':
       break
     default:
       assert(

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -40,6 +40,12 @@ import {
   forDispenseInPlace,
   forDropTipInPlace,
 } from './inPlaceCommandUpdates'
+import {
+  forAbsorbanceReaderCloseLid,
+  forAbsorbanceReaderInitialize,
+  forAbsorbanceReaderOpenLid,
+} from './absorbanceReaderUpdates'
+
 import type { CreateCommand } from '@opentrons/shared-data'
 import type {
   InvariantContext,
@@ -301,6 +307,28 @@ function _getNextRobotStateAndWarningsSingleCommand(
       break
     //  no state updates required
     case 'heaterShaker/waitForTemperature':
+      break
+    case 'absorbanceReader/openLid':
+      forAbsorbanceReaderOpenLid(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
+    case 'absorbanceReader/read':
+    case 'absorbanceReader/closeLid':
+      forAbsorbanceReaderCloseLid(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
+    case 'absorbanceReader/initialize':
+      forAbsorbanceReaderInitialize(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
       break
     default:
       assert(

--- a/step-generation/src/index.ts
+++ b/step-generation/src/index.ts
@@ -1,4 +1,10 @@
 export {
+  absorbanceReaderCloseInitialize,
+  absorbanceReaderCloseLid,
+  absorbanceReaderCloseRead,
+  absorbanceReaderInitialize,
+  absorbanceReaderOpenLid,
+  absorbanceReaderRead,
   aspirate,
   waitForTemperature,
   blowout,

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -1,15 +1,17 @@
 // TODO: Ian 2019-04-18 move orderWells somewhere more general -- shared-data util?
 import min from 'lodash/min'
 import {
-  getTiprackVolume,
-  getLabwareDefURI,
-  THERMOCYCLER_MODULE_TYPE,
-  orderWells,
-  COLUMN,
+  ABSORBANCE_READER_TYPE,
   ALL,
+  COLUMN,
+  getLabwareDefURI,
+  getTiprackVolume,
+  orderWells,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { COLUMN_4_SLOTS } from './constants'
 import type {
+  AbsorbanceReaderState,
   InvariantContext,
   ModuleTemporalProperties,
   RobotState,
@@ -229,6 +231,17 @@ export const thermocyclerStateGetter = (
 ): ThermocyclerModuleState | null => {
   const hardwareModule = robotState.modules[moduleId]?.moduleState
   return hardwareModule && hardwareModule.type === THERMOCYCLER_MODULE_TYPE
+    ? hardwareModule
+    : null
+}
+
+// TODO: refactor this and above utility into one
+export const absorbanceReaderStateGetter = (
+  robotState: RobotState,
+  moduleId: string
+): AbsorbanceReaderState | null => {
+  const hardwareModule = robotState.modules[moduleId]?.moduleState
+  return hardwareModule && hardwareModule.type === ABSORBANCE_READER_TYPE
     ? hardwareModule
     : null
 }

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -450,7 +450,7 @@ export interface AbsorbanceReaderInitializeArgs {
 export interface AbsorbanceReaderReadArgs {
   module: string
   commandCreatorFnName: 'absorbanceReaderRead'
-  filePath: string | null
+  fileName: string | null
   message?: string
 }
 

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -438,6 +438,33 @@ export interface ThermocyclerStateStepArgs {
   message?: string
 }
 
+export interface AbsorbanceReaderInitializeArgs {
+  module: string
+  commandCreatorFnName: 'absorbanceReaderInitialize'
+  mode: 'single' | 'multi'
+  wavelengths: number[]
+  referenceWavelength?: number | null
+  message?: string
+}
+
+export interface AbsorbanceReaderReadArgs {
+  module: string
+  commandCreatorFnName: 'absorbanceReaderRead'
+  filePath: string | null
+  message?: string
+}
+
+export interface AbsorbanceReaderLidArgs {
+  module: string
+  commandCreatorFnName: 'absorbanceReaderOpenLid' | 'absorbanceReaderCloseLid'
+  message?: string
+}
+
+export type AbsorbanceReaderArgs =
+  | AbsorbanceReaderInitializeArgs
+  | AbsorbanceReaderReadArgs
+  | AbsorbanceReaderLidArgs
+
 export interface MoveLabwareArgs extends CommonArgs {
   commandCreatorFnName: 'moveLabware'
   labware: string
@@ -451,6 +478,9 @@ export interface CommentArgs extends CommonArgs {
 }
 
 export type CommandCreatorArgs =
+  | AbsorbanceReaderInitializeArgs
+  | AbsorbanceReaderReadArgs
+  | AbsorbanceReaderLidArgs
   | ConsolidateArgs
   | DistributeArgs
   | MixArgs
@@ -540,6 +570,7 @@ export type RobotState = TimelineFrame // legacy name alias
 
 export type ErrorType =
   | 'ABSORBANCE_READER_LID_CLOSED'
+  | 'ABSORBANCE_READER_NO_INITIALIZATION'
   | 'CANNOT_MOVE_WITH_GRIPPER'
   | 'DROP_TIP_LOCATION_DOES_NOT_EXIST'
   | 'EQUIPMENT_DOES_NOT_EXIST'


### PR DESCRIPTION
# Overview

This PR wires up absorbance reader step form field to step generation, including transforming form to args, getNextRobotStateAndWarnings, and error and command creators for all possible plate reader steps. I also memoize labware presence in AbsorbanceReaderTools for efficiency.

Note that UI for creating initialization will be done in a followup PR. Dummy data is used for now.

Closes AUTH-1268
Closes AUTH-1269
Closes AUTH-1279

## Test Plan and Hands on Testing

- create a protocol with an absorbance reader
- go through the anticipated flow for the reader (initialize, open lid, move labware to reader, read)
- export and inspect protocol and verify that commands are emitted as expected
- to check lid error creator, delete open lid step above and verify that move labware produces a timeline error
- to check initialization error creator, restore previous open lid command, but delete initialization step and verify that read produces a timeline error

TODO:
- [x] test end-to-end on live bot

## Changelog

- wire up step generation for all absorbance reader commands
- create absorbance reader form to args function
- update next robot state
- add form change handlers
- add tests

## Review requests

- see test plan

## Risk assessment

medium