### PR TITLE
fix(shared-data): update tipracks to URIs

### DIFF
--- a/shared-data/liquid-class/definitions/1/ethanol_80.json
+++ b/shared-data/liquid-class/definitions/1/ethanol_80.json
@@ -8,7 +8,7 @@
       "pipetteModel": "flex_1channel_50",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -243,7 +243,7 @@
       "pipetteModel": "flex_8channel_50",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -478,7 +478,7 @@
       "pipetteModel": "flex_1channel_1000",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -713,7 +713,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_200ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -947,7 +947,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_1000ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -1186,7 +1186,7 @@
       "pipetteModel": "flex_8channel_1000",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -1421,7 +1421,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_200ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -1655,7 +1655,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_1000ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -1894,7 +1894,7 @@
       "pipetteModel": "flex_96channel_1000",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -2129,7 +2129,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_200ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -2363,7 +2363,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_1000ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",

--- a/shared-data/liquid-class/definitions/1/glycerol_50.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50.json
@@ -8,7 +8,7 @@
       "pipetteModel": "flex_1channel_50",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -236,7 +236,7 @@
       "pipetteModel": "flex_8channel_50",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -464,7 +464,7 @@
       "pipetteModel": "flex_1channel_1000",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -686,7 +686,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_200ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -904,7 +904,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_1000ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -1127,7 +1127,7 @@
       "pipetteModel": "flex_8channel_1000",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -1349,7 +1349,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_200ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -1567,7 +1567,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_1000ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -1790,7 +1790,7 @@
       "pipetteModel": "flex_96channel_1000",
       "byTipType": [
         {
-          "tiprack": "opentrons_flex_96_tiprack_50ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -2020,7 +2020,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_200ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",
@@ -2238,7 +2238,7 @@
           }
         },
         {
-          "tiprack": "opentrons_flex_96_tiprack_1000ul",
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
           "aspirate": {
             "submerge": {
               "positionReference": "well-top",


### PR DESCRIPTION
Closes AUTH-1293

# Overview

Replaces the tiprack names with URIs in Ethanol & Glycerol definitions

## Review requests

Do we want to rename the `liquid-class` directory to `liquid_class`? (dash vs underscore)

## Risk assessment

None
