### PR TITLE
feat(api): dynamic liquid tracking papi changes

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -2,22 +2,19 @@
 
 from __future__ import annotations
 
-from typing import (
-    Optional,
-    TYPE_CHECKING,
-    cast,
-    Union,
-    List,
-    Tuple,
-    NamedTuple,
+from typing import Optional, TYPE_CHECKING, cast, Union, List, Tuple
+from opentrons.types import (
+    Location,
+    Mount,
+    NozzleConfigurationType,
+    NozzleMapInterface,
+    MeniscusTracking,
 )
-from opentrons.types import Location, Mount, NozzleConfigurationType, NozzleMapInterface
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.util import FlowRates, find_value_for_api_version
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.advanced_control.transfers.common import TransferTipPolicyV2
-from opentrons.protocols.advanced_control.transfers import common as tx_commons
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine import (
     DeckPoint,
@@ -37,33 +34,29 @@ from opentrons.protocol_engine.types import (
     NozzleLayoutConfigurationType,
     AddressableOffsetVector,
     LiquidClassRecord,
-    NextTipInfo,
 )
 from opentrons.protocol_engine.errors.exceptions import TipNotAttachedError
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons_shared_data.pipette.types import PipetteNameType, PIPETTE_API_NAMES_MAP
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.errors.exceptions import (
     UnsupportedHardwareCommand,
 )
 from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from . import overlap_versions, pipette_movement_conflict
-from . import transfer_components_executor as tx_comps_executor
 
 from .well import WellCore
-from .labware import LabwareCore
 from ..instrument import AbstractInstrument
 from ...disposal_locations import TrashBin, WasteChute
 
 if TYPE_CHECKING:
     from .protocol import ProtocolCore
     from opentrons.protocol_api._liquid import LiquidClass
-    from opentrons.protocol_api._liquid_properties import TransferProperties
 
 _DISPENSE_VOLUME_VALIDATION_ADDED_IN = APIVersion(2, 17)
 
 
-class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
+class InstrumentCore(AbstractInstrument[WellCore]):
     """Instrument API core using a ProtocolEngine.
 
     Args:
@@ -147,7 +140,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         rate: float,
         flow_rate: float,
         in_place: bool,
-        is_meniscus: Optional[bool] = None,
+        meniscus_tracking: Optional[MeniscusTracking] = None,
     ) -> None:
         """Aspirate a given volume of liquid from the specified location.
         Args:
@@ -157,6 +150,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             rate: Not used in this core.
             flow_rate: The flow rate in µL/s to aspirate at.
             in_place: whether this is a in-place command.
+            meniscus_tracking: Optional data about where to aspirate from.
         """
         if well_core is None:
             if not in_place:
@@ -186,10 +180,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 labware_id=labware_id,
                 well_name=well_name,
                 absolute_point=location.point,
-                is_meniscus=is_meniscus,
+                meniscus_tracking=meniscus_tracking,
             )
-            if well_location.origin == WellOrigin.MENISCUS:
-                well_location.volumeOffset = "operationVolume"
+            dynamic_liquid_tracking = False
+            # caila bookmark
+            if meniscus_tracking:
+                if meniscus_tracking.target == "end":
+                    well_location.volumeOffset = "operationVolume"
+                elif meniscus_tracking.target == "dynamic_meniscus":
+                    dynamic_liquid_tracking = True
             pipette_movement_conflict.check_safe_for_pipette_movement(
                 engine_state=self._engine_client.state,
                 pipette_id=self._pipette_id,
@@ -197,16 +196,28 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 well_name=well_name,
                 well_location=well_location,
             )
-            self._engine_client.execute_command(
-                cmd.AspirateParams(
-                    pipetteId=self._pipette_id,
-                    labwareId=labware_id,
-                    wellName=well_name,
-                    wellLocation=well_location,
-                    volume=volume,
-                    flowRate=flow_rate,
+            if dynamic_liquid_tracking:
+                self._engine_client.execute_command(
+                    cmd.AspirateWhileTrackingParams(
+                        pipetteId=self._pipette_id,
+                        labwareId=labware_id,
+                        wellName=well_name,
+                        wellLocation=well_location,
+                        volume=volume,
+                        flowRate=flow_rate,
+                    )
                 )
-            )
+            else:
+                self._engine_client.execute_command(
+                    cmd.AspirateParams(
+                        pipetteId=self._pipette_id,
+                        labwareId=labware_id,
+                        wellName=well_name,
+                        wellLocation=well_location,
+                        volume=volume,
+                        flowRate=flow_rate,
+                    )
+                )
 
         self._protocol_core.set_last_location(location=location, mount=self.get_mount())
 
@@ -219,7 +230,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         flow_rate: float,
         in_place: bool,
         push_out: Optional[float],
-        is_meniscus: Optional[bool] = None,
+        meniscus_tracking: Optional[MeniscusTracking] = None,
     ) -> None:
         """Dispense a given volume of liquid into the specified location.
         Args:
@@ -230,7 +241,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             flow_rate: The flow rate in µL/s to dispense at.
             in_place: whether this is a in-place command.
             push_out: The amount to push the plunger below bottom position.
+            meniscus_tracking: Optional data about where to dispense from.
         """
+        # raise ValueError(f"well location = {location}")
         if self._protocol_core.api_version < _DISPENSE_VOLUME_VALIDATION_ADDED_IN:
             # In older API versions, when you try to dispense more than you can,
             # it gets clamped.
@@ -279,8 +292,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 labware_id=labware_id,
                 well_name=well_name,
                 absolute_point=location.point,
-                is_meniscus=is_meniscus,
+                meniscus_tracking=meniscus_tracking,
             )
+            dynamic_liquid_tracking = False
+            if meniscus_tracking:
+                if meniscus_tracking.target == "end":
+                    well_location.volumeOffset = "operationVolume"
+                elif meniscus_tracking.target == "dynamic_meniscus":
+                    dynamic_liquid_tracking = True
             pipette_movement_conflict.check_safe_for_pipette_movement(
                 engine_state=self._engine_client.state,
                 pipette_id=self._pipette_id,
@@ -288,17 +307,30 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 well_name=well_name,
                 well_location=well_location,
             )
-            self._engine_client.execute_command(
-                cmd.DispenseParams(
-                    pipetteId=self._pipette_id,
-                    labwareId=labware_id,
-                    wellName=well_name,
-                    wellLocation=well_location,
-                    volume=volume,
-                    flowRate=flow_rate,
-                    pushOut=push_out,
+            if dynamic_liquid_tracking:
+                self._engine_client.execute_command(
+                    cmd.DispenseWhileTrackingParams(
+                        pipetteId=self._pipette_id,
+                        labwareId=labware_id,
+                        wellName=well_name,
+                        wellLocation=well_location,
+                        volume=volume,
+                        flowRate=flow_rate,
+                        pushOut=push_out,
+                    )
                 )
-            )
+            else:
+                self._engine_client.execute_command(
+                    cmd.DispenseParams(
+                        pipetteId=self._pipette_id,
+                        labwareId=labware_id,
+                        wellName=well_name,
+                        wellLocation=well_location,
+                        volume=volume,
+                        flowRate=flow_rate,
+                        pushOut=push_out,
+                    )
+                )
 
         if isinstance(location, (TrashBin, WasteChute)):
             self._protocol_core.set_last_location(location=None, mount=self.get_mount())
@@ -698,7 +730,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         ).mount.to_hw_mount()
 
     def get_pipette_name(self) -> str:
-        """Get the pipette's name as a string.
+        """Get the pipette's load name as a string.
 
         Will match the load name of the actually loaded pipette,
         which may differ from the requested load name.
@@ -711,24 +743,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             if isinstance(pipette.pipetteName, PipetteNameType)
             else pipette.pipetteName
         )
-
-    def get_load_name(self) -> str:
-        """Get the pipette's requested API load name.
-
-        This is the load name that is specified in the `ProtocolContext.load_instrument()`
-        method. This name might differ from the engine-specific pipette name.
-        """
-        pipette = self._engine_client.state.pipettes.get(self._pipette_id)
-        load_name = next(
-            (
-                pip_api_name
-                for pip_api_name, pip_name in PIPETTE_API_NAMES_MAP.items()
-                if pip_name == pipette.pipetteName
-            ),
-            None,
-        )
-        assert load_name, "Load name not found."
-        return load_name
 
     def get_model(self) -> str:
         return self._engine_client.state.pipettes.get_model_name(self._pipette_id)
@@ -897,28 +911,23 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
     def load_liquid_class(
         self,
-        name: str,
-        transfer_properties: TransferProperties,
+        liquid_class: LiquidClass,
+        pipette_load_name: str,
         tiprack_uri: str,
     ) -> str:
-        """Load a liquid class into the engine and return its ID.
+        """Load a liquid class into the engine and return its ID."""
+        transfer_props = liquid_class.get_for(
+            pipette=pipette_load_name, tiprack=tiprack_uri
+        )
 
-        Args:
-            name: Name of the liquid class
-            transfer_properties: Liquid class properties for a specific pipette & tiprack combination
-            tiprack_uri: URI of the tiprack whose transfer properties we will be using.
-
-        Returns:
-            Liquid class record's ID, as generated by the protocol engine.
-        """
         liquid_class_record = LiquidClassRecord(
-            liquidClassName=name,
-            pipetteModel=self.get_load_name(),
+            liquidClassName=liquid_class.name,
+            pipetteModel=self.get_model(),  # TODO: verify this is the correct 'model' to use
             tiprack=tiprack_uri,
-            aspirate=transfer_properties.aspirate.as_shared_data_model(),
-            singleDispense=transfer_properties.dispense.as_shared_data_model(),
-            multiDispense=transfer_properties.multi_dispense.as_shared_data_model()
-            if transfer_properties.multi_dispense
+            aspirate=transfer_props.aspirate.as_shared_data_model(),
+            singleDispense=transfer_props.dispense.as_shared_data_model(),
+            multiDispense=transfer_props.multi_dispense.as_shared_data_model()
+            if transfer_props.multi_dispense
             else None,
         )
         result = self._engine_client.execute_command_without_recovery(
@@ -928,351 +937,16 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         )
         return result.liquidClassId
 
-    def get_next_tip(
-        self, tip_racks: List[LabwareCore], starting_well: Optional[str]
-    ) -> Optional[NextTipInfo]:
-        """Get the next tip to pick up."""
-        result = self._engine_client.execute_command_without_recovery(
-            cmd.GetNextTipParams(
-                pipetteId=self._pipette_id,
-                labwareIds=[tip_rack.labware_id for tip_rack in tip_racks],
-                startingTipWell=starting_well,
-            )
-        )
-        return (
-            result.nextTipInfo if isinstance(result.nextTipInfo, NextTipInfo) else None
-        )
-
-    def transfer_liquid(  # noqa: C901
+    def transfer_liquid(
         self,
-        liquid_class: LiquidClass,
+        liquid_class_id: str,
         volume: float,
-        source: List[Tuple[Location, WellCore]],
-        dest: List[Tuple[Location, WellCore]],
+        source: List[WellCore],
+        dest: List[WellCore],
         new_tip: TransferTipPolicyV2,
-        tip_racks: List[Tuple[Location, LabwareCore]],
-        trash_location: Union[Location, TrashBin, WasteChute],
+        trash_location: Union[WellCore, Location, TrashBin, WasteChute],
     ) -> None:
-        """Execute transfer using liquid class properties.
-
-        Args:
-            liquid_class: The liquid class to use for transfer properties.
-            volume: Volume to transfer per well.
-            source: List of source wells, with each well represented as a tuple of
-                    types.Location and WellCore.
-                    types.Location is only necessary for saving the last accessed location.
-            dest: List of destination wells, with each well represented as a tuple of
-                    types.Location and WellCore.
-                    types.Location is only necessary for saving the last accessed location.
-            new_tip: Whether the transfer should use a new tip 'once', 'never', 'always',
-                     or 'per source'.
-            tiprack_uri: The URI of the tiprack that the transfer settings are for.
-            tip_drop_location: Location where the tip will be dropped (if appropriate).
-        """
-        if not tip_racks:
-            raise RuntimeError(
-                "No tipracks found for pipette in order to perform transfer"
-            )
-        tiprack_uri_for_transfer_props = tip_racks[0][1].get_uri()
-        transfer_props = liquid_class.get_for(
-            pipette=self.get_load_name(),
-            tiprack=tiprack_uri_for_transfer_props,
-        )
-        # TODO: use the ID returned by load_liquid_class in command annotations
-        self.load_liquid_class(
-            name=liquid_class.name,
-            transfer_properties=transfer_props,
-            tiprack_uri=tiprack_uri_for_transfer_props,
-        )
-
-        # TODO: add multi-channel pipette handling here
-        source_dest_per_volume_step = tx_commons.expand_for_volume_constraints(
-            volumes=[volume for _ in range(len(source))],
-            targets=zip(source, dest),
-            max_volume=self.get_max_volume(),
-        )
-
-        def _drop_tip() -> None:
-            if isinstance(trash_location, (TrashBin, WasteChute)):
-                self.drop_tip_in_disposal_location(
-                    disposal_location=trash_location,
-                    home_after=False,
-                    alternate_tip_drop=True,
-                )
-            elif isinstance(trash_location, Location):
-                self.drop_tip(
-                    location=trash_location,
-                    well_core=trash_location.labware.as_well()._core,  # type: ignore[arg-type]
-                    home_after=False,
-                    alternate_drop_location=True,
-                )
-
-        def _pick_up_tip() -> None:
-            next_tip = self.get_next_tip(
-                tip_racks=[core for loc, core in tip_racks],
-                starting_well=None,
-            )
-            if next_tip is None:
-                raise RuntimeError(
-                    f"No tip available among {tip_racks} for this transfer."
-                )
-            (
-                tiprack_loc,
-                tiprack_uri,
-                tip_well,
-            ) = self._get_location_and_well_core_from_next_tip_info(next_tip, tip_racks)
-            if tiprack_uri != tiprack_uri_for_transfer_props:
-                raise RuntimeError(
-                    f"Tiprack {tiprack_uri} does not match the tiprack designated "
-                    f"for this transfer- {tiprack_uri_for_transfer_props}."
-                )
-            self.pick_up_tip(
-                location=tiprack_loc,
-                well_core=tip_well,
-                presses=None,
-                increment=None,
-            )
-
-        if new_tip == TransferTipPolicyV2.ONCE:
-            _pick_up_tip()
-
-        prev_src: Optional[Tuple[Location, WellCore]] = None
-        post_disp_tip_contents = [
-            tx_comps_executor.LiquidAndAirGapPair(
-                liquid=0,
-                air_gap=0,
-            )
-        ]
-        next_step_volume, next_src_dest_combo = next(source_dest_per_volume_step)
-        is_last_step = False
-        while not is_last_step:
-            step_volume = next_step_volume
-            src_dest_combo = next_src_dest_combo
-            step_source, step_destination = src_dest_combo
-            try:
-                next_step_volume, next_src_dest_combo = next(
-                    source_dest_per_volume_step
-                )
-            except StopIteration:
-                is_last_step = True
-
-            if new_tip == TransferTipPolicyV2.ALWAYS or (
-                new_tip == TransferTipPolicyV2.PER_SOURCE and step_source != prev_src
-            ):
-                if prev_src is not None:
-                    _drop_tip()
-                _pick_up_tip()
-                post_disp_tip_contents = [
-                    tx_comps_executor.LiquidAndAirGapPair(
-                        liquid=0,
-                        air_gap=0,
-                    )
-                ]
-
-            post_asp_tip_contents = self.aspirate_liquid_class(
-                volume=step_volume,
-                source=step_source,
-                transfer_properties=transfer_props,
-                transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
-                tip_contents=post_disp_tip_contents,
-            )
-            post_disp_tip_contents = self.dispense_liquid_class(
-                volume=step_volume,
-                dest=step_destination,
-                source=step_source,
-                transfer_properties=transfer_props,
-                transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
-                tip_contents=post_asp_tip_contents,
-                add_final_air_gap=False
-                if is_last_step and new_tip == TransferTipPolicyV2.NEVER
-                else True,
-                trash_location=trash_location,
-            )
-            prev_src = step_source
-        if new_tip != TransferTipPolicyV2.NEVER:
-            _drop_tip()
-
-    def _get_location_and_well_core_from_next_tip_info(
-        self,
-        tip_info: NextTipInfo,
-        tip_racks: List[Tuple[Location, LabwareCore]],
-    ) -> _TipInfo:
-        tiprack_labware_core = self._protocol_core._labware_cores_by_id[
-            tip_info.labwareId
-        ]
-        tip_well = tiprack_labware_core.get_well_core(tip_info.tipStartingWell)
-
-        tiprack_loc = [
-            loc for loc, lw_core in tip_racks if lw_core == tiprack_labware_core
-        ]
-
-        return _TipInfo(
-            Location(tip_well.get_top(0), tiprack_loc[0].labware),
-            tiprack_labware_core.get_uri(),
-            tip_well,
-        )
-
-    def aspirate_liquid_class(
-        self,
-        volume: float,
-        source: Tuple[Location, WellCore],
-        transfer_properties: TransferProperties,
-        transfer_type: tx_comps_executor.TransferType,
-        tip_contents: List[tx_comps_executor.LiquidAndAirGapPair],
-    ) -> List[tx_comps_executor.LiquidAndAirGapPair]:
-        """Execute aspiration steps.
-
-        1. Submerge
-        2. Mix
-        3. pre-wet
-        4. Aspirate
-        5. Delay- wait inside the liquid
-        6. Aspirate retract
-
-        Return: List of liquid and air gap pairs in tip.
-        """
-        aspirate_props = transfer_properties.aspirate
-        tx_commons.check_valid_volume_parameters(
-            disposal_volume=0,  # No disposal volume for 1-to-1 transfer
-            air_gap=aspirate_props.retract.air_gap_by_volume.get_for_volume(volume),
-            max_volume=self.get_max_volume(),
-        )
-        source_loc, source_well = source
-        aspirate_point = (
-            tx_comps_executor.absolute_point_from_position_reference_and_offset(
-                well=source_well,
-                position_reference=aspirate_props.position_reference,
-                offset=aspirate_props.offset,
-            )
-        )
-        aspirate_location = Location(aspirate_point, labware=source_loc.labware)
-        last_liquid_and_airgap_in_tip = (
-            tip_contents[-1]
-            if tip_contents
-            else tx_comps_executor.LiquidAndAirGapPair(
-                liquid=0,
-                air_gap=0,
-            )
-        )
-        components_executor = tx_comps_executor.TransferComponentsExecutor(
-            instrument_core=self,
-            transfer_properties=transfer_properties,
-            target_location=aspirate_location,
-            target_well=source_well,
-            transfer_type=transfer_type,
-            tip_state=tx_comps_executor.TipState(
-                last_liquid_and_air_gap_in_tip=last_liquid_and_airgap_in_tip
-            ),
-        )
-        components_executor.submerge(submerge_properties=aspirate_props.submerge)
-        # TODO: when aspirating for consolidation, do not perform mix
-        components_executor.mix(
-            mix_properties=aspirate_props.mix, last_dispense_push_out=False
-        )
-        # TODO: when aspirating for consolidation, do not preform pre-wet
-        components_executor.pre_wet(
-            volume=volume,
-        )
-        components_executor.aspirate_and_wait(volume=volume)
-        components_executor.retract_after_aspiration(volume=volume)
-
-        # return copy of tip_contents with last entry replaced by tip state from executor
-        last_contents = components_executor.tip_state.last_liquid_and_air_gap_in_tip
-        new_tip_contents = tip_contents[0:-1] + [last_contents]
-        return new_tip_contents
-
-    def dispense_liquid_class(
-        self,
-        volume: float,
-        dest: Tuple[Location, WellCore],
-        source: Optional[Tuple[Location, WellCore]],
-        transfer_properties: TransferProperties,
-        transfer_type: tx_comps_executor.TransferType,
-        tip_contents: List[tx_comps_executor.LiquidAndAirGapPair],
-        add_final_air_gap: bool,
-        trash_location: Union[Location, TrashBin, WasteChute],
-    ) -> List[tx_comps_executor.LiquidAndAirGapPair]:
-        """Execute single-dispense steps.
-        1. Move pipette to the ‘submerge’ position with normal speed.
-            - The pipette will move in an arc- move to max z height of labware
-              (if asp & disp are in same labware)
-              or max z height of all labware (if asp & disp are in separate labware)
-        2. Air gap removal:
-            - If dispense location is above the meniscus, DO NOT remove air gap
-              (it will be dispensed along with rest of the liquid later).
-              All other scenarios, remove the air gap by doing a dispense
-            - Flow rate = min(dispenseFlowRate, (airGapByVolume)/sec)
-            - Use the post-dispense delay
-        4. Move to the dispense position at the specified ‘submerge’ speed
-           (even if we might not be moving into the liquid)
-           - Do a delay (submerge delay)
-        6. Dispense:
-            - Dispense at the specified flow rate.
-            - Do a push out as specified ONLY IF there is no mix following the dispense AND the tip is empty.
-            Volume for push out is the volume being dispensed. So if we are dispensing 50uL, use pushOutByVolume[50] as push out volume.
-        7. Delay
-        8. Mix using the same flow rate and delays as specified for asp+disp,
-           with the volume and the number of repetitions specified. Use the delays in asp & disp.
-            - If the dispense position is outside the liquid, then raise error if mix is enabled.
-              Can only be checked if using liquid level detection/ meniscus-based positioning.
-            - If the user wants to perform a mix then they should specify a dispense position that’s inside the liquid OR do mix() on the wells after transfer.
-            - Do push out at the last dispense.
-        9. Retract
-
-        Return:
-            List of liquid and air gap pairs in tip.
-        """
-        dispense_props = transfer_properties.dispense
-        dest_loc, dest_well = dest
-        dispense_point = (
-            tx_comps_executor.absolute_point_from_position_reference_and_offset(
-                well=dest_well,
-                position_reference=dispense_props.position_reference,
-                offset=dispense_props.offset,
-            )
-        )
-        dispense_location = Location(dispense_point, labware=dest_loc.labware)
-        last_liquid_and_airgap_in_tip = (
-            tip_contents[-1]
-            if tip_contents
-            else tx_comps_executor.LiquidAndAirGapPair(
-                liquid=0,
-                air_gap=0,
-            )
-        )
-        components_executor = tx_comps_executor.TransferComponentsExecutor(
-            instrument_core=self,
-            transfer_properties=transfer_properties,
-            target_location=dispense_location,
-            target_well=dest_well,
-            transfer_type=transfer_type,
-            tip_state=tx_comps_executor.TipState(
-                last_liquid_and_air_gap_in_tip=last_liquid_and_airgap_in_tip
-            ),
-        )
-        components_executor.submerge(submerge_properties=dispense_props.submerge)
-        if dispense_props.mix.enabled:
-            push_out_vol = 0.0
-        else:
-            # TODO: if distributing, do a push out only at the last dispense
-            push_out_vol = dispense_props.push_out_by_volume.get_for_volume(volume)
-        components_executor.dispense_and_wait(
-            volume=volume,
-            push_out_override=push_out_vol,
-        )
-        components_executor.mix(
-            mix_properties=dispense_props.mix,
-            last_dispense_push_out=True,
-        )
-        components_executor.retract_after_dispensing(
-            trash_location=trash_location,
-            source_location=source[0] if source else None,
-            source_well=source[1] if source else None,
-            add_final_air_gap=add_final_air_gap,
-        )
-        last_contents = components_executor.tip_state.last_liquid_and_air_gap_in_tip
-        new_tip_contents = tip_contents[0:-1] + [last_contents]
-        return new_tip_contents
+        """Execute transfer using liquid class properties."""
 
     def retract(self) -> None:
         """Retract this instrument to the top of the gantry."""
@@ -1339,6 +1013,43 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         self._protocol_core.set_last_location(location=loc, mount=self.get_mount())
 
+    def liquid_probe_testing_data(
+        self,
+        well_core: WellCore,
+        loc: Location,
+        operation_volume: float,
+    ) -> Tuple[float, float, float]:
+        labware_id = well_core.labware_id
+        well_name = well_core.get_name()
+        well_location = WellLocation(
+            origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
+        )
+        result = self._engine_client.execute_command_without_recovery(
+            cmd.LiquidProbeParams(
+                labwareId=labware_id,
+                wellName=well_name,
+                wellLocation=well_location,
+                pipetteId=self.pipette_id,
+            )
+        )
+
+        self._protocol_core.set_last_location(location=loc, mount=self.get_mount())
+        projected_current_volume = (
+            self._engine_client.state.geometry.get_well_volume_at_height(
+                labware_id=labware_id, well_name=well_name, height=result.z_position
+            )
+        )
+        projected_final_height = (
+            self._engine_client.state.geometry.get_well_height_after_volume(
+                labware_id=labware_id,
+                well_name=well_name,
+                initial_height=result.z_position,
+                volume=operation_volume,
+            )
+        )
+
+        return result.z_position, projected_current_volume, projected_final_height
+
     def liquid_probe_without_recovery(
         self, well_core: WellCore, loc: Location
     ) -> float:
@@ -1365,13 +1076,3 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         return self._engine_client.state.pipettes.get_nozzle_configuration_supports_lld(
             self.pipette_id
         )
-
-    def delay(self, seconds: float) -> None:
-        """Call a protocol delay."""
-        self._protocol_core.delay(seconds=seconds, msg=None)
-
-
-class _TipInfo(NamedTuple):
-    tiprack_location: Location
-    tiprack_uri: str
-    tip_well: WellCore

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional, Union, List, Tuple
+from typing import TYPE_CHECKING, Optional, Union, List
 
 from opentrons import types
 from opentrons.hardware_control import CriticalPoint
@@ -25,7 +25,6 @@ from opentrons.protocol_api._liquid import LiquidClass
 from ...disposal_locations import TrashBin, WasteChute
 from ..instrument import AbstractInstrument
 from .legacy_well_core import LegacyWellCore
-from .legacy_labware_core import LegacyLabwareCore
 from .legacy_module_core import LegacyThermocyclerCore, LegacyHeaterShakerCore
 
 if TYPE_CHECKING:
@@ -38,7 +37,7 @@ _PRE_2_2_TIP_DROP_HEIGHT_MM = 10
 """In PAPIv2.1 and below, tips are always dropped 10 mm from the bottom of the well."""
 
 
-class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]):
+class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
     """Implementation of the InstrumentContext interface."""
 
     def __init__(
@@ -85,7 +84,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         rate: float,
         flow_rate: float,
         in_place: bool,
-        is_meniscus: Optional[bool] = None,
+        meniscus_tracking: Optional[types.MeniscusTracking] = None,
     ) -> None:
         """Aspirate a given volume of liquid from the specified location.
         Args:
@@ -95,6 +94,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
             rate: The rate in µL/s to aspirate at.
             flow_rate: Not used in this core.
             in_place: Whether we should move_to location.
+            meniscus_tracking: Optional data about where to aspirate from.
         """
         if self.get_current_volume() == 0:
             # Make sure we're at the top of the labware and clear of any
@@ -128,7 +128,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         flow_rate: float,
         in_place: bool,
         push_out: Optional[float],
-        is_meniscus: Optional[bool] = None,
+        meniscus_tracking: Optional[types.MeniscusTracking] = None,
     ) -> None:
         """Dispense a given volume of liquid into the specified location.
         Args:
@@ -139,6 +139,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
             flow_rate: Not used in this core.
             in_place: Whether we should move_to location.
             push_out: The amount to push the plunger below bottom position.
+            meniscus_tracking: Optional data about where to dispense from.
         """
         if isinstance(location, (TrashBin, WasteChute)):
             raise APIVersionError(
@@ -557,15 +558,24 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         """This will never be called because it was added in API 2.16."""
         pass
 
-    def transfer_liquid(
+    def load_liquid_class(
         self,
         liquid_class: LiquidClass,
+        pipette_load_name: str,
+        tiprack_uri: str,
+    ) -> str:
+        """This will never be called because it was added in .."""
+        # TODO(spp, 2024-11-20): update the docstring and error to include API version
+        assert False, "load_liquid_class is not supported in legacy context"
+
+    def transfer_liquid(
+        self,
+        liquid_class_id: str,
         volume: float,
-        source: List[Tuple[types.Location, LegacyWellCore]],
-        dest: List[Tuple[types.Location, LegacyWellCore]],
+        source: List[LegacyWellCore],
+        dest: List[LegacyWellCore],
         new_tip: TransferTipPolicyV2,
-        tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
-        trash_location: Union[types.Location, TrashBin, WasteChute],
+        trash_location: Union[LegacyWellCore, types.Location, TrashBin, WasteChute],
     ) -> None:
         """This will never be called because it was added in .."""
         # TODO(spp, 2024-11-20): update the docstring and error to include API version

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional, Union, List, Tuple
+from typing import TYPE_CHECKING, Optional, Union, List
 
 from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -23,7 +23,6 @@ from opentrons_shared_data.errors.exceptions import (
     UnexpectedTipAttachError,
 )
 
-from ..legacy.legacy_labware_core import LegacyLabwareCore
 from ...disposal_locations import TrashBin, WasteChute
 from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocol_api._liquid import LiquidClass
@@ -43,9 +42,7 @@ _PRE_2_2_TIP_DROP_HEIGHT_MM = 10
 """In PAPIv2.1 and below, tips are always dropped 10 mm from the bottom of the well."""
 
 
-class LegacyInstrumentCoreSimulator(
-    AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
-):
+class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
     """A simulation of an instrument context."""
 
     def __init__(
@@ -98,7 +95,6 @@ class LegacyInstrumentCoreSimulator(
         rate: float,
         flow_rate: float,
         in_place: bool,
-        is_meniscus: Optional[bool] = None,
     ) -> None:
         if self.get_current_volume() == 0:
             # Make sure we're at the top of the labware and clear of any
@@ -140,7 +136,6 @@ class LegacyInstrumentCoreSimulator(
         flow_rate: float,
         in_place: bool,
         push_out: Optional[float],
-        is_meniscus: Optional[bool] = None,
     ) -> None:
         if isinstance(location, (TrashBin, WasteChute)):
             raise APIVersionError(
@@ -477,15 +472,24 @@ class LegacyInstrumentCoreSimulator(
         """This will never be called because it was added in API 2.15."""
         pass
 
-    def transfer_liquid(
+    def load_liquid_class(
         self,
         liquid_class: LiquidClass,
+        pipette_load_name: str,
+        tiprack_uri: str,
+    ) -> str:
+        """This will never be called because it was added in .."""
+        # TODO(spp, 2024-11-20): update the docstring and error to include API version
+        assert False, "load_liquid_class is not supported in legacy context"
+
+    def transfer_liquid(
+        self,
+        liquid_class_id: str,
         volume: float,
-        source: List[Tuple[types.Location, LegacyWellCore]],
-        dest: List[Tuple[types.Location, LegacyWellCore]],
+        source: List[LegacyWellCore],
+        dest: List[LegacyWellCore],
         new_tip: TransferTipPolicyV2,
-        tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
-        trash_location: Union[types.Location, TrashBin, WasteChute],
+        trash_location: Union[LegacyWellCore, types.Location, TrashBin, WasteChute],
     ) -> None:
         """Transfer a liquid from source to dest according to liquid class properties."""
         # TODO(spp, 2024-11-20): update the docstring and error to include API version

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -24,11 +24,12 @@ from typing import (
     cast,
     Sequence,
     Mapping,
+    Literal,
 )
 
 from opentrons_shared_data.labware.types import LabwareDefinition, LabwareParameters
 
-from opentrons.types import Location, Point, NozzleMapInterface
+from opentrons.types import Location, Point, NozzleMapInterface, MeniscusTracking
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import (
     requires_version,
@@ -233,16 +234,21 @@ class Well:
         return Location(self._core.get_center(), self)
 
     @requires_version(2, 21)
-    def meniscus(self, z: float = 0.0) -> Location:
+    def meniscus(
+        self, target: Literal["beginning", "end", "dynamic_meniscus"], z: float = 0.0
+    ) -> Location:
         """
         :param z: An offset on the z-axis, in mm. Positive offsets are higher and
             negative offsets are lower.
+        :param target: The relative position inside the well to target with respect to a liquid handling operation.
         :return: A :py:class:`~opentrons.types.Location` that indicates location is meniscus and that holds the ``z`` offset in its point.z field.
 
         :meta private:
         """
         return Location(
-            point=Point(x=0, y=0, z=z), labware=self, _ot_internal_is_meniscus=True
+            point=Point(x=0, y=0, z=z),
+            labware=self,
+            _meniscus_tracking=MeniscusTracking(target=target),
         )
 
     @requires_version(2, 8)

--- a/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
@@ -1,0 +1,249 @@
+"""Aspirate command request, result, and implementation models."""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional, Type, Union
+from typing_extensions import Literal
+
+from .pipetting_common import (
+    OverpressureError,
+    PipetteIdMixin,
+    AspirateVolumeMixin,
+    FlowRateMixin,
+    BaseLiquidHandlingResult,
+    aspirate_while_tracking,
+    prepare_for_aspirate,
+)
+from .movement_common import (
+    LiquidHandlingWellLocationMixin,
+    DestinationPositionResult,
+    StallOrCollisionError,
+    move_to_well,
+)
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    DefinedErrorData,
+    SuccessData,
+)
+
+from opentrons.hardware_control import HardwareControlAPI
+
+from ..state.update_types import StateUpdate, CLEAR
+from ..types import (
+    WellLocation,
+    WellOrigin,
+    CurrentWell,
+)
+
+if TYPE_CHECKING:
+    from ..execution import MovementHandler, PipettingHandler
+    from ..resources import ModelUtils
+    from ..state.state import StateView
+    from ..notes import CommandNoteAdder
+
+
+AspirateWhileTrackingCommandType = Literal["aspirateWhileTracking"]
+
+
+class AspirateWhileTrackingParams(
+    PipetteIdMixin,
+    AspirateVolumeMixin,
+    FlowRateMixin,
+    LiquidHandlingWellLocationMixin,
+):
+    """Parameters required to aspirate from a specific well."""
+
+    pass
+
+
+class AspirateWhileTrackingResult(BaseLiquidHandlingResult, DestinationPositionResult):
+    """Result data from execution of an Aspirate command."""
+
+    pass
+
+
+_ExecuteReturn = Union[
+    SuccessData[AspirateWhileTrackingResult],
+    DefinedErrorData[OverpressureError] | DefinedErrorData[StallOrCollisionError],
+]
+
+
+class AspirateWhileTrackingImplementation(
+    AbstractCommandImpl[AspirateWhileTrackingParams, _ExecuteReturn]
+):
+    """AspirateWhileTracking command implementation."""
+
+    def __init__(
+        self,
+        pipetting: PipettingHandler,
+        state_view: StateView,
+        hardware_api: HardwareControlAPI,
+        movement: MovementHandler,
+        command_note_adder: CommandNoteAdder,
+        model_utils: ModelUtils,
+        **kwargs: object,
+    ) -> None:
+        self._pipetting = pipetting
+        self._state_view = state_view
+        self._hardware_api = hardware_api
+        self._movement = movement
+        self._command_note_adder = command_note_adder
+        self._model_utils = model_utils
+
+    async def execute(self, params: AspirateWhileTrackingParams) -> _ExecuteReturn:
+        """Move to and aspirate from the requested well.
+
+        Raises:
+            TipNotAttachedError: if no tip is attached to the pipette.
+        """
+        pipette_id = params.pipetteId
+        labware_id = params.labwareId
+        well_name = params.wellName
+        well_location = params.wellLocation
+
+        state_update = StateUpdate()
+
+        final_location = self._state_view.geometry.get_well_position(
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+            operation_volume=-params.volume,
+            pipette_id=pipette_id,
+        )
+
+        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
+            pipette_id=pipette_id
+        )
+
+        current_well = None
+
+        if not ready_to_aspirate:
+            move_result = await move_to_well(
+                movement=self._movement,
+                model_utils=self._model_utils,
+                pipette_id=pipette_id,
+                labware_id=labware_id,
+                well_name=well_name,
+                well_location=WellLocation(origin=WellOrigin.TOP),
+            )
+            state_update.append(move_result.state_update)
+            if isinstance(move_result, DefinedErrorData):
+                return DefinedErrorData(move_result.public, state_update=state_update)
+
+            prepare_result = await prepare_for_aspirate(
+                pipette_id=pipette_id,
+                pipetting=self._pipetting,
+                model_utils=self._model_utils,
+                # Note that the retryLocation is the final location, inside the liquid,
+                # because that's where we'd want the client to try re-aspirating if this
+                # command fails and the run enters error recovery.
+                location_if_error={"retryLocation": final_location},
+            )
+            state_update.append(prepare_result.state_update)
+            if isinstance(prepare_result, DefinedErrorData):
+                return DefinedErrorData(
+                    public=prepare_result.public, state_update=state_update
+                )
+
+            # set our current deck location to the well now that we've made
+            # an intermediate move for the "prepare for aspirate" step
+            current_well = CurrentWell(
+                pipette_id=pipette_id,
+                labware_id=labware_id,
+                well_name=well_name,
+            )
+        move_result = await move_to_well(
+            movement=self._movement,
+            model_utils=self._model_utils,
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+            current_well=current_well,
+        )
+        state_update.append(move_result.state_update)
+        if isinstance(move_result, DefinedErrorData):
+            return DefinedErrorData(
+                public=move_result.public, state_update=state_update
+            )
+
+        aspirate_result = await aspirate_while_tracking(
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            volume=params.volume,
+            flow_rate=params.flowRate,
+            location_if_error={
+                "retryLocation": (
+                    move_result.public.position.x,
+                    move_result.public.position.y,
+                    move_result.public.position.z,
+                )
+            },
+            command_note_adder=self._command_note_adder,
+            pipetting=self._pipetting,
+            model_utils=self._model_utils,
+        )
+        state_update.append(aspirate_result.state_update)
+        if isinstance(aspirate_result, DefinedErrorData):
+            state_update.set_liquid_operated(
+                labware_id=labware_id,
+                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                    labware_id,
+                    well_name,
+                    params.pipetteId,
+                ),
+                volume_added=CLEAR,
+            )
+            return DefinedErrorData(
+                public=aspirate_result.public, state_update=state_update
+            )
+
+        state_update.set_liquid_operated(
+            labware_id=labware_id,
+            well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                labware_id, well_name, pipette_id
+            ),
+            volume_added=-aspirate_result.public.volume
+            * self._state_view.geometry.get_nozzles_per_well(
+                labware_id,
+                well_name,
+                params.pipetteId,
+            ),
+        )
+
+        return SuccessData(
+            public=AspirateWhileTrackingResult(
+                volume=aspirate_result.public.volume,
+                position=move_result.public.position,
+            ),
+            state_update=state_update,
+        )
+
+
+class AspirateWhileTracking(
+    BaseCommand[
+        AspirateWhileTrackingParams,
+        AspirateWhileTrackingResult,
+        OverpressureError | StallOrCollisionError,
+    ]
+):
+    """AspirateWhileTracking command model."""
+
+    commandType: AspirateWhileTrackingCommandType = "aspirateWhileTracking"
+    params: AspirateWhileTrackingParams
+    result: Optional[AspirateWhileTrackingResult] = None
+
+    _ImplementationCls: Type[
+        AspirateWhileTrackingImplementation
+    ] = AspirateWhileTrackingImplementation
+
+
+class AspirateWhileTrackingCreate(BaseCommandCreate[AspirateWhileTrackingParams]):
+    """Create aspirateWhileTracking command request model."""
+
+    commandType: AspirateWhileTrackingCommandType = "aspirateWhileTracking"
+    params: AspirateWhileTrackingParams
+
+    _CommandCls: Type[AspirateWhileTracking] = AspirateWhileTracking

--- a/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
@@ -1,0 +1,202 @@
+"""Dispense command request, result, and implementation models."""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional, Type, Union, Any
+from typing_extensions import Literal
+
+
+from pydantic import Field
+from pydantic.json_schema import SkipJsonSchema
+
+from ..state.update_types import StateUpdate, CLEAR
+from .pipetting_common import (
+    PipetteIdMixin,
+    DispenseVolumeMixin,
+    FlowRateMixin,
+    BaseLiquidHandlingResult,
+    OverpressureError,
+    dispense_while_tracking,
+)
+from .movement_common import (
+    LiquidHandlingWellLocationMixin,
+    DestinationPositionResult,
+    StallOrCollisionError,
+    move_to_well,
+)
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    DefinedErrorData,
+    SuccessData,
+)
+
+if TYPE_CHECKING:
+    from ..execution import MovementHandler, PipettingHandler
+    from ..resources import ModelUtils
+    from ..state.state import StateView
+
+
+DispenseWhileTrackingCommandType = Literal["dispenseWhileTracking"]
+
+
+def _remove_default(s: dict[str, Any]) -> None:
+    s.pop("default", None)
+
+
+class DispenseWhileTrackingParams(
+    PipetteIdMixin,
+    DispenseVolumeMixin,
+    FlowRateMixin,
+    LiquidHandlingWellLocationMixin,
+):
+    """Payload required to dispense to a specific well."""
+
+    pushOut: float | SkipJsonSchema[None] = Field(
+        None,
+        description="push the plunger a small amount farther than necessary for accurate low-volume dispensing",
+        json_schema_extra=_remove_default,
+    )
+
+
+class DispenseWhileTrackingResult(BaseLiquidHandlingResult, DestinationPositionResult):
+    """Result data from the execution of a Dispense command."""
+
+    pass
+
+
+_ExecuteReturn = Union[
+    SuccessData[DispenseWhileTrackingResult],
+    DefinedErrorData[OverpressureError] | DefinedErrorData[StallOrCollisionError],
+]
+
+
+class DispenseWhileTrackingImplementation(
+    AbstractCommandImpl[DispenseWhileTrackingParams, _ExecuteReturn]
+):
+    """Dispense command implementation."""
+
+    def __init__(
+        self,
+        state_view: StateView,
+        movement: MovementHandler,
+        pipetting: PipettingHandler,
+        model_utils: ModelUtils,
+        **kwargs: object,
+    ) -> None:
+        self._state_view = state_view
+        self._movement = movement
+        self._pipetting = pipetting
+        self._model_utils = model_utils
+
+    async def execute(self, params: DispenseWhileTrackingParams) -> _ExecuteReturn:
+        """Move to and dispense to the requested well."""
+        well_location = params.wellLocation
+        labware_id = params.labwareId
+        well_name = params.wellName
+
+        # TODO(pbm, 10-15-24): call self._state_view.geometry.validate_dispense_volume_into_well()
+
+        move_result = await move_to_well(
+            movement=self._movement,
+            model_utils=self._model_utils,
+            pipette_id=params.pipetteId,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+        )
+        if isinstance(move_result, DefinedErrorData):
+            return move_result
+        dispense_result = await dispense_while_tracking(
+            pipette_id=params.pipetteId,
+            labware_id=labware_id,
+            well_name=well_name,
+            volume=params.volume,
+            flow_rate=params.flowRate,
+            push_out=params.pushOut,
+            location_if_error={
+                "retryLocation": (
+                    move_result.public.position.x,
+                    move_result.public.position.y,
+                    move_result.public.position.z,
+                )
+            },
+            pipetting=self._pipetting,
+            model_utils=self._model_utils,
+        )
+
+        if isinstance(dispense_result, DefinedErrorData):
+            return DefinedErrorData(
+                public=dispense_result.public,
+                state_update=(
+                    StateUpdate.reduce(
+                        move_result.state_update, dispense_result.state_update
+                    ).set_liquid_operated(
+                        labware_id=labware_id,
+                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                            labware_id, well_name, params.pipetteId
+                        ),
+                        volume_added=CLEAR,
+                    )
+                ),
+                state_update_if_false_positive=StateUpdate.reduce(
+                    move_result.state_update,
+                    dispense_result.state_update_if_false_positive,
+                ),
+            )
+        else:
+            volume_added = (
+                self._state_view.pipettes.get_liquid_dispensed_by_ejecting_volume(
+                    pipette_id=params.pipetteId, volume=dispense_result.public.volume
+                )
+            )
+            if volume_added is not None:
+                volume_added *= self._state_view.geometry.get_nozzles_per_well(
+                    labware_id, well_name, params.pipetteId
+                )
+            return SuccessData(
+                public=DispenseWhileTrackingResult(
+                    volume=dispense_result.public.volume,
+                    position=move_result.public.position,
+                ),
+                state_update=(
+                    StateUpdate.reduce(
+                        move_result.state_update, dispense_result.state_update
+                    ).set_liquid_operated(
+                        labware_id=labware_id,
+                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                            labware_id, well_name, params.pipetteId
+                        ),
+                        volume_added=volume_added
+                        if volume_added is not None
+                        else CLEAR,
+                    )
+                ),
+            )
+
+
+class DispenseWhileTracking(
+    BaseCommand[
+        DispenseWhileTrackingParams,
+        DispenseWhileTrackingResult,
+        OverpressureError | StallOrCollisionError,
+    ]
+):
+    """Dispense command model."""
+
+    commandType: DispenseWhileTrackingCommandType = "dispenseWhileTracking"
+    params: DispenseWhileTrackingParams
+    result: Optional[DispenseWhileTrackingResult] = None
+
+    _ImplementationCls: Type[
+        DispenseWhileTrackingImplementation
+    ] = DispenseWhileTrackingImplementation
+
+
+class DispenseWhileTrackingCreate(BaseCommandCreate[DispenseWhileTrackingParams]):
+    """Create dispenseWhileTracking command request model."""
+
+    commandType: DispenseWhileTrackingCommandType = "dispenseWhileTracking"
+    params: DispenseWhileTrackingParams
+
+    _CommandCls: Type[DispenseWhileTracking] = DispenseWhileTracking

--- a/shared-data/command/schemas/11.json
+++ b/shared-data/command/schemas/11.json
@@ -337,6 +337,73 @@
       "title": "AspirateProperties",
       "type": "object"
     },
+    "AspirateWhileTrackingCreate": {
+      "description": "Create aspirateWhileTracking command request model.",
+      "properties": {
+        "commandType": {
+          "const": "aspirateWhileTracking",
+          "default": "aspirateWhileTracking",
+          "enum": ["aspirateWhileTracking"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/AspirateWhileTrackingParams"
+        }
+      },
+      "required": ["params"],
+      "title": "AspirateWhileTrackingCreate",
+      "type": "object"
+    },
+    "AspirateWhileTrackingParams": {
+      "description": "Parameters required to aspirate from a specific well.",
+      "properties": {
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "volume": {
+          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/LiquidHandlingWellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "title": "AspirateWhileTrackingParams",
+      "type": "object"
+    },
     "BlowOutCreate": {
       "description": "Create blow-out command request model.",
       "properties": {
@@ -1410,6 +1477,78 @@
       },
       "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "DispenseParams",
+      "type": "object"
+    },
+    "DispenseWhileTrackingCreate": {
+      "description": "Create dispenseWhileTracking command request model.",
+      "properties": {
+        "commandType": {
+          "const": "dispenseWhileTracking",
+          "default": "dispenseWhileTracking",
+          "enum": ["dispenseWhileTracking"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DispenseWhileTrackingParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DispenseWhileTrackingCreate",
+      "type": "object"
+    },
+    "DispenseWhileTrackingParams": {
+      "description": "Payload required to dispense to a specific well.",
+      "properties": {
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "pushOut": {
+          "description": "push the plunger a small amount farther than necessary for accurate low-volume dispensing",
+          "title": "Pushout",
+          "type": "number"
+        },
+        "volume": {
+          "description": "The amount of liquid to dispense, in \u00b5L. Must not be greater than the currently aspirated volume. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/LiquidHandlingWellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "title": "DispenseWhileTrackingParams",
       "type": "object"
     },
     "DropTipCreate": {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
