### PR TITLE
fix(shared-data): fix getPipetteSpecsV2 finding PEEK pipette specs

### DIFF
--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -161,6 +161,7 @@ const getHighestVersion = (
   path: string,
   pipetteModel: string,
   channels: Channels | null,
+  oemString: string,
   majorVersion: number,
   highestVersion: string
 ): string => {
@@ -174,10 +175,10 @@ const getHighestVersion = (
     //  and make sure the given model, channels, and major/minor versions
     //  are found in the path
     if (
-      minorPathVersion > minorHighestVersion &&
+      minorPathVersion >= minorHighestVersion &&
       path.includes(`${majorPathVersion}_${minorPathVersion}`) &&
       path.includes(pipetteModel) &&
-      path.includes(channels ?? '')
+      path.includes(channels != null ? `${channels}${oemString}` : '')
     ) {
       highestVersion = `${majorPathVersion}_${minorPathVersion}`
     }
@@ -239,6 +240,7 @@ export const getPipetteSpecsV2 = (
         path,
         pipetteModel,
         channels,
+        oemString,
         majorVersion,
         highestVersion
       )


### PR DESCRIPTION
fix RQA-3852

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The display name for the peek pipette was missing from run log because `getPipetteSpecsV2` wasn't constructing the correct path to pull in general and geometry specs.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Look at run log for a protocol that uses the PEEK pipette - see that the display name is now pulled in correctly 
<img width="900" alt="Screen Shot 2025-01-16 at 5 38 40 PM" src="https://github.com/user-attachments/assets/f67c293f-946f-4dd5-aa65-4e65407c763d" />

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Update `getHighestVersion` util in pipettes to take into account the `_em` in the pipette name, and allow for a highest minor version equal to 0
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Was there a reason that we assumed minor version had to be higher than 0?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
