### PR TITLE
fix(protocol-designer): get labware location from current step index 

### DIFF
--- a/protocol-designer/src/ui/labware/utils.ts
+++ b/protocol-designer/src/ui/labware/utils.ts
@@ -39,25 +39,25 @@ function resolveSlotLocation(
   }
 }
 
-export function getLabwareLatestSlot(
+export function getLabwareLatestSlotFromCurrentStepIndex(
   initialDeckSetup: InitialDeckSetup,
   savedStepForms: SavedStepFormState,
   labwareId: string,
-  robotType: RobotType
+  robotType: RobotType,
+  filteredSavedStepFormIds: string[]
 ): string | null {
   const { modules, labware, additionalEquipmentOnDeck } = initialDeckSetup
   const initialSlot = labware[labwareId]?.slot
   const hasWasteChute = getHasWasteChute(additionalEquipmentOnDeck)
 
-  //  latest moveLabware step related to labwareId
-  const moveLabwareStep = Object.values(savedStepForms)
-    .filter(
-      state =>
-        state.stepType === 'moveLabware' &&
-        labwareId != null &&
-        labwareId === state.labware
-    )
-    .reverse()[0]
+  //  latest moveLabware step related to labwareId at given index
+  const moveLabwareStepId = filteredSavedStepFormIds.find(
+    id =>
+      savedStepForms[id].stepType === 'moveLabware' &&
+      savedStepForms[id].labware === labwareId
+  )
+  const moveLabwareStep =
+    moveLabwareStepId != null ? savedStepForms[moveLabwareStepId] : null
 
   if (
     hasWasteChute &&

--- a/protocol-designer/src/ui/labware/utils.ts
+++ b/protocol-designer/src/ui/labware/utils.ts
@@ -51,11 +51,13 @@ export function getLabwareLatestSlotFromCurrentStepIndex(
   const hasWasteChute = getHasWasteChute(additionalEquipmentOnDeck)
 
   //  latest moveLabware step related to labwareId at given index
-  const moveLabwareStepId = filteredSavedStepFormIds.find(
-    id =>
-      savedStepForms[id].stepType === 'moveLabware' &&
-      savedStepForms[id].labware === labwareId
-  )
+  const moveLabwareStepId = filteredSavedStepFormIds
+    .filter(
+      id =>
+        savedStepForms[id].stepType === 'moveLabware' &&
+        savedStepForms[id].labware === labwareId
+    )
+    .pop()
   const moveLabwareStep =
     moveLabwareStepId != null ? savedStepForms[moveLabwareStepId] : null
 


### PR DESCRIPTION
closes RQA-3774

# Overview

Previous logic was grabbing the labware location from the latest move labware step for the whole protocol but didn't account for if you are opening up a previously made step earlier on in the protocol before the labware moved. So now, the logic takes that certain step id index into account

## Test Plan and Hands on Testing

upload the attached protocol and look at step 10. see that the labware in the dropdown menu are not ending with "cutoutD3", should instead say "off-deck"

[Zymo_Magbead_DNA_Cells-Flex_96_channel  Truly fixed.json](https://github.com/user-attachments/files/18455561/Zymo_Magbead_DNA_Cells-Flex_96_channel.Truly.fixed.json)

Additionally, you can test moving a labware to multiple locations and checking that the slot number in the dropdown properly updates.

## Changelog

- fix logic to grab location at certain step index
- align logic for move labware field and labware field in transfer steps

## Risk assessment

low
