### PR TITLE
fix(protocol-designer): oT-2 TC labware highlight refine logic

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -154,7 +154,11 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
                 selected => selected.id === labwareOnDeck.id
               )}
               isLast={true}
-              position={tcModel != null ? tcPosition : position}
+              position={
+                tcModel != null && (labwareSlot === '7' || labwareSlot === 'B1')
+                  ? tcPosition
+                  : position
+              }
               labwareDef={labwareOnDeck.def}
               labelText={
                 hoveredItemLabware == null


### PR DESCRIPTION
closes RQA-3849

# Overview

Accidentally highlighted all the labware when hovering over the TC labware

## Test Plan and Hands on Testing

Test the attached protocol and hover over the labware in the move labware dropdown. see that the highlights occur in the correct locations

[untitled (36).json](https://github.com/user-attachments/files/18457743/untitled.36.json)



## Changelog

make logic more specific for checking labware slot as well

## Risk assessment

low
