### PR TITLE
feat(shared-data): Introduce Tiprack lid labware

### DIFF
--- a/shared-data/labware/definitions/3/opentrons_flex_tiprack_lid/1.json
+++ b/shared-data/labware/definitions/3/opentrons_flex_tiprack_lid/1.json
@@ -76,7 +76,7 @@
       "z": 8.25
     }
   },
-  "stackLimit": 5,
+  "stackLimit": 1,
   "compatibleParentLabware": [
     "opentrons_flex_96_tiprack_20ul",
     "opentrons_flex_96_tiprack_50ul",

--- a/shared-data/labware/definitions/3/opentrons_flex_tiprack_lid/1.json
+++ b/shared-data/labware/definitions/3/opentrons_flex_tiprack_lid/1.json
@@ -1,0 +1,116 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Opentrons Flex Tiprack Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.7,
+    "yDimension": 78.75,
+    "zDimension": 17
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": -0.71
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": [],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "isDeckSlotCompatible": false,
+    "loadName": "opentrons_flex_tiprack_lid"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 3,
+  "stackingOffsetWithLabware": {
+    "default": {
+      "x": 0,
+      "y": 0,
+      "z": 8.193
+    },
+    "opentrons_flex_96_filtertiprack_200ul": {
+      "x": 0,
+      "y": 0,
+      "z": 8.25
+    },
+    "opentrons_flex_96_filtertiprack_1000ul": {
+      "x": 0,
+      "y": 0,
+      "z": 8.25
+    },
+    "opentrons_flex_96_tiprack_20ul": {
+      "x": 0,
+      "y": 0,
+      "z": 8.25
+    },
+    "opentrons_flex_96_tiprack_50ul": {
+      "x": 0,
+      "y": 0,
+      "z": 8.25
+    },
+    "opentrons_flex_96_tiprack_200ul": {
+      "x": 0,
+      "y": 0,
+      "z": 8.25
+    },
+    "opentrons_flex_96_tiprack_1000ul": {
+      "x": 0,
+      "y": 0,
+      "z": 8.25
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "opentrons_flex_96_tiprack_20ul",
+    "opentrons_flex_96_tiprack_50ul",
+    "opentrons_flex_96_tiprack_200ul",
+    "opentrons_flex_96_tiprack_1000ul",
+    "opentrons_flex_96_filertiprack_200ul",
+    "opentrons_flex_96_filertiprack_1000ul"
+  ],
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 8,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Overview
Covers EXEC-1003

Introduce the tiprack lid labware for Opentrons Flex Tipracks. This will enable Flex Stacker protocols involving a Tiprack with a Lid.

The dimensions and grip positions were calculated using data from the DVT Robot Extents spreadsheet, under the Tiprack Lid section.

## Test Plan and Hands on Testing

- [x] The following Protocol should pass analysis and succeed at throwing away a lid (API 2.23):
```
requirements = {"robotType": "Flex", "apiLevel": "2.23"}

def run(protocol):
    
    trash = protocol.load_trash_bin("A3")

    tiprack = protocol.load_labware(load_name="opentrons_flex_96_tiprack_200ul", location="D3", lid="opentrons_flex_tiprack_lid")

    protocol.move_lid(tiprack, trash, True)
```

## Changelog
New Lid labware definition under Labware V3

## Review requests
Anything missing from this? Pretty basic definition, no wells and this labware cannot be placed or loaded on regular lid slots or in stacks.

## Risk assessment
Low - New labware definition.
