### PR TITLE
feat(protocol-designer): add timeline alert translations for absorbance reader

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -159,7 +159,11 @@
         "title": "Pipette collisions likely",
         "body": "There is a possibility that the pipette will collide with the adjascent labware or module for partial tip pick up."
       },
-      "PLATE_READER_LID_CLOSED": {
+      "ABSORBANCE_READER_NO_INITIALIZATION": {
+        "title": "Missing Absorbance Plate Reader initialization step",
+        "body": "The Absorbance Plate Reader must be initialized before reading labware. Initialize the Absorbance Plate Reader module or remove this step to proceed."
+      },
+      "ABSORBANCE_READER_LID_CLOSED": {
         "title": "Absorbance Plate Reader Module lid closed",
         "body": "This step tries to use labware in the Absorbance Plate Reader. Open the lid before this step."
       }

--- a/protocol-designer/src/organisms/Alerts/TimelineAlerts.tsx
+++ b/protocol-designer/src/organisms/Alerts/TimelineAlerts.tsx
@@ -6,7 +6,6 @@ import {
   Banner,
   DIRECTION_COLUMN,
   Flex,
-  SPACING,
   StyledText,
 } from '@opentrons/components'
 import { getRobotStateTimeline } from '../../file-data/selectors'
@@ -38,7 +37,7 @@ function TimelineAlertsComponent(props: StyleProps): JSX.Element | null {
       key={`${alertType}:${key}`}
       width="100%"
     >
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+      <Flex flexDirection={DIRECTION_COLUMN}>
         <StyledText desktopStyle="bodyDefaultSemiBold">{data.title}</StyledText>
         <StyledText desktopStyle="bodyDefaultRegular">
           {data.description}


### PR DESCRIPTION
# Overview

Adds timeline alerts title and body translations for absorbance reader timeline errors. The two additions cover 1) moving labware to/from the absorbance reader if the lid is closed, and 2) attempting a read without a prior initialization (only produced if the initialization step is deleted).

Closes AUTH-1331

## Test Plan and Hands on Testing

- create absorbance reader protocol and add a move labware step to/from the plate reader without first opening the plate reader
- verify correct timeline alert banner shows

https://github.com/user-attachments/assets/e6793180-a95c-4627-bb29-46fdb6d9a587


- create absorbance reader protocol with initialization, open lid, move labware, and read steps
- delete initialization step
- verify correct timeline alert banner shows

https://github.com/user-attachments/assets/94281289-a552-47a0-a825-3eb39a9eee67

## Changelog

- add translations for new absorbance reader timeline errors
- fix grid gap in alerts banner component

## Review requests

- see test plan

## Risk assessment

low