### PR TITLE
fix(app): Fix double drop tip prompting after Error Recovery cancel action

### DIFF
--- a/app/src/local-resources/commands/utils/index.ts
+++ b/app/src/local-resources/commands/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './getCommandTextData'
+export * from './lastRunCommandPromptedErrorRecovery'

--- a/app/src/local-resources/commands/utils/lastRunCommandPromptedErrorRecovery.ts
+++ b/app/src/local-resources/commands/utils/lastRunCommandPromptedErrorRecovery.ts
@@ -1,11 +1,12 @@
 import type { RunCommandSummary } from '@opentrons/api-client'
-// Whether the last run protocol command prompted Error Recovery.
+// Whether the last run protocol command prompted Error Recovery, if Error Recovery is enabled.
 export function lastRunCommandPromptedErrorRecovery(
-  summary: RunCommandSummary[]
+  summary: RunCommandSummary[] | null,
+  isEREnabled: boolean
 ): boolean {
-  const lastProtocolCommand = summary.findLast(
+  const lastProtocolCommand = summary?.findLast(
     command => command.intent !== 'fixit' && command.error != null
   )
   // All recoverable protocol commands have defined errors.
-  return lastProtocolCommand?.error?.isDefined ?? false
+  return isEREnabled ? lastProtocolCommand?.error?.isDefined ?? false : false
 }

--- a/app/src/local-resources/commands/utils/lastRunCommandPromptedErrorRecovery.ts
+++ b/app/src/local-resources/commands/utils/lastRunCommandPromptedErrorRecovery.ts
@@ -1,0 +1,11 @@
+import type { RunCommandSummary } from '@opentrons/api-client'
+// Whether the last run protocol command prompted Error Recovery.
+export function lastRunCommandPromptedErrorRecovery(
+  summary: RunCommandSummary[]
+): boolean {
+  const lastProtocolCommand = summary.findLast(
+    command => command.intent !== 'fixit' && command.error != null
+  )
+  // All recoverable protocol commands have defined errors.
+  return lastProtocolCommand?.error?.isDefined ?? false
+}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
@@ -2,12 +2,18 @@ import { useEffect } from 'react'
 
 import { RUN_STATUS_IDLE, RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import { useErrorRecoverySettings } from '@opentrons/react-api-client'
 
 import { useDropTipWizardFlows } from '/app/organisms/DropTipWizardFlows'
 import { useProtocolDropTipModal } from '../modals'
-import { useCloseCurrentRun, useIsRunCurrent } from '/app/resources/runs'
+import {
+  useCloseCurrentRun,
+  useCurrentRunCommands,
+  useIsRunCurrent,
+} from '/app/resources/runs'
 import { isTerminalRunStatus } from '../../utils'
 import { useTipAttachmentStatus } from '/app/resources/instruments'
+import { lastRunCommandPromptedErrorRecovery } from '/app/local-resources/commands'
 
 import type { RobotType } from '@opentrons/shared-data'
 import type { Run, RunStatus } from '@opentrons/api-client'
@@ -99,17 +105,33 @@ export function useRunHeaderDropTip({
       : { showDTWiz: false, dtWizProps: null }
   }
 
+  const { data } = useErrorRecoverySettings()
+  const isEREnabled = data?.data.enabled ?? true
+  const runSummaryNoFixit = useCurrentRunCommands(
+    {
+      includeFixitCommands: false,
+      pageLength: 1,
+    },
+    { enabled: isTerminalRunStatus(runStatus) }
+  )
+
   // Manage tip checking
   useEffect(() => {
     // If a user begins a new run without navigating away from the run page, reset tip status.
     if (robotType === FLEX_ROBOT_TYPE) {
       if (runStatus === RUN_STATUS_IDLE) {
         resetTipStatus()
-      } else if (isRunCurrent && isTerminalRunStatus(runStatus)) {
+      }
+      // Only run tip checking if it wasn't *just* handled during Error Recovery.
+      else if (
+        !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit, isEREnabled) &&
+        isRunCurrent &&
+        isTerminalRunStatus(runStatus)
+      ) {
         void determineTipStatus()
       }
     }
-  }, [runStatus, robotType, isRunCurrent])
+  }, [runStatus, robotType, isRunCurrent, runSummaryNoFixit, isEREnabled])
 
   // If the run terminates with a "stopped" status, close the run if no tips are attached after running tip check at least once.
   // This marks the robot as "not busy" if drop tip CTAs are unnecessary.


### PR DESCRIPTION
Closes [RQA-3880](https://opentrons.atlassian.net/browse/RQA-3880)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Woops, in https://github.com/Opentrons/opentrons/pull/17235 in https://github.com/Opentrons/opentrons/commit/9b1079391c048b58647d9ba60838296e6f56ac49, I was a bit too overzealous in simplifying post-run tip detection logic, and I forgot to consider the case in which a user just canceled a run during Error Recovery and does tip detection flows. We don't want to prompt the user with the "remove tips" CTA right after we did just that during Error Recovery.

So this PR brings the `lastRunCommandPromptedErrorRecovery` util back and adds the new and improved behavior to also check if Error Recovery is enabled (in settings). If it's not enabled, we need to run tip detection even if the last run command was recoverable.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that we don't double prompt Error Recovery anymore.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Canceling a run during error recovery and confirming no tips are attached no longer prompts tip dropping after the run is cancelled. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3880]: https://opentrons.atlassian.net/browse/RQA-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ