### PR TITLE
feat(protocol-designer): create hook for valid absorbance reader function

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -49,6 +49,7 @@ import {
   TemperatureTools,
   ThermocyclerTools,
 } from './StepTools'
+import { useAbsorbanceReaderCommandType } from './hooks'
 import {
   getSaveStepSnackbarText,
   getVisibleFormErrors,
@@ -138,6 +139,10 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     dependentFields: error.dependentProfileFields,
   }))
   const timeline = useSelector(getRobotStateTimeline)
+  const moduleId = formData.moduleId
+  const enableReadOrInitialization = useAbsorbanceReaderCommandType(
+    moduleId as string | null
+  )
   const [toolboxStep, setToolboxStep] = useState<number>(0)
   const [showFormErrors, setShowFormErrors] = useState<boolean>(false)
   const [tab, setTab] = useState<LiquidHandlingTab>('aspirate')
@@ -205,7 +210,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   }
 
   const isMultiStepToolbox =
-    formData.stepType === 'absorbanceReader' ||
+    (formData.stepType === 'absorbanceReader' &&
+      enableReadOrInitialization != null) ||
     formData.stepType === 'moveLiquid' ||
     formData.stepType === 'mix' ||
     formData.stepType === 'thermocycler'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/hooks/__tests__/useEnableReadOrInitialize.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/hooks/__tests__/useEnableReadOrInitialize.test.ts
@@ -1,0 +1,89 @@
+import { useSelector } from 'react-redux'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ABSORBANCE_READER_TYPE } from '@opentrons/shared-data'
+import { renderHook } from '@testing-library/react'
+import { getRobotStateAtActiveItem } from '../../../../../../top-selectors/labware-locations'
+import { useAbsorbanceReaderCommandType } from '../useAbsorbanceReaderCommandType'
+import type { Initialization, TimelineFrame } from '@opentrons/step-generation'
+import {
+  ABSORBANCE_READER_INITIALIZE,
+  ABSORBANCE_READER_READ,
+} from '../../../../../../constants'
+
+vi.mock('../../../../../../top-selectors/labware-locations')
+vi.mock('react-redux', () => ({
+  useSelector: vi.fn(),
+}))
+const MOCK_MODULE_ID = 'absorbanceReaderId'
+const MOCK_LABWARE_ID = 'labwareId'
+const MOCK_INITIALIZATION = {
+  mode: 'single',
+  wavelengths: [450, 600],
+} as Initialization
+const MOCK_MODULE_STATE = {
+  slot: 'D3',
+  moduleState: {
+    lidOpen: false,
+    type: ABSORBANCE_READER_TYPE,
+    initialization: null,
+  },
+}
+const MOCK_LABWARE = {
+  [MOCK_LABWARE_ID]: {
+    slot: MOCK_MODULE_ID,
+  },
+}
+
+const DEFAULT_ROBOT_STATE = {
+  pipettes: {},
+  tipState: { tipracks: {}, pipettes: {} },
+  liquidState: { labware: {}, pipettes: {}, additionalEquipment: {} },
+  labware: {},
+  modules: {
+    [MOCK_MODULE_ID]: MOCK_MODULE_STATE,
+  },
+} as TimelineFrame
+describe('useEnableReadOrInitialize', () => {
+  beforeEach(() => {
+    vi.mocked(useSelector).mockImplementation(selector => selector({} as any))
+    vi.mocked(getRobotStateAtActiveItem).mockReturnValue(DEFAULT_ROBOT_STATE)
+  })
+  it('returns null if null moduleId passed', () => {
+    const { result } = renderHook(() => useAbsorbanceReaderCommandType(null))
+    expect(result.current).toEqual(null)
+  })
+  it('returns initialize if no labware present on absorbance reader', () => {
+    const { result } = renderHook(() =>
+      useAbsorbanceReaderCommandType(MOCK_MODULE_ID)
+    )
+    expect(result.current).toEqual(ABSORBANCE_READER_INITIALIZE)
+  })
+  it('returns read if labware present on absorbance reader and initialization exists', () => {
+    const moduleState = {
+      ...MOCK_MODULE_STATE,
+      moduleState: {
+        ...MOCK_MODULE_STATE.moduleState,
+        initialization: MOCK_INITIALIZATION,
+      },
+    }
+    vi.mocked(getRobotStateAtActiveItem).mockReturnValue({
+      ...DEFAULT_ROBOT_STATE,
+      modules: { [MOCK_MODULE_ID]: moduleState },
+      labware: MOCK_LABWARE,
+    })
+    const { result } = renderHook(() =>
+      useAbsorbanceReaderCommandType(MOCK_MODULE_ID)
+    )
+    expect(result.current).toEqual(ABSORBANCE_READER_READ)
+  })
+  it('returns null if labware present on absorbance reader and no initialization exists', () => {
+    vi.mocked(getRobotStateAtActiveItem).mockReturnValue({
+      ...DEFAULT_ROBOT_STATE,
+      labware: MOCK_LABWARE,
+    })
+    const { result } = renderHook(() =>
+      useAbsorbanceReaderCommandType(MOCK_MODULE_ID)
+    )
+    expect(result.current).toEqual(null)
+  })
+})

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/hooks/index.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useAbsorbanceReaderCommandType } from './useAbsorbanceReaderCommandType'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/hooks/useAbsorbanceReaderCommandType.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/hooks/useAbsorbanceReaderCommandType.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import { getRobotStateAtActiveItem } from '../../../../../top-selectors/labware-locations'
+import type { AbsorbanceReaderState } from '@opentrons/step-generation'
+import {
+  ABSORBANCE_READER_READ,
+  ABSORBANCE_READER_INITIALIZE,
+} from '../../../../../constants'
+
+export function useAbsorbanceReaderCommandType(
+  moduleId: string | null
+): typeof ABSORBANCE_READER_READ | typeof ABSORBANCE_READER_INITIALIZE | null {
+  const robotState = useSelector(getRobotStateAtActiveItem)
+  const { labware = {}, modules = {} } = robotState ?? {}
+  const isLabwareOnAbsorbanceReader = useMemo(
+    () => Object.values(labware).some(lw => lw.slot === moduleId),
+    [moduleId, labware]
+  )
+  if (moduleId == null) {
+    return null
+  }
+  const absorbanceReaderState = modules[moduleId]
+    ?.moduleState as AbsorbanceReaderState | null
+  const initialization = absorbanceReaderState?.initialization ?? null
+  const enableReadOrInitialization =
+    !isLabwareOnAbsorbanceReader || initialization != null
+  const compoundCommandType = isLabwareOnAbsorbanceReader
+    ? ABSORBANCE_READER_READ
+    : ABSORBANCE_READER_INITIALIZE
+
+  return enableReadOrInitialization ? compoundCommandType : null
+}


### PR DESCRIPTION
# Overview

This PR refactors the logic for determining valid plate reader compound commands (initialize/read) into a custom hook, and wires it up into `StepFormToolbox` and `AbsorbanceReaderTools`. It uses this new logic to fix the part counter for a single-part absorbance reader form.

Closes AUTH-1314
Closes AUTH-1332

## Test Plan and Hands on Testing

- create protocol with absorbance reader
- open lid
- move labware to the absorbance reader
- create a step for that module and verify that there is no page counter at the top of the single-page toolbox

## Changelog

- create custom hook for determining compound absorbance reader command
- implement in stepform toolbox and absorbance reader tools

## Review requests

see test plan

## Risk assessment

low