### PR TITLE
test(protocol-designer): add tests for InitializationSettings and formToArgs

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/__tests__/InitializationSettings.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/__tests__/InitializationSettings.test.tsx
@@ -1,0 +1,83 @@
+import { screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { i18n } from '../../../../../../../assets/localization'
+import { renderWithProviders } from '../../../../../../../__testing-utils__'
+import { InitializationSettings } from '../InitializationSettings'
+import type { ComponentProps } from 'react'
+import type { Initialization } from '@opentrons/step-generation'
+
+// Mocking constants
+const INITIALIZATION_SINGLE_NO_REFERENCE: Initialization = {
+  mode: 'single',
+  wavelengths: [450],
+}
+const INITIALIZATION_SINGLE_REFERENCE: Initialization = {
+  mode: 'single',
+  wavelengths: [450],
+  referenceWavelength: 600,
+}
+const INITIALIZATION_MULTI: Initialization = {
+  mode: 'multi',
+  wavelengths: [450, 600],
+}
+const INITIALIZATION_MULTI_UNKOWN_COLOR: Initialization = {
+  mode: 'multi',
+  wavelengths: [450, 700],
+}
+
+const render = (props: ComponentProps<typeof InitializationSettings>) => {
+  return renderWithProviders(<InitializationSettings {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('InitializationSettings', () => {
+  let props: ComponentProps<typeof InitializationSettings>
+  it('renders no settings message when initialization is null', () => {
+    props = { initialization: null }
+    render(props)
+
+    expect(
+      screen.getByText('Current initialization settings')
+    ).toBeInTheDocument()
+    expect(screen.getByText('No settings defined')).toBeInTheDocument()
+  })
+
+  it('renders single mode wavelength and its color correctly', () => {
+    props = { initialization: INITIALIZATION_SINGLE_NO_REFERENCE }
+    render(props)
+    expect(
+      screen.getByText('Current initialization settings')
+    ).toBeInTheDocument()
+    expect(screen.getByText('450 nm (Blue)')).toBeInTheDocument()
+  })
+  it('renders single mode wavelength with reference and their respective colors correctly', () => {
+    props = { initialization: INITIALIZATION_SINGLE_REFERENCE }
+    render(props)
+    expect(
+      screen.getByText('Current initialization settings')
+    ).toBeInTheDocument()
+    expect(screen.getByText('450 nm (Blue)')).toBeInTheDocument()
+    expect(
+      screen.getByText('600 nm (Orange, reference wavelength)')
+    ).toBeInTheDocument()
+  })
+  it('renders multi mode wavelength and their respective colors correctly', () => {
+    props = { initialization: INITIALIZATION_MULTI }
+    render(props)
+    expect(
+      screen.getByText('Current initialization settings')
+    ).toBeInTheDocument()
+    expect(screen.getByText('450 nm (Blue)')).toBeInTheDocument()
+    expect(screen.getByText('600 nm (Orange)')).toBeInTheDocument()
+  })
+  it('renders multi mode wavelength and their respective colors correctly with unkown color', () => {
+    props = { initialization: INITIALIZATION_MULTI_UNKOWN_COLOR }
+    render(props)
+    expect(
+      screen.getByText('Current initialization settings')
+    ).toBeInTheDocument()
+    expect(screen.getByText('450 nm (Blue)')).toBeInTheDocument()
+    expect(screen.getByText('700 nm')).toBeInTheDocument()
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/absorbanceReaderFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/absorbanceReaderFormToArgs.test.ts
@@ -158,7 +158,7 @@ describe('absorbanceReaderFormToArgs', () => {
     }
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
-  it.only('returns absorbance reader lid command creator to close lid', () => {
+  it('returns absorbance reader lid command creator to close lid', () => {
     const formData: HydratedAbsorbanceReaderFormData = {
       absorbanceReaderFormType: 'absorbanceReaderLid',
       fileName: null,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/absorbanceReaderFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/absorbanceReaderFormToArgs.test.ts
@@ -1,0 +1,164 @@
+import { it, describe, expect } from 'vitest'
+import { absorbanceReaderFormToArgs } from '../absorbanceReaderFormToArgs'
+import type { HydratedAbsorbanceReaderFormData } from '../../../../form-types'
+
+describe('absorbanceReaderFormToArgs', () => {
+  it('returns absorbance reader initialize command creator for single mode with reference', () => {
+    const formData: HydratedAbsorbanceReaderFormData = {
+      absorbanceReaderFormType: 'absorbanceReaderInitialize',
+      fileName: null,
+      id: 'stepId',
+      lidOpen: null,
+      mode: 'single',
+      moduleId: 'absorbanceReaderId',
+      referenceWavelength: '500',
+      referenceWavelengthActive: true,
+      stepDetails: null,
+      stepType: 'absorbanceReader',
+      wavelengths: ['450'],
+    }
+
+    const expected = {
+      module: 'absorbanceReaderId',
+      commandCreatorFnName: 'absorbanceReaderInitialize',
+      mode: 'single',
+      wavelengths: [450],
+      referenceWavelength: 500,
+    }
+    expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
+  })
+  it('returns absorbance reader initialize command creator for single mode with reference, ignorning wavelengths for i > 0', () => {
+    const formData: HydratedAbsorbanceReaderFormData = {
+      absorbanceReaderFormType: 'absorbanceReaderInitialize',
+      fileName: null,
+      id: 'stepId',
+      lidOpen: null,
+      mode: 'single',
+      moduleId: 'absorbanceReaderId',
+      referenceWavelength: '500',
+      referenceWavelengthActive: true,
+      stepDetails: null,
+      stepType: 'absorbanceReader',
+      wavelengths: ['450', '600'],
+    }
+
+    const expected = {
+      module: 'absorbanceReaderId',
+      commandCreatorFnName: 'absorbanceReaderInitialize',
+      mode: 'single',
+      wavelengths: [450],
+      referenceWavelength: 500,
+    }
+    expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
+  })
+  it('returns absorbance reader initialize command creator for single mode without reference active', () => {
+    const formData: HydratedAbsorbanceReaderFormData = {
+      absorbanceReaderFormType: 'absorbanceReaderInitialize',
+      fileName: null,
+      id: 'stepId',
+      lidOpen: null,
+      mode: 'single',
+      moduleId: 'absorbanceReaderId',
+      referenceWavelength: '500',
+      referenceWavelengthActive: false,
+      stepDetails: null,
+      stepType: 'absorbanceReader',
+      wavelengths: ['450'],
+    }
+
+    const expected = {
+      module: 'absorbanceReaderId',
+      commandCreatorFnName: 'absorbanceReaderInitialize',
+      mode: 'single',
+      wavelengths: [450],
+    }
+    expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
+  })
+  it('returns absorbance reader initialize command creator for multi mode', () => {
+    const formData: HydratedAbsorbanceReaderFormData = {
+      absorbanceReaderFormType: 'absorbanceReaderInitialize',
+      fileName: null,
+      id: 'stepId',
+      lidOpen: null,
+      mode: 'multi',
+      moduleId: 'absorbanceReaderId',
+      referenceWavelength: null,
+      referenceWavelengthActive: false,
+      stepDetails: null,
+      stepType: 'absorbanceReader',
+      wavelengths: ['450', '600'],
+    }
+
+    const expected = {
+      module: 'absorbanceReaderId',
+      commandCreatorFnName: 'absorbanceReaderInitialize',
+      mode: 'multi',
+      wavelengths: [450, 600],
+    }
+    expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
+  })
+  it('returns absorbance reader read command creator', () => {
+    const formData: HydratedAbsorbanceReaderFormData = {
+      absorbanceReaderFormType: 'absorbanceReaderRead',
+      fileName: 'output_path.csv',
+      id: 'stepId',
+      lidOpen: null,
+      mode: 'multi',
+      moduleId: 'absorbanceReaderId',
+      referenceWavelength: null,
+      referenceWavelengthActive: false,
+      stepDetails: null,
+      stepType: 'absorbanceReader',
+      wavelengths: [],
+    }
+
+    const expected = {
+      module: 'absorbanceReaderId',
+      commandCreatorFnName: 'absorbanceReaderRead',
+      fileName: 'output_path.csv',
+    }
+    expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
+  })
+  it('returns absorbance reader lid command creator to open lid', () => {
+    const formData: HydratedAbsorbanceReaderFormData = {
+      absorbanceReaderFormType: 'absorbanceReaderLid',
+      fileName: null,
+      id: 'stepId',
+      lidOpen: true,
+      mode: 'single',
+      moduleId: 'absorbanceReaderId',
+      referenceWavelength: null,
+      referenceWavelengthActive: false,
+      stepDetails: null,
+      stepType: 'absorbanceReader',
+      wavelengths: [],
+    }
+
+    const expected = {
+      module: 'absorbanceReaderId',
+      commandCreatorFnName: 'absorbanceReaderOpenLid',
+    }
+    expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
+  })
+  it('returns absorbance reader lid command creator to close lid', () => {
+    const formData: HydratedAbsorbanceReaderFormData = {
+      absorbanceReaderFormType: 'absorbanceReaderLid',
+      fileName: null,
+      id: 'stepId',
+      lidOpen: false,
+      mode: 'single',
+      moduleId: 'absorbanceReaderId',
+      referenceWavelength: null,
+      referenceWavelengthActive: false,
+      stepDetails: null,
+      stepType: 'absorbanceReader',
+      wavelengths: [],
+    }
+
+    const expected = {
+      module: 'absorbanceReaderId',
+      commandCreatorFnName: 'absorbanceReaderCloseLid',
+    }
+    expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/absorbanceReaderFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/absorbanceReaderFormToArgs.test.ts
@@ -13,17 +13,20 @@ describe('absorbanceReaderFormToArgs', () => {
       moduleId: 'absorbanceReaderId',
       referenceWavelength: '500',
       referenceWavelengthActive: true,
-      stepDetails: null,
+      stepName: 'absorbance reader step',
+      stepDetails: '',
       stepType: 'absorbanceReader',
       wavelengths: ['450'],
     }
 
     const expected = {
-      module: 'absorbanceReaderId',
+      moduleId: 'absorbanceReaderId',
       commandCreatorFnName: 'absorbanceReaderInitialize',
-      mode: 'single',
-      wavelengths: [450],
+      measureMode: 'single',
+      sampleWavelengths: [450],
       referenceWavelength: 500,
+      description: '',
+      name: 'absorbance reader step',
     }
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
@@ -37,17 +40,20 @@ describe('absorbanceReaderFormToArgs', () => {
       moduleId: 'absorbanceReaderId',
       referenceWavelength: '500',
       referenceWavelengthActive: true,
-      stepDetails: null,
+      stepName: 'absorbance reader step',
+      stepDetails: '',
       stepType: 'absorbanceReader',
       wavelengths: ['450', '600'],
     }
 
     const expected = {
-      module: 'absorbanceReaderId',
+      moduleId: 'absorbanceReaderId',
       commandCreatorFnName: 'absorbanceReaderInitialize',
-      mode: 'single',
-      wavelengths: [450],
+      measureMode: 'single',
+      sampleWavelengths: [450],
       referenceWavelength: 500,
+      description: '',
+      name: 'absorbance reader step',
     }
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
@@ -61,16 +67,19 @@ describe('absorbanceReaderFormToArgs', () => {
       moduleId: 'absorbanceReaderId',
       referenceWavelength: '500',
       referenceWavelengthActive: false,
-      stepDetails: null,
+      stepName: 'absorbance reader step',
+      stepDetails: '',
       stepType: 'absorbanceReader',
       wavelengths: ['450'],
     }
 
     const expected = {
-      module: 'absorbanceReaderId',
+      moduleId: 'absorbanceReaderId',
       commandCreatorFnName: 'absorbanceReaderInitialize',
-      mode: 'single',
-      wavelengths: [450],
+      measureMode: 'single',
+      sampleWavelengths: [450],
+      description: '',
+      name: 'absorbance reader step',
     }
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
@@ -84,16 +93,19 @@ describe('absorbanceReaderFormToArgs', () => {
       moduleId: 'absorbanceReaderId',
       referenceWavelength: null,
       referenceWavelengthActive: false,
-      stepDetails: null,
+      stepName: 'absorbance reader step',
+      stepDetails: '',
       stepType: 'absorbanceReader',
       wavelengths: ['450', '600'],
     }
 
     const expected = {
-      module: 'absorbanceReaderId',
+      moduleId: 'absorbanceReaderId',
       commandCreatorFnName: 'absorbanceReaderInitialize',
-      mode: 'multi',
-      wavelengths: [450, 600],
+      measureMode: 'multi',
+      sampleWavelengths: [450, 600],
+      description: '',
+      name: 'absorbance reader step',
     }
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
@@ -107,15 +119,18 @@ describe('absorbanceReaderFormToArgs', () => {
       moduleId: 'absorbanceReaderId',
       referenceWavelength: null,
       referenceWavelengthActive: false,
-      stepDetails: null,
+      stepName: 'absorbance reader step',
+      stepDetails: '',
       stepType: 'absorbanceReader',
       wavelengths: [],
     }
 
     const expected = {
-      module: 'absorbanceReaderId',
+      moduleId: 'absorbanceReaderId',
       commandCreatorFnName: 'absorbanceReaderRead',
       fileName: 'output_path.csv',
+      description: '',
+      name: 'absorbance reader step',
     }
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
@@ -129,18 +144,21 @@ describe('absorbanceReaderFormToArgs', () => {
       moduleId: 'absorbanceReaderId',
       referenceWavelength: null,
       referenceWavelengthActive: false,
-      stepDetails: null,
+      stepName: 'absorbance reader step',
+      stepDetails: '',
       stepType: 'absorbanceReader',
       wavelengths: [],
     }
 
     const expected = {
-      module: 'absorbanceReaderId',
+      moduleId: 'absorbanceReaderId',
       commandCreatorFnName: 'absorbanceReaderOpenLid',
+      description: '',
+      name: 'absorbance reader step',
     }
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
-  it('returns absorbance reader lid command creator to close lid', () => {
+  it.only('returns absorbance reader lid command creator to close lid', () => {
     const formData: HydratedAbsorbanceReaderFormData = {
       absorbanceReaderFormType: 'absorbanceReaderLid',
       fileName: null,
@@ -150,14 +168,17 @@ describe('absorbanceReaderFormToArgs', () => {
       moduleId: 'absorbanceReaderId',
       referenceWavelength: null,
       referenceWavelengthActive: false,
-      stepDetails: null,
+      stepName: 'absorbance reader step',
+      stepDetails: '',
       stepType: 'absorbanceReader',
       wavelengths: [],
     }
 
     const expected = {
-      module: 'absorbanceReaderId',
+      moduleId: 'absorbanceReaderId',
       commandCreatorFnName: 'absorbanceReaderCloseLid',
+      description: '',
+      name: 'absorbance reader step',
     }
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })


### PR DESCRIPTION
# Overview

Adds a few unit tests for `InitializationSettings` component and `absorbanceReaderFormToArgs` ahead of step generation.

Closes AUTH-1316

## Test Plan and Hands on Testing

- check logic of tests

## Changelog

- add tests

## Review requests

## Risk assessment

low