### PR TITLE
feat(protocol-designer, step-generation): add gripper error creator for absorbance reader lid commands

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -166,6 +166,10 @@
       "ABSORBANCE_READER_LID_CLOSED": {
         "title": "Absorbance Plate Reader Module lid closed",
         "body": "This step tries to use labware in the Absorbance Plate Reader. Open the lid before this step."
+      },
+      "ABSORBANCE_READER_NO_GRIPPER": {
+        "title": "Cannot change lid state without gripper",
+        "body": "This step involves opening or closing the Absorbance Plate Reader lid with a gripper. Add a gripper or remove step to proceed."
       }
     },
     "warning": {

--- a/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
@@ -24,6 +24,7 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
   let absorbanceReaderCloseInitializeArgs: AbsorbanceReaderInitializeArgs
   const ABSORBANCE_READER_MODULE_ID = 'absorbanceReaderModuleId'
   const ABSORBANCE_READER_MODULE_SLOT = 'D3'
+  const GRIPPER_ID = 'gripperId'
   let robotState: RobotState
   let invariantContext: InvariantContext
   beforeEach(() => {
@@ -42,6 +43,12 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
           id: ABSORBANCE_READER_MODULE_ID,
           type: ABSORBANCE_READER_TYPE,
           model: ABSORBANCE_READER_V1,
+        },
+      },
+      additionalEquipmentEntities: {
+        [GRIPPER_ID]: {
+          id: GRIPPER_ID,
+          name: 'gripper',
         },
       },
     }

--- a/step-generation/src/__tests__/absorbanceReaderCloseLid.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseLid.test.ts
@@ -29,6 +29,12 @@ describe('absorbanceReaderCloseLid', () => {
       type: ABSORBANCE_READER_TYPE,
       model: ABSORBANCE_READER_V1,
     }
+    invariantContext.additionalEquipmentEntities = {
+      gripperId: {
+        name: 'gripper',
+        id: 'gripperId',
+      },
+    }
     robotState = getInitialRobotStateStandard(invariantContext)
     robotState.modules[moduleId] = {
       slot: 'D3',
@@ -74,6 +80,20 @@ describe('absorbanceReaderCloseLid', () => {
     expect(getErrorResult(result).errors).toHaveLength(1)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'MISSING_MODULE',
+    })
+  })
+  it('creates returns error if no gripper', () => {
+    invariantContext.additionalEquipmentEntities = {}
+    const result = absorbanceReaderCloseLid(
+      {
+        moduleId,
+      },
+      invariantContext,
+      robotState
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'ABSORBANCE_READER_NO_GRIPPER',
     })
   })
 })

--- a/step-generation/src/__tests__/absorbanceReaderCloseRead.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseRead.test.ts
@@ -25,6 +25,7 @@ describe('absorbanceReaderCloseRead compound command creator', () => {
   const ABSORBANCE_READER_MODULE_ID = 'absorbanceReaderModuleId'
   const ABSORBANCE_READER_OUTPUT_PATH = 'outputPath.csv'
   const ABSORBANCE_READER_MODULE_SLOT = 'D3'
+  const GRIPPER_ID = 'gripperId'
   let robotState: RobotState
   let invariantContext: InvariantContext
   beforeEach(() => {
@@ -42,6 +43,12 @@ describe('absorbanceReaderCloseRead compound command creator', () => {
           id: ABSORBANCE_READER_MODULE_ID,
           type: ABSORBANCE_READER_TYPE,
           model: ABSORBANCE_READER_V1,
+        },
+      },
+      additionalEquipmentEntities: {
+        [GRIPPER_ID]: {
+          id: GRIPPER_ID,
+          name: 'gripper',
         },
       },
     }

--- a/step-generation/src/__tests__/absorbanceReaderOpenLid.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderOpenLid.test.ts
@@ -29,6 +29,13 @@ describe('absorbanceReaderOpenLid', () => {
       type: ABSORBANCE_READER_TYPE,
       model: ABSORBANCE_READER_V1,
     }
+    invariantContext.additionalEquipmentEntities = {
+      gripperId: {
+        name: 'gripper',
+        id: 'gripperId',
+      },
+    }
+
     robotState = getInitialRobotStateStandard(invariantContext)
     robotState.modules[moduleId] = {
       slot: 'D3',
@@ -74,6 +81,20 @@ describe('absorbanceReaderOpenLid', () => {
     expect(getErrorResult(result).errors).toHaveLength(1)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'MISSING_MODULE',
+    })
+  })
+  it('creates returns error if no gripper', () => {
+    invariantContext.additionalEquipmentEntities = {}
+    const result = absorbanceReaderOpenLid(
+      {
+        moduleId,
+      },
+      invariantContext,
+      robotState
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'ABSORBANCE_READER_NO_GRIPPER',
     })
   })
 })

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
@@ -1,22 +1,29 @@
 import { uuid } from '../../utils'
-import { missingModuleError } from '../../errorCreators'
+import * as errorCreators from '../../errorCreators'
 import { absorbanceReaderStateGetter } from '../../robotStateSelectors'
-import type { ModuleOnlyParams } from '@opentrons/shared-data'
-import type { CommandCreator } from '../../types'
+import type { AbsorbanceReaderCloseLidCreateCommand } from '@opentrons/shared-data'
+import type { CommandCreator, CommandCreatorError } from '../../types'
 
-export const absorbanceReaderCloseLid: CommandCreator<ModuleOnlyParams> = (
-  args,
-  invariantContext,
-  prevRobotState
-) => {
+export const absorbanceReaderCloseLid: CommandCreator<
+  AbsorbanceReaderCloseLidCreateCommand['params']
+> = (args, invariantContext, prevRobotState) => {
   const absorbanceReaderState = absorbanceReaderStateGetter(
     prevRobotState,
     args.moduleId
   )
+  const errors: CommandCreatorError[] = []
   if (args.moduleId == null || absorbanceReaderState == null) {
-    return {
-      errors: [missingModuleError()],
-    }
+    errors.push(errorCreators.missingModuleError())
+  }
+  if (
+    !Object.values(invariantContext.additionalEquipmentEntities).some(
+      ({ name }) => name === 'gripper'
+    )
+  ) {
+    errors.push(errorCreators.absorbanceReaderNoGripper())
+  }
+  if (errors.length > 0) {
+    return { errors }
   }
 
   return {

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -173,6 +173,14 @@ export const absorbanceReaderNoInitialization = (): CommandCreatorError => {
   }
 }
 
+export const absorbanceReaderNoGripper = (): CommandCreatorError => {
+  return {
+    type: 'ABSORBANCE_READER_NO_GRIPPER',
+    message:
+      'This step involves opening or closing the Absorbance Plate Reader lid with a gripper. Add a gripper or remove step to proceed.',
+  }
+}
+
 export const heaterShakerIsShaking = (): CommandCreatorError => {
   return {
     type: 'HEATER_SHAKER_IS_SHAKING',

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -567,6 +567,7 @@ export type RobotState = TimelineFrame // legacy name alias
 
 export type ErrorType =
   | 'ABSORBANCE_READER_LID_CLOSED'
+  | 'ABSORBANCE_READER_NO_GRIPPER'
   | 'ABSORBANCE_READER_NO_INITIALIZATION'
   | 'CANNOT_MOVE_WITH_GRIPPER'
   | 'DROP_TIP_LOCATION_DOES_NOT_EXIST'


### PR DESCRIPTION
# Overview

This PR introduces a new error creator in step generation and wires up to absorbance reader open and close lid commands. These commands should now raise a gripper missing error if attempting to open or close the absorbance reader lid without a gripper configured. Although presence of a gripper is required to add an absorbance reader module or steps, an error scenario can arise if a user correctly configures a gripper and absorbance reader, and then removes the gripper from their protocol.

Closes AUTH-1194

## Test Plan and Hands on Testing

- create a new protocol and configure a gripper and absorbance reader
- create an absorbance reader command to close lid
- navigate back to protocol overview page and remove the gripper
- navigate back to timeline and verify that missing gripper timeline error banner shows correctly

https://github.com/user-attachments/assets/cf81bc81-79a6-4a75-9280-f9cefc69b6e6


## Changelog

- introduce missing gripper error creator
- add translations
- wire up error in atomic `absorbanceReaderOpen/CloseLid` command creators
- fix tests

## Review requests

see test plan

## Risk assessment

low