### PR TITLE
fix(protocol-designer): remove tooltips for move labware dropdown fields

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -61,6 +61,7 @@ export function LabwareLocationField(
       onExit={() => {
         dispatch(hoverSelection({ id: null, text: null }))
       }}
+      tooltipContent={null}
     />
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/MoveLabwareField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/MoveLabwareField.tsx
@@ -20,6 +20,7 @@ export function MoveLabwareField(props: FieldProps): JSX.Element {
       onExit={() => {
         dispatch(hoverSelection({ id: null, text: null }))
       }}
+      tooltipContent={null}
     />
   )
 }


### PR DESCRIPTION
# Overview

remove tooltips for labware and new location fields for move labware tools

Closes AUTH-1225

## Test Plan and Hands on Testing

- verify that tooltips/icons are gone on move labware tools

## Changelog

- remove tooltips

## Review requests

see test plan

## Risk assessment

low