### PR TITLE
feat(step-generation): error creators for absorbance reader closed lid pipetting

### DIFF
--- a/step-generation/src/__tests__/aspirate.test.ts
+++ b/step-generation/src/__tests__/aspirate.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@opentrons/shared-data'
 
 import {
+  absorbanceReaderCollision,
   pipetteIntoHeaterShakerLatchOpen,
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerWhileShaking,
@@ -38,6 +39,7 @@ const fixtureTiprack1000ul = tip1000 as LabwareDefinition2
 const FLEX_PIPETTE = 'p1000_single_flex'
 const FlexPipetteNameSpecs = getPipetteSpecsV2(FLEX_PIPETTE)
 
+vi.mock('../utils/absorbanceReaderCollision')
 vi.mock('../utils/thermocyclerPipetteCollision')
 vi.mock('../utils/heaterShakerCollision')
 
@@ -280,6 +282,41 @@ describe('aspirate', () => {
     expect(getErrorResult(result).errors).toHaveLength(1)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'THERMOCYCLER_LID_CLOSED',
+    })
+  })
+  it.only('should return an error when aspirating from absorbance with pipette collision', () => {
+    vi.mocked(absorbanceReaderCollision).mockImplementationOnce(
+      (
+        modules: RobotState['modules'],
+        labware: RobotState['labware'],
+        labwareId: string
+      ) => {
+        expect(modules).toBe(robotStateWithTip.modules)
+        expect(labware).toBe(robotStateWithTip.labware)
+        expect(labwareId).toBe(SOURCE_LABWARE)
+        return true
+      }
+    )
+    const result = aspirate(
+      {
+        ...({
+          ...flowRateAndOffsets,
+          pipette: DEFAULT_PIPETTE,
+          volume: 50,
+          labware: SOURCE_LABWARE,
+          well: 'A1',
+        } as AspDispAirgapParams),
+        tipRack: 'tipRack',
+        xOffset: 0,
+        yOffset: 0,
+        nozzles: null,
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'ABSORBANCE_READER_LID_CLOSED',
     })
   })
   it('should return an error when aspirating from heaterShaker with latch opened', () => {

--- a/step-generation/src/__tests__/aspirate.test.ts
+++ b/step-generation/src/__tests__/aspirate.test.ts
@@ -284,7 +284,7 @@ describe('aspirate', () => {
       type: 'THERMOCYCLER_LID_CLOSED',
     })
   })
-  it.only('should return an error when aspirating from absorbance with pipette collision', () => {
+  it('should return an error when aspirating from absorbance with pipette collision', () => {
     vi.mocked(absorbanceReaderCollision).mockImplementationOnce(
       (
         modules: RobotState['modules'],

--- a/step-generation/src/__tests__/blowout.test.ts
+++ b/step-generation/src/__tests__/blowout.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { expectTimelineError } from '../__utils__/testMatchers'
 import { blowout } from '../commandCreators/atomic/blowout'
 import {
@@ -13,6 +13,8 @@ import {
 } from '../fixtures'
 import type { BlowoutParams } from '@opentrons/shared-data'
 import type { RobotState, InvariantContext } from '../types'
+
+vi.mock('../utils/heaterShakerCollision')
 
 describe('blowout', () => {
   let invariantContext: InvariantContext

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -2,6 +2,7 @@ import { COLUMN, FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import {
+  absorbanceReaderCollision,
   modulePipetteCollision,
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
@@ -140,6 +141,16 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
     )
   ) {
     errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
+  if (
+    absorbanceReaderCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.absorbanceReaderLidClosed())
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/blowout.ts
+++ b/step-generation/src/commandCreators/atomic/blowout.ts
@@ -1,4 +1,17 @@
-import { uuid, getLabwareSlot } from '../../utils'
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import {
+  uuid,
+  getLabwareSlot,
+  modulePipetteCollision,
+  thermocyclerPipetteCollision,
+  absorbanceReaderCollision,
+  pipetteIntoHeaterShakerLatchOpen,
+  pipetteIntoHeaterShakerWhileShaking,
+  pipetteAdjacentHeaterShakerWhileShaking,
+  getIsHeaterShakerEastWestMultiChannelPipette,
+  getIsHeaterShakerEastWestWithLatchOpen,
+  getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
+} from '../../utils'
 import { COLUMN_4_SLOTS } from '../../constants'
 import * as errorCreators from '../../errorCreators'
 import type { CreateCommand, BlowoutParams } from '@opentrons/shared-data'
@@ -14,6 +27,10 @@ export const blowout: CommandCreator<BlowoutParams> = (
 
   const actionName = 'blowout'
   const errors: CommandCreatorError[] = []
+  const pipetteSpec = invariantContext.pipetteEntities[pipetteId]?.spec
+  const isFlexPipette =
+    (pipetteSpec?.displayCategory === 'FLEX' || pipetteSpec?.channels === 96) ??
+    false
   const pipetteData = prevRobotState.pipettes[pipetteId]
   const labwareState = prevRobotState.labware
   const slotName = getLabwareSlot(
@@ -25,6 +42,14 @@ export const blowout: CommandCreator<BlowoutParams> = (
   // is duplicated across several command creators (eg aspirate & blowout overlap).
   // You can probably make higher-level error creator util fns to be more DRY
   if (!pipetteData) {
+    errors.push(
+      errorCreators.pipetteDoesNotExist({
+        pipette: pipetteId,
+      })
+    )
+  }
+
+  if (pipetteSpec == null) {
     errors.push(
       errorCreators.pipetteDoesNotExist({
         pipette: pipetteId,
@@ -61,6 +86,94 @@ export const blowout: CommandCreator<BlowoutParams> = (
     if (COLUMN_4_SLOTS.includes(adapterSlot)) {
       errors.push(
         errorCreators.pipettingIntoColumn4({ typeOfStep: actionName })
+      )
+    }
+  }
+  if (
+    modulePipetteCollision({
+      pipette: pipetteId,
+      labware: labwareId,
+      invariantContext,
+      prevRobotState,
+    })
+  ) {
+    errors.push(errorCreators.modulePipetteCollisionDanger())
+  }
+
+  if (
+    thermocyclerPipetteCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labwareId
+    )
+  ) {
+    errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
+  if (
+    absorbanceReaderCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labwareId
+    )
+  ) {
+    errors.push(errorCreators.absorbanceReaderLidClosed())
+  }
+
+  if (
+    pipetteIntoHeaterShakerLatchOpen(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labwareId
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerLatchOpen())
+  }
+
+  if (
+    pipetteIntoHeaterShakerWhileShaking(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labwareId
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerIsShaking())
+  }
+  if (
+    pipetteAdjacentHeaterShakerWhileShaking(
+      prevRobotState.modules,
+      slotName,
+      isFlexPipette ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
+    )
+  ) {
+    errors.push(errorCreators.heaterShakerNorthSouthEastWestShaking())
+  }
+  if (!isFlexPipette && pipetteSpec != null) {
+    if (
+      getIsHeaterShakerEastWestWithLatchOpen(prevRobotState.modules, slotName)
+    ) {
+      errors.push(errorCreators.heaterShakerEastWestWithLatchOpen())
+    }
+
+    if (
+      getIsHeaterShakerEastWestMultiChannelPipette(
+        prevRobotState.modules,
+        slotName,
+        pipetteSpec
+      )
+    ) {
+      errors.push(errorCreators.heaterShakerEastWestOfMultiChannelPipette())
+    }
+    if (
+      getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette(
+        prevRobotState.modules,
+        slotName,
+        pipetteSpec,
+        invariantContext.labwareEntities[labwareId]
+      )
+    ) {
+      errors.push(
+        errorCreators.heaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette()
       )
     }
   }

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -1,6 +1,7 @@
 import { COLUMN, FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import {
+  absorbanceReaderCollision,
   modulePipetteCollision,
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
@@ -137,6 +138,16 @@ export const dispense: CommandCreator<ExtendedDispenseParams> = (
     )
   ) {
     errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
+  if (
+    absorbanceReaderCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.absorbanceReaderLidClosed())
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -1,6 +1,7 @@
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import {
+  absorbanceReaderCollision,
   modulePipetteCollision,
   thermocyclerPipetteCollision,
   pipetteIntoHeaterShakerLatchOpen,
@@ -102,6 +103,16 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
     )
   ) {
     errors.push(errorCreators.heaterShakerLatchOpen())
+  }
+
+  if (
+    absorbanceReaderCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.absorbanceReaderLidClosed())
   }
 
   if (

--- a/step-generation/src/utils/absorbanceReaderCollision.ts
+++ b/step-generation/src/utils/absorbanceReaderCollision.ts
@@ -1,0 +1,22 @@
+import { ABSORBANCE_READER_TYPE } from '@opentrons/shared-data'
+import type { RobotState } from '../'
+
+export const absorbanceReaderCollision = (
+  modules: RobotState['modules'],
+  labware: RobotState['labware'],
+  labwareId: string
+): boolean => {
+  const labwareSlot: string = labware[labwareId]?.slot
+  const moduleUnderLabware: string | null | undefined =
+    modules &&
+    labwareSlot &&
+    Object.keys(modules).find((moduleId: string) => moduleId === labwareSlot)
+  const moduleState =
+    moduleUnderLabware && modules[moduleUnderLabware].moduleState
+  const isAbsorbanceReaderLidClosed: boolean = Boolean(
+    moduleState &&
+      moduleState.type === ABSORBANCE_READER_TYPE &&
+      moduleState.lidOpen !== true
+  )
+  return isAbsorbanceReaderLidClosed
+}

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -1,4 +1,5 @@
 import uuidv4 from 'uuid/v4'
+import { absorbanceReaderCollision } from './absorbanceReaderCollision'
 import { commandCreatorsTimeline } from './commandCreatorsTimeline'
 import { curryCommandCreator } from './curryCommandCreator'
 import { reduceCommandCreators } from './reduceCommandCreators'
@@ -8,6 +9,7 @@ import { getLabwareSlot } from './getLabwareSlot'
 import { movableTrashCommandsUtil } from './movableTrashCommandsUtil'
 
 export {
+  absorbanceReaderCollision,
   commandCreatorsTimeline,
   curryCommandCreator,
   reduceCommandCreators,


### PR DESCRIPTION
# Overview

This PR introduces utility to get a possible collision with absorbance reader module if the lid is not open (closed or indeterminate). It wires up the absorbance reader closed lid error creator in aspirate, dispense, and moveToWell error creators (checks already used in moveLabware)

Closes AUTH-1079

## Test Plan and Hands on Testing

- in an absorbance reader protocol, open lid and move compatible labware to it
- close lid
- add a mix or transfer step that access the plate in absorbance reader (either as source or destination labware), and verify that correct error banner shows for absorbance reader closed lid timeline error

## Changelog

- create utility for possible absorbance reader pipette collision
- wire up in aspirate, dispense, and moveToWell command creators
- add tests

## Review requests

- see test plan

## Risk assessment

low