### PR TITLE
fix(protocol-designer): small style cleanup

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -282,8 +282,6 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     }
   }
 
-  console.log('stepName', formData.stepName)
-
   return (
     <>
       {isRename ? (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
@@ -334,6 +334,7 @@ function WavelengthItem(props: WavelengthItemProps): JSX.Element {
             handleDeleteWavelength(index)
           }}
           alignSelf={ALIGN_FLEX_END}
+          padding={SPACING.spacing4}
         >
           <StyledText
             desktopStyle="bodyDefaultRegular"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerState.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerState.tsx
@@ -66,8 +66,7 @@ export function ThermocyclerState(props: ThermocyclerStateProps): JSX.Element {
     <Flex
       flexDirection={DIRECTION_COLUMN}
       gridGap={SPACING.spacing4}
-      paddingX={SPACING.spacing16}
-      paddingY={paddingY}
+      padding={`${paddingY} ${SPACING.spacing16}`}
     >
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         <StyledText desktopStyle="bodyDefaultSemiBold">

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerState.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerState.tsx
@@ -24,6 +24,7 @@ interface ThermocyclerStateProps {
   visibleFormErrors: StepFormErrors
   showFormErrors?: boolean
   focusedField?: string | null
+  paddingY?: string
 }
 
 export function ThermocyclerState(props: ThermocyclerStateProps): JSX.Element {
@@ -33,6 +34,7 @@ export function ThermocyclerState(props: ThermocyclerStateProps): JSX.Element {
     formData,
     isHold = false,
     visibleFormErrors,
+    paddingY = '0',
   } = props
   const { i18n, t } = useTranslation(['application', 'form'])
 
@@ -65,6 +67,7 @@ export function ThermocyclerState(props: ThermocyclerStateProps): JSX.Element {
       flexDirection={DIRECTION_COLUMN}
       gridGap={SPACING.spacing4}
       paddingX={SPACING.spacing16}
+      paddingY={paddingY}
     >
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         <StyledText desktopStyle="bodyDefaultSemiBold">

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/index.tsx
@@ -77,6 +77,7 @@ export function ThermocyclerTools(props: StepFormProps): JSX.Element {
         showFormErrors={showFormErrors}
         visibleFormErrors={visibleFormErrors}
         focusedField={focusedField}
+        paddingY={SPACING.spacing16}
       />
     )
   } else {


### PR DESCRIPTION
# Overview

fix padding in toolboxes, remove console.log

## Test Plan and Hands on Testing

- verify correct style for 'delete' link in wavelength item of absorbance reader initialize form
<img width="306" alt="Screenshot 2025-01-22 at 2 53 15 PM" src="https://github.com/user-attachments/assets/0b0297f1-515e-4888-97a3-53021b694742" />

- verify correct paddingY for thermocycler state form
<img width="332" alt="Screenshot 2025-01-22 at 2 53 39 PM" src="https://github.com/user-attachments/assets/7531e677-6a94-4fed-aa94-1134f99d6e41" />

## Changelog

- fix padding
- remove log

## Review requests

see test plan

## Risk assessment

low