### PR TITLE
fix(protocol-designer): check gripper use with absorbance reader

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -126,8 +126,10 @@ export function ProtocolOverview(): JSX.Element {
   const gripperInUse =
     fileData?.commands.find(
       command =>
-        command.commandType === 'moveLabware' &&
-        command.params.strategy === 'usingGripper'
+        (command.commandType === 'moveLabware' &&
+          command.params.strategy === 'usingGripper') ||
+        command.commandType === 'absorbanceReader/closeLid' ||
+        command.commandType === 'absorbanceReader/openLid'
     ) != null
   const noCommands = fileData != null ? nonLoadCommands.length === 0 : true
   const modulesWithoutStep = getUnusedEntities(

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1113,8 +1113,10 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
 
       const hasGripperCommands = Object.values(file.commands).some(
         (command): command is MoveLabwareCreateCommand =>
-          command.commandType === 'moveLabware' &&
-          command.params.strategy === 'usingGripper'
+          (command.commandType === 'moveLabware' &&
+            command.params.strategy === 'usingGripper') ||
+          command.commandType === 'absorbanceReader/closeLid' ||
+          command.commandType === 'absorbanceReader/openLid'
       )
       const hasWasteChuteCommands = Object.values(file.commands).some(
         command =>


### PR DESCRIPTION
# Overview

In addition to checking move command with gripper, we need to check absorbance reader lid commands which implicitly require use of the gripper. I add this logic to both our LOAD_FILE reducer and our unused equipment warning modal.

Closes AUTH-1344

## Test Plan and Hands on Testing

- create a protocol with a gripper and absorbance reader steps. make sure any move labware steps DO NOT use the gripper
- export the protocol and verify that there is no warning that gripper is not used (it is used implicitly for absorbance reader commands)
- re-import the protocol and verify that gripper is added
https://github.com/user-attachments/assets/f0eed03b-5fc4-4efb-9d1e-14875da87143


## Changelog

- add absorbance reader lid command checks to logic for determining whether gripper is in use


## Review requests

see test plan

## Risk assessment

low