### PR TITLE
feat(protocol-designer): fix whitescreen and add preselect form type

### DIFF
--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -26,11 +26,17 @@ import type {
   RobotState,
   Timeline,
   AdditionalEquipmentEntities,
+  AbsorbanceReaderState,
 } from '@opentrons/step-generation'
 import type { FormData, StepType, StepIdType } from '../../form-types'
 import type { InitialDeckSetup } from '../types'
 import type { FormPatch } from '../../steplist/actions/types'
 import type { SavedStepFormState, OrderedStepIdsState } from '../reducers'
+import {
+  ABSORBANCE_READER_READ,
+  ABSORBANCE_READER_INITIALIZE,
+  ABSORBANCE_READER_LID,
+} from '../../constants'
 
 export interface CreatePresavedStepFormArgs {
   stepId: StepIdType
@@ -290,22 +296,48 @@ const _patchAbsorbanceReaderModuleId = (args: {
   orderedStepIds: OrderedStepIdsState
   savedStepForms: SavedStepFormState
   stepType: StepType
+  robotStateTimeline: Timeline
 }): FormUpdater => () => {
-  const { initialDeckSetup, stepType } = args
+  const { initialDeckSetup, stepType, robotStateTimeline } = args
   const numOfModules =
     Object.values(initialDeckSetup.modules).filter(
       module => module.type === ABSORBANCE_READER_TYPE
     )?.length ?? 1
   const hasAbsorbanceReaderModuleId = stepType === 'absorbanceReader'
 
+  const robotState: RobotState | undefined = last(robotStateTimeline.timeline)
+    ?.robotState
+  if (robotState == null) {
+    return null
+  }
+  const { labware = {}, modules = {} } = robotState
+
+  // pre-select form type if module is set
   if (hasAbsorbanceReaderModuleId && numOfModules === 1) {
     const moduleId =
       getModuleOnDeckByType(initialDeckSetup, ABSORBANCE_READER_TYPE)?.id ??
       null
-    if (moduleId != null) {
-      return {
-        moduleId,
-      }
+
+    if (moduleId == null) {
+      return null
+    }
+
+    const isLabwareOnAbsorbanceReader = Object.values(labware).some(
+      lw => lw.slot === moduleId
+    )
+    const absorbanceReaderState = modules[moduleId]
+      ?.moduleState as AbsorbanceReaderState | null
+    const initialization = absorbanceReaderState?.initialization ?? null
+    const enableReadOrInitialization =
+      !isLabwareOnAbsorbanceReader || initialization != null
+    const compoundCommandType = isLabwareOnAbsorbanceReader
+      ? ABSORBANCE_READER_READ
+      : ABSORBANCE_READER_INITIALIZE
+    return {
+      moduleId,
+      absorbanceReaderFormType: enableReadOrInitialization
+        ? compoundCommandType
+        : ABSORBANCE_READER_LID,
     }
   }
 
@@ -409,6 +441,7 @@ export const createPresavedStepForm = ({
     orderedStepIds,
     savedStepForms,
     stepType,
+    robotStateTimeline,
   })
 
   const updateThermocyclerFields = _patchThermocyclerFields({

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -305,12 +305,11 @@ const _patchAbsorbanceReaderModuleId = (args: {
     )?.length ?? 1
   const hasAbsorbanceReaderModuleId = stepType === 'absorbanceReader'
 
-  const robotState: RobotState | undefined = last(robotStateTimeline.timeline)
-    ?.robotState
-  if (robotState == null) {
-    return null
-  }
-  const { labware = {}, modules = {} } = robotState
+  const { modules } = initialDeckSetup
+  const robotState: RobotState | null =
+    last(robotStateTimeline.timeline)?.robotState ?? null
+
+  const labware = robotState?.labware ?? {}
 
   // pre-select form type if module is set
   if (hasAbsorbanceReaderModuleId && numOfModules === 1) {

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -122,6 +122,8 @@ const MODULE_ID_REQUIRED: FormError = {
   title:
     'Module is required. Ensure the appropriate module is present on the deck and selected for this step',
   dependentFields: ['moduleId'],
+  showAtForm: false,
+  showAtField: true,
 }
 const TARGET_TEMPERATURE_REQUIRED: FormError = {
   title: 'Temperature required',
@@ -390,6 +392,13 @@ const FILENAME_REQUIRED: FormError = {
   showAtForm: false,
   showAtField: true,
   page: 1,
+}
+const ABSORBANCE_READER_MODULE_ID_REQUIRED: FormError = {
+  title: 'Module required',
+  dependentFields: ['moduleId'],
+  showAtForm: false,
+  showAtField: true,
+  page: 0,
 }
 
 export interface HydratedFormData {
@@ -843,6 +852,13 @@ export const referenceWavelengthRequired = (
     absorbanceReaderFormType === ABSORBANCE_READER_INITIALIZE
     ? REFERENCE_WAVELENGTH_REQUIRED
     : null
+}
+export const absorbanceReaderModuleIdRequired = (
+  fields: HydratedFormData
+): FormError | null => {
+  const { moduleId } = fields
+  if (moduleId == null) return ABSORBANCE_READER_MODULE_ID_REQUIRED
+  return null
 }
 export const wavelengthOutOfRange = (
   fields: HydratedFormData

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -47,6 +47,7 @@ import {
   fileNameRequired,
   wavelengthOutOfRange,
   referenceWavelengthOutOfRange,
+  absorbanceReaderModuleIdRequired,
 } from './errors'
 
 import {
@@ -87,7 +88,8 @@ const stepFormHelperMap: Partial<Record<StepType, FormHelpers>> = {
       referenceWavelengthRequired,
       fileNameRequired,
       wavelengthOutOfRange,
-      referenceWavelengthOutOfRange
+      referenceWavelengthOutOfRange,
+      absorbanceReaderModuleIdRequired
     ),
   },
   heaterShaker: {


### PR DESCRIPTION
# Overview

Here, I fix a whitescreen stemming from not correctly using optional chaining when defining initialization. Also, I add a module required error and wire up to the absorbance reader step form. Last, I fix the preselect form type logic by adding a patch to createPresavedStepForm, and also updating the useEffect logic in the step form component to not fire on mount. We do this so that the form type is not updated if opening a saved step form.

Closes AUTH-1343

## Test Plan and Hands on Testing

- create new absorbance reader step and verify that first read/initialize radio button is pre-selected
- create a different absorbance reader step that changes lid position
- re-open the absorbance reader lid step form and verify that lid position radio button is selected, not read/initialize

## Changelog

- update logic for pre-selecting command type and auto-selecting when changing moduleId
- fix optional chaining with initialization to prevent whitescreen

## Review requests

- see test plan

## Risk assessment

medium