### PR TITLE
feat(protocol-designer): handle (no) gripper with absorbance reader

### DIFF
--- a/protocol-designer/src/assets/localization/en/create_new_protocol.json
+++ b/protocol-designer/src/assets/localization/en/create_new_protocol.json
@@ -2,6 +2,7 @@
   "add_custom_tips": "Add custom pipette tips",
   "add_fixtures": "Add your fixtures",
   "add_gripper": "Add a gripper",
+  "add_gripper_for_absorbance_reader": "Add a gripper to enable adding Absorbance Plate Reader",
   "add_modules": "Add your modules",
   "add_pipette": "Add a pipette",
   "add_pipette_to_continue": "Add a pipette to continue",

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
@@ -10,7 +10,9 @@ import {
   ListItem,
   SPACING,
   StyledText,
+  Tooltip,
   TYPOGRAPHY,
+  useHoverTooltip,
   WRAP,
 } from '@opentrons/components'
 import {
@@ -73,6 +75,7 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
     MAGNETIC_BLOCK_TYPE,
     ABSORBANCE_READER_TYPE,
   ]
+  const hasGripper = additionalEquipment.some(aE => aE === 'gripper')
 
   const handleAddModule = (
     moduleModel: ModuleModel,
@@ -189,15 +192,12 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
                     moduleModel
                   )
                   return (
-                    <EmptySelectorButton
+                    <AddModuleEmptySelectorButton
                       key={moduleModel}
-                      disabled={numSlotsAvailable === 0}
-                      textAlignment={TYPOGRAPHY.textAlignLeft}
-                      iconName="plus"
-                      text={getModuleDisplayName(moduleModel)}
-                      onClick={() => {
-                        handleAddModule(moduleModel, numSlotsAvailable === 0)
-                      }}
+                      moduleModel={moduleModel}
+                      areSlotsAvailable={numSlotsAvailable > 0}
+                      isGripperAttached={hasGripper}
+                      handleAddModule={handleAddModule}
                     />
                   )
                 })}
@@ -304,5 +304,49 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
         </Flex>
       </WizardBody>
     </HandleEnter>
+  )
+}
+
+interface AddModuleEmptySelectorButtonProps {
+  moduleModel: ModuleModel
+  areSlotsAvailable: boolean
+  isGripperAttached: boolean
+  handleAddModule: (arg0: ModuleModel, arg1: boolean) => void
+}
+
+function AddModuleEmptySelectorButton(
+  props: AddModuleEmptySelectorButtonProps
+): JSX.Element {
+  const {
+    moduleModel,
+    areSlotsAvailable,
+    isGripperAttached,
+    handleAddModule,
+  } = props
+  const [targetProps, tooltipProps] = useHoverTooltip()
+  const { t } = useTranslation('create_new_protocol')
+  const disableGripperRequired =
+    !isGripperAttached && moduleModel === ABSORBANCE_READER_V1
+
+  console.log({ isGripperAttached, moduleModel, disableGripperRequired })
+  return (
+    <>
+      <Flex {...targetProps}>
+        <EmptySelectorButton
+          disabled={!areSlotsAvailable || disableGripperRequired}
+          textAlignment={TYPOGRAPHY.textAlignLeft}
+          iconName="plus"
+          text={getModuleDisplayName(moduleModel)}
+          onClick={() => {
+            handleAddModule(moduleModel, !areSlotsAvailable)
+          }}
+        />
+      </Flex>
+      {disableGripperRequired ? (
+        <Tooltip tooltipProps={tooltipProps}>
+          {t('add_gripper_for_absorbance_reader')}
+        </Tooltip>
+      ) : null}
+    </>
   )
 }

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/SelectModules.tsx
@@ -196,7 +196,7 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
                       key={moduleModel}
                       moduleModel={moduleModel}
                       areSlotsAvailable={numSlotsAvailable > 0}
-                      isGripperAttached={hasGripper}
+                      hasGripper={hasGripper}
                       handleAddModule={handleAddModule}
                     />
                   )
@@ -310,25 +310,19 @@ export function SelectModules(props: WizardTileProps): JSX.Element | null {
 interface AddModuleEmptySelectorButtonProps {
   moduleModel: ModuleModel
   areSlotsAvailable: boolean
-  isGripperAttached: boolean
+  hasGripper: boolean
   handleAddModule: (arg0: ModuleModel, arg1: boolean) => void
 }
 
 function AddModuleEmptySelectorButton(
   props: AddModuleEmptySelectorButtonProps
 ): JSX.Element {
-  const {
-    moduleModel,
-    areSlotsAvailable,
-    isGripperAttached,
-    handleAddModule,
-  } = props
+  const { moduleModel, areSlotsAvailable, hasGripper, handleAddModule } = props
   const [targetProps, tooltipProps] = useHoverTooltip()
   const { t } = useTranslation('create_new_protocol')
   const disableGripperRequired =
-    !isGripperAttached && moduleModel === ABSORBANCE_READER_V1
+    !hasGripper && moduleModel === ABSORBANCE_READER_V1
 
-  console.log({ isGripperAttached, moduleModel, disableGripperRequired })
   return (
     <>
       <Flex {...targetProps}>

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectModules.test.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectModules.test.tsx
@@ -96,9 +96,8 @@ describe('SelectModules', () => {
     expect(props.goBack).toHaveBeenCalled()
   })
 
-  it.only('disables absorbance reader if no gripper', () => {
+  it('disables absorbance reader if no gripper', () => {
     render(props)
-    screen.debug()
     fireEvent.click(screen.getByText('Absorbance Plate Reader Module GEN1'))
     expect(props.setValue).not.toHaveBeenCalled()
   })

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectModules.test.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectModules.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import { fireEvent, screen } from '@testing-library/react'
@@ -46,7 +46,9 @@ describe('SelectModules', () => {
     } as WizardTileProps
     vi.mocked(getEnableAbsorbanceReader).mockReturnValue(true)
   })
-
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
   it('renders the flex options and overall text', () => {
     render(props)
     screen.getByText('Step 4')
@@ -95,7 +97,6 @@ describe('SelectModules', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Go back' }))
     expect(props.goBack).toHaveBeenCalled()
   })
-
   it('disables absorbance reader if no gripper', () => {
     render(props)
     fireEvent.click(screen.getByText('Absorbance Plate Reader Module GEN1'))

--- a/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectModules.test.tsx
+++ b/protocol-designer/src/pages/CreateNewProtocolWizard/__tests__/SelectModules.test.tsx
@@ -95,4 +95,11 @@ describe('SelectModules', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Go back' }))
     expect(props.goBack).toHaveBeenCalled()
   })
+
+  it.only('disables absorbance reader if no gripper', () => {
+    render(props)
+    screen.debug()
+    fireEvent.click(screen.getByText('Absorbance Plate Reader Module GEN1'))
+    expect(props.setValue).not.toHaveBeenCalled()
+  })
 })

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -18,7 +18,6 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
-  ABSORBANCE_READER_TYPE,
   ABSORBANCE_READER_V1,
   FLEX_ROBOT_TYPE,
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
@@ -36,10 +35,7 @@ import {
   createDeckFixture,
   deleteDeckFixture,
 } from '../../../step-forms/actions/additionalItems'
-import {
-  getAdditionalEquipment,
-  getSavedStepForms,
-} from '../../../step-forms/selectors'
+import { getSavedStepForms } from '../../../step-forms/selectors'
 import { deleteModule } from '../../../step-forms/actions'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import {
@@ -125,10 +121,6 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
 
   const [changeModuleWarningInfo, displayModuleWarning] = useState<boolean>(
     false
-  )
-  const additionalEquipment = useSelector(getAdditionalEquipment)
-  const isGripperAttached = Object.values(additionalEquipment).some(
-    equipment => equipment?.name === 'gripper'
   )
   const [selectedHardware, setSelectedHardware] = useState<
     ModuleModel | Fixture | null
@@ -345,11 +337,6 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     if (selectedModuleModel != null) {
       //  create module
       const moduleType = getModuleType(selectedModuleModel)
-      // enforce gripper present in order to add plate reader
-      if (moduleType === ABSORBANCE_READER_TYPE && !isGripperAttached) {
-        makeSnackbar(t('gripper_required_for_plate_reader') as string)
-        return
-      }
 
       const moduleSteps = Object.values(savedSteps).filter(step => {
         return (

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -196,17 +196,4 @@ describe('DeckSetupTools', () => {
     fireEvent.click(screen.getByText('Done'))
     expect(props.onCloseClick).toHaveBeenCalled()
   })
-  it('should prevent saving plate reader and make toast if gripper not configured', () => {
-    vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
-      selectedLabwareDefUri: null,
-      selectedNestedLabwareDefUri: null,
-      selectedFixture: null,
-      selectedModuleModel: ABSORBANCE_READER_V1,
-      selectedSlot: { slot: 'D3', cutout: 'cutoutD3' },
-    })
-    render(props)
-    fireEvent.click(screen.getByText('Done'))
-    expect(props.onCloseClick).not.toHaveBeenCalled()
-    expect(mockMakeSnackbar).toHaveBeenCalled()
-  })
 })


### PR DESCRIPTION
# Overview

This PR updates logic for adding absorbance reader module given presence or lack thereof of a gripper. During onboarding, if no gripper is added, the selector button for adding an absorbance reader module is disabled with tooltip. However, in deck setup, we no longer prevent the user from adding an absorbance reader module without the presence of a gripper. We will be permissive in setup, and present timeline errors in protocol timeline.

Closes AUTH-1345

## Test Plan and Hands on Testing

- create protocol without gripper
- on modules selection page, verify that absorbance reader button is disabled with tooltip
- finish creating protocol and navigate to edit deck setup
- select a right-column slot and verify that adding an absorbance reader is permitted

## Changelog

- update disable logic in `SelectModules` to check gripper for absorbance reader
- remove gripper check for adding absorbance reader in deck setup tools
- add tests

## Review requests

- see test plan

## Risk assessment
low