### PR TITLE
fix(components, protocol-designer): implement ListButton in step forms

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -243,7 +243,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
       <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
         <Flex
           onClick={(e: MouseEvent) => {
-            e.preventDefault()
+            e.stopPropagation()
             toggleSetShowDropdownMenu()
           }}
           onFocus={onFocus}
@@ -300,9 +300,10 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
                   disabled={option.disabled}
                   zIndex={3}
                   key={`${option.name}-${index}`}
-                  onClick={() => {
+                  onClick={e => {
                     onClick(option.value)
                     setShowDropdownMenu(false)
+                    e.stopPropagation()
                   }}
                   border="none"
                   onMouseEnter={() => onEnter?.(option.value)}

--- a/protocol-designer/src/molecules/InputStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/InputStepFormField/index.tsx
@@ -52,6 +52,9 @@ export function InputStepFormField(
         name={name}
         error={formLevelError ?? errorToShow}
         onBlur={onFieldBlur}
+        onClick={e => {
+          e.stopPropagation()
+        }}
         onFocus={onFieldFocus}
         onChange={e => {
           updateValue(e.currentTarget.value)

--- a/protocol-designer/src/molecules/ToggleExpandStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/ToggleExpandStepFormField/index.tsx
@@ -1,12 +1,11 @@
 import {
   ALIGN_CENTER,
-  Btn,
   COLORS,
   Check,
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
-  ListItem,
+  ListButton,
   SPACING,
   StyledText,
 } from '@opentrons/components'
@@ -73,12 +72,12 @@ export function ToggleExpandStepFormField(
 
   const label = isSelected ? onLabel : offLabel ?? null
   return (
-    <ListItem type="noActive">
-      <Flex
-        padding={SPACING.spacing12}
-        width="100%"
-        flexDirection={DIRECTION_COLUMN}
-      >
+    <ListButton
+      type="noActive"
+      padding={SPACING.spacing12}
+      onClick={onToggleUpdateValue}
+    >
+      <Flex flexDirection={DIRECTION_COLUMN} width="100%">
         <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_CENTER}>
           <StyledText desktopStyle="bodyDefaultRegular">{title}</StyledText>
           <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
@@ -92,14 +91,11 @@ export function ToggleExpandStepFormField(
             ) : null}
             {toggleElement === 'toggle' ? (
               <ToggleButton
-                onClick={onToggleUpdateValue}
                 label={isSelected ? onLabel : offLabel}
                 toggledOn={isSelected}
               />
             ) : (
-              <Btn onClick={onToggleUpdateValue}>
-                <Check color={COLORS.blue50} isChecked={isSelected} />
-              </Btn>
+              <Check color={COLORS.blue50} isChecked={isSelected} />
             )}
           </Flex>
         </Flex>
@@ -121,6 +117,6 @@ export function ToggleExpandStepFormField(
           ) : null}
         </Flex>
       </Flex>
-    </ListItem>
+    </ListButton>
   )
 }

--- a/protocol-designer/src/molecules/ToggleStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/ToggleStepFormField/index.tsx
@@ -4,7 +4,7 @@ import {
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
-  ListItem,
+  ListButton,
   SPACING,
   StyledText,
   TOOLTIP_BOTTOM,
@@ -43,12 +43,14 @@ export function ToggleStepFormField(
 
   return (
     <>
-      <ListItem type="noActive">
-        <Flex
-          padding={SPACING.spacing12}
-          width="100%"
-          flexDirection={DIRECTION_COLUMN}
-        >
+      <ListButton
+        type="noActive"
+        padding={SPACING.spacing12}
+        onClick={() => {
+          toggleUpdateValue(!toggleValue)
+        }}
+      >
+        <Flex width="100%" flexDirection={DIRECTION_COLUMN}>
           <Flex
             justifyContent={JUSTIFY_SPACE_BETWEEN}
             alignItems={ALIGN_CENTER}
@@ -68,9 +70,6 @@ export function ToggleStepFormField(
               {isDisabled ? null : (
                 <ToggleButton
                   disabled={isDisabled}
-                  onClick={() => {
-                    toggleUpdateValue(!toggleValue)
-                  }}
                   label={isSelected ? onLabel : offLabel}
                   toggledOn={isSelected}
                 />
@@ -78,7 +77,7 @@ export function ToggleStepFormField(
             </Flex>
           </Flex>
         </Flex>
-      </ListItem>
+      </ListButton>
     </>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
@@ -14,6 +14,7 @@ import {
   Icon,
   InputField,
   JUSTIFY_SPACE_BETWEEN,
+  ListButton,
   ListItem,
   RadioButton,
   SPACING,
@@ -383,28 +384,29 @@ function ReferenceWavelength(props: ReferenceWavelengthProps): JSX.Element {
           {t('step_edit_form.absorbanceReader.reference_wavelength.tooltip')}
         </Tooltip>
       </Flex>
-      <ListItem
+      <ListButton
         type="noActive"
         padding={SPACING.spacing12}
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing8}
+        onClick={() => {
+          propsForFields.referenceWavelengthActive.updateValue(!isExpanded)
+        }}
       >
-        <Flex width="100%" justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        <Flex
+          width="100%"
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          alignItems={ALIGN_CENTER}
+        >
           <StyledText desktopStyle="bodyDefaultRegular">
             {t(
               'step_edit_form.field.absorbanceReader.referenceWavelengthActive'
             )}
           </StyledText>
-          <Btn
-            onClick={() => {
-              propsForFields.referenceWavelengthActive.updateValue(!isExpanded)
-            }}
-          >
-            <Check
-              color={COLORS.blue50}
-              isChecked={formData.referenceWavelengthActive === true}
-            />
-          </Btn>
+          <Check
+            color={COLORS.blue50}
+            isChecked={formData.referenceWavelengthActive === true}
+          />
         </Flex>
         {isExpanded ? (
           <>
@@ -446,6 +448,9 @@ function ReferenceWavelength(props: ReferenceWavelengthProps): JSX.Element {
                     maskToInteger(e.target.value)
                   )
                 }}
+                onClick={e => {
+                  e.stopPropagation()
+                }}
                 onBlur={() => {
                   setIsFocused(false)
                 }}
@@ -457,7 +462,7 @@ function ReferenceWavelength(props: ReferenceWavelengthProps): JSX.Element {
             ) : null}
           </>
         ) : null}
-      </ListItem>
+      </ListButton>
     </Flex>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -104,7 +104,12 @@ export function ProtocolSteps(): JSX.Element {
           maxWidth={CONTENT_MAX_WIDTH}
         >
           {showTimelineAlerts ? (
-            <TimelineAlerts justifyContent={JUSTIFY_CENTER} width="100%" />
+            <TimelineAlerts
+              justifyContent={JUSTIFY_CENTER}
+              width="100%"
+              flexDirection={DIRECTION_COLUMN}
+              gridGap={SPACING.spacing4}
+            />
           ) : null}
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
             {currentStep != null && hoveredTerminalItem == null ? (


### PR DESCRIPTION
# Overview

ListItems used for toggle/toggleExpand form fields in PD went unnoticed-- according to designs, these fields should actually return ListButtons. This PR swaps those components out where necessary and adds event stopPropogation functions to children input fields and dropdown menus click handlers.

## Test Plan and Hands on Testing


- create or import a protocol with thermocycler, heater shaker, and absorbance reader forms (only forms that include components touched here) ([example](https://github.com/user-attachments/files/18527284/demo.json.zip))
- verify that toggle/toggleExpand fields are now radio buttons. clicking anywhere on the container should toggle the value/expanded state
- for expanded toggle fields, verify that interacting with children (input field, dropdown menu, menu item) does not toggle the expanded state

## Changelog

- replace `ListItem` with `ListButton` in toggle/toggleExpand form fields 
- add `MouseEvent.stopPropagation` protections

## Review requests

see test plan

## Risk assessment

medium