### PR TITLE
fix(api): log the serial number if expected when raising ModuleNotAttachedError.

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1198,7 +1198,10 @@ class ModuleView:
                     else:
                         return m
 
-        raise errors.ModuleNotAttachedError(f"No available {model.value} found.")
+        raise errors.ModuleNotAttachedError(
+            f"No available {model.value} with {expected_serial_number or 'any'}"
+            " serial found."
+        )
 
     def get_heater_shaker_movement_restrictors(
         self,


### PR DESCRIPTION
Deck configuration expects a module with a specific serial number, however, a "ModuleNotAttachedError" will be raised if it can't find it. It would be nice to know if when this error is raised we are looking for a specific serial number or a module of the given type of 'any' serial number.