### PR TITLE
fix(components,-protocol-designer): preselect useGripper in moveLabware form if attached

### DIFF
--- a/components/src/atoms/Checkbox/index.tsx
+++ b/components/src/atoms/Checkbox/index.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../../icons'
 import {
   ALIGN_CENTER,
   CURSOR_AUTO,
+  CURSOR_DEFAULT,
   CURSOR_POINTER,
   DIRECTION_ROW,
   FLEX_MAX_CONTENT,
@@ -66,8 +67,12 @@ export function Checkbox(props: CheckboxProps): JSX.Element {
       outline-offset: 2px;
     }
     &:disabled {
-      background-color: ${COLORS.grey35};
-      color: ${COLORS.grey50};
+      background-color: ${COLORS.grey30};
+      color: ${COLORS.grey40};
+      cursor: ${CURSOR_DEFAULT};
+    }
+    &:disabled:hover {
+      background-color: ${COLORS.grey30}; /* Prevent hover from overriding */
     }
     &:hover {
       background-color: ${isChecked ? COLORS.blue55 : COLORS.blue35};
@@ -93,7 +98,7 @@ export function Checkbox(props: CheckboxProps): JSX.Element {
       <StyledText desktopStyle="bodyDefaultRegular" oddStyle="bodyTextSemiBold">
         {labelText}
       </StyledText>
-      <Check isChecked={isChecked} />
+      <Check isChecked={isChecked} disabled={disabled} />
     </Flex>
   )
 }

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
@@ -398,4 +398,14 @@ describe('createPresavedStepForm', () => {
       })
     })
   })
+  it('should default movdLabware form useGripper value to `true` if gripper is added', () => {
+    const args = {
+      ...defaultArgs,
+      additionalEquipmentEntities: {
+        gripperId: { name: 'gripper', id: 'gripperId' },
+      },
+      stepType: 'moveLabware',
+    }
+    expect(createPresavedStepForm(args)).toHaveProperty('useGripper', true)
+  })
 })

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -378,6 +378,21 @@ const _patchThermocyclerFields = (args: {
   }
 }
 
+const _patchMoveLabwareFields = (args: {
+  additionalEquipmentEntities: AdditionalEquipmentEntities
+  stepType: StepType
+}): FormUpdater => () => {
+  const { additionalEquipmentEntities, stepType } = args
+  const isMoveLabware = stepType === 'moveLabware'
+  const hasGripper = Object.values(additionalEquipmentEntities).some(
+    ({ name }) => name === 'gripper'
+  )
+  if (isMoveLabware && hasGripper) {
+    return { useGripper: true }
+  }
+  return null
+}
+
 export const createPresavedStepForm = ({
   initialDeckSetup,
   labwareEntities,
@@ -449,6 +464,11 @@ export const createPresavedStepForm = ({
     robotStateTimeline,
   })
 
+  const updateMoveLabwareFields = _patchMoveLabwareFields({
+    additionalEquipmentEntities,
+    stepType,
+  })
+
   // finally, compose and apply all the updaters in order,
   // passing the applied result from one updater as the input of the next
   return [
@@ -460,6 +480,7 @@ export const createPresavedStepForm = ({
     updateMagneticModuleId,
     updateAbsorbanceReaderModuleId,
     updateDefaultLabwareLocations,
+    updateMoveLabwareFields,
   ].reduce<FormData>(
     (acc, updater: FormUpdater) => {
       const updates = updater(acc)


### PR DESCRIPTION
# Overview

Update createPresavedStepForm with new patch to pre-select useGripper to true for a moveLabware step form if a gripper is included in additional equipment entities. Fix minor style bugs in Checkbox component.

Closes AUTH-1371

## Test Plan and Hands on Testing

- create a protocol with gripper attached (you can add either in onboarding or in protocol overview)
- create a move labware step and verify that the `useGripper` field is preset to true
- delete that step, and remove gripper from protocol
- again, create a move labware step and verify that the `useGripper` field is set to false and is disabled

## Changelog

- add patch to `createPresavedStepForm` for moveLabware gripper field
- update `Checkbox` style

## Review requests

see test plan

## Risk assessment

low