### PR TITLE
feat(step-generation): introduce airGapInPlace command

### DIFF
--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -22,7 +22,6 @@ import {
   makeTouchTipHelper,
   pickUpTipHelper,
   SOURCE_LABWARE,
-  AIR_GAP_META,
   blowoutInPlaceHelper,
 } from '../fixtures'
 import { DEST_WELL_BLOWOUT_DESTINATION } from '../utils'
@@ -33,16 +32,6 @@ import type {
 } from '@opentrons/shared-data'
 import type { ConsolidateArgs, InvariantContext, RobotState } from '../types'
 
-const airGapHelper = makeAirGapHelper({
-  wellLocation: {
-    origin: 'bottom',
-    offset: {
-      z: 11.54,
-      x: 0,
-      y: 0,
-    },
-  },
-})
 const aspirateHelper = makeAspirateHelper()
 const dispenseHelper = makeDispenseHelper()
 const touchTipHelper = makeTouchTipHelper()
@@ -161,7 +150,7 @@ describe('consolidate single-channel', () => {
       aspirateHelper('A1', 50),
       aspirateHelper('A2', 50),
       dispenseHelper('B1', 100),
-      airGapHelper('B1', 5, { labwareId: 'destPlateId' }),
+      makeAirGapHelper(5)(),
     ])
   })
 
@@ -852,24 +841,24 @@ describe('consolidate single-channel', () => {
 
       aspirateHelper('A1', 100),
       ...delayWithOffset('A1', SOURCE_LABWARE),
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
       delayCommand(12),
 
       aspirateHelper('A2', 100),
       ...delayWithOffset('A2', SOURCE_LABWARE),
-      airGapHelper('A2', 5),
+      makeAirGapHelper(5)(),
       delayCommand(12),
 
       dispenseHelper('B1', 210),
 
       aspirateHelper('A3', 100),
       ...delayWithOffset('A3', SOURCE_LABWARE),
-      airGapHelper('A3', 5),
+      makeAirGapHelper(5)(),
       delayCommand(12),
 
       aspirateHelper('A4', 100),
       ...delayWithOffset('A4', SOURCE_LABWARE),
-      airGapHelper('A4', 5),
+      makeAirGapHelper(5)(),
       delayCommand(12),
 
       dispenseHelper('B1', 210),
@@ -1010,18 +999,18 @@ describe('consolidate single-channel', () => {
       pickUpTipHelper('A1'),
 
       aspirateHelper('A1', 100),
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
 
       aspirateHelper('A2', 100),
-      airGapHelper('A2', 5),
+      makeAirGapHelper(5)(),
 
       dispenseHelper('B1', 210),
 
       aspirateHelper('A3', 100),
-      airGapHelper('A3', 5),
+      makeAirGapHelper(5)(),
 
       aspirateHelper('A4', 100),
-      airGapHelper('A4', 5),
+      makeAirGapHelper(5)(),
 
       dispenseHelper('B1', 210),
     ])
@@ -1044,22 +1033,22 @@ describe('consolidate single-channel', () => {
       pickUpTipHelper('A1'),
 
       aspirateHelper('A1', 150),
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
 
       dispenseHelper('B1', 155),
 
       aspirateHelper('A2', 150),
-      airGapHelper('A2', 5),
+      makeAirGapHelper(5)(),
 
       dispenseHelper('B1', 155),
 
       aspirateHelper('A3', 150),
-      airGapHelper('A3', 5),
+      makeAirGapHelper(5)(),
 
       dispenseHelper('B1', 155),
 
       aspirateHelper('A4', 150),
-      airGapHelper('A4', 5),
+      makeAirGapHelper(5)(),
 
       dispenseHelper('B1', 155),
     ])
@@ -1213,22 +1202,11 @@ describe('consolidate single-channel', () => {
         },
         // Air Gap: after aspirating from A1
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -1300,22 +1278,11 @@ describe('consolidate single-channel', () => {
         },
         // Aspirate > air gap: after aspirating from A2
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A2',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -1560,22 +1527,11 @@ describe('consolidate single-channel', () => {
         },
         // Aspirate > air gap: after aspirating from A3
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A3',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -1703,23 +1659,12 @@ describe('consolidate single-channel', () => {
         },
         // Dispense > air gap in dest well
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            flowRate: 2.1,
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             volume: 35,
+            flowRate: 2.1,
           },
         },
         {
@@ -1888,22 +1833,11 @@ describe('consolidate single-channel', () => {
         },
         // Air Gap: after aspirating from A1
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -1975,22 +1909,11 @@ describe('consolidate single-channel', () => {
         },
         // Aspirate > air gap: after aspirating from A2
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A2',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -2250,22 +2173,11 @@ describe('consolidate single-channel', () => {
         },
         // Aspirate > air gap: after aspirating from A3
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A3',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -2408,23 +2320,12 @@ describe('consolidate single-channel', () => {
         },
         // Dispense > air gap in dest well
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            flowRate: 2.1,
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             volume: 35,
+            flowRate: 2.1,
           },
         },
         {
@@ -2590,22 +2491,11 @@ describe('consolidate single-channel', () => {
         },
         // Air Gap: after aspirating from A1
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -2677,22 +2567,11 @@ describe('consolidate single-channel', () => {
         },
         // Aspirate > air gap: after aspirating from A2
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A2',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -2836,21 +2715,10 @@ describe('consolidate single-channel', () => {
 
         // Change tip is "always" so we can Dispense > Air Gap here
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             volume: 35,
             flowRate: 2.1,
           },
@@ -2989,22 +2857,11 @@ describe('consolidate single-channel', () => {
         },
         // Aspirate > air gap: after aspirating from A3
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A3',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -3147,21 +3004,10 @@ describe('consolidate single-channel', () => {
         },
         // Dispense > air gap in dest well
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             volume: 35,
             flowRate: 2.1,
           },

--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -23,6 +23,7 @@ import {
   pickUpTipHelper,
   SOURCE_LABWARE,
   blowoutInPlaceHelper,
+  makeMoveToWellHelper,
 } from '../fixtures'
 import { DEST_WELL_BLOWOUT_DESTINATION } from '../utils'
 import type {
@@ -150,7 +151,8 @@ describe('consolidate single-channel', () => {
       aspirateHelper('A1', 50),
       aspirateHelper('A2', 50),
       dispenseHelper('B1', 100),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('B1', DEST_LABWARE),
+      makeAirGapHelper(5),
     ])
   })
 
@@ -841,24 +843,28 @@ describe('consolidate single-channel', () => {
 
       aspirateHelper('A1', 100),
       ...delayWithOffset('A1', SOURCE_LABWARE),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
       delayCommand(12),
 
       aspirateHelper('A2', 100),
       ...delayWithOffset('A2', SOURCE_LABWARE),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A2'),
+      makeAirGapHelper(5),
       delayCommand(12),
 
       dispenseHelper('B1', 210),
 
       aspirateHelper('A3', 100),
       ...delayWithOffset('A3', SOURCE_LABWARE),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A3'),
+      makeAirGapHelper(5),
       delayCommand(12),
 
       aspirateHelper('A4', 100),
       ...delayWithOffset('A4', SOURCE_LABWARE),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A4'),
+      makeAirGapHelper(5),
       delayCommand(12),
 
       dispenseHelper('B1', 210),
@@ -999,18 +1005,22 @@ describe('consolidate single-channel', () => {
       pickUpTipHelper('A1'),
 
       aspirateHelper('A1', 100),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
 
       aspirateHelper('A2', 100),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A2'),
+      makeAirGapHelper(5),
 
       dispenseHelper('B1', 210),
 
       aspirateHelper('A3', 100),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A3'),
+      makeAirGapHelper(5),
 
       aspirateHelper('A4', 100),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A4'),
+      makeAirGapHelper(5),
 
       dispenseHelper('B1', 210),
     ])
@@ -1033,22 +1043,26 @@ describe('consolidate single-channel', () => {
       pickUpTipHelper('A1'),
 
       aspirateHelper('A1', 150),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
 
       dispenseHelper('B1', 155),
 
       aspirateHelper('A2', 150),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A2'),
+      makeAirGapHelper(5),
 
       dispenseHelper('B1', 155),
 
       aspirateHelper('A3', 150),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A3'),
+      makeAirGapHelper(5),
 
       dispenseHelper('B1', 155),
 
       aspirateHelper('A4', 150),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A4'),
+      makeAirGapHelper(5),
 
       dispenseHelper('B1', 155),
     ])
@@ -1202,6 +1216,23 @@ describe('consolidate single-channel', () => {
         },
         // Air Gap: after aspirating from A1
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -1277,6 +1308,23 @@ describe('consolidate single-channel', () => {
           },
         },
         // Aspirate > air gap: after aspirating from A2
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A2',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -1527,6 +1575,23 @@ describe('consolidate single-channel', () => {
         },
         // Aspirate > air gap: after aspirating from A3
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A3',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -1658,6 +1723,23 @@ describe('consolidate single-channel', () => {
           },
         },
         // Dispense > air gap in dest well
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'destPlateId',
+            wellName: 'B1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -1833,6 +1915,23 @@ describe('consolidate single-channel', () => {
         },
         // Air Gap: after aspirating from A1
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -1908,6 +2007,23 @@ describe('consolidate single-channel', () => {
           },
         },
         // Aspirate > air gap: after aspirating from A2
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A2',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -2173,6 +2289,23 @@ describe('consolidate single-channel', () => {
         },
         // Aspirate > air gap: after aspirating from A3
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A3',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -2319,6 +2452,23 @@ describe('consolidate single-channel', () => {
           },
         },
         // Dispense > air gap in dest well
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'destPlateId',
+            wellName: 'B1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -2491,6 +2641,23 @@ describe('consolidate single-channel', () => {
         },
         // Air Gap: after aspirating from A1
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -2566,6 +2733,23 @@ describe('consolidate single-channel', () => {
           },
         },
         // Aspirate > air gap: after aspirating from A2
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A2',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -2715,6 +2899,23 @@ describe('consolidate single-channel', () => {
 
         // Change tip is "always" so we can Dispense > Air Gap here
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'destPlateId',
+            wellName: 'B1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -2856,6 +3057,23 @@ describe('consolidate single-channel', () => {
           },
         },
         // Aspirate > air gap: after aspirating from A3
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A3',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -3003,6 +3221,23 @@ describe('consolidate single-channel', () => {
           },
         },
         // Dispense > air gap in dest well
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'destPlateId',
+            wellName: 'B1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -27,6 +27,7 @@ import {
   pickUpTipHelper,
   SOURCE_LABWARE,
   blowoutInPlaceHelper,
+  makeMoveToWellHelper,
 } from '../fixtures'
 import { distribute } from '../commandCreators/compound/distribute'
 import type { CreateCommand, LabwareDefinition2 } from '@opentrons/shared-data'
@@ -446,8 +447,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     expect(res.commands).toEqual([
       aspirateHelper('A1', 200),
       ...delayWithOffset('A1', SOURCE_LABWARE),
-
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
       delayCommand(12),
 
       dispenseAirGapHelper('A2', 5),
@@ -456,8 +457,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
 
       aspirateHelper('A1', 200),
       ...delayWithOffset('A1', SOURCE_LABWARE),
-
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
       delayCommand(12),
       dispenseAirGapHelper('A4', 5),
       dispenseHelper('A4', 100),
@@ -485,13 +486,15 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
       aspirateHelper('A1', 200),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
       dispenseAirGapHelper('A2', 5),
       dispenseHelper('A2', 100),
       dispenseHelper('A3', 100),
 
       aspirateHelper('A1', 200),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
       dispenseAirGapHelper('A4', 5),
       dispenseHelper('A4', 100),
       dispenseHelper('A5', 100),
@@ -519,7 +522,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
       aspirateHelper('A1', 200),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
 
       dispenseAirGapHelper('A2', 5),
       delayCommand(12),
@@ -529,7 +533,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       ...delayWithOffset('A3', DEST_LABWARE),
 
       aspirateHelper('A1', 200),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('A1'),
+      makeAirGapHelper(5),
 
       dispenseAirGapHelper('A4', 5),
       delayCommand(12),
@@ -919,7 +924,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('B1', 31),
@@ -966,7 +972,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -998,7 +1005,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         dispenseAirGapHelper('A4', 31),
         delayCommand(12),
@@ -1009,7 +1017,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A4', { labwareId: DEST_LABWARE }),
         ...blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A4', DEST_LABWARE),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1046,7 +1055,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1062,7 +1072,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A3', { labwareId: DEST_LABWARE }),
         ...blowoutSingleToTrash,
         // dispense > air gap since we are about to change the tip
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A3', DEST_LABWARE),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1083,7 +1094,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1094,7 +1106,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A4', { labwareId: DEST_LABWARE }),
         ...blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A4', DEST_LABWARE),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         // skip blowout into trash b/c we're about to drop tip anyway
@@ -1132,7 +1145,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1163,7 +1177,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1174,7 +1189,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A4', { labwareId: DEST_LABWARE }),
         ...blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A4', DEST_LABWARE),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1209,7 +1225,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1241,7 +1258,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1254,7 +1272,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutSingleToSourceA1,
         // use the dispense > air gap here before moving to trash since it is the final dispense in the step
         // dispense > air gap from source since blowout location is source
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1291,7 +1310,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1308,7 +1328,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // blowout location is source so need to blowout
         blowoutSingleToSourceA1,
         // dispense > air gap so no liquid drops off the tip as pipette moves from source well to trash
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(3),
         // delay after aspirating air
         delayCommand(11),
         // just drop the tip in the trash
@@ -1330,7 +1351,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1342,7 +1364,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // blowout location is source so need to blowout
         blowoutSingleToSourceA1,
         // dispense > air gap so no liquid drops off the tip as pipette moves from source well to trash
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1379,7 +1402,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1411,7 +1435,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1423,7 +1448,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
         blowoutSingleToSourceA1,
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1458,7 +1484,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1490,7 +1517,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1503,7 +1531,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutSingleToDestA4,
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A4', DEST_LABWARE),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1540,7 +1569,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1557,7 +1587,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // blowout location is dest so we gotta blowout
         blowoutSingleToDestA3,
         // dispense > air gap so no liquid drops off the tip as pipette moves from destination well to trash
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A3', DEST_LABWARE),
+        makeAirGapHelper(3),
         // dispense delay
         delayCommand(11),
         // just drop the tip in the trash
@@ -1579,7 +1610,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1591,7 +1623,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
         blowoutSingleToDestA4,
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A4', DEST_LABWARE),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1628,7 +1661,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1660,7 +1694,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        makeAirGapHelper(31)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1673,7 +1708,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutSingleToDestA4,
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
-        makeAirGapHelper(3)(),
+        makeMoveToWellHelper('A4', DEST_LABWARE),
+        makeAirGapHelper(3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -36,17 +36,6 @@ import {
   DEST_WELL_BLOWOUT_DESTINATION,
 } from '../utils/misc'
 
-// well depth for 96 plate is 10.54, so need to add 1mm to top of well
-const airGapHelper = makeAirGapHelper({
-  wellLocation: {
-    origin: 'bottom',
-    offset: {
-      x: 0,
-      y: 0,
-      z: 11.54,
-    },
-  },
-})
 const dispenseAirGapHelper = makeDispenseAirGapHelper({
   wellLocation: {
     origin: 'bottom',
@@ -458,7 +447,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       aspirateHelper('A1', 200),
       ...delayWithOffset('A1', SOURCE_LABWARE),
 
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
       delayCommand(12),
 
       dispenseAirGapHelper('A2', 5),
@@ -468,7 +457,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       aspirateHelper('A1', 200),
       ...delayWithOffset('A1', SOURCE_LABWARE),
 
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
       delayCommand(12),
       dispenseAirGapHelper('A4', 5),
       dispenseHelper('A4', 100),
@@ -496,13 +485,13 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
       aspirateHelper('A1', 200),
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
       dispenseAirGapHelper('A2', 5),
       dispenseHelper('A2', 100),
       dispenseHelper('A3', 100),
 
       aspirateHelper('A1', 200),
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
       dispenseAirGapHelper('A4', 5),
       dispenseHelper('A4', 100),
       dispenseHelper('A5', 100),
@@ -530,7 +519,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
       aspirateHelper('A1', 200),
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
 
       dispenseAirGapHelper('A2', 5),
       delayCommand(12),
@@ -540,7 +529,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       ...delayWithOffset('A3', DEST_LABWARE),
 
       aspirateHelper('A1', 200),
-      airGapHelper('A1', 5),
+      makeAirGapHelper(5)(),
 
       dispenseAirGapHelper('A4', 5),
       delayCommand(12),
@@ -930,7 +919,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('B1', 31),
@@ -977,7 +966,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1009,7 +998,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         dispenseAirGapHelper('A4', 31),
         delayCommand(12),
@@ -1020,7 +1009,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A4', { labwareId: DEST_LABWARE }),
         ...blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
-        airGapHelper('A4', 3, { labwareId: DEST_LABWARE }),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1057,7 +1046,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1073,7 +1062,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A3', { labwareId: DEST_LABWARE }),
         ...blowoutSingleToTrash,
         // dispense > air gap since we are about to change the tip
-        airGapHelper('A3', 3, { labwareId: DEST_LABWARE }), // need to air gap here
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1094,7 +1083,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1105,7 +1094,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A4', { labwareId: DEST_LABWARE }),
         ...blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
-        airGapHelper('A4', 3, { labwareId: DEST_LABWARE }),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         // skip blowout into trash b/c we're about to drop tip anyway
@@ -1143,7 +1132,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1174,7 +1163,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1185,7 +1174,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A4', { labwareId: DEST_LABWARE }),
         ...blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
-        airGapHelper('A4', 3, { labwareId: DEST_LABWARE }),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1220,7 +1209,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1252,7 +1241,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1265,7 +1254,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutSingleToSourceA1,
         // use the dispense > air gap here before moving to trash since it is the final dispense in the step
         // dispense > air gap from source since blowout location is source
-        airGapHelper('A1', 3),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1302,7 +1291,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1319,7 +1308,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // blowout location is source so need to blowout
         blowoutSingleToSourceA1,
         // dispense > air gap so no liquid drops off the tip as pipette moves from source well to trash
-        airGapHelper('A1', 3),
+        makeAirGapHelper(3)(),
         // delay after aspirating air
         delayCommand(11),
         // just drop the tip in the trash
@@ -1341,7 +1330,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1353,7 +1342,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // blowout location is source so need to blowout
         blowoutSingleToSourceA1,
         // dispense > air gap so no liquid drops off the tip as pipette moves from source well to trash
-        airGapHelper('A1', 3),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1390,7 +1379,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1422,7 +1411,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1434,7 +1423,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
         blowoutSingleToSourceA1,
-        airGapHelper('A1', 3),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1469,7 +1458,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1501,7 +1490,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1514,7 +1503,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutSingleToDestA4,
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
-        airGapHelper('A4', 3, { labwareId: DEST_LABWARE }),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1551,7 +1540,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1568,7 +1557,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // blowout location is dest so we gotta blowout
         blowoutSingleToDestA3,
         // dispense > air gap so no liquid drops off the tip as pipette moves from destination well to trash
-        airGapHelper('A3', 3, { labwareId: DEST_LABWARE }),
+        makeAirGapHelper(3)(),
         // dispense delay
         delayCommand(11),
         // just drop the tip in the trash
@@ -1590,7 +1579,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1602,7 +1591,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
         blowoutSingleToDestA4,
-        airGapHelper('A4', 3, { labwareId: DEST_LABWARE }),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),
@@ -1639,7 +1628,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #1
         dispenseAirGapHelper('A2', 31),
@@ -1671,7 +1660,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
           },
         }),
         // aspirate > air gap
-        airGapHelper('A1', 31),
+        makeAirGapHelper(31)(),
         delayCommand(11),
         // dispense #3
         dispenseAirGapHelper('A4', 31),
@@ -1684,7 +1673,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutSingleToDestA4,
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
-        airGapHelper('A4', 3, { labwareId: DEST_LABWARE }),
+        makeAirGapHelper(3)(),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
         ...dropTipHelper(),

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -25,7 +25,6 @@ import {
   pickUpTipHelper,
   SOURCE_LABWARE,
   makeDispenseAirGapHelper,
-  AIR_GAP_META,
 } from '../fixtures'
 import { FIXED_TRASH_ID } from '../constants'
 import {
@@ -36,16 +35,6 @@ import { transfer } from '../commandCreators/compound/transfer'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState, TransferArgs } from '../types'
 
-const airGapHelper = makeAirGapHelper({
-  wellLocation: {
-    origin: 'bottom',
-    offset: {
-      x: 0,
-      y: 0,
-      z: 11.54,
-    },
-  },
-})
 const dispenseAirGapHelper = makeDispenseAirGapHelper({
   wellLocation: {
     origin: 'bottom',
@@ -151,7 +140,7 @@ describe('pick up tip if no tip on pipette', () => {
       pickUpTipHelper('A1'),
       aspirateHelper('A1', 30),
       dispenseHelper('B2', 30),
-      airGapHelper('B2', 5, { labwareId: 'destPlateId' }),
+      makeAirGapHelper(5)(),
     ])
   })
 
@@ -843,11 +832,11 @@ describe('advanced options', () => {
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
         aspirateHelper('A1', 295),
-        airGapHelper('A1', 5),
+        makeAirGapHelper(5)(),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 295),
         aspirateHelper('A1', 55),
-        airGapHelper('A1', 5),
+        makeAirGapHelper(5)(),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 55),
       ])
@@ -863,12 +852,11 @@ describe('advanced options', () => {
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
         aspirateHelper('A1', 150),
-        airGapHelper('A1', 5),
+        makeAirGapHelper(5)(),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 150),
-
         aspirateHelper('A1', 150),
-        airGapHelper('A1', 5),
+        makeAirGapHelper(5)(),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 150),
       ])
@@ -886,8 +874,7 @@ describe('advanced options', () => {
       expect(res.commands).toEqual([
         aspirateHelper('A1', 295),
         ...delayWithOffset('A1', SOURCE_LABWARE),
-
-        airGapHelper('A1', 5),
+        makeAirGapHelper(5)(),
         delayCommand(12),
 
         dispenseAirGapHelper('B1', 5),
@@ -896,7 +883,7 @@ describe('advanced options', () => {
         aspirateHelper('A1', 55),
         ...delayWithOffset('A1', SOURCE_LABWARE),
 
-        airGapHelper('A1', 5),
+        makeAirGapHelper(5)(),
         delayCommand(12),
 
         dispenseAirGapHelper('B1', 5),
@@ -915,7 +902,7 @@ describe('advanced options', () => {
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
         aspirateHelper('A1', 295),
-        airGapHelper('A1', 5),
+        makeAirGapHelper(5)(),
 
         dispenseAirGapHelper('B1', 5),
         delayCommand(12),
@@ -924,7 +911,7 @@ describe('advanced options', () => {
         ...delayWithOffset('B1', DEST_LABWARE),
 
         aspirateHelper('A1', 55),
-        airGapHelper('A1', 5),
+        makeAirGapHelper(5)(),
 
         dispenseAirGapHelper('B1', 5),
         delayCommand(12),
@@ -1288,22 +1275,11 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -1317,7 +1293,7 @@ describe('advanced options', () => {
         // dispense the aspirate > air gap
         {
           commandType: 'dispense',
-          meta: AIR_GAP_META,
+
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1592,22 +1568,11 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -1621,7 +1586,6 @@ describe('advanced options', () => {
         // dispense aspirate > air gap then liquid
         {
           commandType: 'dispense',
-          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1777,22 +1741,11 @@ describe('advanced options', () => {
         },
         // use the dispense > air gap here before moving to trash
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 3,
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -1847,6 +1800,7 @@ describe('advanced options', () => {
         },
         {
           commandType: 'dispense',
+
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1900,6 +1854,7 @@ describe('advanced options', () => {
         },
         {
           commandType: 'dispense',
+
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -1986,22 +1941,11 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -2015,7 +1959,6 @@ describe('advanced options', () => {
         // dispense the aspirate > air gap
         {
           commandType: 'dispense',
-          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -2288,23 +2231,12 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
-            flowRate: 2.1,
-            labwareId: 'sourcePlateId',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
             pipetteId: 'p300SingleId',
             volume: 31,
-            wellName: 'A1',
+            flowRate: 2.1,
           },
         },
         {
@@ -2316,7 +2248,6 @@ describe('advanced options', () => {
         },
         {
           commandType: 'dispense',
-          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             flowRate: 2.2,
@@ -2472,23 +2403,12 @@ describe('advanced options', () => {
         },
         // dispense > air gap on the way to trash
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
-            labwareId: 'destPlateId',
-            wellName: 'B1',
             volume: 3,
             flowRate: 2.1,
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
           },
         },
         {
@@ -2710,22 +2630,11 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -2739,7 +2648,6 @@ describe('advanced options', () => {
         // dispense
         {
           commandType: 'dispense',
-          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3012,22 +2920,11 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -3041,7 +2938,6 @@ describe('advanced options', () => {
         // dispense "aspirate > air gap" then dispense liquid
         {
           commandType: 'dispense',
-          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3197,23 +3093,12 @@ describe('advanced options', () => {
         },
         // dispense > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
-            labwareId: 'destPlateId',
-            wellName: 'B1',
             volume: 3,
             flowRate: 2.1,
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
           },
         },
         {
@@ -3433,22 +3318,11 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -3462,7 +3336,6 @@ describe('advanced options', () => {
         // dispense
         {
           commandType: 'dispense',
-          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3618,23 +3491,12 @@ describe('advanced options', () => {
         },
         // dispense > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            flowRate: 2.1,
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
             volume: 3,
+            flowRate: 2.1,
           },
         },
         {
@@ -3786,22 +3648,11 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
-          commandType: 'aspirate',
+          commandType: 'airGapInPlace',
           key: expect.any(String),
-          meta: AIR_GAP_META,
           params: {
             pipetteId: 'p300SingleId',
             volume: 31,
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
             flowRate: 2.1,
           },
         },
@@ -3815,7 +3666,6 @@ describe('advanced options', () => {
         // dispense "aspirate > air gap" then dispense liquid
         {
           commandType: 'dispense',
-          meta: AIR_GAP_META,
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
@@ -3971,23 +3821,12 @@ describe('advanced options', () => {
         },
         // dispense > air gap
         {
-          commandType: 'aspirate',
-          meta: AIR_GAP_META,
+          commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
             pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
             volume: 3,
             flowRate: 2.1,
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
           },
         },
         {

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -25,6 +25,7 @@ import {
   pickUpTipHelper,
   SOURCE_LABWARE,
   makeDispenseAirGapHelper,
+  makeMoveToWellHelper,
 } from '../fixtures'
 import { FIXED_TRASH_ID } from '../constants'
 import {
@@ -140,7 +141,8 @@ describe('pick up tip if no tip on pipette', () => {
       pickUpTipHelper('A1'),
       aspirateHelper('A1', 30),
       dispenseHelper('B2', 30),
-      makeAirGapHelper(5)(),
+      makeMoveToWellHelper('B2', 'destPlateId'),
+      makeAirGapHelper(5),
     ])
   })
 
@@ -832,11 +834,13 @@ describe('advanced options', () => {
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
         aspirateHelper('A1', 295),
-        makeAirGapHelper(5)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(5),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 295),
         aspirateHelper('A1', 55),
-        makeAirGapHelper(5)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(5),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 55),
       ])
@@ -852,11 +856,13 @@ describe('advanced options', () => {
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
         aspirateHelper('A1', 150),
-        makeAirGapHelper(5)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(5),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 150),
         aspirateHelper('A1', 150),
-        makeAirGapHelper(5)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(5),
         dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 150),
       ])
@@ -874,7 +880,8 @@ describe('advanced options', () => {
       expect(res.commands).toEqual([
         aspirateHelper('A1', 295),
         ...delayWithOffset('A1', SOURCE_LABWARE),
-        makeAirGapHelper(5)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(5),
         delayCommand(12),
 
         dispenseAirGapHelper('B1', 5),
@@ -882,8 +889,8 @@ describe('advanced options', () => {
 
         aspirateHelper('A1', 55),
         ...delayWithOffset('A1', SOURCE_LABWARE),
-
-        makeAirGapHelper(5)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(5),
         delayCommand(12),
 
         dispenseAirGapHelper('B1', 5),
@@ -902,7 +909,8 @@ describe('advanced options', () => {
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
         aspirateHelper('A1', 295),
-        makeAirGapHelper(5)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(5),
 
         dispenseAirGapHelper('B1', 5),
         delayCommand(12),
@@ -911,7 +919,8 @@ describe('advanced options', () => {
         ...delayWithOffset('B1', DEST_LABWARE),
 
         aspirateHelper('A1', 55),
-        makeAirGapHelper(5)(),
+        makeMoveToWellHelper('A1'),
+        makeAirGapHelper(5),
 
         dispenseAirGapHelper('B1', 5),
         delayCommand(12),
@@ -1275,6 +1284,23 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -1568,6 +1594,23 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -1740,6 +1783,23 @@ describe('advanced options', () => {
           },
         },
         // use the dispense > air gap here before moving to trash
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'destPlateId',
+            wellName: 'B1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -1940,6 +2000,23 @@ describe('advanced options', () => {
           },
         },
         // aspirate > air gap
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -2231,6 +2308,23 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -2402,6 +2496,23 @@ describe('advanced options', () => {
           },
         },
         // dispense > air gap on the way to trash
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'destPlateId',
+            wellName: 'B1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -2629,6 +2740,23 @@ describe('advanced options', () => {
           },
         },
         // aspirate > air gap
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -2920,6 +3048,23 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -3092,6 +3237,23 @@ describe('advanced options', () => {
           },
         },
         // dispense > air gap
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'destPlateId',
+            wellName: 'B1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -3318,6 +3480,23 @@ describe('advanced options', () => {
         },
         // aspirate > air gap
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -3491,6 +3670,23 @@ describe('advanced options', () => {
         },
         // dispense > air gap
         {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -3647,6 +3843,23 @@ describe('advanced options', () => {
           },
         },
         // aspirate > air gap
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),
@@ -3820,6 +4033,23 @@ describe('advanced options', () => {
           },
         },
         // dispense > air gap
+        {
+          commandType: 'moveToWell',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+            labwareId: 'sourcePlateId',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'bottom',
+              offset: {
+                x: 0,
+                y: 0,
+                z: 11.54,
+              },
+            },
+          },
+        },
         {
           commandType: 'airGapInPlace',
           key: expect.any(String),

--- a/step-generation/src/commandCreators/atomic/airGapInPlace.ts
+++ b/step-generation/src/commandCreators/atomic/airGapInPlace.ts
@@ -1,0 +1,37 @@
+import { uuid } from '../../utils'
+import { pipetteDoesNotExist } from '../../errorCreators'
+import type { AirGapInPlaceParams } from '@opentrons/shared-data'
+import type { CommandCreator, CommandCreatorError } from '../../types'
+
+export const airGapInPlace: CommandCreator<AirGapInPlaceParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { flowRate, pipetteId, volume } = args
+  const errors: CommandCreatorError[] = []
+  const pipetteSpec = invariantContext.pipetteEntities[pipetteId]?.spec
+
+  if (!pipetteSpec) {
+    errors.push(
+      pipetteDoesNotExist({
+        pipette: pipetteId,
+      })
+    )
+  }
+
+  const commands = [
+    {
+      commandType: 'airGapInPlace' as const,
+      key: uuid(),
+      params: {
+        flowRate,
+        pipetteId,
+        volume,
+      },
+    },
+  ]
+  return {
+    commands,
+  }
+}

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -40,7 +40,6 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
     labwareId,
     wellName,
     flowRate,
-    isAirGap,
     tipRack,
     wellLocation,
     nozzles,
@@ -257,7 +256,6 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
         wellLocation,
         flowRate,
       },
-      ...(isAirGap && { meta: { isAirGap } }),
     },
   ]
   return {

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -26,7 +26,6 @@ import type { CommandCreator, CommandCreatorError } from '../../types'
 export interface DispenseAtomicCommandParams extends DispenseParams {
   nozzles: NozzleConfigurationStyle | null
   tipRack: string
-  isAirGap?: boolean
 }
 /** Dispense with given args. Requires tip. */
 export const dispense: CommandCreator<DispenseAtomicCommandParams> = (
@@ -40,7 +39,6 @@ export const dispense: CommandCreator<DispenseAtomicCommandParams> = (
     labwareId,
     wellName,
     flowRate,
-    isAirGap,
     wellLocation,
     nozzles,
     tipRack,
@@ -226,7 +224,6 @@ export const dispense: CommandCreator<DispenseAtomicCommandParams> = (
         //  pushOut will always be undefined in step-generation for now
         //  since there is no easy way to allow users to  for it in PD
       },
-      ...(isAirGap && { meta: { isAirGap } }),
     },
   ]
   return {

--- a/step-generation/src/commandCreators/atomic/index.ts
+++ b/step-generation/src/commandCreators/atomic/index.ts
@@ -2,13 +2,14 @@ import { absorbanceReaderCloseLid } from './absorbanceReaderCloseLid'
 import { absorbanceReaderInitialize } from './absorbanceReaderInitialize'
 import { absorbanceReaderOpenLid } from './absorbanceReaderOpenLid'
 import { absorbanceReaderRead } from './absorbanceReaderRead'
+import { airGapInPlace } from './airGapInPlace'
 import { aspirate } from './aspirate'
 import { aspirateInPlace } from './aspirateInPlace'
 import { blowout } from './blowout'
 import { blowOutInPlace } from './blowOutInPlace'
+import { comment } from './comment'
 import { configureForVolume } from './configureForVolume'
 import { configureNozzleLayout } from './configureNozzleLayout'
-import { comment } from './comment'
 import { deactivateTemperature } from './deactivateTemperature'
 import { delay } from './delay'
 import { disengageMagnet } from './disengageMagnet'
@@ -21,12 +22,13 @@ import { moveLabware } from './moveLabware'
 import { moveToAddressableArea } from './moveToAddressableArea'
 import { moveToAddressableAreaForDropTip } from './moveToAddressableAreaForDropTip'
 import { moveToWell } from './moveToWell'
+import { pickUpTip } from './pickUpTip'
 import { setTemperature } from './setTemperature'
 import { touchTip } from './touchTip'
 import { waitForTemperature } from './waitForTemperature'
-import { pickUpTip } from './pickUpTip'
 
 export {
+  airGapInPlace,
   absorbanceReaderCloseLid,
   absorbanceReaderInitialize,
   absorbanceReaderOpenLid,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -19,6 +19,7 @@ import {
   getIsSafePipetteMovement,
   getWasteChuteAddressableAreaNamePip,
   getHasWasteChute,
+  getDispenseAirGapLocation,
 } from '../../utils'
 import {
   airGapInPlace,
@@ -204,12 +205,30 @@ export const distribute: CommandCreator<DistributeArgs> = (
     destWellChunks,
     (destWellChunk: string[], chunkIndex: number): CurriedCommandCreator[] => {
       const firstDestWell = destWellChunk[0]
+      const sourceLabwareDef =
+        invariantContext.labwareEntities[args.sourceLabware].def
       const destLabwareDef =
         invariantContext.labwareEntities[args.destLabware].def
+      const airGapOffsetSourceWell =
+        getWellDepth(sourceLabwareDef, args.sourceWell) +
+        AIR_GAP_OFFSET_FROM_TOP
       const airGapOffsetDestWell =
         getWellDepth(destLabwareDef, firstDestWell) + AIR_GAP_OFFSET_FROM_TOP
       const airGapAfterAspirateCommands = aspirateAirGapVolume
         ? [
+            curryCommandCreator(moveToWell, {
+              pipetteId: args.pipette,
+              labwareId: args.sourceLabware,
+              wellName: args.sourceWell,
+              wellLocation: {
+                origin: 'bottom',
+                offset: {
+                  z: airGapOffsetSourceWell,
+                  x: 0,
+                  y: 0,
+                },
+              },
+            }),
             curryCommandCreator(airGapInPlace, {
               pipetteId: args.pipette,
               volume: aspirateAirGapVolume,
@@ -326,12 +345,35 @@ export const distribute: CommandCreator<DistributeArgs> = (
           }),
         ]
       }
-
+      const {
+        dispenseAirGapLabware,
+        dispenseAirGapWell,
+      } = getDispenseAirGapLocation({
+        blowoutLocation,
+        sourceLabware: args.sourceLabware,
+        destLabware: args.destLabware,
+        sourceWell: args.sourceWell,
+        // @ts-expect-error(SA, 2021-05-05): last can return undefined
+        destWell: last(destWellChunk),
+      })
       const isLastChunk = chunkIndex + 1 === destWellChunks.length
       const willReuseTip = args.changeTip !== 'always' && !isLastChunk
       const airGapAfterDispenseCommands =
         dispenseAirGapVolume && !willReuseTip
           ? [
+              curryCommandCreator(moveToWell, {
+                pipetteId: args.pipette,
+                labwareId: dispenseAirGapLabware,
+                wellName: dispenseAirGapWell,
+                wellLocation: {
+                  origin: 'bottom',
+                  offset: {
+                    z: airGapOffsetDestWell,
+                    x: 0,
+                    y: 0,
+                  },
+                },
+              }),
               curryCommandCreator(airGapInPlace, {
                 pipetteId: args.pipette,
                 volume: dispenseAirGapVolume,

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -3,7 +3,6 @@ import {
   tiprackWellNamesFlat,
   DEFAULT_PIPETTE,
   SOURCE_LABWARE,
-  AIR_GAP_META,
   DEFAULT_BLOWOUT_WELL,
   DEST_LABWARE,
 } from './data'
@@ -139,21 +138,13 @@ export const makeAspirateHelper: MakeAspDispHelper<AspDispAirgapParams> = bakedP
     ...params,
   },
 })
-export const makeAirGapHelper: MakeAirGapHelper<AspDispAirgapParams> = bakedParams => (
-  wellName,
-  volume,
-  params
-) => ({
-  commandType: 'aspirate',
-  meta: AIR_GAP_META,
+export const makeAirGapHelper = (volume: number) => () => ({
+  commandType: 'airGapInPlace',
   key: expect.any(String),
   params: {
-    ..._defaultAspirateParams,
-    ...bakedParams,
-    wellName,
+    pipetteId: DEFAULT_PIPETTE,
     volume,
     flowRate: ASPIRATE_FLOW_RATE,
-    ...params,
   },
 })
 export const blowoutHelper = (
@@ -238,7 +229,6 @@ export const makeDispenseAirGapHelper: MakeDispenseAirGapHelper<AspDispAirgapPar
     volume,
     ...params,
   },
-  meta: AIR_GAP_META,
 })
 const _defaultTouchTipParams = {
   pipetteId: DEFAULT_PIPETTE,

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -138,7 +138,24 @@ export const makeAspirateHelper: MakeAspDispHelper<AspDispAirgapParams> = bakedP
     ...params,
   },
 })
-export const makeAirGapHelper = (volume: number) => () => ({
+export const makeMoveToWellHelper = (wellName: string, labwareId?: string) => ({
+  commandType: 'moveToWell',
+  key: expect.any(String),
+  params: {
+    pipetteId: DEFAULT_PIPETTE,
+    labwareId: labwareId ?? SOURCE_LABWARE,
+    wellName,
+    wellLocation: {
+      origin: 'bottom',
+      offset: {
+        x: 0,
+        y: 0,
+        z: 11.54,
+      },
+    },
+  },
+})
+export const makeAirGapHelper = (volume: number) => ({
   commandType: 'airGapInPlace',
   key: expect.any(String),
   params: {

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -126,6 +126,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'delay': // deprecated, use waitForDuration instead
     case 'custom': // fall-back
     case 'comment':
+    case 'airGapInPlace':
       break
 
     case 'loadLiquid':


### PR DESCRIPTION
closes AUTH-1365

# Overview

introduce `airGapInPlace` command to be used whenever there is an aspirate command that is meant to be an air gap - meaning an aspirate air gap is now: `moveToWell` followed by `airGapInPlace`

Dispense air gap (in the form of `meta: isAirGap` in a `dispense` command) was removed because

> the engine internally tracks whether a dispense is dispensing air or liquid (based on whether it was an aspirate or air gap command that added the liquid to the pipette). The engine doesn't look at meta information like that

## Test Plan and Hands on Testing

create a protocol with a transfer step utilizing the advanced settings air gap for aspirate. export it and see that `moveToWell` followed by `airGapInPlace` is emitted in the json file. then upload it to the app and make sure that it passes analysis.

## Changelog

- introduce new `airGapInPlace` atomic command and wire it into `transfer`, `consolidate`, and `distribute`
- add `moveToWell` to emit before the airgap in place

## Risk assessment

medium-ish