### PR TITLE
feat(api): add new InstrumentContext.consolidate_liquid() method

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1110,6 +1110,18 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     ) -> None:
         pass
 
+    def consolidate_liquid(
+        self,
+        liquid_class: LiquidClass,
+        volume: float,
+        source: List[Tuple[Location, WellCore]],
+        dest: Tuple[Location, WellCore],
+        new_tip: TransferTipPolicyV2,
+        tip_racks: List[Tuple[Location, LabwareCore]],
+        trash_location: Union[Location, TrashBin, WasteChute],
+    ) -> None:
+        pass
+
     def _get_location_and_well_core_from_next_tip_info(
         self,
         tip_info: NextTipInfo,

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -344,6 +344,23 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         ...
 
     @abstractmethod
+    def consolidate_liquid(
+        self,
+        liquid_class: LiquidClass,
+        volume: float,
+        source: List[Tuple[types.Location, WellCoreType]],
+        dest: Tuple[types.Location, WellCoreType],
+        new_tip: TransferTipPolicyV2,
+        tip_racks: List[Tuple[types.Location, LabwareCoreType]],
+        trash_location: Union[types.Location, TrashBin, WasteChute],
+    ) -> None:
+        """
+        Consolidate liquid from multiple sources to a single destination
+        using the specified liquid class properties.
+        """
+        ...
+
+    @abstractmethod
     def is_tip_tracking_available(self) -> bool:
         """Return whether auto tip tracking is available for the pipette's current nozzle configuration."""
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -586,6 +586,19 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
 
+    def consolidate_liquid(
+        self,
+        liquid_class: LiquidClass,
+        volume: float,
+        source: List[Tuple[types.Location, LegacyWellCore]],
+        dest: Tuple[types.Location, LegacyWellCore],
+        new_tip: TransferTipPolicyV2,
+        tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
+        trash_location: Union[types.Location, TrashBin, WasteChute],
+    ) -> None:
+        """This will never be called because it was added in API 2.23."""
+        assert False, "consolidate_liquid is not supported in legacy context"
+
     def get_active_channels(self) -> int:
         """This will never be called because it was added in API 2.16."""
         assert False, "get_active_channels only supported in API 2.16 & later"

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -506,6 +506,19 @@ class LegacyInstrumentCoreSimulator(
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
 
+    def consolidate_liquid(
+        self,
+        liquid_class: LiquidClass,
+        volume: float,
+        source: List[Tuple[types.Location, LegacyWellCore]],
+        dest: Tuple[types.Location, LegacyWellCore],
+        new_tip: TransferTipPolicyV2,
+        tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
+        trash_location: Union[types.Location, TrashBin, WasteChute],
+    ) -> None:
+        """This will never be called because it was added in API 2.23."""
+        assert False, "consolidate_liquid is not supported in legacy context"
+
     def get_active_channels(self) -> int:
         """This will never be called because it was added in API 2.16."""
         assert False, "get_active_channels only supported in API 2.16 & later"

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1689,6 +1689,94 @@ class InstrumentContext(publisher.CommandPublisher):
         )
         return self
 
+    def consolidate_liquid(
+        self,
+        liquid_class: LiquidClass,
+        volume: float,
+        source: Union[
+            labware.Well, Sequence[labware.Well], Sequence[Sequence[labware.Well]]
+        ],
+        dest: labware.Well,
+        new_tip: TransferTipPolicyV2Type = "once",
+        trash_location: Optional[
+            Union[types.Location, labware.Well, TrashBin, WasteChute]
+        ] = None,
+    ) -> InstrumentContext:
+        """
+        Consolidate liquid from multiple sources to a single destination
+        using the specified liquid class properties.
+
+        TODO: Add args description.
+        """
+        if not feature_flags.allow_liquid_classes(
+            robot_type=RobotTypeEnum.robot_literal_to_enum(
+                self._protocol_core.robot_type
+            )
+        ):
+            raise NotImplementedError("This method is not implemented.")
+        if not isinstance(dest, labware.Well):
+            raise ValueError(
+                f"Destination should be a single Well but received {dest}."
+            )
+        flat_sources_list = validation.ensure_valid_flat_wells_list_for_transfer_v2(
+            source
+        )
+        for well in flat_sources_list + [dest]:
+            instrument.validate_takes_liquid(
+                location=well.top(),
+                reject_module=True,
+                reject_adapter=True,
+            )
+
+        valid_new_tip = validation.ensure_new_tip_policy(new_tip)
+        if valid_new_tip == TransferTipPolicyV2.NEVER:
+            if self._last_tip_picked_up_from is None:
+                raise RuntimeError(
+                    "Pipette has no tip attached to perform transfer."
+                    " Either do a pick_up_tip beforehand or specify a new_tip parameter"
+                    " of 'once' or 'always'."
+                )
+            else:
+                tip_racks = [self._last_tip_picked_up_from.parent]
+        else:
+            tip_racks = self._tip_racks
+        if self.current_volume != 0:
+            raise RuntimeError(
+                "A transfer on a liquid class cannot start with liquid already in the tip."
+                " Ensure that all previously aspirated liquid is dispensed before starting"
+                " a new transfer."
+            )
+
+        _trash_location: Union[types.Location, labware.Well, TrashBin, WasteChute]
+        if trash_location is None:
+            saved_trash = self.trash_container
+            if isinstance(saved_trash, labware.Labware):
+                _trash_location = saved_trash.wells()[0]
+            else:
+                _trash_location = saved_trash
+        else:
+            _trash_location = trash_location
+
+        checked_trash_location = validation.ensure_valid_trash_location_for_transfer_v2(
+            trash_location=_trash_location
+        )
+        self._core.consolidate_liquid(
+            liquid_class=liquid_class,
+            volume=volume,
+            source=[
+                (types.Location(types.Point(), labware=well), well._core)
+                for well in flat_sources_list
+            ],
+            dest=(types.Location(types.Point(), labware=dest), dest._core),
+            new_tip=valid_new_tip,
+            tip_racks=[
+                (types.Location(types.Point(), labware=rack), rack._core)
+                for rack in tip_racks
+            ],
+            trash_location=checked_trash_location,
+        )
+        return self
+
     @requires_version(2, 0)
     def delay(self, *args: Any, **kwargs: Any) -> None:
         """

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2247,3 +2247,265 @@ def test_distribute_liquid_delegates_to_engine_core(
             trash_location=trash_location.move(Point(1, 2, 3)),
         )
     )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_consolidate_liquid_raises_for_invalid_locations(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentContext,
+    mock_feature_flags: None,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should raise errors if source or destination is invalid."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(
+        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
+    ).then_return(True)
+    decoy.when(
+        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([[mock_well]])
+    ).then_raise(ValueError("Oh no"))
+    with pytest.raises(ValueError):
+        subject.consolidate_liquid(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[[mock_well]],
+            dest=mock_well,
+        )
+    with pytest.raises(ValueError, match="Destination should be a single Well"):
+        subject.consolidate_liquid(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[mock_well],
+            dest="abc",  # type: ignore
+        )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_consolidate_liquid_raises_if_more_than_one_destination(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentContext,
+    mock_feature_flags: None,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should raise error if destination is more than one well."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(
+        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
+    ).then_return(True)
+    with pytest.raises(ValueError, match="Destination should be a single Well"):
+        subject.consolidate_liquid(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[mock_well, mock_well],
+            dest=[mock_well, mock_well],  # type: ignore
+        )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_consolidate_liquid_raises_for_non_liquid_handling_locations(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentContext,
+    mock_feature_flags: None,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should raise errors if sources or destination are not a valid liquid handling target."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(
+        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
+    ).then_return(True)
+    decoy.when(
+        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
+    ).then_return([mock_well])
+    decoy.when(
+        mock_instrument_support.validate_takes_liquid(
+            mock_well.top(), reject_module=True, reject_adapter=True
+        )
+    ).then_raise(ValueError("Uh oh"))
+    with pytest.raises(ValueError, match="Uh oh"):
+        subject.consolidate_liquid(
+            liquid_class=test_liq_class, volume=10, source=[mock_well], dest=mock_well
+        )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_consolidate_liquid_raises_for_bad_tip_policy(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentContext,
+    mock_feature_flags: None,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should raise errors if new_tip is invalid."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(
+        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
+    ).then_return(True)
+    decoy.when(
+        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
+    ).then_return([mock_well])
+    decoy.when(mock_validation.ensure_new_tip_policy("once")).then_raise(
+        ValueError("Uh oh")
+    )
+    with pytest.raises(ValueError, match="Uh oh"):
+        subject.consolidate_liquid(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[mock_well],
+            dest=mock_well,
+            new_tip="once",
+        )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_consolidate_liquid_raises_for_no_tip(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentContext,
+    mock_feature_flags: None,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should raise errors if there is no tip attached."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(
+        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
+    ).then_return(True)
+    decoy.when(
+        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
+    ).then_return([mock_well])
+    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
+        TransferTipPolicyV2.NEVER
+    )
+    with pytest.raises(RuntimeError, match="Pipette has no tip"):
+        subject.consolidate_liquid(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[mock_well],
+            dest=mock_well,
+            new_tip="never",
+        )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_consolidate_liquid_raises_if_tip_has_liquid(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    mock_feature_flags: None,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should raise errors if there is liquid in the tip."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    tip_racks = [decoy.mock(cls=Labware)]
+
+    subject.starting_tip = None
+    subject.tip_racks = tip_racks
+
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(
+        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
+    ).then_return(True)
+    decoy.when(
+        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
+    ).then_return([mock_well])
+    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
+        TransferTipPolicyV2.ONCE
+    )
+    decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
+    decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
+    decoy.when(
+        labware.next_available_tip(
+            starting_tip=None,
+            tip_racks=tip_racks,
+            channels=2,
+            nozzle_map=MOCK_MAP,
+        )
+    ).then_return((decoy.mock(cls=Labware), decoy.mock(cls=Well)))
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(1000)
+    with pytest.raises(RuntimeError, match="liquid already in the tip"):
+        subject.consolidate_liquid(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[mock_well],
+            dest=mock_well,
+            new_tip="never",
+        )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_consolidate_liquid_delegates_to_engine_core(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    mock_feature_flags: None,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should delegate the execution to core."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    tip_racks = [decoy.mock(cls=Labware)]
+    trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
+    next_tiprack = decoy.mock(cls=Labware)
+    subject.starting_tip = None
+    subject._tip_racks = tip_racks
+
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(
+        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
+    ).then_return(True)
+    decoy.when(
+        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
+    ).then_return([mock_well])
+    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
+        TransferTipPolicyV2.ONCE
+    )
+    decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
+    decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
+    decoy.when(
+        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
+    ).then_return(trash_location.move(Point(1, 2, 3)))
+    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
+    decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
+
+    subject.consolidate_liquid(
+        liquid_class=test_liq_class,
+        volume=10,
+        source=[mock_well],
+        dest=mock_well,
+        new_tip="never",
+        trash_location=trash_location,
+    )
+    decoy.verify(
+        mock_instrument_core.consolidate_liquid(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[(Location(Point(), labware=mock_well), mock_well._core)],
+            dest=(Location(Point(), labware=mock_well), mock_well._core),
+            new_tip=TransferTipPolicyV2.ONCE,
+            tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
+            trash_location=trash_location.move(Point(1, 2, 3)),
+        )
+    )


### PR DESCRIPTION
# Overview

Closes AUTH-845

This PR is a fast follow to #17355, adding the instrument context `consolidate_liquid` method for use with liquid classes while adding a stub for engine code. Like `distribute_liquid`, the instrument context does argument validation and normalization before delegating to the core.

## Test Plan and Hands on Testing

Unit tests should cover this part of `consolidate_liquid`, once fully implemented on-robot testing and integration tests can be added.

## Changelog

- added `consolidate_liquid` to `InstrumentContext`


## Risk assessment

Low, new code.