### PR TITLE
fix(protocol-designer): fix offdeck container border

### DIFF
--- a/protocol-designer/src/pages/Designer/Offdeck/OffDeckDetails.tsx
+++ b/protocol-designer/src/pages/Designer/Offdeck/OffDeckDetails.tsx
@@ -68,7 +68,7 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
   return (
     <Flex
       backgroundColor={COLORS.white}
-      borderRadius={BORDERS.borderRadius8}
+      borderRadius={BORDERS.borderRadius12}
       width="100%"
       height="65vh"
       padding={padding}


### PR DESCRIPTION
# Overview

container border should be 12px

Closes RQA-3699

## Test Plan and Hands on Testing

- navigate to any PD step > off deck tab
- verify container padding of 12px

## Changelog

- update border radius to 12px

## Review requests

see test plan

## Risk assessment

low