### PR TITLE
fix(protocol-designer): add clear all liquids functionality

### DIFF
--- a/protocol-designer/src/assets/localization/en/application.json
+++ b/protocol-designer/src/assets/localization/en/application.json
@@ -1,5 +1,6 @@
 {
   "are_you_sure": "Are you sure you want to remove liquids from all selected wells?",
+  "are_you_sure_clear_all_wells": "Are you sure you want to remove liquids from all wells?",
   "are_you_sure_delete_well": "Are you sure you want to delete well {{well}}?",
   "blowout": "Blowout",
   "cancel": "cancel",

--- a/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -89,6 +89,17 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
 
+  const allWellsForActiveItem =
+    labwareId != null
+      ? Object.keys(allWellContentsForActiveItem?.[labwareId] ?? {})
+      : []
+  const activeItemHasLiquids =
+    labwareId != null
+      ? Object.values(allWellContentsForActiveItem?.[labwareId] ?? {}).some(
+          value => value.groupIds.length > 0
+        )
+      : false
+
   const selectionHasLiquids = Boolean(
     labwareId != null &&
       liquidLocations[labwareId] != null &&
@@ -141,6 +152,21 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
     dispatch(deselectAllWells())
     setShowBadFormState(false)
     reset()
+  }
+
+  const handleClearAllWells: () => void = () => {
+    if (labwareId != null && activeItemHasLiquids) {
+      if (
+        global.confirm(t('application:are_you_sure_clear_all_wells') as string)
+      ) {
+        dispatch(
+          removeWellsContents({
+            labwareId,
+            wells: allWellsForActiveItem,
+          })
+        )
+      }
+    }
   }
 
   const handleChangeVolume: (e: ChangeEvent<HTMLInputElement>) => void = e => {
@@ -247,16 +273,13 @@ export function LiquidToolbox(props: LiquidToolboxProps): JSX.Element {
           dispatch(deselectAllWells())
           onClose()
         }}
-        onCloseClick={handleClearSelectedWells}
+        onCloseClick={handleClearAllWells}
         height="100%"
         width="21.875rem"
         closeButton={
           <StyledText desktopStyle="bodyDefaultRegular">
             {t('clear_wells')}
           </StyledText>
-        }
-        disableCloseButton={
-          !(labwareId != null && selectedWells != null && selectionHasLiquids)
         }
       >
         {(liquidsInLabware != null && liquidsInLabware.length > 0) ||


### PR DESCRIPTION
# Overview

In liquids toolbox, the toolbox close button should be a button to clear all wells. On click, all wells of the labware should be cleared after confirming on a dialogue box. If no wells have liquid, the click no-ops, but the button remains enabled to reflect new design system.

Closes RQA-3681

## Test Plan and Hands on Testing

- open a labware and add/edit liquid. make sure at least one well has liquid
- without selecting any wells with click and drag, select "clear wells" at the top of the toolbox
- verify that dialogue box prompts you to clear all wells and confirm
- with empty labware, verify that clicking "clear wells" does nothing
https://github.com/user-attachments/assets/cfa15412-35b8-4970-b353-ea983feff72b


## Changelog

- add clear all wells functionality
- add translation for confirmation 

## Review requests

see test plan

## Risk assessment

low