### PR TITLE
fix(api):show plate reader files in run log

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -181,7 +181,9 @@ class ReadAbsorbanceImpl(
                         )
                     )
                     file_ids.append(file_id)
-                    state_update.files_added = update_types.FilesAddedUpdate(file_ids=file_ids)
+                    state_update.files_added = update_types.FilesAddedUpdate(
+                        file_ids=file_ids
+                    )
 
                 # Return success data to api
                 return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -181,10 +181,10 @@ class ReadAbsorbanceImpl(
                         )
                     )
                     file_ids.append(file_id)
-                    state_update.files_added = update_types.FilesAddedUpdate(
-                        file_ids=file_ids
-                    )
 
+                state_update.files_added = update_types.FilesAddedUpdate(
+                    file_ids=file_ids
+                )
                 # Return success data to api
                 return SuccessData(
                     public=ReadAbsorbanceResult(

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -181,6 +181,7 @@ class ReadAbsorbanceImpl(
                         )
                     )
                     file_ids.append(file_id)
+                    state_update.files_added = update_types.FilesAddedUpdate(file_ids=file_ids)
 
                 # Return success data to api
                 return SuccessData(

--- a/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_read.py
+++ b/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_read.py
@@ -88,67 +88,6 @@ async def test_absorbance_reader_implementation(
     )
 
 
-async def test_absorbance_reader_implementation_with_file_name(
-    decoy: Decoy,
-    state_view: StateView,
-    equipment: EquipmentHandler,
-    file_provider: FileProvider,
-) -> None:
-    """It should validate, find hardware module if not virtualized, and disengage."""
-    subject = ReadAbsorbanceImpl(
-        state_view=state_view, equipment=equipment, file_provider=file_provider
-    )
-
-    params = ReadAbsorbanceParams(moduleId="unverified-module-id", fileName="test")
-
-    mabsorbance_module_substate = decoy.mock(cls=AbsorbanceReaderSubState)
-    absorbance_module_hw = decoy.mock(cls=AbsorbanceReader)
-    verified_module_id = AbsorbanceReaderId("module-id")
-    asbsorbance_result = {1: {"A1": 1.2}}
-
-    decoy.when(state_view.files.get_filecount()).then_return(1)
-    decoy.when(
-        state_view.modules.get_absorbance_reader_substate("unverified-module-id")
-    ).then_return(mabsorbance_module_substate)
-
-    decoy.when(mabsorbance_module_substate.module_id).then_return(verified_module_id)
-    decoy.when(mabsorbance_module_substate.configured_wavelengths).then_return([1, 2])
-
-    decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(
-        absorbance_module_hw
-    )
-
-    decoy.when(await absorbance_module_hw.start_measure()).then_return([[1.2, 1.3]])
-    decoy.when(absorbance_module_hw._measurement_config).then_return(
-        ABSMeasurementConfig(
-            measure_mode=ABSMeasurementMode.SINGLE,
-            sample_wavelengths=[1, 2],
-            reference_wavelength=None,
-        )
-    )
-    decoy.when(
-        state_view.modules.convert_absorbance_reader_data_points([1.2, 1.3])
-    ).then_return({"A1": 1.2})
-
-    result = await subject.execute(params=params)
-
-    assert result == SuccessData(
-        public=ReadAbsorbanceResult(
-            data=asbsorbance_result,
-            fileIds=[],
-        ),
-        state_update=update_types.StateUpdate(
-            files_added=update_types.FilesAddedUpdate(file_ids=[]),
-            absorbance_reader_state_update=update_types.AbsorbanceReaderStateUpdate(
-                module_id="module-id",
-                absorbance_reader_data=update_types.AbsorbanceReaderDataUpdate(
-                    read_result=asbsorbance_result
-                ),
-            ),
-        ),
-    )
-
-
 async def test_read_raises_cannot_preform_action(
     decoy: Decoy,
     state_view: StateView,

--- a/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_read.py
+++ b/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_read.py
@@ -88,6 +88,67 @@ async def test_absorbance_reader_implementation(
     )
 
 
+async def test_absorbance_reader_implementation_with_file_name(
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+    file_provider: FileProvider,
+) -> None:
+    """It should validate, find hardware module if not virtualized, and disengage."""
+    subject = ReadAbsorbanceImpl(
+        state_view=state_view, equipment=equipment, file_provider=file_provider
+    )
+
+    params = ReadAbsorbanceParams(moduleId="unverified-module-id", fileName="test")
+
+    mabsorbance_module_substate = decoy.mock(cls=AbsorbanceReaderSubState)
+    absorbance_module_hw = decoy.mock(cls=AbsorbanceReader)
+    verified_module_id = AbsorbanceReaderId("module-id")
+    asbsorbance_result = {1: {"A1": 1.2}}
+
+    decoy.when(state_view.files.get_filecount()).then_return(1)
+    decoy.when(
+        state_view.modules.get_absorbance_reader_substate("unverified-module-id")
+    ).then_return(mabsorbance_module_substate)
+
+    decoy.when(mabsorbance_module_substate.module_id).then_return(verified_module_id)
+    decoy.when(mabsorbance_module_substate.configured_wavelengths).then_return([1, 2])
+
+    decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(
+        absorbance_module_hw
+    )
+
+    decoy.when(await absorbance_module_hw.start_measure()).then_return([[1.2, 1.3]])
+    decoy.when(absorbance_module_hw._measurement_config).then_return(
+        ABSMeasurementConfig(
+            measure_mode=ABSMeasurementMode.SINGLE,
+            sample_wavelengths=[1, 2],
+            reference_wavelength=None,
+        )
+    )
+    decoy.when(
+        state_view.modules.convert_absorbance_reader_data_points([1.2, 1.3])
+    ).then_return({"A1": 1.2})
+
+    result = await subject.execute(params=params)
+
+    assert result == SuccessData(
+        public=ReadAbsorbanceResult(
+            data=asbsorbance_result,
+            fileIds=[],
+        ),
+        state_update=update_types.StateUpdate(
+            files_added=update_types.FilesAddedUpdate(file_ids=[]),
+            absorbance_reader_state_update=update_types.AbsorbanceReaderStateUpdate(
+                module_id="module-id",
+                absorbance_reader_data=update_types.AbsorbanceReaderDataUpdate(
+                    read_result=asbsorbance_result
+                ),
+            ),
+        ),
+    )
+
+
 async def test_read_raises_cannot_preform_action(
     decoy: Decoy,
     state_view: StateView,


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-3867.
append file names to state when given file name. 

## Test Plan and Hands on Testing

run the following protocol and make sure the files appear in the run log. 
```
from typing import cast
from opentrons import protocol_api
from opentrons.protocol_api.module_contexts import AbsorbanceReaderContext

# metadata
metadata = {
    'protocolName': 'Absorbance Reader Demo',
    'author': 'Platform Expansion',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.21",
}

# protocol run function
def run(protocol: protocol_api.ProtocolContext):
    mod = cast(AbsorbanceReaderContext, protocol.load_module("absorbanceReaderV1", "D3"))
    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "C2")

    # Initialize to a single wavelength with reference wavelength
    mod.close_lid()
    mod.initialize('multi', [600, 450])

    # Remove the Plate Reader lid and move labware into the module.
    mod.open_lid()
    protocol.move_labware(plate, mod, use_gripper=True)
    mod.close_lid()

    # Take a reading and save to csv
    mod.read(export_filename="plate_reader_csv.csv")
```
see screenshot of example worked:
<img width="880" alt="Screenshot 2025-01-28 at 1 23 21 PM" src="https://github.com/user-attachments/assets/50fccc62-6d0b-42de-acd9-d5f207f728eb" />

## Changelog

append file names to state. 

## Review requests

changes make sense? 

## Risk assessment

low. bug fix. 
