### PR TITLE
fix(protocol-designer): set PathField width to 100%

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PathField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PathField.tsx
@@ -69,7 +69,7 @@ interface PathButtonProps {
 }
 
 function PathButton(props: PathButtonProps): JSX.Element {
-  const { disabled, onClick, id, path, selected, subtitle } = props
+  const { disabled, onClick, path, selected, subtitle } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP_START,
   })
@@ -79,14 +79,18 @@ function PathButton(props: PathButtonProps): JSX.Element {
     <Tooltip tooltipProps={tooltipProps} maxWidth="24.5rem">
       <Flex gridGap={SPACING.spacing8} flexDirection={DIRECTION_COLUMN}>
         <Box>{t(`step_edit_form.field.path.title.${path}`)}</Box>
-        <img src={PATH_ANIMATION_IMAGES[path]} width="361px" />
+        <img
+          src={PATH_ANIMATION_IMAGES[path]}
+          width="361px"
+          alt="path animation"
+        />
         <Box>{subtitle}</Box>
       </Flex>
     </Tooltip>
   )
 
   return (
-    <Flex {...targetProps} key={id} flexDirection={DIRECTION_COLUMN}>
+    <Flex {...targetProps} flexDirection={DIRECTION_COLUMN}>
       {tooltip}
       <RadioButton
         width="100%"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PathField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PathField.tsx
@@ -86,7 +86,7 @@ function PathButton(props: PathButtonProps): JSX.Element {
   )
 
   return (
-    <Flex {...targetProps} key={id}>
+    <Flex {...targetProps} key={id} flexDirection={DIRECTION_COLUMN}>
       {tooltip}
       <RadioButton
         width="100%"


### PR DESCRIPTION
# Overview

Fixes width of `PathField` `PathButton` used in move liquid step form

## Test Plan and Hands on Testing

- open or create a transfer step and verify width of path buttons

#### before
<img width="325" alt="Screenshot 2025-01-28 at 1 49 57 PM" src="https://github.com/user-attachments/assets/d44da9b5-0fb4-4dcf-a335-3ceafbeeb869" />

#### after
<img width="291" alt="Screenshot 2025-01-28 at 1 49 41 PM" src="https://github.com/user-attachments/assets/c887602a-9186-4bc3-8f0c-f7eeee599811" />

## Changelog

- fix style for `PathButton`

## Review requests

see test plan

## Risk assessment

low