### PR TITLE
fix(protocol-designer): fix no tiprack-related whitescreen

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -73,6 +73,7 @@
   "multiAspirate": "Consolidate path",
   "multiDispense": "Distribute path",
   "new_location": "New location",
+  "no_tiprack": "No tiprack available",
   "off_deck": "Off-Deck",
   "pause": {
     "untilResume": "Pausing until manually told to resume",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TiprackField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TiprackField.tsx
@@ -64,7 +64,7 @@ export function TiprackField(props: TiprackFieldProps): JSX.Element {
           <ListItem type="noActive">
             <Flex padding={SPACING.spacing12}>
               <StyledText desktopStyle="bodyDefaultRegular">
-                {tiprackOptions[0].name}
+                {tiprackOptions[0]?.name ?? t('no_tiprack')}
               </StyledText>
             </Flex>
           </ListItem>


### PR DESCRIPTION
# Overview

This PR fixes a PD whitescreen bug where a user tries to create a transfer step wihout a tiprack available on the deck. As a temporary fix, I null check the first tiprack option in `TiprackField` and default to a placeholder string. This prevents a whitescreen, and creates a not-enough-tips timeline error if the step is saved, instructing the user to add tipracks to the deck to fix.

Closes RESC-380

## Test Plan and Hands on Testing

- create a protocol with a wellplate
- delete all tiprack instances
- create a transfer step and verify that no whitescreen occurs, and that the tiprack field defaults to "No tiprack available"
- fill out the form and save
- verify that a not-enough-tips timeline error is shown

## Changelog

- null check tiprack list in `TiprackField`
- add translation

## Review requests

see test plan

## Risk assessment

low