### PR TITLE
fix(api): Use the latest information when estimating liquid height

### DIFF
--- a/api/src/opentrons/protocol_engine/state/wells.py
+++ b/api/src/opentrons/protocol_engine/state/wells.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from typing import Dict, List, Union, Iterator, Optional, Tuple, overload, TypeVar
+from datetime import datetime
 
 from opentrons.protocol_engine.types import (
     ProbedHeightInfo,
@@ -176,6 +177,22 @@ class WellView:
             probed_height=probed_height_info,
             probed_volume=probed_volume_info,
         )
+
+    def get_last_liquid_update(
+        self, labware_id: str, well_name: str
+    ) -> Optional[datetime]:
+        """Return the timestamp of the last load or probe done on the well."""
+        info = self.get_well_liquid_info(labware_id, well_name)
+        update_times: List[datetime] = []
+        if info.loaded_volume is not None and info.loaded_volume.volume is not None:
+            update_times.append(info.loaded_volume.last_loaded)
+        if info.probed_height is not None and info.probed_height.height is not None:
+            update_times.append(info.probed_height.last_probed)
+        if info.probed_volume is not None and info.probed_volume.volume is not None:
+            update_times.append(info.probed_volume.last_probed)
+        if len(update_times) > 0:
+            return max(update_times)
+        return None
 
     def get_all(self) -> List[WellInfoSummary]:
         """Get all well liquid info summaries."""

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -1579,7 +1579,9 @@ def test_get_well_position_with_meniscus_offset(
         well_def
     )
     probe_time = datetime.now()
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(probe_time)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(
+        probe_time
+    )
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "B2")).then_return(
         WellLiquidInfo(
             probed_volume=None,
@@ -1643,7 +1645,9 @@ def test_get_well_position_with_volume_offset_raises_error(
         well_def
     )
     probe_time = datetime.now()
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(probe_time)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(
+        probe_time
+    )
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "B2")).then_return(
         WellLiquidInfo(
             loaded_volume=None,
@@ -1704,7 +1708,9 @@ def test_get_well_position_with_meniscus_and_literal_volume_offset(
         mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_4.id)
     ).then_return(slot_pos)
     probe_time = datetime.now()
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(probe_time)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(
+        probe_time
+    )
     decoy.when(mock_labware_view.get_well_definition("labware-id", "B2")).then_return(
         well_def
     )
@@ -1779,7 +1785,9 @@ def test_get_well_position_with_meniscus_and_float_volume_offset(
         well_def
     )
     probe_time = datetime.now()
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(probe_time)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(
+        probe_time
+    )
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "B2")).then_return(
         WellLiquidInfo(
             loaded_volume=None,
@@ -1850,7 +1858,9 @@ def test_get_well_position_raises_validation_error(
         well_def
     )
     probe_time = datetime.now()
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(probe_time)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(
+        probe_time
+    )
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "B2")).then_return(
         WellLiquidInfo(
             loaded_volume=None,
@@ -1917,7 +1927,9 @@ def test_get_meniscus_height(
         well_def
     )
     probe_time = datetime.now()
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(probe_time)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "B2")).then_return(
+        probe_time
+    )
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "B2")).then_return(
         WellLiquidInfo(
             loaded_volume=LoadedVolumeInfo(
@@ -3363,11 +3375,13 @@ def test_validate_dispense_volume_into_well_meniscus(
         inner_well_def
     )
     probe_time = datetime.now()
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(probe_time)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(
+        probe_time
+    )
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "A1")).then_return(
         WellLiquidInfo(
             loaded_volume=None,
-            probed_height=ProbedHeightInfo(height=40.0, last_probed=datetime.now()),
+            probed_height=ProbedHeightInfo(height=40.0, last_probed=probe_time),
             probed_volume=None,
         )
     )
@@ -3384,8 +3398,7 @@ def test_validate_dispense_volume_into_well_meniscus(
         )
 
 
-
-def test_validate_dispense_volume_into_well_meniscus(
+def test_get_latest_volume_information(
     decoy: Decoy,
     mock_labware_view: LabwareView,
     mock_well_view: WellView,
@@ -3409,18 +3422,16 @@ def test_validate_dispense_volume_into_well_meniscus(
         inner_well_def
     )
     ten_ul_height = subject.get_well_height_at_volume(
-            labware_id="labware-id",
-            well_name="A1",
-            volume=10.0
+        labware_id="labware-id", well_name="A1", volume=10.0
     )
     twenty_ul_height = subject.get_well_height_at_volume(
-            labware_id="labware-id",
-            well_name="A1",
-            volume=20.0
+        labware_id="labware-id", well_name="A1", volume=20.0
     )
 
     # Make sure Get height with no information raises an error
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(None)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(
+        None
+    )
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "A1")).then_return(
         WellLiquidInfo(
             loaded_volume=None,
@@ -3428,70 +3439,87 @@ def test_validate_dispense_volume_into_well_meniscus(
             probed_volume=None,
         )
     )
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(None)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(
+        None
+    )
 
     with pytest.raises(errors.LiquidHeightUnknownError):
-        subject.get_meniscus_height(
-            labware_id="labware-id",
-            well_name="A1"
-        )
+        subject.get_meniscus_height(labware_id="labware-id", well_name="A1")
     # Make sure get height with a valid load returns the correct height
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "A1")).then_return(
         WellLiquidInfo(
-            loaded_volume=LoadedVolumeInfo(volume=10.0, last_loaded=load_time, operations_since_load = 0),
+            loaded_volume=LoadedVolumeInfo(
+                volume=10.0, last_loaded=load_time, operations_since_load=0
+            ),
             probed_height=None,
             probed_volume=None,
         )
     )
 
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(load_time)
-    assert subject.get_meniscus_height(
-            labware_id="labware-id",
-            well_name="A1"
-        ) == ten_ul_height
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(
+        load_time
+    )
+    assert (
+        subject.get_meniscus_height(labware_id="labware-id", well_name="A1")
+        == ten_ul_height
+    )
 
     # Make sure that if there is a probe after a load that we get the correct height
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "A1")).then_return(
         WellLiquidInfo(
-            loaded_volume=LoadedVolumeInfo(volume=10.0, last_loaded=load_time, operations_since_load = 0),
+            loaded_volume=LoadedVolumeInfo(
+                volume=10.0, last_loaded=load_time, operations_since_load=0
+            ),
             probed_height=ProbedHeightInfo(height=40.0, last_probed=probe_time),
             probed_volume=None,
         )
     )
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(probe_time)
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(
+        probe_time
+    )
 
-    assert subject.get_meniscus_height(
-            labware_id="labware-id",
-            well_name="A1"
-        ) == 40.0
+    assert subject.get_meniscus_height(labware_id="labware-id", well_name="A1") == 40.0
 
     # Simulate a pipetting action and make sure we get the height based on the most current one
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "A1")).then_return(
         WellLiquidInfo(
-            loaded_volume=LoadedVolumeInfo(volume=10.0, last_loaded=load_time, operations_since_load = 1),
+            loaded_volume=LoadedVolumeInfo(
+                volume=10.0, last_loaded=load_time, operations_since_load=1
+            ),
             probed_height=None,
-            probed_volume=ProbedVolumeInfo(volume=20.0, last_probed=probe_time, operations_since_probe = 1),
+            probed_volume=ProbedVolumeInfo(
+                volume=20.0, last_probed=probe_time, operations_since_probe=1
+            ),
         )
     )
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(probe_time)
-    assert subject.get_meniscus_height(
-            labware_id="labware-id",
-            well_name="A1"
-        ) == twenty_ul_height
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(
+        probe_time
+    )
+    assert (
+        subject.get_meniscus_height(labware_id="labware-id", well_name="A1")
+        == twenty_ul_height
+    )
 
     # Simulate a calling load_liquid after a probe and make sure we get the height based on the load_liquid
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "A1")).then_return(
         WellLiquidInfo(
-            loaded_volume=LoadedVolumeInfo(volume=10.0, last_loaded=datetime.max, operations_since_load = 0),
+            loaded_volume=LoadedVolumeInfo(
+                volume=10.0, last_loaded=datetime.max, operations_since_load=0
+            ),
             probed_height=ProbedHeightInfo(height=40.0, last_probed=probe_time),
-            probed_volume=ProbedVolumeInfo(volume=20.0, last_probed=probe_time, operations_since_probe = 0),
+            probed_volume=ProbedVolumeInfo(
+                volume=20.0, last_probed=probe_time, operations_since_probe=0
+            ),
         )
     )
-    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(datetime.max)
-    assert subject.get_meniscus_height(
-            labware_id="labware-id",
-            well_name="A1"
-        ) == ten_ul_height
+    decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(
+        datetime.max
+    )
+    assert (
+        subject.get_meniscus_height(labware_id="labware-id", well_name="A1")
+        == ten_ul_height
+    )
+
 
 @pytest.mark.parametrize(
     [


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
There was a bug in the estimation code under the following scenario
Well volume is set with Load Liquid
Well is then probed
Well is operated on and the probed volume and loaded volume are updated based on the operation
Future well operations are based on the load liquid and not the probe because it happened to be first in the "is_valid" check


Now the well volume after an operation is based on which happened LAST load_liquid or liquid probe.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
