### PR TITLE
fix(shared-data): add D3 as provided addressable area to the flexStackerModuleV1WithWasteChuteRightAdapterCovered fixture.

### DIFF
--- a/shared-data/deck/definitions/5/ot3_standard.json
+++ b/shared-data/deck/definitions/5/ot3_standard.json
@@ -1026,7 +1026,8 @@
         "cutoutD3": [
           "1ChannelWasteChute",
           "8ChannelWasteChute",
-          "flexStackerModuleV1D4"
+          "flexStackerModuleV1D4",
+          "D3"
         ]
       },
       "fixtureGroup": {},
@@ -1043,7 +1044,8 @@
           "8ChannelWasteChute",
           "96ChannelWasteChute",
           "gripperWasteChute",
-          "flexStackerModuleV1D4"
+          "flexStackerModuleV1D4",
+          "D3"
         ]
       },
       "fixtureGroup": {},


### PR DESCRIPTION
add waste chute + flex stacker fixture for deck config

Closes: [EXEC-1106](https://opentrons.atlassian.net/browse/EXEC-1106)

[EXEC-1106]: https://opentrons.atlassian.net/browse/EXEC-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ