### PR TITLE
feat(api): remove liquid classes feature flag, gate liquid classes behind 2.23

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -2,6 +2,15 @@ For more details about this release, please see the full [technical change log][
 
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.4.0-alpha.1
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.4.0. It's for internal testing only.
+
+### New Stuff In This Release (list in progress):
+
+- Python API version bumped to 2.23
+- Added liquid classes and new transfer functions
+
 ## Internal Release 2.3.0-alpha.2
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.3.0. It's for internal testing only.

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -222,17 +222,6 @@ settings = [
         robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
         internal_only=True,
     ),
-    SettingDefinition(
-        _id="allowLiquidClasses",
-        title="Allow the use of liquid classes",
-        description=(
-            "Do not enable."
-            " This is an Opentrons internal setting to allow using in-development"
-            " liquid classes."
-        ),
-        robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
-        internal_only=True,
-    ),
 ]
 
 
@@ -736,6 +725,14 @@ def _migrate35to36(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate36to37(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 37 of the feature flags file.
+
+    - Removes the allowLiquidClasses flag.
+    """
+    return {k: v for k, v in previous.items() if "allowLiquidClasses" != k}
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -773,6 +770,7 @@ _MIGRATIONS = [
     _migrate33to34,
     _migrate34to35,
     _migrate35to36,
+    _migrate36to37,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -78,7 +78,3 @@ def enable_performance_metrics(robot_type: RobotTypeEnum) -> bool:
 
 def oem_mode_enabled() -> bool:
     return advs.get_setting_with_env_overload("enableOEMMode", RobotTypeEnum.FLEX)
-
-
-def allow_liquid_classes(robot_type: RobotTypeEnum) -> bool:
-    return advs.get_setting_with_env_overload("allowLiquidClasses", robot_type)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -8,7 +8,6 @@ from opentrons_shared_data.errors.exceptions import (
     UnexpectedTipRemovalError,
     UnsupportedHardwareCommand,
 )
-from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -38,7 +37,6 @@ from .disposal_locations import TrashBin, WasteChute
 from ._nozzle_layout import NozzleLayout
 from ._liquid import LiquidClass
 from . import labware, validation
-from ..config import feature_flags
 from ..protocols.advanced_control.transfers.common import (
     TransferTipPolicyV2,
     TransferTipPolicyV2Type,
@@ -1509,6 +1507,7 @@ class InstrumentContext(publisher.CommandPublisher):
         for cmd in plan:
             getattr(self, cmd["method"])(*cmd["args"], **cmd["kwargs"])
 
+    @requires_version(2, 23)
     def transfer_liquid(
         self,
         liquid_class: LiquidClass,
@@ -1528,13 +1527,6 @@ class InstrumentContext(publisher.CommandPublisher):
 
         TODO: Add args description.
         """
-        if not feature_flags.allow_liquid_classes(
-            robot_type=RobotTypeEnum.robot_literal_to_enum(
-                self._protocol_core.robot_type
-            )
-        ):
-            raise NotImplementedError("This method is not implemented.")
-
         flat_sources_list = validation.ensure_valid_flat_wells_list_for_transfer_v2(
             source
         )
@@ -1604,6 +1596,7 @@ class InstrumentContext(publisher.CommandPublisher):
         )
         return self
 
+    @requires_version(2, 23)
     def distribute_liquid(
         self,
         liquid_class: LiquidClass,
@@ -1623,13 +1616,6 @@ class InstrumentContext(publisher.CommandPublisher):
 
         TODO: Add args description.
         """
-        if not feature_flags.allow_liquid_classes(
-            robot_type=RobotTypeEnum.robot_literal_to_enum(
-                self._protocol_core.robot_type
-            )
-        ):
-            raise NotImplementedError("This method is not implemented.")
-
         if not isinstance(source, labware.Well):
             raise ValueError(f"Source should be a single Well but received {source}.")
         flat_dests_list = validation.ensure_valid_flat_wells_list_for_transfer_v2(dest)
@@ -1689,6 +1675,7 @@ class InstrumentContext(publisher.CommandPublisher):
         )
         return self
 
+    @requires_version(2, 23)
     def consolidate_liquid(
         self,
         liquid_class: LiquidClass,
@@ -1708,12 +1695,6 @@ class InstrumentContext(publisher.CommandPublisher):
 
         TODO: Add args description.
         """
-        if not feature_flags.allow_liquid_classes(
-            robot_type=RobotTypeEnum.robot_literal_to_enum(
-                self._protocol_core.robot_type
-            )
-        ):
-            raise NotImplementedError("This method is not implemented.")
         if not isinstance(dest, labware.Well):
             raise ValueError(
                 f"Destination should be a single Well but received {dest}."

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -14,10 +14,8 @@ from typing import (
 
 from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons_shared_data.pipette.types import PipetteNameType
-from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from opentrons.types import Mount, Location, DeckLocation, DeckSlotName, StagingSlotName
-from opentrons.config import feature_flags
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.hardware_control.modules.types import (
     MagneticBlockModel,
@@ -1354,17 +1352,13 @@ class ProtocolContext(CommandPublisher):
             display_color=display_color,
         )
 
+    @requires_version(2, 23)
     def define_liquid_class(
         self,
         name: str,
     ) -> LiquidClass:
         """Define a liquid class for use in the protocol."""
-        if feature_flags.allow_liquid_classes(
-            robot_type=RobotTypeEnum.robot_literal_to_enum(self._core.robot_type)
-        ):
-            return self._core.define_liquid_class(name=name)
-        else:
-            raise NotImplementedError("This method is not implemented.")
+        return self._core.define_liquid_class(name=name)
 
     @property
     @requires_version(2, 5)

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -8,7 +8,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 36
+    return 37
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -30,7 +30,6 @@ def default_file_settings() -> Dict[str, Any]:
         "enableErrorRecoveryExperiments": None,
         "enableOEMMode": None,
         "enablePerformanceMetrics": None,
-        "allowLiquidClasses": None,
     }
 
 
@@ -432,6 +431,13 @@ def v36_config(v35_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v37_config(v36_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = {k: v for k, v in v36_config.items() if k != "allowLiquidClasses"}
+    r["_version"] = 37
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -473,6 +479,7 @@ def v36_config(v35_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v34_config"),
         lazy_fixture("v35_config"),
         lazy_fixture("v36_config"),
+        lazy_fixture("v37_config"),
     ],
 )
 def old_settings(request: SubRequest) -> Dict[str, Any]:
@@ -563,5 +570,4 @@ def test_ensures_config() -> None:
         "enableErrorRecoveryExperiments": None,
         "enableOEMMode": None,
         "enablePerformanceMetrics": None,
-        "allowLiquidClasses": None,
     }

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -10,7 +10,6 @@ from unittest.mock import sentinel
 from decoy import Decoy
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
-from opentrons.config import feature_flags as ff
 from opentrons.protocol_engine.commands.pipetting_common import LiquidNotFoundError
 from opentrons.protocol_engine.errors.error_occurrence import (
     ProtocolCommandFailedError,
@@ -63,7 +62,7 @@ from opentrons_shared_data.errors.exceptions import (
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
 )
-from opentrons_shared_data.robot.types import RobotTypeEnum, RobotType
+from opentrons_shared_data.robot.types import RobotType
 from . import versions_at_or_above, versions_between
 
 
@@ -1737,7 +1736,6 @@ def test_transfer_liquid_raises_for_invalid_locations(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -1745,9 +1743,6 @@ def test_transfer_liquid_raises_for_invalid_locations(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_raise(ValueError("Oh no"))
@@ -1765,7 +1760,6 @@ def test_transfer_liquid_raises_for_unequal_source_and_dest(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -1773,9 +1767,6 @@ def test_transfer_liquid_raises_for_unequal_source_and_dest(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
     ).then_return([mock_well, mock_well])
@@ -1795,7 +1786,6 @@ def test_transfer_liquid_raises_for_non_liquid_handling_locations(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -1803,9 +1793,6 @@ def test_transfer_liquid_raises_for_non_liquid_handling_locations(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -1825,7 +1812,6 @@ def test_transfer_liquid_raises_for_bad_tip_policy(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -1833,9 +1819,6 @@ def test_transfer_liquid_raises_for_bad_tip_policy(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -1857,7 +1840,6 @@ def test_transfer_liquid_raises_for_no_tip(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -1865,9 +1847,6 @@ def test_transfer_liquid_raises_for_no_tip(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -1890,7 +1869,6 @@ def test_transfer_liquid_raises_if_tip_has_liquid(
     mock_protocol_core: ProtocolCore,
     mock_instrument_core: InstrumentCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -1903,9 +1881,6 @@ def test_transfer_liquid_raises_if_tip_has_liquid(
     subject.tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -1939,7 +1914,6 @@ def test_transfer_liquid_delegates_to_engine_core(
     mock_protocol_core: ProtocolCore,
     mock_instrument_core: InstrumentCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -1953,9 +1927,6 @@ def test_transfer_liquid_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -1996,7 +1967,6 @@ def test_distribute_liquid_raises_for_invalid_locations(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2004,9 +1974,6 @@ def test_distribute_liquid_raises_for_invalid_locations(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([[mock_well]])
     ).then_raise(ValueError("Oh no"))
@@ -2031,7 +1998,6 @@ def test_distribute_liquid_raises_if_more_than_one_source(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2039,9 +2005,6 @@ def test_distribute_liquid_raises_if_more_than_one_source(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     with pytest.raises(ValueError, match="Source should be a single Well"):
         subject.distribute_liquid(
             liquid_class=test_liq_class, volume=10, source=[mock_well, mock_well], dest=[mock_well]  # type: ignore
@@ -2053,7 +2016,6 @@ def test_distribute_liquid_raises_for_non_liquid_handling_locations(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2061,9 +2023,6 @@ def test_distribute_liquid_raises_for_non_liquid_handling_locations(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2083,7 +2042,6 @@ def test_distribute_liquid_raises_for_bad_tip_policy(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2091,9 +2049,6 @@ def test_distribute_liquid_raises_for_bad_tip_policy(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2115,7 +2070,6 @@ def test_distribute_liquid_raises_for_no_tip(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2123,9 +2077,6 @@ def test_distribute_liquid_raises_for_no_tip(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2148,7 +2099,6 @@ def test_distribute_liquid_raises_if_tip_has_liquid(
     mock_protocol_core: ProtocolCore,
     mock_instrument_core: InstrumentCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2161,9 +2111,6 @@ def test_distribute_liquid_raises_if_tip_has_liquid(
     subject.tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2197,7 +2144,6 @@ def test_distribute_liquid_delegates_to_engine_core(
     mock_protocol_core: ProtocolCore,
     mock_instrument_core: InstrumentCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2211,9 +2157,6 @@ def test_distribute_liquid_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2254,7 +2197,6 @@ def test_consolidate_liquid_raises_for_invalid_locations(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2262,9 +2204,6 @@ def test_consolidate_liquid_raises_for_invalid_locations(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([[mock_well]])
     ).then_raise(ValueError("Oh no"))
@@ -2289,7 +2228,6 @@ def test_consolidate_liquid_raises_if_more_than_one_destination(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2297,9 +2235,6 @@ def test_consolidate_liquid_raises_if_more_than_one_destination(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     with pytest.raises(ValueError, match="Destination should be a single Well"):
         subject.consolidate_liquid(
             liquid_class=test_liq_class,
@@ -2314,7 +2249,6 @@ def test_consolidate_liquid_raises_for_non_liquid_handling_locations(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2322,9 +2256,6 @@ def test_consolidate_liquid_raises_for_non_liquid_handling_locations(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2344,7 +2275,6 @@ def test_consolidate_liquid_raises_for_bad_tip_policy(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2352,9 +2282,6 @@ def test_consolidate_liquid_raises_for_bad_tip_policy(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2376,7 +2303,6 @@ def test_consolidate_liquid_raises_for_no_tip(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2384,9 +2310,6 @@ def test_consolidate_liquid_raises_for_no_tip(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2409,7 +2332,6 @@ def test_consolidate_liquid_raises_if_tip_has_liquid(
     mock_protocol_core: ProtocolCore,
     mock_instrument_core: InstrumentCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2422,9 +2344,6 @@ def test_consolidate_liquid_raises_if_tip_has_liquid(
     subject.tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])
@@ -2458,7 +2377,6 @@ def test_consolidate_liquid_delegates_to_engine_core(
     mock_protocol_core: ProtocolCore,
     mock_instrument_core: InstrumentCore,
     subject: InstrumentContext,
-    mock_feature_flags: None,
     robot_type: RobotType,
     minimal_liquid_class_def2: LiquidClassSchemaV1,
 ) -> None:
@@ -2472,9 +2390,6 @@ def test_consolidate_liquid_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     decoy.when(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_return([mock_well])

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -7,11 +7,10 @@ from decoy import Decoy, matchers
 
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
-from opentrons_shared_data.robot.types import RobotTypeEnum, RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.protocol_api._liquid import LiquidClass
 from opentrons.types import Mount, DeckSlotName, StagingSlotName
-from opentrons.config import feature_flags as ff
 from opentrons.protocol_api import OFF_DECK
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.hardware_control.modules.types import (
@@ -1456,7 +1455,6 @@ def test_define_liquid_class(
     mock_core: ProtocolCore,
     subject: ProtocolContext,
     robot_type: RobotType,
-    mock_feature_flags: None,
 ) -> None:
     """It should create the liquid class definition."""
     expected_liquid_class = LiquidClass(
@@ -1466,14 +1464,11 @@ def test_define_liquid_class(
         expected_liquid_class
     )
     decoy.when(mock_core.robot_type).then_return(robot_type)
-    decoy.when(
-        ff.allow_liquid_classes(RobotTypeEnum.robot_literal_to_enum(robot_type))
-    ).then_return(True)
     assert subject.define_liquid_class("volatile_90") == expected_liquid_class
 
 
 def test_bundled_data(
-    decoy: Decoy, mock_core_map: LoadedCoreMap, mock_deck: Deck, mock_core: ProtocolCore
+    mock_core_map: LoadedCoreMap, mock_deck: Deck, mock_core: ProtocolCore
 ) -> None:
     """It should return bundled data."""
     subject = ProtocolContext(

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -1,23 +1,17 @@
 """Tests for the APIs around liquid classes."""
 import pytest
-from decoy import Decoy
-from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from opentrons.protocol_api import ProtocolContext
-from opentrons.config import feature_flags as ff
 
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.20", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
 )
 def test_liquid_class_creation_and_property_fetching(
-    decoy: Decoy,
-    mock_feature_flags: None,
     simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should create the liquid class and provide access to its properties."""
-    decoy.when(ff.allow_liquid_classes(RobotTypeEnum.FLEX)).then_return(True)
     pipette_load_name = "flex_8channel_50"
     simulated_protocol_context.load_instrument(pipette_load_name, mount="left")
     tiprack = simulated_protocol_context.load_labware(
@@ -51,12 +45,3 @@ def test_liquid_class_creation_and_property_fetching(
 
     with pytest.raises(ValueError, match="Liquid class definition not found"):
         simulated_protocol_context.define_liquid_class("non-existent-liquid")
-
-
-@pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.20", "OT-2")], indirect=True
-)
-def test_liquid_class_feature_flag(simulated_protocol_context: ProtocolContext) -> None:
-    """It should raise a not implemented error without the allowLiquidClass flag set."""
-    with pytest.raises(NotImplementedError):
-        simulated_protocol_context.define_liquid_class("water")

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -1,11 +1,8 @@
 """Tests for the transfer APIs using liquid classes."""
 import pytest
 import mock
-from decoy import Decoy
-from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from opentrons.protocol_api import ProtocolContext
-from opentrons.config import feature_flags as ff
 from opentrons.protocol_api.core.engine import InstrumentCore
 from opentrons.protocol_api.core.engine.transfer_components_executor import (
     TransferType,
@@ -15,10 +12,10 @@ from opentrons.protocol_api.core.engine.transfer_components_executor import (
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.20", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
 )
 def test_water_transfer_with_volume_more_than_tip_max(
-    decoy: Decoy, mock_feature_flags: None, simulated_protocol_context: ProtocolContext
+    simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should run the transfer steps without any errors.
 
@@ -26,7 +23,6 @@ def test_water_transfer_with_volume_more_than_tip_max(
     analyze successfully. It doesn't check whether the steps are as expected.
     That will be covered in analysis snapshot tests.
     """
-    decoy.when(ff.allow_liquid_classes(RobotTypeEnum.FLEX)).then_return(True)
     trash = simulated_protocol_context.load_trash_bin("A3")
     tiprack = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul", "D1"
@@ -88,10 +84,10 @@ def test_water_transfer_with_volume_more_than_tip_max(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.20", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
 )
 def test_order_of_water_transfer_steps(
-    decoy: Decoy, mock_feature_flags: None, simulated_protocol_context: ProtocolContext
+    simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should run the transfer steps without any errors.
 
@@ -99,7 +95,6 @@ def test_order_of_water_transfer_steps(
     analyze successfully. It doesn't check whether the steps are as expected.
     That will be covered in analysis snapshot tests.
     """
-    decoy.when(ff.allow_liquid_classes(RobotTypeEnum.FLEX)).then_return(True)
     trash = simulated_protocol_context.load_trash_bin("A3")
     tiprack = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul", "D1"
@@ -239,10 +234,10 @@ def test_order_of_water_transfer_steps(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.20", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
 )
 def test_order_of_water_transfer_steps_with_no_new_tips(
-    decoy: Decoy, mock_feature_flags: None, simulated_protocol_context: ProtocolContext
+    simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should run the transfer steps without any errors.
 
@@ -250,7 +245,6 @@ def test_order_of_water_transfer_steps_with_no_new_tips(
     analyze successfully. It doesn't check whether the steps are as expected.
     That will be covered in analysis snapshot tests.
     """
-    decoy.when(ff.allow_liquid_classes(RobotTypeEnum.FLEX)).then_return(True)
     trash = simulated_protocol_context.load_trash_bin("A3")
     tiprack = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul", "D1"


### PR DESCRIPTION
Closes AUTH-1294

# Overview

- Removes the `allowLiquidClasses` feature flag
- Gates all liquid classes features (including `transfer_liquid()`, `distribute_liquid()`, `consolidate_liquid()`) behind PAPI version 2.23 
- Updates tests

## Test Plan and Hands on Testing

Unit tests should suffice

## Risk assessment

Low. Makes the liquid classes feature available for use in the new API. But this work does not affect any existing APIs.
