### PR TITLE
fix(api): Over pressure while probing should trigger ER

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -209,6 +209,7 @@ async def _execute_common(  # noqa: C901
                 ],
                 errorInfo=(
                     {
+                        # This is here bc its not optional in the type but we are not using the retry location for this case
                         "retryLocation": (
                             current_position.x,
                             current_position.y,

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -45,7 +45,7 @@ from .command import (
 from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
-    from ..execution import MovementHandler, PipettingHandler
+    from ..execution import MovementHandler, PipettingHandler, GantryMover
     from ..resources import ModelUtils
     from ..state.state import StateView
 
@@ -125,6 +125,7 @@ class _ExecuteCommonResult(NamedTuple):
 async def _execute_common(  # noqa: C901
     state_view: StateView,
     movement: MovementHandler,
+    gantry_mover: GantryMover,
     pipetting: PipettingHandler,
     model_utils: ModelUtils,
     params: _CommonParams,
@@ -181,7 +182,7 @@ async def _execute_common(  # noqa: C901
     if isinstance(move_result, DefinedErrorData):
         return move_result
     try:
-        current_position = await movement._gantry_mover.get_position(params.pipetteId)
+        current_position = await gantry_mover.get_position(params.pipetteId)
         z_pos = await pipetting.liquid_probe_in_place(
             pipette_id=pipette_id,
             labware_id=labware_id,
@@ -237,12 +238,14 @@ class LiquidProbeImplementation(
         self,
         state_view: StateView,
         movement: MovementHandler,
+        gantry_mover: GantryMover,
         pipetting: PipettingHandler,
         model_utils: ModelUtils,
         **kwargs: object,
     ) -> None:
         self._state_view = state_view
         self._movement = movement
+        self._gantry_mover = gantry_mover
         self._pipetting = pipetting
         self._model_utils = model_utils
 
@@ -265,6 +268,7 @@ class LiquidProbeImplementation(
         result = await _execute_common(
             state_view=self._state_view,
             movement=self._movement,
+            gantry_mover=self._gantry_mover,
             pipetting=self._pipetting,
             model_utils=self._model_utils,
             params=params,
@@ -331,12 +335,14 @@ class TryLiquidProbeImplementation(
         self,
         state_view: StateView,
         movement: MovementHandler,
+        gantry_mover: GantryMover,
         pipetting: PipettingHandler,
         model_utils: ModelUtils,
         **kwargs: object,
     ) -> None:
         self._state_view = state_view
         self._movement = movement
+        self._gantry_mover = gantry_mover
         self._pipetting = pipetting
         self._model_utils = model_utils
 
@@ -350,6 +356,7 @@ class TryLiquidProbeImplementation(
         result = await _execute_common(
             state_view=self._state_view,
             movement=self._movement,
+            gantry_mover=self._gantry_mover,
             pipetting=self._pipetting,
             model_utils=self._model_utils,
             params=params,

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -49,6 +49,7 @@ from opentrons.protocol_engine.commands.movement_common import StallOrCollisionE
 from opentrons.protocol_engine.execution import (
     MovementHandler,
     PipettingHandler,
+    GantryMover,
 )
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 
@@ -106,6 +107,7 @@ def subject(
     implementation_type: EitherImplementationType,
     state_view: StateView,
     movement: MovementHandler,
+    gantry_mover: GantryMover,
     pipetting: PipettingHandler,
     model_utils: ModelUtils,
 ) -> Union[LiquidProbeImplementation, TryLiquidProbeImplementation]:
@@ -114,6 +116,7 @@ def subject(
         state_view=state_view,
         pipetting=pipetting,
         movement=movement,
+        gantry_mover=gantry_mover,
         model_utils=model_utils,
     )
 
@@ -317,7 +320,8 @@ async def test_liquid_not_found_error(
             operation_volume=None,
         ),
     ).then_return(position)
-
+    # print(movement)
+    # decoy.when(await movement._gantry_mover.get_position("pipette-id")).then_return({"x":0, "y":0, "z":0})
     decoy.when(
         await pipetting.liquid_probe_in_place(
             pipette_id=pipette_id,

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -320,8 +320,6 @@ async def test_liquid_not_found_error(
             operation_volume=None,
         ),
     ).then_return(position)
-    # print(movement)
-    # decoy.when(await movement._gantry_mover.get_position("pipette-id")).then_return({"x":0, "y":0, "z":0})
     decoy.when(
         await pipetting.liquid_probe_in_place(
             pipette_id=pipette_id,


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RABR-692.
trigger ER while getting an over pressuring  error when liquid probing. 

## Test Plan and Hands on Testing

trigger over pressure when doing the liquid probe step (right after the pause) 
test on the flex with protocol:
```
from opentrons.protocol_api import ProtocolContext

metadata = {
    "protocolName": "QA Protocol - MEGAAA PROTOCOL - LETS BREAK, I MEAN TEST, EVERYTHING!!!!!",
    "author": "Derek Maggio <derek.maggio@opentrons.com>",
}

requirements = {
    "robotType": "OT-3",
    "apiLevel": "2.21",
}


def run(protocol:ProtocolContext):
    tiprack_50 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
    reservoir = protocol.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt", "D2")
    pipette = protocol.load_instrument("flex_1channel_1000", "right", tip_racks = [tiprack_50])
    pipette.pick_up_tip(tiprack_50)
    protocol.pause("about to probe. get ready to over pressure.")
    pipette.require_liquid_presence(reservoir["A1"])


```
tested with Dev server and works as expected. need to test on the robot. 

## Changelog

catch over pressure when probing and raise a defined error.

## Review requests

changes make sense? 

## Risk assessment

low. raise a defined error.
