### PR TITLE
fix(protocol-designer): filter trashbins from move labware new location

### DIFF
--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -225,7 +225,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
       .filter(slotId => {
         const isTrashSlot =
           robotType === FLEX_ROBOT_TYPE
-            ? MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slotId)
+            ? MOVABLE_TRASH_ADDRESSABLE_AREAS.some(aE => aE.includes(slotId))
             : ['fixedTrash', '12'].includes(slotId)
         return (
           !slotIdsOccupiedByModules.includes(slotId) &&

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -128,6 +128,13 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
 
     if (robotState == null) return null
 
+    const trashCutouts = Object.values(additionalEquipmentEntities).reduce<
+      string[]
+    >(
+      (acc, { name, location }) =>
+        name === 'trashBin' && location != null ? [...acc, location] : acc,
+      []
+    )
     const { modules, labware } = robotState
     const slotIdsOccupiedByModules = Object.entries(modules).reduce<string[]>(
       (acc, [modId, modOnDeck]) => {
@@ -225,7 +232,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
       .filter(slotId => {
         const isTrashSlot =
           robotType === FLEX_ROBOT_TYPE
-            ? MOVABLE_TRASH_ADDRESSABLE_AREAS.some(aE => aE.includes(slotId))
+            ? MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slotId)
             : ['fixedTrash', '12'].includes(slotId)
         return (
           !slotIdsOccupiedByModules.includes(slotId) &&
@@ -233,6 +240,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
             .map(lw => lw.slot)
             .includes(slotId) &&
           !isTrashSlot &&
+          !trashCutouts.some(cutout => cutout.includes(slotId)) &&
           !WASTE_CHUTE_ADDRESSABLE_AREAS.includes(slotId) &&
           !notSelectedStagingAreaAddressableAreas.includes(slotId) &&
           !FLEX_MODULE_ADDRESSABLE_AREAS.includes(slotId) &&


### PR DESCRIPTION
# Overview

This PR fixes a bug where a user can select a slot occupied by a trash bin as the new location for a move labware step. The user should be prevented from moving labware to a trash bin for Flex and OT-2.

Closes RQA-3902

## Test Plan and Hands on Testing

- create a protocol with at least one trash bin
- create a move labware step and expand new location dropdown menu
- verify that neither the trash itself nor its occupied slot ID shows as an option for the new location

## Changelog

- fix logic for filtering moveable trash from unoccupiedSlotOptions for new location

## Review requests

see test plan