### PR TITLE
feat(app): Stub out flex stacker in deck config

### DIFF
--- a/api-client/src/modules/api-types.ts
+++ b/api-client/src/modules/api-types.ts
@@ -10,6 +10,7 @@ interface PhysicalPort {
   port: number
   hub: boolean
   portGroup: PortGroup
+  hubPort?: number
 }
 
 type ModuleOffsetSource =

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -358,22 +358,30 @@ export function AddFixtureModal({
     closeModal()
   }
 
-  const fixtureOptions = availableOptions.map(cutoutConfigs => (
-    <FixtureOption
-      key={cutoutConfigs[0].cutoutFixtureId}
-      optionName={getFixtureDisplayName(
-        cutoutConfigs[0].cutoutFixtureId,
-        (modulesData?.data ?? []).find(
-          m => m.serialNumber === cutoutConfigs[0].opentronsModuleSerialNumber
-        )?.usbPort.port
-      )}
-      buttonText={t('add')}
-      onClickHandler={() => {
-        handleAddFixture(cutoutConfigs)
-      }}
-      isOnDevice={isOnDevice}
-    />
-  ))
+  const fixtureOptions = availableOptions.map(cutoutConfigs => {
+    const usbPort = (modulesData?.data ?? []).find(
+      m => m.serialNumber === cutoutConfigs[0].opentronsModuleSerialNumber
+    )?.usbPort
+    const portDisplay =
+      usbPort?.hubPort != null
+        ? `${usbPort.port}.${usbPort.hubPort}`
+        : usbPort?.port
+
+    return (
+      <FixtureOption
+        key={cutoutConfigs[0].cutoutFixtureId}
+        optionName={getFixtureDisplayName(
+          cutoutConfigs[0].cutoutFixtureId,
+          portDisplay
+        )}
+        buttonText={t('add')}
+        onClickHandler={() => {
+          handleAddFixture(cutoutConfigs)
+        }}
+        isOnDevice={isOnDevice}
+      />
+    )
+  })
 
   return (
     <>

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -49,6 +49,8 @@ import {
   WASTE_CHUTE_FIXTURES,
   FLEX_STACKER_MODULE_V1,
   FLEX_STACKER_V1_FIXTURE,
+  FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE,
+  FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
 } from '@opentrons/shared-data'
 
 import { ODD_FOCUS_VISIBLE } from '/app/atoms/buttons/constants'
@@ -252,6 +254,30 @@ export function AddFixtureModal({
       }
     }
     if (
+      cutoutId === 'cutoutD3' &&
+      unconfiguredMods.some(m => m.moduleModel === FLEX_STACKER_MODULE_V1)
+    ) {
+      const unconfiguredFlexStackers = unconfiguredMods
+        .filter(mod => mod.moduleModel === FLEX_STACKER_MODULE_V1)
+        .map(mod => [
+          {
+            cutoutId,
+            cutoutFixtureId: FLEX_STACKER_V1_FIXTURE,
+            opentronsModuleSerialNumber: mod.serialNumber,
+          },
+          {
+            cutoutId,
+            cutoutFixtureId: FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE,
+            opentronsModuleSerialNumber: mod.serialNumber,
+          },
+          {
+            cutoutId,
+            cutoutFixtureId: FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
+            opentronsModuleSerialNumber: mod.serialNumber,
+          },
+        ])
+      availableOptions = [...availableOptions, ...unconfiguredFlexStackers]
+    } else if (
       STAGING_AREA_CUTOUTS.includes(cutoutId) &&
       unconfiguredMods.some(m => m.moduleModel === FLEX_STACKER_MODULE_V1)
     ) {

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -257,26 +257,33 @@ export function AddFixtureModal({
       cutoutId === 'cutoutD3' &&
       unconfiguredMods.some(m => m.moduleModel === FLEX_STACKER_MODULE_V1)
     ) {
-      const unconfiguredFlexStackers = unconfiguredMods
+      const unconfiguredFlexStackers: CutoutConfig[][] = []
+      unconfiguredMods
         .filter(mod => mod.moduleModel === FLEX_STACKER_MODULE_V1)
-        .map(mod => [
-          {
-            cutoutId,
-            cutoutFixtureId: FLEX_STACKER_V1_FIXTURE,
-            opentronsModuleSerialNumber: mod.serialNumber,
-          },
-          {
-            cutoutId,
-            cutoutFixtureId: FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE,
-            opentronsModuleSerialNumber: mod.serialNumber,
-          },
-          {
-            cutoutId,
-            cutoutFixtureId: FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
-            opentronsModuleSerialNumber: mod.serialNumber,
-          },
-        ])
-      availableOptions = [...availableOptions, ...unconfiguredFlexStackers]
+        .forEach(mod => {
+          unconfiguredFlexStackers.push([
+            {
+              cutoutId,
+              cutoutFixtureId: FLEX_STACKER_V1_FIXTURE,
+              opentronsModuleSerialNumber: mod.serialNumber,
+            },
+          ])
+          unconfiguredFlexStackers.push([
+            {
+              cutoutId,
+              cutoutFixtureId: FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE,
+              opentronsModuleSerialNumber: mod.serialNumber,
+            },
+          ])
+          unconfiguredFlexStackers.push([
+            {
+              cutoutId,
+              cutoutFixtureId: FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
+              opentronsModuleSerialNumber: mod.serialNumber,
+            },
+          ])
+        })
+      availableOptions.push(...unconfiguredFlexStackers)
     } else if (
       STAGING_AREA_CUTOUTS.includes(cutoutId) &&
       unconfiguredMods.some(m => m.moduleModel === FLEX_STACKER_MODULE_V1)

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -47,6 +47,8 @@ import {
   TRASH_BIN_ADAPTER_FIXTURE,
   WASTE_CHUTE_CUTOUT,
   WASTE_CHUTE_FIXTURES,
+  FLEX_STACKER_MODULE_V1,
+  FLEX_STACKER_V1_FIXTURE,
 } from '@opentrons/shared-data'
 
 import { ODD_FOCUS_VISIBLE } from '/app/atoms/buttons/constants'
@@ -248,6 +250,21 @@ export function AddFixtureModal({
           ...unconfiguredAbsorbanceReaders,
         ]
       }
+    }
+    if (
+      STAGING_AREA_CUTOUTS.includes(cutoutId) &&
+      unconfiguredMods.some(m => m.moduleModel === FLEX_STACKER_MODULE_V1)
+    ) {
+      const unconfiguredFlexStackers = unconfiguredMods
+        .filter(mod => mod.moduleModel === FLEX_STACKER_MODULE_V1)
+        .map(mod => [
+          {
+            cutoutId,
+            cutoutFixtureId: FLEX_STACKER_V1_FIXTURE,
+            opentronsModuleSerialNumber: mod.serialNumber,
+          },
+        ])
+      availableOptions = [...availableOptions, ...unconfiguredFlexStackers]
     }
   } else if (optionStage === 'wasteChuteOptions') {
     availableOptions = WASTE_CHUTE_FIXTURES.map(fixture => [

--- a/components/src/hardware-sim/DeckConfigurator/FlexStackerFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/FlexStackerFixture.tsx
@@ -1,0 +1,91 @@
+import { Icon } from '../../icons'
+import { Btn, Text } from '../../primitives'
+import { TYPOGRAPHY } from '../../ui-style-constants'
+import { COLORS } from '../../helix-design-system'
+import { RobotCoordsForeignObject } from '../Deck/RobotCoordsForeignObject'
+import {
+  COLUMN_3_X_ADJUSTMENT,
+  CONFIG_STYLE_EDITABLE,
+  CONFIG_STYLE_READ_ONLY,
+  FIXTURE_HEIGHT,
+  STAGING_AREA_FIXTURE_WIDTH,
+  Y_ADJUSTMENT,
+  CONFIG_STYLE_SELECTED,
+} from './constants'
+
+import type {
+  CutoutFixtureId,
+  CutoutId,
+  DeckDefinition,
+} from '@opentrons/shared-data'
+
+interface FlexStackerFixtureProps {
+  deckDefinition: DeckDefinition
+  fixtureLocation: CutoutId
+  cutoutFixtureId: CutoutFixtureId
+  handleClickRemove?: (
+    fixtureLocation: CutoutId,
+    cutoutFixtureId: CutoutFixtureId
+  ) => void
+  selected?: boolean
+}
+
+const FLEX_STACKER_FIXTURE_DISPLAY_NAME = 'Stacker'
+
+export function FlexStackerFixture(
+  props: FlexStackerFixtureProps
+): JSX.Element {
+  const {
+    deckDefinition,
+    handleClickRemove,
+    fixtureLocation,
+    cutoutFixtureId,
+    selected = false,
+  } = props
+
+  const cutoutDef = deckDefinition.locations.cutouts.find(
+    cutout => cutout.id === fixtureLocation
+  )
+
+  /**
+   * deck definition cutout position is the position of the single slot located within that cutout
+   * so, to get the position of the cutout itself we must add an adjustment to the slot position
+   * the adjustment for x is different for right side/left side
+   */
+  const [xSlotPosition = 0, ySlotPosition = 0] = cutoutDef?.position ?? []
+
+  const x = xSlotPosition + COLUMN_3_X_ADJUSTMENT
+
+  const y = ySlotPosition + Y_ADJUSTMENT
+
+  const editableStyle = selected ? CONFIG_STYLE_SELECTED : CONFIG_STYLE_EDITABLE
+  return (
+    <RobotCoordsForeignObject
+      width={STAGING_AREA_FIXTURE_WIDTH}
+      height={FIXTURE_HEIGHT}
+      x={x}
+      y={y}
+      flexProps={{ flex: '1' }}
+      foreignObjectProps={{ flex: '1' }}
+    >
+      <Btn
+        css={handleClickRemove != null ? editableStyle : CONFIG_STYLE_READ_ONLY}
+        cursor={handleClickRemove != null ? 'pointer' : 'default'}
+        onClick={
+          handleClickRemove != null
+            ? () => {
+                handleClickRemove(fixtureLocation, cutoutFixtureId)
+              }
+            : () => {}
+        }
+      >
+        <Text css={TYPOGRAPHY.smallBodyTextSemiBold}>
+          {FLEX_STACKER_FIXTURE_DISPLAY_NAME}
+        </Text>
+        {handleClickRemove != null ? (
+          <Icon name="remove" color={COLORS.white} size="2rem" />
+        ) : null}
+      </Btn>
+    </RobotCoordsForeignObject>
+  )
+}

--- a/components/src/hardware-sim/DeckConfigurator/FlexStackerFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/FlexStackerFixture.tsx
@@ -23,6 +23,7 @@ interface FlexStackerFixtureProps {
   deckDefinition: DeckDefinition
   fixtureLocation: CutoutId
   cutoutFixtureId: CutoutFixtureId
+  hasWasteChute: boolean
   handleClickRemove?: (
     fixtureLocation: CutoutId,
     cutoutFixtureId: CutoutFixtureId
@@ -31,6 +32,7 @@ interface FlexStackerFixtureProps {
 }
 
 const FLEX_STACKER_FIXTURE_DISPLAY_NAME = 'Stacker'
+const FLEX_STACKER_WASTE_CHUTE_DISPLAY_NAME = 'Stacker + Waste chute'
 
 export function FlexStackerFixture(
   props: FlexStackerFixtureProps
@@ -40,6 +42,7 @@ export function FlexStackerFixture(
     handleClickRemove,
     fixtureLocation,
     cutoutFixtureId,
+    hasWasteChute,
     selected = false,
   } = props
 
@@ -80,7 +83,9 @@ export function FlexStackerFixture(
         }
       >
         <Text css={TYPOGRAPHY.smallBodyTextSemiBold}>
-          {FLEX_STACKER_FIXTURE_DISPLAY_NAME}
+          {hasWasteChute
+            ? FLEX_STACKER_WASTE_CHUTE_DISPLAY_NAME
+            : FLEX_STACKER_FIXTURE_DISPLAY_NAME}
         </Text>
         {handleClickRemove != null ? (
           <Icon name="remove" color={COLORS.white} size="2rem" />

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -11,6 +11,7 @@ import {
   TEMPERATURE_MODULE_V2_FIXTURE,
   MAGNETIC_BLOCK_V1_FIXTURE,
   ABSORBANCE_READER_V1_FIXTURE,
+  FLEX_STACKER_V1_FIXTURE,
   STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE,
   THERMOCYCLER_MODULE_CUTOUTS,
 } from '@opentrons/shared-data'
@@ -24,6 +25,12 @@ import { StagingAreaConfigFixture } from './StagingAreaConfigFixture'
 import { TrashBinConfigFixture } from './TrashBinConfigFixture'
 import { WasteChuteConfigFixture } from './WasteChuteConfigFixture'
 import { StaticFixture } from './StaticFixture'
+import { TemperatureModuleFixture } from './TemperatureModuleFixture'
+import { HeaterShakerFixture } from './HeaterShakerFixture'
+import { MagneticBlockFixture } from './MagneticBlockFixture'
+import { ThermocyclerFixture } from './ThermocyclerFixture'
+import { AbsorbanceReaderFixture } from './AbsorbanceReaderFixture'
+import { FlexStackerFixture } from './FlexStackerFixture'
 
 import type { ReactNode } from 'react'
 import type {
@@ -31,11 +38,6 @@ import type {
   CutoutId,
   DeckConfiguration,
 } from '@opentrons/shared-data'
-import { TemperatureModuleFixture } from './TemperatureModuleFixture'
-import { HeaterShakerFixture } from './HeaterShakerFixture'
-import { MagneticBlockFixture } from './MagneticBlockFixture'
-import { ThermocyclerFixture } from './ThermocyclerFixture'
-import { AbsorbanceReaderFixture } from './AbsorbanceReaderFixture'
 
 export * from './constants'
 
@@ -115,6 +117,9 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
   const magneticBlockStagingAreaFixtures = deckConfig.filter(
     ({ cutoutFixtureId }) =>
       cutoutFixtureId === STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE
+  )
+  const flexStackerFixtures = deckConfig.filter(
+    ({ cutoutFixtureId }) => cutoutFixtureId === FLEX_STACKER_V1_FIXTURE
   )
 
   return (
@@ -252,6 +257,18 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
       })}
       {absorbanceReaderFixtures.map(({ cutoutId, cutoutFixtureId }) => (
         <AbsorbanceReaderFixture
+          key={cutoutId}
+          deckDefinition={deckDef}
+          handleClickRemove={
+            editableCutoutIds.includes(cutoutId) ? handleClickRemove : undefined
+          }
+          fixtureLocation={cutoutId}
+          cutoutFixtureId={cutoutFixtureId}
+          selected={cutoutId === selectedCutoutId}
+        />
+      ))}
+      {flexStackerFixtures.map(({ cutoutId, cutoutFixtureId }) => (
+        <FlexStackerFixture
           key={cutoutId}
           deckDefinition={deckDef}
           handleClickRemove={

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -12,6 +12,7 @@ import {
   MAGNETIC_BLOCK_V1_FIXTURE,
   ABSORBANCE_READER_V1_FIXTURE,
   FLEX_STACKER_V1_FIXTURE,
+  FLEX_STACKER_FIXTURES,
   STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE,
   THERMOCYCLER_MODULE_CUTOUTS,
 } from '@opentrons/shared-data'
@@ -118,8 +119,8 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
     ({ cutoutFixtureId }) =>
       cutoutFixtureId === STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE
   )
-  const flexStackerFixtures = deckConfig.filter(
-    ({ cutoutFixtureId }) => cutoutFixtureId === FLEX_STACKER_V1_FIXTURE
+  const flexStackerFixtures = deckConfig.filter(({ cutoutFixtureId }) =>
+    FLEX_STACKER_FIXTURES.includes(cutoutFixtureId)
   )
 
   return (
@@ -276,6 +277,7 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
           }
           fixtureLocation={cutoutId}
           cutoutFixtureId={cutoutFixtureId}
+          hasWasteChute={cutoutFixtureId !== FLEX_STACKER_V1_FIXTURE}
           selected={cutoutId === selectedCutoutId}
         />
       ))}

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -565,6 +565,10 @@ export const ABSORBANCE_READER_V1_FIXTURE: 'absorbanceReaderV1' =
   'absorbanceReaderV1'
 export const FLEX_STACKER_V1_FIXTURE: 'flexStackerModuleV1' =
   'flexStackerModuleV1'
+export const FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE: 'flexStackerModuleV1WithWasteChuteRightAdapterCovered' =
+  'flexStackerModuleV1WithWasteChuteRightAdapterCovered'
+export const FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE: 'flexStackerModuleV1WithWasteChuteRightAdapterNoCover' =
+  'flexStackerModuleV1WithWasteChuteRightAdapterNoCover'
 
 export const MODULE_FIXTURES_BY_MODEL: {
   [moduleModel in ModuleModel]?: CutoutFixtureId[]
@@ -615,6 +619,12 @@ export const WASTE_CHUTE_ONLY_FIXTURES: CutoutFixtureId[] = [
 export const WASTE_CHUTE_STAGING_AREA_FIXTURES: CutoutFixtureId[] = [
   STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
   STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
+]
+
+export const FLEX_STACKER_FIXTURES: CutoutFixtureId[] = [
+  FLEX_STACKER_V1_FIXTURE,
+  FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE,
+  FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
 ]
 
 export const LOW_VOLUME_PIPETTES = ['p50_single_flex', 'p50_multi_flex']

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -42,6 +42,10 @@ import {
   ABSORBANCE_READER_V1,
   MODULE_FIXTURES_BY_MODEL,
   STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE,
+  FLEX_STACKER_MODULE_V1,
+  FLEX_STACKER_V1_FIXTURE,
+  FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE,
+  FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
 } from './constants'
 import { getModuleDisplayName } from './modules'
 import { getCutoutIdForSlotName } from './helpers'
@@ -290,6 +294,26 @@ export function getFixtureDisplayName(
             ABSORBANCE_READER_V1
           )} in USB-${usbPortNumber}`
         : getModuleDisplayName(ABSORBANCE_READER_V1)
+    case FLEX_STACKER_V1_FIXTURE:
+      return usbPortNumber != null
+        ? `${getModuleDisplayName(
+            FLEX_STACKER_MODULE_V1
+          )} in USB-${usbPortNumber}`
+        : getModuleDisplayName(FLEX_STACKER_MODULE_V1)
+    case FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE:
+      return usbPortNumber != null
+        ? `${getModuleDisplayName(
+            FLEX_STACKER_MODULE_V1
+          )} in USB-${usbPortNumber} with waste chute with cover`
+        : `${getModuleDisplayName(
+            FLEX_STACKER_MODULE_V1
+          )} with waste chute with cover`
+    case FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE:
+      return usbPortNumber != null
+        ? `${getModuleDisplayName(
+            FLEX_STACKER_MODULE_V1
+          )} in USB-${usbPortNumber} with waste chute`
+        : `${getModuleDisplayName(FLEX_STACKER_MODULE_V1)} with waste chute`
     default:
       return 'Slot'
   }

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -304,16 +304,16 @@ export function getFixtureDisplayName(
       return usbPortNumber != null
         ? `${getModuleDisplayName(
             FLEX_STACKER_MODULE_V1
-          )} in USB-${usbPortNumber} with waste chute with cover`
+          )} in USB-${usbPortNumber} and waste chute with cover`
         : `${getModuleDisplayName(
             FLEX_STACKER_MODULE_V1
-          )} with waste chute with cover`
+          )} and waste chute with cover`
     case FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE:
       return usbPortNumber != null
         ? `${getModuleDisplayName(
             FLEX_STACKER_MODULE_V1
-          )} in USB-${usbPortNumber} with waste chute`
-        : `${getModuleDisplayName(FLEX_STACKER_MODULE_V1)} with waste chute`
+          )} in USB-${usbPortNumber} and waste chute`
+        : `${getModuleDisplayName(FLEX_STACKER_MODULE_V1)} and waste chute`
     default:
       return 'Slot'
   }

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -245,7 +245,7 @@ export function getAddressableAreaNamesFromLoadedModule(
 // note: we've decided not to translate these strings
 export function getFixtureDisplayName(
   cutoutFixtureId: CutoutFixtureId | null,
-  usbPortNumber?: number
+  usbPortNumber?: number | string
 ): string {
   switch (cutoutFixtureId) {
     case STAGING_AREA_RIGHT_SLOT_FIXTURE:


### PR DESCRIPTION
Fix EXEC-1087 [EXEC-1109](https://opentrons.atlassian.net/browse/EXEC-1109)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds interim support for the stacker and stacker+waste chute in deck config. In later iterations, these will be separated out into a new 4th column instead of also taking up column 3
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Select D3 on deck configuration for a device with unconfigured stacker, see that you're able to add stacker with or without waste chute
Select A3-C3 and see you're only able to add the stacker
<img width="406" alt="Screenshot 2025-01-29 at 3 15 32 PM" src="https://github.com/user-attachments/assets/a4deb9b7-3df5-44e8-b737-4f75d37915fd" />
<img width="678" alt="Screenshot 2025-01-29 at 3 15 16 PM" src="https://github.com/user-attachments/assets/924296e4-2b25-433d-a130-36c11203cb18" />
<img width="655" alt="Screenshot 2025-01-29 at 3 16 21 PM" src="https://github.com/user-attachments/assets/c3591614-fa16-45e6-ac73-c5f8c7442420" />

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Add necessary types for flex stacker fixtures with and without waste chute
2. Update `DeckConfigurator` to display flex stacker items
3. Update `AddFixtureModal` to display flex stacker for all 3rd column slots, flex stacker and waste chute options for D3
 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Test this out on a bot with an unconfigured stacker
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1109]: https://opentrons.atlassian.net/browse/EXEC-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ