### PR TITLE
fix(api): tune store_labware motion parameters and current to increase the z torque.

### DIFF
--- a/api/src/opentrons/drivers/flex_stacker/driver.py
+++ b/api/src/opentrons/drivers/flex_stacker/driver.py
@@ -67,14 +67,14 @@ STACKER_MOTION_CONFIG = {
             max_speed=10.0,
             acceleration=100.0,
             max_speed_discont=40,
-            current=1.8,
+            current=1.5,
         ),
         "move": MoveParams(
             StackerAxis.Z,
             max_speed=200.0,
             acceleration=500.0,
             max_speed_discont=40,
-            current=1.8,
+            current=1.5,
         ),
     },
     StackerAxis.L: {

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -273,7 +273,9 @@ class FlexStacker(mod_abc.AbstractModule):
         await self.reset_stall_detected()
         motion_params = STACKER_MOTION_CONFIG[axis]["move"]
         await self._driver.set_run_current(axis, current or motion_params.current or 0)
-        if any([speed, acceleration]):
+        if any([speed, acceleration, current]):
+            motion_params = self._reader.motion_params[axis]
+            motion_params.current = current or motion_params.current
             motion_params.max_speed = speed or motion_params.max_speed
             motion_params.acceleration = acceleration or motion_params.acceleration
         distance = direction.distance(distance)
@@ -391,8 +393,9 @@ class FlexStacker(mod_abc.AbstractModule):
 
         # Transfer
         await self.open_latch()
-        await self.move_axis(StackerAxis.Z, Direction.EXTEND, (labware_height / 2))
-        await self.home_axis(StackerAxis.Z, Direction.EXTEND)
+        z_speed = (STACKER_MOTION_CONFIG[StackerAxis.Z]["move"].max_speed or 0) / 2
+        await self.move_axis(StackerAxis.Z, Direction.EXTEND, (labware_height / 2), z_speed)
+        await self.home_axis(StackerAxis.Z, Direction.EXTEND, z_speed)
         await self.close_latch()
 
         # Move Z then X axis
@@ -448,7 +451,7 @@ class FlexStackerReader(Reader):
 
     async def get_motion_parameters(self) -> None:
         """Get the motion parameters used by the axis motors."""
-        self.move_params = {
+        self.motion_params = {
             axis: await self._driver.get_motion_params(axis) for axis in StackerAxis
         }
 

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -394,7 +394,9 @@ class FlexStacker(mod_abc.AbstractModule):
         # Transfer
         await self.open_latch()
         z_speed = (STACKER_MOTION_CONFIG[StackerAxis.Z]["move"].max_speed or 0) / 2
-        await self.move_axis(StackerAxis.Z, Direction.EXTEND, (labware_height / 2), z_speed)
+        await self.move_axis(
+            StackerAxis.Z, Direction.EXTEND, (labware_height / 2), z_speed
+        )
         await self.home_axis(StackerAxis.Z, Direction.EXTEND, z_speed)
         await self.close_latch()
 


### PR DESCRIPTION
# Overview

Motion parameters need to be adjusted to account for tiprack weight by decreasing the speed when moving on the z axis when storing labware. This pull request decreases the z speed to half the move speed and also decreases the current back down to 1.5mAmps since the lower speeds increase the torque.

## Test Plan and Hands on Testing

- [x] Make sure we can store and dispense full tipracks and PCR plates

## Changelog

- decrease the speed to half when moving the z axis in the store_labware function for higher torque.
- decrease the move and home current for the z axis back to 1.5mAmps since the higher torque makes up for the current.
- fix an issue when storing motion_parameters

## Review requests
## Risk assessment

Low, unreleased.