### PR TITLE
feat(protocol-designer): add python field to commands and timeline

### DIFF
--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -619,6 +619,7 @@ export interface CommandsAndRobotState {
   commands: CreateCommand[]
   robotState: RobotState
   warnings?: CommandCreatorWarning[]
+  python?: string
 }
 
 export interface CommandCreatorErrorResponse {
@@ -629,6 +630,7 @@ export interface CommandCreatorErrorResponse {
 export interface CommandsAndWarnings {
   commands: CreateCommand[]
   warnings?: CommandCreatorWarning[]
+  python?: string
 }
 export type CommandCreatorResult =
   | CommandsAndWarnings

--- a/step-generation/src/utils/commandCreatorsTimeline.ts
+++ b/step-generation/src/utils/commandCreatorsTimeline.ts
@@ -53,6 +53,7 @@ export const commandCreatorsTimeline = (
         commands: commandCreatorResult.commands,
         robotState: nextRobotStateAndWarnings.robotState,
         warnings: commandCreatorResult.warnings,
+        python: commandCreatorResult.python,
       }
       return {
         timeline: [...acc.timeline, nextResult],

--- a/step-generation/src/utils/reduceCommandCreators.ts
+++ b/step-generation/src/utils/reduceCommandCreators.ts
@@ -13,6 +13,7 @@ interface CCReducerAcc {
   commands: CreateCommand[]
   errors: CommandCreatorError[]
   warnings: CommandCreatorWarning[]
+  python?: string
 }
 export const reduceCommandCreators = (
   commandCreators: CurriedCommandCreator[],
@@ -36,6 +37,10 @@ export const reduceCommandCreators = (
         }
       }
       const allCommands = [...prev.commands, ...next.commands]
+      const allPython = [
+        ...(prev.python ? [prev.python] : []),
+        ...(next.python ? [next.python] : []),
+      ].join('\n')
       const updates = getNextRobotStateAndWarnings(
         next.commands,
         invariantContext,
@@ -50,6 +55,7 @@ export const reduceCommandCreators = (
           ...(next.warnings || []),
           ...updates.warnings,
         ],
+        ...(allPython && { python: allPython }),
       }
     },
     {
@@ -69,5 +75,6 @@ export const reduceCommandCreators = (
   return {
     commands: result.commands,
     warnings: result.warnings,
+    ...(result.python && { python: result.python }),
   }
 }


### PR DESCRIPTION
# Overview

This starts the plumbing for Python generation from Protocol Designer. AUTH-1385

We're adding a field for Python code to each command (`CommandsAndWarnings`) and to each entry of the timeline (`CommandsAndRobotState`). And in the reducer, we concatenate the Python commands together, analogously to how we concatenate the JSON commands together.

## Test Plan and Hands on Testing

I added unit tests to show that the Python code concatenation works, and that the Python code gets copied from the CommandCreators to the Timeline. The tests also demonstrate that the changes do NOT affect the behavior of existing commands that don't generate Python.

I've also done hands-on testing in a private experimental branch that has a more complete implementation of Python generation.

## Review requests

My first time making a functional change to PD, let me know if I'm overlooking anything.

## Risk assessment

Low. Should not cause any observable change to PD's behavior.