### PR TITLE
fix(app): App support for new lid commands and fix lid error boundary trigger

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -38,6 +38,8 @@
   "latching_hs_latch": "Latching labware on Heater-Shaker",
   "left": "Left",
   "load_labware_to_display_location": "Load {{labware}} {{display_location}}",
+  "load_lid": "Loading lid",
+  "load_lid_stack": "Loading lid stack",
   "load_liquids_info_protocol_setup": "Load {{liquid}} into {{labware}}",
   "load_module_protocol_setup": "Load {{module}} in Slot {{slot_name}}",
   "load_pipette_protocol_setup": "Load {{pipette_name}} in {{mount_name}} Mount",

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -287,7 +287,7 @@ export function getFailedCmdRelevantLabware(
   const failedLWURI = runRecord?.data.labware.find(
     labware => labware.id === recentRelevantFailedLabwareCmd?.params.labwareId
   )?.definitionUri
-  if (failedLWURI != null) {
+  if (failedLWURI != null && Object.keys(lwDefsByURI).includes(failedLWURI)) {
     return {
       name: getLabwareDisplayName(lwDefsByURI[failedLWURI]),
       nickname: labwareNickname,

--- a/components/src/organisms/CommandText/useCommandTextString/index.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/index.ts
@@ -100,6 +100,8 @@ export function useCommandTextString(
 
     case 'loadLabware':
     case 'reloadLabware':
+    case 'loadLid':
+    case 'loadLidStack':
     case 'loadPipette':
     case 'loadModule':
     case 'loadLiquid':

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
@@ -73,6 +73,13 @@ export const getLoadCommandText = ({
         display_location: displayLocation,
       })
     }
+    // TODO: finish these strings
+    case 'loadLid': {
+      return t('load_lid')
+    }
+    case 'loadLidStack': {
+      return t('load_lid_stack')
+    }
     case 'reloadLabware': {
       const { labwareId } = command.params
       const labware =

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
@@ -73,7 +73,7 @@ export const getLoadCommandText = ({
         display_location: displayLocation,
       })
     }
-    // TODO: finish these strings
+    // TODO(sb, 01/29): Add full support for these commands in run log once location refactor is complete
     case 'loadLid': {
       return t('load_lid')
     }

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -65,6 +65,15 @@ export interface MoveLabwareRunTimeCommand
     MoveLabwareCreateCommand {
   result?: MoveLabwareResult
 }
+export interface MoveLidCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'moveLid'
+  params: MoveLidParams
+}
+export interface MoveLidRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    MoveLidCreateCommand {
+  result?: MoveLidResult
+}
 export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
   commandType: 'loadModule'
   params: LoadModuleParams
@@ -109,6 +118,7 @@ export type SetupRunTimeCommand =
   | MoveLabwareRunTimeCommand
   | LoadLidRunTimeCommand
   | LoadLidStackRunTimeCommand
+  | MoveLidCreateCommand
 
 export type SetupCreateCommand =
   | ConfigureNozzleLayoutCreateCommand
@@ -120,6 +130,7 @@ export type SetupCreateCommand =
   | MoveLabwareCreateCommand
   | LoadLidCreateCommand
   | LoadLidRunTimeCommand
+  | MoveLidRunTimeCommand
 
 export type LabwareLocation =
   | 'offDeck'
@@ -185,7 +196,14 @@ export interface MoveLabwareParams {
 interface MoveLabwareResult {
   offsetId: string
 }
-
+interface MoveLidParams {
+  labwareId: string
+  newLocation: LabwareLocation
+  strategy: LabwareMovementStrategy
+}
+interface MoveLidResult {
+  offsetId: string
+}
 interface LoadModuleParams {
   moduleId?: string
   location: ModuleLocation

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -65,15 +65,6 @@ export interface MoveLabwareRunTimeCommand
     MoveLabwareCreateCommand {
   result?: MoveLabwareResult
 }
-export interface MoveLidCreateCommand extends CommonCommandCreateInfo {
-  commandType: 'moveLid'
-  params: MoveLidParams
-}
-export interface MoveLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveLidCreateCommand {
-  result?: MoveLidResult
-}
 export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
   commandType: 'loadModule'
   params: LoadModuleParams
@@ -118,7 +109,6 @@ export type SetupRunTimeCommand =
   | MoveLabwareRunTimeCommand
   | LoadLidRunTimeCommand
   | LoadLidStackRunTimeCommand
-  | MoveLidCreateCommand
 
 export type SetupCreateCommand =
   | ConfigureNozzleLayoutCreateCommand
@@ -130,7 +120,6 @@ export type SetupCreateCommand =
   | MoveLabwareCreateCommand
   | LoadLidCreateCommand
   | LoadLidRunTimeCommand
-  | MoveLidRunTimeCommand
 
 export type LabwareLocation =
   | 'offDeck'
@@ -194,14 +183,6 @@ export interface MoveLabwareParams {
   strategy: LabwareMovementStrategy
 }
 interface MoveLabwareResult {
-  offsetId: string
-}
-interface MoveLidParams {
-  labwareId: string
-  newLocation: LabwareLocation
-  strategy: LabwareMovementStrategy
-}
-interface MoveLidResult {
   offsetId: string
 }
 interface LoadModuleParams {

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -29,6 +29,24 @@ export interface LoadLabwareRunTimeCommand
     LoadLabwareCreateCommand {
   result?: LoadLabwareResult
 }
+export interface LoadLidCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'loadLid'
+  params: LoadLidParams
+}
+export interface LoadLidRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    LoadLidCreateCommand {
+  result?: LoadLidResult
+}
+export interface LoadLidStackCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'loadLidStack'
+  params: LoadLidStackParams
+}
+export interface LoadLidStackRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    LoadLidStackCreateCommand {
+  result?: LoadLidStackResult
+}
 export interface ReloadLabwareCreateCommand extends CommonCommandCreateInfo {
   commandType: 'reloadLabware'
   params: { labwareId: string }
@@ -89,6 +107,8 @@ export type SetupRunTimeCommand =
   | LoadModuleRunTimeCommand
   | LoadLiquidRunTimeCommand
   | MoveLabwareRunTimeCommand
+  | LoadLidRunTimeCommand
+  | LoadLidStackRunTimeCommand
 
 export type SetupCreateCommand =
   | ConfigureNozzleLayoutCreateCommand
@@ -98,6 +118,8 @@ export type SetupCreateCommand =
   | LoadModuleCreateCommand
   | LoadLiquidCreateCommand
   | MoveLabwareCreateCommand
+  | LoadLidCreateCommand
+  | LoadLidRunTimeCommand
 
 export type LabwareLocation =
   | 'offDeck'
@@ -202,4 +224,31 @@ interface NozzleConfigurationParams {
 export interface ConfigureNozzleLayoutParams {
   pipetteId: string
   configurationParams: NozzleConfigurationParams
+}
+
+interface LoadLidStackParams {
+  location: LabwareLocation
+  loadName: string
+  namespace: string
+  version: number
+  quantity: number
+}
+
+interface LoadLidStackResult {
+  stackLabwareId: string
+  labwareIds: string[]
+  definition: LabwareDefinition2
+  location: LabwareLocation
+}
+
+interface LoadLidParams {
+  location: LabwareLocation
+  loadName: string
+  namespace: string
+  version: number
+}
+
+interface LoadLidResult {
+  labwareId: string
+  definition: LabwareDefinition2
 }

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -119,7 +119,7 @@ export type SetupCreateCommand =
   | LoadLiquidCreateCommand
   | MoveLabwareCreateCommand
   | LoadLidCreateCommand
-  | LoadLidRunTimeCommand
+  | LoadLidStackCreateCommand
 
 export type LabwareLocation =
   | 'offDeck'

--- a/shared-data/js/helpers/getAddressableAreasInProtocol.ts
+++ b/shared-data/js/helpers/getAddressableAreasInProtocol.ts
@@ -17,7 +17,7 @@ export function getAddressableAreasInProtocol(
     (acc, command) => {
       const { commandType, params } = command
       if (
-        commandType === 'moveLabware' &&
+        (commandType === 'moveLabware' || commandType === 'moveLid') &&
         params.newLocation !== 'offDeck' &&
         params.newLocation !== 'systemLocation' &&
         'slotName' in params.newLocation &&
@@ -34,7 +34,7 @@ export function getAddressableAreasInProtocol(
           return [...acc, addressableAreaName]
         }
       } else if (
-        commandType === 'moveLabware' &&
+        (commandType === 'moveLabware' || commandType === 'moveLid') &&
         params.newLocation !== 'offDeck' &&
         params.newLocation !== 'systemLocation' &&
         'addressableAreaName' in params.newLocation &&
@@ -42,7 +42,9 @@ export function getAddressableAreasInProtocol(
       ) {
         return [...acc, params.newLocation.addressableAreaName]
       } else if (
-        commandType === 'loadLabware' &&
+        (commandType === 'loadLabware' ||
+          commandType === 'loadLid' ||
+          commandType === 'loadLidStack') &&
         params.location !== 'offDeck' &&
         params.location !== 'systemLocation' &&
         'slotName' in params.location &&
@@ -75,7 +77,9 @@ export function getAddressableAreasInProtocol(
 
         return [...acc, ...addressableAreaNames]
       } else if (
-        commandType === 'loadLabware' &&
+        (commandType === 'loadLabware' ||
+          commandType === 'loadLid' ||
+          commandType === 'loadLidStack') &&
         params.location !== 'offDeck' &&
         params.location !== 'systemLocation' &&
         'addressableAreaName' in params.location &&

--- a/shared-data/js/helpers/getAddressableAreasInProtocol.ts
+++ b/shared-data/js/helpers/getAddressableAreasInProtocol.ts
@@ -17,7 +17,7 @@ export function getAddressableAreasInProtocol(
     (acc, command) => {
       const { commandType, params } = command
       if (
-        (commandType === 'moveLabware' || commandType === 'moveLid') &&
+        commandType === 'moveLabware' &&
         params.newLocation !== 'offDeck' &&
         params.newLocation !== 'systemLocation' &&
         'slotName' in params.newLocation &&
@@ -34,7 +34,7 @@ export function getAddressableAreasInProtocol(
           return [...acc, addressableAreaName]
         }
       } else if (
-        (commandType === 'moveLabware' || commandType === 'moveLid') &&
+        commandType === 'moveLabware' &&
         params.newLocation !== 'offDeck' &&
         params.newLocation !== 'systemLocation' &&
         'addressableAreaName' in params.newLocation &&

--- a/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
+++ b/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
@@ -9,7 +9,11 @@ export function getLoadedLabwareDefinitionsByUri(
   commands: RunTimeCommand[]
 ): LabwareDefinitionsByUri {
   return commands.reduce((acc, command) => {
-    if (command.commandType === 'loadLabware') {
+    if (
+      command.commandType === 'loadLabware' ||
+      command.commandType === 'loadLid' ||
+      command.commandType === 'loadLidStack'
+    ) {
       const labwareDef: LabwareDefinition2 | undefined =
         command.result?.definition
       if (labwareDef == null) {


### PR DESCRIPTION
fix EXEC-1042, RABR-712
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds the new `loadLid` and `loadLidStack` commands to the typescript command schema, makes a few necessary utils aware that labware can be loaded through these commands, and adds some null protection where we were hitting an error boundary in the recovery flow due to missing labware
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
On this branch, run a protocol that loads a lid, trigger a stall/collision, and see that you no longer hit an error boundary 
I tested this out on desktop and it works as expected! Error recover is now launched and you can address the gripper failure
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. adds the new `loadLid` and `loadLidStack` commands to the typescript command schema
2. Add prelim support for these in the run log
3. Make a few necessary utils aware that labware can be loaded through these commands
4. Adds some null protection where we were hitting an error boundary in the recovery flow due to missing labware, even though it should no longer be missing

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over code changes and test this out if you can
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
