### PR TITLE
fix(api): use smaller of max pipette volume and max tip volume for splitting large transfer volumes

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1008,7 +1008,12 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         source_dest_per_volume_step = tx_commons.expand_for_volume_constraints(
             volumes=[volume for _ in range(len(source))],
             targets=zip(source, dest),
-            max_volume=self.get_max_volume(),
+            max_volume=min(
+                self.get_max_volume(),
+                tip_racks[0][1]
+                .get_well_core("A1")
+                .get_max_volume(),  # Assuming all tips in tiprack are of same volume
+            ),
         )
 
         def _drop_tip() -> None:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1180,10 +1180,11 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         Return: List of liquid and air gap pairs in tip.
         """
         aspirate_props = transfer_properties.aspirate
+        # TODO (spp, 2025-01-30): check if check_valid_volume_parameters is necessary and is enough.
         tx_commons.check_valid_volume_parameters(
             disposal_volume=0,  # No disposal volume for 1-to-1 transfer
             air_gap=aspirate_props.retract.air_gap_by_volume.get_for_volume(volume),
-            max_volume=self.get_max_volume(),
+            max_volume=self.get_working_volume(),
         )
         source_loc, source_well = source
         aspirate_point = (

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -27,8 +27,8 @@ def test_water_transfer_with_volume_more_than_tip_max(
     tiprack = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul", "D1"
     )
-    pipette_50 = simulated_protocol_context.load_instrument(
-        "flex_1channel_50", mount="left", tip_racks=[tiprack]
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
     )
     nest_plate = simulated_protocol_context.load_labware(
         "nest_96_wellplate_200ul_flat", "C3"
@@ -47,7 +47,7 @@ def test_water_transfer_with_volume_more_than_tip_max(
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
 
-        pipette_50.transfer_liquid(
+        pipette_1k.transfer_liquid(
             liquid_class=water,
             volume=60,
             source=nest_plate.rows()[0],
@@ -58,7 +58,7 @@ def test_water_transfer_with_volume_more_than_tip_max(
         assert patched_pick_up_tip.call_count == 24
         patched_pick_up_tip.reset_mock()
 
-        pipette_50.transfer_liquid(
+        pipette_1k.transfer_liquid(
             liquid_class=water,
             volume=100,
             source=nest_plate.rows()[0],
@@ -69,8 +69,8 @@ def test_water_transfer_with_volume_more_than_tip_max(
         assert patched_pick_up_tip.call_count == 12
         patched_pick_up_tip.reset_mock()
 
-        pipette_50.pick_up_tip()
-        pipette_50.transfer_liquid(
+        pipette_1k.pick_up_tip()
+        pipette_1k.transfer_liquid(
             liquid_class=water,
             volume=50,
             source=nest_plate.rows()[0],
@@ -78,7 +78,7 @@ def test_water_transfer_with_volume_more_than_tip_max(
             new_tip="never",
             trash_location=trash,
         )
-        pipette_50.drop_tip()
+        pipette_1k.drop_tip()
         assert patched_pick_up_tip.call_count == 1
 
 


### PR DESCRIPTION
# Overview

Found a bug in the logic that splits large volume transfers into smaller volumes. 
Bug is that we only check the transfer volume against max pipette volume. So if you use a 50uL pipette with a 200uL tip, everything works correctly, but if you use a 1000uL pipette with 50uL tip, it attempts to pipette upto 1000uL, instead of clipping to the max tip volume of 50uL.

This PR fixes that by taking the smaller of pipette volume and tip volume as the max volume a single transfer can take.

## Test Plan and Hands on Testing

Unit and integration tests would be enough to catch the error and fix.

## Review requests

Check for code sanity

## Risk assessment

Low. A scope-limited bug fix
