### PR TITLE
fix(step-generation): remove unneeded dispense after airGapInPlace

### DIFF
--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -66,9 +66,6 @@ const _createNextTimelineFrame = (args: {
     volume: args.volume,
     activeTips: _getNewActiveTips(args.nextFrame.commands.slice(0, args.index)),
   }
-  const command = args.command
-  const isAirGapCommand =
-    'meta' in command && command.meta != null && 'isAirGap' in command.meta
 
   const newTimelineFrame =
     args.command.commandType === 'aspirate' ||
@@ -76,12 +73,10 @@ const _createNextTimelineFrame = (args: {
       ? {
           ..._newTimelineFrameKeys,
           source: args.wellInfo,
-          isAirGap: isAirGapCommand,
         }
       : {
           ..._newTimelineFrameKeys,
           dest: args.wellInfo,
-          isAirGap: isAirGapCommand,
         }
   return newTimelineFrame
 }

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.ts
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.ts
@@ -201,7 +201,6 @@ describe('generateSubstepItem', () => {
                 preIngreds: {},
                 well: 'C1',
               },
-              isAirGap: false,
             },
           ],
         },
@@ -240,7 +239,6 @@ describe('generateSubstepItem', () => {
                 preIngreds: {},
                 well: 'A1',
               },
-              isAirGap: false,
               source: {
                 postIngreds: {},
                 preIngreds: {},
@@ -295,7 +293,6 @@ describe('generateSubstepItem', () => {
                 labwareId: tiprackId,
                 wellName: 'A1',
               },
-              isAirGap: false,
               source: { well: 'A1', preIngreds: {}, postIngreds: {} },
               dest: {
                 well: 'A1',
@@ -316,7 +313,6 @@ describe('generateSubstepItem', () => {
                 labwareId: tiprackId,
                 wellName: 'A1',
               },
-              isAirGap: false,
               dest: {
                 postIngreds: {
                   __air__: {
@@ -407,7 +403,6 @@ describe('generateSubstepItem', () => {
             preIngreds: {},
             well: 'A1',
           },
-          isAirGap: false,
           source: {
             postIngreds: {},
             preIngreds: {},
@@ -434,7 +429,6 @@ describe('generateSubstepItem', () => {
             },
             well: 'A1',
           },
-          isAirGap: false,
           source: {
             postIngreds: {
               __air__: {
@@ -465,7 +459,6 @@ describe('generateSubstepItem', () => {
             preIngreds: {},
             well: 'A2',
           },
-          isAirGap: false,
           source: {
             postIngreds: {},
             preIngreds: {},
@@ -492,7 +485,6 @@ describe('generateSubstepItem', () => {
             },
             well: 'A2',
           },
-          isAirGap: false,
           source: {
             postIngreds: {
               __air__: {

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -22,7 +22,6 @@ import {
   makeAspirateHelper,
   makeContext,
   makeDispenseHelper,
-  makeDispenseAirGapHelper,
   makeTouchTipHelper,
   pickUpTipHelper,
   SOURCE_LABWARE,
@@ -37,16 +36,6 @@ import {
   DEST_WELL_BLOWOUT_DESTINATION,
 } from '../utils/misc'
 
-const dispenseAirGapHelper = makeDispenseAirGapHelper({
-  wellLocation: {
-    origin: 'bottom',
-    offset: {
-      x: 0,
-      y: 0,
-      z: 11.54,
-    },
-  },
-})
 const aspirateHelper = makeAspirateHelper()
 const dispenseHelper = makeDispenseHelper()
 const touchTipHelper = makeTouchTipHelper()
@@ -450,8 +439,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       makeMoveToWellHelper('A1'),
       makeAirGapHelper(5),
       delayCommand(12),
-
-      dispenseAirGapHelper('A2', 5),
       dispenseHelper('A2', 100),
       dispenseHelper('A3', 100),
 
@@ -460,7 +447,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       makeMoveToWellHelper('A1'),
       makeAirGapHelper(5),
       delayCommand(12),
-      dispenseAirGapHelper('A4', 5),
       dispenseHelper('A4', 100),
       dispenseHelper('A5', 100),
     ])
@@ -488,14 +474,12 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       aspirateHelper('A1', 200),
       makeMoveToWellHelper('A1'),
       makeAirGapHelper(5),
-      dispenseAirGapHelper('A2', 5),
       dispenseHelper('A2', 100),
       dispenseHelper('A3', 100),
 
       aspirateHelper('A1', 200),
       makeMoveToWellHelper('A1'),
       makeAirGapHelper(5),
-      dispenseAirGapHelper('A4', 5),
       dispenseHelper('A4', 100),
       dispenseHelper('A5', 100),
     ])
@@ -524,9 +508,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       aspirateHelper('A1', 200),
       makeMoveToWellHelper('A1'),
       makeAirGapHelper(5),
-
-      dispenseAirGapHelper('A2', 5),
-      delayCommand(12),
       dispenseHelper('A2', 100),
       ...delayWithOffset('A2', DEST_LABWARE),
       dispenseHelper('A3', 100),
@@ -535,9 +516,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       aspirateHelper('A1', 200),
       makeMoveToWellHelper('A1'),
       makeAirGapHelper(5),
-
-      dispenseAirGapHelper('A4', 5),
-      delayCommand(12),
       dispenseHelper('A4', 100),
       ...delayWithOffset('A4', DEST_LABWARE),
       dispenseHelper('A5', 100),
@@ -928,8 +906,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('B1', 31),
-        delayCommand(12),
         dispenseHelper('B1', 45),
         ...delayWithOffset('B1', DEST_LABWARE),
         // touch tip (disp #1)
@@ -976,8 +952,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1008,8 +982,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(31),
         delayCommand(11),
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         // dispense #3
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
@@ -1059,8 +1031,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1098,8 +1068,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
@@ -1149,8 +1117,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1181,8 +1147,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
@@ -1229,8 +1193,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1262,8 +1224,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
@@ -1314,8 +1274,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1355,8 +1313,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
@@ -1406,8 +1362,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1439,8 +1393,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
@@ -1488,8 +1440,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1521,8 +1471,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
@@ -1573,8 +1521,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1614,8 +1560,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
@@ -1665,8 +1609,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #1
-        dispenseAirGapHelper('A2', 31),
-        delayCommand(12),
         dispenseHelper('A2', 100),
         ...delayWithOffset('A2', DEST_LABWARE),
         // touch tip (disp #1)
@@ -1698,8 +1640,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         makeAirGapHelper(31),
         delayCommand(11),
         // dispense #3
-        dispenseAirGapHelper('A4', 31),
-        delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -24,7 +24,6 @@ import {
   makeTouchTipHelper,
   pickUpTipHelper,
   SOURCE_LABWARE,
-  makeDispenseAirGapHelper,
   makeMoveToWellHelper,
 } from '../fixtures'
 import { FIXED_TRASH_ID } from '../constants'
@@ -36,16 +35,6 @@ import { transfer } from '../commandCreators/compound/transfer'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState, TransferArgs } from '../types'
 
-const dispenseAirGapHelper = makeDispenseAirGapHelper({
-  wellLocation: {
-    origin: 'bottom',
-    offset: {
-      x: 0,
-      y: 0,
-      z: 11.54,
-    },
-  },
-})
 const aspirateHelper = makeAspirateHelper()
 const dispenseHelper = makeDispenseHelper()
 const touchTipHelper = makeTouchTipHelper()
@@ -836,12 +825,10 @@ describe('advanced options', () => {
         aspirateHelper('A1', 295),
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(5),
-        dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 295),
         aspirateHelper('A1', 55),
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(5),
-        dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 55),
       ])
     })
@@ -858,12 +845,10 @@ describe('advanced options', () => {
         aspirateHelper('A1', 150),
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(5),
-        dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 150),
         aspirateHelper('A1', 150),
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(5),
-        dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 150),
       ])
     })
@@ -883,8 +868,6 @@ describe('advanced options', () => {
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(5),
         delayCommand(12),
-
-        dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 295),
 
         aspirateHelper('A1', 55),
@@ -892,8 +875,6 @@ describe('advanced options', () => {
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(5),
         delayCommand(12),
-
-        dispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 55),
       ])
     })
@@ -912,18 +893,12 @@ describe('advanced options', () => {
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(5),
 
-        dispenseAirGapHelper('B1', 5),
-        delayCommand(12),
-
         dispenseHelper('B1', 295),
         ...delayWithOffset('B1', DEST_LABWARE),
 
         aspirateHelper('A1', 55),
         makeMoveToWellHelper('A1'),
         makeAirGapHelper(5),
-
-        dispenseAirGapHelper('B1', 5),
-        delayCommand(12),
         dispenseHelper('B1', 55),
         ...delayWithOffset('B1', DEST_LABWARE),
       ])
@@ -1316,34 +1291,6 @@ describe('advanced options', () => {
             seconds: 11,
           },
         },
-        // dispense the aspirate > air gap
-        {
-          commandType: 'dispense',
-
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
-            flowRate: 2.2,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 12,
-          },
-        },
         {
           commandType: 'dispense',
           key: expect.any(String),
@@ -1624,33 +1571,6 @@ describe('advanced options', () => {
           key: expect.any(String),
           params: {
             seconds: 11,
-          },
-        },
-        // dispense aspirate > air gap then liquid
-        {
-          commandType: 'dispense',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
-            flowRate: 2.2,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 12,
           },
         },
         {
@@ -2033,33 +1953,6 @@ describe('advanced options', () => {
             seconds: 11,
           },
         },
-        // dispense the aspirate > air gap
-        {
-          commandType: 'dispense',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
-            flowRate: 2.2,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 12,
-          },
-        },
         {
           commandType: 'dispense',
           key: expect.any(String),
@@ -2338,32 +2231,6 @@ describe('advanced options', () => {
           key: expect.any(String),
           params: {
             seconds: 11,
-          },
-        },
-        {
-          commandType: 'dispense',
-          key: expect.any(String),
-          params: {
-            flowRate: 2.2,
-            labwareId: 'destPlateId',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            wellName: 'B1',
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 12,
           },
         },
         {
@@ -2773,33 +2640,6 @@ describe('advanced options', () => {
             seconds: 11,
           },
         },
-        // dispense
-        {
-          commandType: 'dispense',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
-            flowRate: 2.2,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 12,
-          },
-        },
         {
           commandType: 'dispense',
           key: expect.any(String),
@@ -3078,33 +2918,6 @@ describe('advanced options', () => {
           key: expect.any(String),
           params: {
             seconds: 11,
-          },
-        },
-        // dispense "aspirate > air gap" then dispense liquid
-        {
-          commandType: 'dispense',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
-            flowRate: 2.2,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 12,
           },
         },
         {
@@ -3512,33 +3325,7 @@ describe('advanced options', () => {
             seconds: 11,
           },
         },
-        // dispense
-        {
-          commandType: 'dispense',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                z: 11.54,
-                y: 0,
-                x: 0,
-              },
-            },
-            flowRate: 2.2,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 12,
-          },
-        },
+
         {
           commandType: 'dispense',
           key: expect.any(String),
@@ -3876,33 +3663,7 @@ describe('advanced options', () => {
             seconds: 11,
           },
         },
-        // dispense "aspirate > air gap" then dispense liquid
-        {
-          commandType: 'dispense',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            labwareId: 'destPlateId',
-            wellName: 'B1',
-            wellLocation: {
-              origin: 'bottom',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 11.54,
-              },
-            },
-            flowRate: 2.2,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 12,
-          },
-        },
+
         {
           commandType: 'dispense',
           key: expect.any(String),

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -26,7 +26,6 @@ import type { Point } from '../../utils'
 export interface ExtendedAspirateParams extends AspDispAirgapParams {
   tipRack: string
   nozzles: NozzleConfigurationStyle | null
-  isAirGap?: boolean
 }
 /** Aspirate with given args. Requires tip. */
 export const aspirate: CommandCreator<ExtendedAspirateParams> = (

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -241,30 +241,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
                   }),
                 ]
               : []),
-            curryCommandCreator(dispense, {
-              pipetteId: args.pipette,
-              volume: aspirateAirGapVolume,
-              labwareId: args.destLabware,
-              wellName: firstDestWell,
-              flowRate: dispenseFlowRateUlSec,
-              wellLocation: {
-                origin: 'bottom',
-                offset: {
-                  z: airGapOffsetDestWell,
-                  x: 0,
-                  y: 0,
-                },
-              },
-              nozzles,
-              tipRack: args.tipRack,
-            }),
-            ...(dispenseDelay != null
-              ? [
-                  curryCommandCreator(delay, {
-                    seconds: dispenseDelay.seconds,
-                  }),
-                ]
-              : []),
           ]
         : []
       const dispenseCommands = flatMap(

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -26,7 +26,6 @@ import {
   aspirate,
   configureForVolume,
   delay,
-  dispense,
   dropTip,
   moveToWell,
   touchTip,
@@ -417,30 +416,6 @@ export const transfer: CommandCreator<TransferArgs> = (
                     ? [
                         curryCommandCreator(delay, {
                           seconds: aspirateDelay.seconds,
-                        }),
-                      ]
-                    : []),
-                  curryCommandCreator(dispense, {
-                    pipetteId: args.pipette,
-                    volume: aspirateAirGapVolume,
-                    labwareId: args.destLabware,
-                    wellName: destinationWell,
-                    flowRate: dispenseFlowRateUlSec,
-                    wellLocation: {
-                      origin: 'bottom',
-                      offset: {
-                        z: airGapOffsetDestWell,
-                        x: 0,
-                        y: 0,
-                      },
-                    },
-                    tipRack: args.tipRack,
-                    nozzles: args.nozzles,
-                  }),
-                  ...(dispenseDelay != null
-                    ? [
-                        curryCommandCreator(delay, {
-                          seconds: dispenseDelay.seconds,
                         }),
                       ]
                     : []),

--- a/step-generation/src/fixtures/data.ts
+++ b/step-generation/src/fixtures/data.ts
@@ -104,4 +104,3 @@ export const DEST_LABWARE = 'destPlateId'
 export const TROUGH_LABWARE = 'troughId'
 export const DEFAULT_BLOWOUT_WELL = 'A1'
 export const TIPRACK_1 = 'tiprack1Id'
-export const AIR_GAP_META = { isAirGap: true } // to differentiate if the aspirate or dispense command is an air gap or not

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -31,7 +31,7 @@ export function forAspirate(
     labwareDef,
     params.wellName
   )
-  console.log('volume in forAspirate', volume)
+
   console.assert(
     // @ts-expect-error (sa, 2021-05-03): this assert is unnecessary
     uniq(wellsForTips).length === allWellsShared ? 1 : wellsForTips.length,

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -31,7 +31,7 @@ export function forAspirate(
     labwareDef,
     params.wellName
   )
-
+  console.log('volume in forAspirate', volume)
   console.assert(
     // @ts-expect-error (sa, 2021-05-03): this assert is unnecessary
     uniq(wellsForTips).length === allWellsShared ? 1 : wellsForTips.length,

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -63,19 +63,11 @@ function _getNextRobotStateAndWarningsSingleCommand(
   assert(command, 'undefined command passed to getNextRobotStateAndWarning')
   switch (command.commandType) {
     case 'aspirate':
-      if (command.meta?.isAirGap === true) {
-        break
-      } else {
-        forAspirate(command.params, invariantContext, robotStateAndWarnings)
-      }
+      forAspirate(command.params, invariantContext, robotStateAndWarnings)
       break
 
     case 'dispense':
-      if (command.meta?.isAirGap === true) {
-        break
-      } else {
-        forDispense(command.params, invariantContext, robotStateAndWarnings)
-      }
+      forDispense(command.params, invariantContext, robotStateAndWarnings)
       break
 
     case 'blowout':

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -112,7 +112,7 @@ export function splitLiquid(
   sourceLiquidState: LocationLiquidState
 ): SourceAndDest {
   const totalSourceVolume = getLocationTotalVolume(sourceLiquidState)
-  console.log('volume in splitLiquid', volume)
+
   if (totalSourceVolume === 0) {
     // Splitting from empty source
     return {
@@ -647,7 +647,7 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
     sourceWell,
     volume,
   } = args
-
+  console.log('airgaphelper', volume)
   const trashOrLabware = getTrashOrLabware(
     invariantContext.labwareEntities,
     invariantContext.additionalEquipmentEntities,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -112,7 +112,7 @@ export function splitLiquid(
   sourceLiquidState: LocationLiquidState
 ): SourceAndDest {
   const totalSourceVolume = getLocationTotalVolume(sourceLiquidState)
-
+  console.log('volume in splitLiquid', volume)
   if (totalSourceVolume === 0) {
     // Splitting from empty source
     return {


### PR DESCRIPTION
closes RQA-3913

# Overview

NOTE: need to double check that an `airGapInPlace` takes care of dispensing the air gap amount. If yes, then this PR is correct. if not, then i need to modify the `dispense` robot state following an `airGapInPlace`

## Test Plan and Hands on Testing

Upload the attached protocol and see that the liquid volume is correct, as outlined in the ticket

[RQA 3931.json](https://github.com/user-attachments/files/18612422/RQA.3931.json)


## Changelog

- remove some remnants of `meta: isAirGap`
- remove the unnecessary dispense and delay commands that were initially needed to dispense the air gap after an aspirate. but the new `airGapInPlace` doesn't need it

## Risk assessment

med-ish
