### PR TITLE
fix(api): fix the test_deck_configuration_provider unit test for the waste+stacker fixtures.

### DIFF
--- a/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
@@ -211,6 +211,32 @@ def test_get_provided_addressable_area_names(
                         {"D3", "flexStackerModuleV1D4"}
                     ),
                 ),
+                PotentialCutoutFixture(
+                    cutout_id="cutoutD3",
+                    cutout_fixture_id="flexStackerModuleV1WithWasteChuteRightAdapterCovered",
+                    provided_addressable_areas=frozenset(
+                        {
+                            "1ChannelWasteChute",
+                            "8ChannelWasteChute",
+                            "flexStackerModuleV1D4",
+                            "D3",
+                        }
+                    ),
+                ),
+                PotentialCutoutFixture(
+                    cutout_id="cutoutD3",
+                    cutout_fixture_id="flexStackerModuleV1WithWasteChuteRightAdapterNoCover",
+                    provided_addressable_areas=frozenset(
+                        {
+                            "1ChannelWasteChute",
+                            "8ChannelWasteChute",
+                            "96ChannelWasteChute",
+                            "gripperWasteChute",
+                            "flexStackerModuleV1D4",
+                            "D3",
+                        }
+                    ),
+                ),
             },
             lazy_fixture("ot3_standard_deck_def"),
         ),


### PR DESCRIPTION

I forgot to add the Flex Stacker deck configuration shared data changes to this unit test and it broke, this pull request fixes that.