### PR TITLE
fix(protocol-designer): delete labware if staging area deleted

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -422,7 +422,9 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
         //  if nested labware changes but labware doesn't, still create both both
         (createdLabwareForSlot.labwareDefURI === selectedLabwareDefUri &&
           createdNestedLabwareForSlot?.labwareDefURI !==
-            selectedNestedLabwareDefUri))
+            selectedNestedLabwareDefUri &&
+          (createdNestedLabwareForSlot?.labwareDefURI != null ||
+            selectedNestedLabwareDefUri != null)))
     ) {
       //   create adapter + labware on module
       dispatch(

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -419,7 +419,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
       selectedModuleModel != null &&
       selectedLabwareDefUri != null &&
       (createdLabwareForSlot?.labwareDefURI !== selectedLabwareDefUri ||
-        //  if nested labware changes but labware doesn't, still create both both
+        //  if nested labware changes but labware doesn't, still create both
         (createdLabwareForSlot.labwareDefURI === selectedLabwareDefUri &&
           createdNestedLabwareForSlot?.labwareDefURI !==
             selectedNestedLabwareDefUri &&

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -357,7 +357,8 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
     }
     if (
       matchingLabwareFor4thColumn != null &&
-      selectedFixture !== 'stagingArea'
+      selectedFixture !== 'stagingArea' &&
+      selectedFixture !== 'wasteChuteAndStagingArea'
     ) {
       dispatch(deleteContainer({ labwareId: matchingLabwareFor4thColumn.id }))
     }

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -301,6 +301,7 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
           createdLabwareForSlot.labwareDefURI !== selectedLabwareDefUri ||
           //  if nested labware changes but labware doesn't, still delete both
           (createdLabwareForSlot.labwareDefURI === selectedLabwareDefUri &&
+            selectedNestedLabwareDefUri != null &&
             createdNestedLabwareForSlot?.labwareDefURI !==
               selectedNestedLabwareDefUri))
       ) {

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupTools.tsx
@@ -354,6 +354,12 @@ export function DeckSetupTools(props: DeckSetupToolsProps): JSX.Element | null {
         dispatch(createDeckFixture(selectedFixture, cutout))
       }
     }
+    if (
+      matchingLabwareFor4thColumn != null &&
+      selectedFixture !== 'stagingArea'
+    ) {
+      dispatch(deleteContainer({ labwareId: matchingLabwareFor4thColumn.id }))
+    }
     if (selectedModuleModel != null) {
       //  create module
       const moduleType = getModuleType(selectedModuleModel)

--- a/protocol-designer/src/pages/Designer/DeckSetup/FixtureRender.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/FixtureRender.tsx
@@ -4,22 +4,28 @@ import {
   COLORS,
   FixedTrash,
   FlexTrash,
+  Module,
   SingleSlotFixture,
   StagingAreaFixture,
   WasteChuteFixture,
   WasteChuteStagingAreaFixture,
 } from '@opentrons/components'
-import { OT2_ROBOT_TYPE, getPositionFromSlotId } from '@opentrons/shared-data'
+import {
+  OT2_ROBOT_TYPE,
+  getModuleDef2,
+  getPositionFromSlotId,
+} from '@opentrons/shared-data'
 import { getInitialDeckSetup } from '../../../step-forms/selectors'
 import { LabwareOnDeck as LabwareOnDeckComponent } from '../../../organisms'
 import { lightFill, darkFill } from './DeckSetupContainer'
-import { getAdjacentLabware } from './utils'
+import { getAdjacentSlots } from './utils'
 import type {
   TrashCutoutId,
   StagingAreaLocation,
   DeckLabelProps,
 } from '@opentrons/components'
 import type {
+  AddressableAreaName,
   CutoutId,
   DeckDefinition,
   RobotType,
@@ -38,17 +44,54 @@ interface FixtureRenderProps {
 export const FixtureRender = (props: FixtureRenderProps): JSX.Element => {
   const { fixture, cutout, deckDef, robotType, showHighlight, tagInfo } = props
   const deckSetup = useSelector(getInitialDeckSetup)
-  const { labware } = deckSetup
-  const adjacentLabware = getAdjacentLabware(fixture, cutout, labware)
+  const { labware, modules } = deckSetup
+  const adjacentSlots = getAdjacentSlots(fixture, cutout)
 
+  // magnetic block in column 3 if staging area is used
+  const adjacentModule = Object.values(modules).find(({ slot }) =>
+    adjacentSlots?.includes(slot as AddressableAreaName)
+  )
+
+  // labware in column 3 or 4, possibly on a magnetic block in column 3
+  const adjacentLabwares = Object.values(labware).filter(
+    ({ slot }) =>
+      adjacentSlots?.includes(slot as AddressableAreaName) ||
+      slot === adjacentModule?.id
+  )
   const renderLabwareOnDeck = (): JSX.Element | null => {
-    if (!adjacentLabware) return null
-    const slotPosition = getPositionFromSlotId(adjacentLabware.slot, deckDef)
     return (
-      <LabwareOnDeckComponent
+      <>
+        {adjacentLabwares.map(adjacentLabware => {
+          const slotPosition = getPositionFromSlotId(
+            adjacentLabware.slot,
+            deckDef
+          )
+          return (
+            <LabwareOnDeckComponent
+              key={adjacentLabware.id}
+              x={slotPosition != null ? slotPosition[0] : 0}
+              y={slotPosition != null ? slotPosition[1] : 0}
+              labwareOnDeck={adjacentLabware}
+            />
+          )
+        })}
+      </>
+    )
+  }
+  const renderModuleOnDeck = (): JSX.Element | null => {
+    if (adjacentModule == null) {
+      return null
+    }
+    const slotPosition = getPositionFromSlotId(adjacentModule.slot, deckDef)
+
+    return (
+      <Module
+        key={adjacentModule.id}
         x={slotPosition != null ? slotPosition[0] : 0}
         y={slotPosition != null ? slotPosition[1] : 0}
-        labwareOnDeck={adjacentLabware}
+        def={getModuleDef2(adjacentModule.model)}
+        targetSlotId={adjacentModule.slot}
+        targetDeckId={deckDef.otId}
       />
     )
   }
@@ -56,13 +99,18 @@ export const FixtureRender = (props: FixtureRenderProps): JSX.Element => {
   switch (fixture) {
     case 'stagingArea': {
       return (
-        <Fragment key={`fixtureRender_${fixture}_${adjacentLabware?.id ?? 0}`}>
+        <Fragment
+          key={`fixtureRender_${fixture}_${
+            adjacentLabwares.length > 0 ? adjacentLabwares[0]?.id : 0
+          }`}
+        >
           <StagingAreaFixture
             cutoutId={cutout as StagingAreaLocation}
             deckDefinition={deckDef}
             slotClipColor={darkFill}
             fixtureBaseColor={lightFill}
           />
+          {renderModuleOnDeck()}
           {renderLabwareOnDeck()}
         </Fragment>
       )
@@ -105,7 +153,11 @@ export const FixtureRender = (props: FixtureRenderProps): JSX.Element => {
     }
     case 'wasteChuteAndStagingArea': {
       return (
-        <Fragment key={`fixtureRender_${fixture}_${adjacentLabware?.id ?? 0}`}>
+        <Fragment
+          key={`fixtureRender_${fixture}_${
+            adjacentLabwares.length > 0 ? adjacentLabwares[0]?.id : 0
+          }`}
+        >
           <WasteChuteStagingAreaFixture
             cutoutId={cutout as typeof WASTE_CHUTE_CUTOUT}
             deckDefinition={deckDef}

--- a/protocol-designer/src/pages/Designer/DeckSetup/FixtureRender.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/FixtureRender.tsx
@@ -15,6 +15,7 @@ import {
   getModuleDef2,
   getPositionFromSlotId,
 } from '@opentrons/shared-data'
+import { getLabwareSlot } from '@opentrons/step-generation'
 import { getInitialDeckSetup } from '../../../step-forms/selectors'
 import { LabwareOnDeck as LabwareOnDeckComponent } from '../../../organisms'
 import { lightFill, darkFill } from './DeckSetupContainer'
@@ -62,10 +63,8 @@ export const FixtureRender = (props: FixtureRenderProps): JSX.Element => {
     return (
       <>
         {adjacentLabwares.map(adjacentLabware => {
-          const slotPosition = getPositionFromSlotId(
-            adjacentLabware.slot,
-            deckDef
-          )
+          const slot = getLabwareSlot(adjacentLabware.id, labware, modules)
+          const slotPosition = getPositionFromSlotId(slot, deckDef)
           return (
             <LabwareOnDeckComponent
               key={adjacentLabware.id}

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -290,6 +290,20 @@ export const getAdjacentLabware = (
   return adjacentLabware
 }
 
+export const getAdjacentSlots = (
+  fixture: Fixture,
+  cutout: CutoutId
+): AddressableAreaName[] | null => {
+  if (fixture === 'stagingArea' || fixture === 'wasteChuteAndStagingArea') {
+    const stagingAreaAddressableAreaNames = getStagingAreaAddressableAreas(
+      [cutout],
+      false
+    )
+    return stagingAreaAddressableAreaNames
+  }
+  return null
+}
+
 type BreakPoint = 'small' | 'medium' | 'large'
 
 export function useDeckSetupWindowBreakPoint(): BreakPoint {

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -147,19 +147,24 @@ export const getHas96Channel = (pipettes: PipetteEntities): boolean => {
 }
 
 export const getStagingAreaAddressableAreas = (
-  cutoutIds: CutoutId[]
+  cutoutIds: CutoutId[],
+  filterStandardSlots: boolean = true
 ): AddressableAreaName[] => {
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
   const cutoutFixtures = deckDef.cutoutFixtures
 
-  return cutoutIds
-    .flatMap(cutoutId => {
-      const addressableAreasOnCutout = cutoutFixtures.find(
-        cutoutFixture => cutoutFixture.id === STAGING_AREA_RIGHT_SLOT_FIXTURE
-      )?.providesAddressableAreas[cutoutId]
-      return addressableAreasOnCutout ?? []
-    })
-    .filter(aa => !isAddressableAreaStandardSlot(aa, deckDef))
+  const addressableAreasRaw = cutoutIds.flatMap(cutoutId => {
+    const addressableAreasOnCutout = cutoutFixtures.find(
+      cutoutFixture => cutoutFixture.id === STAGING_AREA_RIGHT_SLOT_FIXTURE
+    )?.providesAddressableAreas[cutoutId]
+    return addressableAreasOnCutout ?? []
+  })
+  if (filterStandardSlots) {
+    return addressableAreasRaw.filter(
+      aa => !isAddressableAreaStandardSlot(aa, deckDef)
+    )
+  }
+  return addressableAreasRaw
 }
 
 export const getCutoutIdByAddressableArea = (


### PR DESCRIPTION
# Overview

If a user has added labware in column 4 provided by a staging area, that labware should be deleted if the hardware is changed such that the staging area is removed.

Closes RQA-3907

## Test Plan and Hands on Testing

- import or create a Flex protocol
- in column 3, add a staging area / magblock with staging area / waste chute with staging area
- add a labware to the newly provided column 4
- edit the column 3 hardware, and select another module without a staging area
- click "done" and verify that the labware is deleted from column 4

## Changelog

- delete labware in column 4 when necessary

## Review requests

see test plan

## Risk assessment

low