### PR TITLE
refactor(app): support fullscreen styling for LPC flows on the ODD

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCWizardFlex.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCWizardFlex.tsx
@@ -69,18 +69,18 @@ export function LPCWizardFlex(props: LPCWizardFlexProps): JSX.Element {
 function LPCWizardFlexComponent(props: LPCWizardContentProps): JSX.Element {
   const isOnDevice = useSelector(getIsOnDevice)
 
-  return createPortal(
-    isOnDevice ? (
-      <ModalShell fullPage>
-        <LPCWizardHeader {...props} />
-        <LPCWizardContent {...props} />
-      </ModalShell>
-    ) : (
+  return isOnDevice ? (
+    <>
+      <LPCWizardHeader {...props} />
+      <LPCWizardContent {...props} />
+    </>
+  ) : (
+    createPortal(
       <ModalShell width="47rem" header={<LPCWizardHeader {...props} />}>
         <LPCWizardContent {...props} />
-      </ModalShell>
-    ),
-    getTopPortalEl()
+      </ModalShell>,
+      getTopPortalEl()
+    )
   )
 }
 

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/index.tsx
@@ -77,7 +77,10 @@ export function ProtocolSetupOffsets({
   return (
     <>
       {LPCWizard ?? (
-        <>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          padding={`${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40}`}
+        >
           <Flex
             flexDirection={DIRECTION_ROW}
             justifyContent={JUSTIFY_SPACE_BETWEEN}
@@ -136,7 +139,7 @@ export function ProtocolSetupOffsets({
               }
             }}
           />
-        </>
+        </Flex>
       )}
     </>
   )

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import first from 'lodash/first'
+import { css } from 'styled-components'
 
 import { RUN_STATUS_IDLE, RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import {
@@ -91,6 +92,7 @@ import {
 import { useLPCFlows, LPCFlows } from '/app/organisms/LabwarePositionCheck'
 
 import type { Dispatch, SetStateAction } from 'react'
+import type { FlattenSimpleInterpolation } from 'styled-components'
 import type { Run } from '@opentrons/api-client'
 import type { CutoutFixtureId, CutoutId } from '@opentrons/shared-data'
 import type { OnDeviceRouteParams } from '/app/App/types'
@@ -902,16 +904,29 @@ export function ProtocolSetup(): JSX.Element {
           onConfirmClick={handleProceedToRunClick}
         />
       ) : null}
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        padding={
-          setupScreen === 'prepare to run'
-            ? `0 ${SPACING.spacing32} ${SPACING.spacing40}`
-            : `${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40}`
-        }
-      >
+      <Flex css={buildSetupScreenStyle(setupScreen)}>
         {setupComponentByScreen[setupScreen]}
       </Flex>
     </>
   )
+}
+
+const buildSetupScreenStyle = (
+  setupScreen: SetupScreens
+): FlattenSimpleInterpolation => {
+  const paddingStyle = (): string => {
+    switch (setupScreen) {
+      case 'prepare to run':
+        return `0 ${SPACING.spacing32} ${SPACING.spacing40}`
+      case 'offsets':
+        return ''
+      default:
+        return `${SPACING.spacing32} ${SPACING.spacing40} ${SPACING.spacing40}`
+    }
+  }
+
+  return css`
+    flex-direction: ${DIRECTION_COLUMN};
+    padding: ${paddingStyle()};
+  `
 }


### PR DESCRIPTION
Closes [EXEC-1095](https://opentrons.atlassian.net/browse/EXEC-1095)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

New designs utilize the ODD’s full screen as opposed to a modal within a page (current LPC view). This PR refactors LPC by removing the modal and adjusting some CSS to occupy the ODD's entire screen. 

Particular LPC views are not refactored to account for the differences, since these views will soon be overhauled.

https://github.com/user-attachments/assets/75f91c5b-b9ed-42b7-971e-4fb8c74324f8

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
- Verified changes do not adversely impact Legacy Flex LPC flows.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
none, behind ff
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1095]: https://opentrons.atlassian.net/browse/EXEC-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ