### PR TITLE
fix(protocol-designer): fix StepSummary wrapping

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -3,11 +3,14 @@ import { Trans, useTranslation } from 'react-i18next'
 import first from 'lodash/first'
 import flatten from 'lodash/flatten'
 import last from 'lodash/last'
+import styled from 'styled-components'
 import {
   ALIGN_CENTER,
   DIRECTION_COLUMN,
+  DISPLAY_FLEX,
   Flex,
   ListItem,
+  NO_WRAP,
   SPACING,
   StyledText,
   Tag,
@@ -41,15 +44,24 @@ function StyledTrans(props: StyledTransProps): JSX.Element {
     <Flex
       gridGap={SPACING.spacing4}
       alignItems={ALIGN_CENTER}
-      flexWrap={WRAP}
-      wordBreak="break-word"
+      flexWrap={NO_WRAP}
     >
       <Trans
         t={t}
         i18nKey={i18nKey}
         components={{
-          text: <StyledText desktopStyle="bodyDefaultRegular" />,
-          semiBoldText: <StyledText desktopStyle="bodyDefaultSemiBold" />,
+          text: (
+            <StyledText
+              desktopStyle="bodyDefaultRegular"
+              style={{ whiteSpace: 'nowrap' }}
+            />
+          ),
+          semiBoldText: (
+            <StyledText
+              desktopStyle="bodyDefaultSemiBold"
+              style={{ whiteSpace: 'nowrap' }}
+            />
+          ),
           tag: <Tag type="default" text={tagText ?? ''} />,
         }}
         values={values}
@@ -57,7 +69,6 @@ function StyledTrans(props: StyledTransProps): JSX.Element {
     </Flex>
   )
 }
-
 const getWellsForStepSummary = (
   targetWells: string[],
   labwareWells: string[]
@@ -164,63 +175,55 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       } = currentStep
       stepSummaryContent =
         thermocyclerFormType === 'thermocyclerState' ? (
-          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+          <StepSummaryContainer>
             {blockIsActive ? (
               <StyledTrans
                 i18nKey="protocol_steps:thermocycler_module.thermocycler_state.block"
                 tagText={`${blockTargetTemp}${t('application:units.degrees')}`}
               />
             ) : null}
-            <Flex gridGap={SPACING.spacing20} alignItems={ALIGN_CENTER}>
-              {lidIsActive ? (
-                <StyledTrans
-                  i18nKey="protocol_steps:thermocycler_module.thermocycler_state.lid_temperature"
-                  tagText={`${lidTargetTemp}${t('application:units.degrees')}`}
-                />
-              ) : null}
+            {lidIsActive ? (
               <StyledTrans
-                i18nKey="protocol_steps:thermocycler_module.thermocycler_state.lid_position"
-                tagText={t(
-                  `protocol_steps:thermocycler_module.lid_position.${
-                    lidOpen ? 'open' : 'closed'
-                  }`
-                )}
+                i18nKey="protocol_steps:thermocycler_module.thermocycler_state.lid_temperature"
+                tagText={`${lidTargetTemp}${t('application:units.degrees')}`}
               />
-            </Flex>
-          </Flex>
+            ) : null}
+            <StyledTrans
+              i18nKey="protocol_steps:thermocycler_module.thermocycler_state.lid_position"
+              tagText={t(
+                `protocol_steps:thermocycler_module.lid_position.${
+                  lidOpen ? 'open' : 'closed'
+                }`
+              )}
+            />
+          </StepSummaryContainer>
         ) : (
-          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-            <Flex gridGap={SPACING.spacing20}>
-              <StyledTrans
-                i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.volume"
-                tagText={`${profileVolume} ${t(
-                  'application:units.microliter'
-                )}`}
-              />
-              <StyledTrans
-                i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.lid_temperature"
-                tagText={`${profileTargetLidTemp}${t(
-                  'application:units.degrees'
-                )}`}
-              />
-            </Flex>
-            <Flex gridGap={SPACING.spacing20}>
-              <StyledTrans
-                i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.end_hold.block"
-                tagText={`${blockTargetTempHold}${t(
-                  'application:units.degrees'
-                )}`}
-              />
-              <StyledTrans
-                i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.end_hold.lid_position"
-                tagText={t(
-                  `protocol_steps:thermocycler_module.lid_position.${
-                    lidOpenHold ? 'open' : 'closed'
-                  }`
-                )}
-              />
-            </Flex>
-          </Flex>
+          <StepSummaryContainer>
+            <StyledTrans
+              i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.volume"
+              tagText={`${profileVolume} ${t('application:units.microliter')}`}
+            />
+            <StyledTrans
+              i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.lid_temperature"
+              tagText={`${profileTargetLidTemp}${t(
+                'application:units.degrees'
+              )}`}
+            />
+            <StyledTrans
+              i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.end_hold.block"
+              tagText={`${blockTargetTempHold}${t(
+                'application:units.degrees'
+              )}`}
+            />
+            <StyledTrans
+              i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.end_hold.lid_position"
+              tagText={t(
+                `protocol_steps:thermocycler_module.lid_position.${
+                  lidOpenHold ? 'open' : 'closed'
+                }`
+              )}
+            />
+          </StepSummaryContainer>
         )
       break
     }
@@ -383,43 +386,39 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         getModuleDisplayName(modules[heaterShakerModuleId]?.model) ??
         unknownModule
       stepSummaryContent = (
-        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-          <Flex gridGap={SPACING.spacing20} alignItems={ALIGN_CENTER}>
+        <StepSummaryContainer>
+          <StyledTrans
+            i18nKey="protocol_steps:heater_shaker.active.temperature"
+            values={{ module: moduleDisplayName }}
+            tagText={
+              targetHeaterShakerTemperature
+                ? `${targetHeaterShakerTemperature}${t(
+                    'application:units.degrees'
+                  )}`
+                : t('protocol_steps:heater_shaker.active.ambient')
+            }
+          />
+          {targetSpeed ? (
             <StyledTrans
-              i18nKey="protocol_steps:heater_shaker.active.temperature"
-              values={{ module: moduleDisplayName }}
-              tagText={
-                targetHeaterShakerTemperature
-                  ? `${targetHeaterShakerTemperature}${t(
-                      'application:units.degrees'
-                    )}`
-                  : t('protocol_steps:heater_shaker.active.ambient')
-              }
+              i18nKey="protocol_steps:heater_shaker.active.shake"
+              tagText={`${targetSpeed}${t('application:units.rpm')}`}
             />
-            {targetSpeed ? (
-              <StyledTrans
-                i18nKey="protocol_steps:heater_shaker.active.shake"
-                tagText={`${targetSpeed}${t('application:units.rpm')}`}
-              />
-            ) : null}
-          </Flex>
-          <Flex gridGap={SPACING.spacing20}>
-            {heaterShakerTimer ? (
-              <StyledTrans
-                i18nKey="protocol_steps:heater_shaker.active.time"
-                tagText={formatTime(heaterShakerTimer as string)}
-              />
-            ) : null}
+          ) : null}
+          {heaterShakerTimer ? (
             <StyledTrans
-              i18nKey="protocol_steps:heater_shaker.active.latch"
-              tagText={t(
-                latchOpen
-                  ? 'protocol_steps:heater_shaker.latch.open'
-                  : 'protocol_steps:heater_shaker.latch.closed'
-              )}
+              i18nKey="protocol_steps:heater_shaker.active.time"
+              tagText={formatTime(heaterShakerTimer as string)}
             />
-          </Flex>
-        </Flex>
+          ) : null}
+          <StyledTrans
+            i18nKey="protocol_steps:heater_shaker.active.latch"
+            tagText={t(
+              latchOpen
+                ? 'protocol_steps:heater_shaker.latch.open'
+                : 'protocol_steps:heater_shaker.latch.closed'
+            )}
+          />
+        </StepSummaryContainer>
       )
       break
     }
@@ -454,3 +453,10 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
     </Flex>
   ) : null
 }
+
+const StepSummaryContainer = styled.div`
+  display: ${DISPLAY_FLEX};
+  flex-wrap: ${WRAP};
+  gap: ${SPACING.spacing20};
+  row-gap: ${SPACING.spacing4};
+`

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components'
 import {
   ALIGN_CENTER,
   DIRECTION_COLUMN,
-  DISPLAY_FLEX,
   Flex,
   ListItem,
   NO_WRAP,
@@ -53,13 +52,13 @@ function StyledTrans(props: StyledTransProps): JSX.Element {
           text: (
             <StyledText
               desktopStyle="bodyDefaultRegular"
-              style={{ whiteSpace: 'nowrap' }}
+              style={{ whiteSpace: NO_WRAP }}
             />
           ),
           semiBoldText: (
             <StyledText
               desktopStyle="bodyDefaultSemiBold"
-              style={{ whiteSpace: 'nowrap' }}
+              style={{ whiteSpace: NO_WRAP }}
             />
           ),
           tag: <Tag type="default" text={tagText ?? ''} />,
@@ -454,8 +453,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
   ) : null
 }
 
-const StepSummaryContainer = styled.div`
-  display: ${DISPLAY_FLEX};
+const StepSummaryContainer = styled(Flex)`
   flex-wrap: ${WRAP};
   gap: ${SPACING.spacing20};
   row-gap: ${SPACING.spacing4};


### PR DESCRIPTION
# Overview

This PR fixes the wrapping behavior for StepSummary elements. Each component (StyledTrans) of the StepSummary should wrap to the next line dynamically, not have a pre-defined row.

Closes RQA-3698

## Test Plan and Hands on Testing

- create thermocycler / heater shaker steps with a lot of settings turned on (profile, temperature, shake speed, latch/lid)
- hover or single-click the step to view its step summary
- verify that the step summary components wrap as expected
<img width="816" alt="Screenshot 2025-01-31 at 2 58 07 PM" src="https://github.com/user-attachments/assets/32054c06-98fc-4966-a9c3-ac397e7458a6" />
<img width="760" alt="Screenshot 2025-01-31 at 2 57 31 PM" src="https://github.com/user-attachments/assets/565b37ec-eb43-4339-a722-81d91a2d671b" />

## Changelog

- update step summary styles and add new container for handling wrapping

## Review requests

- see test plan

## Risk assessment

low