### PR TITLE
feat(protocol-designer): create Export python feature flag

### DIFF
--- a/protocol-designer/src/assets/localization/en/feature_flags.json
+++ b/protocol-designer/src/assets/localization/en/feature_flags.json
@@ -35,5 +35,9 @@
   "OT_PD_ENABLE_TIMELINE_SCRUBBER": {
     "title": "Enable timeline scrubber",
     "description": "See the protocol timeline visualization in overview"
+  },
+  "OT_PD_ENABLE_PYTHON_EXPORT": {
+    "title": "Enable exporting python",
+    "description": "Enables the ability to export python for pd/python interop"
   }
 }

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -32,6 +32,8 @@ const initialFlags: Flags = {
     process.env.OT_PD_ENABLE_LIQUID_CLASSES === '1' || false,
   OT_PD_ENABLE_TIMELINE_SCRUBBER:
     process.env.OT_PD_ENABLE_TIMELINE_SCRUBBER === '1' || false,
+  OT_PD_ENABLE_PYTHON_EXPORT:
+    process.env.OT_PD_ENABLE_PYTHON_EXPORT === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -49,3 +49,7 @@ export const getEnableTimelineScrubber: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_TIMELINE_SCRUBBER ?? false
 )
+export const getEnablePythonExport: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_PYTHON_EXPORT ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -38,6 +38,7 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_REACT_SCAN'
   | 'OT_PD_ENABLE_LIQUID_CLASSES'
   | 'OT_PD_ENABLE_TIMELINE_SCRUBBER'
+  | 'OT_PD_ENABLE_PYTHON_EXPORT'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',
@@ -52,5 +53,6 @@ export const allFlags: FlagTypes[] = [
   'OT_PD_ENABLE_REACT_SCAN',
   'OT_PD_ENABLE_LIQUID_CLASSES',
   'OT_PD_ENABLE_TIMELINE_SCRUBBER',
+  'OT_PD_ENABLE_PYTHON_EXPORT',
 ]
 export type Flags = Partial<Record<FlagTypes, boolean | null | undefined>>

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -28,7 +28,10 @@ import {
 import { selectors as fileSelectors } from '../../file-data'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { actions as loadFileActions } from '../../load-file'
-import { getEnableTimelineScrubber } from '../../feature-flags/selectors'
+import {
+  getEnablePythonExport,
+  getEnableTimelineScrubber,
+} from '../../feature-flags/selectors'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import { MaterialsListModal } from '../../organisms/MaterialsListModal'
 import { LINE_CLAMP_TEXT_STYLE, COLUMN_STYLE } from '../../atoms'
@@ -81,6 +84,7 @@ export function ProtocolOverview(): JSX.Element {
     showEditInstrumentsModal,
     setShowEditInstrumentsModal,
   ] = useState<boolean>(false)
+  const enablePythonExport = useSelector(getEnablePythonExport)
   const enableTimelineScrubber = useSelector(getEnableTimelineScrubber)
   const [showEditMetadataModal, setShowEditMetadataModal] = useState<boolean>(
     false
@@ -295,6 +299,21 @@ export function ProtocolOverview(): JSX.Element {
               whiteSpace={NO_WRAP}
               height="3.5rem"
             />
+            {enablePythonExport ? (
+              <LargeButton
+                buttonType="stroke"
+                buttonText="Export python"
+                onClick={() => {
+                  console.log('wire this up')
+                }}
+                whiteSpace={NO_WRAP}
+                height="3.5rem"
+                iconName="arrow-right"
+                css={css`
+                  border: 2px solid ${COLORS.blue50};
+                `}
+              />
+            ) : null}
           </Flex>
         </Flex>
         <Flex gridGap={SPACING.spacing80} flexWrap={WRAP}>


### PR DESCRIPTION
closes AUTH-1393

# Overview

Create a feature flag for exporting python and adds a button to the overview page thats hidden behind the feature flag

## Test Plan and Hands on Testing

launch the PD dev environment or sandbox
type in `enablePreleaseMode()` in devtools console
refresh the page
click on the settings page
toggle "Enable exporting python"
create a protocol and see on the overview page that the button shows up

<img width="1392" alt="Screenshot 2025-02-03 at 09 32 31" src="https://github.com/user-attachments/assets/3e208121-bb1e-409f-ae1b-b63a3073abc5" />


## Changelog

create feature flag
wire up feature flag selector to overview page and add a button hidden behind ff

## Risk assessment

low, behind ff
