### PR TITLE
chore(release): internal release notes 2.4.0-alpha.0

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -2,11 +2,11 @@ For more details about this release, please see the full [technical change log][
 
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
-## Internal Release 2.4.0-alpha.1
+## Internal Release 2.4.0-alpha.0
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.4.0. It's for internal testing only.
 
-### New Stuff In This Release (list in progress):
+### New Stuff In This Release (list in progress)
 
 - Python API version bumped to 2.23
 - Added liquid classes and new transfer functions

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,6 +1,10 @@
 For more details about this release, please see the full [technical changelog][].
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.4.0-alpha.0
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.4.0. It's for internal testing only.
+
 ## Internal Release 2.3.0-alpha.2
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.3.0. It's for internal testing only.


### PR DESCRIPTION
## Notes for Internal Release `2.4.0-alpha.0`

Thank you @sanni-t for getting these in.

A bit of cleanup.