### PR TITLE
docs(api): clarify in docs that Well.has_tip checks only for clean tips

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -117,8 +117,13 @@ class Well:
     @property
     @requires_version(2, 0)
     def has_tip(self) -> bool:
-        """Whether this well contains a tip. Always ``False`` if the parent labware
-        isn't a tip rack."""
+        """Whether this well contains a clean tip.
+
+        From API v2.2 on: Returns ``False`` if the well has an unclean tip.
+        Before API v2.2: Returns ``True`` as long as the well has a tip, even if it is unclean.
+
+        Always ``False`` if the parent labware isn't a tip rack.
+        """
         return self._core.has_tip()
 
     @has_tip.setter

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -120,12 +120,16 @@ class Well:
         """Whether this well contains an unused tip.
 
         From API v2.2 on:
+
         - Returns ``False`` if:
-            - the well has no tip present or
-            - the well has a tip that's been used by the protocol previously.
+
+          - the well has no tip present, or
+          - the well has a tip that's been used by the protocol previously
+
         - Returns ``True`` if the well has an unused tip.
 
         Before API v2.2:
+
         - Returns ``True`` as long as the well has a tip, even if it is used.
 
         Always ``False`` if the parent labware isn't a tip rack.

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -117,10 +117,16 @@ class Well:
     @property
     @requires_version(2, 0)
     def has_tip(self) -> bool:
-        """Whether this well contains a clean tip.
+        """Whether this well contains an unused tip.
 
-        From API v2.2 on: Returns ``False`` if the well has an unclean tip.
-        Before API v2.2: Returns ``True`` as long as the well has a tip, even if it is unclean.
+        From API v2.2 on:
+        - Returns ``False`` if:
+            - the well has no tip present or
+            - the well has a tip that's been used by the protocol previously.
+        - Returns ``True`` if the well has an unused tip.
+
+        Before API v2.2:
+        - Returns ``True`` as long as the well has a tip, even if it is used.
 
         Always ``False`` if the parent labware isn't a tip rack.
         """


### PR DESCRIPTION
Closes RQA-3790

# Overview

`Well.has_tip` property has been checking for only clean tips since API v2.2 but the docstrings don't mention that. That has understandably caused some confusion in protocol behaviors. This PR helps mitigate that issue by clarifying the exact behavior of this property

## Review requests

Is the language clear enough?

## Risk assessment

None.
