### PR TITLE
feat(protocol-designer): introduce new -locationUpdates

### DIFF
--- a/protocol-designer/cypress/support/import.ts
+++ b/protocol-designer/cypress/support/import.ts
@@ -104,6 +104,7 @@ export const migrateAndMatchSnapshot = ({
         savedFile.designerApplication.version as string
       )
       assert(version !== null, 'PD version is not valid semver')
+      const isBelowVersion850 = semver.lt(version ?? '', '8.5.0')
 
       const files = [savedFile, expectedFile]
       files.forEach(f => {
@@ -111,25 +112,43 @@ export const migrateAndMatchSnapshot = ({
         f.designerApplication.data._internalAppBuildDate = 'Foo Date'
         f.designerApplication.version = 'x.x.x'
 
-        Object.values(
-          f.designerApplication.data.savedStepForms as Record<string, unknown>
-        ).forEach(stepForm => {
-          const stepFormTyped = stepForm as {
-            stepType: string
-            dropTip_location?: string
-            blowout_location?: string
+        const savedStepForms = f.designerApplication.data.savedStepForms
+        const initialDeckSetupStep = '__INITIAL_DECK_SETUP_STEP__'
+
+        //  a uuid is randomly generated each time you upload a protocol that is less than version 8_5_0
+        //  which is the migration version that adds these keys. Due to this, we need to ignore
+        //  the uuids
+        if (savedStepForms[initialDeckSetupStep] && isBelowVersion850) {
+          savedStepForms[initialDeckSetupStep].trashBinLocationUpdate = {
+            trashBin: 'trashLocation',
           }
-          if (stepFormTyped.stepType === 'moveLiquid') {
-            stepFormTyped.dropTip_location = 'trash drop tip location'
-            if (stepFormTyped.blowout_location?.includes('trashBin') ?? false) {
+          savedStepForms[initialDeckSetupStep].gripperLocationUpdate = {
+            gripper: 'gripperLocation',
+          }
+        }
+
+        Object.values(savedStepForms as Record<string, unknown>).forEach(
+          stepForm => {
+            const stepFormTyped = stepForm as {
+              stepType: string
+              dropTip_location?: string
+              blowout_location?: string
+            }
+            if (stepFormTyped.stepType === 'moveLiquid') {
+              stepFormTyped.dropTip_location = 'trash drop tip location'
+              if (
+                stepFormTyped.blowout_location?.includes('trashBin') ??
+                false
+              ) {
+                stepFormTyped.blowout_location = 'trash blowout location'
+              }
+            }
+            if (stepFormTyped.stepType === 'mix') {
+              stepFormTyped.dropTip_location = 'trash drop tip location'
               stepFormTyped.blowout_location = 'trash blowout location'
             }
           }
-          if (stepFormTyped.stepType === 'mix') {
-            stepFormTyped.dropTip_location = 'trash drop tip location'
-            stepFormTyped.blowout_location = 'trash blowout location'
-          }
-        })
+        )
 
         f.commands.forEach((command: { key: string }) => {
           if ('key' in command) command.key = '123'

--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -34,10 +34,10 @@
       "ingredients": {
         "0": {
           "displayName": "Water",
+          "displayColor": "#b925ff",
           "description": null,
-          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "displayColor": "#b925ff"
+          "liquidGroupId": "0"
         }
       },
       "ingredLocations": {

--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Fixture",
     "description": "Test all v3 commands",
     "created": 1585930833548,
-    "lastModified": 1738157114365,
+    "lastModified": 1738682273658,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Wed, 29 Jan 2025 13:23:47 GMT",
+      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:16:30 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -34,10 +34,10 @@
       "ingredients": {
         "0": {
           "displayName": "Water",
-          "displayColor": "#b925ff",
           "description": null,
+          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "liquidGroupId": "0"
+          "displayColor": "#b925ff"
         }
       },
       "ingredLocations": {
@@ -135,6 +135,12 @@
           "pipetteLocationUpdate": {
             "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
           },
+          "trashBinLocationUpdate": {
+            "bcdf4269-85da-4293-aeb6-bc7eddce6ecf:trashBin": "cutout12"
+          },
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {},
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
         },
@@ -162,7 +168,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "64e49cf0-e3d6-4da3-966f-a3da759c57b8:trashBin",
+          "blowout_location": "bcdf4269-85da-4293-aeb6-bc7eddce6ecf:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_airGap_checkbox": false,
@@ -187,7 +193,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "20",
-          "dropTip_location": "64e49cf0-e3d6-4da3-966f-a3da759c57b8:trashBin",
+          "dropTip_location": "bcdf4269-85da-4293-aeb6-bc7eddce6ecf:trashBin",
           "nozzles": null,
           "path": "multiDispense",
           "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
@@ -228,13 +234,13 @@
           "aspirate_flowRate": 40,
           "blowout_checkbox": true,
           "blowout_flowRate": 46.43,
-          "blowout_location": "64e49cf0-e3d6-4da3-966f-a3da759c57b8:trashBin",
+          "blowout_location": "bcdf4269-85da-4293-aeb6-bc7eddce6ecf:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": 35,
-          "dropTip_location": "64e49cf0-e3d6-4da3-966f-a3da759c57b8:trashBin",
+          "dropTip_location": "bcdf4269-85da-4293-aeb6-bc7eddce6ecf:trashBin",
           "labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
           "mix_mmFromBottom": 0.5,
           "mix_touchTip_checkbox": true,
@@ -2618,7 +2624,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "3bed79e7-58b0-44f7-b69b-f6bbfca92050",
+      "key": "6419176b-cd87-4854-81de-ff98c98e02ff",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p300_single_gen2",
@@ -2627,7 +2633,7 @@
       }
     },
     {
-      "key": "4dde1dc9-5acc-472b-a31c-bde389335fa6",
+      "key": "65aef24f-726a-48de-8791-171484462a98",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Tip Rack 300 µL",
@@ -2641,7 +2647,7 @@
       }
     },
     {
-      "key": "224b643f-b209-4d3f-99c4-c277ea89bc8f",
+      "key": "c40e41be-86b5-4895-a9d5-83d3e433085f",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -2655,7 +2661,7 @@
       }
     },
     {
-      "key": "a4e63613-8f60-4bc7-bb1e-112564d35720",
+      "key": "bbeda67b-78da-4797-89a3-7f8cd1c62af5",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
@@ -2670,7 +2676,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "c820e00d-268f-4d4c-86ee-cdd27b529efc",
+      "key": "8bfed0bd-7ea5-4d38-a51e-e8e4ada4a2c5",
       "params": {
         "liquidId": "0",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2696,7 +2702,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "243817c3-d196-48ca-b644-2869c8831be8",
+      "key": "7790203c-558f-41b2-b9e3-51945c332c46",
       "params": {
         "seconds": 62,
         "message": ""
@@ -2704,7 +2710,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "d9a2045f-f90d-4f38-9853-48ccee28ae19",
+      "key": "21ecac03-c066-4533-bba7-0c5565022cc1",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2713,7 +2719,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "cd570d0a-52d3-4c05-be48-951c0c697a70",
+      "key": "7e76d464-1033-44fe-a4c1-7c6eb162f087",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2732,7 +2738,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1324b2c8-7000-4eb5-bb99-8044e5d2d4a1",
+      "key": "e6e1b4e9-e957-424c-899a-12e0d6225812",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2751,7 +2757,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d6fc2391-2fce-4757-841e-b812a0ca7cbd",
+      "key": "0f7fdf60-f57b-4ddc-8812-de968ac82f1a",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2770,7 +2776,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0e182daa-bba3-4709-94a2-c09cadf77049",
+      "key": "43933543-902f-47e9-9f5f-58c13c404913",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2789,7 +2795,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8e66053b-fea4-4ac1-9509-23dd7371678b",
+      "key": "8144319f-d13a-4bce-bab3-778fd104bc7e",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 100,
@@ -2808,7 +2814,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "39c918f8-615c-4a0d-99b7-d5439942ced3",
+      "key": "e3dfde52-41fe-41e0-939a-74de6032ae1a",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2823,7 +2829,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5f583194-0869-4fc9-93f7-bc07580ff7ba",
+      "key": "98ea90df-2a74-4fdc-934e-98101d3a1b8a",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 40,
@@ -2842,7 +2848,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "670e4b7e-c246-4fba-8f76-490d0064f8e7",
+      "key": "7260abd2-176c-4893-8df5-2c8027d9b00d",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
@@ -2857,7 +2863,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "40cfe456-331b-43d8-bee0-1806d93b45a2",
+      "key": "05cd3ff2-9057-40b1-93ce-00aea1817b98",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 40,
@@ -2876,7 +2882,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "b8335845-cabd-4af1-ab1b-1379c7bcd62b",
+      "key": "6632555e-36f1-48dd-98ce-36304ff52769",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
@@ -2891,7 +2897,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "c1d8d6b9-1a62-456f-8ca5-c4f21b3af4f3",
+      "key": "44dfa5fa-72bf-4ff7-a15a-7eb28641d6fa",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2904,7 +2910,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "8352e715-668b-4f80-aa35-0d2776137243",
+      "key": "46471c16-ca43-4756-a2c0-aac770de55af",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -2912,7 +2918,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "79c8d331-5c79-4f03-b8c5-4dc4b3315546",
+      "key": "46b7a955-be07-4d7b-be96-390cecc365de",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2926,21 +2932,21 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "52ee7e0d-ccb4-4e1e-b706-0ee8f9037bcb",
+      "key": "36a530a3-7a1c-4a93-8096-62e627866160",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "waitForResume",
-      "key": "add4e276-fc31-4b72-a3c5-612506159a10",
+      "key": "d326737f-cbea-478a-ada0-9f203daf4b25",
       "params": {
         "message": "Wait until user intervention"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "c3ced120-cd18-4abf-9e89-0cacea5a5da6",
+      "key": "6f000bcb-b2d0-4064-a68f-71760550bd06",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2949,7 +2955,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "cc110c4c-0d07-4373-919a-7941b288a0f8",
+      "key": "40646531-5cc5-4cf6-a0d0-21a5ce517ce9",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -2968,7 +2974,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "61d7a6ed-1fb7-4c5f-b8c0-b8a02385a9a5",
+      "key": "58d50ea9-5ec1-4b21-ba19-f0ba8d3d420b",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -2987,7 +2993,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1e1174dd-f3e9-446a-9e3d-46c68958487d",
+      "key": "6e151ed2-4cc1-4be3-ad2c-32457158e267",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3006,7 +3012,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "fc92a66c-c81d-4645-9761-17b82eace5ca",
+      "key": "9fedc83e-e57e-40ff-9c38-13d83c803bba",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3025,7 +3031,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d5ae7a38-aa11-47ea-a3a9-72dcc81bbed3",
+      "key": "c1815836-420a-425d-8a55-3615b34e99ea",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3044,7 +3050,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "96411ac4-fe34-4d79-8197-69be37727d22",
+      "key": "0cacce9a-e295-489e-a4a9-b02a06f7110e",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3063,7 +3069,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "2c6a94b7-ded9-4613-8440-07d61d1aeab9",
+      "key": "cdc11c6e-25ab-4829-bef8-3081c5dc7de9",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3076,7 +3082,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "388ff506-8805-43c4-a28d-fdb1d71af2d6",
+      "key": "b19f51af-7b62-4943-94f7-e7a9d8126ca8",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -3084,7 +3090,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "e5af286f-12fb-4f6a-9ce9-fdc4a2e630df",
+      "key": "00297047-f664-4682-8b60-d0ff5b7fa2d5",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3099,7 +3105,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "e2e64d0a-98f7-44b2-a30e-55f947ce383b",
+      "key": "60374221-4dae-45fc-9571-30981f3e54e3",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3113,14 +3119,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "c66dab4c-5675-468f-a202-be5136e26d97",
+      "key": "f4ed4d99-695e-4c33-b451-c96b3a8fe6f8",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "9b0ee879-5d40-44b4-b8d6-7de4dc308448",
+      "key": "2d3f2caa-2b46-450e-a5bd-ab8d2f5a1b61",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -3129,7 +3135,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "59c5aff6-b946-4846-84a3-68701edbd869",
+      "key": "1405face-d940-42a8-aa3d-c3dcfdf9f819",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3148,7 +3154,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4b1e2446-55b0-4503-8528-c446066b8f95",
+      "key": "6e29b113-6ffc-4b92-b7c9-f6639ba502ff",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3167,7 +3173,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1454a903-58ab-401b-ba6e-682ee6144051",
+      "key": "4fa89603-362f-4526-b19a-9e8cb1c2cf9f",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3186,7 +3192,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "b0f636be-6cce-4d2d-8526-51c80ed8fbe1",
+      "key": "dc862f46-d111-44e8-aeec-b8e55bba3271",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3205,7 +3211,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c2ad1175-0a40-4982-9fa9-1354744ca6d4",
+      "key": "6fb0201b-6839-44ce-86b6-c384cd763c9b",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3224,7 +3230,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d1147be5-d627-48ca-97a9-c92e643b313a",
+      "key": "f6b42a01-340b-43f7-b9fa-25cc68612df2",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3243,7 +3249,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "563170a0-0e79-4992-8f1c-830653392ef7",
+      "key": "48da44e2-869a-4af8-9001-d165a3b86b0e",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3256,7 +3262,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "40f0e993-5b4b-4d9e-b9df-a7ef8a3bdf9b",
+      "key": "b1181ea5-9121-4bde-a3f4-fc67f4059aa6",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -3264,7 +3270,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "19a60b57-c610-4df1-88a2-5259038b3687",
+      "key": "f102022c-8365-490f-a7e4-cbc11395bd57",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3279,7 +3285,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "f703c506-0bf4-4736-9790-7eab435672ae",
+      "key": "750b4051-6a23-4c0b-b999-e68a1d9285fd",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3293,7 +3299,7 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "49ded239-d74e-4a3f-944d-0b307cfa3de1",
+      "key": "4b4dcf1d-59e7-4691-aa73-9a159c72cd74",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -34,10 +34,10 @@
       "ingredients": {
         "0": {
           "displayName": "Water",
+          "displayColor": "#b925ff",
           "description": null,
-          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "displayColor": "#b925ff"
+          "liquidGroupId": "0"
         }
       },
       "ingredLocations": {

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Fixture",
     "description": "Test all v4 commands",
     "created": 1585930833548,
-    "lastModified": 1738157148111,
+    "lastModified": 1738682299723,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Wed, 29 Jan 2025 13:23:47 GMT",
+      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:16:30 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -34,10 +34,10 @@
       "ingredients": {
         "0": {
           "displayName": "Water",
-          "displayColor": "#b925ff",
           "description": null,
+          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "liquidGroupId": "0"
+          "displayColor": "#b925ff"
         }
       },
       "ingredLocations": {
@@ -138,6 +138,12 @@
           "pipetteLocationUpdate": {
             "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
           },
+          "trashBinLocationUpdate": {
+            "8c280499-46f1-4a7c-9096-553e87fe9d1e:trashBin": "cutout12"
+          },
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {},
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
         },
@@ -194,7 +200,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "9bf036e9-ccfd-4732-80bc-d366731ce6d1:trashBin",
+          "blowout_location": "8c280499-46f1-4a7c-9096-553e87fe9d1e:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_airGap_checkbox": false,
@@ -219,7 +225,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "20",
-          "dropTip_location": "9bf036e9-ccfd-4732-80bc-d366731ce6d1:trashBin",
+          "dropTip_location": "8c280499-46f1-4a7c-9096-553e87fe9d1e:trashBin",
           "nozzles": null,
           "path": "single",
           "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
@@ -2640,7 +2646,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "8f11bef2-009b-4a4d-99f3-7c710ada996b",
+      "key": "f18c57de-1196-4656-9149-6f8f519ded50",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p300_single_gen2",
@@ -2649,7 +2655,7 @@
       }
     },
     {
-      "key": "9a510ad2-a606-4227-86e5-14635f3ec519",
+      "key": "f659bbae-c163-4770-ba70-94d779944e3e",
       "commandType": "loadModule",
       "params": {
         "model": "magneticModuleV2",
@@ -2660,7 +2666,7 @@
       }
     },
     {
-      "key": "c98334f7-8f68-4f0b-9ff3-d98a85764e19",
+      "key": "211b1d23-4554-4fcb-9053-9b7620f3370a",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -2671,7 +2677,7 @@
       }
     },
     {
-      "key": "692d8775-0de4-472c-9e1a-0a7458e6c080",
+      "key": "02c8120e-ca2c-4fa2-a48c-0bf29c82d552",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Tip Rack 300 µL",
@@ -2685,7 +2691,7 @@
       }
     },
     {
-      "key": "2f354149-0585-4fe6-ac4d-571e5d020f9a",
+      "key": "692d6fc7-be48-40ae-8b96-46a6ae939af3",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -2699,7 +2705,7 @@
       }
     },
     {
-      "key": "e873508f-7a6b-472a-88cc-4d83a0d9d303",
+      "key": "e96ea68c-e1e6-43f2-a4b2-213372f41623",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
@@ -2714,7 +2720,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "0a0b8038-bf92-4829-9d3b-cd6e950aafd1",
+      "key": "8e9bdf50-5ef7-451f-9d0e-95015241fc6e",
       "params": {
         "liquidId": "0",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2740,7 +2746,7 @@
     },
     {
       "commandType": "magneticModule/engage",
-      "key": "7d74d316-4910-4827-836e-bb211eb6f9f0",
+      "key": "77b1d364-2ab1-4a4e-8fae-a9ecf4b88323",
       "params": {
         "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType",
         "height": 6
@@ -2748,7 +2754,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "200de5f5-905a-4ea8-b48f-95b748597b56",
+      "key": "11956c88-bcad-4580-9036-869cc86a7b6b",
       "params": {
         "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
         "celsius": 25
@@ -2756,7 +2762,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "93982f84-7c02-4609-aac0-916c85341221",
+      "key": "c9520683-6f9d-44ae-b158-3f5de7b1a4b5",
       "params": {
         "seconds": 62,
         "message": ""
@@ -2764,7 +2770,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "8336f57c-7e0d-41a7-b4a7-d76b6436c073",
+      "key": "56cecd58-ca52-433d-aa71-98d59558d388",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2773,7 +2779,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c7ada14a-1730-4237-9a6a-b9c9659cc70a",
+      "key": "e5f246a4-3ebf-4f73-99c9-2a69ad19f4bc",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2792,7 +2798,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "cb1db2cb-2901-4fac-9953-84227b284de9",
+      "key": "fb1f0bb6-8f12-4662-be15-7e8d49368112",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2811,7 +2817,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "3b131455-38d8-4657-a72a-154e3e2e79c9",
+      "key": "321568ae-8d86-4c60-9ff3-2af0e73b6ab1",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2825,14 +2831,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "7fbc3b35-82c0-4db1-83ba-f079d1b6f8a7",
+      "key": "d432d161-9da6-462d-a757-196de673d3d4",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "8facdb58-99b9-4838-8276-7c0e834ec587",
+      "key": "1fd1fdbf-592a-43f4-99ad-b1e5c3b1feab",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2841,7 +2847,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "3284fa14-23dd-40c2-8e93-74ccd0ebb309",
+      "key": "8af4e21b-c9da-4dc9-b033-3f2ae823fa4c",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2860,7 +2866,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f713e4a5-f9f0-4814-8856-c606f88d26e1",
+      "key": "6b4526b1-4738-4600-9920-53881f0735c8",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2879,7 +2885,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "b05b8e43-b996-49d3-b5fe-0197a66783e9",
+      "key": "0510a4d6-796d-4917-8a2f-f26a19078091",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2893,14 +2899,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "dc46cc37-9c1b-4da3-b8fc-60fff04b758c",
+      "key": "69bac7a6-d8a0-4674-9b7f-5b8b0174d765",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "temperatureModule/waitForTemperature",
-      "key": "d71653aa-0905-4d08-aa6c-661389fee829",
+      "key": "d58f0651-b95c-4997-a06d-017fab7c27e4",
       "params": {
         "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
         "celsius": 25
@@ -2908,14 +2914,14 @@
     },
     {
       "commandType": "magneticModule/disengage",
-      "key": "a156c1ba-2508-46b5-8318-f735bb8b42bb",
+      "key": "92a4f6f7-521f-42d7-aa0a-c8553fc11333",
       "params": {
         "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType"
       }
     },
     {
       "commandType": "waitForResume",
-      "key": "c53a9aa2-c092-45d5-b427-2f2c6c7c9b8b",
+      "key": "df776ec4-c8ef-416b-be42-1b2ea7ef51bc",
       "params": {
         "message": "Wait until user intervention"
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -37,17 +37,17 @@
       "ingredients": {
         "0": {
           "displayName": "Water",
+          "displayColor": "#b925ff",
           "description": null,
-          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "displayColor": "#b925ff"
+          "liquidGroupId": "0"
         },
         "1": {
           "displayName": "Samples",
+          "displayColor": "#ffd600",
           "description": null,
-          "liquidGroupId": "1",
           "pythonName": "liquid_2",
-          "displayColor": "#ffd600"
+          "liquidGroupId": "1"
         }
       },
       "ingredLocations": {

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1689346890165,
-    "lastModified": 1738157178084,
+    "lastModified": 1738682341234,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Wed, 29 Jan 2025 13:23:47 GMT",
+      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:16:30 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -37,17 +37,17 @@
       "ingredients": {
         "0": {
           "displayName": "Water",
-          "displayColor": "#b925ff",
           "description": null,
+          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "liquidGroupId": "0"
+          "displayColor": "#b925ff"
         },
         "1": {
           "displayName": "Samples",
-          "displayColor": "#ffd600",
           "description": null,
+          "liquidGroupId": "1",
           "pythonName": "liquid_2",
-          "liquidGroupId": "1"
+          "displayColor": "#ffd600"
         }
       },
       "ingredLocations": {
@@ -119,6 +119,14 @@
           "pipetteLocationUpdate": {
             "2e7c6344-58ab-465c-b542-489883cb63fe": "left",
             "6d1e53c3-2db3-451b-ad60-3fe13781a193": "right"
+          },
+          "trashBinLocationUpdate": {
+            "302cf064-0438-4a62-9ce5-a80556c04cf2:trashBin": "cutoutA3"
+          },
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {
+            "08c02e37-4783-4c70-89bd-1f72ddb37a37:gripper": "mounted"
           },
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
@@ -211,7 +219,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "ba8cacad-80e9-4cb8-b16e-12a5dc3669f0:trashBin",
+          "blowout_location": "302cf064-0438-4a62-9ce5-a80556c04cf2:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_airGap_checkbox": false,
@@ -236,7 +244,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "100",
-          "dropTip_location": "ba8cacad-80e9-4cb8-b16e-12a5dc3669f0:trashBin",
+          "dropTip_location": "302cf064-0438-4a62-9ce5-a80556c04cf2:trashBin",
           "nozzles": null,
           "path": "single",
           "pipette": "2e7c6344-58ab-465c-b542-489883cb63fe",
@@ -255,13 +263,13 @@
           "aspirate_flowRate": null,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "ba8cacad-80e9-4cb8-b16e-12a5dc3669f0:trashBin",
+          "blowout_location": "302cf064-0438-4a62-9ce5-a80556c04cf2:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": null,
-          "dropTip_location": "ba8cacad-80e9-4cb8-b16e-12a5dc3669f0:trashBin",
+          "dropTip_location": "302cf064-0438-4a62-9ce5-a80556c04cf2:trashBin",
           "labware": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
           "mix_mmFromBottom": 0.5,
           "mix_touchTip_checkbox": false,
@@ -3867,7 +3875,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "086f94d9-065f-4c44-8006-caf80b83783c",
+      "key": "f265d7a8-ea31-479c-8908-2e14bb0c9bd6",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -3876,7 +3884,7 @@
       }
     },
     {
-      "key": "505163b8-41fd-4983-93a7-be71a7d6ae9c",
+      "key": "91f878d6-9229-4f2f-94d1-3d7ee7e9f698",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_multi_flex",
@@ -3885,7 +3893,7 @@
       }
     },
     {
-      "key": "aec18895-04b5-4fef-a696-77741e3aea42",
+      "key": "63f60970-b543-4c00-a945-957a7c4c2be3",
       "commandType": "loadModule",
       "params": {
         "model": "magneticBlockV1",
@@ -3896,7 +3904,7 @@
       }
     },
     {
-      "key": "f36b8ebe-0c9b-41bc-a1c0-eb754f7648f2",
+      "key": "789473a8-de30-4530-852d-ad88c445ed8c",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -3907,7 +3915,7 @@
       }
     },
     {
-      "key": "8db7cf16-2bf4-404d-9112-08c448797f28",
+      "key": "9fa18898-60a7-4773-8977-545029d36c0d",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -3918,7 +3926,7 @@
       }
     },
     {
-      "key": "cfe53e87-ab1d-487a-b48c-d7ae8f82da0f",
+      "key": "2beee7c0-d00b-4e41-b301-881c2fb5cc1b",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -3929,7 +3937,7 @@
       }
     },
     {
-      "key": "625d5aa2-3b3e-4eea-8255-906705b30f56",
+      "key": "68412459-534c-461f-a207-d728cec975ae",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
@@ -3943,7 +3951,7 @@
       }
     },
     {
-      "key": "01f439b9-bd14-4b2a-829a-04dc59532b28",
+      "key": "5bcbacbc-5cca-4bf9-805c-25c164337ac8",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Filter Tip Rack 50 µL",
@@ -3957,7 +3965,7 @@
       }
     },
     {
-      "key": "ce2c9a52-8e8c-4499-a9f4-28d875310ddc",
+      "key": "1ce1022c-ecca-4cc9-bf5f-160f5bd31798",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -3971,7 +3979,7 @@
       }
     },
     {
-      "key": "8e919382-c46f-4715-8acc-3e89d9ad20da",
+      "key": "ddcf60bc-f272-4cc5-9e47-9bcac0e99991",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap",
@@ -3985,7 +3993,7 @@
       }
     },
     {
-      "key": "e3c83855-cea3-4c64-9a83-4569d7ec6c1c",
+      "key": "6f98dbb8-15f2-4fe1-bde1-4e5964e610e8",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 200 µL Flat",
@@ -4000,7 +4008,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "4e2f124b-fdbd-4468-b13f-ff623614c7d5",
+      "key": "0f2a8671-36fc-47a4-a82b-30c740665573",
       "params": {
         "liquidId": "1",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4011,7 +4019,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "d1b5d49e-0c3a-4fcf-8908-d5683f62ef8d",
+      "key": "b282401a-e28e-4f5c-a6ec-506cedfa3eb5",
       "params": {
         "liquidId": "0",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4029,7 +4037,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "92fc9b4c-1952-447a-a6fa-d3f8c572f74c",
+      "key": "eb2202f7-0004-47ff-9b37-2b914259d64b",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType",
         "celsius": 4
@@ -4037,7 +4045,7 @@
     },
     {
       "commandType": "heaterShaker/waitForTemperature",
-      "key": "a0a69251-318f-42df-953f-de79a0caf8c7",
+      "key": "dc7697a9-0490-4327-a4e0-0d2268cee8a8",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "celsius": 4
@@ -4045,14 +4053,14 @@
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "86747e7e-5adf-4739-8372-da00fd6081f0",
+      "key": "fa3191c0-243e-4b4c-bf7f-6bb16e6626fc",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetLidTemperature",
-      "key": "2c00f180-7898-461e-a7a2-d087e92812bb",
+      "key": "b9d2da30-cf26-41a6-8946-d2c70323ef91",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "celsius": 40
@@ -4060,14 +4068,14 @@
     },
     {
       "commandType": "thermocycler/waitForLidTemperature",
-      "key": "64440fd5-a728-4ad3-b5ac-8f952d0f6a10",
+      "key": "3f3acf32-7d90-4a54-b20f-55ebf801519b",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/runProfile",
-      "key": "b5b4ff79-43a7-4ff5-91a1-fdc9e481190a",
+      "key": "b22bef2a-43d2-45da-ac7c-1f536ef436c6",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "profile": [
@@ -4085,28 +4093,28 @@
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "4105ee32-8759-4410-b87f-15d19fa555dd",
+      "key": "658817ba-e619-4a4b-9869-08d7b65b9c3f",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateLid",
-      "key": "7b8c3e27-58d7-4385-a1e9-3e4353b6c837",
+      "key": "84525785-eac5-49a8-a651-b1c41694bc8d",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "155179f3-86a7-4588-ade0-7f68fe5f0254",
+      "key": "aba48bb7-787f-45a2-a168-b0152b4ef8dd",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "4460ed34-d392-47ec-acc1-be1b1193282e",
+      "key": "bbe616eb-f6b9-41d5-b493-6b0c41a39571",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4115,7 +4123,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "5d23683a-9a8b-4e0f-a934-faf55d04e62b",
+      "key": "9888f41d-7b3d-430d-8559-449bfa6040d2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4134,7 +4142,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2ce5f9af-f4d3-4467-92f1-4a748db40c60",
+      "key": "3aaaeb62-8ff0-4a8c-9373-53bf404f37db",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4153,7 +4161,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "a6c0a9ba-3986-4c58-9423-30d802dc7aa4",
+      "key": "23d49cfb-0387-415b-9d03-c6f67d5448d7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4167,14 +4175,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0e93144b-9c3d-4444-b69e-a2aa5a731886",
+      "key": "fc7a5edf-6500-4a65-ad28-72d0ce576d8b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "5a636309-7090-49fc-8630-c1d00b014427",
+      "key": "c922a053-4b6f-4526-9447-42d907785d0e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4183,7 +4191,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "dfe14619-1011-4e6d-a6f5-ec4412332cb1",
+      "key": "56136b24-573e-4025-b491-b41d6c6771a8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4202,7 +4210,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d47fae77-e4b8-47bd-8749-ed3b1ae597a5",
+      "key": "225b7a34-db3e-4d33-9068-3edc597d5624",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4221,7 +4229,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "152e5896-8695-4805-b85c-819db216921c",
+      "key": "8e2e3fe7-80db-446c-9126-87590ba95471",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4235,14 +4243,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "a85f27c1-2384-4da8-98a8-108836e8eb71",
+      "key": "997fa5ed-e3e9-4187-88d2-7375cb83f16c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d45ffd65-eff6-4a8b-bd6f-5abde6dbf388",
+      "key": "4fbb8d44-4c69-4ab1-874f-e357d868d1b9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4251,7 +4259,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ea9a5388-329c-4587-8363-549269e6a4c8",
+      "key": "4f707665-6a5b-4668-a9c4-5fd00370475a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4270,7 +4278,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d496cd3f-2189-438e-b9d5-95c698d8a6c0",
+      "key": "540f30fc-b8f8-4f05-8182-0a12c3647b01",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4289,7 +4297,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "7c444a4b-626d-449c-98a9-beeaf09e9196",
+      "key": "9a0e07ae-4c90-4b7e-b353-3ca7fc993ca7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4303,14 +4311,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "168dc853-1c29-4304-aa4c-5d706d2863a9",
+      "key": "b4116910-b28e-4e71-8a7b-dfb41cc99204",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "3e501992-3a68-48a3-8a35-c97f6d922fb5",
+      "key": "c777b30d-05c8-4dc7-af5d-c41acaa617df",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4319,7 +4327,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e414d931-38f5-4ca3-93e0-28ab8d09a5ce",
+      "key": "106c22bd-295a-44e9-8dfb-580348ba8cc2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4338,7 +4346,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1b30be1e-9ab1-4ad2-8528-d0aac15649be",
+      "key": "1316892d-4ba4-4c8d-bdc6-117478905f1e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4357,7 +4365,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "333263db-9887-48f9-9cec-5e76264d02de",
+      "key": "c53a4989-107d-4e0d-a12a-39ef4558abe7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4371,14 +4379,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0613a633-8c69-4273-a40b-25f7d432b9ef",
+      "key": "b5ad828c-bd7f-4de9-b421-904c31eba20a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "dce17552-dc58-4420-9566-720bd62d2723",
+      "key": "be671102-5e97-4a4b-b863-f05d8aca05b8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4387,7 +4395,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d102217f-33c0-4f6d-81e8-ebfa23227b3b",
+      "key": "ceaa9cc8-30da-4161-a76b-91946d48995b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4406,7 +4414,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5624dd4a-9428-4764-b72b-854c372ac9b9",
+      "key": "e6a5d225-a65b-4c22-b6fa-f865a64473f8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4425,7 +4433,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "c9bb306f-9769-4fdf-8425-e6ef485b8053",
+      "key": "b14be9e9-2970-411e-b1d1-7f1e94e52f5c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4439,14 +4447,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4d34ac41-1e14-47dc-bddd-e035bc34562c",
+      "key": "4bff8b00-01b9-442d-88dc-3dba96e2d069",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "0737c0cc-cf01-4fa0-b624-ba162f8a5daf",
+      "key": "600313ef-a0a0-49f2-bc0a-f348297314f9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4455,7 +4463,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d121c382-86f2-4743-b043-d8f3606186de",
+      "key": "74e5e835-ade4-45e3-9932-b1482d2db302",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4474,7 +4482,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5b3da3c8-578e-4570-a9c0-12ba4eccd8ef",
+      "key": "e3389ddd-33e9-4ca2-95b9-1a65fe29c086",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4493,7 +4501,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "7a73f125-8cea-4846-9503-b1c15b16ca7f",
+      "key": "99778c37-6113-442e-9e86-cab1d013e876",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4507,14 +4515,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "ad8346ba-09c0-48e5-a4e2-585992b780ff",
+      "key": "2355a34d-8412-4b88-8af3-916d885df3a2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "bb55a704-2741-4543-8ec9-9d7cbe646913",
+      "key": "65af5661-1c7e-45e5-986d-ce8daf7a3eff",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4523,7 +4531,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "fa987ffe-4b77-4f23-87e3-26ffff498da2",
+      "key": "6a847f78-42ac-445b-b19d-e1630756a5fa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4542,7 +4550,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e2fead50-1166-45a6-9a7c-19239a635dcb",
+      "key": "6784a579-0b34-43b8-9326-77e637f8bbb2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4561,7 +4569,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "37bd2126-ea04-43d9-8153-abca7aa37bf2",
+      "key": "1ff4b385-ae44-4fd2-946d-46ee52afe6ac",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4575,14 +4583,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "f2254539-3d1c-475f-9545-2254338bc877",
+      "key": "4f557a9c-80da-4494-afab-d8257227e355",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d238b33c-0a51-4593-884d-f294ca9b34bd",
+      "key": "eb772f74-767e-4356-bd3c-2f3b53b85668",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4591,7 +4599,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d8cc4fb2-c789-4c19-a279-3ab277db620a",
+      "key": "d91a44ad-f6fe-43ba-a208-947b82e8bb17",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4610,7 +4618,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "04130047-9fc1-4a1d-a437-6d35c9bbc736",
+      "key": "0883bc19-bb17-4e75-b825-16bf0bf608a0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4629,7 +4637,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "ea98ad61-5358-4695-aeac-5c45e45f3945",
+      "key": "43f04f6e-29e3-41fc-846f-70159de5b574",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4643,14 +4651,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "aa748779-1bee-4277-9a0b-cef4c9596db2",
+      "key": "12f108e2-5910-416e-8986-cd4eab636d07",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "1104a432-4c46-4048-a167-66935bcbbe46",
+      "key": "cc7a1825-c463-472a-93ff-01961ca421ad",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4659,7 +4667,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "96051ed2-d577-406e-8fcc-6d57489b8098",
+      "key": "5993e970-eaaa-4fff-be59-6718e4f97869",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4678,7 +4686,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2aa56498-12ea-4ed1-8d1f-cfc771631231",
+      "key": "dcfc6676-d254-44ca-80da-70f79ee7db21",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4697,7 +4705,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "feec6043-4715-4e0f-8ffb-c7e11625b8ae",
+      "key": "a5cfb634-c2cb-4098-8279-5c43d26e6e55",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4711,14 +4719,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "18c174f1-00c7-4429-a00d-1fb23fa1ab95",
+      "key": "27a06d31-9297-467d-a634-ad39b172fe64",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "c6e4b756-57e6-4b99-a13f-b4cc9f68007e",
+      "key": "8b20661a-2842-4d0c-b307-988a0ac3232f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4727,7 +4735,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f2d8efcd-563d-400e-a517-19c2e5b6daff",
+      "key": "6f05b0af-50df-4ce8-9c29-682caa2a1c58",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4746,7 +4754,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a167d2fa-005b-4cd7-b877-bc9bc7118576",
+      "key": "717b0e93-244b-4570-b1e0-c332a5a2445d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4765,7 +4773,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "d9b25719-f389-47d7-969c-f4b9d5eac924",
+      "key": "dbefc2d7-4e42-497f-825c-a78fc748b7b6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4779,14 +4787,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "f120bb0a-aeb5-456f-9400-61c0d086405c",
+      "key": "7d46b0cc-f7ca-4d0a-8bb6-bcb818533a47",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "181f302a-6f86-43ea-8bec-34787329ea91",
+      "key": "e3b4e5f9-e7a8-4656-8823-f4beb6770cc3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4795,7 +4803,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "7af713fd-92ec-4125-9fdc-c4caf6d96881",
+      "key": "66ae5863-34b3-4c17-bdfb-e43ddc9b7b77",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4814,7 +4822,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "74f0f1d4-ede7-4034-bb8a-569af6e51116",
+      "key": "07642783-9101-4233-b42a-aa4a09ad66f0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4833,7 +4841,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "e1062927-fbc0-43f4-aec0-2c4db796f520",
+      "key": "cc7a366d-b712-4871-9ce6-e3ba29d1a0f8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4847,14 +4855,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4fb208b2-406f-41d9-bd75-1bb25c7b6090",
+      "key": "2bd9a08c-f47e-4107-846f-ac7fc0931617",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "99e371f5-ac49-40f5-b077-0ba095fb8b0e",
+      "key": "96bdb207-8b5d-4d7d-855c-94fed7b1047f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4863,7 +4871,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "36456527-abc3-46b3-9be8-d8c3e35d7589",
+      "key": "619cc69d-c660-4128-b0d3-91440e65332c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4882,7 +4890,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "fcc09ee3-1280-42ad-9c96-5a35cc7e3682",
+      "key": "115828bc-a4f1-44db-8169-7f50d2d31957",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4901,7 +4909,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "973f8392-57e1-4436-8ff3-066370111552",
+      "key": "c0e44ca1-3f1a-468c-ba46-223f08885e21",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4915,14 +4923,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "61e589ec-3621-4296-832e-ddf05ed87d71",
+      "key": "18e8f523-31d1-4586-8b1b-4b91a76f89d7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "dee716cf-0a38-434f-87cf-ed2db7753f22",
+      "key": "fc6a5426-0655-4b8a-85ee-8f6dc1fac2f4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4931,7 +4939,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2de3cf3c-ec05-4c71-8da5-5f202dd2067d",
+      "key": "0fd9c8d4-e795-4ebc-9eb6-7295033e4474",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4950,7 +4958,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "27a832fc-a5da-4c38-ba4f-53fe056a3289",
+      "key": "4fe712c2-b11d-48a2-976a-cc83c5d4a4d0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4969,7 +4977,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "272a9711-02c5-4290-8ef5-82c66ae6db99",
+      "key": "10f14f3b-098b-4250-8212-351906ee2b6d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4983,14 +4991,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "9b5c566f-2fb7-4803-9f87-d613609a1766",
+      "key": "05c86f7d-da3a-4239-bab1-95b8b898b149",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "c4e4cc2b-1151-471b-82d4-75291a5a85fc",
+      "key": "de4b2c5a-75a5-467d-aee0-fee7fda26f72",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4999,7 +5007,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "134995c4-0c67-4fbc-be2a-60c9284e30a9",
+      "key": "99b31e9c-bdbf-43cf-b0b8-7412322ffb47",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5018,7 +5026,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4db8313b-64f1-499b-9f52-4df29c5d4ca7",
+      "key": "8afd5122-fa7b-48a2-b976-ee1c1b27cb4f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5037,7 +5045,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "f2bbe525-de0c-4309-90c9-d09ca189f8de",
+      "key": "d100c5db-07fb-4ac5-a880-71d9a8666a2c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5051,14 +5059,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "56125dae-842e-45c7-af67-ffdeb9fb6869",
+      "key": "3dce1c59-9d80-484e-be98-28609a791928",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d2b518d3-97d0-4a59-80c7-7a73a64579d3",
+      "key": "11cdde60-4006-4389-8de6-ef236788f07b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5067,7 +5075,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "72198d46-cbfb-4b7a-9a26-d1ea9f7dff77",
+      "key": "c846af6e-2991-4d0e-a77d-0e35165bd016",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5086,7 +5094,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "138f0bf8-14f1-431b-9db6-8566a9078e83",
+      "key": "b1f96011-4c25-4cc3-b571-dd8727377d2e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5105,7 +5113,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "a6f012e5-f1e3-46fe-8243-4f64987786bf",
+      "key": "88565966-2577-4aca-9f43-7f772da64315",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5119,14 +5127,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "c3f57ad8-cf7d-42ba-b009-f62e309b9c7c",
+      "key": "b1e8abbb-693b-4541-a72a-4ec3c49f523e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6590c871-dbef-474b-86f8-1c4b71388df2",
+      "key": "8526f83f-2860-4596-8620-45063361d374",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5135,7 +5143,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ce93c608-81b7-4a26-b5fd-b6cfa4004ce4",
+      "key": "2ad19b06-5c41-4b4e-b546-e0bdd0f66a45",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5154,7 +5162,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6c20edf3-2d8e-48e1-b872-708e23b71e5d",
+      "key": "2cae1082-1b08-4abf-989a-c09ef7288ad7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5173,7 +5181,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "4ae15bd8-e502-4267-a1ef-844ccd97fe73",
+      "key": "4a85393c-fe4a-48f1-a5ae-32174c09abac",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5187,14 +5195,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "9358bb52-e112-4ac8-ac27-c75fa3a31129",
+      "key": "60828ffa-b38c-460e-936c-8641ad617a38",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "1e35aa06-95f7-4073-8f8f-68fdc557e3bc",
+      "key": "35a89a24-24a7-409f-b7b9-d30befbba26b",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5203,7 +5211,7 @@
     },
     {
       "commandType": "configureForVolume",
-      "key": "1953c27c-abd9-4284-80b5-42c1df10bfa9",
+      "key": "c176761e-3996-47ea-ba6c-3af6e5d1a983",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10
@@ -5211,7 +5219,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ae530f5a-e921-4cbb-bea2-8563e38d6966",
+      "key": "f0d53d5e-00de-4d4a-854d-0d074da37350",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -5230,7 +5238,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "756cfa2f-0df6-4d73-8dd0-4869c25aaa00",
+      "key": "74dd1f94-3e6d-49c7-9fb1-4ae0cc859e9d",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -5249,7 +5257,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e12837d4-0bc3-454e-80a5-a530a046b03c",
+      "key": "fcae4e04-1a58-449a-a248-2f561cbfd793",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -5268,7 +5276,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1435fcd2-2e3d-480b-9b3c-c606b83e1507",
+      "key": "62875262-eab0-4519-a11e-354b14a2793b",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -5287,7 +5295,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "3e9986af-42fe-4168-b49d-67b25072aedb",
+      "key": "ebb19d7f-4ccb-43b8-b60c-44db670096b1",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "addressableAreaName": "movableTrashA3",
@@ -5301,14 +5309,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "c51cf48c-ff9f-4329-b2bb-475589c03cc8",
+      "key": "cfe4bc7d-4153-4d9e-ad28-61ef961835ed",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "ca2b894f-a4d4-425a-b85b-9954f9b61819",
+      "key": "08d54fbe-590c-4f7a-b585-86faf5c94af9",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -5319,7 +5327,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "4f455d59-03a6-4b79-be48-64db49d6ff59",
+      "key": "6fcaa53f-b9fa-4e22-9d1c-0d4b9717540e",
       "params": {
         "seconds": 60,
         "message": ""
@@ -5327,7 +5335,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "4481fc65-451f-4c8f-aa14-2b369a600312",
+      "key": "3a7099a7-7a2d-42c4-a739-24e8585c3aee",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -5338,21 +5346,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "3e22fda8-3a29-4ec1-a8c5-4a1c2311537b",
+      "key": "d10e7bf3-5322-4abd-9306-343d481996c1",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "68523f3c-f1be-46ec-b235-768fad253de5",
+      "key": "97ca52a8-e23f-457f-9015-f010f330531c",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "364c37d4-826a-4d67-ae4a-8c3a4f246577",
+      "key": "b315a60a-32ab-4572-8d62-f6c8dbcb7889",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "rpm": 500
@@ -5360,28 +5368,28 @@
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "d5c426ba-1acc-440c-939b-9c0be548a4a3",
+      "key": "314fba64-2efd-4f53-b07c-917bc04dc01a",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "ff1818d5-6f75-44f5-bfd2-fe5bc202e050",
+      "key": "f20d8dc8-c41c-4aa8-9447-06f00854fdfa",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "497f9b04-7d40-47ae-9a87-185280821361",
+      "key": "a72f4873-d977-4b22-aa7f-3c18c17f334c",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "1ab82be8-439a-4c7f-ae3d-2421bc2b85a6",
+      "key": "bf8a31d9-23ab-4c8b-9c3d-7dc894bda46c",
       "params": {
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "strategy": "manualMoveWithPause",
@@ -5390,7 +5398,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "6dc1e703-64ee-48ad-a5e5-451ce9eb917a",
+      "key": "2c067101-8353-4bfa-ad4b-869569ce4923",
       "params": {
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
         "strategy": "manualMoveWithPause",

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1701659107408,
-    "lastModified": 1738157218097,
+    "lastModified": 1738682469059,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Wed, 29 Jan 2025 13:23:47 GMT",
+      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:16:30 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -33,18 +33,18 @@
       },
       "ingredients": {
         "0": {
-          "displayName": "h20",
-          "displayColor": "#b925ff",
+          "displayName": "",
           "description": null,
-          "pythonName": "liquid_0",
-          "liquidGroupId": "1"
+          "liquidGroupId": "0",
+          "pythonName": "liquid_1",
+          "displayColor": "#b925ff"
         },
         "1": {
-          "displayName": "sample",
-          "displayColor": "#ffd600",
+          "displayName": "",
           "description": null,
-          "liquidGroupId": "2",
-          "pythonName": "liquid_1"
+          "liquidGroupId": "1",
+          "pythonName": "liquid_2",
+          "displayColor": "#ffd600"
         }
       },
       "ingredLocations": {
@@ -112,6 +112,17 @@
           },
           "pipetteLocationUpdate": {
             "9fcd50d9-92b2-45ac-acf1-e2cf773feffc": "left"
+          },
+          "trashBinLocationUpdate": {},
+          "wasteChuteLocationUpdate": {
+            "9d61f642-8f9b-467d-b2f7-b67fb162fd26:wasteChute": "cutoutD3"
+          },
+          "stagingAreaLocationUpdate": {
+            "428315a8-b60c-4e5e-bbee-545777bba553:stagingArea": "cutoutB3",
+            "9ae21fb7-f599-4ec4-9c88-d002bfe20607:stagingArea": "cutoutA3"
+          },
+          "gripperLocationUpdate": {
+            "1e57bed9-4911-4bfc-991b-3ade7cc098cf:gripper": "mounted"
           },
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
@@ -206,8 +217,8 @@
           "stepType": "moveLiquid",
           "stepName": "transfer",
           "stepDetails": "",
-          "id": "d2f74144-a7bf-4ba2-aaab-30d70b2b62c7",
-          "dispense_touchTip_mmfromTop": null
+          "dispense_touchTip_mmfromTop": null,
+          "id": "d2f74144-a7bf-4ba2-aaab-30d70b2b62c7"
         },
         "240a2c96-3db8-4679-bdac-049306b7b9c4": {
           "blockIsActive": true,
@@ -3519,12 +3530,12 @@
   "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {
     "0": {
-      "displayName": "h20",
+      "displayName": "",
       "description": "",
       "displayColor": "#b925ff"
     },
     "1": {
-      "displayName": "sample",
+      "displayName": "",
       "description": "",
       "displayColor": "#ffd600"
     }
@@ -3532,7 +3543,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "fdb1f640-85f6-4bcf-bfff-63e37f55ce27",
+      "key": "592d7376-9a32-4daa-8327-d82c2ed17d9d",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -3541,7 +3552,7 @@
       }
     },
     {
-      "key": "5913deb1-157f-4ac4-bcbc-f8915aa68fa2",
+      "key": "c43dd720-32ee-4bd5-bef8-e3d4a82b822c",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -3552,7 +3563,7 @@
       }
     },
     {
-      "key": "279b491f-78fe-4147-bdbd-31469adf8c01",
+      "key": "3109c949-0f2c-4b51-a3b7-411bfa935c2d",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -3563,7 +3574,7 @@
       }
     },
     {
-      "key": "d4a96fb9-9d44-444b-8eef-f69bee47b4f7",
+      "key": "98b2d887-f97d-49c8-a29c-50c8d87fa505",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 PCR Heater-Shaker Adapter",
@@ -3577,7 +3588,7 @@
       }
     },
     {
-      "key": "c3a137ef-3ecd-44c7-9221-7167c6576d5b",
+      "key": "c40e41df-1264-49a9-ab5b-5dc80c12f453",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
@@ -3591,7 +3602,7 @@
       }
     },
     {
-      "key": "83929c9c-e7b0-49a3-a369-d2061a29af8f",
+      "key": "20caeedf-c66d-4736-8007-5f437badb681",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt",
@@ -3605,7 +3616,7 @@
       }
     },
     {
-      "key": "e16a38b6-1a7a-47e0-bd3f-10f3044813dc",
+      "key": "01f19c1c-4d3f-4196-9fac-7118452e6609",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Axygen 1 Well Reservoir 90 mL",
@@ -3620,7 +3631,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "5eef2542-3751-49f9-a83f-cdfbdb3bcd60",
+      "key": "9bdaafb6-6ae7-4af8-916d-ce4d61b7e97c",
       "params": {
         "liquidId": "1",
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
@@ -3638,7 +3649,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "347a434b-a0e3-40ab-9821-4bd8b5fa22cd",
+      "key": "3f5bed8a-22f1-4b11-9dad-b13720639c60",
       "params": {
         "liquidId": "0",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3649,14 +3660,14 @@
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "bfc09a97-2926-4995-9fb2-0e014373d0e1",
+      "key": "241f78d6-f55d-4404-8d20-574d7f6d23b1",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "767e876f-0cb7-4d0c-a5ff-a415585d6a62",
+      "key": "1a4f9911-11e0-42dc-a450-68edc791aceb",
       "params": {
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "strategy": "usingGripper",
@@ -3667,7 +3678,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "8d183275-f3e4-4e20-a148-1280a28be7ea",
+      "key": "34f0d000-7e21-470a-a44b-77b93b241764",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3676,7 +3687,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "63759336-84a5-4812-b762-1a9aebf34cfe",
+      "key": "da2614b8-73c1-4549-969c-a3673ac6597d",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3695,7 +3706,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "ff8ba56e-1a2c-49d7-852b-9bad8dbf34b0",
+      "key": "9d3cefb6-860f-4094-a8fb-291ec3dd070e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3714,7 +3725,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "1b1844e7-f89f-4594-b76a-e789972a6495",
+      "key": "20935b08-1ac6-4227-adb3-bf003c17c3ed",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3727,14 +3738,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0bb4b9ce-c7f1-4436-be9f-682ba654c130",
+      "key": "60c1e426-1922-4171-a91c-2e868f46e25a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "f6ff0fe7-1331-4c28-81ff-a35fed4ad8e5",
+      "key": "6e57df65-47b8-4872-9cc6-62bd661b64b7",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3743,7 +3754,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c5cd2686-6a09-4b35-b098-c57eac017185",
+      "key": "efc97730-6629-40ec-af32-9c2a7daf080f",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3762,7 +3773,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2f187fb7-9fea-4854-9e98-a311d265bcb6",
+      "key": "3c52688d-1e47-4914-ac5d-f638ecfa9e6b",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3781,7 +3792,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "1307485b-cd41-47a5-a044-b028c8224d4f",
+      "key": "1ebe7097-ef5d-4af1-b874-0e9b33928951",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3794,14 +3805,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "8ade5883-8117-425e-8a60-4670efeb9883",
+      "key": "782b51ef-b97c-41a0-be1b-49713430b4b2",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "cb28e92b-993f-474e-bc73-e72764652c1a",
+      "key": "5eb76907-000b-4c38-8cc9-33d90ad3b7e1",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3810,7 +3821,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "14f97753-b078-482a-bf27-204bc3ce8c61",
+      "key": "4ecfa4fc-e587-490c-a628-1fd5f6cd3fb4",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3829,7 +3840,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5810d6b0-8e1e-4ee8-b89d-bd298e452fbf",
+      "key": "d1d3c3b5-7373-421b-a682-f75bffc42be8",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3848,7 +3859,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "2e29334d-4195-40ad-a423-f7200177caae",
+      "key": "ba4e1b5f-4083-4686-b251-b0c9032368cd",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3861,14 +3872,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "d17b7128-1a57-4ef2-b46b-280e97b564c3",
+      "key": "5c508ce2-5b10-4fe1-8bd6-4f7046613b75",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "4e957f48-d363-48b3-ab6c-7c32c0d5ab80",
+      "key": "d9fdba94-cee1-4ecb-a4b2-fba959e8a74c",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3877,7 +3888,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1de52706-ab40-48ac-9114-b918de28d0ed",
+      "key": "bf990e75-b411-4d10-bf3b-f66e3c2f583d",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3896,7 +3907,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6bdc0516-21ac-48a4-9323-2712e60afe7e",
+      "key": "811efcf9-997a-4046-8459-8da5f1e8c4a3",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3915,7 +3926,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "c273367a-57a3-4879-9a2d-93d8ab671265",
+      "key": "6d259094-74bf-4a81-9a06-8b3c7b1f1d06",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3928,14 +3939,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "5e2e4629-426f-41c5-af38-4a252ef544f6",
+      "key": "70a1e2ce-4928-43db-8e7e-15f3c18019cd",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6aa9ea70-9d0c-4c9a-8b26-d168c66edcac",
+      "key": "fb5aae91-688c-4372-b6f8-86180c2f80f4",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3944,7 +3955,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c1848064-ccac-4488-b658-54765b53c014",
+      "key": "dc738649-c278-48ad-88f9-77d3922e1ff3",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3963,7 +3974,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "79622aac-e2ae-4578-8ea8-5288d566b17b",
+      "key": "4fb6307f-f047-46ef-a5cd-1d930f5c953a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3982,7 +3993,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "0a2c66b2-97cc-45ae-ad05-d4e644b5d09d",
+      "key": "16e4a863-2db3-4afb-8115-4d9e66836177",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3995,14 +4006,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "88141e29-f3e9-456a-9227-53cc3e4b7306",
+      "key": "cf011a03-b8f5-4873-86d4-10fe03b015c6",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "493734a6-abb9-4e4a-bbd7-9b7b46a18b21",
+      "key": "c4024ed8-fda1-4f99-8559-184627439bee",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4011,7 +4022,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "17284684-55c4-477a-a775-33989cccb7a7",
+      "key": "f3edd5c6-00b8-4ae3-919b-d8d1c65d98d4",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4030,7 +4041,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f1acfe9d-4496-433e-b40f-1a5409ff4094",
+      "key": "0ba9c37b-6978-4c82-add9-6e5a84c7045e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4049,7 +4060,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "025a6244-db88-4635-95a0-14648468a844",
+      "key": "c6c43fac-9038-4ee6-922d-4037212a0a13",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4062,14 +4073,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "8257d866-81f5-4327-8fde-908c2cc58f4b",
+      "key": "b0cf4f10-e2c4-4ee3-8beb-6a39fe81ee81",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "3f000483-4802-4332-9ed8-7986267d4bf0",
+      "key": "9dae4395-75fc-405e-a274-90fb0dd5c68e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4078,7 +4089,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "cc718e17-898c-475e-8213-18a8c4e7de63",
+      "key": "5577681d-dc3e-4a01-b3f1-3493a0ee500b",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4097,7 +4108,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "9b2d6845-866c-4cbb-85c5-be29f0e59c7f",
+      "key": "f3e917f7-9c16-486c-89fb-593123298022",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4116,7 +4127,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "e204cacd-03f9-4f52-a48a-a4fba1f217c4",
+      "key": "2d7d2e57-21d5-4eb8-be36-03cab9e8bed9",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4129,14 +4140,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "3f3a6583-8548-4e1b-af12-c4157c573aa6",
+      "key": "2cbe3f00-0972-4ca6-8155-10c59bf09577",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "3000eef7-2dbb-49b7-8242-b5f71cee8e84",
+      "key": "b7f480c4-ef86-47ff-a101-d44dbf42ee14",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4145,7 +4156,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4e21f8b9-a480-43a5-b3bb-23a0baa99bc4",
+      "key": "41639beb-fc1a-4223-858f-618dc6860929",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4164,7 +4175,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a4ed53f0-3ba5-4b30-9a8a-a0abf5f558bc",
+      "key": "0ae16397-6c0c-4bac-8f42-9b4eef741755",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4183,7 +4194,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "920cc11e-1a35-4a84-ba6b-93f742bd8780",
+      "key": "92a05df3-de68-4202-8cb0-b6cd62ba685a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4196,21 +4207,21 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "b05b1f55-87ac-4989-a937-c6e63abc04fc",
+      "key": "0ca3a6c4-d4b2-41e3-9d8f-458f92c67623",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "f4e356c4-5160-478d-9419-b919f411324a",
+      "key": "60e55a58-5473-4264-905f-7665ec3be709",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetBlockTemperature",
-      "key": "bc344e58-dedd-44a1-bcbb-1108852aa188",
+      "key": "4216117e-756b-459a-822a-4db1513bdb4b",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType",
         "celsius": 40
@@ -4218,14 +4229,14 @@
     },
     {
       "commandType": "thermocycler/waitForBlockTemperature",
-      "key": "b573b603-fa89-4213-a1ea-6f6d24f4f372",
+      "key": "c1b5a16d-3316-41d0-9c39-2eaa5eeef849",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "waitForDuration",
-      "key": "1e8e67b6-e2ed-476b-8f5a-f985a68fbd22",
+      "key": "c13c571e-be5d-4ff9-8e92-e0ba17cf5be7",
       "params": {
         "seconds": 60,
         "message": ""
@@ -4233,35 +4244,35 @@
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "165eaa13-69df-49b5-965a-83cf19c40fda",
+      "key": "6850df32-c140-46fc-ae27-47ef39523903",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "d9c25977-9163-472b-b0e6-4840b8135b52",
+      "key": "ab943b1f-e644-471c-a844-d42476f4fff9",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "a9591c3d-4413-447b-81ed-b10e0b64593a",
+      "key": "dc5ffb4f-7adc-492a-b6b3-dee081fd9e3d",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "8e0d13ac-d6c9-4aee-bf38-8b65cbb23cd3",
+      "key": "96243e7a-4197-4100-95b2-ed046733a43d",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "cdbee473-2621-49d4-b233-99a80d4aa6ea",
+      "key": "f3fe581e-4c3f-40f1-a6aa-c17bd13c4992",
       "params": {
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4272,21 +4283,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "90f0a48f-d198-49cc-b985-8b60b9eeb97a",
+      "key": "c1e16dfd-cfc0-475c-9eb2-d02c5d61fdf6",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "66d3b91c-6a48-4ccc-880f-8f9b00702e47",
+      "key": "e39b41ad-ab3e-45e4-8582-4a0e0ad45df1",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "f4746eaa-e860-44ec-ba60-27c60a3f251f",
+      "key": "76eb57dd-d061-4e33-8e0c-1c8b44324f12",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType",
         "rpm": 200
@@ -4294,42 +4305,42 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "4f9d6581-3793-4f5e-b29b-a4f59878348b",
+      "key": "8a4a81a1-898b-46a5-b677-8ae7a5b6610f",
       "params": {
         "seconds": 60
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "9a4026e4-5fb0-4cca-9cc0-09274213418d",
+      "key": "bc9cb419-5fe7-41a8-b7c3-00258c0c2481",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "0e0a6e22-6d87-457e-841e-063e74b92bcd",
+      "key": "8c37f57f-f4ee-4b99-8665-a3a32cbec77b",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "43ef8004-1be7-4eec-9fca-83571590170d",
+      "key": "54f118bd-bf05-4049-a722-06b5d3a662b0",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "d3a2cb1e-b4dd-4431-ae89-84d71ed5f900",
+      "key": "6bf8a81f-a3d6-4413-b251-b3c39a58cc8c",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "0554f9d9-5de2-4faa-bde6-a291c503379c",
+      "key": "59670f67-59d3-4c51-8e02-b4b59b8f346c",
       "params": {
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4340,7 +4351,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "25d91423-5565-4063-ada0-87692ca2dbbd",
+      "key": "ac9b0247-7e7d-44d3-9773-df14466209c3",
       "params": {
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
         "strategy": "usingGripper",

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1701659107408,
-    "lastModified": 1738682469059,
+    "lastModified": 1738780362701,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:16:30 GMT",
+      "_internalAppBuildDate": "Wed, 05 Feb 2025 18:32:26 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -118,11 +118,11 @@
             "9d61f642-8f9b-467d-b2f7-b67fb162fd26:wasteChute": "cutoutD3"
           },
           "stagingAreaLocationUpdate": {
-            "428315a8-b60c-4e5e-bbee-545777bba553:stagingArea": "cutoutB3",
-            "9ae21fb7-f599-4ec4-9c88-d002bfe20607:stagingArea": "cutoutA3"
+            "f2213242-0dd4-416c-9994-38432d85e5e2:stagingArea": "cutoutB3",
+            "db5516ce-eb6a-47b7-8d5e-d983836679ef:stagingArea": "cutoutA3"
           },
           "gripperLocationUpdate": {
-            "1e57bed9-4911-4bfc-991b-3ade7cc098cf:gripper": "mounted"
+            "13816147-787e-46f1-b950-a925eddfd65f:gripper": "mounted"
           },
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
@@ -217,8 +217,8 @@
           "stepType": "moveLiquid",
           "stepName": "transfer",
           "stepDetails": "",
-          "dispense_touchTip_mmfromTop": null,
-          "id": "d2f74144-a7bf-4ba2-aaab-30d70b2b62c7"
+          "id": "d2f74144-a7bf-4ba2-aaab-30d70b2b62c7",
+          "dispense_touchTip_mmfromTop": null
         },
         "240a2c96-3db8-4679-bdac-049306b7b9c4": {
           "blockIsActive": true,
@@ -3530,12 +3530,12 @@
   "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {
     "0": {
-      "displayName": "",
+      "displayName": "h20",
       "description": "",
       "displayColor": "#b925ff"
     },
     "1": {
-      "displayName": "",
+      "displayName": "sample",
       "description": "",
       "displayColor": "#ffd600"
     }
@@ -3543,7 +3543,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "592d7376-9a32-4daa-8327-d82c2ed17d9d",
+      "key": "49fc1872-6cc3-410a-9aa7-5af54346a9fc",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -3552,7 +3552,7 @@
       }
     },
     {
-      "key": "c43dd720-32ee-4bd5-bef8-e3d4a82b822c",
+      "key": "dd48f009-562a-4b60-8873-ac25455668bf",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -3563,7 +3563,7 @@
       }
     },
     {
-      "key": "3109c949-0f2c-4b51-a3b7-411bfa935c2d",
+      "key": "48f70873-c026-439f-8588-1353aa72d88e",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -3574,7 +3574,7 @@
       }
     },
     {
-      "key": "98b2d887-f97d-49c8-a29c-50c8d87fa505",
+      "key": "1b2d55b6-d739-4ba1-ad73-f48e978ac550",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 PCR Heater-Shaker Adapter",
@@ -3588,7 +3588,7 @@
       }
     },
     {
-      "key": "c40e41df-1264-49a9-ab5b-5dc80c12f453",
+      "key": "0b252830-d1f1-408a-b2a6-95cc6c21f436",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
@@ -3602,7 +3602,7 @@
       }
     },
     {
-      "key": "20caeedf-c66d-4736-8007-5f437badb681",
+      "key": "d4e64cb5-fd40-4b1f-a22d-72f24219d366",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt",
@@ -3616,7 +3616,7 @@
       }
     },
     {
-      "key": "01f19c1c-4d3f-4196-9fac-7118452e6609",
+      "key": "3501c509-5979-420a-b7e3-dc84ebe3b032",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Axygen 1 Well Reservoir 90 mL",
@@ -3631,7 +3631,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "9bdaafb6-6ae7-4af8-916d-ce4d61b7e97c",
+      "key": "244176d2-3b89-4fe6-a7c7-590dccb09b3f",
       "params": {
         "liquidId": "1",
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
@@ -3649,7 +3649,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "3f5bed8a-22f1-4b11-9dad-b13720639c60",
+      "key": "9c34fe7c-38e4-4939-959c-3120653a51bb",
       "params": {
         "liquidId": "0",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3660,14 +3660,14 @@
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "241f78d6-f55d-4404-8d20-574d7f6d23b1",
+      "key": "7b08e12a-df2a-4205-925a-b7e69683e3fd",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "1a4f9911-11e0-42dc-a450-68edc791aceb",
+      "key": "c543fe64-a47d-4b17-8127-0d0115d458c7",
       "params": {
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "strategy": "usingGripper",
@@ -3678,7 +3678,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "34f0d000-7e21-470a-a44b-77b93b241764",
+      "key": "d541acc1-ef32-4088-a8b8-d22e945bf472",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3687,7 +3687,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "da2614b8-73c1-4549-969c-a3673ac6597d",
+      "key": "58ad495c-586a-4753-8595-e9bd3ea684e0",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3706,7 +3706,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "9d3cefb6-860f-4094-a8fb-291ec3dd070e",
+      "key": "a7759e48-c23e-478f-a605-cc8e873fd800",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3725,7 +3725,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "20935b08-1ac6-4227-adb3-bf003c17c3ed",
+      "key": "031cfe55-1318-4cf0-9fdd-85dcd3a54700",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3738,14 +3738,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "60c1e426-1922-4171-a91c-2e868f46e25a",
+      "key": "7b3f4a34-e56a-4b45-a019-4b2a9e52a912",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6e57df65-47b8-4872-9cc6-62bd661b64b7",
+      "key": "86dd97b7-eef2-4a17-b7d6-862a56f750bc",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3754,7 +3754,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "efc97730-6629-40ec-af32-9c2a7daf080f",
+      "key": "de7b1a56-e6f6-44de-b47c-05fb6b80db6f",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3773,7 +3773,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "3c52688d-1e47-4914-ac5d-f638ecfa9e6b",
+      "key": "ccf526b2-2186-4c00-a882-818e1eeb1fb7",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3792,7 +3792,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "1ebe7097-ef5d-4af1-b874-0e9b33928951",
+      "key": "ca62bd2f-6a7f-44c0-98e2-0330a4642d10",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3805,14 +3805,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "782b51ef-b97c-41a0-be1b-49713430b4b2",
+      "key": "06623121-26be-487f-b355-2d49d3af3bbe",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "5eb76907-000b-4c38-8cc9-33d90ad3b7e1",
+      "key": "9baaba76-fe28-4ced-8936-c4d1c38af6a6",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3821,7 +3821,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4ecfa4fc-e587-490c-a628-1fd5f6cd3fb4",
+      "key": "700f6fee-6870-446c-a7e9-3921f48f214d",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3840,7 +3840,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d1d3c3b5-7373-421b-a682-f75bffc42be8",
+      "key": "01c89683-7d52-42c2-b3d1-6df5a190c494",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3859,7 +3859,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "ba4e1b5f-4083-4686-b251-b0c9032368cd",
+      "key": "9dd839fe-326a-4e63-985c-b68477e217cf",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3872,14 +3872,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "5c508ce2-5b10-4fe1-8bd6-4f7046613b75",
+      "key": "2221613f-1e5a-4a44-88c2-66e4fbfacef1",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d9fdba94-cee1-4ecb-a4b2-fba959e8a74c",
+      "key": "e6f8407d-1611-4d46-bfe2-8059b2b47432",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3888,7 +3888,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "bf990e75-b411-4d10-bf3b-f66e3c2f583d",
+      "key": "bb19aeb4-024c-4df8-beba-3408c96a331a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3907,7 +3907,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "811efcf9-997a-4046-8459-8da5f1e8c4a3",
+      "key": "c8cbae6d-9cb1-47e3-a7f2-b7d01756d8a3",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3926,7 +3926,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "6d259094-74bf-4a81-9a06-8b3c7b1f1d06",
+      "key": "e7cd3520-2abd-4fcd-a251-a62ba48e02a9",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3939,14 +3939,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "70a1e2ce-4928-43db-8e7e-15f3c18019cd",
+      "key": "483d5ffa-3f63-4146-ab1f-9fa0aa516e85",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "fb5aae91-688c-4372-b6f8-86180c2f80f4",
+      "key": "571a56a0-a9ac-4782-a6a9-5305e2c91e2c",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3955,7 +3955,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "dc738649-c278-48ad-88f9-77d3922e1ff3",
+      "key": "bcbcfca7-f535-4a30-a6ab-2b9656bcb504",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3974,7 +3974,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4fb6307f-f047-46ef-a5cd-1d930f5c953a",
+      "key": "bf428081-b108-4791-877f-4cbccc32d9fe",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3993,7 +3993,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "16e4a863-2db3-4afb-8115-4d9e66836177",
+      "key": "24890fba-56b8-4ee8-bbe1-3fdadc84e433",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4006,14 +4006,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "cf011a03-b8f5-4873-86d4-10fe03b015c6",
+      "key": "27b9ed52-4dde-4188-9959-3d60064398f0",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "c4024ed8-fda1-4f99-8559-184627439bee",
+      "key": "30526659-9e21-4229-a300-ff5b35e86df1",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4022,7 +4022,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f3edd5c6-00b8-4ae3-919b-d8d1c65d98d4",
+      "key": "95b90404-e7ca-4afd-ab79-18fc5e309604",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4041,7 +4041,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0ba9c37b-6978-4c82-add9-6e5a84c7045e",
+      "key": "e32849fe-bb1b-44c1-adb3-91dac3165a44",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4060,7 +4060,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "c6c43fac-9038-4ee6-922d-4037212a0a13",
+      "key": "b0f2fcac-d86f-4221-9395-3ee3ab4af76b",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4073,14 +4073,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "b0cf4f10-e2c4-4ee3-8beb-6a39fe81ee81",
+      "key": "d528da30-bd87-4719-bb1e-1c615ae0aac6",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "9dae4395-75fc-405e-a274-90fb0dd5c68e",
+      "key": "15623419-24fd-48a3-ab69-b4b083c754df",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4089,7 +4089,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "5577681d-dc3e-4a01-b3f1-3493a0ee500b",
+      "key": "8ab0f6a8-d0dd-4505-99f6-240d1c73c39a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4108,7 +4108,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f3e917f7-9c16-486c-89fb-593123298022",
+      "key": "dc325be3-9e6b-468b-84f6-b7e2efc7ddba",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4127,7 +4127,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "2d7d2e57-21d5-4eb8-be36-03cab9e8bed9",
+      "key": "1d23f50b-2735-4818-b53f-bffebcfacfeb",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4140,14 +4140,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "2cbe3f00-0972-4ca6-8155-10c59bf09577",
+      "key": "417cfecc-87f2-468a-9164-d654f72afddc",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "b7f480c4-ef86-47ff-a101-d44dbf42ee14",
+      "key": "0bedaae9-376e-48fe-93ba-21d7af4447b4",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4156,7 +4156,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "41639beb-fc1a-4223-858f-618dc6860929",
+      "key": "6591d94b-b15a-42ee-a8f8-428d98c51351",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4175,7 +4175,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0ae16397-6c0c-4bac-8f42-9b4eef741755",
+      "key": "ebade313-94ab-4438-9cbf-63a0219a1eaf",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4194,7 +4194,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "92a05df3-de68-4202-8cb0-b6cd62ba685a",
+      "key": "90528e7c-da57-4747-a752-f3c591931fb0",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4207,21 +4207,21 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0ca3a6c4-d4b2-41e3-9d8f-458f92c67623",
+      "key": "67862c8f-0825-4e69-9f3a-43b97dfd076d",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "60e55a58-5473-4264-905f-7665ec3be709",
+      "key": "a7278a36-19b0-4842-801e-76361a8aa766",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetBlockTemperature",
-      "key": "4216117e-756b-459a-822a-4db1513bdb4b",
+      "key": "09d59dec-9554-4ebb-8166-c77a9395914f",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType",
         "celsius": 40
@@ -4229,14 +4229,14 @@
     },
     {
       "commandType": "thermocycler/waitForBlockTemperature",
-      "key": "c1b5a16d-3316-41d0-9c39-2eaa5eeef849",
+      "key": "731dcfcf-07ca-48fd-ae41-9a7011ede0bb",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "waitForDuration",
-      "key": "c13c571e-be5d-4ff9-8e92-e0ba17cf5be7",
+      "key": "cc242e9f-90d1-4801-bb91-97090d67f7d7",
       "params": {
         "seconds": 60,
         "message": ""
@@ -4244,35 +4244,35 @@
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "6850df32-c140-46fc-ae27-47ef39523903",
+      "key": "8bb12bf8-0ef2-4725-af0a-1a398f70bf23",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "ab943b1f-e644-471c-a844-d42476f4fff9",
+      "key": "00476092-d870-469d-a86c-1b3c28e33d95",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "dc5ffb4f-7adc-492a-b6b3-dee081fd9e3d",
+      "key": "cdbb8ffd-dcba-4c2c-9900-93b9876209f6",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "96243e7a-4197-4100-95b2-ed046733a43d",
+      "key": "ac78164f-d06e-468c-8a2e-7f665773bf5e",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "f3fe581e-4c3f-40f1-a6aa-c17bd13c4992",
+      "key": "dd7006a1-71cb-4927-9380-5869aea6cf5c",
       "params": {
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4283,21 +4283,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "c1e16dfd-cfc0-475c-9eb2-d02c5d61fdf6",
+      "key": "8297dcfd-1dc2-48d4-a03c-e9136c6ad2c3",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "e39b41ad-ab3e-45e4-8582-4a0e0ad45df1",
+      "key": "629e702b-aade-4a3c-9967-6ebb8f8ddb6f",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "76eb57dd-d061-4e33-8e0c-1c8b44324f12",
+      "key": "7be4d22c-bd4d-4aef-973a-54ac5e43853b",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType",
         "rpm": 200
@@ -4305,42 +4305,42 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "8a4a81a1-898b-46a5-b677-8ae7a5b6610f",
+      "key": "e8b35707-452c-490b-937a-a6f0a55b8549",
       "params": {
         "seconds": 60
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "bc9cb419-5fe7-41a8-b7c3-00258c0c2481",
+      "key": "c70641c6-d6bc-46ad-9812-6acfdacff8be",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "8c37f57f-f4ee-4b99-8665-a3a32cbec77b",
+      "key": "86d364f1-b6a0-4069-ad7b-1973a3160488",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "54f118bd-bf05-4049-a722-06b5d3a662b0",
+      "key": "a6a78183-cefd-4c2d-ba40-e16f43b50ea2",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "6bf8a81f-a3d6-4413-b251-b3c39a58cc8c",
+      "key": "0ede6628-3007-453b-8dcc-088798893ac8",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "59670f67-59d3-4c51-8e02-b4b59b8f346c",
+      "key": "c9e44bb3-3354-4350-afcb-a0574afedbb3",
       "params": {
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4351,7 +4351,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "ac9b0247-7e7d-44d3-9773-df14466209c3",
+      "key": "7a39f8b8-d95b-47ca-bc5d-8e01bc6a4c4d",
       "params": {
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
         "strategy": "usingGripper",

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -33,14 +33,14 @@
       },
       "ingredients": {
         "0": {
-          "displayName": "",
+          "displayName": "h20",
           "description": null,
           "liquidGroupId": "0",
           "pythonName": "liquid_1",
           "displayColor": "#b925ff"
         },
         "1": {
-          "displayName": "",
+          "displayName": "sample",
           "description": null,
           "liquidGroupId": "1",
           "pythonName": "liquid_2",

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -38,16 +38,16 @@
         "0": {
           "displayName": "samples",
           "description": null,
-          "liquidGroupId": "0",
+          "displayColor": "#b925ff",
           "pythonName": "liquid_1",
-          "displayColor": "#b925ff"
+          "liquidGroupId": "0"
         },
         "1": {
           "displayName": "dna",
           "description": null,
-          "liquidGroupId": "1",
           "pythonName": "liquid_2",
-          "displayColor": "#ffd600"
+          "displayColor": "#ffd600",
+          "liquidGroupId": "1"
         }
       },
       "ingredLocations": {

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Author name",
     "description": "Description here",
     "created": 1560957631666,
-    "lastModified": 1738256741877,
+    "lastModified": 1738682213024,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Thu, 30 Jan 2025 17:05:24 GMT",
+      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:16:30 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -38,16 +38,16 @@
         "0": {
           "displayName": "samples",
           "description": null,
-          "displayColor": "#b925ff",
+          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "liquidGroupId": "0"
+          "displayColor": "#b925ff"
         },
         "1": {
           "displayName": "dna",
           "description": null,
+          "liquidGroupId": "1",
           "pythonName": "liquid_2",
-          "displayColor": "#ffd600",
-          "liquidGroupId": "1"
+          "displayColor": "#ffd600"
         }
       },
       "ingredLocations": {
@@ -106,6 +106,12 @@
             "c6f45030-92a5-11e9-ac62-1b173f839d9e": "left",
             "c6f47740-92a5-11e9-ac62-1b173f839d9e": "right"
           },
+          "trashBinLocationUpdate": {
+            "2e4b0821-520d-46f5-af61-bf4e2db2e378:trashBin": "cutout12"
+          },
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {},
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
         },
@@ -133,7 +139,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": true,
           "blowout_flowRate": 1000,
-          "blowout_location": "099f7422-f81c-4188-8fb7-d70f32c574cc:trashBin",
+          "blowout_location": "2e4b0821-520d-46f5-af61-bf4e2db2e378:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_airGap_checkbox": false,
@@ -168,7 +174,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "1",
-          "dropTip_location": "099f7422-f81c-4188-8fb7-d70f32c574cc:trashBin",
+          "dropTip_location": "2e4b0821-520d-46f5-af61-bf4e2db2e378:trashBin",
           "nozzles": null,
           "path": "single",
           "pipette": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
@@ -193,7 +199,7 @@
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": 7,
-          "dropTip_location": "099f7422-f81c-4188-8fb7-d70f32c574cc:trashBin",
+          "dropTip_location": "2e4b0821-520d-46f5-af61-bf4e2db2e378:trashBin",
           "labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
           "mix_mmFromBottom": 0.5,
           "mix_touchTip_checkbox": true,
@@ -3407,7 +3413,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "653466a2-8020-453e-ab02-c005028a2f85",
+      "key": "b6c156db-64b4-424d-99e8-916d3323abfd",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p10_single",
@@ -3416,7 +3422,7 @@
       }
     },
     {
-      "key": "e7c4cb6c-5fb9-4657-ac3e-d88fc0d22504",
+      "key": "5b46cbfe-9158-4339-9373-ab5919dd45eb",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_single",
@@ -3425,7 +3431,7 @@
       }
     },
     {
-      "key": "88a0549f-4dc9-4ff2-8224-0840707768de",
+      "key": "8fff61b7-564d-4264-9ac2-287c0c61aba8",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 10ul (1)",
@@ -3439,7 +3445,7 @@
       }
     },
     {
-      "key": "f8177762-b4d6-4c64-829c-86c43c890013",
+      "key": "b77b662d-6eab-4d73-b2bf-60ea5027f84a",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 200ul (1)",
@@ -3453,7 +3459,7 @@
       }
     },
     {
-      "key": "dc5b0ab1-d6d8-422e-b329-6d450ed47606",
+      "key": "7bcef684-8950-4ce0-b7f7-9a22807014e3",
       "commandType": "loadLabware",
       "params": {
         "displayName": "96 deep well (1)",
@@ -3468,7 +3474,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "029fb680-4e9c-4751-9f46-63bb351213b9",
+      "key": "76b01918-6f03-45e7-b0d3-5a50adae4475",
       "params": {
         "liquidId": "1",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3481,7 +3487,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "c528eb17-0030-4047-a762-160ca37128e9",
+      "key": "4e0754ed-f87f-4840-8bd7-f2f48fa252a0",
       "params": {
         "liquidId": "0",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3496,7 +3502,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "df727ce4-87e9-4ec5-bea2-6b95b046c939",
+      "key": "a20d621e-08b0-4536-8525-74c54dca7aa3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -3505,7 +3511,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "11775a09-4adc-41aa-a8e9-7c9ce4be9e27",
+      "key": "57aeb7aa-75b4-46f0-868c-8fbf420ce168",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3524,7 +3530,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "28f64155-ed7b-4b7d-b28b-15a225f67256",
+      "key": "b3ed2e58-c3a8-4a16-a403-dcae2807c233",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3543,7 +3549,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "85694006-ab52-4adb-8442-ddb909a00859",
+      "key": "73496d06-8799-4a22-a151-f0186c1ce848",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3562,7 +3568,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "7bf0394c-1b42-477a-b342-9c692340e3c9",
+      "key": "172b940a-2997-4560-8f83-6b0b1555e21f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3581,7 +3587,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e4fae21c-fb4d-4d37-a95d-eae6122058b8",
+      "key": "47ec6a53-51c5-44ee-b493-01860b9a8b28",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3600,7 +3606,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "bba3e2c7-abae-4c26-905a-c5bdc377563d",
+      "key": "28c9e028-4b32-48e2-9d1d-6ee3b7ba6631",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3619,7 +3625,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "44baadee-dbe5-42ba-91dc-789a37f095ec",
+      "key": "cfc6b018-0f01-4b7d-9a8b-e99ab361e261",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3638,7 +3644,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "e5f76399-cd91-4e7b-90e2-9f67b51835ff",
+      "key": "d4ce9260-49a8-47af-a6d9-6531a02480d8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3653,7 +3659,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "191ca16f-1556-4c99-97c4-44a1a6ffcf69",
+      "key": "4ba7ff37-f2fe-47fc-bdb1-af1a374c2086",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3672,7 +3678,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "424d1f8d-2372-484a-bf34-51a49b4f8c1a",
+      "key": "777b079c-95fb-41e5-a41a-e5317979d5c9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3691,7 +3697,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "940b80b5-eda9-4fbb-a3f2-dd89ad874b0f",
+      "key": "7a24e96c-16bd-41b0-88f4-87cb03a1b945",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3710,7 +3716,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "586dffd7-11a0-49cc-a768-842e80f7a083",
+      "key": "7a5c9a41-240a-4784-a4dd-a5eb3088ba0a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3729,7 +3735,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "babc33bb-2642-4c1d-9142-5ba7e58f3219",
+      "key": "0dcde7d8-27aa-4dde-836f-646fea39f55a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3748,7 +3754,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "417d2cad-ae9d-44ef-8ceb-ad2d68e379cd",
+      "key": "ce280842-b3a4-42fa-92b2-3a5340b649c8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3761,7 +3767,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "8bc64b78-501e-416a-91d1-4ee65a3744d8",
+      "key": "7cf2f5dc-186e-49bb-a537-d136428af488",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -3769,7 +3775,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "b84bf61c-2878-48da-8910-de9cd9b64fde",
+      "key": "5e939a37-aff7-44ff-ab2c-440c713ef9d5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3784,7 +3790,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "20d90f09-623d-4c7b-b19a-d4afea3437ab",
+      "key": "bde57f47-6a7e-460a-8d6d-8d0c888b6b5e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3798,14 +3804,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "6bdd2267-a54f-4f0b-b3a9-a29fc6facd48",
+      "key": "8cb86963-8158-47b5-a0ce-a6c656776be1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "778e0f97-7810-4392-8816-3390e773c402",
+      "key": "fb168973-b02a-4fb0-9d65-9a3d5b994966",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -3814,7 +3820,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "488ed1c9-5e31-4abf-ac13-7739170f7055",
+      "key": "e7074256-07bc-4a56-970c-11aab79dd2f2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3833,7 +3839,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "8fffd70f-f145-4550-8a8b-75ef67c62713",
+      "key": "90e02d3e-7ec4-4f0b-b490-058fe0145f0a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3852,7 +3858,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "53a14ffd-8bcd-4478-a175-c6ccbbc99138",
+      "key": "28d9526c-26f6-48df-be3c-37f8a4d87911",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3871,7 +3877,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d6f5bfc6-b873-4d72-8b23-ff761a428189",
+      "key": "0075638c-85cb-4f75-a762-6e2d3e242388",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3890,7 +3896,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8c27405f-c328-419a-889d-9045d58e4e33",
+      "key": "488fc2f2-8408-417e-aa19-074945e961e7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3909,7 +3915,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1bb1272d-ce76-41f2-9d53-c1273303880e",
+      "key": "0052650f-0ddd-4af5-bfbc-8385560bb42e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3928,7 +3934,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b941dbde-54a4-445e-a29d-543e159bedbf",
+      "key": "9e201efb-f4b2-4445-9e76-85eed025788b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3947,7 +3953,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "ff5bb79b-e077-4d94-9475-d1ca50852284",
+      "key": "347111ba-db00-4cb8-89c2-a615757e60a7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3962,7 +3968,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "14bf5fb9-d05b-4e51-b74a-ef627109d257",
+      "key": "58d5e6d2-522f-45f7-a4a2-e8fbfc098acb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3981,7 +3987,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "dfba6f40-6a41-4a3e-bf7e-49f63414e6ef",
+      "key": "45ad8b88-b830-4ec8-9c87-d06a54312cad",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4000,7 +4006,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "73686f51-4623-488c-ae1d-cf954e67ac2a",
+      "key": "8e07b1e1-c481-4708-8360-35b19960b0c2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4019,7 +4025,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "87b23803-be29-44ff-b464-53bc9e7ec9d4",
+      "key": "88e873c5-db3f-4434-b526-abd2d34ce72d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4038,7 +4044,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "01d936c2-c68f-4da4-9e58-47c505a479c7",
+      "key": "840c2cce-dab2-4d73-96b6-e268a9fa88d9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4057,7 +4063,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "e575881c-12c0-4291-aee7-a9838ae46669",
+      "key": "9f6f8ae6-94cc-4abd-9df0-6467e82e97f6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4070,7 +4076,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "3208e8c0-5a0f-457c-9344-7f2966b44d47",
+      "key": "21869e3d-fe14-4ee1-843b-b7f791d74e3d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4078,7 +4084,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "c356873a-300c-4e28-855a-b265ced0e7f2",
+      "key": "11428031-e985-4122-82aa-594da85fa23b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4093,7 +4099,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "0377b295-3529-4f46-8e16-c368ab6ebe49",
+      "key": "2a6c179f-997d-49de-af12-1cdc546c849e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4107,14 +4113,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "07e93710-93cc-4dde-9e14-9ae43d132da3",
+      "key": "c4d14c1c-0d84-45a7-aea7-464720456231",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "12083522-572b-42ae-8e29-cc269f844dda",
+      "key": "6202eb05-3a13-409c-a2be-f2a8611f13dd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4123,7 +4129,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b44b017d-8793-4916-ba75-a0fcf17941a6",
+      "key": "c4baf2d7-4d99-494f-abc9-45c837b984f3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4142,7 +4148,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "71ee0966-e142-4748-b9ed-c222e9240495",
+      "key": "0532430f-294c-4e0f-9836-2537bd9d334b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4161,7 +4167,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "52b3c2fd-fb1f-4ed8-8a55-cef464e285c8",
+      "key": "4c0ea920-56dd-4b5c-aaa7-064d9da947c1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4180,7 +4186,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "09e89c72-abf8-4763-a17e-f0b68451e4bb",
+      "key": "faa87389-c3e3-4550-863d-129175764d55",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4199,7 +4205,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b5a4c0be-90a7-44de-9471-81e0057718bb",
+      "key": "f413ce0a-41e8-4b34-a191-d679e5d23387",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4218,7 +4224,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a1ee83f2-5933-4d3e-98b6-84aa33b24e5b",
+      "key": "d4c158a0-80a1-4d3b-9c57-426c514068d8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4237,7 +4243,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8ba0eb8b-3090-41b4-a1b3-aad2f50187ff",
+      "key": "dba81a82-52e8-4341-a883-d63e43b5b9aa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4256,7 +4262,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "86d7ea41-8ecf-402a-8b4d-25809005e4ba",
+      "key": "c9c708f9-aad2-47fe-ac4a-83d37fc2f0ee",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4271,7 +4277,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "577ce715-206f-4a51-b121-cacdb1160ec3",
+      "key": "dd91b34e-0d1e-4a25-812b-51974152257f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4290,7 +4296,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4e900e98-c62e-49b7-b617-298684c919f0",
+      "key": "0526d9c4-c94e-4f76-b9b9-3f7f00b389fd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4309,7 +4315,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "7e39af6a-1a82-435a-98d8-c652bb734836",
+      "key": "40e0f8b6-5270-4a61-8b85-4474a30e9662",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4328,7 +4334,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "6a4d013b-e5ae-4c00-ab32-d255cbe3199c",
+      "key": "0fce3b34-b179-462d-808c-e3fd6ff34148",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4347,7 +4353,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "50bc592a-7d11-44db-87d1-c1fac3f33aca",
+      "key": "6c39cac0-874b-49a5-8a56-fd5f73440a54",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4366,7 +4372,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "b07dc9b0-ae2b-4e6d-a2f2-7689c53c3865",
+      "key": "c7f399ce-e23a-4bd9-b593-4fae8bfb51a5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4379,7 +4385,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "99375975-5737-4632-acf3-a1e4ea1034ca",
+      "key": "e30b2754-065e-4656-91ab-aef8f3fd8cb2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4387,7 +4393,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "e643590b-d941-4660-972f-e73f013cf923",
+      "key": "620fa759-c780-4ec4-9778-0f758bbdf816",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4402,7 +4408,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "33f25151-526c-400e-9c36-02257a6b02b9",
+      "key": "d88909c0-fde0-4ae7-9072-d361a400bbb3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4416,14 +4422,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0f621a52-7ac3-49b1-a732-4a4547737217",
+      "key": "ead98234-1143-4f73-80b7-e00eb5176abf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "25ecc88a-bb2d-40aa-b03d-8c070b64bcfc",
+      "key": "b70c8c23-bc75-4943-8199-75aeeb0e98b4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4432,7 +4438,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1bec23d2-cf63-4e75-a758-c8035f509adc",
+      "key": "77ffe4f4-96f7-484a-8df8-abdc081a005a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4451,7 +4457,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "84b0d168-b6e6-4bdd-a1b2-714bc49a92b6",
+      "key": "a1766c9a-08b0-4636-afcc-566618839c42",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4470,7 +4476,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "75c1c612-a887-4f27-87da-0f43823d416a",
+      "key": "95a0f7eb-4c13-4e66-9f47-2b3f56c9566c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4489,7 +4495,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d168f003-f78d-46fd-9e5a-4f9eda0b3118",
+      "key": "9601d22b-9cba-4187-94cd-cc5e5e52cf3b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4508,7 +4514,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b78fd127-21c8-49b0-aed2-0805c8be3e86",
+      "key": "ed294942-e998-4f02-a945-85d2a6bf8ff7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4527,7 +4533,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "344402c1-a8fd-43e1-ac66-9432edb241f5",
+      "key": "1fbffe57-ecd7-4244-ba04-1a0621cbf311",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4546,7 +4552,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "02347dbb-2094-4e01-b8b6-d01581dde145",
+      "key": "d6711159-63a5-470d-a88a-e80a75d656d2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4565,7 +4571,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "975cd29b-7803-4784-afb4-803f0f0d423e",
+      "key": "12adcc53-2ece-4e50-8e81-bd27349b6053",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4580,7 +4586,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "b7f1a73a-8831-4a44-9ba7-b5cb519bb215",
+      "key": "0f7a13fb-99c7-4cd7-bb4b-6f615dbcf0b3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4599,7 +4605,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4cc4dd8d-096e-46c1-b679-5350affd8b8a",
+      "key": "0ca8c2f1-3f53-4309-ab08-5fc2232bcc44",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4618,7 +4624,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "53c53d98-c333-4071-8b9c-7ddd30af9156",
+      "key": "bcbf6cf0-0387-4f32-ac2f-09f5cf0b4f61",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4637,7 +4643,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "99bf4d65-85f8-4759-9ba9-97e2aa2e7c0d",
+      "key": "79c82d3c-0f3c-40ab-acde-0ddec69fb452",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4656,7 +4662,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "aca6fcb1-3f17-444c-9ec8-f15a8abfcfc0",
+      "key": "0a6b23c1-510f-4e14-9703-f547c95229aa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4675,7 +4681,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "03e1fe26-33b6-44b6-be58-0287e71c28f3",
+      "key": "d1a4a476-c7a6-43f5-ae9c-b535eaa75085",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4688,7 +4694,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "5a2c56e4-bc46-4855-8c5e-9bfce14ae3b9",
+      "key": "e1d91545-60cb-424f-b312-e2ab186ed231",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4696,7 +4702,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "6d85e783-0eca-4bb3-a3a2-166d2071ebe8",
+      "key": "464f544c-bbdd-4356-af91-609b34a051a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4711,7 +4717,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "41c7dd1d-0e8a-4586-8ba1-f1daf5e749e6",
+      "key": "7173b1e3-ba16-4e2f-bc37-5e6f3a8fcf05",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4725,14 +4731,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "eb5b780c-0a3e-411e-b596-0e32558910a0",
+      "key": "adb1abc6-ae8a-40b5-91b2-86e58b2a8e86",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d797963b-39f7-4720-a4c1-8d81f4f9c472",
+      "key": "d87cf05c-e6f8-4c28-b9e4-84c15a7e9888",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4741,7 +4747,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "5c224719-928e-4af8-b7aa-f10b65946c11",
+      "key": "0842af17-ba02-4040-b97b-f9f6d9e384f9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4760,7 +4766,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1aba110d-735e-46ad-a5e6-020663d29ebc",
+      "key": "f38338b8-f3c8-4d47-b449-e39eb5699e80",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4779,7 +4785,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "7254a835-c333-43a6-b9e1-25ef28edbad5",
+      "key": "5eab1add-4039-4253-b96b-10a0c62fffa4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4798,7 +4804,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0450994c-9de9-4f5e-9c26-710421e396d6",
+      "key": "46346f68-fca5-4cff-906b-ca50596f2ad3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4817,7 +4823,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d1b342f4-62d8-49a8-be58-2dd480edd145",
+      "key": "6a4aef6d-88f1-416a-b49f-95f2980e65bc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4836,7 +4842,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "032db156-a716-4fa2-8683-99cd424483c6",
+      "key": "4c21f952-f8a3-4174-b49d-8211605c8623",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4855,7 +4861,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "0c4b6581-62ce-49f2-8916-1086071c579b",
+      "key": "97710ca5-fee5-41e6-8e5f-dd2dbcaef1a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4874,7 +4880,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "b4a66d40-394a-4350-ad29-0a3b7bbde31b",
+      "key": "e0203037-a9f1-4438-89d3-43568ff0a69c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4889,7 +4895,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "8409f328-898c-48d5-b2f0-14334072d2a2",
+      "key": "052412a5-94a2-4179-9a81-57f06ac6143c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4908,7 +4914,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "3f6459ee-02d6-499e-ba89-f0ebffb48d88",
+      "key": "df97f1f7-65c1-4bd7-ba7e-1dbc63f432f3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4927,7 +4933,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1bf54eb3-f3ba-43f7-9ccc-43c83b1fcf13",
+      "key": "0d0a7e80-8576-46dc-be69-ca24544b02f2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4946,7 +4952,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8166d4a6-0a41-4a2c-bccb-043859a9f1d8",
+      "key": "aba04cf1-2028-492b-a28a-f629eeab5f65",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4965,7 +4971,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "47d7fd68-05b0-41f6-9c4c-7a37aa7bcb13",
+      "key": "de937cbb-c4aa-45fb-9548-d0f84e4dda28",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4984,7 +4990,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "3809644f-92fa-4da0-9db5-542c0a181e8c",
+      "key": "235df24b-9d44-4d15-96ca-42c5e632251f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4997,7 +5003,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "929ce1cb-82cb-4c39-92a3-39c628b019c9",
+      "key": "2e49a1a0-3885-45ed-a8a1-1e5cd3ff9846",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5005,7 +5011,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "6d135454-0d51-49df-bf4c-4e2bb813f1d2",
+      "key": "587f7545-ddaa-41fa-abdd-0fbce07e1fc6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5020,7 +5026,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "349625a9-aa2b-4d35-b40b-8ef14e586a51",
+      "key": "5319b473-6b31-4be2-af1e-01e14fff25ba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5034,14 +5040,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "444440c9-00d5-4348-99a9-1a3cb1f742fd",
+      "key": "8ac985b6-3686-4bec-9491-303aa2d4e5a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "4c52ae1d-70b1-4dc9-83e7-02b3af2c200e",
+      "key": "b092ef81-4360-4ad7-a444-c6d9307446ab",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5050,7 +5056,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "5640b654-9339-4845-9b40-a6beba046904",
+      "key": "2c6a096e-59de-4662-8cc2-dab696f55064",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5069,7 +5075,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "592654fb-22db-4ace-b2a7-f68f56a9967b",
+      "key": "f18e7e75-783b-407e-a84a-3e1ecfa9cb01",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5088,7 +5094,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "3d039399-6e83-4a41-a3d1-2ab1c5482824",
+      "key": "9f68dfdd-f18f-4d29-823c-3554ca017e0c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5107,7 +5113,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d0fe6ba1-5037-4b30-a5c5-22efa87fa431",
+      "key": "46f31d39-b423-48c5-ab1f-29555f2e1957",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5126,7 +5132,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "df2ba6f0-4d77-430b-97fc-5ce88b1f3947",
+      "key": "61713144-9c70-493d-8207-118892ae1afb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5145,7 +5151,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "85078a16-bdf9-471d-9b07-4938634c49c9",
+      "key": "d6e61857-d24c-49c5-b590-17e7e16ce460",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5164,7 +5170,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "bc04ada5-ca7f-4bc5-bf00-d85e82360ab8",
+      "key": "64ff64a6-62a9-4612-8e4d-adc40254a760",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5183,7 +5189,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "2cc0af02-6209-4482-9436-4a3cbf4e52d6",
+      "key": "9525512e-10c3-46bc-bd51-e82af933a363",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5198,7 +5204,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6d084361-fbed-49c1-af3e-28e58e8e60b7",
+      "key": "f600f10b-b5e6-44aa-92f1-ddefb91eefc1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5217,7 +5223,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "dd665ee5-3242-4c63-afe0-e2083810ee37",
+      "key": "8a6d29a0-8555-4f87-b859-adf93b9ec598",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5236,7 +5242,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "7ef70d87-4be3-4260-8098-39599f8a1fb0",
+      "key": "0fb0c6c9-d7fe-46cf-959d-84e23d164236",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5255,7 +5261,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "588334ee-930e-4a6d-a1ab-69c145197023",
+      "key": "f35ecbf2-32c7-478d-a273-3c924f3ca7ee",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5274,7 +5280,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "857d9f81-2181-4ca2-9389-cad3fa9aee70",
+      "key": "a1043e5a-83ae-47a1-ad43-a1dae2089850",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5293,7 +5299,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "ad2d67a4-625c-437b-96c8-e48fd7918577",
+      "key": "687ea83a-9c5f-45ad-acb0-356d80b8ac5a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5306,7 +5312,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "2d154de5-d3e3-4641-a1e3-5c006d810006",
+      "key": "06d1f4d9-c932-4c58-9182-aea2232cae42",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5314,7 +5320,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "6b0659e9-1856-4550-8279-fb82fc2e94a7",
+      "key": "30da32b8-1d0f-449a-8ad6-c8d2ab8f21d6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5329,7 +5335,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "cec99b96-c228-4e2a-a143-fbbbfb50901e",
+      "key": "9e5c1bee-e858-4c05-bd23-d76bf3e9905b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5343,14 +5349,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "15825029-3fab-4e68-9469-560e148e7ced",
+      "key": "cf676e27-7b50-4441-9503-54799055c61c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "161b384c-5c92-4056-8015-2719ee427475",
+      "key": "31187b3d-8c42-469b-af23-7cdce6d06b44",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5359,7 +5365,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "08f3fb64-eaf8-4416-aa23-baba231efed0",
+      "key": "f9e1a43e-8959-4640-8f08-3fa850c84f0c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5378,7 +5384,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "651d97ff-dc34-41cd-8dd4-c0b94f21c674",
+      "key": "c7913d86-ff26-453a-9032-88d3674b4439",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5397,7 +5403,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ca22a85d-6732-4c43-a8ea-4a857065ddd2",
+      "key": "34831446-bce1-440f-a765-9c53571e9c65",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5416,7 +5422,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f16da0ca-bba1-4ee1-a2ed-f68fdbeee204",
+      "key": "caa88df0-25b6-40de-a25b-aa147369c086",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5435,7 +5441,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c91c5044-4c23-420e-9892-a4067215d78d",
+      "key": "b9900e0a-2149-4ebb-9182-5446ddcf999b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5454,7 +5460,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "47346096-1081-4817-96c9-77d799327011",
+      "key": "6affd104-4b47-4419-a1d4-8afcc93b88e6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5473,7 +5479,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "35813192-b966-4cbd-95a9-9d87cae07adc",
+      "key": "eec6bd80-d9c6-4001-ac19-c521246f008a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5492,7 +5498,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "eac2a4b2-65cc-4c8d-b8d8-01b2c9bf2a20",
+      "key": "7c9a3c45-e6ee-42db-8c31-1f75c89042c4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5507,7 +5513,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "194be867-02d5-48d1-a19f-9c01fb832068",
+      "key": "0fd7e858-2609-4a4b-aa94-04c8b7663452",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5526,7 +5532,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "99ffbb3c-e5a2-48f4-a4a4-811b6839aeea",
+      "key": "8a310593-cab4-4874-aa09-f5fc3b5d1aca",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5545,7 +5551,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "78a477c6-5414-480e-8953-0ba4bb94f220",
+      "key": "9baf1ed3-b439-41cf-ad6b-c501b155dbda",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5564,7 +5570,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1f7e8e1b-8f71-4782-b731-266da9db63ff",
+      "key": "d463c700-dac1-463b-8dd2-8667f3eb037e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5583,7 +5589,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "7e06c384-46d3-40af-b820-96c86d8a5da5",
+      "key": "61fba73d-bf33-46c6-b569-637c01ef1395",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5602,7 +5608,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "fca397e0-65a0-48d6-83fe-05132b2ddc24",
+      "key": "62e22ade-d8fd-4877-ae72-a3316e2e0608",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5615,7 +5621,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "8f53ee29-11fb-441b-9719-97c132f275b5",
+      "key": "0dc6e24a-18ca-4793-9059-084b040e3c7e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5623,7 +5629,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "0699658d-fb6c-4b56-b803-00dd96940cc4",
+      "key": "6c4dca23-1208-4e35-9dce-17b90f9da4db",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5638,7 +5644,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "9b306194-770b-49ef-bcd3-95c64244679e",
+      "key": "63591b00-dc8d-413b-afb4-925431ba0fef",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5652,14 +5658,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0c9714a3-0018-44fa-a531-8dcf9c168d1a",
+      "key": "65010ce3-901b-4608-968b-ae7b1726512d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "e13d0327-a840-4de7-b7ce-fbde43257c34",
+      "key": "670b61af-2f95-4e23-a5c1-ad6155244add",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5668,7 +5674,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2a19acac-8b2f-4f28-8eee-826a8d6bff15",
+      "key": "47bca455-b34f-4333-ac30-47768fa98ff0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5687,7 +5693,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "88afadcf-1256-437e-856c-4f615ccb4a72",
+      "key": "5c1930a8-cf8a-49b8-b7ee-51205d0afb1b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5706,7 +5712,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d8319c46-7fd0-4f68-82d1-6a761556ec85",
+      "key": "384a6802-77fe-4b0e-ad14-709c2fdbe1cb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5725,7 +5731,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5e18da13-4b92-4733-9e9c-26f57a5eb5b4",
+      "key": "77a0e5bf-9892-4998-b775-b45ea8032e51",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5744,7 +5750,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "18fb939f-0390-4741-9fee-50b1911936c0",
+      "key": "71c0d2ab-505f-4e7d-9681-76c98fc7670a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5763,7 +5769,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "40da27db-1412-440d-bbd0-5148b6f64ed7",
+      "key": "1992b40f-0ded-4cbb-8feb-3345771cc685",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5782,7 +5788,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9f504ffd-465d-495b-a656-109d35cfe9b1",
+      "key": "7cc44132-fc06-4808-91fa-977efa07b01c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5801,7 +5807,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "394d2f74-5e28-4e6f-b815-c97087c89691",
+      "key": "a7d6848f-621b-4e5a-a1cf-f11fca3f448c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5816,7 +5822,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "8cb558bd-2ea6-497c-b070-af6e41664a26",
+      "key": "9096cb20-4e87-4249-9da3-327a7f746d5c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5835,7 +5841,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "3274dd59-0600-4c2a-890a-fecfac8b5862",
+      "key": "91c83d69-771c-48c1-920b-951664d66df1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5854,7 +5860,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "21d4fc28-b92e-4e45-a1ef-cccee395e3ec",
+      "key": "45e2a957-49b1-4f9e-9c97-f6ff470457c8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5873,7 +5879,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "7d9b7d52-8963-41bd-869a-afb3273ad34e",
+      "key": "78cd4847-b928-43df-b2df-ec89a3211243",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5892,7 +5898,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "35a3b1ab-efa8-4f6b-b074-b5bedb66f827",
+      "key": "1de06143-7e09-4030-bb53-d2b769690b95",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5911,7 +5917,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "9acfc10b-c99c-4f11-a270-0f5eec661be5",
+      "key": "ae8c36f1-2af0-43c3-892f-af8f7a057e99",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5924,7 +5930,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "e3135725-cb6f-45a1-9fe0-d19f04f27656",
+      "key": "a2dc3be0-b847-4fc0-a2c7-529794908f2b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5932,7 +5938,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "96673cd7-fd03-4c0a-bb2a-b14a0ffb0ccb",
+      "key": "0017585f-5ff6-49c7-84c5-dccfae364cbd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5947,7 +5953,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "2132f0ae-ea2e-443b-a971-5c79ee30f789",
+      "key": "b287747c-81fc-4c6a-a422-705377142116",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5961,14 +5967,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "9c328923-a752-40b1-9270-ed97a3a0c553",
+      "key": "0551b764-b82f-4ae2-beb2-c7adf2dc6b54",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "988563f5-56c4-4e21-a92b-b6e2dfb8bde5",
+      "key": "1e0289a4-61cf-4990-ba90-2f385a213079",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5977,7 +5983,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c98f3b96-fd38-40f2-9794-828ff525969c",
+      "key": "8709c899-db94-42fa-b1dc-f3c97733abdc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5996,7 +6002,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "576cd475-ef5a-4016-a705-efd349d2e442",
+      "key": "d826a43b-5440-4ba1-bc27-048c59c48821",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6015,7 +6021,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e7ee52ac-8fcf-44ba-82a2-1db637e376be",
+      "key": "60f35226-94d0-4bc1-b529-144945af67bc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6034,7 +6040,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "77016b31-a245-40fc-a52e-c83b3004b81f",
+      "key": "dd214b0c-cc5b-403d-8ae1-e41d946521e4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6053,7 +6059,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "7db3ab8a-5903-4960-bbdc-26497da191ad",
+      "key": "cc898a43-afd4-4a11-96ae-0fba6c8e3e3f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6072,7 +6078,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "910d7439-52d6-4a16-a6a5-0b71e3c32696",
+      "key": "e99ba431-0662-427f-ae20-fbbcb1ecc454",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6091,7 +6097,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "39bfaad3-fdc2-42d1-8f12-d2684d0a9bbf",
+      "key": "e3a612d0-1a8a-4b89-bd2e-8c94b646e5a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -6110,7 +6116,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "44f4d1a4-26c3-435e-810c-ecaad59a55ab",
+      "key": "b196c957-003b-4d2b-b0e0-9fabbb467015",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -6125,7 +6131,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "ddc2756d-38e4-4d42-81a1-ad531797ec79",
+      "key": "186ff8c9-57c9-43a2-9dd3-12c886d85c6e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -6144,7 +6150,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "23ecb712-813c-4221-92b5-b7ad0df7c91e",
+      "key": "92958a8f-18cf-4770-a5c7-520578a9e1ac",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6163,7 +6169,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "020d2f92-da37-4230-9041-0d746dbc81c8",
+      "key": "81269d20-c06b-4e6d-ac0b-28beaa42e84d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6182,7 +6188,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9493caea-f0ee-459a-b286-b656c540fa19",
+      "key": "944816f0-75fa-427a-91e6-241a17d335ef",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6201,7 +6207,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2fd36c9a-4387-4e0d-b96b-c095c325450c",
+      "key": "50baa2c8-09cb-4457-a88f-d4bf2025ab62",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6220,7 +6226,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "c5c15d57-b094-4344-8a9d-ef55442e587c",
+      "key": "f6860db4-02f6-42de-9c5e-952861986160",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6233,7 +6239,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "9f3a5bc5-d27e-47f3-996c-873edee7e793",
+      "key": "b3a42537-456b-4d2e-9909-aa6050280bdf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -6241,7 +6247,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "817158fe-bf57-4d1e-a6a4-020cfd8d79ab",
+      "key": "6eb19d13-f030-4b84-a68d-4be98fa8d1c4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -6256,7 +6262,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "30538d0c-d451-46fe-a19d-56f564b351e5",
+      "key": "83acf0f8-37fc-4b46-8788-0125b35d79c7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6270,14 +6276,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "08f1c64b-09d5-4ac2-a5c3-3d152da7cad2",
+      "key": "33cdfe7e-00c2-4deb-a276-57e41a25c689",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "45323d95-f2a6-47a2-8854-62e54e92585b",
+      "key": "40946613-5d56-490f-892f-4570ce6dc494",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -6286,7 +6292,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "befaaff7-d4e1-4b3c-9c0c-d40c2b956962",
+      "key": "7a975917-cb11-4947-82d4-ec0fb6ff48e4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6305,7 +6311,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "bac1ea10-10c5-41ca-96ce-781304f8675e",
+      "key": "a82ee50c-437b-4861-bfa7-1a390fc3e19b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6324,7 +6330,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f37e217e-4939-44e2-9671-9b05ad14786d",
+      "key": "8a93c248-0c06-49fe-a39e-7b0111d52112",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6343,7 +6349,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "c159f36c-e926-4875-b99b-4add3525c4e3",
+      "key": "6a94836c-c4d7-422e-b79f-e42accd7ce7d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6362,7 +6368,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "25ae2b7c-b305-4e87-840d-42de7ded3b4b",
+      "key": "871678da-eed3-42d1-bff6-ec89a3ce578d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6381,7 +6387,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "23397b4a-4383-42ed-b8f4-e44f3a010a71",
+      "key": "79880e8a-41d3-4b67-ac46-b133f6c06877",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6400,7 +6406,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "890a6535-a85d-466f-8505-64405697b5a0",
+      "key": "ec7ec1b4-d6e9-437d-802a-9b9df4fe39f5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6413,7 +6419,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "c8253121-dac9-4f54-93f9-f5db77f7c879",
+      "key": "4aa188ff-d2c1-4484-a43f-91164ab987b2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -6421,7 +6427,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "57b65cb0-810c-44f2-b3bb-9a4c9d7e829d",
+      "key": "e62327c7-e230-410a-8304-a1c37ff4708e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -6436,7 +6442,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "0d13cd12-8ca0-4ead-bfbd-debe41d9a00e",
+      "key": "3bcc74cd-956f-428d-8978-dd359c7ed802",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6450,14 +6456,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "087b6b54-6e37-48c3-aeda-91ee0b43febc",
+      "key": "59c39c03-fd02-4e7a-b26e-c99ec30d0aaa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "waitForDuration",
-      "key": "f1e0270b-15e2-4ba6-adaa-4369bd92c271",
+      "key": "74d10946-d37d-456f-bf79-afaada065939",
       "params": {
         "seconds": 3723,
         "message": "Delay plz"

--- a/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
+++ b/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
@@ -36,6 +36,9 @@
           },
           "pipetteLocationUpdate": { "pipetteId": "left" },
           "moduleLocationUpdate": {},
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {},
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
         },

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1714565695341,
-    "lastModified": 1738157367073,
+    "lastModified": 1738682506391,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Wed, 29 Jan 2025 13:23:47 GMT",
+      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:16:30 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -48,6 +48,12 @@
           "pipetteLocationUpdate": {
             "21087f15-4c03-4587-8a2b-1ba0b5a501a0": "left"
           },
+          "trashBinLocationUpdate": {
+            "20ab923c-1290-402e-8476-bba30991f24e:trashBin": "cutoutA3"
+          },
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {},
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
         },
@@ -110,8 +116,8 @@
           "stepType": "moveLiquid",
           "stepName": "transfer",
           "stepDetails": "",
-          "id": "292e8b18-f59e-4c63-b0f3-e242bf50094b",
-          "dispense_touchTip_mmfromTop": null
+          "dispense_touchTip_mmfromTop": null,
+          "id": "292e8b18-f59e-4c63-b0f3-e242bf50094b"
         },
         "960c2d3b-9cf9-49b0-ab4c-af4113f6671a": {
           "moduleId": "d6966555-6c0e-45e0-8056-428d7c486401:temperatureModuleType",
@@ -3591,7 +3597,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "bc9f6354-a7a7-407a-86fa-d764fed37892",
+      "key": "4e81978e-27c9-4d5c-b3af-0548d0356a69",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_single_flex",
@@ -3600,7 +3606,7 @@
       }
     },
     {
-      "key": "5653381b-77ed-49c5-b13a-a897108e25b2",
+      "key": "edcdab68-334b-4b49-ac81-af0741538f44",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -3611,7 +3617,7 @@
       }
     },
     {
-      "key": "9b05da10-4b23-4e6b-82f0-03d078c0aafc",
+      "key": "d408749c-8240-491e-9397-05cb9d0e117f",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -3622,7 +3628,7 @@
       }
     },
     {
-      "key": "c195d07a-ca33-4a3c-a33d-1f5df2f3b906",
+      "key": "9a607dd5-2a6c-4f65-befb-1927ab1d96c3",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Well Aluminum Block",
@@ -3636,7 +3642,7 @@
       }
     },
     {
-      "key": "cad83091-9a60-4df4-aaa8-86316b44e6b4",
+      "key": "c461976c-2b67-405b-a5b4-30d8e843aa59",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
@@ -3650,7 +3656,7 @@
       }
     },
     {
-      "key": "3128ec57-5aed-4824-8b91-f9a3f7a9ea1f",
+      "key": "69314eb3-f57f-4a63-b1db-bf3e874d7de7",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap",
@@ -3664,7 +3670,7 @@
       }
     },
     {
-      "key": "d70bb67b-f388-4eda-84a5-51accd89c534",
+      "key": "9b6120d9-1d75-4bbb-b165-03c22541c92f",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -3679,7 +3685,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "5535c00b-3931-43b4-bd39-6f7498ac3739",
+      "key": "5ad19fa0-44d6-46f9-9d7c-834a8c1daa2a",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "labwareId": "0d39213c-49c2-4170-bf19-4c09e1b72aca:opentrons/opentrons_flex_96_tiprack_50ul/1",
@@ -3688,7 +3694,7 @@
     },
     {
       "commandType": "configureForVolume",
-      "key": "a35a7664-c44a-41fb-9e67-08b01f2339f7",
+      "key": "214ad986-39fd-4fd8-a3d1-11e7a3fee49f",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "volume": 10
@@ -3696,7 +3702,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d7a2bb3f-4158-41c2-83fa-95c33f02c076",
+      "key": "1677354b-365b-478f-902a-2356d7caffdb",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "volume": 10,
@@ -3715,7 +3721,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5c6fc843-d3e9-46ba-88a7-34f88771010a",
+      "key": "eb29cc00-3d96-484f-9c5c-36b3f6d3b2f6",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "volume": 10,
@@ -3734,7 +3740,7 @@
     },
     {
       "commandType": "blowout",
-      "key": "e53ccf8f-b3e3-4a63-a84e-b000457162e6",
+      "key": "dd09a42d-78d0-451f-9ad8-00a2573fe98a",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "labwareId": "c0093e5f-3f7d-4cbf-aa17-d88394108501:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -3750,7 +3756,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "287251ef-d8dc-4ae5-ad72-ac84cd81e5b6",
+      "key": "442a0535-ed1d-42b0-a98c-5234fd4a8570",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "addressableAreaName": "movableTrashA3",
@@ -3764,14 +3770,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "ea735ed4-a2c6-41af-ae6e-7eb223db25bf",
+      "key": "8e3e6a32-3a2c-4b8e-a2d3-d028e952fd9e",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0"
       }
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "c45ee0b8-08fa-4854-8a0d-e65f513c2f08",
+      "key": "97e3e319-2254-4842-8280-551a35f40f30",
       "params": {
         "moduleId": "d6966555-6c0e-45e0-8056-428d7c486401:temperatureModuleType",
         "celsius": 40
@@ -3779,7 +3785,7 @@
     },
     {
       "commandType": "temperatureModule/waitForTemperature",
-      "key": "f994033a-27cf-4ce1-999b-242edae5538e",
+      "key": "3bb0e089-4a38-4bcc-b92c-19957bef78a2",
       "params": {
         "moduleId": "d6966555-6c0e-45e0-8056-428d7c486401:temperatureModuleType",
         "celsius": 40
@@ -3787,7 +3793,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "6ceb2f9e-7ac4-4807-ada9-5d1d3cd316ce",
+      "key": "b758e33e-4c6d-46d6-be6f-807e9da90dfb",
       "params": {
         "moduleId": "b9c56153-9026-42d1-8113-949e15254571:temperatureModuleType",
         "celsius": 4
@@ -3795,7 +3801,7 @@
     },
     {
       "commandType": "temperatureModule/waitForTemperature",
-      "key": "e090a25b-48ec-4a2e-8744-23df852efee2",
+      "key": "76613ed5-1871-465b-aaf8-8b0de51e9265",
       "params": {
         "moduleId": "b9c56153-9026-42d1-8113-949e15254571:temperatureModuleType",
         "celsius": 4

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1701805621086,
-    "lastModified": 1738157515738,
+    "lastModified": 1738682533383,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Wed, 29 Jan 2025 13:23:47 GMT",
+      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:16:30 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -47,6 +47,12 @@
           "pipetteLocationUpdate": {
             "de7da440-95ec-43e8-8723-851321fbd6f9": "left"
           },
+          "trashBinLocationUpdate": {
+            "1e553651-9e4d-44b1-a31b-92459642bfd7:trashBin": "cutoutA3"
+          },
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {},
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
         },
@@ -69,7 +75,9 @@
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
           "aspirate_wells_grouped": false,
-          "aspirate_wells": ["A1"],
+          "aspirate_wells": [
+            "A1"
+          ],
           "aspirate_x_position": 0,
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
@@ -109,8 +117,8 @@
           "stepType": "moveLiquid",
           "stepName": "transfer",
           "stepDetails": "",
-          "id": "83a095fa-b649-4105-99d4-177f1a3f363a",
-          "dispense_touchTip_mmfromTop": null
+          "dispense_touchTip_mmfromTop": null,
+          "id": "83a095fa-b649-4105-99d4-177f1a3f363a"
         },
         "f5ea3139-1585-4848-9d5f-832eb88c99ca": {
           "aspirate_airGap_checkbox": false,
@@ -131,7 +139,9 @@
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
           "aspirate_wells_grouped": false,
-          "aspirate_wells": ["A7"],
+          "aspirate_wells": [
+            "A7"
+          ],
           "aspirate_x_position": 0,
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
@@ -171,8 +181,8 @@
           "stepType": "moveLiquid",
           "stepName": "transfer",
           "stepDetails": "",
-          "id": "f5ea3139-1585-4848-9d5f-832eb88c99ca",
-          "dispense_touchTip_mmfromTop": null
+          "dispense_touchTip_mmfromTop": null,
+          "id": "f5ea3139-1585-4848-9d5f-832eb88c99ca"
         }
       },
       "orderedStepIds": [
@@ -189,18 +199,126 @@
   "labwareDefinitions": {
     "opentrons/opentrons_flex_96_tiprack_50ul/1": {
       "ordering": [
-        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
-        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
-        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
-        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
-        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
-        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
-        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
-        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
-        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
-        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
-        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
-        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
       ],
       "brand": {
         "brand": "Opentrons",
@@ -1239,7 +1357,9 @@
       ],
       "parameters": {
         "format": "96Standard",
-        "quirks": ["tiprackAdapterFor96Channel"],
+        "quirks": [
+          "tiprackAdapterFor96Channel"
+        ],
         "isTiprack": false,
         "isMagneticModuleCompatible": false,
         "loadName": "opentrons_flex_96_tiprack_adapter"
@@ -1247,7 +1367,9 @@
       "namespace": "opentrons",
       "version": 1,
       "schemaVersion": 2,
-      "allowedRoles": ["adapter"],
+      "allowedRoles": [
+        "adapter"
+      ],
       "cornerOffsetFromSlot": {
         "x": -14.25,
         "y": -3.5,
@@ -1256,18 +1378,126 @@
     },
     "opentrons/biorad_96_wellplate_200ul_pcr/2": {
       "ordering": [
-        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
-        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
-        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
-        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
-        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
-        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
-        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
-        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
-        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
-        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
-        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
-        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
       ],
       "schemaVersion": 2,
       "version": 2,
@@ -2160,7 +2390,9 @@
       },
       "brand": {
         "brand": "Bio-Rad",
-        "brandId": ["hsp9601"],
+        "brandId": [
+          "hsp9601"
+        ],
         "links": [
           "http://www.bio-rad.com/en-us/sku/hsp9601-hard-shell-96-well-pcr-plates-low-profile-thin-wall-skirted-white-clear?ID=hsp9601"
         ]
@@ -2306,7 +2538,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "261b6dcd-ec1c-405c-bc13-bdca44557a4c",
+      "key": "8b0499d8-e1c0-4f8d-8e1f-fb8f5ca968f0",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_96",
@@ -2315,7 +2547,7 @@
       }
     },
     {
-      "key": "4889f04d-e1fb-49ba-9f10-a0030c68ac7f",
+      "key": "6d18b281-8a99-427f-8e7f-6a5f1d75c691",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack Adapter",
@@ -2329,7 +2561,7 @@
       }
     },
     {
-      "key": "60a8ced3-f7bb-44db-a492-aa2d102cc465",
+      "key": "25bf1936-d9af-4554-9ac9-f3d125c71505",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
@@ -2343,7 +2575,7 @@
       }
     },
     {
-      "key": "608c4a16-9751-44c8-96f8-eec999611c79",
+      "key": "31a2baad-d37a-4502-8ca8-7217746b5eec",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Bio-Rad 96 Well Plate 200 µL PCR",
@@ -2357,7 +2589,7 @@
       }
     },
     {
-      "key": "9905fa02-358f-4d23-b936-8711b2bf5600",
+      "key": "b1030040-9a1d-409c-824d-fb3c1c5e74fe",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
@@ -2372,7 +2604,7 @@
     },
     {
       "commandType": "configureNozzleLayout",
-      "key": "e8d646ad-3046-4186-803f-a01e329cef97",
+      "key": "92de0faf-c381-4f9a-a3e5-bdd8dfbdc9a7",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "configurationParams": {
@@ -2382,7 +2614,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "ecf30773-7a3c-47c3-8c79-6b1f91bf20b2",
+      "key": "17719786-baf8-404b-8de3-05bcc1e86259",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "75aa666f-98d8-4af9-908e-963ced428580:opentrons/opentrons_flex_96_tiprack_50ul/1",
@@ -2391,7 +2623,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "bb5f9927-b5a2-4e5e-8015-a93d808aa3ea",
+      "key": "7ac552fa-97ce-4144-b18d-86624511f04d",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
@@ -2410,7 +2642,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "efd35098-e1b1-4353-b5e9-9cc8c87e66df",
+      "key": "0d5de06e-b28f-41c6-8087-3eef54823651",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "addressableAreaName": "movableTrashA3",
@@ -2423,7 +2655,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "b2da7fa8-1359-40fb-ab30-92e21fb879de",
+      "key": "061e56ac-b3b1-4632-85bc-bf98f5b3e440",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
@@ -2432,7 +2664,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "9cdf6b7f-3fe4-455d-82db-2b0f3a8179bc",
+      "key": "bfbec11e-831f-48cd-8766-c40bcd77c33a",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "addressableAreaName": "movableTrashA3",
@@ -2446,14 +2678,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "335acc42-668d-4159-9943-df822419adae",
+      "key": "151289b6-cccd-47e7-b519-c0b327c69b63",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9"
       }
     },
     {
       "commandType": "configureNozzleLayout",
-      "key": "1950c1e6-1eb6-46c8-ba4b-c7c38c825094",
+      "key": "26a8d10e-40dc-4915-88fb-7131a4e0191a",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "configurationParams": {
@@ -2464,7 +2696,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "34b5dc55-8096-445d-b77c-40918b657c9f",
+      "key": "472ff857-edd5-4225-b555-2aa07ff4d6d9",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "9bd16b50-4ae9-4cfd-8583-3378087e6a6c:opentrons/opentrons_flex_96_tiprack_50ul/1",
@@ -2473,7 +2705,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "42132ae0-4321-4251-9b12-5aec2a398617",
+      "key": "02833246-8dd6-408f-9481-9408551727a7",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
@@ -2492,7 +2724,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "e6468d3a-d076-40be-bc49-da13f38c7e4e",
+      "key": "992c6b3c-ccef-409a-ab4b-a55b0cfcd549",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "addressableAreaName": "movableTrashA3",
@@ -2505,7 +2737,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "acbf26f8-2025-48df-85a8-8696815906f6",
+      "key": "f0e4d408-47ae-45f3-a7fc-d88dd2b42a35",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
@@ -2514,7 +2746,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "0e00ce33-ab8f-4600-9a4c-72677d2d4408",
+      "key": "dce3b716-77e3-4b80-82dd-2a6a61a57a17",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "addressableAreaName": "movableTrashA3",
@@ -2528,7 +2760,7 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "bfba211e-b4a7-475d-88ce-134c134dc7a1",
+      "key": "93d69b14-2d41-4272-bcac-78d5810db8f0",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9"
       }

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -75,9 +75,7 @@
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
           "aspirate_wells_grouped": false,
-          "aspirate_wells": [
-            "A1"
-          ],
+          "aspirate_wells": ["A1"],
           "aspirate_x_position": 0,
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
@@ -139,9 +137,7 @@
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
           "aspirate_wells_grouped": false,
-          "aspirate_wells": [
-            "A7"
-          ],
+          "aspirate_wells": ["A7"],
           "aspirate_x_position": 0,
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
@@ -199,126 +195,18 @@
   "labwareDefinitions": {
     "opentrons/opentrons_flex_96_tiprack_50ul/1": {
       "ordering": [
-        [
-          "A1",
-          "B1",
-          "C1",
-          "D1",
-          "E1",
-          "F1",
-          "G1",
-          "H1"
-        ],
-        [
-          "A2",
-          "B2",
-          "C2",
-          "D2",
-          "E2",
-          "F2",
-          "G2",
-          "H2"
-        ],
-        [
-          "A3",
-          "B3",
-          "C3",
-          "D3",
-          "E3",
-          "F3",
-          "G3",
-          "H3"
-        ],
-        [
-          "A4",
-          "B4",
-          "C4",
-          "D4",
-          "E4",
-          "F4",
-          "G4",
-          "H4"
-        ],
-        [
-          "A5",
-          "B5",
-          "C5",
-          "D5",
-          "E5",
-          "F5",
-          "G5",
-          "H5"
-        ],
-        [
-          "A6",
-          "B6",
-          "C6",
-          "D6",
-          "E6",
-          "F6",
-          "G6",
-          "H6"
-        ],
-        [
-          "A7",
-          "B7",
-          "C7",
-          "D7",
-          "E7",
-          "F7",
-          "G7",
-          "H7"
-        ],
-        [
-          "A8",
-          "B8",
-          "C8",
-          "D8",
-          "E8",
-          "F8",
-          "G8",
-          "H8"
-        ],
-        [
-          "A9",
-          "B9",
-          "C9",
-          "D9",
-          "E9",
-          "F9",
-          "G9",
-          "H9"
-        ],
-        [
-          "A10",
-          "B10",
-          "C10",
-          "D10",
-          "E10",
-          "F10",
-          "G10",
-          "H10"
-        ],
-        [
-          "A11",
-          "B11",
-          "C11",
-          "D11",
-          "E11",
-          "F11",
-          "G11",
-          "H11"
-        ],
-        [
-          "A12",
-          "B12",
-          "C12",
-          "D12",
-          "E12",
-          "F12",
-          "G12",
-          "H12"
-        ]
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
       ],
       "brand": {
         "brand": "Opentrons",
@@ -1357,9 +1245,7 @@
       ],
       "parameters": {
         "format": "96Standard",
-        "quirks": [
-          "tiprackAdapterFor96Channel"
-        ],
+        "quirks": ["tiprackAdapterFor96Channel"],
         "isTiprack": false,
         "isMagneticModuleCompatible": false,
         "loadName": "opentrons_flex_96_tiprack_adapter"
@@ -1367,9 +1253,7 @@
       "namespace": "opentrons",
       "version": 1,
       "schemaVersion": 2,
-      "allowedRoles": [
-        "adapter"
-      ],
+      "allowedRoles": ["adapter"],
       "cornerOffsetFromSlot": {
         "x": -14.25,
         "y": -3.5,
@@ -1378,126 +1262,18 @@
     },
     "opentrons/biorad_96_wellplate_200ul_pcr/2": {
       "ordering": [
-        [
-          "A1",
-          "B1",
-          "C1",
-          "D1",
-          "E1",
-          "F1",
-          "G1",
-          "H1"
-        ],
-        [
-          "A2",
-          "B2",
-          "C2",
-          "D2",
-          "E2",
-          "F2",
-          "G2",
-          "H2"
-        ],
-        [
-          "A3",
-          "B3",
-          "C3",
-          "D3",
-          "E3",
-          "F3",
-          "G3",
-          "H3"
-        ],
-        [
-          "A4",
-          "B4",
-          "C4",
-          "D4",
-          "E4",
-          "F4",
-          "G4",
-          "H4"
-        ],
-        [
-          "A5",
-          "B5",
-          "C5",
-          "D5",
-          "E5",
-          "F5",
-          "G5",
-          "H5"
-        ],
-        [
-          "A6",
-          "B6",
-          "C6",
-          "D6",
-          "E6",
-          "F6",
-          "G6",
-          "H6"
-        ],
-        [
-          "A7",
-          "B7",
-          "C7",
-          "D7",
-          "E7",
-          "F7",
-          "G7",
-          "H7"
-        ],
-        [
-          "A8",
-          "B8",
-          "C8",
-          "D8",
-          "E8",
-          "F8",
-          "G8",
-          "H8"
-        ],
-        [
-          "A9",
-          "B9",
-          "C9",
-          "D9",
-          "E9",
-          "F9",
-          "G9",
-          "H9"
-        ],
-        [
-          "A10",
-          "B10",
-          "C10",
-          "D10",
-          "E10",
-          "F10",
-          "G10",
-          "H10"
-        ],
-        [
-          "A11",
-          "B11",
-          "C11",
-          "D11",
-          "E11",
-          "F11",
-          "G11",
-          "H11"
-        ],
-        [
-          "A12",
-          "B12",
-          "C12",
-          "D12",
-          "E12",
-          "F12",
-          "G12",
-          "H12"
-        ]
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
       ],
       "schemaVersion": 2,
       "version": 2,
@@ -2390,9 +2166,7 @@
       },
       "brand": {
         "brand": "Bio-Rad",
-        "brandId": [
-          "hsp9601"
-        ],
+        "brandId": ["hsp9601"],
         "links": [
           "http://www.bio-rad.com/en-us/sku/hsp9601-hard-shell-96-well-pcr-plates-low-profile-thin-wall-skirted-white-clear?ID=hsp9601"
         ]

--- a/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
@@ -34,10 +34,10 @@
       "ingredients": {
         "0": {
           "displayName": "123",
+          "displayColor": "#b925ff",
           "description": null,
-          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "displayColor": "#b925ff"
+          "liquidGroupId": "0"
         }
       },
       "ingredLocations": {

--- a/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
@@ -96,7 +96,7 @@
             "733ba018-3550-476c-9fa3-0b5259d1a1d6": "left"
           },
           "trashBinLocationUpdate": {
-            "dc2c4599-29b3-4ec8-adff-56677ac0821e:fixedTrash": "cutout12"
+            "dc2c4599-29b3-4ec8-adff-56677ac0821e:trashBin": "cutout12"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},

--- a/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Hopia",
     "description": "testing a thermocycler on OT-2",
     "created": 1731356664582,
-    "lastModified": 1738157325544,
+    "lastModified": 1738683623686,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Wed, 29 Jan 2025 13:23:47 GMT",
+      "_internalAppBuildDate": "Tue, 04 Feb 2025 15:40:12 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -34,10 +34,10 @@
       "ingredients": {
         "0": {
           "displayName": "123",
-          "displayColor": "#b925ff",
           "description": null,
+          "liquidGroupId": "0",
           "pythonName": "liquid_1",
-          "liquidGroupId": "0"
+          "displayColor": "#b925ff"
         }
       },
       "ingredLocations": {
@@ -95,6 +95,12 @@
           "pipetteLocationUpdate": {
             "733ba018-3550-476c-9fa3-0b5259d1a1d6": "left"
           },
+          "trashBinLocationUpdate": {
+            "dc2c4599-29b3-4ec8-adff-56677ac0821e:fixedTrash": "cutout12"
+          },
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {},
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
         },
@@ -2260,7 +2266,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "01d12a6f-a134-41ad-8a96-0f1db1caa648",
+      "key": "06942533-7498-4507-9a3e-a80640e0b11b",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p20_single_gen2",
@@ -2269,7 +2275,7 @@
       }
     },
     {
-      "key": "984a7baa-bf2d-4b9b-8d22-7fa864d443d5",
+      "key": "2d40fefe-7a97-4885-9813-745e87b558d3",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV1",
@@ -2280,7 +2286,7 @@
       }
     },
     {
-      "key": "70bd414e-8191-4c73-a79d-ec514a775cdd",
+      "key": "b6313d6a-b046-4c83-bd79-171ab2267d4a",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -2295,7 +2301,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "6eeecce1-bf14-4ba9-ac27-99d4a45c1352",
+      "key": "2ae9cd8f-caaf-4236-8fa5-f389fdc11c61",
       "params": {
         "liquidId": "0",
         "labwareId": "ac928a51-a248-4304-be43-e9cb19c34fa9:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -2313,14 +2319,14 @@
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "b3f3d0ef-d186-451b-b019-92170d4c54b0",
+      "key": "689eb7ee-b3ef-4fd0-ace8-6a095dc8079e",
       "params": {
         "moduleId": "82858229-5c25-46cc-87d4-35ab318c18ce:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetLidTemperature",
-      "key": "a61991d4-e5ca-4828-88e1-16121263e580",
+      "key": "460e9a31-986e-491f-bf71-a3f93bfbd8f5",
       "params": {
         "moduleId": "82858229-5c25-46cc-87d4-35ab318c18ce:thermocyclerModuleType",
         "celsius": 50
@@ -2328,14 +2334,14 @@
     },
     {
       "commandType": "thermocycler/waitForLidTemperature",
-      "key": "5433a727-f2fc-49ef-a7b2-f88e426fa310",
+      "key": "0ecc6124-c69d-4627-b5db-4955291473fe",
       "params": {
         "moduleId": "82858229-5c25-46cc-87d4-35ab318c18ce:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetLidTemperature",
-      "key": "cd2d7b9e-c308-4efd-9cbd-cca366abbe2d",
+      "key": "ac9e312f-077c-40b8-8962-3cc2f48c9e90",
       "params": {
         "moduleId": "82858229-5c25-46cc-87d4-35ab318c18ce:thermocyclerModuleType",
         "celsius": 40
@@ -2343,14 +2349,14 @@
     },
     {
       "commandType": "thermocycler/waitForLidTemperature",
-      "key": "ea9d18cd-d9a3-461e-96c1-ac41436474d6",
+      "key": "175ed209-4a23-4a8a-ae23-c896c1b45acc",
       "params": {
         "moduleId": "82858229-5c25-46cc-87d4-35ab318c18ce:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/runProfile",
-      "key": "5d773732-71d8-45af-83f7-be31f4f89689",
+      "key": "541e8c3a-a19e-48e9-8f67-56898f309a95",
       "params": {
         "moduleId": "82858229-5c25-46cc-87d4-35ab318c18ce:thermocyclerModuleType",
         "profile": [
@@ -2388,14 +2394,14 @@
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "49c7e428-7a42-4bc0-93a8-8c30c375fe58",
+      "key": "55aad3e0-0854-408a-a46d-c8834cc5a601",
       "params": {
         "moduleId": "82858229-5c25-46cc-87d4-35ab318c18ce:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateLid",
-      "key": "3358c263-9ce4-4a02-846f-26faf626ed50",
+      "key": "d878f02b-dda5-4bdd-8c8b-344493e498eb",
       "params": {
         "moduleId": "82858229-5c25-46cc-87d4-35ab318c18ce:thermocyclerModuleType"
       }

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -193,3 +193,5 @@ export const ABSORBANCE_READER_COLOR_BY_WAVELENGTH: Record<number, string> = {
   600: 'Orange',
   650: 'Red',
 }
+
+export const GRIPPER_LOCATION: 'mounted' = 'mounted'

--- a/protocol-designer/src/file-types.ts
+++ b/protocol-designer/src/file-types.ts
@@ -5,12 +5,13 @@ import type { ProtocolFile as ProtocolFileV3 } from '@opentrons/shared-data/prot
 import type { ProtocolFile as ProtocolFileV4 } from '@opentrons/shared-data/protocol/types/schemaV4'
 import type { ProtocolFile as ProtocolFileV5 } from '@opentrons/shared-data/protocol/types/schemaV5'
 import type { ProtocolFile as ProtocolFileV6 } from '@opentrons/shared-data/protocol/types/schemaV6'
+import { LiquidEntities } from '@opentrons/step-generation'
 
 export interface PDMetadata {
   // pipetteId to tiprackModel
   pipetteTiprackAssignments: Record<string, string[]>
   dismissedWarnings: DismissRoot['dismissedWarnings']
-  ingredients: IngredRoot['ingredients']
+  ingredients: LiquidEntities
   ingredLocations: IngredRoot['ingredLocations']
   savedStepForms: StepformRoot['savedStepForms']
   orderedStepIds: StepformRoot['orderedStepIds']

--- a/protocol-designer/src/file-types.ts
+++ b/protocol-designer/src/file-types.ts
@@ -5,7 +5,7 @@ import type { ProtocolFile as ProtocolFileV3 } from '@opentrons/shared-data/prot
 import type { ProtocolFile as ProtocolFileV4 } from '@opentrons/shared-data/protocol/types/schemaV4'
 import type { ProtocolFile as ProtocolFileV5 } from '@opentrons/shared-data/protocol/types/schemaV5'
 import type { ProtocolFile as ProtocolFileV6 } from '@opentrons/shared-data/protocol/types/schemaV6'
-import { LiquidEntities } from '@opentrons/step-generation'
+import type { LiquidEntities } from '@opentrons/step-generation'
 
 export interface PDMetadata {
   // pipetteId to tiprackModel

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -144,7 +144,7 @@ export const migrateFile = (
           ...acc,
           [id]: {
             ...form,
-            additionalEquipmentLocationUpdate: getAdditionalEquipmentLocationUpdate(
+            ...getAdditionalEquipmentLocationUpdate(
               commands,
               robot.model,
               savedStepForms
@@ -156,7 +156,7 @@ export const migrateFile = (
     },
     {}
   )
-
+  console.log('updatedInitialStep', updatedInitialStep)
   return {
     ...appData,
     designerApplication: {

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -1,7 +1,8 @@
 import floor from 'lodash/floor'
 import { swatchColors } from '../../organisms/DefineLiquidsModal/swatchColors'
+import { getMigratedPositionFromTop } from './utils/getMigrationPositionFromTop'
+import { getAdditionalEquipmentLocationUpdate } from './utils/getAdditionalEquipmentLocationUpdate'
 import type {
-  LabwareDefinition2,
   LoadLabwareCreateCommand,
   ProtocolFile,
 } from '@opentrons/shared-data'
@@ -9,51 +10,16 @@ import type { LiquidEntities } from '@opentrons/step-generation'
 import type { DesignerApplicationDataV8_5 } from '../../file-data/selectors'
 import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
 
-const getMigratedPositionFromTop = (
-  labwareDefinitions: {
-    [definitionId: string]: LabwareDefinition2
-  },
-  loadLabwareCommands: LoadLabwareCreateCommand[],
-  labware: string,
-  type: 'aspirate' | 'dispense' | 'mix'
-): number => {
-  const matchingLoadLabware = loadLabwareCommands.find(
-    command =>
-      command.commandType === 'loadLabware' &&
-      command.params.labwareId === labware
-  )
-  if (matchingLoadLabware == null) {
-    console.error(
-      `expected to find matching ${type} labware load command but could not with ${type}_labware from form data as ${labware}`
-    )
-  }
-  const labwareUri =
-    matchingLoadLabware != null
-      ? `${matchingLoadLabware.params.namespace}/${matchingLoadLabware.params.loadName}/${matchingLoadLabware.params.version}`
-      : ''
-
-  //    early exit for dispense_labware equaling trashBin or wasteChute
-  if (labwareDefinitions[labwareUri] == null) {
-    return 0
-  }
-
-  const matchingLabwareWellDepth = labwareUri
-    ? labwareDefinitions[labwareUri].wells.A1.depth
-    : 0
-
-  if (matchingLabwareWellDepth === 0) {
-    console.error(
-      `error in finding the ${type} labware well depth with labware uri ${labwareUri}`
-    )
-  }
-  return matchingLabwareWellDepth
-}
-
 export const migrateFile = (
   appData: ProtocolFile<DesignerApplicationData>
 ): ProtocolFile<DesignerApplicationDataV8_5> => {
-  const { designerApplication, commands, labwareDefinitions, liquids } = appData
-
+  const {
+    designerApplication,
+    commands,
+    labwareDefinitions,
+    liquids,
+    robot,
+  } = appData
   if (designerApplication == null || designerApplication?.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
   }
@@ -170,6 +136,27 @@ export const migrateFile = (
     {}
   )
 
+  const updatedInitialStep = Object.values(savedStepForms).reduce(
+    (acc, form) => {
+      const { id } = form
+      if (id === '__INITIAL_DECK_SETUP_STEP__') {
+        return {
+          ...acc,
+          [id]: {
+            ...form,
+            additionalEquipmentLocationUpdate: getAdditionalEquipmentLocationUpdate(
+              commands,
+              robot.model,
+              savedStepForms
+            ),
+          },
+        }
+      }
+      return acc
+    },
+    {}
+  )
+
   return {
     ...appData,
     designerApplication: {
@@ -179,6 +166,7 @@ export const migrateFile = (
         ingredients: migratedIngredients,
         savedStepForms: {
           ...designerApplication.data.savedStepForms,
+          ...updatedInitialStep,
           ...savedStepsWithUpdatedMoveLiquidFields,
           ...savedStepsWithUpdatedMixFields,
         },

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -156,7 +156,6 @@ export const migrateFile = (
     },
     {}
   )
-  console.log('updatedInitialStep', updatedInitialStep)
   return {
     ...appData,
     designerApplication: {

--- a/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
@@ -9,7 +9,6 @@ import { COLUMN_4_SLOTS, uuid } from '@opentrons/step-generation'
 import { getUnoccupiedSlotForTrash } from '../../../step-forms'
 import { getCutoutIdByAddressableArea } from '../../../utils'
 import { GRIPPER_LOCATION } from '../../../constants'
-import type { RobotType } from '@opentrons/shared-data'
 import type {
   AddressableAreaName,
   CreateCommand,
@@ -17,10 +16,11 @@ import type {
   MoveLabwareCreateCommand,
   MoveToAddressableAreaCreateCommand,
   MoveToAddressableAreaForDropTipCreateCommand,
+  RobotType,
 } from '@opentrons/shared-data'
 import type { SavedStepFormState } from '../../../step-forms'
 
-type LocationUpdate = Record<string, string>
+export type LocationUpdate = Record<string, string>
 
 export interface AdditionalEquipmentLocationUpdate {
   trashBinLocationUpdate: LocationUpdate

--- a/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
@@ -157,12 +157,6 @@ export const getAdditionalEquipmentLocationUpdate = (
         )
       : null
 
-  if (trashBinCommand == null && robotType === OT2_ROBOT_TYPE) {
-    console.error(
-      'expected to find a fixedTrash command for the OT-2 but could not'
-    )
-  }
-
   const moveLiquidStepWasteChute =
     savedStepForms != null
       ? Object.values(savedStepForms).find(
@@ -211,37 +205,13 @@ export const getAdditionalEquipmentLocationUpdate = (
       }
     : {}
 
-  const hardcodedTrashBinIdOt2 = `${uuid()}:fixedTrash`
+  const hardcodedTrashBinIdOt2 = `${uuid()}:trashBin`
   const hardcodedTrashBinOt2 = {
     [hardcodedTrashBinIdOt2]: getCutoutIdByAddressableArea(
       'fixedTrash' as AddressableAreaName,
       'fixedTrashSlot',
       OT2_ROBOT_TYPE
     ),
-  }
-
-  const hardcodedTrashAddressableAreaName =
-    unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
-      ? 'wasteChute'
-      : `movableTrash${unoccupiedSlotForTrash}`
-
-  const hardcodedTrashIdFlex = `${uuid()}:${hardcodedTrashAddressableAreaName}`
-
-  const hardCodedTrashLocation =
-    unoccupiedSlotForTrash === ''
-      ? ''
-      : unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
-      ? WASTE_CHUTE_CUTOUT
-      : getCutoutIdByAddressableArea(
-          hardcodedTrashAddressableAreaName as AddressableAreaName,
-          'trashBinAdapter',
-          FLEX_ROBOT_TYPE
-        )
-
-  const hardcodedTrashFlex = {
-    [hardcodedTrashIdFlex]: hasWasteChuteCommands
-      ? WASTE_CHUTE_CUTOUT
-      : hardCodedTrashLocation,
   }
 
   let trashBinLocationUpdate: LocationUpdate = hasWasteChuteCommands
@@ -252,11 +222,27 @@ export const getAdditionalEquipmentLocationUpdate = (
     trashBinLocationUpdate = {
       [trashBinId]: trashCutoutId as string,
     }
+    //  in case the user has no pipetting steps, auto-generate a trashBin or wasteChute entity for Flex
   } else if (isFlex && !hasWasteChuteCommands) {
+    const hardCodedTrashIdFlex = `${uuid()}:movableTrash${unoccupiedSlotForTrash}`
+    const hardCodedWasteChuteId = `${uuid()}:wasteChute`
+
     trashBinLocationUpdate =
-      unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT ? {} : hardcodedTrashFlex
+      unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
+        ? {}
+        : {
+            [hardCodedTrashIdFlex]: getCutoutIdByAddressableArea(
+              `movableTrash${unoccupiedSlotForTrash}` as AddressableAreaName,
+              'trashBinAdapter',
+              FLEX_ROBOT_TYPE
+            ),
+          }
     wasteChuteLocationUpdate =
-      unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT ? hardcodedTrashFlex : {}
+      unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
+        ? {
+            [hardCodedWasteChuteId]: WASTE_CHUTE_CUTOUT,
+          }
+        : {}
   }
 
   const stagingAreaLocationUpdate: LocationUpdate = stagingAreaSlotNames.reduce(

--- a/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
@@ -1,28 +1,24 @@
 import {
   WASTE_CHUTE_ADDRESSABLE_AREAS,
-  RobotType,
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { COLUMN_4_SLOTS, uuid } from '@opentrons/step-generation'
-import {
-  SavedStepFormState,
-  getUnoccupiedSlotForTrash,
-} from '../../../step-forms'
+import { getUnoccupiedSlotForTrash } from '../../../step-forms'
 import { getCutoutIdByAddressableArea } from '../../../utils'
 import { GRIPPER_LOCATION } from '../../../constants'
+import type { RobotType } from '@opentrons/shared-data'
 import type {
   AddressableAreaName,
   CreateCommand,
   LoadLabwareCreateCommand,
-  LoadLabwareParams,
   MoveLabwareCreateCommand,
-  MoveLabwareParams,
   MoveToAddressableAreaCreateCommand,
   MoveToAddressableAreaForDropTipCreateCommand,
 } from '@opentrons/shared-data'
+import type { SavedStepFormState } from '../../../step-forms'
 
 type LocationUpdate = Record<string, string>
 

--- a/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
@@ -70,7 +70,7 @@ const getStagingAreaSlotNames = (
           command
         ): command is MoveLabwareCreateCommand | LoadLabwareCreateCommand =>
           command.commandType === commandType &&
-          //  @ts-expect-error
+          //  @ts-expect-error: ts doesn't trust that locationkey is actually found in the command params
           command.params[locationKey] !== 'offDeck' &&
           //  @ts-expect-error
           command.params[locationKey] !== 'systemLocation' &&

--- a/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
@@ -1,0 +1,265 @@
+import {
+  WASTE_CHUTE_ADDRESSABLE_AREAS,
+  RobotType,
+  FLEX_ROBOT_TYPE,
+  OT2_ROBOT_TYPE,
+  MOVABLE_TRASH_ADDRESSABLE_AREAS,
+  WASTE_CHUTE_CUTOUT,
+} from '@opentrons/shared-data'
+import { COLUMN_4_SLOTS, uuid } from '@opentrons/step-generation'
+import {
+  SavedStepFormState,
+  getUnoccupiedSlotForTrash,
+} from '../../../step-forms'
+import { getCutoutIdByAddressableArea } from '../../../utils'
+import { GRIPPER_LOCATION } from '../../../constants'
+import type {
+  AddressableAreaName,
+  CreateCommand,
+  LoadLabwareCreateCommand,
+  MoveLabwareCreateCommand,
+  MoveToAddressableAreaCreateCommand,
+  MoveToAddressableAreaForDropTipCreateCommand,
+} from '@opentrons/shared-data'
+
+type AdditionalEquipmentLocationUpdate = Record<string, string>
+
+const findTrashBinId = (savedStepForms: SavedStepFormState): string | null => {
+  if (!savedStepForms) {
+    return null
+  }
+
+  for (const stepForm of Object.values(savedStepForms)) {
+    if (stepForm.stepType === 'moveLiquid') {
+      if (stepForm.dispense_labware.toLowerCase().includes('trash')) {
+        return stepForm.dispense_labware
+      }
+      if (stepForm.dropTip_location.toLowerCase().includes('trash')) {
+        return stepForm.dropTip_location
+      }
+      if (stepForm.blowout_location?.toLowerCase().includes('trash')) {
+        return stepForm.blowout_location
+      }
+    }
+    if (stepForm.stepType === 'mix') {
+      if (stepForm.dropTip_location.toLowerCase().includes('trash')) {
+        return stepForm.dropTip_location
+      } else if (stepForm.blowout_location?.toLowerCase().includes('trash')) {
+        return stepForm.blowout_location
+      }
+    }
+  }
+
+  return null
+}
+
+const getStagingAreaSlotNames = (
+  commands: CreateCommand[],
+  commandType: 'moveLabware' | 'loadLabware',
+  locationKey: 'newLocation' | 'location'
+): AddressableAreaName[] => {
+  return Object.values(commands)
+    .filter(
+      (
+        command
+      ): command is MoveLabwareCreateCommand | LoadLabwareCreateCommand =>
+        command.commandType === commandType &&
+        command.params[locationKey] !== 'offDeck' &&
+        command.params[locationKey] !== 'systemLocation' &&
+        'addressableAreaName' in command.params[locationKey] &&
+        COLUMN_4_SLOTS.includes(
+          command.params[locationKey].addressableAreaName as AddressableAreaName
+        )
+    )
+    .map(command => command.params[locationKey].addressableAreaName)
+}
+
+export const getAdditionalEquipmentLocationUpdate = (
+  commands: CreateCommand[],
+  robotType: RobotType,
+  savedStepForms: SavedStepFormState
+): AdditionalEquipmentLocationUpdate => {
+  const isFlex = robotType === FLEX_ROBOT_TYPE
+
+  const hasGripperCommands = Object.values(commands).some(
+    (command): command is MoveLabwareCreateCommand =>
+      (command.commandType === 'moveLabware' &&
+        command.params.strategy === 'usingGripper') ||
+      command.commandType === 'absorbanceReader/closeLid' ||
+      command.commandType === 'absorbanceReader/openLid'
+  )
+  const hasWasteChuteCommands = Object.values(commands).some(
+    command =>
+      (command.commandType === 'moveToAddressableArea' &&
+        WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
+          command.params.addressableAreaName as AddressableAreaName
+        )) ||
+      (command.commandType === 'moveLabware' &&
+        command.params.newLocation !== 'offDeck' &&
+        command.params.newLocation !== 'systemLocation' &&
+        'addressableAreaName' in command.params.newLocation &&
+        WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
+          command.params.newLocation.addressableAreaName as AddressableAreaName
+        ))
+  )
+
+  const stagingAreaSlotNames = [
+    ...new Set([
+      ...getStagingAreaSlotNames(commands, 'moveLabware', 'newLocation'),
+      ...getStagingAreaSlotNames(commands, 'loadLabware', 'location'),
+    ]),
+  ]
+
+  const unoccupiedSlotForTrash = hasWasteChuteCommands
+    ? ''
+    : getUnoccupiedSlotForTrash(
+        commands,
+        hasWasteChuteCommands,
+        stagingAreaSlotNames
+      )
+
+  const trashBinCommand = Object.values(commands).find(
+    (
+      command
+    ): command is
+      | MoveToAddressableAreaCreateCommand
+      | MoveToAddressableAreaForDropTipCreateCommand =>
+      (command.commandType === 'moveToAddressableArea' &&
+        (MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(
+          command.params.addressableAreaName as AddressableAreaName
+        ) ||
+          command.params.addressableAreaName === 'fixedTrash')) ||
+      command.commandType === 'moveToAddressableAreaForDropTip'
+  )
+
+  const trashAddressableAreaName = trashBinCommand?.params.addressableAreaName
+
+  const trashBinId = findTrashBinId(savedStepForms)
+  const trashCutoutId =
+    trashAddressableAreaName != null
+      ? getCutoutIdByAddressableArea(
+          trashAddressableAreaName as AddressableAreaName,
+          isFlex ? 'trashBinAdapter' : 'fixedTrashSlot',
+          isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
+        )
+      : null
+
+  if (trashBinCommand == null && robotType === OT2_ROBOT_TYPE) {
+    console.error(
+      'expected to find a fixedTrash command for the OT-2 but could not'
+    )
+  }
+
+  const moveLiquidStepWasteChute =
+    savedStepForms != null
+      ? Object.values(savedStepForms).find(
+          stepForm =>
+            stepForm.stepType === 'moveLiquid' &&
+            (stepForm.aspirate_labware.includes('wasteChute') ||
+              stepForm.dispense_labware.includes('wasteChute') ||
+              stepForm.dropTip_location.includes('wasteChute') ||
+              stepForm.blowout_location?.includes('wasteChute'))
+        )
+      : null
+
+  let wasteChuteId: string | null = null
+  if (hasWasteChuteCommands && moveLiquidStepWasteChute != null) {
+    if (moveLiquidStepWasteChute.aspirate_labware.includes('wasteChute')) {
+      wasteChuteId = moveLiquidStepWasteChute.aspirate_labware
+    } else if (
+      moveLiquidStepWasteChute.dispense_labware.includes('wasteChute')
+    ) {
+      wasteChuteId = moveLiquidStepWasteChute.dispense_labware
+    } else if (
+      moveLiquidStepWasteChute.dropTip_location.includes('wasteChute')
+    ) {
+      wasteChuteId = moveLiquidStepWasteChute.dropTip_location
+    } else if (
+      moveLiquidStepWasteChute.blowOut_location?.includes('wasteChute')
+    ) {
+      wasteChuteId = moveLiquidStepWasteChute.blowOut_location
+    }
+    //  new wasteChuteId generated for if there are only moveLabware commands
+  } else if (hasWasteChuteCommands && moveLiquidStepWasteChute == null) {
+    wasteChuteId = `${uuid()}:wasteChute`
+  }
+
+  const wasteChuteLocationUpdate: AdditionalEquipmentLocationUpdate =
+    hasWasteChuteCommands && wasteChuteId != null
+      ? {
+          [wasteChuteId]: WASTE_CHUTE_CUTOUT,
+        }
+      : {}
+
+  const gripperId = `${uuid()}:gripper`
+  const gripperLocationUpdate: AdditionalEquipmentLocationUpdate = hasGripperCommands
+    ? {
+        [gripperId]: GRIPPER_LOCATION,
+      }
+    : {}
+
+  const hardcodedTrashBinIdOt2 = `${uuid()}:fixedTrash`
+  const hardcodedTrashBinOt2 = {
+    [hardcodedTrashBinIdOt2]: getCutoutIdByAddressableArea(
+      'fixedTrash' as AddressableAreaName,
+      'fixedTrashSlot',
+      OT2_ROBOT_TYPE
+    ),
+  }
+
+  const hardcodedTrashAddressableAreaName =
+    unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
+      ? 'wasteChute'
+      : `movableTrash${unoccupiedSlotForTrash}`
+
+  const hardcodedTrashIdFlex = `${uuid()}:${hardcodedTrashAddressableAreaName}`
+
+  const hardCodedTrashLocation =
+    unoccupiedSlotForTrash === ''
+      ? ''
+      : unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
+      ? WASTE_CHUTE_CUTOUT
+      : getCutoutIdByAddressableArea(
+          hardcodedTrashAddressableAreaName as AddressableAreaName,
+          'trashBinAdapter',
+          FLEX_ROBOT_TYPE
+        )
+
+  const hardcodedTrashFlex = {
+    [hardcodedTrashIdFlex]: hasWasteChuteCommands
+      ? WASTE_CHUTE_CUTOUT
+      : hardCodedTrashLocation,
+  }
+
+  let trashBinLocationUpdate: AdditionalEquipmentLocationUpdate = hardcodedTrashBinOt2
+  if (trashAddressableAreaName != null && trashBinId != null) {
+    trashBinLocationUpdate = {
+      [trashBinId]: trashCutoutId as string,
+    }
+  } else if (isFlex) {
+    trashBinLocationUpdate = hardcodedTrashFlex
+  }
+
+  const stagingAreaLocationUpdate: AdditionalEquipmentLocationUpdate = stagingAreaSlotNames.reduce(
+    (acc, slot) => {
+      const stagingAreaId = `${uuid()}:stagingArea`
+      const cutoutId = getCutoutIdByAddressableArea(
+        slot,
+        'stagingAreaRightSlot',
+        isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
+      )
+      return {
+        ...acc,
+        [stagingAreaId]: cutoutId,
+      }
+    },
+    {}
+  )
+
+  return {
+    ...stagingAreaLocationUpdate,
+    ...gripperLocationUpdate,
+    ...wasteChuteLocationUpdate,
+    ...trashBinLocationUpdate,
+  }
+}

--- a/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
+++ b/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
@@ -1,0 +1,44 @@
+import type {
+  LabwareDefinition2,
+  LoadLabwareCreateCommand,
+} from '@opentrons/shared-data'
+
+export const getMigratedPositionFromTop = (
+  labwareDefinitions: {
+    [definitionId: string]: LabwareDefinition2
+  },
+  loadLabwareCommands: LoadLabwareCreateCommand[],
+  labware: string,
+  type: 'aspirate' | 'dispense' | 'mix'
+): number => {
+  const matchingLoadLabware = loadLabwareCommands.find(
+    command =>
+      command.commandType === 'loadLabware' &&
+      command.params.labwareId === labware
+  )
+  if (matchingLoadLabware == null) {
+    console.error(
+      `expected to find matching ${type} labware load command but could not with ${type}_labware from form data as ${labware}`
+    )
+  }
+  const labwareUri =
+    matchingLoadLabware != null
+      ? `${matchingLoadLabware.params.namespace}/${matchingLoadLabware.params.loadName}/${matchingLoadLabware.params.version}`
+      : ''
+
+  //    early exit for dispense_labware equaling trashBin or wasteChute
+  if (labwareDefinitions[labwareUri] == null) {
+    return 0
+  }
+
+  const matchingLabwareWellDepth = labwareUri
+    ? labwareDefinitions[labwareUri].wells.A1.depth
+    : 0
+
+  if (matchingLabwareWellDepth === 0) {
+    console.error(
+      `error in finding the ${type} labware well depth with labware uri ${labwareUri}`
+    )
+  }
+  return matchingLabwareWellDepth
+}

--- a/protocol-designer/src/organisms/EditInstrumentsModal/PipetteOverview.tsx
+++ b/protocol-designer/src/organisms/EditInstrumentsModal/PipetteOverview.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import mapValues from 'lodash/mapValues'
 
 import {
@@ -36,6 +36,7 @@ import type {
 } from '../../step-forms'
 import type { ThunkDispatch } from '../../types'
 import type { PipetteConfig } from './usePipetteConfig'
+import { getAdditionalEquipmentEntities } from '../../step-forms/selectors'
 
 interface Gripper {
   name: AdditionalEquipmentName
@@ -66,6 +67,12 @@ export function PipetteOverview({
 }: PipetteOverviewProps): JSX.Element {
   const { t } = useTranslation(['create_new_protocol', 'protocol_overview'])
   const dispatch = useDispatch<ThunkDispatch<any>>()
+  const additionalEquipmentEntities = useSelector(
+    getAdditionalEquipmentEntities
+  )
+  const gripperId = Object.values(additionalEquipmentEntities).find(
+    ae => ae.name === 'gripper'
+  )?.id
 
   const swapPipetteUpdate = mapValues(pipettes, pipette => {
     if (!pipette.mount) return pipette.mount
@@ -228,7 +235,7 @@ export function PipetteOverview({
                     textDecoration={TYPOGRAPHY.textDecorationUnderline}
                     padding={SPACING.spacing4}
                     onClick={() => {
-                      dispatch(toggleIsGripperRequired())
+                      dispatch(toggleIsGripperRequired(gripperId))
                     }}
                   >
                     <StyledText desktopStyle="bodyDefaultRegular">

--- a/protocol-designer/src/step-forms/actions/additionalItems.ts
+++ b/protocol-designer/src/step-forms/actions/additionalItems.ts
@@ -2,10 +2,14 @@ import { uuid } from '../../utils'
 
 export interface ToggleIsGripperRequiredAction {
   type: 'TOGGLE_IS_GRIPPER_REQUIRED'
+  payload: { id: string }
 }
 
-export const toggleIsGripperRequired = (): ToggleIsGripperRequiredAction => ({
+export const toggleIsGripperRequired = (
+  id?: string
+): ToggleIsGripperRequiredAction => ({
   type: 'TOGGLE_IS_GRIPPER_REQUIRED',
+  payload: { id: id != null ? id : `${uuid()}:gripper` },
 })
 
 export type DeckFixture = 'wasteChute' | 'stagingArea' | 'trashBin'

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -117,6 +117,7 @@ import type {
   NormalizedLabwareById,
   ModuleEntities,
 } from '../types'
+import { AdditionalEquipmentLocationUpdate } from '../../load-file/migration/utils/getAdditionalEquipmentLocationUpdate'
 
 type FormState = FormData | null
 const unsavedFormInitialState = null
@@ -247,7 +248,10 @@ export const initialDeckSetupStepForm: FormData = {
   labwareLocationUpdate: {},
   pipetteLocationUpdate: {},
   moduleLocationUpdate: {},
-  additionalEquipmentLocationUpdate: {},
+  trashBinLocationUpdate: {},
+  wasteChuteLocationUpdate: {},
+  stagingAreaLocationUpdate: {},
+  gripperLocationUpdate: {},
 }
 export const initialSavedStepFormsState: SavedStepFormState = {
   [INITIAL_DECK_SETUP_STEP_ID]: initialDeckSetupStepForm,
@@ -378,15 +382,16 @@ export const savedStepForms = (
       }))
     }
     case 'CREATE_DECK_FIXTURE': {
-      const { id, location } = action.payload
+      const { id, location, name } = action.payload
       const prevInitialDeckSetupStep =
         savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
+      const locationUpdate = `${name}LocationUpdate`
       return {
         ...savedStepForms,
         [INITIAL_DECK_SETUP_STEP_ID]: {
           ...prevInitialDeckSetupStep,
-          additionalEquipmentLocationUpdate: {
-            ...prevInitialDeckSetupStep.additionalEquipmentLocationUpdate,
+          [locationUpdate]: {
+            ...prevInitialDeckSetupStep[locationUpdate],
             [id]: location,
           },
         },
@@ -394,15 +399,18 @@ export const savedStepForms = (
     }
     case 'DELETE_DECK_FIXTURE': {
       const { id } = action.payload
+      const name = id.split(':')[1]
+      const locationUpdate = `${name}LocationUpdate`
+
       return mapValues(
         savedStepForms,
         (form: FormData): FormData => {
+          const updatedLocation = omit(form[locationUpdate] || {}, id)
+
           return {
             ...form,
-            additionalEquipmentLocationUpdate: omit(
-              form.additionalEquipmentLocationUpdate,
-              id
-            ),
+            [locationUpdate]:
+              Object.keys(updatedLocation).length > 0 ? updatedLocation : {},
           }
         }
       )
@@ -411,34 +419,31 @@ export const savedStepForms = (
       const { id } = action.payload
       const prevInitialDeckSetupStep =
         savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
-      const gripperKey = Object.entries(
-        prevInitialDeckSetupStep.additionalEquipmentLocationUpdate
-      ).find(([_, value]) => value === GRIPPER_LOCATION)?.[0]
+      const gripperLocationUpdate =
+        prevInitialDeckSetupStep.gripperLocationUpdate
+      const gripperKey = Object.entries(gripperLocationUpdate).find(
+        ([_, value]) => value === GRIPPER_LOCATION
+      )?.[0]
 
       if (gripperKey == null) {
         return {
           ...savedStepForms,
           [INITIAL_DECK_SETUP_STEP_ID]: {
             ...prevInitialDeckSetupStep,
-            additionalEquipmentLocationUpdate: {
-              ...prevInitialDeckSetupStep.additionalEquipmentLocationUpdate,
+            gripperLocationUpdate: {
+              ...gripperLocationUpdate,
               [id]: GRIPPER_LOCATION,
             },
           },
         }
       } else {
-        return mapValues(
-          savedStepForms,
-          (form: FormData): FormData => {
-            return {
-              ...form,
-              additionalEquipmentLocationUpdate: omit(
-                form.additionalEquipmentLocationUpdate,
-                gripperKey
-              ),
-            }
-          }
-        )
+        return {
+          ...savedStepForms,
+          [INITIAL_DECK_SETUP_STEP_ID]: {
+            ...prevInitialDeckSetupStep,
+            gripperLocationUpdate: {},
+          },
+        }
       }
     }
     case 'DUPLICATE_LABWARE':
@@ -1180,285 +1185,71 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
       action: LoadFileAction
     ): NormalizedAdditionalEquipmentById => {
       const { file } = action.payload
-      const isFlex = file.robot.model === FLEX_ROBOT_TYPE
+      const savedStepForms = file.designerApplication?.data?.savedStepForms
+      const initialDeckSetup: AdditionalEquipmentLocationUpdate = savedStepForms?.[
+        INITIAL_DECK_SETUP_STEP_ID
+      ] as any
+      const {
+        gripperLocationUpdate,
+        trashBinLocationUpdate,
+        wasteChuteLocationUpdate,
+        stagingAreaLocationUpdate,
+      } = initialDeckSetup
 
-      const hasGripperCommands = Object.values(file.commands).some(
-        (command): command is MoveLabwareCreateCommand =>
-          (command.commandType === 'moveLabware' &&
-            command.params.strategy === 'usingGripper') ||
-          command.commandType === 'absorbanceReader/closeLid' ||
-          command.commandType === 'absorbanceReader/openLid'
-      )
-      const hasWasteChuteCommands = Object.values(file.commands).some(
-        command =>
-          (command.commandType === 'moveToAddressableArea' &&
-            WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
-              command.params.addressableAreaName as AddressableAreaName
-            )) ||
-          (command.commandType === 'moveLabware' &&
-            command.params.newLocation !== 'offDeck' &&
-            'addressableAreaName' in command.params.newLocation &&
-            WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
-              command.params.newLocation
-                .addressableAreaName as AddressableAreaName
-            ))
-      )
-      const getStagingAreaSlotNames = (
-        commandType: 'moveLabware' | 'loadLabware',
-        locationKey: 'newLocation' | 'location'
-      ): AddressableAreaName[] => {
-        return Object.values(file.commands)
-          .filter(
-            command =>
-              command.commandType === commandType &&
-              command.params[locationKey] !== 'offDeck' &&
-              'addressableAreaName' in command.params[locationKey] &&
-              COLUMN_4_SLOTS.includes(
-                command.params[locationKey]
-                  .addressableAreaName as AddressableAreaName
-              )
-          )
-          .map(command => command.params[locationKey].addressableAreaName)
-      }
-
-      const stagingAreaSlotNames = [
-        ...new Set([
-          ...getStagingAreaSlotNames('moveLabware', 'newLocation'),
-          ...getStagingAreaSlotNames('loadLabware', 'location'),
-        ]),
-      ]
-
-      const unoccupiedSlotForTrash = hasWasteChuteCommands
-        ? ''
-        : getUnoccupiedSlotForTrash(
-            file.commands,
-            hasWasteChuteCommands,
-            stagingAreaSlotNames
-          )
-
-      const stagingAreas = stagingAreaSlotNames.reduce((acc, slot) => {
-        const stagingAreaId = `${uuid()}:stagingArea`
-        const cutoutId = getCutoutIdByAddressableArea(
-          slot,
-          'stagingAreaRightSlot',
-          isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
-        )
-        return {
-          ...acc,
-          [stagingAreaId]: {
-            name: 'stagingArea' as const,
-            id: stagingAreaId,
-            location: cutoutId,
+      let gripper
+      if (Object.keys(gripperLocationUpdate).length > 0) {
+        const id = Object.keys(gripperLocationUpdate)[0]
+        gripper = {
+          [id]: {
+            name: 'gripper' as const,
+            id,
+            location: GRIPPER_LOCATION,
           },
         }
-      }, {})
-
-      const trashBinCommand = Object.values(file.commands).find(
-        (
-          command
-        ): command is
-          | MoveToAddressableAreaCreateCommand
-          | MoveToAddressableAreaForDropTipCreateCommand =>
-          (command.commandType === 'moveToAddressableArea' &&
-            (MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(
-              command.params.addressableAreaName as AddressableAreaName
-            ) ||
-              command.params.addressableAreaName === 'fixedTrash')) ||
-          command.commandType === 'moveToAddressableAreaForDropTip'
-      )
-
-      const trashAddressableAreaName =
-        trashBinCommand?.params.addressableAreaName
-      const savedStepForms = file.designerApplication?.data?.savedStepForms
-
-      const findTrashBinId = (): string | null => {
-        if (!savedStepForms) {
-          return null
-        }
-
-        for (const stepForm of Object.values(savedStepForms)) {
-          if (stepForm.stepType === 'moveLiquid') {
-            if (stepForm.dispense_labware.toLowerCase().includes('trash')) {
-              return stepForm.dispense_labware
-            }
-            if (stepForm.dropTip_location.toLowerCase().includes('trash')) {
-              return stepForm.dropTip_location
-            }
-            if (stepForm.blowout_location?.toLowerCase().includes('trash')) {
-              return stepForm.blowout_location
-            }
-          }
-          if (stepForm.stepType === 'mix') {
-            if (stepForm.dropTip_location.toLowerCase().includes('trash')) {
-              return stepForm.dropTip_location
-            } else if (
-              stepForm.blowout_location?.toLowerCase().includes('trash')
-            ) {
-              return stepForm.blowout_location
-            }
-          }
-        }
-
-        return null
       }
-
-      const trashBinId = findTrashBinId()
-      const trashCutoutId =
-        trashAddressableAreaName != null
-          ? getCutoutIdByAddressableArea(
-              trashAddressableAreaName as AddressableAreaName,
-              isFlex ? 'trashBinAdapter' : 'fixedTrashSlot',
-              isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
-            )
-          : null
-
-      const trashBin =
-        trashAddressableAreaName != null && trashBinId != null
-          ? {
-              [trashBinId]: {
-                name: 'trashBin' as const,
-                id: trashBinId,
-                //  TODO(should be type cutoutId when location is type cutoutId)
-                location: trashCutoutId as string,
-              },
-            }
-          : null
-
-      if (trashBinCommand == null && file.robot.model === OT2_ROBOT_TYPE) {
-        console.error(
-          'expected to find a fixedTrash command for the OT-2 but could not'
+      let trashBin
+      if (Object.keys(trashBinLocationUpdate).length > 0) {
+        const id = Object.keys(trashBinLocationUpdate)[0]
+        trashBin = {
+          [id]: {
+            name: 'trashBin' as const,
+            id,
+            location: Object.values(trashBinLocationUpdate)[0],
+          },
+        }
+      }
+      let wasteChute
+      if (Object.keys(wasteChuteLocationUpdate).length > 0) {
+        const id = Object.keys(wasteChuteLocationUpdate)[0]
+        wasteChute = {
+          [id]: {
+            name: 'wasteChute' as const,
+            id,
+            location: Object.values(wasteChuteLocationUpdate)[0],
+          },
+        }
+      }
+      let stagingArea
+      if (Object.keys(stagingAreaLocationUpdate).length > 0) {
+        stagingArea = Object.entries(stagingAreaLocationUpdate).reduce(
+          (acc, [id, location]) => ({
+            ...acc,
+            [id]: {
+              name: 'stagingArea' as const,
+              id,
+              location,
+            },
+          }),
+          {}
         )
       }
 
-      const moveLiquidStepWasteChute =
-        savedStepForms != null
-          ? Object.values(savedStepForms).find(
-              stepForm =>
-                stepForm.stepType === 'moveLiquid' &&
-                (stepForm.aspirate_labware.includes('wasteChute') ||
-                  stepForm.dispense_labware.includes('wasteChute') ||
-                  stepForm.dropTip_location.includes('wasteChute') ||
-                  stepForm.blowout_location?.includes('wasteChute'))
-            )
-          : null
-
-      let wasteChuteId: string | null = null
-      if (hasWasteChuteCommands && moveLiquidStepWasteChute != null) {
-        if (moveLiquidStepWasteChute.aspirate_labware.includes('wasteChute')) {
-          wasteChuteId = moveLiquidStepWasteChute.aspirate_labware
-        } else if (
-          moveLiquidStepWasteChute.dispense_labware.includes('wasteChute')
-        ) {
-          wasteChuteId = moveLiquidStepWasteChute.dispense_labware
-        } else if (
-          moveLiquidStepWasteChute.dropTip_location.includes('wasteChute')
-        ) {
-          wasteChuteId = moveLiquidStepWasteChute.dropTip_location
-        } else if (
-          moveLiquidStepWasteChute.blowOut_location?.includes('wasteChute')
-        ) {
-          wasteChuteId = moveLiquidStepWasteChute.blowOut_location
-        }
-        //  new wasteChuteId generated for if there are only moveLabware commands
-      } else if (hasWasteChuteCommands && moveLiquidStepWasteChute == null) {
-        wasteChuteId = `${uuid()}:wasteChute`
-      }
-
-      const wasteChute =
-        hasWasteChuteCommands && wasteChuteId != null
-          ? {
-              [wasteChuteId]: {
-                name: 'wasteChute' as const,
-                id: wasteChuteId,
-                location: 'cutoutD3',
-              },
-            }
-          : {}
-
-      const gripperId = `${uuid()}:gripper`
-      const gripper = hasGripperCommands
-        ? {
-            [gripperId]: {
-              name: 'gripper' as const,
-              id: gripperId,
-            },
-          }
-        : {}
-      const hardcodedTrashBinIdOt2 = `${uuid()}:fixedTrash`
-      const hardcodedTrashBinOt2 = {
-        [hardcodedTrashBinIdOt2]: {
-          name: 'trashBin' as const,
-          id: hardcodedTrashBinIdOt2,
-          location: getCutoutIdByAddressableArea(
-            'fixedTrash' as AddressableAreaName,
-            'fixedTrashSlot',
-            OT2_ROBOT_TYPE
-          ),
-        },
-      }
-      const hardcodedTrashAddressableAreaName =
-        unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
-          ? 'wasteChute'
-          : `movableTrash${unoccupiedSlotForTrash}`
-
-      const hardcodedTrashIdFlex = `${uuid()}:${hardcodedTrashAddressableAreaName}`
-
-      const hardCodedTrashLocation =
-        unoccupiedSlotForTrash === ''
-          ? ''
-          : unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
-          ? WASTE_CHUTE_CUTOUT
-          : getCutoutIdByAddressableArea(
-              hardcodedTrashAddressableAreaName as AddressableAreaName,
-              'trashBinAdapter',
-              FLEX_ROBOT_TYPE
-            )
-
-      const hardcodedTrashFlex = {
-        [hardcodedTrashIdFlex]: {
-          name:
-            unoccupiedSlotForTrash === WASTE_CHUTE_CUTOUT
-              ? ('wasteChute' as const)
-              : ('trashBin' as const),
-          id: hardcodedTrashIdFlex,
-          location: hasWasteChuteCommands ? '' : hardCodedTrashLocation,
-        },
-      }
-      if (isFlex) {
-        if (trashBin != null) {
-          return {
-            ...state,
-            ...gripper,
-            ...trashBin,
-            ...wasteChute,
-            ...stagingAreas,
-          }
-        } else if (trashBin == null && !hasWasteChuteCommands) {
-          //  always hardcode a trash bin or waste chute when no pipetting command is provided since return tip
-          //  is not supported
-          return {
-            ...state,
-            ...gripper,
-            ...hardcodedTrashFlex,
-            ...wasteChute,
-            ...stagingAreas,
-          }
-        } else {
-          return {
-            ...state,
-            ...gripper,
-            ...wasteChute,
-            ...stagingAreas,
-          }
-        }
-      } else {
-        if (trashBin != null) {
-          return { ...state, ...trashBin }
-        } else {
-          //  always hardcode a trash bin when no pipetting command is provided since no trash for
-          //  OT-2 is not supported
-          return { ...state, ...hardcodedTrashBinOt2 }
-        }
+      return {
+        ...state,
+        ...trashBin,
+        ...wasteChute,
+        ...gripper,
+        ...stagingArea,
       }
     },
     //  @ts-expect-error

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -5,20 +5,14 @@ import merge from 'lodash/merge'
 import omit from 'lodash/omit'
 import reduce from 'lodash/reduce'
 import {
-  FLEX_ROBOT_TYPE,
-  OT2_ROBOT_TYPE,
   getLabwareDefaultEngageHeight,
   getLabwareDefURI,
   getModuleType,
   MAGNETIC_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
   THERMOCYCLER_MODULE_TYPE,
-  WASTE_CHUTE_ADDRESSABLE_AREAS,
-  MOVABLE_TRASH_ADDRESSABLE_AREAS,
-  WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { rootReducer as labwareDefsRootReducer } from '../../labware-defs'
-import { getCutoutIdByAddressableArea, uuid } from '../../utils'
 import {
   GRIPPER_LOCATION,
   INITIAL_DECK_SETUP_STEP_ID,
@@ -33,7 +27,6 @@ import { PRESAVED_STEP_ID } from '../../steplist/types'
 import { getLabwareIsCompatible } from '../../utils/labwareModuleCompatibility'
 import { getLabwareOnModule } from '../../ui/modules/utils'
 import { nestedCombineReducers } from './nestedCombineReducers'
-import { COLUMN_4_SLOTS } from '@opentrons/step-generation'
 import {
   _getPipetteEntitiesRootState,
   _getLabwareEntitiesRootState,
@@ -44,7 +37,6 @@ import {
   createPresavedStepForm,
   getDeckItemIdInSlot,
   getIdsInRange,
-  getUnoccupiedSlotForTrash,
 } from '../utils'
 
 import type { Reducer } from 'redux'
@@ -57,11 +49,7 @@ import type {
   LoadLabwareCreateCommand,
   LoadModuleCreateCommand,
   LoadPipetteCreateCommand,
-  MoveLabwareCreateCommand,
-  MoveToAddressableAreaCreateCommand,
-  MoveToAddressableAreaForDropTipCreateCommand,
   PipetteName,
-  AddressableAreaName,
 } from '@opentrons/shared-data'
 import type { RootState as LabwareDefsRootState } from '../../labware-defs'
 import type { LoadFileAction } from '../../load-file'
@@ -112,12 +100,12 @@ import type {
   SelectMultipleStepsAction,
 } from '../../ui/steps/actions/types'
 import type { Action } from '../../types'
+import type { AdditionalEquipmentLocationUpdate } from '../../load-file/migration/utils/getAdditionalEquipmentLocationUpdate'
 import type {
   NormalizedLabware,
   NormalizedLabwareById,
   ModuleEntities,
 } from '../types'
-import { AdditionalEquipmentLocationUpdate } from '../../load-file/migration/utils/getAdditionalEquipmentLocationUpdate'
 
 type FormState = FormData | null
 const unsavedFormInitialState = null

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -100,7 +100,10 @@ import type {
   SelectMultipleStepsAction,
 } from '../../ui/steps/actions/types'
 import type { Action } from '../../types'
-import type { AdditionalEquipmentLocationUpdate } from '../../load-file/migration/utils/getAdditionalEquipmentLocationUpdate'
+import type {
+  AdditionalEquipmentLocationUpdate,
+  LocationUpdate,
+} from '../../load-file/migration/utils/getAdditionalEquipmentLocationUpdate'
 import type {
   NormalizedLabware,
   NormalizedLabwareById,
@@ -407,7 +410,7 @@ export const savedStepForms = (
       const { id } = action.payload
       const prevInitialDeckSetupStep =
         savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
-      const gripperLocationUpdate =
+      const gripperLocationUpdate: LocationUpdate =
         prevInitialDeckSetupStep.gripperLocationUpdate
       const gripperKey = Object.entries(gripperLocationUpdate).find(
         ([_, value]) => value === GRIPPER_LOCATION

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -270,11 +270,7 @@ const _getInitialDeckSetup = (
   const additionalEquipmentEntitiesOnDeck = Object.values(
     additionalEquipmentEntities
   ).reduce((aeEntities: AdditionalEquipmentEntities, ae) => {
-    if (
-      ae.name === 'wasteChute' ||
-      ae.name === 'stagingArea' ||
-      ae.name === 'trashBin'
-    ) {
+    if (ae.name !== 'gripper') {
       aeEntities[ae.id] = ae
     }
     return aeEntities

--- a/protocol-designer/src/step-forms/test/utils.test.ts
+++ b/protocol-designer/src/step-forms/test/utils.test.ts
@@ -34,347 +34,342 @@ describe('getIdsInRange', () => {
 })
 describe('getUnoccupiedSlotForTrash', () => {
   it('returns slot C1 when all other slots are occupied by modules, labware, moveLabware, and staging areas', () => {
-    const mockPDFile: any = {
-      commands: [
-        {
-          key: '7353ae60-c85e-45c4-8d69-59ff3a97debd',
-          commandType: 'loadModule',
-          params: {
-            model: 'thermocyclerModuleV2',
-            location: { slotName: 'B1' },
-            moduleId:
-              '771f390f-01a9-4615-9c4e-4dbfc95844b5:thermocyclerModuleType',
-          },
+    const mockCreateCommands: CreateCommand[] = [
+      {
+        key: '7353ae60-c85e-45c4-8d69-59ff3a97debd',
+        commandType: 'loadModule',
+        params: {
+          model: 'thermocyclerModuleV2',
+          location: { slotName: 'B1' },
+          moduleId:
+            '771f390f-01a9-4615-9c4e-4dbfc95844b5:thermocyclerModuleType',
         },
-        {
-          key: '82e5d08f-ceae-4eb8-8600-b61a973d47d9',
-          commandType: 'loadModule',
-          params: {
-            model: 'heaterShakerModuleV1',
-            location: { slotName: 'D1' },
-            moduleId:
-              'b9df03af-3844-4ae8-a1cf-cae61a6b4992:heaterShakerModuleType',
-          },
+      },
+      {
+        key: '82e5d08f-ceae-4eb8-8600-b61a973d47d9',
+        commandType: 'loadModule',
+        params: {
+          model: 'heaterShakerModuleV1',
+          location: { slotName: 'D1' },
+          moduleId:
+            'b9df03af-3844-4ae8-a1cf-cae61a6b4992:heaterShakerModuleType',
         },
-        {
-          key: '49bc2a29-a7d2-42a6-8610-e07a9ad166df',
-          commandType: 'loadModule',
-          params: {
-            model: 'temperatureModuleV2',
-            location: { slotName: 'D3' },
-            moduleId:
-              '52bea856-eea6-473c-80df-b316f3559692:temperatureModuleType',
-          },
+      },
+      {
+        key: '49bc2a29-a7d2-42a6-8610-e07a9ad166df',
+        commandType: 'loadModule',
+        params: {
+          model: 'temperatureModuleV2',
+          location: { slotName: 'D3' },
+          moduleId:
+            '52bea856-eea6-473c-80df-b316f3559692:temperatureModuleType',
         },
-        {
-          key: '864fadd7-f2c1-400a-b2ef-24d0c887a3c8',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons Flex 96 Tip Rack 50 µL',
-            labwareId:
-              '88881828-037c-4445-ba57-121164f4a53a:opentrons/opentrons_flex_96_tiprack_50ul/1',
-            loadName: 'opentrons_flex_96_tiprack_50ul',
-            namespace: 'opentrons',
-            version: 1,
-            location: { slotName: 'C2' },
-          },
+      },
+      {
+        key: '864fadd7-f2c1-400a-b2ef-24d0c887a3c8',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons Flex 96 Tip Rack 50 µL',
+          labwareId:
+            '88881828-037c-4445-ba57-121164f4a53a:opentrons/opentrons_flex_96_tiprack_50ul/1',
+          loadName: 'opentrons_flex_96_tiprack_50ul',
+          namespace: 'opentrons',
+          version: 1,
+          location: { slotName: 'C2' },
         },
-        {
-          key: '79994418-d664-4884-9441-4b0fa62bd143',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Bio-Rad 96 Well Plate 200 µL PCR',
-            labwareId:
-              '733c04a8-ae8c-449f-a1f9-ca3783fdda58:opentrons/biorad_96_wellplate_200ul_pcr/2',
-            loadName: 'biorad_96_wellplate_200ul_pcr',
-            namespace: 'opentrons',
-            version: 2,
-            location: { addressableAreaName: 'A4' },
-          },
+      },
+      {
+        key: '79994418-d664-4884-9441-4b0fa62bd143',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Bio-Rad 96 Well Plate 200 µL PCR',
+          labwareId:
+            '733c04a8-ae8c-449f-a1f9-ca3783fdda58:opentrons/biorad_96_wellplate_200ul_pcr/2',
+          loadName: 'biorad_96_wellplate_200ul_pcr',
+          namespace: 'opentrons',
+          version: 2,
+          location: { addressableAreaName: 'A4' },
         },
-        {
-          key: 'b2170a2c-d202-4129-9cd7-ffa4e35d57bb',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Corning 24 Well Plate 3.4 mL Flat',
-            labwareId:
-              '32e97c67-866e-4153-bcb7-2b86b1d3f1fe:opentrons/corning_24_wellplate_3.4ml_flat/2',
-            loadName: 'corning_24_wellplate_3.4ml_flat',
-            namespace: 'opentrons',
-            version: 2,
-            location: { slotName: 'B3' },
-          },
+      },
+      {
+        key: 'b2170a2c-d202-4129-9cd7-ffa4e35d57bb',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Corning 24 Well Plate 3.4 mL Flat',
+          labwareId:
+            '32e97c67-866e-4153-bcb7-2b86b1d3f1fe:opentrons/corning_24_wellplate_3.4ml_flat/2',
+          loadName: 'corning_24_wellplate_3.4ml_flat',
+          namespace: 'opentrons',
+          version: 2,
+          location: { slotName: 'B3' },
         },
-        {
-          key: 'fb1807fe-ca16-4f75-b44d-803d704c7d98',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons Flex 96 Tip Rack 50 µL',
-            labwareId:
-              '11fdsa8b1-bf4b-4a6c-80cb-b8e5bdfe309b:opentrons/opentrons_flex_96_tiprack_50ul/1',
-            loadName: 'opentrons_flex_96_tiprack_50ul',
-            namespace: 'opentrons',
-            version: 1,
-            location: {
-              labwareId:
-                '32e97c67-866e-4153-bcb7-2b86b1d3f1fe:opentrons/corning_24_wellplate_3.4ml_flat/2',
-            },
-          },
-        },
-        {
-          commandType: 'moveLabware',
-          key: '1395243a-958f-4305-9687-52cdaf39f2b6',
-          params: {
-            labwareId:
-              '733c04a8-ae8c-449f-a1f9-ca3783fdda58:opentrons/biorad_96_wellplate_200ul_pcr/2',
-            strategy: 'usingGripper',
-            newLocation: { slotName: 'C1' },
-          },
-        },
-        {
-          commandType: 'moveLabware',
-          key: '4e39e7ec-4ada-4e3c-8369-1ff7421061a9',
-          params: {
+      },
+      {
+        key: 'fb1807fe-ca16-4f75-b44d-803d704c7d98',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons Flex 96 Tip Rack 50 µL',
+          labwareId:
+            '11fdsa8b1-bf4b-4a6c-80cb-b8e5bdfe309b:opentrons/opentrons_flex_96_tiprack_50ul/1',
+          loadName: 'opentrons_flex_96_tiprack_50ul',
+          namespace: 'opentrons',
+          version: 1,
+          location: {
             labwareId:
               '32e97c67-866e-4153-bcb7-2b86b1d3f1fe:opentrons/corning_24_wellplate_3.4ml_flat/2',
-            strategy: 'usingGripper',
-            newLocation: { addressableAreaName: 'A4' },
           },
         },
-      ] as CreateCommand[],
-    }
+      },
+      {
+        commandType: 'moveLabware',
+        key: '1395243a-958f-4305-9687-52cdaf39f2b6',
+        params: {
+          labwareId:
+            '733c04a8-ae8c-449f-a1f9-ca3783fdda58:opentrons/biorad_96_wellplate_200ul_pcr/2',
+          strategy: 'usingGripper',
+          newLocation: { slotName: 'C1' },
+        },
+      },
+      {
+        commandType: 'moveLabware',
+        key: '4e39e7ec-4ada-4e3c-8369-1ff7421061a9',
+        params: {
+          labwareId:
+            '32e97c67-866e-4153-bcb7-2b86b1d3f1fe:opentrons/corning_24_wellplate_3.4ml_flat/2',
+          strategy: 'usingGripper',
+          newLocation: { addressableAreaName: 'A4' },
+        },
+      },
+    ]
     const mockStagingAreaSlotNames: AddressableAreaName[] = ['A4', 'B4']
     const mockHasWasteChuteCommands = false
 
     expect(
       getUnoccupiedSlotForTrash(
-        mockPDFile,
+        mockCreateCommands,
         mockHasWasteChuteCommands,
         mockStagingAreaSlotNames
       )
     ).toStrictEqual('C3')
   })
   it('returns cutoutD3 for waste chute when every slot is occupied except for D3 on a staging area', () => {
-    const mockPDFile: any = {
-      commands: [
-        {
-          key: '159e778d-0fc5-4d24-a662-b1e59a7babda',
-          commandType: 'loadModule',
-          params: {
-            model: 'thermocyclerModuleV2',
-            location: { slotName: 'B1' },
-            moduleId:
-              '8932e104-7d57-42cf-88e4-ade334c84a76:thermocyclerModuleType',
-          },
+    const mockCommands: CreateCommand[] = [
+      {
+        key: '159e778d-0fc5-4d24-a662-b1e59a7babda',
+        commandType: 'loadModule',
+        params: {
+          model: 'thermocyclerModuleV2',
+          location: { slotName: 'B1' },
+          moduleId:
+            '8932e104-7d57-42cf-88e4-ade334c84a76:thermocyclerModuleType',
         },
-        {
-          key: '7d1fdcce-fa27-4520-8f97-a901751a4396',
-          commandType: 'loadModule',
-          params: {
-            model: 'temperatureModuleV2',
-            location: { slotName: 'C1' },
+      },
+      {
+        key: '7d1fdcce-fa27-4520-8f97-a901751a4396',
+        commandType: 'loadModule',
+        params: {
+          model: 'temperatureModuleV2',
+          location: { slotName: 'C1' },
+          moduleId:
+            '2944a6a5-45f7-4d96-a4a2-d2853206a9f0:temperatureModuleType',
+        },
+      },
+      {
+        key: '1c223945-bfa3-4174-9923-5ed84afd1820',
+        commandType: 'loadModule',
+        params: {
+          model: 'heaterShakerModuleV1',
+          location: { slotName: 'D1' },
+          moduleId:
+            '528620a6-6eb9-4000-bce3-a58809e16d4c:heaterShakerModuleType',
+        },
+      },
+      {
+        key: 'e06d0fd5-2ca8-4d0a-bcfd-4121849604da',
+        commandType: 'loadModule',
+        params: {
+          model: 'magneticBlockV1',
+          location: { slotName: 'D2' },
+          moduleId: 'c8f8c89f-06df-468c-895d-33006db69beb:magneticBlockType',
+        },
+      },
+      {
+        key: 'f49ebdff-9780-4ca0-994c-2d2dd7c04b1d',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons 96 Well Aluminum Block',
+          labwareId:
+            'a69bcf2e-9461-4d43-be63-f3b8db66e5e7:opentrons/opentrons_96_well_aluminum_block/1',
+          loadName: 'opentrons_96_well_aluminum_block',
+          namespace: 'opentrons',
+          version: 1,
+          location: {
             moduleId:
               '2944a6a5-45f7-4d96-a4a2-d2853206a9f0:temperatureModuleType',
           },
         },
-        {
-          key: '1c223945-bfa3-4174-9923-5ed84afd1820',
-          commandType: 'loadModule',
-          params: {
-            model: 'heaterShakerModuleV1',
-            location: { slotName: 'D1' },
+      },
+      {
+        key: 'dda244f9-ff80-4ede-a585-1a546a88ee77',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons 96 PCR Heater-Shaker Adapter',
+          labwareId:
+            '723a9551-ebba-4b4a-a92e-8d1fa0e813df:opentrons/opentrons_96_pcr_adapter/1',
+          loadName: 'opentrons_96_pcr_adapter',
+          namespace: 'opentrons',
+          version: 1,
+          location: {
             moduleId:
               '528620a6-6eb9-4000-bce3-a58809e16d4c:heaterShakerModuleType',
           },
         },
-        {
-          key: 'e06d0fd5-2ca8-4d0a-bcfd-4121849604da',
-          commandType: 'loadModule',
-          params: {
-            model: 'magneticBlockV1',
-            location: { slotName: 'D2' },
+      },
+      {
+        key: '8c28ac95-c8d0-4481-8204-26b1babb54bf',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons Flex 96 Tip Rack 50 µL',
+          labwareId:
+            'c80cffe7-d89d-430e-ba96-3c12f879e993:opentrons/opentrons_flex_96_tiprack_50ul/1',
+          loadName: 'opentrons_flex_96_tiprack_50ul',
+          namespace: 'opentrons',
+          version: 1,
+          location: { slotName: 'C3' },
+        },
+      },
+      {
+        key: 'f0357fde-125a-464c-98ed-b1b9492daab8',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons Flex 96 Filter Tip Rack 200 µL (1)',
+          labwareId:
+            '0a2d4b6f-a43d-428a-98f2-284809596776:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
+          loadName: 'opentrons_flex_96_filtertiprack_200ul',
+          namespace: 'opentrons',
+          version: 1,
+          location: { slotName: 'A3' },
+        },
+      },
+      {
+        key: 'e27ba758-8d28-486f-a443-6e2276842ad0',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons Flex 96 Filter Tip Rack 200 µL (2)',
+          labwareId:
+            '417a6bb2-8831-4b4d-840b-7d9329606865:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
+          loadName: 'opentrons_flex_96_filtertiprack_200ul',
+          namespace: 'opentrons',
+          version: 1,
+          location: { slotName: 'B3' },
+        },
+      },
+      {
+        key: '37848c2a-4a1b-44f0-851a-d264368c47f8',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons Flex 96 Filter Tip Rack 200 µL (3)',
+          labwareId:
+            'ebb13651-0a60-4f42-ab85-f7084aeb0c08:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
+          loadName: 'opentrons_flex_96_filtertiprack_200ul',
+          namespace: 'opentrons',
+          version: 1,
+          location: { slotName: 'A2' },
+        },
+      },
+      {
+        key: '768626df-b249-4d68-8f95-193b03113457',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons Flex 96 Filter Tip Rack 200 µL (4)',
+          labwareId:
+            'b17e8c1b-a308-4eaa-a852-10ad300ddea8:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
+          loadName: 'opentrons_flex_96_filtertiprack_200ul',
+          namespace: 'opentrons',
+          version: 1,
+          location: { slotName: 'B2' },
+        },
+      },
+      {
+        key: 'b12a4e6e-7ffc-421f-a2b6-44ae49d6f7bf',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Reagent Plate',
+          labwareId:
+            'aab3280f-6e7b-4e60-8326-c1d38999e08f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2',
+          loadName: 'opentrons_96_wellplate_200ul_pcr_full_skirt',
+          namespace: 'opentrons',
+          version: 2,
+          location: {
+            labwareId:
+              'a69bcf2e-9461-4d43-be63-f3b8db66e5e7:opentrons/opentrons_96_well_aluminum_block/1',
+          },
+        },
+      },
+      {
+        key: 'e6863a1e-8aa0-4484-9aff-74ea9195a815',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Sample Plate 1',
+          labwareId:
+            '8e755287-33cb-483f-b525-fff876893754:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2',
+          loadName: 'opentrons_96_wellplate_200ul_pcr_full_skirt',
+          namespace: 'opentrons',
+          version: 2,
+          location: {
+            labwareId:
+              '723a9551-ebba-4b4a-a92e-8d1fa0e813df:opentrons/opentrons_96_pcr_adapter/1',
+          },
+        },
+      },
+      {
+        key: 'b29f48ef-3b20-457e-8499-df709818c47f',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'NEST 96 Deep Well Plate 2mL',
+          labwareId:
+            'f0d30267-b0f6-493a-b0ea-70303428fa83:opentrons/nest_96_wellplate_2ml_deep/2',
+          loadName: 'nest_96_wellplate_2ml_deep',
+          namespace: 'opentrons',
+          version: 2,
+          location: {
             moduleId: 'c8f8c89f-06df-468c-895d-33006db69beb:magneticBlockType',
           },
         },
-        {
-          key: 'f49ebdff-9780-4ca0-994c-2d2dd7c04b1d',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons 96 Well Aluminum Block',
-            labwareId:
-              'a69bcf2e-9461-4d43-be63-f3b8db66e5e7:opentrons/opentrons_96_well_aluminum_block/1',
-            loadName: 'opentrons_96_well_aluminum_block',
-            namespace: 'opentrons',
-            version: 1,
-            location: {
-              moduleId:
-                '2944a6a5-45f7-4d96-a4a2-d2853206a9f0:temperatureModuleType',
-            },
-          },
+      },
+      {
+        key: '50be2f72-c7bc-4fd4-b10c-2054b90f922d',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'NEST 12 Well Reservoir 15 mL',
+          labwareId:
+            'b60bbc39-cd82-4ede-b744-e88777a32b62:opentrons/nest_12_reservoir_15ml/1',
+          loadName: 'nest_12_reservoir_15ml',
+          namespace: 'opentrons',
+          version: 1,
+          location: { slotName: 'C2' },
         },
-        {
-          key: 'dda244f9-ff80-4ede-a585-1a546a88ee77',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons 96 PCR Heater-Shaker Adapter',
-            labwareId:
-              '723a9551-ebba-4b4a-a92e-8d1fa0e813df:opentrons/opentrons_96_pcr_adapter/1',
-            loadName: 'opentrons_96_pcr_adapter',
-            namespace: 'opentrons',
-            version: 1,
-            location: {
-              moduleId:
-                '528620a6-6eb9-4000-bce3-a58809e16d4c:heaterShakerModuleType',
-            },
-          },
+      },
+      {
+        key: 'a2f0c011-9983-46d9-a3ae-763a04856651',
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'Opentrons Flex 96 Tip Rack 50 µL (1)',
+          labwareId:
+            '0d3d02a6-6501-4f28-81b9-12b2fe66998b:opentrons/opentrons_flex_96_tiprack_50ul/1',
+          loadName: 'opentrons_flex_96_tiprack_50ul',
+          namespace: 'opentrons',
+          version: 1,
+          location: { addressableAreaName: 'D4' },
         },
-        {
-          key: '8c28ac95-c8d0-4481-8204-26b1babb54bf',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons Flex 96 Tip Rack 50 µL',
-            labwareId:
-              'c80cffe7-d89d-430e-ba96-3c12f879e993:opentrons/opentrons_flex_96_tiprack_50ul/1',
-            loadName: 'opentrons_flex_96_tiprack_50ul',
-            namespace: 'opentrons',
-            version: 1,
-            location: { slotName: 'C3' },
-          },
-        },
-        {
-          key: 'f0357fde-125a-464c-98ed-b1b9492daab8',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons Flex 96 Filter Tip Rack 200 µL (1)',
-            labwareId:
-              '0a2d4b6f-a43d-428a-98f2-284809596776:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
-            loadName: 'opentrons_flex_96_filtertiprack_200ul',
-            namespace: 'opentrons',
-            version: 1,
-            location: { slotName: 'A3' },
-          },
-        },
-        {
-          key: 'e27ba758-8d28-486f-a443-6e2276842ad0',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons Flex 96 Filter Tip Rack 200 µL (2)',
-            labwareId:
-              '417a6bb2-8831-4b4d-840b-7d9329606865:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
-            loadName: 'opentrons_flex_96_filtertiprack_200ul',
-            namespace: 'opentrons',
-            version: 1,
-            location: { slotName: 'B3' },
-          },
-        },
-        {
-          key: '37848c2a-4a1b-44f0-851a-d264368c47f8',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons Flex 96 Filter Tip Rack 200 µL (3)',
-            labwareId:
-              'ebb13651-0a60-4f42-ab85-f7084aeb0c08:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
-            loadName: 'opentrons_flex_96_filtertiprack_200ul',
-            namespace: 'opentrons',
-            version: 1,
-            location: { slotName: 'A2' },
-          },
-        },
-        {
-          key: '768626df-b249-4d68-8f95-193b03113457',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons Flex 96 Filter Tip Rack 200 µL (4)',
-            labwareId:
-              'b17e8c1b-a308-4eaa-a852-10ad300ddea8:opentrons/opentrons_flex_96_filtertiprack_200ul/1',
-            loadName: 'opentrons_flex_96_filtertiprack_200ul',
-            namespace: 'opentrons',
-            version: 1,
-            location: { slotName: 'B2' },
-          },
-        },
-        {
-          key: 'b12a4e6e-7ffc-421f-a2b6-44ae49d6f7bf',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Reagent Plate',
-            labwareId:
-              'aab3280f-6e7b-4e60-8326-c1d38999e08f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2',
-            loadName: 'opentrons_96_wellplate_200ul_pcr_full_skirt',
-            namespace: 'opentrons',
-            version: 2,
-            location: {
-              labwareId:
-                'a69bcf2e-9461-4d43-be63-f3b8db66e5e7:opentrons/opentrons_96_well_aluminum_block/1',
-            },
-          },
-        },
-        {
-          key: 'e6863a1e-8aa0-4484-9aff-74ea9195a815',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Sample Plate 1',
-            labwareId:
-              '8e755287-33cb-483f-b525-fff876893754:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2',
-            loadName: 'opentrons_96_wellplate_200ul_pcr_full_skirt',
-            namespace: 'opentrons',
-            version: 2,
-            location: {
-              labwareId:
-                '723a9551-ebba-4b4a-a92e-8d1fa0e813df:opentrons/opentrons_96_pcr_adapter/1',
-            },
-          },
-        },
-        {
-          key: 'b29f48ef-3b20-457e-8499-df709818c47f',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'NEST 96 Deep Well Plate 2mL',
-            labwareId:
-              'f0d30267-b0f6-493a-b0ea-70303428fa83:opentrons/nest_96_wellplate_2ml_deep/2',
-            loadName: 'nest_96_wellplate_2ml_deep',
-            namespace: 'opentrons',
-            version: 2,
-            location: {
-              moduleId:
-                'c8f8c89f-06df-468c-895d-33006db69beb:magneticBlockType',
-            },
-          },
-        },
-        {
-          key: '50be2f72-c7bc-4fd4-b10c-2054b90f922d',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'NEST 12 Well Reservoir 15 mL',
-            labwareId:
-              'b60bbc39-cd82-4ede-b744-e88777a32b62:opentrons/nest_12_reservoir_15ml/1',
-            loadName: 'nest_12_reservoir_15ml',
-            namespace: 'opentrons',
-            version: 1,
-            location: { slotName: 'C2' },
-          },
-        },
-        {
-          key: 'a2f0c011-9983-46d9-a3ae-763a04856651',
-          commandType: 'loadLabware',
-          params: {
-            displayName: 'Opentrons Flex 96 Tip Rack 50 µL (1)',
-            labwareId:
-              '0d3d02a6-6501-4f28-81b9-12b2fe66998b:opentrons/opentrons_flex_96_tiprack_50ul/1',
-            loadName: 'opentrons_flex_96_tiprack_50ul',
-            namespace: 'opentrons',
-            version: 1,
-            location: { addressableAreaName: 'D4' },
-          },
-        },
-      ],
-    }
+      },
+    ]
     const mockStagingAreaSlotNames: AddressableAreaName[] = ['D4']
     const mockHasWasteChuteCommands = false
 
     expect(
       getUnoccupiedSlotForTrash(
-        mockPDFile,
+        mockCommands,
         mockHasWasteChuteCommands,
         mockStagingAreaSlotNames
       )

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -35,7 +35,6 @@ import type {
 } from '@opentrons/step-generation'
 import type { DeckSlot } from '../../types'
 import type { FormData, HydratedFormData } from '../../form-types'
-import type { PDProtocolFile } from '../../file-types'
 import type {
   AdditionalEquipmentOnDeck,
   InitialDeckSetup,

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -17,6 +17,7 @@ import { getCutoutIdByAddressableArea } from '../../utils'
 import type { LabwareDefByDefURI } from '../../labware-defs'
 import type {
   AddressableAreaName,
+  CreateCommand,
   CutoutId,
   DeckSlotId,
   LoadLabwareCreateCommand,
@@ -296,7 +297,7 @@ export function getHydratedForm(
 }
 
 export const getUnoccupiedSlotForTrash = (
-  file: PDProtocolFile,
+  commands: CreateCommand[],
   hasWasteChuteCommands: boolean,
   stagingAreaSlotNames: AddressableAreaName[]
 ): string => {
@@ -308,7 +309,7 @@ export const getUnoccupiedSlotForTrash = (
       FLEX_ROBOT_TYPE
     )
   )
-  const allLoadLabwareSlotNames = Object.values(file.commands)
+  const allLoadLabwareSlotNames = Object.values(commands)
     .filter(
       (command): command is LoadLabwareCreateCommand =>
         command.commandType === 'loadLabware'
@@ -326,7 +327,7 @@ export const getUnoccupiedSlotForTrash = (
       return acc
     }, [])
 
-  const allLoadModuleSlotNames = Object.values(file.commands)
+  const allLoadModuleSlotNames = Object.values(commands)
     .filter(
       (command): command is LoadModuleCreateCommand =>
         command.commandType === 'loadModule'
@@ -340,7 +341,7 @@ export const getUnoccupiedSlotForTrash = (
       }
     })
 
-  const allMoveLabwareLocations = Object.values(file.commands)
+  const allMoveLabwareLocations = Object.values(commands)
     .filter(
       (command): command is MoveLabwareCreateCommand =>
         command.commandType === 'moveLabware'

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -135,6 +135,7 @@ export function getDefaultsForStepType(
         labwareLocationUpdate: {},
         moduleLocationUpdate: {},
         pipetteLocationUpdate: {},
+        additionalEquipmentLocationUpdate: {},
       }
 
     case 'magnet':

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -135,7 +135,10 @@ export function getDefaultsForStepType(
         labwareLocationUpdate: {},
         moduleLocationUpdate: {},
         pipetteLocationUpdate: {},
-        additionalEquipmentLocationUpdate: {},
+        trashBinLocationUpdate: {},
+        wasteChuteLocationUpdate: {},
+        stagingAreaLocationUpdate: {},
+        gripperLocationUpdate: {},
       }
 
     case 'magnet':

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
@@ -132,6 +132,10 @@ describe('getDefaultsForStepType', () => {
         labwareLocationUpdate: {},
         pipetteLocationUpdate: {},
         moduleLocationUpdate: {},
+        trashBinLocationUpdate: {},
+        wasteChuteLocationUpdate: {},
+        stagingAreaLocationUpdate: {},
+        gripperLocationUpdate: {},
       })
     })
   })

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -152,7 +152,7 @@ export interface LoadPipetteParams {
 interface LoadPipetteResult {
   pipetteId: string
 }
-export interface LoadLabwareParams {
+interface LoadLabwareParams {
   location: LabwareLocation
   version: number
   namespace: string

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -152,7 +152,7 @@ export interface LoadPipetteParams {
 interface LoadPipetteResult {
   pipetteId: string
 }
-interface LoadLabwareParams {
+export interface LoadLabwareParams {
   location: LabwareLocation
   version: number
   namespace: string


### PR DESCRIPTION
closes AUTH-1396

# Overview

The goal of this PR is so when importing JSON/python protocols back into PD, we can determine the additionalEquipment entities from `stepForms` instead of reading the commands.

This PR introduces a few new `-locationUpdate` keys in `savedStepForms`'s `INITIAL_DECK_SETUP_STEP` step. The locations include:
- `trashBinLocationUpdate`
- `wasteChuteLocationUpdate`
- `gripperLocationUpdate`
- `stagingAreaLocationUpdate`

Each of them include the entity's id as the key and the location as the value. This is for pd/py interop so we can easily grab these additional equipment entities from the step forms instead of reading from the commands

## Test Plan and Hands on Testing

Test this out with different variations of deleting/adding gripper, staging areas, trash bin/waste chute. and then import old versions of PD and test that the migration works as expected.

I did smoke test this a lot so i think everything is working as expected.

## Changelog

add the new `locationUpdate` keys in stepForms for py/pd interop and wire it up in the reducer
fix fixtures for the migration cypress test

## Risk assessment

low-ish, will be well tested before merging
