### PR TITLE
test(shared-data): Continue testing other labware if one test fails

### DIFF
--- a/shared-data/js/__tests__/labwareDefSchemaV1.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV1.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import glob from 'glob'
 import Ajv from 'ajv'
-import { describe, expect, it, beforeAll } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 
 import { labwareSchemaV1 } from '../schema'
 import type { LabwareDefinition1 } from '../types'
@@ -57,26 +57,25 @@ describe('test the schema against a minimalist fixture', () => {
   })
 })
 
-describe('test schemas of all definitions', () => {
+describe('test all definitions', () => {
   const labwarePaths = glob.sync(DEFINITIONS_GLOB_PATTERN, GLOB_OPTIONS)
 
-  beforeAll(() => {
-    // Make sure definitions path didn't break, which would give you false positives
+  test("definition paths didn't break, which would give false positives", () => {
     expect(labwarePaths.length).toBeGreaterThan(0)
   })
 
-  labwarePaths.forEach(labwarePath => {
+  describe.each(labwarePaths)('%s', labwarePath => {
     const filename = path.parse(labwarePath).name
     const labwareDef = require(labwarePath) as LabwareDefinition1
 
-    it(filename, () => {
+    it('validates against the schema', () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
 
-    it(`file name matches metadata.name: ${filename}`, () => {
+    it(`has a file name that matches metadata.name: ${filename}`, () => {
       expect(labwareDef.metadata.name).toEqual(filename)
     })
   })

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -197,34 +197,33 @@ test('fail on bad labware', () => {
 describe('test schemas of all opentrons definitions', () => {
   const labwarePaths = glob.sync(globPattern, { cwd: definitionsDir })
 
-  beforeAll(() => {
-    // Make sure definitions path didn't break, which would give you false positives
+  test("definition paths didn't break, which would give false positives", () => {
     expect(labwarePaths.length).toBeGreaterThan(0)
   })
 
-  labwarePaths.forEach(labwarePath => {
+  describe.each(labwarePaths)('%s', labwarePath => {
     const filename = path.parse(labwarePath).base
     const fullLabwarePath = path.join(definitionsDir, labwarePath)
     const labwareDef = require(fullLabwarePath) as LabwareDefinition2
 
-    it(`${filename} validates against schema`, () => {
+    it('validates against the schema', () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
 
-    it(`file name matches version: ${labwarePath}`, () => {
+    test('file name matches version', () => {
       expect(`${labwareDef.version}`).toEqual(path.basename(filename, '.json'))
     })
 
-    it(`parent dir matches loadName: ${labwarePath}`, () => {
+    test('parent dir matches loadName', () => {
       expect(labwareDef.parameters.loadName).toEqual(
         path.basename(path.dirname(labwarePath))
       )
     })
 
-    it(`namespace is "opentrons": ${labwarePath}`, () => {
+    test('namespace is "opentrons"', () => {
       expect(labwareDef.namespace).toEqual('opentrons')
     })
 
@@ -266,30 +265,29 @@ describe('test that the dimensions in all opentrons definitions make sense', () 
 describe('test schemas of all v2 labware fixtures', () => {
   const labwarePaths = glob.sync(globPattern, { cwd: fixturesDir })
 
-  beforeAll(() => {
-    // Make sure fixtures path didn't break, which would give you false positives
+  test("definition paths didn't break, which would give false positives", () => {
     expect(labwarePaths.length).toBeGreaterThan(0)
   })
 
-  labwarePaths.forEach(labwarePath => {
+  describe.each(labwarePaths)('%s', labwarePath => {
     const filename = path.parse(labwarePath).base
     const fullLabwarePath = path.join(fixturesDir, labwarePath)
     const labwareDef = require(fullLabwarePath) as LabwareDefinition2
 
-    it(`${filename} validates against schema`, () => {
+    test(`${filename} validates against schema`, () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
 
-    it(`fixture file name matches loadName: ${labwarePath}`, () => {
+    test(`fixture file name matches loadName: ${labwarePath}`, () => {
       expect(labwareDef.parameters.loadName).toEqual(
         path.basename(filename, '.json')
       )
     })
 
-    it(`namespace is "fixture": ${labwarePath}`, () => {
+    test(`namespace is "fixture": ${labwarePath}`, () => {
       expect(labwareDef.namespace).toEqual('fixture')
     })
 

--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import glob from 'glob'
-import { describe, expect, it, beforeAll, test } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 
 import type { LabwareDefinition3 } from '../types'
 import Ajv from 'ajv'
@@ -44,17 +44,14 @@ const checkGeometryDefinitions = (
 describe(`test additions to labware schema in v3`, () => {
   const labwarePaths = glob.sync(globPattern, { cwd: fixturesDir })
 
-  beforeAll(() => {
-    // Make sure definitions path didn't break, which would give you false positives
+  test("definition paths didn't break, which would give false positives", () => {
     expect(labwarePaths.length).toBeGreaterThan(0)
   })
 
-  labwarePaths.forEach(labwarePath => {
+  describe.each(labwarePaths)('%s', labwarePath => {
     const filename = path.parse(labwarePath).base
     const fullLabwarePath = path.join(fixturesDir, labwarePath)
     const labwareDef = require(fullLabwarePath) as LabwareDefinition3
-
-    checkGeometryDefinitions(labwareDef, labwarePath)
 
     it(`${filename} validates against schema`, () => {
       const valid = validate(labwareDef)
@@ -62,5 +59,7 @@ describe(`test additions to labware schema in v3`, () => {
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
     })
+
+    checkGeometryDefinitions(labwareDef, labwarePath)
   })
 })


### PR DESCRIPTION
## Overview

Minor adjustments to our labware definition tests.

## Changelog

* When we're iterating over labware definition files to test, instead of using a JavaScript-level `forEach`, use a Vitest-level `it.each` or `test.each`. This just makes the error reporting a little bit better: if multiple labware definitions have errors, Vitest will now detect and print all of them instead of just the first one.
* Adjust messages and swap some things between `it` and `test`. This is just for code readability and does not have any functional difference.

## Review requests

None in particular.

## Risk assessment

No risk. Changes are trivial and only to tests.
