### PR TITLE
chore(app): change default labware view to map

### DIFF
--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
@@ -101,6 +101,7 @@ describe('ProtocolSetupLabware', () => {
 
   it('renders the Labware Setup page', () => {
     render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     screen.getByText('Labware')
     screen.getByText('Labware name')
     screen.getByText('Location')
@@ -119,6 +120,7 @@ describe('ProtocolSetupLabware', () => {
     fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     expect(screen.queryByText('List View')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Map View' }))
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     screen.getByText('Labware')
     screen.getByText('Labware name')
     screen.getByText('Location')

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
@@ -161,32 +161,31 @@ describe('ProtocolSetupLabware', () => {
   })
 
   it('shows opening transition states of the labware latch button', () => {
-    render()
-    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     vi.mocked(useModulesQuery).mockReturnValue(
       mockUseModulesQueryOpening as any
     )
 
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     screen.getByText('Opening...')
   })
 
   it('shows closing transition state of the labware latch button', () => {
-    render()
-    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     vi.mocked(useModulesQuery).mockReturnValue(
       mockUseModulesQueryClosing as any
     )
-
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     screen.getByText('Closing...')
   })
 
   it('defaults to open when latch status is unknown', () => {
-    render()
-    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     vi.mocked(useModulesQuery).mockReturnValue(
       mockUseModulesQueryUnknown as any
     )
 
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     screen.getByText('Open')
   })
 })

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
@@ -115,10 +115,10 @@ describe('ProtocolSetupLabware', () => {
 
   it('should toggle between map view and list view', () => {
     render()
-    expect(screen.queryByText('List View')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: 'Map View' }))
     expect(screen.queryByText('Map View')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'List View' }))
+    expect(screen.queryByText('List View')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Map View' }))
     screen.getByText('Labware')
     screen.getByText('Labware name')
     screen.getByText('Location')

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
@@ -126,6 +126,7 @@ describe('ProtocolSetupLabware', () => {
 
   it('sends a latch-close command when the labware latch is open and the button is clicked', () => {
     render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     fireEvent.click(screen.getByText('Labware Latch'))
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
@@ -144,6 +145,7 @@ describe('ProtocolSetupLabware', () => {
       refetch: mockRefetch,
     } as any)
     render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     fireEvent.click(screen.getByText('Labware Latch'))
     expect(mockCreateLiveCommand).toHaveBeenCalledWith({
       command: {
@@ -157,29 +159,32 @@ describe('ProtocolSetupLabware', () => {
   })
 
   it('shows opening transition states of the labware latch button', () => {
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     vi.mocked(useModulesQuery).mockReturnValue(
       mockUseModulesQueryOpening as any
     )
 
-    render()
     screen.getByText('Opening...')
   })
 
   it('shows closing transition state of the labware latch button', () => {
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     vi.mocked(useModulesQuery).mockReturnValue(
       mockUseModulesQueryClosing as any
     )
 
-    render()
     screen.getByText('Closing...')
   })
 
   it('defaults to open when latch status is unknown', () => {
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }))
     vi.mocked(useModulesQuery).mockReturnValue(
       mockUseModulesQueryUnknown as any
     )
 
-    render()
     screen.getByText('Open')
   })
 })

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -83,7 +83,7 @@ export function ProtocolSetupLabware({
   setIsConfirmed,
 }: ProtocolSetupLabwareProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
-  const [showMapView, setShowMapView] = useState<boolean>(false)
+  const [showMapView, setShowMapView] = useState<boolean>(true)
   const [
     showLabwareDetailsModal,
     setShowLabwareDetailsModal,


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-1142.
set default labware view in protocol setup to map. 

## Test Plan and Hands on Testing

- send a protocol to the flex.
- go to protocol setup -> labware
- make sure the default view is the map view.
- make sure toggling works as expected.
