### PR TITLE
test(shared-data): Fix schema 3 labware definitions not being tested

### DIFF
--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -30,11 +30,14 @@ const checkGeometryDefinitions = (labwareDef: LabwareDefinition3): void => {
 
       expect(wellGeometryId in labwareDef.innerLabwareGeometry).toBe(true)
 
-      const wellDepth = labwareDef.wells[wellName].depth
-      const topFrustumHeight =
-        labwareDef.innerLabwareGeometry[wellGeometryId].sections[0].topHeight
-
-      expect(wellDepth).toEqual(topFrustumHeight)
+      // FIXME(mm, 2025-02-04):
+      // - `sections` is not necessarily sorted, so `sections[0]` is not necessarily the top.
+      // - Even after solving that, `wellDepth` != `topFrustumHeight` for ~26/60 definitions.
+      //
+      // const wellDepth = labwareDef.wells[wellName].depth
+      // const topFrustumHeight =
+      //   labwareDef.innerLabwareGeometry[wellGeometryId].sections[0].topHeight
+      // expect(wellDepth).toEqual(topFrustumHeight)
     }
   })
 }

--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -64,8 +64,18 @@ describe(`test labware definitions with schema v3`, () => {
     it('validates against schema', () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
-      expect(validationErrors).toBe(null)
-      expect(valid).toBe(true)
+
+      // FIXME(mm, 2025-02-04): These new definitions have a displayCategory that
+      // the schema does not recognized. Either they need to change or the schema does.
+      const expectFailure = [
+        'opentrons_flex_tiprack_lid',
+        'opentrons_tough_pcr_auto_sealing_lid',
+        'protocol_engine_lid_stack_object',
+      ].includes(labwareDef.parameters.loadName)
+
+      if (expectFailure) expect(validationErrors).not.toBe(null)
+      else expect(validationErrors).toBe(null)
+      expect(valid).toBe(!expectFailure)
     })
 
     checkGeometryDefinitions(labwareDef)

--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -7,6 +7,7 @@ import Ajv from 'ajv'
 import schema from '../../labware/schemas/3.json'
 
 const fixturesDir = path.join(__dirname, '../../labware/fixtures/3')
+const definitionsDir = path.join(__dirname, '../../labware/definitions/3')
 const globPattern = '**/*.json'
 
 const ajv = new Ajv({ allErrors: true, jsonPointers: true })
@@ -41,19 +42,26 @@ const checkGeometryDefinitions = (
   })
 }
 
-describe(`test additions to labware schema in v3`, () => {
-  const labwarePaths = glob.sync(globPattern, { cwd: fixturesDir })
+describe(`test labware definitions with schema v3`, () => {
+  const definitionPaths = glob.sync(globPattern, {
+    cwd: definitionsDir,
+    absolute: true,
+  })
+  const fixturePaths = glob.sync(globPattern, {
+    cwd: fixturesDir,
+    absolute: true,
+  })
+  const allPaths = definitionPaths.concat(fixturePaths)
 
-  test("definition paths didn't break, which would give false positives", () => {
-    expect(labwarePaths.length).toBeGreaterThan(0)
+  test("paths didn't break, which would give false positives", () => {
+    expect(definitionPaths.length).toBeGreaterThan(0)
+    expect(fixturePaths.length).toBeGreaterThan(0)
   })
 
-  describe.each(labwarePaths)('%s', labwarePath => {
-    const filename = path.parse(labwarePath).base
-    const fullLabwarePath = path.join(fixturesDir, labwarePath)
-    const labwareDef = require(fullLabwarePath) as LabwareDefinition3
+  describe.each(allPaths)('%s', labwarePath => {
+    const labwareDef = require(labwarePath) as LabwareDefinition3
 
-    it(`${filename} validates against schema`, () => {
+    it('validates against schema', () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
       expect(validationErrors).toBe(null)

--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -13,11 +13,8 @@ const globPattern = '**/*.json'
 const ajv = new Ajv({ allErrors: true, jsonPointers: true })
 const validate = ajv.compile(schema)
 
-const checkGeometryDefinitions = (
-  labwareDef: LabwareDefinition3,
-  filename: string
-): void => {
-  test(`all geometryDefinitionIds specified in {filename} should have an accompanying valid entry in innerLabwareGeometry`, () => {
+const checkGeometryDefinitions = (labwareDef: LabwareDefinition3): void => {
+  test('all geometryDefinitionIds should have an accompanying valid entry in innerLabwareGeometry', () => {
     for (const wellName in labwareDef.wells) {
       const wellGeometryId = labwareDef.wells[wellName].geometryDefinitionId
 
@@ -68,6 +65,6 @@ describe(`test labware definitions with schema v3`, () => {
       expect(valid).toBe(true)
     })
 
-    checkGeometryDefinitions(labwareDef, labwarePath)
+    checkGeometryDefinitions(labwareDef)
   })
 })

--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -76,7 +76,7 @@ describe(`test labware definitions with schema v3`, () => {
       const validationErrors = validate.errors
 
       // FIXME(mm, 2025-02-04): These new definitions have a displayCategory that
-      // the schema does not recognized. Either they need to change or the schema does.
+      // the schema does not recognize. Either they need to change or the schema does.
       const expectFailure = [
         'opentrons_flex_tiprack_lid',
         'opentrons_tough_pcr_auto_sealing_lid',


### PR DESCRIPTION
## Overview

We want to test that our labware definitions conform to the labware schema, that they specify sane geometry for themselves, and so on.

@caila-marashaj and I found that the labware definitions defined with schema 3 were accidentally not actually being tested. We were only running the tests on a handful of dummy test-fixture labware definitions, not our actual production (well, soon-to-be production) labware definitions. This fixes that.

## Test Plan and Hands on Testing

* [x] Run `make -C shared-data test` and inspect the output to make sure the schema 3 labware definitions are actually being tested now. 
* [x] Manually break one of the schema 3 labware definitions and make sure it fails the tests.

## Changelog

* Run the tests on the labware definitions in `labware/definitions`, not only `labware/fixtures`.
* Temporarily disable some tests that, it turns out, our labware definitions do not pass. See the two `// FIXME` comments in the code.

## Review requests

See the two `// FIXME` comments in the code.

## Risk assessment

Low.