### PR TITLE
fix(shared-data): Pre-sort innerLabwareGeometry sections

### DIFF
--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -16,6 +16,17 @@ const checkGeometryDefinitions = (
   labwareDef: LabwareDefinition3,
   filename: string
 ): void => {
+  test('innerLabwareGeometry sections should be sorted top to bottom', () => {
+    const geometries = Object.values(labwareDef.innerLabwareGeometry ?? [])
+    for (const geometry of geometries) {
+      const sectionList = geometry.sections
+      const sortedSectionList = sectionList.toSorted(
+        (a, b) => b.topHeight - a.topHeight
+      )
+      expect(sortedSectionList).toStrictEqual(sectionList)
+    }
+  })
+
   test(`all geometryDefinitionIds specified in {filename} should have an accompanying valid entry in innerLabwareGeometry`, () => {
     for (const wellName in labwareDef.wells) {
       const wellGeometryId = labwareDef.wells[wellName].geometryDefinitionId

--- a/shared-data/labware/definitions/3/agilent_1_reservoir_290ml/2.json
+++ b/shared-data/labware/definitions/3/agilent_1_reservoir_290ml/2.json
@@ -57,6 +57,15 @@
       "sections": [
         {
           "shape": "cuboidal",
+          "topXDimension": 107.5,
+          "topYDimension": 71.25,
+          "bottomXDimension": 106.79,
+          "bottomYDimension": 71.0,
+          "topHeight": 39.23,
+          "bottomHeight": 2.0
+        },
+        {
+          "shape": "cuboidal",
           "topXDimension": 106.79,
           "topYDimension": 8,
           "bottomXDimension": 101.25,
@@ -64,15 +73,6 @@
           "topHeight": 2,
           "bottomHeight": 0,
           "yCount": 8
-        },
-        {
-          "shape": "cuboidal",
-          "topXDimension": 107.5,
-          "topYDimension": 71.25,
-          "bottomXDimension": 106.79,
-          "bottomYDimension": 71.0,
-          "topHeight": 39.23,
-          "bottomHeight": 2.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/appliedbiosystemsmicroamp_384_wellplate_40ul/2.json
+++ b/shared-data/labware/definitions/3/appliedbiosystemsmicroamp_384_wellplate_40ul/2.json
@@ -4705,10 +4705,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 0.89,
-          "topHeight": 0.34,
-          "bottomHeight": 0.0
+          "shape": "conical",
+          "bottomDiameter": 3.17,
+          "topDiameter": 3.17,
+          "topHeight": 9.09,
+          "bottomHeight": 5.77
         },
         {
           "shape": "conical",
@@ -4718,11 +4719,10 @@
           "bottomHeight": 0.34
         },
         {
-          "shape": "conical",
-          "bottomDiameter": 3.17,
-          "topDiameter": 3.17,
-          "topHeight": 9.09,
-          "bottomHeight": 5.77
+          "shape": "spherical",
+          "radiusOfCurvature": 0.89,
+          "topHeight": 0.34,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/armadillo_96_wellplate_200ul_pcr_full_skirt/3.json
+++ b/shared-data/labware/definitions/3/armadillo_96_wellplate_200ul_pcr_full_skirt/3.json
@@ -1142,10 +1142,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 1.25,
-          "topHeight": 0.8,
-          "bottomHeight": 0.0
+          "shape": "conical",
+          "bottomDiameter": 5.5,
+          "topDiameter": 5.5,
+          "topHeight": 14.95,
+          "bottomHeight": 11.35
         },
         {
           "shape": "conical",
@@ -1155,11 +1156,10 @@
           "bottomHeight": 0.8
         },
         {
-          "shape": "conical",
-          "bottomDiameter": 5.5,
-          "topDiameter": 5.5,
-          "topHeight": 14.95,
-          "bottomHeight": 11.35
+          "shape": "spherical",
+          "radiusOfCurvature": 1.25,
+          "topHeight": 0.8,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/biorad_384_wellplate_50ul/3.json
+++ b/shared-data/labware/definitions/3/biorad_384_wellplate_50ul/3.json
@@ -4716,10 +4716,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 0.94,
-          "topHeight": 0.35,
-          "bottomHeight": 0.0
+          "shape": "conical",
+          "bottomDiameter": 3,
+          "topDiameter": 3.1,
+          "topHeight": 9.35,
+          "bottomHeight": 5.35
         },
         {
           "shape": "conical",
@@ -4729,11 +4730,10 @@
           "bottomHeight": 0.35
         },
         {
-          "shape": "conical",
-          "bottomDiameter": 3,
-          "topDiameter": 3.1,
-          "topHeight": 9.35,
-          "bottomHeight": 5.35
+          "shape": "spherical",
+          "radiusOfCurvature": 0.94,
+          "topHeight": 0.35,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/biorad_96_wellplate_200ul_pcr/3.json
+++ b/shared-data/labware/definitions/3/biorad_96_wellplate_200ul_pcr/3.json
@@ -1143,24 +1143,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 1.42,
-          "topHeight": 1.21,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "topDiameter": 3.0,
-          "bottomDiameter": 2.81,
-          "topHeight": 1.87,
-          "bottomHeight": 1.21
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 4.98,
-          "bottomDiameter": 3,
-          "topHeight": 8.58,
-          "bottomHeight": 1.87
+          "bottomDiameter": 5.44,
+          "topDiameter": 5.44,
+          "topHeight": 14.57,
+          "bottomHeight": 10.14
         },
         {
           "shape": "conical",
@@ -1171,10 +1158,23 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 5.44,
-          "topDiameter": 5.44,
-          "topHeight": 14.57,
-          "bottomHeight": 10.14
+          "topDiameter": 4.98,
+          "bottomDiameter": 3,
+          "topHeight": 8.58,
+          "bottomHeight": 1.87
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 3.0,
+          "bottomDiameter": 2.81,
+          "topHeight": 1.87,
+          "bottomHeight": 1.21
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 1.42,
+          "topHeight": 1.21,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/nest_12_reservoir_15ml/2.json
+++ b/shared-data/labware/definitions/3/nest_12_reservoir_15ml/2.json
@@ -204,21 +204,21 @@
       "sections": [
         {
           "shape": "cuboidal",
-          "topXDimension": 7.95,
-          "topYDimension": 70.53,
-          "bottomXDimension": 1.87,
-          "bottomYDimension": 64.45,
-          "topHeight": 2.05,
-          "bottomHeight": 0.0
-        },
-        {
-          "shape": "cuboidal",
           "topXDimension": 8.35,
           "topYDimension": 71.25,
           "bottomXDimension": 7.95,
           "bottomYDimension": 70.53,
           "topHeight": 26.85,
           "bottomHeight": 2.05
+        },
+        {
+          "shape": "cuboidal",
+          "topXDimension": 7.95,
+          "topYDimension": 70.53,
+          "bottomXDimension": 1.87,
+          "bottomYDimension": 64.45,
+          "topHeight": 2.05,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/nest_1_reservoir_195ml/3.json
+++ b/shared-data/labware/definitions/3/nest_1_reservoir_195ml/3.json
@@ -59,6 +59,15 @@
       "sections": [
         {
           "shape": "cuboidal",
+          "topXDimension": 71.3,
+          "topYDimension": 107.3,
+          "bottomXDimension": 70.6,
+          "bottomYDimension": 106.8,
+          "topHeight": 26.85,
+          "bottomHeight": 2.0
+        },
+        {
+          "shape": "cuboidal",
           "topXDimension": 9,
           "topYDimension": 9,
           "bottomXDimension": 1.93,
@@ -67,15 +76,6 @@
           "bottomHeight": 0,
           "xCount": 12,
           "yCount": 8
-        },
-        {
-          "shape": "cuboidal",
-          "topXDimension": 71.3,
-          "topYDimension": 107.3,
-          "bottomXDimension": 70.6,
-          "bottomYDimension": 106.8,
-          "topHeight": 26.85,
-          "bottomHeight": 2.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/nest_1_reservoir_290ml/2.json
+++ b/shared-data/labware/definitions/3/nest_1_reservoir_290ml/2.json
@@ -57,6 +57,15 @@
       "sections": [
         {
           "shape": "cuboidal",
+          "topXDimension": 107.76,
+          "topYDimension": 71.0,
+          "bottomXDimension": 106.75,
+          "bottomYDimension": 70.75,
+          "topHeight": 39.55,
+          "bottomHeight": 2.0
+        },
+        {
+          "shape": "cuboidal",
           "topXDimension": 7.75,
           "topYDimension": 70.75,
           "bottomXDimension": 3.127,
@@ -64,15 +73,6 @@
           "topHeight": 2.0,
           "bottomHeight": 0.0,
           "xCount": 12
-        },
-        {
-          "shape": "cuboidal",
-          "topXDimension": 107.76,
-          "topYDimension": 71.0,
-          "bottomXDimension": 106.75,
-          "bottomYDimension": 70.75,
-          "topHeight": 39.55,
-          "bottomHeight": 2.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/nest_96_wellplate_100ul_pcr_full_skirt/3.json
+++ b/shared-data/labware/definitions/3/nest_96_wellplate_100ul_pcr_full_skirt/3.json
@@ -1136,10 +1136,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 3.015,
-          "topHeight": 0.2,
-          "bottomHeight": 0.0
+          "shape": "conical",
+          "bottomDiameter": 5.26,
+          "topDiameter": 5.34,
+          "topHeight": 14.7,
+          "bottomHeight": 9.89
         },
         {
           "shape": "conical",
@@ -1149,11 +1150,10 @@
           "bottomHeight": 0.2
         },
         {
-          "shape": "conical",
-          "bottomDiameter": 5.26,
-          "topDiameter": 5.34,
-          "topHeight": 14.7,
-          "bottomHeight": 9.89
+          "shape": "spherical",
+          "radiusOfCurvature": 3.015,
+          "topHeight": 0.2,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/nest_96_wellplate_2ml_deep/3.json
+++ b/shared-data/labware/definitions/3/nest_96_wellplate_2ml_deep/3.json
@@ -1240,21 +1240,21 @@
       "sections": [
         {
           "shape": "cuboidal",
-          "topXDimension": 7.4,
-          "topYDimension": 7.4,
-          "bottomXDimension": 2.63,
-          "bottomYDimension": 2.63,
-          "topHeight": 1.67,
-          "bottomHeight": 0.0
-        },
-        {
-          "shape": "cuboidal",
           "topXDimension": 8.2,
           "topYDimension": 8.2,
           "bottomXDimension": 7.4,
           "bottomYDimension": 7.4,
           "topHeight": 38.05,
           "bottomHeight": 1.67
+        },
+        {
+          "shape": "cuboidal",
+          "topXDimension": 7.4,
+          "topYDimension": 7.4,
+          "bottomXDimension": 2.63,
+          "bottomYDimension": 2.63,
+          "topHeight": 1.67,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical/2.json
+++ b/shared-data/labware/definitions/3/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical/2.json
@@ -175,17 +175,11 @@
     "15mlconicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 2.9,
-          "topHeight": 0.8,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "bottomDiameter": 4,
-          "topDiameter": 13.5,
-          "topHeight": 20.7,
-          "bottomHeight": 0.8
+          "bottomDiameter": 14.5,
+          "topDiameter": 14.7,
+          "topHeight": 118.2,
+          "bottomHeight": 108.6
         },
         {
           "shape": "conical",
@@ -196,10 +190,16 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 14.5,
-          "topDiameter": 14.7,
-          "topHeight": 118.2,
-          "bottomHeight": 108.6
+          "bottomDiameter": 4,
+          "topDiameter": 13.5,
+          "topHeight": 20.7,
+          "bottomHeight": 0.8
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 2.9,
+          "topHeight": 0.8,
+          "bottomHeight": 0.0
         }
       ]
     },
@@ -207,10 +207,10 @@
       "sections": [
         {
           "shape": "conical",
-          "bottomDiameter": 6.15,
-          "topDiameter": 26.18,
-          "topHeight": 14.3,
-          "bottomHeight": 0.0
+          "bottomDiameter": 27.52,
+          "topDiameter": 27.81,
+          "topHeight": 112.85,
+          "bottomHeight": 100.65
         },
         {
           "shape": "conical",
@@ -221,10 +221,10 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 27.52,
-          "topDiameter": 27.81,
-          "topHeight": 112.85,
-          "bottomHeight": 100.65
+          "bottomDiameter": 6.15,
+          "topDiameter": 26.18,
+          "topHeight": 14.3,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/2.json
+++ b/shared-data/labware/definitions/3/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical_acrylic/2.json
@@ -173,17 +173,11 @@
     "15mlconicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 2.9,
-          "topHeight": 0.8,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "bottomDiameter": 4,
-          "topDiameter": 13.5,
-          "topHeight": 20.7,
-          "bottomHeight": 0.8
+          "bottomDiameter": 14.5,
+          "topDiameter": 14.7,
+          "topHeight": 118.2,
+          "bottomHeight": 108.6
         },
         {
           "shape": "conical",
@@ -194,10 +188,16 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 14.5,
-          "topDiameter": 14.7,
-          "topHeight": 118.2,
-          "bottomHeight": 108.6
+          "bottomDiameter": 4,
+          "topDiameter": 13.5,
+          "topHeight": 20.7,
+          "bottomHeight": 0.8
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 2.9,
+          "topHeight": 0.8,
+          "bottomHeight": 0.0
         }
       ]
     },
@@ -205,10 +205,10 @@
       "sections": [
         {
           "shape": "conical",
-          "bottomDiameter": 6.15,
-          "topDiameter": 26.18,
-          "topHeight": 14.3,
-          "bottomHeight": 0.0
+          "bottomDiameter": 27.52,
+          "topDiameter": 27.81,
+          "topHeight": 112.85,
+          "bottomHeight": 100.65
         },
         {
           "shape": "conical",
@@ -219,10 +219,10 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 27.52,
-          "topDiameter": 27.81,
-          "topHeight": 112.85,
-          "bottomHeight": 100.65
+          "bottomDiameter": 6.15,
+          "topDiameter": 26.18,
+          "topHeight": 14.3,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_10_tuberack_nest_4x50ml_6x15ml_conical/2.json
+++ b/shared-data/labware/definitions/3/opentrons_10_tuberack_nest_4x50ml_6x15ml_conical/2.json
@@ -171,17 +171,11 @@
     "conicalWell15mL": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 1.235,
-          "topHeight": 0.92,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "topDiameter": 13.8,
-          "bottomDiameter": 2.38,
-          "topHeight": 22.55,
-          "bottomHeight": 0.92
+          "topDiameter": 15.5,
+          "bottomDiameter": 14.56,
+          "topHeight": 117.8,
+          "bottomHeight": 113.8
         },
         {
           "shape": "conical",
@@ -192,10 +186,16 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 15.5,
-          "bottomDiameter": 14.56,
-          "topHeight": 117.8,
-          "bottomHeight": 113.8
+          "topDiameter": 13.8,
+          "bottomDiameter": 2.38,
+          "topHeight": 22.55,
+          "bottomHeight": 0.92
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 1.235,
+          "topHeight": 0.92,
+          "bottomHeight": 0.0
         }
       ]
     },
@@ -203,17 +203,10 @@
       "sections": [
         {
           "shape": "conical",
-          "topDiameter": 26.0,
-          "bottomDiameter": 4.5,
-          "topHeight": 14.35,
-          "bottomHeight": 0.0
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 27.69,
-          "bottomDiameter": 26.0,
-          "topHeight": 108.8,
-          "bottomHeight": 14.35
+          "topDiameter": 28.18,
+          "bottomDiameter": 27.95,
+          "topHeight": 113.1,
+          "bottomHeight": 109.1
         },
         {
           "shape": "conical",
@@ -224,10 +217,17 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 28.18,
-          "bottomDiameter": 27.95,
-          "topHeight": 113.1,
-          "bottomHeight": 109.1
+          "topDiameter": 27.69,
+          "bottomDiameter": 26.0,
+          "topHeight": 108.8,
+          "bottomHeight": 14.35
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 26.0,
+          "bottomDiameter": 4.5,
+          "topHeight": 14.35,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_15_tuberack_falcon_15ml_conical/2.json
+++ b/shared-data/labware/definitions/3/opentrons_15_tuberack_falcon_15ml_conical/2.json
@@ -227,17 +227,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 2.9,
-          "topHeight": 0.8,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "bottomDiameter": 4,
-          "topDiameter": 13.5,
-          "topHeight": 20.7,
-          "bottomHeight": 0.8
+          "bottomDiameter": 14.5,
+          "topDiameter": 14.7,
+          "topHeight": 118.2,
+          "bottomHeight": 108.6
         },
         {
           "shape": "conical",
@@ -248,10 +242,16 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 14.5,
-          "topDiameter": 14.7,
-          "topHeight": 118.2,
-          "bottomHeight": 108.6
+          "bottomDiameter": 4,
+          "topDiameter": 13.5,
+          "topHeight": 20.7,
+          "bottomHeight": 0.8
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 2.9,
+          "topHeight": 0.8,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_15_tuberack_nest_15ml_conical/2.json
+++ b/shared-data/labware/definitions/3/opentrons_15_tuberack_nest_15ml_conical/2.json
@@ -226,10 +226,10 @@
       "sections": [
         {
           "shape": "conical",
-          "topDiameter": 13.8,
-          "bottomDiameter": 2.5,
-          "topHeight": 22.55,
-          "bottomHeight": 0.0
+          "topDiameter": 15.5,
+          "bottomDiameter": 14.78,
+          "topHeight": 117.8,
+          "bottomHeight": 109.03
         },
         {
           "shape": "conical",
@@ -240,10 +240,10 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 15.5,
-          "bottomDiameter": 14.78,
-          "topHeight": 117.8,
-          "bottomHeight": 109.03
+          "topDiameter": 13.8,
+          "bottomDiameter": 2.5,
+          "topHeight": 22.55,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_0.5ml_screwcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_0.5ml_screwcap/2.json
@@ -324,31 +324,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 3.64,
-          "topHeight": 0.14,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "bottomDiameter": 2,
-          "topDiameter": 3,
-          "topHeight": 0.95,
-          "bottomHeight": 0.14
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 3,
-          "topDiameter": 5.8,
-          "topHeight": 10.2,
-          "bottomHeight": 0.95
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 5.8,
-          "topDiameter": 7.9,
-          "topHeight": 11.9,
-          "bottomHeight": 10.2
+          "bottomDiameter": 8.56,
+          "topDiameter": 8.56,
+          "topHeight": 25.2,
+          "bottomHeight": 13.95
         },
         {
           "shape": "conical",
@@ -359,10 +339,30 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 8.56,
-          "topDiameter": 8.56,
-          "topHeight": 25.2,
-          "bottomHeight": 13.95
+          "bottomDiameter": 5.8,
+          "topDiameter": 7.9,
+          "topHeight": 11.9,
+          "bottomHeight": 10.2
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 3,
+          "topDiameter": 5.8,
+          "topHeight": 10.2,
+          "bottomHeight": 0.95
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 2,
+          "topDiameter": 3,
+          "topHeight": 0.95,
+          "bottomHeight": 0.14
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 3.64,
+          "topHeight": 0.14,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_1.5ml_screwcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_1.5ml_screwcap/2.json
@@ -324,17 +324,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 2.36,
-          "topHeight": 0.2,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "topDiameter": 3.2,
-          "bottomDiameter": 1.9,
-          "topHeight": 1.88,
-          "bottomHeight": 0.2
+          "topDiameter": 8.55,
+          "bottomDiameter": 8.2,
+          "topHeight": 42.6,
+          "bottomHeight": 13.7
         },
         {
           "shape": "conical",
@@ -345,10 +339,16 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 8.55,
-          "bottomDiameter": 8.2,
-          "topHeight": 42.6,
-          "bottomHeight": 13.7
+          "topDiameter": 3.2,
+          "bottomDiameter": 1.9,
+          "topHeight": 1.88,
+          "bottomHeight": 0.2
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 2.36,
+          "topHeight": 0.2,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_1.5ml_snapcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_1.5ml_snapcap/2.json
@@ -326,10 +326,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 2.72,
-          "topHeight": 1.57,
-          "bottomHeight": 0.0
+          "shape": "conical",
+          "topDiameter": 9.28,
+          "bottomDiameter": 8.9,
+          "topHeight": 37.9,
+          "bottomHeight": 17.7
         },
         {
           "shape": "conical",
@@ -339,11 +340,10 @@
           "bottomHeight": 1.57
         },
         {
-          "shape": "conical",
-          "topDiameter": 9.28,
-          "bottomDiameter": 8.9,
-          "topHeight": 37.9,
-          "bottomHeight": 17.7
+          "shape": "spherical",
+          "radiusOfCurvature": 2.72,
+          "topHeight": 1.57,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_2ml_screwcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_2ml_screwcap/2.json
@@ -325,10 +325,10 @@
       "sections": [
         {
           "shape": "conical",
-          "bottomDiameter": 1.21,
-          "topDiameter": 6.5,
-          "topHeight": 2.08,
-          "bottomHeight": 0.0
+          "bottomDiameter": 8.14,
+          "topDiameter": 8.55,
+          "topHeight": 43.4,
+          "bottomHeight": 3.04
         },
         {
           "shape": "conical",
@@ -339,10 +339,10 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 8.14,
-          "topDiameter": 8.55,
-          "topHeight": 43.4,
-          "bottomHeight": 3.04
+          "bottomDiameter": 1.21,
+          "topDiameter": 6.5,
+          "topHeight": 2.08,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_2ml_snapcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_2ml_snapcap/2.json
@@ -326,38 +326,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 3.19,
-          "topHeight": 1.21,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "bottomDiameter": 5,
-          "topDiameter": 6,
-          "topHeight": 1.83,
-          "bottomHeight": 1.21
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 6,
-          "topDiameter": 7,
-          "topHeight": 2.59,
-          "bottomHeight": 1.83
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 7,
-          "topDiameter": 7.2,
-          "topHeight": 2.74,
-          "bottomHeight": 2.59
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 7.2,
-          "topDiameter": 8,
-          "topHeight": 3.89,
-          "bottomHeight": 2.74
+          "bottomDiameter": 8.9,
+          "topDiameter": 9.28,
+          "topHeight": 39.28,
+          "bottomHeight": 15.04
         },
         {
           "shape": "conical",
@@ -368,10 +341,37 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 8.9,
-          "topDiameter": 9.28,
-          "topHeight": 39.28,
-          "bottomHeight": 15.04
+          "bottomDiameter": 7.2,
+          "topDiameter": 8,
+          "topHeight": 3.89,
+          "bottomHeight": 2.74
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 7,
+          "topDiameter": 7.2,
+          "topHeight": 2.74,
+          "bottomHeight": 2.59
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 6,
+          "topDiameter": 7,
+          "topHeight": 2.59,
+          "bottomHeight": 1.83
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 5,
+          "topDiameter": 6,
+          "topHeight": 1.83,
+          "bottomHeight": 1.21
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 3.19,
+          "topHeight": 1.21,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap/2.json
@@ -337,66 +337,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 2.6,
-          "topHeight": 0.2,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "bottomDiameter": 2,
-          "topDiameter": 3.26,
-          "topHeight": 1,
-          "bottomHeight": 0.2
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 3.26,
-          "topDiameter": 4,
-          "topHeight": 2.9,
-          "bottomHeight": 1
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 4,
-          "topDiameter": 6,
-          "topHeight": 9.24,
-          "bottomHeight": 2.9
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 6,
-          "topDiameter": 8,
-          "topHeight": 15.89,
-          "bottomHeight": 9.24
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 8,
-          "topDiameter": 8.5,
-          "topHeight": 17.56,
-          "bottomHeight": 15.89
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 8.5,
-          "topDiameter": 8.9,
-          "topHeight": 28.16,
-          "bottomHeight": 17.56
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 8.9,
-          "topDiameter": 9.02,
-          "topHeight": 31.16,
-          "bottomHeight": 28.16
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 9.02,
-          "topDiameter": 9.2,
-          "topHeight": 31.97,
-          "bottomHeight": 31.16
+          "bottomDiameter": 9.6,
+          "topDiameter": 10,
+          "topHeight": 37.8,
+          "bottomHeight": 32.49
         },
         {
           "shape": "conical",
@@ -407,10 +352,65 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 9.6,
-          "topDiameter": 10,
-          "topHeight": 37.8,
-          "bottomHeight": 32.49
+          "bottomDiameter": 9.02,
+          "topDiameter": 9.2,
+          "topHeight": 31.97,
+          "bottomHeight": 31.16
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 8.9,
+          "topDiameter": 9.02,
+          "topHeight": 31.16,
+          "bottomHeight": 28.16
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 8.5,
+          "topDiameter": 8.9,
+          "topHeight": 28.16,
+          "bottomHeight": 17.56
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 8,
+          "topDiameter": 8.5,
+          "topHeight": 17.56,
+          "bottomHeight": 15.89
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 6,
+          "topDiameter": 8,
+          "topHeight": 15.89,
+          "bottomHeight": 9.24
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 4,
+          "topDiameter": 6,
+          "topHeight": 9.24,
+          "bottomHeight": 2.9
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 3.26,
+          "topDiameter": 4,
+          "topHeight": 2.9,
+          "bottomHeight": 1
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 2,
+          "topDiameter": 3.26,
+          "topHeight": 1,
+          "bottomHeight": 0.2
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 2.6,
+          "topHeight": 0.2,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap/2.json
@@ -336,122 +336,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 2.88,
-          "topHeight": 1.45,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "topDiameter": 6.0,
-          "bottomDiameter": 5.0,
-          "topHeight": 2.2,
-          "bottomHeight": 1.45
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 6.4,
-          "bottomDiameter": 6.0,
-          "topHeight": 2.45,
-          "bottomHeight": 2.2
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 6.8,
-          "bottomDiameter": 6.4,
-          "topHeight": 2.75,
-          "bottomHeight": 2.45
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 7.2,
-          "bottomDiameter": 6.8,
-          "topHeight": 3.14,
-          "bottomHeight": 2.75
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 7.6,
-          "bottomDiameter": 7.2,
-          "topHeight": 3.67,
-          "bottomHeight": 3.14
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 7.7,
-          "bottomDiameter": 7.6,
-          "topHeight": 3.93,
-          "bottomHeight": 3.67
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.0,
-          "bottomDiameter": 7.7,
-          "topHeight": 4.29,
-          "bottomHeight": 3.93
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.2,
-          "bottomDiameter": 8.0,
-          "topHeight": 4.53,
-          "bottomHeight": 4.29
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.4,
-          "bottomDiameter": 8.2,
-          "topHeight": 5.03,
-          "bottomHeight": 4.53
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.5,
-          "bottomDiameter": 8.4,
-          "topHeight": 5.15,
-          "bottomHeight": 5.03
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.6,
-          "bottomDiameter": 8.5,
-          "topHeight": 5.43,
-          "bottomHeight": 5.15
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.78,
-          "bottomDiameter": 8.6,
-          "topHeight": 6.97,
-          "bottomHeight": 5.43
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.9,
-          "bottomDiameter": 8.78,
-          "topHeight": 10.17,
-          "bottomHeight": 6.97
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 9.0,
-          "bottomDiameter": 8.9,
-          "topHeight": 13.32,
-          "bottomHeight": 10.17
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 9.1,
-          "bottomDiameter": 9.0,
-          "topHeight": 25.26,
-          "bottomHeight": 13.32
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 9.2,
-          "bottomDiameter": 9.1,
-          "topHeight": 32.5,
-          "bottomHeight": 25.26
+          "topDiameter": 10.0,
+          "bottomDiameter": 9.6,
+          "topHeight": 39.02,
+          "bottomHeight": 33.96
         },
         {
           "shape": "conical",
@@ -462,10 +351,121 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 10.0,
-          "bottomDiameter": 9.6,
-          "topHeight": 39.02,
-          "bottomHeight": 33.96
+          "topDiameter": 9.2,
+          "bottomDiameter": 9.1,
+          "topHeight": 32.5,
+          "bottomHeight": 25.26
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 9.1,
+          "bottomDiameter": 9.0,
+          "topHeight": 25.26,
+          "bottomHeight": 13.32
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 9.0,
+          "bottomDiameter": 8.9,
+          "topHeight": 13.32,
+          "bottomHeight": 10.17
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.9,
+          "bottomDiameter": 8.78,
+          "topHeight": 10.17,
+          "bottomHeight": 6.97
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.78,
+          "bottomDiameter": 8.6,
+          "topHeight": 6.97,
+          "bottomHeight": 5.43
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.6,
+          "bottomDiameter": 8.5,
+          "topHeight": 5.43,
+          "bottomHeight": 5.15
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.5,
+          "bottomDiameter": 8.4,
+          "topHeight": 5.15,
+          "bottomHeight": 5.03
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.4,
+          "bottomDiameter": 8.2,
+          "topHeight": 5.03,
+          "bottomHeight": 4.53
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.2,
+          "bottomDiameter": 8.0,
+          "topHeight": 4.53,
+          "bottomHeight": 4.29
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.0,
+          "bottomDiameter": 7.7,
+          "topHeight": 4.29,
+          "bottomHeight": 3.93
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 7.7,
+          "bottomDiameter": 7.6,
+          "topHeight": 3.93,
+          "bottomHeight": 3.67
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 7.6,
+          "bottomDiameter": 7.2,
+          "topHeight": 3.67,
+          "bottomHeight": 3.14
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 7.2,
+          "bottomDiameter": 6.8,
+          "topHeight": 3.14,
+          "bottomHeight": 2.75
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 6.8,
+          "bottomDiameter": 6.4,
+          "topHeight": 2.75,
+          "bottomHeight": 2.45
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 6.4,
+          "bottomDiameter": 6.0,
+          "topHeight": 2.45,
+          "bottomHeight": 2.2
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 6.0,
+          "bottomDiameter": 5.0,
+          "topHeight": 2.2,
+          "bottomHeight": 1.45
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 2.88,
+          "topHeight": 1.45,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_generic_2ml_screwcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_generic_2ml_screwcap/2.json
@@ -326,10 +326,10 @@
       "sections": [
         {
           "shape": "conical",
-          "topDiameter": 6.5,
-          "bottomDiameter": 1.21,
-          "topHeight": 2.08,
-          "bottomHeight": 0.0
+          "topDiameter": 8.5,
+          "bottomDiameter": 8.14,
+          "topHeight": 42.0,
+          "bottomHeight": 3.04
         },
         {
           "shape": "conical",
@@ -340,10 +340,10 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 8.5,
-          "bottomDiameter": 8.14,
-          "topHeight": 42.0,
-          "bottomHeight": 3.04
+          "topDiameter": 6.5,
+          "bottomDiameter": 1.21,
+          "topHeight": 2.08,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_0.5ml_screwcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_0.5ml_screwcap/2.json
@@ -325,31 +325,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 3.64,
-          "topHeight": 0.14,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "topDiameter": 3,
-          "bottomDiameter": 2,
-          "topHeight": 0.95,
-          "bottomHeight": 0.14
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 5.8,
-          "bottomDiameter": 3,
-          "topHeight": 10.2,
-          "bottomHeight": 0.95
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 7.9,
-          "bottomDiameter": 5.8,
-          "topHeight": 11.9,
-          "bottomHeight": 10.2
+          "topDiameter": 8.56,
+          "bottomDiameter": 8.56,
+          "topHeight": 25.2,
+          "bottomHeight": 13.95
         },
         {
           "shape": "conical",
@@ -360,10 +340,30 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 8.56,
-          "bottomDiameter": 8.56,
-          "topHeight": 25.2,
-          "bottomHeight": 13.95
+          "topDiameter": 7.9,
+          "bottomDiameter": 5.8,
+          "topHeight": 11.9,
+          "bottomHeight": 10.2
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 5.8,
+          "bottomDiameter": 3,
+          "topHeight": 10.2,
+          "bottomHeight": 0.95
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 3,
+          "bottomDiameter": 2,
+          "topHeight": 0.95,
+          "bottomHeight": 0.14
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 3.64,
+          "topHeight": 0.14,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_1.5ml_screwcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_1.5ml_screwcap/2.json
@@ -325,17 +325,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 2.36,
-          "topHeight": 0.2,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "topDiameter": 3.2,
-          "bottomDiameter": 1.9,
-          "topHeight": 1.88,
-          "bottomHeight": 0.2
+          "topDiameter": 8.55,
+          "bottomDiameter": 8.2,
+          "topHeight": 42.6,
+          "bottomHeight": 13.7
         },
         {
           "shape": "conical",
@@ -346,10 +340,16 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 8.55,
-          "bottomDiameter": 8.2,
-          "topHeight": 42.6,
-          "bottomHeight": 13.7
+          "topDiameter": 3.2,
+          "bottomDiameter": 1.9,
+          "topHeight": 1.88,
+          "bottomHeight": 0.2
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 2.36,
+          "topHeight": 0.2,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_1.5ml_snapcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_1.5ml_snapcap/2.json
@@ -327,17 +327,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 1.87,
-          "topHeight": 1.56,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "topDiameter": 8.98,
-          "bottomDiameter": 3.69,
-          "topHeight": 17.4,
-          "bottomHeight": 1.56
+          "topDiameter": 9.9,
+          "bottomDiameter": 9.28,
+          "topHeight": 37.9,
+          "bottomHeight": 35.4
         },
         {
           "shape": "conical",
@@ -348,10 +342,16 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 9.9,
-          "bottomDiameter": 9.28,
-          "topHeight": 37.9,
-          "bottomHeight": 35.4
+          "topDiameter": 8.98,
+          "bottomDiameter": 3.69,
+          "topHeight": 17.4,
+          "bottomHeight": 1.56
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 1.87,
+          "topHeight": 1.56,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_2ml_screwcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_2ml_screwcap/2.json
@@ -326,10 +326,10 @@
       "sections": [
         {
           "shape": "conical",
-          "bottomDiameter": 1.21,
-          "topDiameter": 6.5,
-          "topHeight": 2.08,
-          "bottomHeight": 0.0
+          "topDiameter": 8.55,
+          "bottomDiameter": 8.14,
+          "topHeight": 43.4,
+          "bottomHeight": 3.04
         },
         {
           "shape": "conical",
@@ -340,10 +340,10 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 8.55,
-          "bottomDiameter": 8.14,
-          "topHeight": 43.4,
-          "bottomHeight": 3.04
+          "bottomDiameter": 1.21,
+          "topDiameter": 6.5,
+          "topHeight": 2.08,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_2ml_snapcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_nest_2ml_snapcap/2.json
@@ -327,45 +327,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 3.19,
-          "topHeight": 1.21,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "topDiameter": 6.0,
-          "bottomDiameter": 5.0,
-          "topHeight": 1.83,
-          "bottomHeight": 1.21
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 7.0,
-          "bottomDiameter": 6.0,
-          "topHeight": 2.59,
-          "bottomHeight": 1.83
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 7.2,
-          "bottomDiameter": 7.0,
-          "topHeight": 2.74,
-          "bottomHeight": 2.59
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.0,
-          "bottomDiameter": 7.2,
-          "topHeight": 3.98,
-          "bottomHeight": 2.74
-        },
-        {
-          "shape": "conical",
-          "topDiameter": 8.74,
-          "bottomDiameter": 8.0,
-          "topHeight": 6.26,
-          "bottomHeight": 3.98
+          "topDiameter": 9.28,
+          "bottomDiameter": 8.9,
+          "topHeight": 39.28,
+          "bottomHeight": 15.04
         },
         {
           "shape": "conical",
@@ -376,10 +342,44 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 9.28,
-          "bottomDiameter": 8.9,
-          "topHeight": 39.28,
-          "bottomHeight": 15.04
+          "topDiameter": 8.74,
+          "bottomDiameter": 8.0,
+          "topHeight": 6.26,
+          "bottomHeight": 3.98
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.0,
+          "bottomDiameter": 7.2,
+          "topHeight": 3.98,
+          "bottomHeight": 2.74
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 7.2,
+          "bottomDiameter": 7.0,
+          "topHeight": 2.74,
+          "bottomHeight": 2.59
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 7.0,
+          "bottomDiameter": 6.0,
+          "topHeight": 2.59,
+          "bottomHeight": 1.83
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 6.0,
+          "bottomDiameter": 5.0,
+          "topHeight": 1.83,
+          "bottomHeight": 1.21
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 3.19,
+          "topHeight": 1.21,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_6_tuberack_falcon_50ml_conical/2.json
+++ b/shared-data/labware/definitions/3/opentrons_6_tuberack_falcon_50ml_conical/2.json
@@ -120,10 +120,10 @@
       "sections": [
         {
           "shape": "conical",
-          "bottomDiameter": 6.15,
-          "topDiameter": 26.18,
-          "topHeight": 14.3,
-          "bottomHeight": 0.0
+          "bottomDiameter": 27.52,
+          "topDiameter": 27.81,
+          "topHeight": 112.85,
+          "bottomHeight": 100.65
         },
         {
           "shape": "conical",
@@ -134,10 +134,10 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 27.52,
-          "topDiameter": 27.81,
-          "topHeight": 112.85,
-          "bottomHeight": 100.65
+          "bottomDiameter": 6.15,
+          "topDiameter": 26.18,
+          "topHeight": 14.3,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_6_tuberack_nest_50ml_conical/2.json
+++ b/shared-data/labware/definitions/3/opentrons_6_tuberack_nest_50ml_conical/2.json
@@ -118,10 +118,10 @@
       "sections": [
         {
           "shape": "conical",
-          "topDiameter": 26.0,
-          "bottomDiameter": 6.0,
-          "topHeight": 14.28,
-          "bottomHeight": 0.0
+          "topDiameter": 27.45,
+          "bottomDiameter": 27.0,
+          "topHeight": 113.3,
+          "bottomHeight": 109.0
         },
         {
           "shape": "conical",
@@ -132,10 +132,10 @@
         },
         {
           "shape": "conical",
-          "topDiameter": 27.45,
-          "bottomDiameter": 27.0,
-          "topHeight": 113.3,
-          "bottomHeight": 109.0
+          "topDiameter": 26.0,
+          "bottomDiameter": 6.0,
+          "topHeight": 14.28,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_96_aluminumblock_biorad_wellplate_200ul/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_aluminumblock_biorad_wellplate_200ul/2.json
@@ -1126,24 +1126,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 1.42,
-          "topHeight": 1.21,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
-          "bottomDiameter": 2.81,
-          "topDiameter": 3,
-          "topHeight": 1.87,
-          "bottomHeight": 1.21
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 3,
-          "topDiameter": 4.98,
-          "topHeight": 8.58,
-          "bottomHeight": 1.87
+          "bottomDiameter": 5.44,
+          "topDiameter": 5.44,
+          "topHeight": 14.57,
+          "bottomHeight": 10.14
         },
         {
           "shape": "conical",
@@ -1154,10 +1141,23 @@
         },
         {
           "shape": "conical",
-          "bottomDiameter": 5.44,
-          "topDiameter": 5.44,
-          "topHeight": 14.57,
-          "bottomHeight": 10.14
+          "bottomDiameter": 3,
+          "topDiameter": 4.98,
+          "topHeight": 8.58,
+          "bottomHeight": 1.87
+        },
+        {
+          "shape": "conical",
+          "bottomDiameter": 2.81,
+          "topDiameter": 3,
+          "topHeight": 1.87,
+          "bottomHeight": 1.21
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 1.42,
+          "topHeight": 1.21,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_96_aluminumblock_nest_wellplate_100ul/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_aluminumblock_nest_wellplate_100ul/2.json
@@ -1124,6 +1124,13 @@
     "conicalWell": {
       "sections": [
         {
+          "shape": "conical",
+          "bottomDiameter": 5.26,
+          "topDiameter": 5.34,
+          "topHeight": 14.7,
+          "bottomHeight": 9.89
+        },
+        {
           "shape": "spherical",
           "radiusOfCurvature": 3.015,
           "topHeight": 0.2,
@@ -1134,13 +1141,6 @@
           "bottomDiameter": 2.16,
           "topDiameter": 5.26,
           "topHeight": 0.2,
-          "bottomHeight": 9.89
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 5.26,
-          "topDiameter": 5.34,
-          "topHeight": 14.7,
           "bottomHeight": 9.89
         }
       ]

--- a/shared-data/labware/definitions/3/opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep/2.json
@@ -1219,21 +1219,21 @@
       "sections": [
         {
           "shape": "cuboidal",
-          "topXDimension": 7.4,
-          "topYDimension": 7.4,
-          "bottomXDimension": 2.63,
-          "bottomYDimension": 2.63,
-          "topHeight": 1.67,
-          "bottomHeight": 0.0
-        },
-        {
-          "shape": "cuboidal",
           "topXDimension": 8.2,
           "topYDimension": 8.2,
           "bottomXDimension": 7.4,
           "bottomYDimension": 7.4,
           "topHeight": 38.05,
           "bottomHeight": 1.67
+        },
+        {
+          "shape": "cuboidal",
+          "topXDimension": 7.4,
+          "topYDimension": 7.4,
+          "bottomXDimension": 2.63,
+          "bottomYDimension": 2.63,
+          "topHeight": 1.67,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_96_pcr_adapter_armadillo_wellplate_200ul/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_pcr_adapter_armadillo_wellplate_200ul/2.json
@@ -1124,10 +1124,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 1.25,
-          "topHeight": 0.8,
-          "bottomHeight": 0.0
+          "shape": "conical",
+          "bottomDiameter": 5.5,
+          "topDiameter": 5.5,
+          "topHeight": 14.95,
+          "bottomHeight": 11.35
         },
         {
           "shape": "conical",
@@ -1137,11 +1138,10 @@
           "bottomHeight": 0.8
         },
         {
-          "shape": "conical",
-          "bottomDiameter": 5.5,
-          "topDiameter": 5.5,
-          "topHeight": 14.95,
-          "bottomHeight": 11.35
+          "shape": "spherical",
+          "radiusOfCurvature": 1.25,
+          "topHeight": 0.8,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/2.json
@@ -1122,6 +1122,13 @@
     "conicalWell": {
       "sections": [
         {
+          "shape": "conical",
+          "bottomDiameter": 5.26,
+          "topDiameter": 5.34,
+          "topHeight": 14.7,
+          "bottomHeight": 9.89
+        },
+        {
           "shape": "spherical",
           "radiusOfCurvature": 3.015,
           "topHeight": 0.2,
@@ -1132,13 +1139,6 @@
           "bottomDiameter": 2.16,
           "topDiameter": 5.26,
           "topHeight": 0.2,
-          "bottomHeight": 9.89
-        },
-        {
-          "shape": "conical",
-          "bottomDiameter": 5.26,
-          "topDiameter": 5.34,
-          "topHeight": 14.7,
           "bottomHeight": 9.89
         }
       ]

--- a/shared-data/labware/definitions/3/opentrons_96_wellplate_200ul_pcr_full_skirt/3.json
+++ b/shared-data/labware/definitions/3/opentrons_96_wellplate_200ul_pcr_full_skirt/3.json
@@ -1149,10 +1149,11 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 1.25,
-          "topHeight": 0.8,
-          "bottomHeight": 0.0
+          "shape": "conical",
+          "bottomDiameter": 5.5,
+          "topDiameter": 5.5,
+          "topHeight": 14.95,
+          "bottomHeight": 11.35
         },
         {
           "shape": "conical",
@@ -1162,11 +1163,10 @@
           "bottomHeight": 0.8
         },
         {
-          "shape": "conical",
-          "bottomDiameter": 5.5,
-          "topDiameter": 5.5,
-          "topHeight": 14.95,
-          "bottomHeight": 11.35
+          "shape": "spherical",
+          "radiusOfCurvature": 1.25,
+          "topHeight": 0.8,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/thermoscientificnunc_96_wellplate_1300ul/2.json
+++ b/shared-data/labware/definitions/3/thermoscientificnunc_96_wellplate_1300ul/2.json
@@ -1116,17 +1116,17 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 3.6,
-          "topHeight": 3.6,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
           "bottomDiameter": 7.2,
           "topDiameter": 8.4,
           "topHeight": 29.1,
           "bottomHeight": 3.6
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 3.6,
+          "topHeight": 3.6,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/thermoscientificnunc_96_wellplate_2000ul/2.json
+++ b/shared-data/labware/definitions/3/thermoscientificnunc_96_wellplate_2000ul/2.json
@@ -1116,17 +1116,17 @@
     "conicalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 3.6,
-          "topHeight": 3.6,
-          "bottomHeight": 0.0
-        },
-        {
           "shape": "conical",
           "bottomDiameter": 7.2,
           "topDiameter": 8.5,
           "topHeight": 41.5,
           "bottomHeight": 3.6
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 3.6,
+          "topHeight": 3.6,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/definitions/3/usascientific_12_reservoir_22ml/2.json
+++ b/shared-data/labware/definitions/3/usascientific_12_reservoir_22ml/2.json
@@ -205,11 +205,13 @@
     "cuboidalWell": {
       "sections": [
         {
-          "shape": "spherical",
-          "radiusOfCurvature": 1.5362,
-          "topHeight": 0.25,
-          "bottomHeight": 0.0,
-          "yCount": 8
+          "shape": "cuboidal",
+          "topXDimension": 8.34,
+          "topYDimension": 71.85,
+          "bottomXDimension": 7.9,
+          "bottomYDimension": 71.75,
+          "topHeight": 41.75,
+          "bottomHeight": 4.0
         },
         {
           "shape": "squaredcone",
@@ -223,13 +225,11 @@
           "yCount": 8
         },
         {
-          "shape": "cuboidal",
-          "topXDimension": 8.34,
-          "topYDimension": 71.85,
-          "bottomXDimension": 7.9,
-          "bottomYDimension": 71.75,
-          "topHeight": 41.75,
-          "bottomHeight": 4.0
+          "shape": "spherical",
+          "radiusOfCurvature": 1.5362,
+          "topHeight": 0.25,
+          "bottomHeight": 0.0,
+          "yCount": 8
         }
       ]
     }

--- a/shared-data/labware/definitions/3/usascientific_96_wellplate_2.4ml_deep/2.json
+++ b/shared-data/labware/definitions/3/usascientific_96_wellplate_2.4ml_deep/2.json
@@ -1214,21 +1214,21 @@
       "sections": [
         {
           "shape": "cuboidal",
-          "topXDimension": 7.52,
-          "topYDimension": 7.52,
-          "bottomXDimension": 0.25,
-          "bottomYDimension": 0.25,
-          "topHeight": 2.63,
-          "bottomHeight": 0.0
-        },
-        {
-          "shape": "cuboidal",
           "topXDimension": 8.2,
           "topYDimension": 8.2,
           "bottomXDimension": 7.52,
           "bottomYDimension": 7.52,
           "topHeight": 41.3,
           "bottomHeight": 2.63
+        },
+        {
+          "shape": "cuboidal",
+          "topXDimension": 7.52,
+          "topYDimension": 7.52,
+          "bottomXDimension": 0.25,
+          "bottomYDimension": 0.25,
+          "topHeight": 2.63,
+          "bottomHeight": 0.0
         }
       ]
     }

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -277,7 +277,7 @@
       "required": ["sections"],
       "properties": {
         "sections": {
-          "description": "A list of all of the sections of the well that have a contiguous shape",
+          "description": "A list of all of the sections of the well that have a contiguous shape. Must be ordered from top (highest z) to bottom (lowest z).",
           "type": "array",
           "items": {
             "oneOf": [

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -679,7 +679,7 @@ WellSegment = Union[
 class InnerWellGeometry(BaseModel):
     sections: List[WellSegment] = Field(
         ...,
-        description="A list of all of the sections of the well that have a contiguous shape",
+        description="A list of all of the sections of the well that have a contiguous shape. Must be ordered from top (highest z) to bottom (lowest z).",
     )
 
 


### PR DESCRIPTION
## Overview

This addresses one of the labware definition problems identified in #17425, now that the labware definitions are actually being tested.

One of those tests makes sure that the different parts of the labware definition agree on where the tops of the wells are. The implementation of that test relies on an assumption that a well's geometry sections are defined in order from physical top to physical bottom. That assumption does not hold for most of these definitions, so the test has a lot of spurious failures, now that it's actually running.

There are two ways to resolve this:

1. Edit the labware schema and the labware definitions so the ordering assumption *does* hold.
2. Rewrite the test to do its own sorting. It sounds like we already do this in the robot backend.

After discussion with @caila-marashaj, we're going with option 1.

## Changelog

* Update the property description to mention this new ordering requirement.
* Update all labware definitions to conform to this new ordering requirement. [You know I love my one-off scripts.](https://gist.github.com/SyntaxColoring/00f8f4ad1552c3ba3c85d648ac7f6f5e)
* Add a test to explicitly check the ordering.

## Test Plan and Hands on Testing

* [x] Uncomment the `checkGeometryDefinitions` test that was commented out in [#17425](https://github.com/Opentrons/opentrons/pull/17425). Make sure it has fewer failures now.
    * It still has *some* failures, for unrelated reasons, so we can't totally uncomment it just yet. See the `// FIXME` comment in `checkGeometryDefinitions` in [#17425](https://github.com/Opentrons/opentrons/pull/17425). 

## Review requests

Glance through the labware definition changes and make sure nothing unexpected snuck into the diff.

## Risk assessment

Low.