### PR TITLE
fix(shared-data): tc lids are schema v2 now

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -1248,13 +1248,6 @@
             "brand": "Opentrons",
             "brandId": []
           },
-          "compatibleParentLabware": [
-            "armadillo_96_wellplate_200ul_pcr_full_skirt",
-            "biorad_96_wellplate_200ul_pcr",
-            "opentrons_96_wellplate_200ul_pcr_full_skirt",
-            "opentrons_flex_deck_riser",
-            "opentrons_tough_pcr_auto_sealing_lid"
-          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1326,7 +1319,7 @@
             "loadName": "opentrons_tough_pcr_auto_sealing_lid",
             "quirks": []
           },
-          "schemaVersion": 3,
+          "schemaVersion": 2,
           "stackLimit": 5,
           "stackingOffsetWithLabware": {
             "armadillo_96_wellplate_200ul_pcr_full_skirt": {
@@ -1400,13 +1393,6 @@
             "brand": "Opentrons",
             "brandId": []
           },
-          "compatibleParentLabware": [
-            "armadillo_96_wellplate_200ul_pcr_full_skirt",
-            "biorad_96_wellplate_200ul_pcr",
-            "opentrons_96_wellplate_200ul_pcr_full_skirt",
-            "opentrons_flex_deck_riser",
-            "opentrons_tough_pcr_auto_sealing_lid"
-          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1478,7 +1464,7 @@
             "loadName": "opentrons_tough_pcr_auto_sealing_lid",
             "quirks": []
           },
-          "schemaVersion": 3,
+          "schemaVersion": 2,
           "stackLimit": 5,
           "stackingOffsetWithLabware": {
             "armadillo_96_wellplate_200ul_pcr_full_skirt": {
@@ -1552,13 +1538,6 @@
             "brand": "Opentrons",
             "brandId": []
           },
-          "compatibleParentLabware": [
-            "armadillo_96_wellplate_200ul_pcr_full_skirt",
-            "biorad_96_wellplate_200ul_pcr",
-            "opentrons_96_wellplate_200ul_pcr_full_skirt",
-            "opentrons_flex_deck_riser",
-            "opentrons_tough_pcr_auto_sealing_lid"
-          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1630,7 +1609,7 @@
             "loadName": "opentrons_tough_pcr_auto_sealing_lid",
             "quirks": []
           },
-          "schemaVersion": 3,
+          "schemaVersion": 2,
           "stackLimit": 5,
           "stackingOffsetWithLabware": {
             "armadillo_96_wellplate_200ul_pcr_full_skirt": {
@@ -1704,13 +1683,6 @@
             "brand": "Opentrons",
             "brandId": []
           },
-          "compatibleParentLabware": [
-            "armadillo_96_wellplate_200ul_pcr_full_skirt",
-            "biorad_96_wellplate_200ul_pcr",
-            "opentrons_96_wellplate_200ul_pcr_full_skirt",
-            "opentrons_flex_deck_riser",
-            "opentrons_tough_pcr_auto_sealing_lid"
-          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1782,7 +1754,7 @@
             "loadName": "opentrons_tough_pcr_auto_sealing_lid",
             "quirks": []
           },
-          "schemaVersion": 3,
+          "schemaVersion": 2,
           "stackLimit": 5,
           "stackingOffsetWithLabware": {
             "armadillo_96_wellplate_200ul_pcr_full_skirt": {
@@ -1856,13 +1828,6 @@
             "brand": "Opentrons",
             "brandId": []
           },
-          "compatibleParentLabware": [
-            "armadillo_96_wellplate_200ul_pcr_full_skirt",
-            "biorad_96_wellplate_200ul_pcr",
-            "opentrons_96_wellplate_200ul_pcr_full_skirt",
-            "opentrons_flex_deck_riser",
-            "opentrons_tough_pcr_auto_sealing_lid"
-          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1934,7 +1899,7 @@
             "loadName": "opentrons_tough_pcr_auto_sealing_lid",
             "quirks": []
           },
-          "schemaVersion": 3,
+          "schemaVersion": 2,
           "stackLimit": 5,
           "stackingOffsetWithLabware": {
             "armadillo_96_wellplate_200ul_pcr_full_skirt": {

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -112,7 +112,7 @@ import opentronsFlex96Tiprack50UlV1Uncasted from '../labware/definitions/2/opent
 import opentronsFlex96TiprackAdapterV1Uncasted from '../labware/definitions/2/opentrons_flex_96_tiprack_adapter/1.json'
 import opentronsFlexDeckRiserV1Uncasted from '../labware/definitions/2/opentrons_flex_deck_riser/1.json'
 import opentronsFlexLidAbsorbancePlateReaderModuleV1Uncasted from '../labware/definitions/2/opentrons_flex_lid_absorbance_plate_reader_module/1.json'
-import opentronsToughPcrAutoSealingLidV1Uncasted from '../labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/1.json'
+import opentronsToughPcrAutoSealingLidV1Uncasted from '../labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json'
 import opentronsUniversalFlatAdapterV1Uncasted from '../labware/definitions/2/opentrons_universal_flat_adapter/1.json'
 import opentronsUniversalFlatAdapterCorning384Wellplate112UlFlatV1Uncasted from '../labware/definitions/2/opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json'
 import opentrons96DeepWellTempModAdapterV1Uncasted from '../labware/definitions/2/opentrons_96_deep_well_temp_mod_adapter/1.json'

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -256,6 +256,7 @@ export interface LabwareDefinition2 {
   allowedRoles?: LabwareRoles[]
   stackingOffsetWithLabware?: Record<string, LabwareOffset>
   stackingOffsetWithModule?: Record<string, LabwareOffset>
+  stackLimit?: number
 }
 
 export interface LabwareDefinition3 {

--- a/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
@@ -37,7 +37,7 @@
   },
   "namespace": "opentrons",
   "version": 1,
-  "schemaVersion": 3,
+  "schemaVersion": 2,
   "stackingOffsetWithModule": {
     "thermocyclerModuleV2": {
       "x": 0,
@@ -78,13 +78,6 @@
     }
   },
   "stackLimit": 5,
-  "compatibleParentLabware": [
-    "armadillo_96_wellplate_200ul_pcr_full_skirt",
-    "opentrons_96_wellplate_200ul_pcr_full_skirt",
-    "opentrons_tough_pcr_auto_sealing_lid",
-    "biorad_96_wellplate_200ul_pcr",
-    "opentrons_flex_deck_riser"
-  ],
   "gripForce": 15,
   "gripHeightFromLabwareBottom": 7.91,
   "gripperOffsets": {

--- a/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/2.json
+++ b/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/2.json
@@ -1,0 +1,128 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Opentrons Tough PCR Auto-Sealing Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.7,
+    "yDimension": 85.48,
+    "zDimension": 12.8
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": -0.71
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": [],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_tough_pcr_auto_sealing_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithModule": {
+    "thermocyclerModuleV2": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackingOffsetWithLabware": {
+    "default": {
+      "x": 0,
+      "y": 0,
+      "z": 8.193
+    },
+    "opentrons_tough_pcr_auto_sealing_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 6.492
+    },
+    "armadillo_96_wellplate_200ul_pcr_full_skirt": {
+      "x": 0,
+      "y": 0,
+      "z": 8.193
+    },
+    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
+      "x": 0,
+      "y": 0,
+      "z": 8.193
+    },
+    "biorad_96_wellplate_200ul_pcr": {
+      "x": 0,
+      "y": 0,
+      "z": 8.08
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 34
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "armadillo_96_wellplate_200ul_pcr_full_skirt",
+    "opentrons_96_wellplate_200ul_pcr_full_skirt",
+    "opentrons_tough_pcr_auto_sealing_lid",
+    "biorad_96_wellplate_200ul_pcr",
+    "opentrons_flex_deck_riser"
+  ],
+  "gripForce": 15,
+  "gripHeightFromLabwareBottom": 7.91,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 1.5
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0.52,
+        "z": -6
+      }
+    },
+    "lidOffsets": {
+      "pickUpOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -5
+      },
+      "dropOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -1
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -391,6 +391,10 @@
     "gripHeightFromLabwareBottom": {
       "type": "number",
       "description": "Recommended Z-height, from labware bottom to the center of gripper pads, when gripping the labware."
+    },
+    "stackLimit": {
+      "type": "number",
+      "description": "The limit representing the maximum stack size for a given labware."
     }
   }
 }


### PR DESCRIPTION
We need to not use any schema v3 labware in 8.3 because we're going to change the schema. The thermocycler lids were only available in schema
3. Change that by making the lid v1 def a schema 2 def, and making a lid v2 def that is a schema 3 def.

All the data is the same, and we even kept the stackLimit and added it to labware schema 2, so all the machine behavior should be exactly the same. The only other thing that's not in schema 2 now is the new lid stuff support, but that code isn't in 8.3 so we should be good.

Closes EXEC-1180

## review
- seem ok?

## testing
- run a smoke test for these. the data is literally all the same and nothing identity checks schemas, just whether data is there, and the same data is all still there.