### PR TITLE
fix(shared-data): evotips v1 are schema 2 now

### DIFF
--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_dispense.py
@@ -1,7 +1,5 @@
 """Test evotip dispense in place commands."""
 
-import json
-
 import pytest
 from decoy import Decoy
 
@@ -29,7 +27,7 @@ from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state import update_types
 
-from opentrons_shared_data import load_shared_data
+from opentrons_shared_data.labware import load_definition
 
 
 @pytest.fixture
@@ -37,11 +35,7 @@ def evotips_definition() -> LabwareDefinition:
     """A fixturee of the evotips definition."""
     # TODO (chb 2025-01-29): When we migrate all labware to v3 we can clean this up
     return LabwareDefinition.model_validate(
-        json.loads(
-            load_shared_data(
-                "labware/definitions/2/evotips_opentrons_96_labware/1.json"
-            )
-        )
+        load_definition("evotips_opentrons_96_labware", 1)
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_dispense.py
@@ -1,4 +1,5 @@
 """Test evotip dispense in place commands."""
+
 import json
 
 import pytest
@@ -38,7 +39,7 @@ def evotips_definition() -> LabwareDefinition:
     return LabwareDefinition.model_validate(
         json.loads(
             load_shared_data(
-                "labware/definitions/3/evotips_opentrons_96_labware/1.json"
+                "labware/definitions/2/evotips_opentrons_96_labware/1.json"
             )
         )
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_seal_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_seal_pipette.py
@@ -47,7 +47,7 @@ def evotips_definition() -> LabwareDefinition:
     return LabwareDefinition.model_validate(
         json.loads(
             load_shared_data(
-                "labware/definitions/3/evotips_opentrons_96_labware/1.json"
+                "labware/definitions/2/evotips_opentrons_96_labware/1.json"
             )
         )
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_seal_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_seal_pipette.py
@@ -36,8 +36,8 @@ from opentrons.protocol_engine.execution import (
     PipettingHandler,
 )
 from opentrons.hardware_control import HardwareControlAPI
-import json
-from opentrons_shared_data import load_shared_data
+
+from opentrons_shared_data.labware import load_definition
 
 
 @pytest.fixture
@@ -45,11 +45,7 @@ def evotips_definition() -> LabwareDefinition:
     """A fixturee of the evotips definition."""
     # TODO (chb 2025-01-29): When we migrate all labware to v3 we can clean this up
     return LabwareDefinition.model_validate(
-        json.loads(
-            load_shared_data(
-                "labware/definitions/2/evotips_opentrons_96_labware/1.json"
-            )
-        )
+        load_definition("evotips_opentrons_96_labware", 1)
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_unseal_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_unseal_pipette.py
@@ -27,8 +27,8 @@ from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.execution import MovementHandler, GantryMover, TipHandler
 from opentrons.protocols.models import LabwareDefinition
-import json
-from opentrons_shared_data import load_shared_data
+
+from opentrons_shared_data.labware import load_definition
 
 from opentrons.types import Point
 
@@ -89,11 +89,7 @@ def evotips_definition() -> LabwareDefinition:
     """A fixturee of the evotips definition."""
     # TODO (chb 2025-01-29): When we migrate all labware to v3 we can clean this up
     return LabwareDefinition.model_validate(
-        json.loads(
-            load_shared_data(
-                "labware/definitions/2/evotips_opentrons_96_labware/1.json"
-            )
-        )
+        load_definition("evotips_opentrons_96_labware", 1)
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_unseal_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_unseal_pipette.py
@@ -91,7 +91,7 @@ def evotips_definition() -> LabwareDefinition:
     return LabwareDefinition.model_validate(
         json.loads(
             load_shared_data(
-                "labware/definitions/3/evotips_opentrons_96_labware/1.json"
+                "labware/definitions/2/evotips_opentrons_96_labware/1.json"
             )
         )
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/constants.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/constants.ts
@@ -146,6 +146,7 @@ export const EIGHT_CHANNEL_COMPATIBLE_LABWARE = [
   'opentrons/usascientific_12_reservoir_22ml/1',
   'opentrons/usascientific_96_wellplate_2.4ml_deep/1',
   'opentrons/evotips_opentrons_96_labware/1',
+  'opentrons/evotips_opentrons_96_labware/2',
 ]
 
 export const NINETY_SIX_CHANNEL_COMPATIBLE_LABWARE = [
@@ -191,4 +192,5 @@ export const NINETY_SIX_CHANNEL_COMPATIBLE_LABWARE = [
   'opentrons/usascientific_12_reservoir_22ml/1',
   'opentrons/usascientific_96_wellplate_2.4ml_deep/1',
   'opentrons/evotips_opentrons_96_labware/1',
+  'opentrons/evotips_opentrons_96_labware/2',
 ]

--- a/app/src/organisms/ODD/QuickTransferFlow/constants.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/constants.ts
@@ -146,7 +146,6 @@ export const EIGHT_CHANNEL_COMPATIBLE_LABWARE = [
   'opentrons/usascientific_12_reservoir_22ml/1',
   'opentrons/usascientific_96_wellplate_2.4ml_deep/1',
   'opentrons/evotips_opentrons_96_labware/1',
-  'opentrons/evotips_opentrons_96_labware/2',
 ]
 
 export const NINETY_SIX_CHANNEL_COMPATIBLE_LABWARE = [
@@ -192,5 +191,4 @@ export const NINETY_SIX_CHANNEL_COMPATIBLE_LABWARE = [
   'opentrons/usascientific_12_reservoir_22ml/1',
   'opentrons/usascientific_96_wellplate_2.4ml_deep/1',
   'opentrons/evotips_opentrons_96_labware/1',
-  'opentrons/evotips_opentrons_96_labware/2',
 ]

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -303,8 +303,6 @@ const usascientific12Reservoir22MlV1 = usascientific12Reservoir22MlV1Uncasted as
 const usascientific96Wellplate24MlDeepV1 = usascientific96Wellplate24MlDeepV1Uncasted as LabwareDefinition2
 const evotipsFlex96TiprackAdapterV1 = evotipsFlex96TiprackAdapterV1Uncasted as LabwareDefinition2
 const evotipsOpentrons96LabwareV1 = evotipsOpentrons96LabwareV1Uncasted as LabwareDefinition2
-const evotipsFlex96TiprackAdapterV2 = evotipsFlex96TiprackAdapterV2Uncasted as LabwareDefinition2
-const evotipsOpentrons96LabwareV2 = evotipsOpentrons96LabwareV2Uncasted as LabwareDefinition2
 
 // cast v1 defs
 
@@ -476,8 +474,6 @@ const latestDefs = {
   usascientific96Wellplate24MlDeepV1,
   evotipsFlex96TiprackAdapterV1,
   evotipsOpentrons96LabwareV1,
-  evotipsFlex96TiprackAdapterV2,
-  evotipsOpentrons96LabwareV2,
 }
 
 // labware definitions

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -121,8 +121,10 @@ import thermoscientificnunc96Wellplate2000UlV1Uncasted from '../labware/definiti
 import tipone96Tiprack200UlV1Uncasted from '../labware/definitions/2/tipone_96_tiprack_200ul/1.json'
 import usascientific12Reservoir22MlV1Uncasted from '../labware/definitions/2/usascientific_12_reservoir_22ml/1.json'
 import usascientific96Wellplate24MlDeepV1Uncasted from '../labware/definitions/2/usascientific_96_wellplate_2.4ml_deep/1.json'
-import evotipsFlex96TiprackAdapterV1Uncasted from '../labware/definitions/3/evotips_flex_96_tiprack_adapter/1.json'
-import evotipsOpentrons96LabwareV1Uncasted from '../labware/definitions/3/evotips_opentrons_96_labware/1.json'
+import evotipsFlex96TiprackAdapterV1Uncasted from '../labware/definitions/2/evotips_flex_96_tiprack_adapter/1.json'
+import evotipsOpentrons96LabwareV1Uncasted from '../labware/definitions/2/evotips_opentrons_96_labware/1.json'
+import evotipsFlex96TiprackAdapterV2Uncasted from '../labware/definitions/3/evotips_flex_96_tiprack_adapter/2.json'
+import evotipsOpentrons96LabwareV2Uncasted from '../labware/definitions/3/evotips_opentrons_96_labware/2.json'
 
 // v1 legacy labware definitions
 
@@ -301,6 +303,8 @@ const usascientific12Reservoir22MlV1 = usascientific12Reservoir22MlV1Uncasted as
 const usascientific96Wellplate24MlDeepV1 = usascientific96Wellplate24MlDeepV1Uncasted as LabwareDefinition2
 const evotipsFlex96TiprackAdapterV1 = evotipsFlex96TiprackAdapterV1Uncasted as LabwareDefinition2
 const evotipsOpentrons96LabwareV1 = evotipsOpentrons96LabwareV1Uncasted as LabwareDefinition2
+const evotipsFlex96TiprackAdapterV2 = evotipsFlex96TiprackAdapterV2Uncasted as LabwareDefinition2
+const evotipsOpentrons96LabwareV2 = evotipsOpentrons96LabwareV2Uncasted as LabwareDefinition2
 
 // cast v1 defs
 
@@ -472,7 +476,10 @@ const latestDefs = {
   usascientific96Wellplate24MlDeepV1,
   evotipsFlex96TiprackAdapterV1,
   evotipsOpentrons96LabwareV1,
+  evotipsFlex96TiprackAdapterV2,
+  evotipsOpentrons96LabwareV2,
 }
+
 // labware definitions
 const getAllLabwareDefs = (): Record<
   keyof typeof latestDefs,

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -123,8 +123,6 @@ import usascientific12Reservoir22MlV1Uncasted from '../labware/definitions/2/usa
 import usascientific96Wellplate24MlDeepV1Uncasted from '../labware/definitions/2/usascientific_96_wellplate_2.4ml_deep/1.json'
 import evotipsFlex96TiprackAdapterV1Uncasted from '../labware/definitions/2/evotips_flex_96_tiprack_adapter/1.json'
 import evotipsOpentrons96LabwareV1Uncasted from '../labware/definitions/2/evotips_opentrons_96_labware/1.json'
-import evotipsFlex96TiprackAdapterV2Uncasted from '../labware/definitions/3/evotips_flex_96_tiprack_adapter/2.json'
-import evotipsOpentrons96LabwareV2Uncasted from '../labware/definitions/3/evotips_opentrons_96_labware/2.json'
 
 // v1 legacy labware definitions
 

--- a/shared-data/labware/definitions/2/evotips_flex_96_tiprack_adapter/1.json
+++ b/shared-data/labware/definitions/2/evotips_flex_96_tiprack_adapter/1.json
@@ -1,0 +1,41 @@
+{
+  "ordering": [],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Evotips adapter",
+    "displayCategory": "adapter",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 156.5,
+    "yDimension": 105,
+    "zDimension": 132
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "quirks": ["tiprackAdapterFor96Channel", "stackingMaxFive"],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "evotips_flex_96_tiprack_adapter"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "allowedRoles": ["adapter"],
+  "cornerOffsetFromSlot": {
+    "x": -14.25,
+    "y": -3.5,
+    "z": 0
+  }
+}

--- a/shared-data/labware/definitions/2/evotips_opentrons_96_labware/1.json
+++ b/shared-data/labware/definitions/2/evotips_opentrons_96_labware/1.json
@@ -1018,7 +1018,7 @@
     "y": 0,
     "z": 0
   },
-  "gripHeightFromLabwareBottom": 14.5,
+  "gripHeightFromLabwareBottom": 21.5,
   "gripForce": 15,
   "gripperOffsets": {
     "default": {
@@ -1038,17 +1038,17 @@
     "nest_96_wellplate_2ml_deep": {
       "x": 0,
       "y": 0,
-      "z": 38.25
+      "z": 22.5
     },
     "nest_1_reservoir_195ml": {
       "x": 0,
       "y": 0,
-      "z": 38.25
+      "z": 22.5
     },
     "evotips_flex_96_tiprack_adapter": {
       "x": 0,
       "y": 0,
-      "z": 92.53
+      "z": 76.78
     }
   }
 }

--- a/shared-data/labware/definitions/2/evotips_opentrons_96_labware/1.json
+++ b/shared-data/labware/definitions/2/evotips_opentrons_96_labware/1.json
@@ -26,7 +26,7 @@
   "dimensions": {
     "xDimension": 127.75,
     "yDimension": 86,
-    "zDimension": 39.25
+    "zDimension": 55
   },
   "wells": {
     "A1": {
@@ -1038,17 +1038,17 @@
     "nest_96_wellplate_2ml_deep": {
       "x": 0,
       "y": 0,
-      "z": 22.5
+      "z": 38.25
     },
     "nest_1_reservoir_195ml": {
       "x": 0,
       "y": 0,
-      "z": 22.5
+      "z": 38.25
     },
     "evotips_flex_96_tiprack_adapter": {
       "x": 0,
       "y": 0,
-      "z": 76.78
+      "z": 92.53
     }
   }
 }

--- a/shared-data/labware/definitions/2/evotips_opentrons_96_labware/1.json
+++ b/shared-data/labware/definitions/2/evotips_opentrons_96_labware/1.json
@@ -1,0 +1,1054 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "brand": {
+    "brand": "opentrons",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Evotips",
+    "displayCategory": "wellPlate",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.75,
+    "yDimension": 86,
+    "zDimension": 39.25
+  },
+  "wells": {
+    "A1": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 14.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B1": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 14.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C1": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 14.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D1": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 14.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E1": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 14.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F1": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 14.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G1": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 14.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H1": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 14.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A2": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 23.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B2": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 23.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C2": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 23.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D2": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 23.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E2": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 23.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F2": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 23.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G2": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 23.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H2": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 23.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A3": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 32.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B3": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 32.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C3": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 32.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D3": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 32.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E3": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 32.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F3": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 32.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G3": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 32.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H3": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 32.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A4": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 41.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B4": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 41.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C4": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 41.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D4": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 41.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E4": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 41.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F4": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 41.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G4": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 41.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H4": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 41.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A5": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 50.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B5": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 50.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C5": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 50.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D5": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 50.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E5": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 50.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F5": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 50.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G5": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 50.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H5": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 50.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A6": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 59.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B6": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 59.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C6": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 59.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D6": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 59.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E6": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 59.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F6": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 59.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G6": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 59.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H6": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 59.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A7": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 68.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B7": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 68.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C7": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 68.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D7": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 68.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E7": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 68.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F7": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 68.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G7": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 68.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H7": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 68.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A8": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 77.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B8": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 77.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C8": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 77.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D8": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 77.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E8": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 77.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F8": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 77.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G8": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 77.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H8": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 77.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A9": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 86.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B9": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 86.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C9": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 86.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D9": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 86.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E9": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 86.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F9": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 86.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G9": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 86.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H9": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 86.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A10": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 95.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B10": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 95.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C10": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 95.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D10": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 95.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E10": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 95.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F10": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 95.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G10": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 95.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H10": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 95.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A11": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 104.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B11": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 104.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C11": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 104.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D11": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 104.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E11": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 104.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F11": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 104.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G11": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 104.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H11": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 104.08,
+      "y": 12.25,
+      "z": 1
+    },
+    "A12": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 113.08,
+      "y": 75.25,
+      "z": 1
+    },
+    "B12": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 113.08,
+      "y": 66.25,
+      "z": 1
+    },
+    "C12": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 113.08,
+      "y": 57.25,
+      "z": 1
+    },
+    "D12": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 113.08,
+      "y": 48.25,
+      "z": 1
+    },
+    "E12": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 113.08,
+      "y": 39.25,
+      "z": 1
+    },
+    "F12": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 113.08,
+      "y": 30.25,
+      "z": 1
+    },
+    "G12": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 113.08,
+      "y": 21.25,
+      "z": 1
+    },
+    "H12": {
+      "depth": 54,
+      "totalLiquidVolume": 1000,
+      "shape": "circular",
+      "diameter": 7,
+      "x": 113.08,
+      "y": 12.25,
+      "z": 1
+    }
+  },
+  "groups": [
+    {
+      "metadata": {
+        "wellBottomShape": "v"
+      },
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ]
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "quirks": ["stackingOnly"],
+    "isTiprack": false,
+    "tipLength": 42.0,
+    "tipOverlap": 10.0,
+    "isMagneticModuleCompatible": false,
+    "loadName": "evotips_opentrons_96_labware"
+  },
+  "namespace": "opentrons",
+  "allowedRoles": ["labware"],
+  "version": 1,
+  "stackLimit": 5,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "gripHeightFromLabwareBottom": 14.5,
+  "gripForce": 15,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 15
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 15
+      }
+    }
+  },
+  "stackingOffsetWithLabware": {
+    "nest_96_wellplate_2ml_deep": {
+      "x": 0,
+      "y": 0,
+      "z": 22.5
+    },
+    "nest_1_reservoir_195ml": {
+      "x": 0,
+      "y": 0,
+      "z": 22.5
+    },
+    "evotips_flex_96_tiprack_adapter": {
+      "x": 0,
+      "y": 0,
+      "z": 76.78
+    }
+  }
+}

--- a/shared-data/labware/definitions/3/evotips_flex_96_tiprack_adapter/2.json
+++ b/shared-data/labware/definitions/3/evotips_flex_96_tiprack_adapter/2.json
@@ -30,7 +30,7 @@
     "loadName": "evotips_flex_96_tiprack_adapter"
   },
   "namespace": "opentrons",
-  "version": 1,
+  "version": 2,
   "schemaVersion": 3,
   "allowedRoles": ["adapter"],
   "cornerOffsetFromSlot": {

--- a/shared-data/labware/definitions/3/evotips_opentrons_96_labware/2.json
+++ b/shared-data/labware/definitions/3/evotips_opentrons_96_labware/2.json
@@ -1010,7 +1010,7 @@
   },
   "namespace": "opentrons",
   "allowedRoles": ["labware"],
-  "version": 1,
+  "version": 2,
   "stackLimit": 5,
   "compatibleParentLabware": [
     "nest_96_wellplate_2ml_deep",

--- a/shared-data/labware/definitions/3/evotips_opentrons_96_labware/2.json
+++ b/shared-data/labware/definitions/3/evotips_opentrons_96_labware/2.json
@@ -1043,17 +1043,17 @@
     "nest_96_wellplate_2ml_deep": {
       "x": 0,
       "y": 0,
-      "z": 38.25
+      "z": 22.5
     },
     "nest_1_reservoir_195ml": {
       "x": 0,
       "y": 0,
-      "z": 38.25
+      "z": 22.5
     },
     "evotips_flex_96_tiprack_adapter": {
       "x": 0,
       "y": 0,
-      "z": 92.53
+      "z": 76.78
     }
   }
 }

--- a/shared-data/labware/definitions/3/evotips_opentrons_96_labware/2.json
+++ b/shared-data/labware/definitions/3/evotips_opentrons_96_labware/2.json
@@ -26,7 +26,7 @@
   "dimensions": {
     "xDimension": 127.75,
     "yDimension": 86,
-    "zDimension": 39.25
+    "zDimension": 55
   },
   "wells": {
     "A1": {
@@ -1043,17 +1043,17 @@
     "nest_96_wellplate_2ml_deep": {
       "x": 0,
       "y": 0,
-      "z": 22.5
+      "z": 38.25
     },
     "nest_1_reservoir_195ml": {
       "x": 0,
       "y": 0,
-      "z": 22.5
+      "z": 38.25
     },
     "evotips_flex_96_tiprack_adapter": {
       "x": 0,
       "y": 0,
-      "z": 76.78
+      "z": 92.53
     }
   }
 }


### PR DESCRIPTION
We had the evotips labware and adapter as schema 3 labware. This was probably necessary while this was a 3-element stack, but now it is not, and we need to avoid shipping schema 3 labware in 8.3 so that we retain the ability to change it.

Closes EXEC-1179

## review
- seem fine?

## testing
- smoke test. nothing checks schema identity, just whether data is there, and all the data that the code in 8.3 uses is still there.