### PR TITLE
feat(robot-server): Allow adding multiple labware offsets in a single request

### DIFF
--- a/api-client/src/runs/createLabwareOffset.ts
+++ b/api-client/src/runs/createLabwareOffset.ts
@@ -7,6 +7,16 @@ import type { LabwareOffset, LegacyLabwareOffsetCreateData } from './types'
 export function createLabwareOffset(
   config: HostConfig,
   runId: string,
+  data: LegacyLabwareOffsetCreateData
+): ResponsePromise<LabwareOffset>
+export function createLabwareOffset(
+  config: HostConfig,
+  runId: string,
+  data: LegacyLabwareOffsetCreateData[]
+): ResponsePromise<LabwareOffset[]>
+export function createLabwareOffset(
+  config: HostConfig,
+  runId: string,
   data: LegacyLabwareOffsetCreateData | LegacyLabwareOffsetCreateData[]
 ): ResponsePromise<LabwareOffset | LabwareOffset[]> {
   return request<

--- a/api-client/src/runs/createLabwareOffset.ts
+++ b/api-client/src/runs/createLabwareOffset.ts
@@ -7,16 +7,6 @@ import type { LabwareOffset, LegacyLabwareOffsetCreateData } from './types'
 export function createLabwareOffset(
   config: HostConfig,
   runId: string,
-  data: LegacyLabwareOffsetCreateData
-): ResponsePromise<LabwareOffset>
-export function createLabwareOffset(
-  config: HostConfig,
-  runId: string,
-  data: LegacyLabwareOffsetCreateData[]
-): ResponsePromise<LabwareOffset[]>
-export function createLabwareOffset(
-  config: HostConfig,
-  runId: string,
   data: LegacyLabwareOffsetCreateData | LegacyLabwareOffsetCreateData[]
 ): ResponsePromise<LabwareOffset | LabwareOffset[]> {
   return request<

--- a/api-client/src/runs/createLabwareOffset.ts
+++ b/api-client/src/runs/createLabwareOffset.ts
@@ -2,17 +2,25 @@ import { POST, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
-import type { LegacyLabwareOffsetCreateData, Run } from './types'
+import type { LabwareOffset, LegacyLabwareOffsetCreateData } from './types'
 
 export function createLabwareOffset(
   config: HostConfig,
   runId: string,
   data: LegacyLabwareOffsetCreateData
-): ResponsePromise<Run> {
-  return request<Run, { data: LegacyLabwareOffsetCreateData }>(
-    POST,
-    `/runs/${runId}/labware_offsets`,
-    { data },
-    config
-  )
+): ResponsePromise<LabwareOffset>
+export function createLabwareOffset(
+  config: HostConfig,
+  runId: string,
+  data: LegacyLabwareOffsetCreateData[]
+): ResponsePromise<LabwareOffset[]>
+export function createLabwareOffset(
+  config: HostConfig,
+  runId: string,
+  data: LegacyLabwareOffsetCreateData | LegacyLabwareOffsetCreateData[]
+): ResponsePromise<LabwareOffset | LabwareOffset[]> {
+  return request<
+    LabwareOffset | LabwareOffset[],
+    { data: LegacyLabwareOffsetCreateData | LegacyLabwareOffsetCreateData[] }
+  >(POST, `/runs/${runId}/labware_offsets`, { data }, config)
 }

--- a/react-api-client/src/runs/useCreateLabwareOffsetMutation.ts
+++ b/react-api-client/src/runs/useCreateLabwareOffsetMutation.ts
@@ -3,8 +3,8 @@ import { createLabwareOffset } from '@opentrons/api-client'
 import { useHost } from '../api'
 import type {
   HostConfig,
-  Run,
   LegacyLabwareOffsetCreateData,
+  LabwareOffset,
 } from '@opentrons/api-client'
 import type { UseMutationResult, UseMutateAsyncFunction } from 'react-query'
 
@@ -14,12 +14,12 @@ interface CreateLabwareOffsetParams {
 }
 
 export type UseCreateLabwareOffsetMutationResult = UseMutationResult<
-  Run,
+  LabwareOffset,
   unknown,
   CreateLabwareOffsetParams
 > & {
   createLabwareOffset: UseMutateAsyncFunction<
-    Run,
+    LabwareOffset,
     unknown,
     CreateLabwareOffsetParams
   >
@@ -29,19 +29,22 @@ export function useCreateLabwareOffsetMutation(): UseCreateLabwareOffsetMutation
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<Run, unknown, CreateLabwareOffsetParams>(
-    ({ runId, data }) =>
-      createLabwareOffset(host as HostConfig, runId, data)
-        .then(response => {
-          queryClient.invalidateQueries([host, 'runs']).catch((e: Error) => {
-            console.error(`error invalidating runs query: ${e.message}`)
-          })
-          return response.data
+  const mutation = useMutation<
+    LabwareOffset,
+    unknown,
+    CreateLabwareOffsetParams
+  >(({ runId, data }) =>
+    createLabwareOffset(host as HostConfig, runId, data)
+      .then(response => {
+        queryClient.invalidateQueries([host, 'runs']).catch((e: Error) => {
+          console.error(`error invalidating runs query: ${e.message}`)
         })
-        .catch((e: Error) => {
-          console.error(`error creating labware offsets: ${e.message}`)
-          throw e
-        })
+        return response.data
+      })
+      .catch((e: Error) => {
+        console.error(`error creating labware offsets: ${e.message}`)
+        throw e
+      })
   )
 
   return {

--- a/robot-server/robot_server/labware_offsets/router.py
+++ b/robot-server/robot_server/labware_offsets/router.py
@@ -12,7 +12,10 @@ from server_utils.fastapi_utils.light_router import LightRouter
 from opentrons.protocol_engine import ModuleModel
 
 from robot_server.labware_offsets.models import LabwareOffsetNotFound
-from robot_server.service.dependencies import get_current_time, get_unique_id
+from robot_server.service.dependencies import (
+    UniqueIDFactory,
+    get_current_time,
+)
 from robot_server.service.json_api.request import RequestModel
 from robot_server.service.json_api.response import (
     MultiBodyMeta,
@@ -42,42 +45,67 @@ router = LightRouter()
 @PydanticResponse.wrap_route(
     router.post,
     path="/labwareOffsets",
-    summary="Store a labware offset",
+    summary="Store labware offsets",
     description=textwrap.dedent(
         """\
-        Store a labware offset for later retrieval through `GET /labwareOffsets`.
+        Store labware offsets for later retrieval through `GET /labwareOffsets`.
 
         On its own, this does not affect robot motion.
-        To do that, you must add the offset to a run, through the `/runs` endpoints.
+        To do that, you must add the offsets to a run, through the `/runs` endpoints.
+
+        The response body's `data` will either be a single offset or a list of offsets,
+        depending on whether you provided a single offset or a list in the request body's `data`.
         """
     ),
     status_code=201,
     include_in_schema=False,  # todo(mm, 2025-01-08): Include for v8.4.0.
 )
-async def post_labware_offset(  # noqa: D103
+async def post_labware_offsets(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],
-    new_offset_id: Annotated[str, fastapi.Depends(get_unique_id)],
+    new_offset_id_factory: Annotated[UniqueIDFactory, fastapi.Depends(UniqueIDFactory)],
     new_offset_created_at: Annotated[datetime, fastapi.Depends(get_current_time)],
-    request_body: Annotated[RequestModel[StoredLabwareOffsetCreate], fastapi.Body()],
-) -> PydanticResponse[SimpleBody[StoredLabwareOffset]]:
-    new_offset = IncomingStoredLabwareOffset(
-        id=new_offset_id,
-        createdAt=new_offset_created_at,
-        definitionUri=request_body.data.definitionUri,
-        locationSequence=request_body.data.locationSequence,
-        vector=request_body.data.vector,
+    request_body: Annotated[
+        RequestModel[StoredLabwareOffsetCreate | list[StoredLabwareOffsetCreate]],
+        fastapi.Body(),
+    ],
+) -> PydanticResponse[SimpleBody[StoredLabwareOffset | list[StoredLabwareOffset]]]:
+    new_offsets = [
+        IncomingStoredLabwareOffset(
+            id=new_offset_id_factory.get(),
+            createdAt=new_offset_created_at,
+            definitionUri=request_body_element.definitionUri,
+            locationSequence=request_body_element.locationSequence,
+            vector=request_body_element.vector,
+        )
+        for request_body_element in (
+            request_body.data
+            if isinstance(request_body.data, list)
+            else [request_body.data]
+        )
+    ]
+
+    for new_offset in new_offsets:
+        store.add(new_offset)
+
+    stored_offsets = [
+        StoredLabwareOffset.model_construct(
+            id=incoming.id,
+            createdAt=incoming.createdAt,
+            definitionUri=incoming.definitionUri,
+            locationSequence=incoming.locationSequence,
+            vector=incoming.vector,
+        )
+        for incoming in new_offsets
+    ]
+
+    # Return a list if the client POSTed a list, or an object if the client POSTed an object.
+    # For some reason, mypy needs to be given the type annotation explicitly.
+    response_data: StoredLabwareOffset | list[StoredLabwareOffset] = (
+        stored_offsets if isinstance(request_body.data, list) else stored_offsets[0]
     )
-    store.add(new_offset)
+
     return await PydanticResponse.create(
-        content=SimpleBody.model_construct(
-            data=StoredLabwareOffset(
-                id=new_offset_id,
-                createdAt=new_offset_created_at,
-                definitionUri=request_body.data.definitionUri,
-                locationSequence=request_body.data.locationSequence,
-                vector=request_body.data.vector,
-            )
-        ),
+        content=SimpleBody.model_construct(data=response_data),
         status_code=201,
     )
 

--- a/robot-server/robot_server/maintenance_runs/router/labware_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/labware_router.py
@@ -36,33 +36,57 @@ labware_router = LightRouter()
         "There is no matching `GET /maintenance_runs/{runId}/labware_offsets` endpoint."
         " To read the list of labware offsets currently on the run,"
         " see the run's `labwareOffsets` field."
+        "\n\n"
+        "The response body's `data` will either be a single offset or a list of offsets,"
+        " depending on whether you provided a single offset or a list in the request body's `data`."
     ),
     status_code=status.HTTP_201_CREATED,
     responses={
-        status.HTTP_201_CREATED: {"model": SimpleBody[LabwareOffset]},
+        status.HTTP_201_CREATED: {
+            "model": SimpleBody[LabwareOffset | list[LabwareOffset]]
+        },
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunNotIdle]},
     },
 )
 async def add_labware_offset(
-    request_body: RequestModel[LabwareOffsetCreate | LegacyLabwareOffsetCreate],
+    request_body: RequestModel[
+        LabwareOffsetCreate
+        | LegacyLabwareOffsetCreate
+        | list[LabwareOffsetCreate | LegacyLabwareOffsetCreate]
+    ],
     run_orchestrator_store: Annotated[
         MaintenanceRunOrchestratorStore, Depends(get_maintenance_run_orchestrator_store)
     ],
     run: Annotated[MaintenanceRun, Depends(get_run_data_from_url)],
-) -> PydanticResponse[SimpleBody[LabwareOffset]]:
-    """Add a labware offset to a maintenance run.
+) -> PydanticResponse[SimpleBody[LabwareOffset | list[LabwareOffset]]]:
+    """Add labware offsets to a maintenance run.
 
     Args:
         request_body: New labware offset request data from request body.
         run_orchestrator_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
     """
-    added_offset = run_orchestrator_store.add_labware_offset(request_body.data)
-    log.info(f'Added labware offset "{added_offset.id}"' f' to run "{run.id}".')
+    offsets_to_add = (
+        request_body.data
+        if isinstance(request_body.data, list)
+        else [request_body.data]
+    )
+
+    added_offsets: list[LabwareOffset] = []
+    for offset_to_add in offsets_to_add:
+        added_offset = run_orchestrator_store.add_labware_offset(offset_to_add)
+        added_offsets.append(added_offset)
+        log.info(f'Added labware offset "{added_offset.id}" to run "{run.id}".')
+
+    # Return a list if the client POSTed a list, or an object if the client POSTed an object.
+    # For some reason, mypy needs to be given the type annotation explicitly.
+    response_data: LabwareOffset | list[LabwareOffset] = (
+        added_offsets if isinstance(request_body.data, list) else added_offsets[0]
+    )
 
     return await PydanticResponse.create(
-        content=SimpleBody.model_construct(data=added_offset),
+        content=SimpleBody.model_construct(data=response_data),
         status_code=status.HTTP_201_CREATED,
     )
 

--- a/robot-server/robot_server/runs/router/labware_router.py
+++ b/robot-server/robot_server/runs/router/labware_router.py
@@ -35,29 +35,38 @@ labware_router = LightRouter()
 @PydanticResponse.wrap_route(
     labware_router.post,
     path="/runs/{runId}/labware_offsets",
-    summary="Add a labware offset to a run",
+    summary="Add labware offsets to a run",
     description=(
-        "Add a labware offset to an existing run, returning the created offset."
+        "Add labware offsets to an existing run, returning the created offsets."
         "\n\n"
         "There is no matching `GET /runs/{runId}/labware_offsets` endpoint."
         " To read the list of labware offsets currently on the run,"
         " see the run's `labwareOffsets` field."
+        "\n\n"
+        "The response body's `data` will either be a single offset or a list of offsets,"
+        " depending on whether you provided a single offset or a list in the request body's `data`."
     ),
     status_code=status.HTTP_201_CREATED,
     responses={
-        status.HTTP_201_CREATED: {"model": SimpleBody[LabwareOffset]},
+        status.HTTP_201_CREATED: {
+            "model": SimpleBody[LabwareOffset | list[LabwareOffset]]
+        },
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
     },
 )
 async def add_labware_offset(
-    request_body: RequestModel[LegacyLabwareOffsetCreate | LabwareOffsetCreate],
+    request_body: RequestModel[
+        LegacyLabwareOffsetCreate
+        | LabwareOffsetCreate
+        | list[LegacyLabwareOffsetCreate | LabwareOffsetCreate]
+    ],
     run_orchestrator_store: Annotated[
         RunOrchestratorStore, Depends(get_run_orchestrator_store)
     ],
     run: Annotated[Run, Depends(get_run_data_from_url)],
-) -> PydanticResponse[SimpleBody[LabwareOffset]]:
-    """Add a labware offset to a run.
+) -> PydanticResponse[SimpleBody[LabwareOffset | list[LabwareOffset]]]:
+    """Add labware offsets to a run.
 
     Args:
         request_body: New labware offset request data from request body.
@@ -69,11 +78,26 @@ async def add_labware_offset(
             status.HTTP_409_CONFLICT
         )
 
-    added_offset = run_orchestrator_store.add_labware_offset(request_body.data)
-    log.info(f'Added labware offset "{added_offset.id}"' f' to run "{run.id}".')
+    offsets_to_add = (
+        request_body.data
+        if isinstance(request_body.data, list)
+        else [request_body.data]
+    )
+
+    added_offsets: list[LabwareOffset] = []
+    for offset_to_add in offsets_to_add:
+        added_offset = run_orchestrator_store.add_labware_offset(offset_to_add)
+        added_offsets.append(added_offset)
+        log.info(f'Added labware offset "{added_offset.id}" to run "{run.id}".')
+
+    # Return a list if the client POSTed a list, or an object if the client POSTed an object.
+    # For some reason, mypy needs to be given the type annotation explicitly.
+    response_data: LabwareOffset | list[LabwareOffset] = (
+        added_offsets if isinstance(request_body.data, list) else added_offsets[0]
+    )
 
     return await PydanticResponse.create(
-        content=SimpleBody.model_construct(data=added_offset),
+        content=SimpleBody.model_construct(data=response_data),
         status_code=status.HTTP_201_CREATED,
     )
 

--- a/robot-server/robot_server/service/dependencies.py
+++ b/robot-server/robot_server/service/dependencies.py
@@ -35,7 +35,27 @@ async def get_session_manager(
 
 async def get_unique_id() -> str:
     """Get a unique ID string to use as a resource identifier."""
-    return str(uuid4())
+    return UniqueIDFactory().get()
+
+
+class UniqueIDFactory:
+    """
+    This is equivalent to the `get_unique_id()` free function. Wrapping it in a factory
+    class makes things easier for FastAPI endpoint functions that need multiple unique
+    IDs. They can do:
+
+        unique_id_factory: UniqueIDFactory = fastapi.Depends(UniqueIDFactory)
+
+    And then:
+
+        unique_id_1 = await unique_id_factory.get()
+        unique_id_2 = await unique_id_factory.get()
+    """
+
+    @staticmethod
+    def get() -> str:
+        """Get a unique ID to use as a resource identifier."""
+        return str(uuid4())
 
 
 async def get_current_time() -> datetime:

--- a/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
@@ -151,13 +151,97 @@ stages:
           totalLength: 0
 
 ---
+test_name: Test POSTing multiple offsets in a single request
+
+marks:
+  - usefixtures:
+      - ot3_server_base_url
+
+stages:
+  - name: POST multiple offsets and check the response
+    request:
+      method: POST
+      url: '{ot3_server_base_url}/labwareOffsets'
+      json:
+        data:
+          - definitionUri: testNamespace/loadName1/1
+            locationSequence:
+              - kind: onAddressableArea
+                addressableAreaName: A1
+            vector:
+              x: 1
+              y: 1
+              z: 1
+          - definitionUri: testNamespace/loadName2/1
+            locationSequence:
+              - kind: onAddressableArea
+                addressableAreaName: A2
+            vector:
+              x: 2
+              y: 2
+              z: 2
+    response:
+      status_code: 201
+      json:
+        data:
+          - id: !anystr
+            createdAt: !anystr
+            definitionUri: testNamespace/loadName1/1
+            locationSequence:
+              - kind: onAddressableArea
+                addressableAreaName: A1
+            vector:
+              x: 1
+              y: 1
+              z: 1
+          - id: !anystr
+            createdAt: !anystr
+            definitionUri: testNamespace/loadName2/1
+            locationSequence:
+              - kind: onAddressableArea
+                addressableAreaName: A2
+            vector:
+              x: 2
+              y: 2
+              z: 2
+      save:
+        json:
+          offset_1_data: data[0]
+          offset_2_data: data[1]
+
+  - name: POST an empty list of offsets and check the response
+    request:
+      method: POST
+      url: '{ot3_server_base_url}/labwareOffsets'
+      json:
+        data: []
+    response:
+      status_code: 201
+      json:
+        data: []
+
+  - name: Make sure all offsets got stored
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets'
+    response:
+      json:
+        data:
+          - !force_format_include '{offset_1_data}'
+          - !force_format_include '{offset_2_data}'
+        meta:
+          cursor: 0
+          totalLength: 2
+
+---
 # Some of the filter query parameters can have `null` values or be omitted,
 # with different semantics between the two. That distinction takes a bit of care to
 # preserve across our code, so here we test it specifically.
 test_name: Test null vs. omitted filter query parameters
+
 marks:
   - usefixtures:
       - ot3_server_base_url
+
 stages:
   - name: POST test offset 1
     request:
@@ -180,6 +264,7 @@ stages:
       save:
         json:
           offset_1_data: data
+
   - name: POST test offset 2
     request:
       method: POST
@@ -202,6 +287,7 @@ stages:
       save:
         json:
           offset_2_data: data
+
   - name: POST test offset 3
     request:
       method: POST
@@ -224,6 +310,7 @@ stages:
       save:
         json:
           offset_3_data: data
+
   - name: POST test offset 4
     request:
       method: POST
@@ -247,6 +334,7 @@ stages:
       save:
         json:
           offset_4_data: data
+
   - name: Test no filters
     request:
       url: '{ot3_server_base_url}/labwareOffsets'
@@ -258,6 +346,7 @@ stages:
           - !force_format_include '{offset_3_data}'
           - !force_format_include '{offset_4_data}'
         meta: !anydict
+
   - name: Test filtering on locationModuleModel=null
     request:
       url: '{ot3_server_base_url}/labwareOffsets?locationModuleModel=null'
@@ -267,6 +356,7 @@ stages:
           - !force_format_include '{offset_1_data}'
           - !force_format_include '{offset_3_data}'
         meta: !anydict
+
   - name: Test filtering on locationDefinitionUri=null
     request:
       url: '{ot3_server_base_url}/labwareOffsets?locationDefinitionUri=null'

--- a/robot-server/tests/maintenance_runs/router/test_labware_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_labware_router.py
@@ -50,20 +50,32 @@ def labware_definition(minimal_labware_def: LabwareDefDict) -> LabwareDefinition
     return LabwareDefinition.model_validate(minimal_labware_def)
 
 
-async def test_add_labware_offset(
+async def test_add_labware_offsets(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     run: MaintenanceRun,
 ) -> None:
-    """It should add the labware offset to the engine, assuming the run is current."""
-    labware_offset_request = pe_types.LegacyLabwareOffsetCreate(
+    """It should add the labware offsets to the engine, assuming the run is current."""
+    labware_offset_request_1 = pe_types.LegacyLabwareOffsetCreate(
         definitionUri="namespace_1/load_name_1/123",
         location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
         vector=pe_types.LabwareOffsetVector(x=1, y=2, z=3),
     )
+    labware_offset_request_2 = pe_types.LegacyLabwareOffsetCreate(
+        definitionUri="namespace_1/load_name_2/123",
+        location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+        vector=pe_types.LabwareOffsetVector(x=1, y=2, z=3),
+    )
 
-    labware_offset = pe_types.LabwareOffset(
-        id="labware-offset-id",
+    labware_offset_1 = pe_types.LabwareOffset(
+        id="labware-offset-id-1",
+        createdAt=datetime(year=2022, month=2, day=2),
+        definitionUri="labware-definition-uri",
+        location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+        vector=pe_types.LabwareOffsetVector(x=0, y=0, z=0),
+    )
+    labware_offset_2 = pe_types.LabwareOffset(
+        id="labware-offset-id-2",
         createdAt=datetime(year=2022, month=2, day=2),
         definitionUri="labware-definition-uri",
         location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
@@ -72,17 +84,39 @@ async def test_add_labware_offset(
 
     decoy.when(
         mock_maintenance_run_orchestrator_store.add_labware_offset(
-            labware_offset_request
+            labware_offset_request_1
         )
-    ).then_return(labware_offset)
+    ).then_return(labware_offset_1)
+    decoy.when(
+        mock_maintenance_run_orchestrator_store.add_labware_offset(
+            labware_offset_request_2
+        )
+    ).then_return(labware_offset_2)
 
     result = await add_labware_offset(
-        request_body=RequestModel(data=labware_offset_request),
+        request_body=RequestModel(data=labware_offset_request_1),
         run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         run=run,
     )
+    assert result.content == SimpleBody(data=labware_offset_1)
+    assert result.status_code == 201
 
-    assert result.content == SimpleBody(data=labware_offset)
+    result = await add_labware_offset(
+        request_body=RequestModel(
+            data=[labware_offset_request_1, labware_offset_request_2]
+        ),
+        run_orchestrator_store=mock_maintenance_run_orchestrator_store,
+        run=run,
+    )
+    assert result.content == SimpleBody(data=[labware_offset_1, labware_offset_2])
+    assert result.status_code == 201
+
+    result = await add_labware_offset(
+        request_body=RequestModel(data=[]),
+        run_orchestrator_store=mock_maintenance_run_orchestrator_store,
+        run=run,
+    )
+    assert result.content == SimpleBody(data=[])
     assert result.status_code == 201
 
 

--- a/robot-server/tests/runs/router/test_labware_router.py
+++ b/robot-server/tests/runs/router/test_labware_router.py
@@ -53,20 +53,32 @@ def labware_definition(minimal_labware_def: LabwareDefDict) -> LabwareDefinition
     return LabwareDefinition.model_validate(minimal_labware_def)
 
 
-async def test_add_labware_offset(
+async def test_add_labware_offsets(
     decoy: Decoy,
     mock_run_orchestrator_store: RunOrchestratorStore,
     run: Run,
 ) -> None:
-    """It should add the labware offset to the engine, assuming the run is current."""
-    labware_offset_request = pe_types.LegacyLabwareOffsetCreate(
+    """It should add the labware offsets to the engine, assuming the run is current."""
+    labware_offset_request_1 = pe_types.LegacyLabwareOffsetCreate(
         definitionUri="namespace_1/load_name_1/123",
         location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
         vector=pe_types.LabwareOffsetVector(x=1, y=2, z=3),
     )
+    labware_offset_request_2 = pe_types.LegacyLabwareOffsetCreate(
+        definitionUri="namespace_1/load_name_2/123",
+        location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+        vector=pe_types.LabwareOffsetVector(x=1, y=2, z=3),
+    )
 
-    labware_offset = pe_types.LabwareOffset(
-        id="labware-offset-id",
+    labware_offset_1 = pe_types.LabwareOffset(
+        id="labware-offset-id-1",
+        createdAt=datetime(year=2022, month=2, day=2),
+        definitionUri="labware-definition-uri",
+        location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+        vector=pe_types.LabwareOffsetVector(x=0, y=0, z=0),
+    )
+    labware_offset_2 = pe_types.LabwareOffset(
+        id="labware-offset-id-2",
         createdAt=datetime(year=2022, month=2, day=2),
         definitionUri="labware-definition-uri",
         location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
@@ -74,16 +86,36 @@ async def test_add_labware_offset(
     )
 
     decoy.when(
-        mock_run_orchestrator_store.add_labware_offset(labware_offset_request)
-    ).then_return(labware_offset)
+        mock_run_orchestrator_store.add_labware_offset(labware_offset_request_1)
+    ).then_return(labware_offset_1)
+    decoy.when(
+        mock_run_orchestrator_store.add_labware_offset(labware_offset_request_2)
+    ).then_return(labware_offset_2)
 
     result = await add_labware_offset(
-        request_body=RequestModel(data=labware_offset_request),
+        request_body=RequestModel(data=labware_offset_request_1),
         run_orchestrator_store=mock_run_orchestrator_store,
         run=run,
     )
+    assert result.content == SimpleBody(data=labware_offset_1)
+    assert result.status_code == 201
 
-    assert result.content == SimpleBody(data=labware_offset)
+    result = await add_labware_offset(
+        request_body=RequestModel(
+            data=[labware_offset_request_1, labware_offset_request_2]
+        ),
+        run_orchestrator_store=mock_run_orchestrator_store,
+        run=run,
+    )
+    assert result.content == SimpleBody(data=[labware_offset_1, labware_offset_2])
+    assert result.status_code == 201
+
+    result = await add_labware_offset(
+        request_body=RequestModel(data=[]),
+        run_orchestrator_store=mock_run_orchestrator_store,
+        run=run,
+    )
+    assert result.content == SimpleBody(data=[])
     assert result.status_code == 201
 
 


### PR DESCRIPTION
## Overview

Closes EXEC-1194.

## Test Plan and Hands on Testing

I'm leaning on automated tests.

## Changelog

* In the `POST /runs/{id}/labware_offsets` HTTP endpoint, the request `data` can now be a *list* of offset request objects, instead of just a single offset request object.

  Sending a single offset request object is still allowed, for backwards compatibility.
  
  The response shape will mirror the request shape: the server will return a list if the client sent a list, or a single object if the client sent a single object.
* Ditto for `POST /maintenance_runs/{id}/labware_offsets`.
* Ditto for `POST /labwareOffsets`.
* Update `api-client`'s binding for `/POST /runs/{id}/labware_offsets` accordingly. I don't think `api-client` has bindings for the other two endpoints yet. Also, fix a declared return type of `Run` where it looks like it should have been `LabwareOffset`.

## Review requests

Do these changes in `api-client` and `react-api-client` look right?

## Risk assessment

Low.