### PR TITLE
fix(protocol-designer): various DQA fixes

### DIFF
--- a/components/src/atoms/ListButton/__tests__/ListButton.test.tsx
+++ b/components/src/atoms/ListButton/__tests__/ListButton.test.tsx
@@ -25,7 +25,7 @@ describe('ListButton', () => {
   it('should render correct style - noActive', () => {
     render(props)
     const listButton = screen.getByTestId('ListButton_noActive')
-    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.grey30}`)
+    expect(listButton).toHaveStyle(`backgroundColor: ${COLORS.grey20}`)
   })
   it('should render correct style - connected', () => {
     props.type = 'connected'

--- a/components/src/atoms/ListButton/index.tsx
+++ b/components/src/atoms/ListButton/index.tsx
@@ -23,8 +23,8 @@ const LISTBUTTON_PROPS_BY_TYPE: Record<
   { backgroundColor: string; hoverBackgroundColor: string }
 > = {
   noActive: {
-    backgroundColor: COLORS.grey30,
-    hoverBackgroundColor: COLORS.grey35,
+    backgroundColor: COLORS.grey20,
+    hoverBackgroundColor: COLORS.grey30,
   },
   connected: {
     backgroundColor: COLORS.green30,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -248,7 +248,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
           numErrors,
           stepTypeDisplayName: i18n.format(
             t(`stepType.${formData.stepType}`),
-            'capitalize'
+            'titleCase'
           ),
           t,
         })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
@@ -24,6 +24,7 @@ import {
   Tooltip,
   useHoverTooltip,
 } from '@opentrons/components'
+import { LINK_BUTTON_STYLE } from '../../../../../../atoms'
 import {
   ABSORBANCE_READER_MAX_WAVELENGTH_NM,
   ABSORBANCE_READER_MIN_WAVELENGTH_NM,
@@ -244,6 +245,7 @@ function IntializationEditor(props: InitializationEditorProps): JSX.Element {
               text={t('step_edit_form.absorbanceReader.add_wavelength.label')}
               textAlignment="left"
               disabled={numWavelengths === MAX_WAVELENGTHS}
+              iconName="plus"
             />
           </Flex>
         ) : null}
@@ -337,13 +339,12 @@ function WavelengthItem(props: WavelengthItemProps): JSX.Element {
           onClick={() => {
             handleDeleteWavelength(index)
           }}
-          alignSelf={ALIGN_FLEX_END}
           padding={SPACING.spacing4}
+          css={LINK_BUTTON_STYLE}
+          alignSelf={ALIGN_FLEX_END}
+          textDecoration={TEXT_DECORATION_UNDERLINE}
         >
-          <StyledText
-            desktopStyle="bodyDefaultRegular"
-            textDecoration={TEXT_DECORATION_UNDERLINE}
-          >
+          <StyledText desktopStyle="bodyDefaultRegular">
             {t('step_edit_form.absorbanceReader.delete')}
           </StyledText>
         </Btn>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepOverflowButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepOverflowButton.tsx
@@ -45,7 +45,7 @@ export function AddStepOverflowButton(
         <StyledText desktopStyle="bodyDefaultRegular">
           {i18n.format(
             t(`application:stepType.${stepType}`, stepType),
-            'capitalize'
+            'titleCase'
           )}
         </StyledText>
       </MenuButton>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -62,7 +62,7 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
     setOpenedOverflowMenuId,
     sidebarWidth,
   } = props
-  const { t } = useTranslation('application')
+  const { i18n, t } = useTranslation('application')
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const stepIds = useSelector(getOrderedStepIds)
   const step = useSelector(stepFormSelectors.getSavedStepForms)[stepId]
@@ -227,7 +227,8 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
         onMouseEnter={highlightStep}
         iconName={hasError || hasWarnings ? 'alert-circle' : iconName}
         title={`${stepNumber}. ${
-          step.stepName || t(`stepType.${step.stepType}`)
+          i18n.format(step.stepName, 'titleCase') ||
+          t(`stepType.${step.stepType}`)
         }`}
         dragHovered={dragHovered}
         sidebarWidth={sidebarWidth}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -87,7 +87,7 @@ describe('AddStepButton', () => {
     screen.getByText('Mix')
     screen.getByText('Pause')
     screen.getByText('Thermocycler')
-    screen.getByText('Heater-shaker')
+    screen.getByText('Heater-Shaker')
     screen.getByText('Temperature')
     screen.getByText('Magnet')
   })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
@@ -115,6 +115,6 @@ describe('ProtocolSteps', () => {
 
   it('renders the current step name', () => {
     render()
-    screen.getByText('Custom pause')
+    screen.getByText('Custom Pause')
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -120,7 +120,7 @@ export function ProtocolSteps(): JSX.Element {
           >
             {currentStep != null && hoveredTerminalItem == null ? (
               <StyledText desktopStyle="headingSmallBold">
-                {i18n.format(currentStep.stepName, 'capitalize')}
+                {i18n.format(currentStep.stepName, 'titleCase')}
               </StyledText>
             ) : null}
             {(hoveredTerminalItem != null || selectedTerminalItem != null) &&


### PR DESCRIPTION
# Overview

This PR provides DQA fixes for 8.4.0 alpha.1.

Closes RQA-3929, Closes RQA-3930, Closes RQA-3931, Closes RQA-3933, Closes RQA-3934

## Test Plan and Hands on Testing

#### Timeline Toolbox
- verify that draggable step names are title-cased
- in add step overflow menu, verify that step names are title-cased

**before**: 
<img width="480" alt="Screenshot 2025-02-05 at 3 39 12 PM" src="https://github.com/user-attachments/assets/7780cf06-2fc5-4cf7-a234-167e021854bd" />

**after**: 
<img width="478" alt="Screenshot 2025-02-05 at 3 37 10 PM" src="https://github.com/user-attachments/assets/606cc636-fc59-40bf-8d54-8bbc18eb5991" />

#### Absorbance reader toolbox
- In lid controls, verify that `ListButton` is correct updated styling (grey20, grey30 for hover). Note that this component is updated across the application according to designs
- In initialization settings (multi setting), verify that empty selector button for "add wavelength" now has a "+" icon
- In initialization settings (multi setting), verify that "delete" link has correct style (blue hover)

**before**: 
<img width="346" alt="Screenshot 2025-02-05 at 3 39 52 PM" src="https://github.com/user-attachments/assets/171037e5-b044-44ea-a167-961ee33eaa37" />


https://github.com/user-attachments/assets/ee39ea3a-d2d1-4a58-92c9-eaa82864c4b8


**after**: 
<img width="301" alt="Screenshot 2025-02-05 at 3 37 58 PM" src="https://github.com/user-attachments/assets/e2feeaa0-d8a8-4e26-a86b-3fcdaed0de0a" />

https://github.com/user-attachments/assets/69cf7288-5c49-48b7-96fd-82271a0344a4


## Changelog

- capitalize step names
- fix "delete" wavelength link
- fix "add wavelength" button icon
- fix `ListButton` style
- fix tests

## Review requests

see test plan

## Risk assessment

low
