### PR TITLE
docs(robot-server): Include `/labwareOffsets` endpoints in docs again

### DIFF
--- a/robot-server/robot_server/labware_offsets/router.py
+++ b/robot-server/robot_server/labware_offsets/router.py
@@ -52,7 +52,6 @@ router = LightRouter()
         """
     ),
     status_code=201,
-    include_in_schema=False,  # todo(mm, 2025-01-08): Include for v8.4.0.
 )
 async def post_labware_offset(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],
@@ -91,7 +90,6 @@ async def post_labware_offset(  # noqa: D103
         " Filters are ANDed together."
         " Results are returned in order from oldest to newest."
     ),
-    include_in_schema=False,  # todo(mm, 2025-01-08): Include for v8.4.0.
 )
 async def get_labware_offsets(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],
@@ -183,7 +181,6 @@ async def get_labware_offsets(  # noqa: D103
     path="/labwareOffsets/{id}",
     summary="Delete a single labware offset",
     description="Delete a single labware offset. The deleted offset is returned.",
-    include_in_schema=False,  # todo(mm, 2025-01-08): Include for v8.4.0.
 )
 async def delete_labware_offset(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],
@@ -206,7 +203,6 @@ async def delete_labware_offset(  # noqa: D103
     router.delete,
     path="/labwareOffsets",
     summary="Delete all labware offsets",
-    include_in_schema=False,  # todo(mm, 2025-01-08): Include for v8.4.0.
 )
 async def delete_all_labware_offsets(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],


### PR DESCRIPTION
These HTTP API endpoints were hidden from the docs because they were incomplete and we didn't want the soon-to-be-released v8.3.0 software to advertise them.

v8.3.0 is in its own branch now, so we can undo that, so the docs match the in-development state of v8.4.0.

Reverts commit 5f869ea04c29cb6d1b2e4884af8d859dbbd88149, PR #17219.