### PR TITLE
fix(components, protocol-designer): fix design bugs from PD 8.4.0 alpha.1

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -332,7 +332,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
                       </StyledText>
                       <StyledText
                         desktopStyle="captionRegular"
-                        color={COLORS.black70}
+                        color={COLORS.grey60}
                       >
                         {option.subtext}
                       </StyledText>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
@@ -282,6 +282,7 @@ function WavelengthItem(props: WavelengthItemProps): JSX.Element {
     handleDeleteWavelength,
     index,
     error,
+    mode,
   } = props
   const { t } = useTranslation('form')
   const showCustom = !DEFINED_OPTIONS.some(({ value }) => value === wavelength)
@@ -332,7 +333,7 @@ function WavelengthItem(props: WavelengthItemProps): JSX.Element {
           error={!isFocused ? error : null}
         />
       ) : null}
-      {wavelengths.length > 1 ? (
+      {wavelengths.length > 1 && mode === 'multi' ? (
         <Btn
           onClick={() => {
             handleDeleteWavelength(index)

--- a/protocol-designer/src/ui/modules/selectors.ts
+++ b/protocol-designer/src/ui/modules/selectors.ts
@@ -19,6 +19,7 @@ import {
 import type { DropdownOption } from '@opentrons/components'
 import type { Selector } from '../../types'
 import type { LabwareNamesByModuleId } from '../../steplist/types'
+import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
 
 export const getLabwareNamesByModuleId: Selector<LabwareNamesByModuleId> = createSelector(
   getInitialDeckSetup,
@@ -86,11 +87,11 @@ export const getHeaterShakerLabwareOptions: Selector<
 export const getAbsorbanceReaderLabwareOptions: Selector<
   DropdownOption[]
 > = createSelector(
-  getInitialDeckSetup,
+  getDeckSetupForActiveItem,
   getLabwareNicknamesById,
-  (initialDeckSetup, nicknamesById) => {
+  (deckSetup, nicknamesById) => {
     const absorbanceReaderModuleOptions = getModuleLabwareOptions(
-      initialDeckSetup,
+      deckSetup,
       nicknamesById,
       ABSORBANCE_READER_TYPE
     )

--- a/protocol-designer/src/ui/modules/selectors.ts
+++ b/protocol-designer/src/ui/modules/selectors.ts
@@ -8,6 +8,7 @@ import {
   TEMPERATURE_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { getInitialDeckSetup } from '../../step-forms/selectors'
+import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
 import { getLabwareNicknamesById } from '../labware/selectors'
 import {
   getModuleLabwareOptions,
@@ -19,7 +20,6 @@ import {
 import type { DropdownOption } from '@opentrons/components'
 import type { Selector } from '../../types'
 import type { LabwareNamesByModuleId } from '../../steplist/types'
-import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
 
 export const getLabwareNamesByModuleId: Selector<LabwareNamesByModuleId> = createSelector(
   getInitialDeckSetup,


### PR DESCRIPTION
# Overview

Fix several bugs including
1) properly displaying labware on absorbance reader in absorbance reader step form module options
2) removing the 'delete' button from wavelengths if selected insitialization mode is 'single'

Closes RQA-3942, Closes RQA-3945

## Test plan

#### Initialization bug RQA-3942
- open or create absorbance reader initialization step and select multi mode
- add several wavelengths, then switch to single mode
- verify that "delete" button does not render when in single mode

#### labware bug RQA-3945
- create or load a protocol with a plate reader and a plate reader-compatible labware
- create a step to open the plate reader lid
- create a move step to move the labware into the plate reader
- create a new plate reader step. inspect module options and verify that both the labware name and the plate reader show (both for single option and multiple options)
<img width="323" alt="Screenshot 2025-02-05 at 5 33 07 PM" src="https://github.com/user-attachments/assets/4052dc5f-a825-4339-a768-460c9280331d" />
<img width="312" alt="Screenshot 2025-02-05 at 5 31 57 PM" src="https://github.com/user-attachments/assets/0f285a6e-3268-4381-8d55-02c19b3802b7" />

## Changelog

- fix selector to take in robot state at active item rather than initial deck state for absorbance reader labware
- fix logic for render 'delete' button for wavelengths

## Review requests

see test plan

## Risk assessment

low