### PR TITLE
fix(protocol-designer): fix presaved absorbance reader step form type

### DIFF
--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -305,10 +305,10 @@ const _patchAbsorbanceReaderModuleId = (args: {
     )?.length ?? 1
   const hasAbsorbanceReaderModuleId = stepType === 'absorbanceReader'
 
-  const { modules } = initialDeckSetup
   const robotState: RobotState | null =
     last(robotStateTimeline.timeline)?.robotState ?? null
 
+  const modules = robotState?.modules ?? {}
   const labware = robotState?.labware ?? {}
 
   // pre-select form type if module is set


### PR DESCRIPTION
# Overview

Properly preselect absorbance reader form type based on the module state at the creation of that form. The bug here arose from using the initial robot state to determine module state rather than the current robot state.

Closes RQA-3943

## Test Plan and Hands on Testing

- create a protocol with an absorbance reader
- create an absorbance reader step and verify that initialization option preselects
- create the initialization, open the lid, and move a compatible labware to the plate reader
- create a new absorbance reader step and verify that the 'read' option preselects

## Changelog

- fix logic for module state in `createPresavedStepForm`

## Review requests

see test plan

## Risk assessment

low-med