### PR TITLE
fix(components, protocol-designer): fix lineclamp for dropdown menu

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -27,6 +27,7 @@ import { LiquidIcon } from '../LiquidIcon'
 import { DeckInfoLabel } from '../DeckInfoLabel'
 
 import type { FocusEventHandler } from 'react'
+import type { FlattenSimpleInterpolation } from 'styled-components'
 
 export interface DropdownOption {
   name: string
@@ -268,7 +269,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
             >
               <StyledText
                 desktopStyle="captionRegular"
-                css={LINE_CLAMP_TEXT_STYLE}
+                css={LINE_CLAMP_TEXT_STYLE(1)}
               >
                 {currentOption.name}
               </StyledText>
@@ -327,7 +328,10 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
                       flexDirection={DIRECTION_COLUMN}
                       gridGap={option.subtext != null ? SPACING.spacing4 : '0'}
                     >
-                      <StyledText desktopStyle="captionRegular">
+                      <StyledText
+                        desktopStyle="captionRegular"
+                        css={LINE_CLAMP_TEXT_STYLE(3)}
+                      >
                         {option.name}
                       </StyledText>
                       <StyledText
@@ -363,12 +367,17 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
   )
 }
 
-const LINE_CLAMP_TEXT_STYLE = css`
+export const LINE_CLAMP_TEXT_STYLE = (
+  lineClamp?: number,
+  title?: boolean
+): FlattenSimpleInterpolation => css`
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: ${OVERFLOW_HIDDEN};
   text-overflow: ellipsis;
   word-wrap: break-word;
-  -webkit-line-clamp: 1;
-  word-break: break-all;
+  -webkit-line-clamp: ${lineClamp ?? 1};
+  word-break: ${title === true
+    ? 'normal'
+    : 'break-all'}; // normal for tile and break-all for a non word case like aaaaaaaa
 `

--- a/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
@@ -7,6 +7,7 @@ import {
   DeckInfoLabel,
   DropdownMenu,
   Flex,
+  LINE_CLAMP_TEXT_STYLE,
   ListItem,
   SPACING,
   StyledText,
@@ -122,7 +123,10 @@ export function DropdownStepFormField(
                 flexDirection={DIRECTION_COLUMN}
                 gridGap={options[0].subtext != null ? SPACING.spacing4 : '0'}
               >
-                <StyledText desktopStyle="captionRegular">
+                <StyledText
+                  desktopStyle="captionRegular"
+                  css={LINE_CLAMP_TEXT_STYLE(3)}
+                >
                   {options[0].name}
                 </StyledText>
                 <StyledText


### PR DESCRIPTION
# Overview

According to designs, the main text for a dropdown option should be clamped to 3 lines maximum. In the event that only one option is produced in DropDownStepFormField, the line clamp should also apply to the returned styled text.

Closes RQA-3945

## Test Plan and Hands on Testing

- import or create a [protocol](https://github.com/user-attachments/files/18693926/demo.4.json) with multiple absorbance readers
- add an absorbance reader-compatible labware with very long name
- open a reader and move the labware to it
- create an absorbance reader step and verify that the dropdown menu shows the labware name with absorbance reader, and clamps at 3 lines
<img width="329" alt="Screenshot 2025-02-06 at 12 18 16 PM" src="https://github.com/user-attachments/assets/c9ca271e-1769-4ba3-a9d7-1f031e3e8ead" />


- repeat for a [protocol](https://github.com/user-attachments/files/18693927/demo.5.json) with a single absorbance reader

<img width="332" alt="Screenshot 2025-02-06 at 12 20 54 PM" src="https://github.com/user-attachments/assets/65237ca4-1841-4ade-b114-36c2dc822690" />

## Changelog

- fix line clamp style for dropdown option

## Review requests

see test plan

## Risk assessment

low