### PR TITLE
feat(protocol-designer): start wiring up "Export Python" button to generate Python

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -14,7 +14,11 @@ import {
   fixture_tiprack_300_ul,
 } from '@opentrons/shared-data/labware/fixtures/2'
 import { getLoadLiquidCommands } from '../../load-file/migration/utils/getLoadLiquidCommands'
-import { createFile, getLabwareDefinitionsInUse } from '../selectors'
+import {
+  createFile,
+  createPythonFile,
+  getLabwareDefinitionsInUse,
+} from '../selectors'
 import {
   fileMetadata,
   dismissedWarnings,
@@ -92,7 +96,29 @@ describe('createFile selector', () => {
       ingredLocations
     )
   })
+
+  it('should return a valid Python protocol file', () => {
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
+    const result = createPythonFile.resultFunc(fileMetadata, {})
+    // This is just a quick smoke test to make sure createPythonFile() produces
+    // something that looks like a Python file. The individual sections of the
+    // generated Python will be tested in separate unit tests.
+    expect(result).toBe(
+      `
+from contextlib import nullcontext as pd_step
+from opentrons import protocol_api
+
+metadata = {
+    "protocolName": "Test Protocol",
+    "author": "The Author",
+    "description": "Protocol description",
+    "created": "2020-02-25T21:48:32.515Z",
+}
+`.trimStart()
+    )
+  })
 })
+
 describe('getLabwareDefinitionsInUse util', () => {
   it('should exclude definitions that are neither on the deck nor assigned to a pipette', () => {
     const assignedTiprackOnDeckDef = fixture_tiprack_10_ul

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { pythonMetadata } from '../selectors/pythonFile'
+
+describe('pythonMetadata', () => {
+  it('should generate metadata section', () => {
+    expect(
+      pythonMetadata({
+        protocolName: 'Name of Protocol',
+        author: 'Some Author',
+        description: 'The description.',
+        created: 1000000000000,
+        lastModified: 1000000001000,
+        category: 'PCR',
+        subcategory: 'PCR Prep',
+        tags: ['wombat', 'kangaroo', 'wallaby'],
+      })
+    ).toBe(
+      `
+metadata = {
+    "protocolName": "Name of Protocol",
+    "author": "Some Author",
+    "description": "The description.",
+    "created": "2001-09-09T01:46:40.000Z",
+    "lastModified": "2001-09-09T01:46:41.000Z",
+    "category": "PCR",
+    "subcategory": "PCR Prep",
+    "tags": "wombat, kangaroo, wallaby",
+}`.trimStart()
+    )
+  })
+})

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -26,6 +26,7 @@ import {
   getModulesLoadInfo,
   getPipettesLoadInfo,
 } from './utils'
+import { pythonImports, pythonMetadata } from './pythonFile'
 
 import type { SecondOrderCommandAnnotation } from '@opentrons/shared-data/commandAnnotation/types'
 import type {
@@ -47,7 +48,6 @@ import type {
 import type { LabwareDefByDefURI } from '../../labware-defs'
 import type { Selector } from '../../types'
 import type { PDMetadata } from '../../file-types'
-import { pythonImports, pythonMetadata } from './pythonFile'
 
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
 // console.assert(!isEmpty(process.env.OT_PD_VERSION), 'Could not find application version!')

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -47,6 +47,7 @@ import type {
 import type { LabwareDefByDefURI } from '../../labware-defs'
 import type { Selector } from '../../types'
 import type { PDMetadata } from '../../file-types'
+import { pythonImports, pythonMetadata } from './pythonFile'
 
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
 // console.assert(!isEmpty(process.env.OT_PD_VERSION), 'Could not find application version!')
@@ -272,5 +273,20 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       ...commandv8Mixin,
       ...commandAnnotionaV1Mixin,
     }
+  }
+)
+
+export const createPythonFile: Selector<string> = createSelector(
+  getFileMetadata,
+  fileMetadata => {
+    return (
+      [
+        // Here are the sections of the Python file:
+        pythonImports(),
+        pythonMetadata(fileMetadata),
+      ]
+        .filter(section => section) // skip any blank sections
+        .join('\n\n') + '\n'
+    )
   }
 )

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -1,0 +1,31 @@
+/** Generate sections of the Python file for fileCreator.ts */
+
+import { formatPyDict } from '@opentrons/step-generation'
+import type { FileMetadataFields } from '../types'
+
+export function pythonImports(): string {
+  return [
+    'from contextlib import nullcontext as pd_step',
+    'from opentrons import protocol_api',
+  ].join('\n')
+}
+
+export function pythonMetadata(fileMetadata: FileMetadataFields): string {
+  // FileMetadataFields has timestamps, lists, etc., but Python metadata dict can only contain strings
+  function formatTimestamp(timestamp: number | null | undefined): string {
+    return timestamp ? new Date(timestamp).toISOString() : ''
+  }
+  const stringifiedMetadata = Object.fromEntries(
+    Object.entries({
+      protocolName: fileMetadata.protocolName,
+      author: fileMetadata.author,
+      description: fileMetadata.description,
+      created: formatTimestamp(fileMetadata.created),
+      lastModified: formatTimestamp(fileMetadata.lastModified),
+      category: fileMetadata.category,
+      subcategory: fileMetadata.subcategory,
+      tags: fileMetadata.tags?.length && fileMetadata.tags.join(', '),
+    }).filter(([key, value]) => value) // drop blank entries
+  )
+  return `metadata = ${formatPyDict(stringifiedMetadata)}`
+}

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -1,6 +1,6 @@
 import { migration } from './migration'
 import { selectors as fileDataSelectors } from '../file-data'
-import { saveFile } from './utils'
+import { saveFile, savePythonFile } from './utils'
 
 import type { SyntheticEvent } from 'react'
 import type { PDProtocolFile } from '../file-types'
@@ -111,4 +111,24 @@ export const saveProtocolFile: () => ThunkAction<SaveProtocolFileAction> = () =>
     fileDataSelectors.getFileMetadata(state).protocolName || 'untitled'
   const fileName = `${protocolName}.json`
   saveFile(fileData, fileName)
+}
+// Eventually this will replace saveProtocolFile:
+export const savePythonProtocolFile: () => ThunkAction<SaveProtocolFileAction> = () => (
+  dispatch,
+  getState
+) => {
+  // dispatching this should update the state, eg lastModified timestamp
+  dispatch({
+    type: 'SAVE_PROTOCOL_FILE',
+  })
+  const state = getState()
+  const fileData = fileDataSelectors.createPythonFile(state)
+  const protocolName =
+    fileDataSelectors.getFileMetadata(state).protocolName || 'untitled'
+  // unlike JSON files, Python filenames can't have funny characters
+  const fileName = `${protocolName
+    .trim()
+    .replace(/\S+/g, '_')
+    .replace(/[^A-Za-z0-9_]/g, '')}.py`
+  savePythonFile(fileData, fileName)
 }

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -6,3 +6,9 @@ export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
   })
   saveAs(blob, fileName)
 }
+export const savePythonFile = (fileData: string, fileName: string): void => {
+  const blob = new Blob([fileData], { type: 'text/x-python;charset=UTF-8' })
+  // For now, show the generated Python in a new window instead of saving it to a file.
+  // (A saved Python file wouldn't be runnable anyway until we finish this project.)
+  window.open(URL.createObjectURL(blob), '_blank')
+}

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -301,9 +301,9 @@ export function ProtocolOverview(): JSX.Element {
             {enablePythonExport ? (
               <LargeButton
                 buttonType="stroke"
-                buttonText="Export python"
+                buttonText="Export Python"
                 onClick={() => {
-                  console.log('wire this up')
+                  dispatch(loadFileActions.savePythonProtocolFile())
                 }}
                 whiteSpace={NO_WRAP}
                 height="3.5rem"


### PR DESCRIPTION
# Overview

Make the "Export Python" button start generating the skeleton of a Python protocol file. This just generates the `metadata` section right now. AUTH-1091 AUTH-1393 AUTH-1385

I tried to follow the structure of the existing `createFile()` function. Eventually, the `createPythonFile()` function is just going to replace `createFile()`, so that's why I'm reusing the existing `SAVE_PROTOCOL_FILE` action rather than defining a bunch of new Python-specific constants and interfaces.

## Test Plan and Hands on Testing

Added unit tests for both the top-level file creator, and for the specific metadata fields.

I also tested the button in my browser.

## Risk assessment

Low. This is all hidden behind a feature flag, and doesn't interact with any existing functionality.