### PR TITLE
fix(app): fix multi-location tip selection during error recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/shared/TipSelection.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TipSelection.tsx
@@ -37,6 +37,7 @@ export function TipSelection(props: TipSelectionProps): JSX.Element {
         relevantActiveNozzleLayout
       )}
       allowSelect={allowTipSelection}
+      allowMultiDrag={false}
     />
   )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TipSelection.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TipSelection.test.tsx
@@ -42,6 +42,7 @@ describe('TipSelection', () => {
         channels:
           props.failedPipetteUtils.failedPipetteInfo?.data.channels ?? 1,
         allowSelect: props.allowTipSelection,
+        allowMultiDrag: false,
         pipetteNozzleDetails: undefined,
       }),
       {}

--- a/app/src/organisms/WellSelection/index.tsx
+++ b/app/src/organisms/WellSelection/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import reduce from 'lodash/reduce'
+import pick from 'lodash/pick'
 
 import { COLORS, Labware, RobotCoordinateSpace } from '@opentrons/components'
 import {
@@ -29,6 +30,8 @@ interface WellSelectionProps {
   pipetteNozzleDetails?: NozzleLayoutDetails
   /* Whether highlighting and selectWells() updates are permitted. */
   allowSelect?: boolean
+  /* Whether selecting more than the channel count of well locations is permitted. */
+  allowMultiDrag?: boolean
 }
 
 export function WellSelection(props: WellSelectionProps): JSX.Element {
@@ -40,6 +43,7 @@ export function WellSelection(props: WellSelectionProps): JSX.Element {
     channels,
     pipetteNozzleDetails,
     allowSelect = true,
+    allowMultiDrag = true,
   } = props
   const [highlightedWells, setHighlightedWells] = useState<WellGroup>({})
 
@@ -61,16 +65,21 @@ export function WellSelection(props: WellSelectionProps): JSX.Element {
           })
           if (!wellSet) {
             return acc
+          } else if (allowMultiDrag) {
+            return { ...acc, [wellSet[0]]: null }
+          } else {
+            return { [wellSet[0]]: null }
           }
-          return { ...acc, [wellSet[0]]: null }
         },
         {}
       )
       return primaryWells
+    } else {
+      // single-channel or ingred selection mode
+      return allowMultiDrag
+        ? selectedWells
+        : pick(selectedWells, Object.keys(selectedWells)[0])
     }
-
-    // single-channel or ingred selection mode
-    return selectedWells
   }
 
   const _getWellsFromRect: (rect: GenericRect) => WellGroup = rect => {


### PR DESCRIPTION
Closes [RQA-3927](https://opentrons.atlassian.net/browse/RQA-3927)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

During Error Recovery, when a user selects a "retry tip pickup location", it should not be possible to drag select multiple wells. This PR adds an optional prop to `WellSection` for permitting drag, and disables drag during Error Recovery.

### Current Behavior

https://github.com/user-attachments/assets/0b31e0be-d230-4b3e-bac4-6b027d40515b

### Fixed Behavior

https://github.com/user-attachments/assets/d3a77257-18bf-4542-abb3-85238eec3767

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
- Verified the pipette moves to the correct, selected tip location(s).
- Verified QT flows remain unaffected by the change.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed drag-selection for tip-pickup in Error Recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3927]: https://opentrons.atlassian.net/browse/RQA-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ