### PR TITLE
docs(api): clarify in docs that Well.has_tip checks only for unused tips

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -115,8 +115,23 @@ class Well:
     @property
     @requires_version(2, 0)
     def has_tip(self) -> bool:
-        """Whether this well contains a tip. Always ``False`` if the parent labware
-        isn't a tip rack."""
+        """Whether this well contains an unused tip.
+
+        From API v2.2 on:
+
+        - Returns ``False`` if:
+
+          - the well has no tip present, or
+          - the well has a tip that's been used by the protocol previously
+
+        - Returns ``True`` if the well has an unused tip.
+
+        Before API v2.2:
+
+        - Returns ``True`` as long as the well has a tip, even if it is used.
+
+        Always ``False`` if the parent labware isn't a tip rack.
+        """
         return self._core.has_tip()
 
     @has_tip.setter


### PR DESCRIPTION
Cherry-picked commit for 8.3.0 release branch

Original PR: #17412 
Closes RQA-3790

# Overview

`Well.has_tip` property has been checking for only clean/ unused tips since API v2.2 but the docstrings don't mention that. That has understandably caused some confusion in protocol behaviors. This PR helps mitigate that issue by clarifying the exact behavior of this property

## Risk assessment

None.
