### PR TITLE
fix(components, protocol-designer): fix word break in dropdown menu

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -330,7 +330,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
                     >
                       <StyledText
                         desktopStyle="captionRegular"
-                        css={LINE_CLAMP_TEXT_STYLE(3)}
+                        css={LINE_CLAMP_TEXT_STYLE(3, true)}
                       >
                         {option.name}
                       </StyledText>
@@ -369,7 +369,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
 
 export const LINE_CLAMP_TEXT_STYLE = (
   lineClamp?: number,
-  title?: boolean
+  wordBreak?: boolean
 ): FlattenSimpleInterpolation => css`
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -377,7 +377,7 @@ export const LINE_CLAMP_TEXT_STYLE = (
   text-overflow: ellipsis;
   word-wrap: break-word;
   -webkit-line-clamp: ${lineClamp ?? 1};
-  word-break: ${title === true
+  word-break: ${wordBreak === true
     ? 'normal'
     : 'break-all'}; // normal for tile and break-all for a non word case like aaaaaaaa
 `

--- a/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
@@ -125,7 +125,7 @@ export function DropdownStepFormField(
               >
                 <StyledText
                   desktopStyle="captionRegular"
-                  css={LINE_CLAMP_TEXT_STYLE(3)}
+                  css={LINE_CLAMP_TEXT_STYLE(3, true)}
                 >
                   {options[0].name}
                 </StyledText>


### PR DESCRIPTION
# Overview

According to designs, the main text for a dropdown option should be clamped to 3 lines maximum. In the event that only one option is produced in DropDownStepFormField, the line clamp should also apply to the returned styled text.

Closes RQA-3950

## Test Plan and Hands on Testing

- import or create a [protocol](https://github.com/user-attachments/files/18693926/demo.4.json) with multiple absorbance readers
- add an absorbance reader-compatible labware with very long name
- open a reader and move the labware to it
- create an absorbance reader step and verify that the dropdown menu shows the labware name with absorbance reader, and clamps at 3 lines
<img width="329" alt="Screenshot 2025-02-06 at 12 18 16 PM" src="https://github.com/user-attachments/assets/c9ca271e-1769-4ba3-a9d7-1f031e3e8ead" />


- repeat for a [protocol](https://github.com/user-attachments/files/18693927/demo.5.json) with a single absorbance reader

<img width="332" alt="Screenshot 2025-02-06 at 12 20 54 PM" src="https://github.com/user-attachments/assets/65237ca4-1841-4ade-b114-36c2dc822690" />

## Changelog

- fix line clamp style for dropdown option

## Review requests

see test plan

## Risk assessment

low