### PR TITLE
fix(app): translate close button text for ODD toasts

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -31,7 +31,7 @@ export function useSoftwareUpdatePoll(): void {
 
 export function useProtocolReceiptToast(): void {
   const host = useHost()
-  const { t } = useTranslation('protocol_info')
+  const { t, i18n } = useTranslation(['protocol_info', 'shared'])
   const { makeToast } = useToaster()
   const queryClient = useQueryClient()
   const protocolIdsQuery = useAllProtocolIdsQuery(
@@ -83,7 +83,7 @@ export function useProtocolReceiptToast(): void {
               }) as string,
               'success',
               {
-                closeButton: true,
+                buttonText: i18n.format(t('shared:close'), 'capitalize'),
                 disableTimeout: true,
                 displayType: 'odd',
               }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
@@ -27,6 +27,7 @@ export function useRecoveryToasts({
   ...rest
 }: BuildToast): RecoveryToasts {
   const { currentStepNumber, hasRunDiverged } = stepCounts
+  const { i18n, t } = useTranslation('shared')
   const { makeToast } = useToaster()
   const displayType = isOnDevice ? 'odd' : 'desktop'
 
@@ -53,6 +54,10 @@ export function useRecoveryToasts({
   const makeSuccessToast = (): void => {
     if (selectedRecoveryOption !== RECOVERY_MAP.CANCEL_RUN.ROUTE) {
       makeToast(bodyText, 'success', {
+        buttonText:
+          displayType === 'odd'
+            ? i18n.format(t('shared:close'), 'capitalize')
+            : undefined,
         closeButton: true,
         disableTimeout: true,
         displayType,

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectDestWells.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectDestWells.tsx
@@ -123,7 +123,7 @@ export function SelectDestWells(props: SelectDestWellsProps): JSX.Element {
         }) as string,
         'error',
         {
-          closeButton: true,
+          buttonText: i18n.format(t('shared:close'), 'capitalize'),
           disableTimeout: true,
           displayType: 'odd',
           linkText: t('learn_more'),


### PR DESCRIPTION
fix RQA-3946

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
ODD toasts that pass `closeButton=true` in props were showing an un-translated "Close". This PR passes the `buttonText` prop instead, so that the string will be translated
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Look at one of these toasts on ODD with language as english and Chinese
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->
<img width="1015" alt="Screenshot 2025-02-06 at 5 48 56 PM" src="https://github.com/user-attachments/assets/bb18f4fe-df5f-459c-910b-974107933b81" />
<img width="1025" alt="Screenshot 2025-02-06 at 5 48 35 PM" src="https://github.com/user-attachments/assets/8d311719-0d19-4cb6-bd95-01690d319c98" />


## Changelog
Use `buttonText` instead of `closeButton` boolean prop
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick code check
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
