### PR TITLE
chore(shared-data,app): Block evotips labware from PD, LL, and Quick Transfer

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/constants.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/constants.ts
@@ -100,7 +100,6 @@ export const SINGLE_CHANNEL_COMPATIBLE_LABWARE = [
   'opentrons/thermoscientificnunc_96_wellplate_2000ul/1',
   'opentrons/usascientific_12_reservoir_22ml/1',
   'opentrons/usascientific_96_wellplate_2.4ml_deep/1',
-  'opentrons/evotips_opentrons_96_labware/1',
 ]
 
 export const EIGHT_CHANNEL_COMPATIBLE_LABWARE = [
@@ -145,7 +144,6 @@ export const EIGHT_CHANNEL_COMPATIBLE_LABWARE = [
   'opentrons/thermoscientificnunc_96_wellplate_2000ul/1',
   'opentrons/usascientific_12_reservoir_22ml/1',
   'opentrons/usascientific_96_wellplate_2.4ml_deep/1',
-  'opentrons/evotips_opentrons_96_labware/1',
 ]
 
 export const NINETY_SIX_CHANNEL_COMPATIBLE_LABWARE = [
@@ -190,5 +188,4 @@ export const NINETY_SIX_CHANNEL_COMPATIBLE_LABWARE = [
   'opentrons/thermoscientificnunc_96_wellplate_2000ul/1',
   'opentrons/usascientific_12_reservoir_22ml/1',
   'opentrons/usascientific_96_wellplate_2.4ml_deep/1',
-  'opentrons/evotips_opentrons_96_labware/1',
 ]

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getCompatibleLabwareByCategory.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getCompatibleLabwareByCategory.ts
@@ -7,6 +7,7 @@ import {
   EIGHT_CHANNEL_COMPATIBLE_LABWARE,
   NINETY_SIX_CHANNEL_COMPATIBLE_LABWARE,
 } from '../constants'
+
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { LabwareFilter } from '/app/local-resources/labware'
 
@@ -15,7 +16,6 @@ export function getCompatibleLabwareByCategory(
   category: LabwareFilter
 ): LabwareDefinition2[] | undefined {
   const allLabwareDefinitions = getAllDefinitions(LABWAREV2_DO_NOT_LIST)
-  console.log(allLabwareDefinitions)
   let compatibleLabwareUris: string[] = SINGLE_CHANNEL_COMPATIBLE_LABWARE
   if (pipetteChannels === 8) {
     compatibleLabwareUris = EIGHT_CHANNEL_COMPATIBLE_LABWARE

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getCompatibleLabwareByCategory.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getCompatibleLabwareByCategory.ts
@@ -1,10 +1,12 @@
-import { getAllDefinitions } from '@opentrons/shared-data'
+import {
+  getAllDefinitions,
+  LABWAREV2_DO_NOT_LIST,
+} from '@opentrons/shared-data'
 import {
   SINGLE_CHANNEL_COMPATIBLE_LABWARE,
   EIGHT_CHANNEL_COMPATIBLE_LABWARE,
   NINETY_SIX_CHANNEL_COMPATIBLE_LABWARE,
 } from '../constants'
-
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { LabwareFilter } from '/app/local-resources/labware'
 
@@ -12,7 +14,8 @@ export function getCompatibleLabwareByCategory(
   pipetteChannels: 1 | 8 | 96,
   category: LabwareFilter
 ): LabwareDefinition2[] | undefined {
-  const allLabwareDefinitions = getAllDefinitions()
+  const allLabwareDefinitions = getAllDefinitions(LABWAREV2_DO_NOT_LIST)
+  console.log(allLabwareDefinitions)
   let compatibleLabwareUris: string[] = SINGLE_CHANNEL_COMPATIBLE_LABWARE
   if (pipetteChannels === 8) {
     compatibleLabwareUris = EIGHT_CHANNEL_COMPATIBLE_LABWARE

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -44,6 +44,9 @@ export const LABWAREV2_DO_NOT_LIST = [
   'opentrons_ot3_96_tiprack_1000ul',
   'opentrons_ot3_96_tiprack_50ul',
   'opentrons_flex_lid_absorbance_plate_reader_module',
+  //  temporarily blocking evotips until it is out of beta
+  'evotips_flex_96_tiprack_adapter',
+  'evotips_opentrons_96_labware',
 ]
 // NOTE(sa, 2020-7-14): in PD we do not want to list calibration blocks
 // or the adapter/labware combos since we migrated to splitting them up
@@ -60,6 +63,9 @@ export const PD_DO_NOT_LIST = [
   //  temporarily blocking TC lid adapter and deck riser until it is supported in PD
   'opentrons_tough_pcr_auto_sealing_lid',
   'opentrons_flex_deck_riser',
+  //  temporarily blocking evotips until it is supported in PD
+  'evotips_flex_96_tiprack_adapter',
+  'evotips_opentrons_96_labware',
 ]
 
 export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
While evotips is in beta, we don't want it to be visible in PD or LL. We also want to block it from quick transfer since despite it having a display category `wellPlate`, it does not behave like a normal well plate and isn't compatible with quick transfers
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Look at quick transfer, ensure evotips lawbare is no longer displayed as an option
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Add evotips labware to blocklist for PD and LL
2. Update quick transfer to use the same block list and remove evotips from generated lists of compatible laware
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick code check - I've tested this out
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
