### PR TITLE
refactor(shared-data): Normalize "\u00b5" to "µ"

### DIFF
--- a/shared-data/labware/definitions/3/appliedbiosystemsmicroamp_384_wellplate_40ul/2.json
+++ b/shared-data/labware/definitions/3/appliedbiosystemsmicroamp_384_wellplate_40ul/2.json
@@ -441,9 +441,9 @@
     ]
   },
   "metadata": {
-    "displayName": "Applied Biosystems MicroAmp 384 Well Plate 40 \u00b5L",
+    "displayName": "Applied Biosystems MicroAmp 384 Well Plate 40 µL",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/armadillo_96_wellplate_200ul_pcr_full_skirt/3.json
+++ b/shared-data/labware/definitions/3/armadillo_96_wellplate_200ul_pcr_full_skirt/3.json
@@ -9,9 +9,9 @@
     "isMagneticModuleCompatible": true
   },
   "metadata": {
-    "displayName": "Armadillo 96 Well Plate 200 \u00b5L PCR Full Skirt",
+    "displayName": "Armadillo 96 Well Plate 200 µL PCR Full Skirt",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "brand": {

--- a/shared-data/labware/definitions/3/biorad_384_wellplate_50ul/3.json
+++ b/shared-data/labware/definitions/3/biorad_384_wellplate_50ul/3.json
@@ -450,9 +450,9 @@
     ]
   },
   "metadata": {
-    "displayName": "Bio-Rad 384 Well Plate 50 \u00b5L",
+    "displayName": "Bio-Rad 384 Well Plate 50 µL",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/biorad_96_wellplate_200ul_pcr/3.json
+++ b/shared-data/labware/definitions/3/biorad_96_wellplate_200ul_pcr/3.json
@@ -17,9 +17,9 @@
   "version": 3,
   "namespace": "opentrons",
   "metadata": {
-    "displayName": "Bio-Rad 96 Well Plate 200 \u00b5L PCR",
+    "displayName": "Bio-Rad 96 Well Plate 200 µL PCR",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/corning_384_wellplate_112ul_flat/3.json
+++ b/shared-data/labware/definitions/3/corning_384_wellplate_112ul_flat/3.json
@@ -437,8 +437,8 @@
     ]
   ],
   "metadata": {
-    "displayName": "Corning 384 Well Plate 112 \u00b5L Flat",
-    "displayVolumeUnits": "\u00b5L",
+    "displayName": "Corning 384 Well Plate 112 µL Flat",
+    "displayVolumeUnits": "µL",
     "displayCategory": "wellPlate",
     "tags": []
   },

--- a/shared-data/labware/definitions/3/corning_96_wellplate_360ul_flat/3.json
+++ b/shared-data/labware/definitions/3/corning_96_wellplate_360ul_flat/3.json
@@ -51,9 +51,9 @@
     ]
   },
   "metadata": {
-    "displayName": "Corning 96 Well Plate 360 \u00b5L Flat",
+    "displayName": "Corning 96 Well Plate 360 µL Flat",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/evotips_flex_96_tiprack_adapter/1.json
+++ b/shared-data/labware/definitions/3/evotips_flex_96_tiprack_adapter/1.json
@@ -7,7 +7,7 @@
   "metadata": {
     "displayName": "Evotips adapter",
     "displayCategory": "adapter",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/nest_96_wellplate_100ul_pcr_full_skirt/3.json
+++ b/shared-data/labware/definitions/3/nest_96_wellplate_100ul_pcr_full_skirt/3.json
@@ -19,9 +19,9 @@
     "links": ["https://www.nest-biotech.com/pcr-plates/58773587.html"]
   },
   "metadata": {
-    "displayName": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt",
+    "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/nest_96_wellplate_200ul_flat/3.json
+++ b/shared-data/labware/definitions/3/nest_96_wellplate_200ul_flat/3.json
@@ -19,9 +19,9 @@
     "links": ["https://www.nest-biotech.com/cell-culture-plates/59415537.html"]
   },
   "metadata": {
-    "displayName": "NEST 96 Well Plate 200 \u00b5L Flat",
+    "displayName": "NEST 96 Well Plate 200 µL Flat",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/nest_96_wellplate_2ml_deep/3.json
+++ b/shared-data/labware/definitions/3/nest_96_wellplate_2ml_deep/3.json
@@ -21,7 +21,7 @@
   "metadata": {
     "displayName": "NEST 96 Deep Well Plate 2mL",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/opentrons_96_aluminumblock_biorad_wellplate_200ul/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_aluminumblock_biorad_wellplate_200ul/2.json
@@ -17,8 +17,8 @@
   "version": 2,
   "namespace": "opentrons",
   "metadata": {
-    "displayName": "Opentrons 96 Well Aluminum Block with Bio-Rad Well Plate 200 \u00b5L",
-    "displayVolumeUnits": "\u00b5L",
+    "displayName": "Opentrons 96 Well Aluminum Block with Bio-Rad Well Plate 200 µL",
+    "displayVolumeUnits": "µL",
     "displayCategory": "aluminumBlock",
     "tags": []
   },
@@ -1104,7 +1104,7 @@
         "H12"
       ],
       "metadata": {
-        "displayName": "Bio-Rad 96 Well Plate 200 \u00b5L",
+        "displayName": "Bio-Rad 96 Well Plate 200 µL",
         "displayCategory": "wellPlate",
         "wellBottomShape": "v"
       },

--- a/shared-data/labware/definitions/3/opentrons_96_aluminumblock_generic_pcr_strip_200ul/3.json
+++ b/shared-data/labware/definitions/3/opentrons_96_aluminumblock_generic_pcr_strip_200ul/3.json
@@ -17,8 +17,8 @@
   "version": 3,
   "namespace": "opentrons",
   "metadata": {
-    "displayName": "Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L",
-    "displayVolumeUnits": "\u00b5L",
+    "displayName": "Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL",
+    "displayVolumeUnits": "µL",
     "displayCategory": "aluminumBlock",
     "tags": []
   },

--- a/shared-data/labware/definitions/3/opentrons_96_aluminumblock_nest_wellplate_100ul/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_aluminumblock_nest_wellplate_100ul/2.json
@@ -21,9 +21,9 @@
     ]
   },
   "metadata": {
-    "displayName": "Opentrons 96 Well Aluminum Block with NEST Well Plate 100 \u00b5L",
+    "displayName": "Opentrons 96 Well Aluminum Block with NEST Well Plate 100 µL",
     "displayCategory": "aluminumBlock",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {
@@ -996,7 +996,7 @@
   "groups": [
     {
       "metadata": {
-        "displayName": "NEST 96 Well Plate 100 \u00b5L",
+        "displayName": "NEST 96 Well Plate 100 µL",
         "displayCategory": "wellPlate",
         "wellBottomShape": "v"
       },

--- a/shared-data/labware/definitions/3/opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep/2.json
@@ -21,7 +21,7 @@
   "metadata": {
     "displayName": "Opentrons 96 Deep Well Heater-Shaker Adapter with NEST Deep Well Plate 2 mL",
     "displayCategory": "adapter",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/2.json
@@ -19,9 +19,9 @@
     "links": []
   },
   "metadata": {
-    "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter with NEST 96 Well Plate 200 \u00b5L Flat",
+    "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter with NEST 96 Well Plate 200 µL Flat",
     "displayCategory": "adapter",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {
@@ -994,7 +994,7 @@
   "groups": [
     {
       "metadata": {
-        "displayName": "NEST 96 Well Plate 200 \u00b5L Flat",
+        "displayName": "NEST 96 Well Plate 200 µL Flat",
         "displayCategory": "wellPlate",
         "wellBottomShape": "flat"
       },

--- a/shared-data/labware/definitions/3/opentrons_96_pcr_adapter_armadillo_wellplate_200ul/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_pcr_adapter_armadillo_wellplate_200ul/2.json
@@ -10,9 +10,9 @@
     "isMagneticModuleCompatible": false
   },
   "metadata": {
-    "displayName": "Opentrons 96 PCR Heater-Shaker Adapter with Armadillo Well Plate 200 \u00b5l",
+    "displayName": "Opentrons 96 PCR Heater-Shaker Adapter with Armadillo Well Plate 200 µl",
     "displayCategory": "aluminumBlock",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "brand": {
@@ -1009,7 +1009,7 @@
   "groups": [
     {
       "metadata": {
-        "displayName": "Armadillo 96 Well Plate 200 \u00b5L PCR Full Skirt",
+        "displayName": "Armadillo 96 Well Plate 200 µL PCR Full Skirt",
         "displayCategory": "wellPlate",
         "wellBottomShape": "v"
       },

--- a/shared-data/labware/definitions/3/opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/2.json
+++ b/shared-data/labware/definitions/3/opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/2.json
@@ -19,9 +19,9 @@
     "links": []
   },
   "metadata": {
-    "displayName": "Opentrons 96 PCR Heater-Shaker Adapter with NEST Well Plate 100 \u00b5l",
+    "displayName": "Opentrons 96 PCR Heater-Shaker Adapter with NEST Well Plate 100 µl",
     "displayCategory": "adapter",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {
@@ -994,7 +994,7 @@
   "groups": [
     {
       "metadata": {
-        "displayName": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt",
+        "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
         "displayCategory": "wellPlate",
         "wellBottomShape": "v"
       },

--- a/shared-data/labware/definitions/3/opentrons_96_wellplate_200ul_pcr_full_skirt/3.json
+++ b/shared-data/labware/definitions/3/opentrons_96_wellplate_200ul_pcr_full_skirt/3.json
@@ -9,9 +9,9 @@
     "isMagneticModuleCompatible": true
   },
   "metadata": {
-    "displayName": "Opentrons Tough 96 Well Plate 200 \u00b5L PCR Full Skirt",
+    "displayName": "Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "brand": {

--- a/shared-data/labware/definitions/3/opentrons_flex_tiprack_lid/1.json
+++ b/shared-data/labware/definitions/3/opentrons_flex_tiprack_lid/1.json
@@ -8,7 +8,7 @@
   "metadata": {
     "displayName": "Opentrons Flex Tiprack Lid",
     "displayCategory": "lid",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/1.json
+++ b/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/1.json
@@ -8,7 +8,7 @@
   "metadata": {
     "displayName": "Opentrons Tough PCR Auto-Sealing Lid",
     "displayCategory": "lid",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/2.json
+++ b/shared-data/labware/definitions/3/opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/2.json
@@ -438,9 +438,9 @@
     "brandId": []
   },
   "metadata": {
-    "displayName": "Opentrons Universal Flat Heater-Shaker Adapter with Corning 384 Well Plate 112 \u00b5l Flat",
+    "displayName": "Opentrons Universal Flat Heater-Shaker Adapter with Corning 384 Well Plate 112 µl Flat",
     "displayCategory": "adapter",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {
@@ -4677,7 +4677,7 @@
   "groups": [
     {
       "metadata": {
-        "displayName": "Corning 384 Well Plate 112 \u00b5L Flat",
+        "displayName": "Corning 384 Well Plate 112 µL Flat",
         "displayCategory": "wellPlate",
         "wellBottomShape": "flat"
       },

--- a/shared-data/labware/definitions/3/protocol_engine_lid_stack_object/1.json
+++ b/shared-data/labware/definitions/3/protocol_engine_lid_stack_object/1.json
@@ -8,7 +8,7 @@
   "metadata": {
     "displayName": "Protocol Engine Lid Stack",
     "displayCategory": "system",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/thermoscientificnunc_96_wellplate_1300ul/2.json
+++ b/shared-data/labware/definitions/3/thermoscientificnunc_96_wellplate_1300ul/2.json
@@ -19,9 +19,9 @@
     "links": ["https://www.thermofisher.com/order/catalog/product/260251"]
   },
   "metadata": {
-    "displayName": "Thermo Scientific Nunc 96 Well Plate 1300 \u00b5L",
+    "displayName": "Thermo Scientific Nunc 96 Well Plate 1300 µL",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {

--- a/shared-data/labware/definitions/3/thermoscientificnunc_96_wellplate_2000ul/2.json
+++ b/shared-data/labware/definitions/3/thermoscientificnunc_96_wellplate_2000ul/2.json
@@ -19,9 +19,9 @@
     "links": ["https://www.thermofisher.com/order/catalog/product/278743"]
   },
   "metadata": {
-    "displayName": "Thermo Scientific Nunc 96 Well Plate 2000 \u00b5L",
+    "displayName": "Thermo Scientific Nunc 96 Well Plate 2000 µL",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "\u00b5L",
+    "displayVolumeUnits": "µL",
     "tags": []
   },
   "dimensions": {


### PR DESCRIPTION
## Overview

In a JSON file, there are two ways for a string to contain "µ":

* Like `"displayName": "1000 µL"`
* Like `"displayName": "1000 \u00b5L"`

The two are equivalent. After a JSON file has been parsed, code cannot tell the difference.

Our labware definition files are inconsistent: some of them use "µ" while others use "\u00b5". For EXEC-77, we're mass-editing these files, and my scripts keep accidentally normalizing these characters as a side effect of the parse/serialize round trip. This PR does all the normalization up front so subsequent PRs can have tidier diffs.

## Test Plan and Hands on Testing

Just CI.

## Review requests

* Do we like normalizing it in the direction of "µ", or should I switch everything to "\u00b5" instead? I figured "µ" has better readability, but "\u00b5" is more foolproof with respect to file encodings—see below.
* I'm only touching *schema 3 labware definitions* here, because that's all I care about for my scripts. So schema 2 definitions, various non-labware things, and various non-definition things are untouched. I can normalize those things too if the inconsistency bothers anyone.

## Risk assessment

Low.

One risk of "µ" is that it's less foolproof with respect to file encodings.

* In Python, we must either:
    * Open the file in binary mode and let `json.loads()` autodetect the encoding from the bytes.
    * Open the file in text mode with `encoding="utf-8"`, matching how these files are stored in our Git repo and overriding the platform default encoding, which is often something else.
* In JavaScript, I dunno, but probably something similar.

I think we're good because many of these definitions already contained "µ", and it has apparently been fine.