### PR TITLE
fix(protocol-designer): fix createFile() test and delete unused `ot2Robot` constant

### DIFF
--- a/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
@@ -71,5 +71,3 @@ export const labwareDefsByURI: LabwareDefByDefURI = {
   'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': fixture96Plate,
   'opentrons/opentrons_1_trash_1100ml_fixed/1': fixtureTrash,
 }
-
-export const ot2Robot = { model: OT2_ROBOT_TYPE, deckId: OT2_STANDARD_DECKID }

--- a/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
@@ -4,11 +4,7 @@ import {
   fixture_tiprack_10_ul,
   fixture_trash,
 } from '@opentrons/shared-data/labware/fixtures/2'
-import {
-  OT2_ROBOT_TYPE,
-  OT2_STANDARD_DECKID,
-  fixtureP10SingleV2Specs,
-} from '@opentrons/shared-data'
+import { fixtureP10SingleV2Specs } from '@opentrons/shared-data'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type {
   LabwareLiquidState,

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -6,6 +6,7 @@ import {
   fixtureP300SingleV2Specs,
   labwareSchemaV2,
   protocolSchemaV8,
+  OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import {
   fixture_12_trough,
@@ -28,7 +29,6 @@ import {
   labwareNicknamesById,
   labwareDefsByURI,
   pipetteEntities,
-  ot2Robot,
 } from '../__fixtures__/createFile/commonFields'
 import * as v7Fixture from '../__fixtures__/createFile/v7Fixture'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -76,7 +76,7 @@ describe('createFile selector', () => {
       fileMetadata,
       v7Fixture.initialRobotState,
       v7Fixture.robotStateTimeline,
-      ot2Robot,
+      OT2_ROBOT_TYPE,
       dismissedWarnings,
       ingredients,
       ingredLocations,


### PR DESCRIPTION
# Overview

In `createFile(..., robotType=...)`, the `robotType` needs to be a string, but the test was incorrectly calling the function with an object instead.

We previously defined a constant object `ot2Robot = { model: OT2_ROBOT_TYPE, deckId: OT2_STANDARD_DECKID }` for tests, but nothing uses it anymore, so we can just delete it.

## Test Plan and Hands on Testing

Updated unit tests and confirmed that they pass.

## Risk assessment

Low, this just fixes an incorrect unit test.