### PR TITLE
docs(app): add quick transfer doc to keep track of versioning

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/README.md
+++ b/app/src/organisms/ODD/QuickTransferFlow/README.md
@@ -1,0 +1,59 @@
+# Quick Transfer Versioning:
+
+Quick Transfer is versioned under the `designerApplicationData` field on the resulting protocol file
+Since this data is not yet read or migrated, this doc details the versions, type of `quickTransferState` per version, and changes made so that migration can occur in the future if needed
+
+## Version 1.0.0
+
+```
+export interface QuickTransferSummaryState {
+  pipette: PipetteV2Specs
+  mount: Mount
+  tipRack: LabwareDefinition2
+  source: LabwareDefinition2
+  sourceWells: string[]
+  destination: LabwareDefinition2 | 'source'
+  destinationWells: string[]
+  transferType: TransferType
+  volume: number
+  aspirateFlowRate: number
+  dispenseFlowRate: number
+  path: PathOption
+  tipPositionAspirate: number
+  preWetTip: boolean
+  mixOnAspirate?: {
+    mixVolume: number
+    repititions: number
+  }
+  delayAspirate?: {
+    delayDuration: number
+    positionFromBottom: number
+  }
+  touchTipAspirate?: number
+  airGapAspirate?: number
+  tipPositionDispense: number
+  mixOnDispense?: {
+    mixVolume: number
+    repititions: number
+  }
+  delayDispense?: {
+    delayDuration: number
+    positionFromBottom: number
+  }
+  touchTipDispense?: number
+  disposalVolume?: number
+  blowOut?: BlowOutLocation
+  airGapDispense?: number
+  changeTip: ChangeTipOptions
+  dropTipLocation: CutoutConfig
+}
+```
+
+## Version 1.1.0
+
+Type is the same as in `1.0.0`, but the number represented by `touchTipAspirate` and `touchTipDispense` is now the distance from the top of the well instead of distance from the bottom of the well. This can be migrated using the well height from the definition on both source and dest labware.
+
+```
+touchTipAspirate = -(sourceWellHeight - prevTouchTipAspirate)
+touchTipDispense = -(destWellHeight - prevTouchTipDispense)
+```

--- a/app/src/organisms/ODD/QuickTransferFlow/README.md
+++ b/app/src/organisms/ODD/QuickTransferFlow/README.md
@@ -1,7 +1,6 @@
 # Quick Transfer Versioning:
 
-Quick Transfer is versioned under the `designerApplicationData` field on the resulting protocol file
-Since this data is not yet read or migrated, this doc details the versions, type of `quickTransferState` per version, and changes made so that migration can occur in the future if needed
+Quick Transfer is versioned under the `designerApplicationData` field on the resulting protocol file. Since this data is not yet read or migrated this doc details the versions, type of `quickTransferState` per version, and other changes made so that migration can occur in the future if needed.
 
 ## Version 1.0.0
 

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -202,6 +202,7 @@ export function createQuickTransferFile(
       subcategory: null,
       tags: [],
     },
+    // see QuickTransferFlow/README.md for versioning details
     designerApplication: {
       name: 'opentrons/quick-transfer',
       version: '1.0.0',


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->
This PR adds a versioning doc to keep track of changes in Quick Transfer. We don't currently read `designerApplicationData` for QT but this will enable us to do so in the future and migrate old iterations if need be.
## Review requests
Does this location make sense as the place to store this information?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Docs only
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
