### PR TITLE
feat(protocol-designer): generate `requirements` section of Python file

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -99,7 +99,7 @@ describe('createFile selector', () => {
 
   it('should return a valid Python protocol file', () => {
     // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
-    const result = createPythonFile.resultFunc(fileMetadata, {})
+    const result = createPythonFile.resultFunc(fileMetadata, OT2_ROBOT_TYPE, {})
     // This is just a quick smoke test to make sure createPythonFile() produces
     // something that looks like a Python file. The individual sections of the
     // generated Python will be tested in separate unit tests.
@@ -113,6 +113,11 @@ metadata = {
     "author": "The Author",
     "description": "Protocol description",
     "created": "2020-02-25T21:48:32.515Z",
+}
+
+requirements = {
+    "robotType": "OT-2",
+    "apiLevel": "2.23",
 }
 `.trimStart()
     )

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { pythonMetadata } from '../selectors/pythonFile'
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import { pythonMetadata, pythonRequirements } from '../selectors/pythonFile'
 
 describe('pythonMetadata', () => {
   it('should generate metadata section', () => {
@@ -25,6 +26,26 @@ metadata = {
     "category": "PCR",
     "subcategory": "PCR Prep",
     "tags": "wombat, kangaroo, wallaby",
+}`.trimStart()
+    )
+  })
+})
+
+describe('pythonRequirements', () => {
+  it('should generate requirements section', () => {
+    expect(pythonRequirements(OT2_ROBOT_TYPE)).toBe(
+      `
+requirements = {
+    "robotType": "OT-2",
+    "apiLevel": "2.23",
+}`.trimStart()
+    )
+
+    expect(pythonRequirements(FLEX_ROBOT_TYPE)).toBe(
+      `
+requirements = {
+    "robotType": "Flex",
+    "apiLevel": "2.23",
 }`.trimStart()
     )
   })

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -26,7 +26,7 @@ import {
   getModulesLoadInfo,
   getPipettesLoadInfo,
 } from './utils'
-import { pythonImports, pythonMetadata } from './pythonFile'
+import { pythonImports, pythonMetadata, pythonRequirements } from './pythonFile'
 
 import type { SecondOrderCommandAnnotation } from '@opentrons/shared-data/commandAnnotation/types'
 import type {
@@ -302,12 +302,14 @@ export const createFile: Selector<ProtocolFile> = createSelector(
 
 export const createPythonFile: Selector<string> = createSelector(
   getFileMetadata,
-  fileMetadata => {
+  getRobotType,
+  (fileMetadata, robotType) => {
     return (
       [
         // Here are the sections of the Python file:
         pythonImports(),
         pythonMetadata(fileMetadata),
+        pythonRequirements(robotType),
       ]
         .filter(section => section) // skip any blank sections
         .join('\n\n') + '\n'

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -1,7 +1,11 @@
 /** Generate sections of the Python file for fileCreator.ts */
 
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import { formatPyDict } from '@opentrons/step-generation'
 import type { FileMetadataFields } from '../types'
+import type { RobotType } from '@opentrons/shared-data'
+
+const PAPI_VERSION = '2.23' // latest version from api/src/opentrons/protocols/api_support/definitions.py
 
 export function pythonImports(): string {
   return [
@@ -28,4 +32,17 @@ export function pythonMetadata(fileMetadata: FileMetadataFields): string {
     }).filter(([key, value]) => value) // drop blank entries
   )
   return `metadata = ${formatPyDict(stringifiedMetadata)}`
+}
+
+export function pythonRequirements(robotType: RobotType): string {
+  const ROBOTTYPE_TO_PAPI_NAME = {
+    // values from api/src/opentrons/protocols/parse.py
+    [OT2_ROBOT_TYPE]: 'OT-2',
+    [FLEX_ROBOT_TYPE]: 'Flex',
+  }
+  const requirements = {
+    robotType: ROBOTTYPE_TO_PAPI_NAME[robotType],
+    apiLevel: PAPI_VERSION,
+  }
+  return `requirements = ${formatPyDict(requirements)}`
 }


### PR DESCRIPTION
# Overview

Add the `requirements=` section to the Python file export. AUTH-1091

## Test Plan and Hands on Testing

Added unit tests for the Flex and OT-2.

## Risk assessment

Low: Python export is hidden behind a feature flag, and no one is using it yet.