### PR TITLE
fix(protocol-designer): retain timeline data when overwriting protocol via import

### DIFF
--- a/protocol-designer/src/configureStore.ts
+++ b/protocol-designer/src/configureStore.ts
@@ -89,8 +89,8 @@ export function configureStore(): StoreType {
     /* preloadedState, */
     composeEnhancers(
       applyMiddleware(
-        thunk,
         timelineMiddleware as Middleware<BaseState, Record<string, any>, any>,
+        thunk,
         trackEventMiddleware as Middleware<BaseState, Record<string, any>, any>
       )
     ) as StoreEnhancer<unknown, unknown>


### PR DESCRIPTION
# Overview

This PR moves redux-thunk to get applied to actions AFTER timeline middleware so that if timeline middleware ever depends on a thunk action our logic will still work as expected. This PR also explicitly regenerates the timeline and substeps whenever a protocol is imported into PD.

This fixes a bug where importing a protocol (when you already have a protocol loaded into application state) does not trigger timeline computation, which means that sub steps, liquid tracking, and commands never get loaded into application state.

closes AUTH-1429

## Test Plan and Hands on Testing

Import a protocol into PD (like the one attached to this PR), import it again, and make sure that exported protocol you get back out has liquid handling commands. Also make sure the starting deck state and ending deck state are different.

[Reagent-transfer-10.json](https://github.com/user-attachments/files/18736541/Reagent-transfer-10.json)


## Changelog

- Reorder redux middleware
- Always regenerate timeline and substeps when a protocol is imported into PD

## Review requests

See test plan

## Risk assessment

Medium/high