### PR TITLE
feat(api): add GCodes to interface with the Time-Of-Flight sensors on the Flex Stacker.

### DIFF
--- a/api/src/opentrons/drivers/flex_stacker/abstract.py
+++ b/api/src/opentrons/drivers/flex_stacker/abstract.py
@@ -11,6 +11,8 @@ from .types import (
     StackerInfo,
     LEDColor,
     StallGuardParams,
+    TOFSensor,
+    TOFSensorStatus,
 )
 
 
@@ -59,6 +61,10 @@ class AbstractFlexStackerDriver(Protocol):
         """Enables and sets the stallguard threshold for the given axis motor."""
         ...
 
+    async def enable_tof_sensor(self, sensor: TOFSensor, enable: bool) -> bool:
+        """Enable or disable the TOF sensor."""
+        ...
+
     async def set_motor_driver_register(
         self, axis: StackerAxis, reg: int, value: int
     ) -> bool:
@@ -67,6 +73,20 @@ class AbstractFlexStackerDriver(Protocol):
 
     async def get_motor_driver_register(self, axis: StackerAxis, reg: int) -> int:
         """Gets the register value of the given motor axis driver."""
+        ...
+
+    async def set_tof_driver_register(
+        self, sensor: TOFSensor, reg: int, value: int
+    ) -> bool:
+        """Set the register of the given tof sensor driver to the given value."""
+        ...
+
+    async def get_tof_driver_register(self, sensor: TOFSensor, reg: int) -> int:
+        """Gets the register value of the given tof sensor driver."""
+        ...
+
+    async def get_tof_sensor_status(self, sensor: TOFSensor) -> TOFSensorStatus:
+        """Get the status of the tof sensor."""
         ...
 
     async def get_motion_params(self, axis: StackerAxis) -> MoveParams:

--- a/api/src/opentrons/drivers/flex_stacker/driver.py
+++ b/api/src/opentrons/drivers/flex_stacker/driver.py
@@ -20,6 +20,10 @@ from .types import (
     LimitSwitchStatus,
     LEDColor,
     StallGuardParams,
+    TOFSensor,
+    TOFSensorMode,
+    TOFSensorState,
+    TOFSensorStatus,
 )
 
 
@@ -190,7 +194,7 @@ class FlexStackerDriver(AbstractFlexStackerDriver):
 
     @classmethod
     def parse_get_motor_register(cls, response: str) -> int:
-        """Parse get register value."""
+        """Parse get motor register value."""
         pattern = r"(?P<M>[XZL]):(?P<R>\d+) V:(?P<V>\d+)"
         _RE = re.compile(f"^{GCODE.GET_MOTOR_DRIVER_REGISTER} {pattern}$")
         m = _RE.match(response)
@@ -199,6 +203,36 @@ class FlexStackerDriver(AbstractFlexStackerDriver):
                 f"Incorrect Response for get motor driver register: {response}"
             )
         return int(m.group("V"))
+
+    @classmethod
+    def parse_get_tof_sensor_register(cls, response: str) -> int:
+        """Parse get tof sensor register value."""
+        pattern = r"(?P<S>[XZ]):(?P<R>\d+) V:(?P<V>\d+)"
+        _RE = re.compile(f"^{GCODE.GET_TOF_DRIVER_REGISTER} {pattern}$")
+        m = _RE.match(response)
+        if not m:
+            raise ValueError(
+                f"Incorrect Response for get tof sensor driver register: {response}"
+            )
+        return int(m.group("V"))
+
+    @classmethod
+    def parse_tof_sensor_status(cls, response: str) -> TOFSensorStatus:
+        """Parse get tof sensor status response."""
+        pattern = r"(?P<S>[XZ]):(?P<R>\d) T:(?P<T>\d M:(?P<M>\d) E:(?P<E>\d))"
+        _RE = re.compile(f"^{GCODE.GET_TOF_SENSOR_STATUS} {pattern}$")
+        m = _RE.match(response)
+        if not m:
+            raise ValueError(
+                f"Incorrect Response for get tof sensor status: {response}"
+            )
+        return TOFSensorStatus(
+            sensor=TOFSensor(m.group("S")),
+            state=TOFSensorState(m.group("T")),
+            mode=TOFSensorMode(m.group("M")),
+            enabled=bool(m.group("E")),
+            ready=bool(m.group("R")),
+        )
 
     @classmethod
     def append_move_params(
@@ -334,6 +368,15 @@ class FlexStackerDriver(AbstractFlexStackerDriver):
             raise ValueError(f"Incorrect Response for set stallguard threshold: {resp}")
         return True
 
+    async def enable_tof_sensor(self, sensor: TOFSensor, enable: bool) -> bool:
+        """Enable or disable the TOF sensor."""
+        resp = await self._connection.send_command(
+            GCODE.ENABLE_TOF_SENSOR.build_command().add_int(sensor.name, int(enable))
+        )
+        if not re.match(rf"^{GCODE.ENABLE_TOF_SENSOR}$", resp):
+            raise ValueError(f"Incorrect Response for enable TOF sensor: {resp}")
+        return True
+
     async def set_motor_driver_register(
         self, axis: StackerAxis, reg: int, value: int
     ) -> bool:
@@ -355,6 +398,35 @@ class FlexStackerDriver(AbstractFlexStackerDriver):
             GCODE.GET_MOTOR_DRIVER_REGISTER.build_command().add_int(axis.name, reg)
         )
         return self.parse_get_motor_register(response)
+
+    async def set_tof_driver_register(
+        self, sensor: TOFSensor, reg: int, value: int
+    ) -> bool:
+        """Set the register of the given tof sensor driver to the given value."""
+        resp = await self._connection.send_command(
+            GCODE.SET_TOF_DRIVER_REGISTER.build_command()
+            .add_int(sensor.name, reg)
+            .add_element(str(value))
+        )
+        if not re.match(rf"^{GCODE.SET_TOF_DRIVER_REGISTER}$", resp):
+            raise ValueError(
+                f"Incorrect Response for set tof sensor driver register: {resp}"
+            )
+        return True
+
+    async def get_tof_driver_register(self, sensor: TOFSensor, reg: int) -> int:
+        """Gets the register value of the given tof sensor driver."""
+        response = await self._connection.send_command(
+            GCODE.GET_TOF_DRIVER_REGISTER.build_command().add_int(sensor.name, reg)
+        )
+        return self.parse_get_tof_sensor_register(response)
+
+    async def get_tof_sensor_status(self, sensor: TOFSensor) -> TOFSensorStatus:
+        """Get the status of the tof sensor."""
+        response = await self._connection.send_command(
+            GCODE.GET_TOF_SENSOR_STATUS.build_command()
+        )
+        return self.parse_tof_sensor_status(response)
 
     async def get_motion_params(self, axis: StackerAxis) -> MoveParams:
         """Get the motion parameters used by the given axis motor."""

--- a/api/src/opentrons/drivers/flex_stacker/driver.py
+++ b/api/src/opentrons/drivers/flex_stacker/driver.py
@@ -424,7 +424,7 @@ class FlexStackerDriver(AbstractFlexStackerDriver):
     async def get_tof_sensor_status(self, sensor: TOFSensor) -> TOFSensorStatus:
         """Get the status of the tof sensor."""
         response = await self._connection.send_command(
-            GCODE.GET_TOF_SENSOR_STATUS.build_command()
+            GCODE.GET_TOF_SENSOR_STATUS.build_command().add_element(sensor.name)
         )
         return self.parse_tof_sensor_status(response)
 

--- a/api/src/opentrons/drivers/flex_stacker/simulator.py
+++ b/api/src/opentrons/drivers/flex_stacker/simulator.py
@@ -15,6 +15,10 @@ from .types import (
     MoveParams,
     LimitSwitchStatus,
     StallGuardParams,
+    TOFSensor,
+    TOFSensorMode,
+    TOFSensorState,
+    TOFSensorStatus,
 )
 
 
@@ -32,6 +36,9 @@ class SimulatingDriver(AbstractFlexStackerDriver):
         }
         self._motor_registers: Dict[StackerAxis, Dict[int, int]] = {
             a: {} for a in StackerAxis
+        }
+        self._tof_registers: Dict[TOFSensor, Dict[int, int]] = {
+            a: {} for a in TOFSensor
         }
 
     def set_limit_switch(self, status: LimitSwitchStatus) -> bool:
@@ -97,6 +104,10 @@ class SimulatingDriver(AbstractFlexStackerDriver):
         self._stallgard_threshold[axis] = StallGuardParams(axis, enable, threshold)
         return True
 
+    async def enable_tof_sensor(self, sensor: TOFSensor, enable: bool) -> bool:
+        """Enable or disable the TOF sensor."""
+        return True
+
     async def set_motor_driver_register(
         self, axis: StackerAxis, reg: int, value: int
     ) -> bool:
@@ -107,6 +118,26 @@ class SimulatingDriver(AbstractFlexStackerDriver):
     async def get_motor_driver_register(self, axis: StackerAxis, reg: int) -> int:
         """Gets the register value of the given motor axis driver."""
         return self._motor_registers[axis].get(reg, 0)
+
+    async def set_tof_driver_register(
+        self, sensor: TOFSensor, reg: int, value: int
+    ) -> bool:
+        """Set the register of the given tof sensor driver to the given value."""
+        self._tof_registers[sensor].update({reg: value})
+        return True
+
+    async def get_tof_driver_register(self, sensor: TOFSensor, reg: int) -> int:
+        """Gets the register value of the given tof sensor driver."""
+        return self._tof_registers[sensor].get(reg, 0)
+
+    async def get_tof_sensor_status(self, sensor: TOFSensor) -> TOFSensorStatus:
+        """Get the status of the tof sensor."""
+        return TOFSensorStatus(
+            sensor=sensor,
+            mode=TOFSensorMode.MEASURE,
+            state=TOFSensorState.IDLE,
+            ok=True,
+        )
 
     async def get_motion_params(self, axis: StackerAxis) -> MoveParams:
         """Get the motion parameters used by the given axis motor."""

--- a/api/src/opentrons/drivers/flex_stacker/types.py
+++ b/api/src/opentrons/drivers/flex_stacker/types.py
@@ -132,7 +132,7 @@ class Direction(Enum):
 class TOFSensorState(Enum):
     """TOF Sensor state."""
 
-    INITIALIZING = (0,)
+    INITIALIZING = 0
     IDLE = 1
     MEASURING = 2
     ERROR = 3

--- a/api/src/opentrons/drivers/flex_stacker/types.py
+++ b/api/src/opentrons/drivers/flex_stacker/types.py
@@ -20,12 +20,16 @@ class GCODE(str, Enum):
     GET_DOOR_SWITCH = "M122"
     GET_STALLGUARD_THRESHOLD = "M911"
     GET_MOTOR_DRIVER_REGISTER = "M920"
+    GET_TOF_SENSOR_STATUS = "M215"
+    GET_TOF_DRIVER_REGISTER = "M222"
+    ENABLE_TOF_SENSOR = "M224"
     SET_LED = "M200"
     SET_SERIAL_NUMBER = "M996"
     SET_RUN_CURRENT = "M906"
     SET_IHOLD_CURRENT = "M907"
     SET_STALLGUARD = "M910"
     SET_MOTOR_DRIVER_REGISTER = "M921"
+    SET_TOF_DRIVER_REGISTER = "M223"
     ENTER_BOOTLOADER = "dfu"
 
     def build_command(self) -> CommandBuilder:
@@ -76,6 +80,17 @@ class StackerAxis(Enum):
         return self.name
 
 
+class TOFSensor(Enum):
+    """Stacker TOF sensor."""
+
+    X = "X"
+    Z = "Z"
+
+    def __str__(self) -> str:
+        """Name."""
+        return self.name
+
+
 class LEDColor(Enum):
     """Stacker LED Color."""
 
@@ -112,6 +127,23 @@ class Direction(Enum):
     def distance(self, distance: float) -> float:
         """Get signed distance, where retract direction is negative."""
         return distance * -1 if self == Direction.RETRACT else distance
+
+
+class TOFSensorState(Enum):
+    """TOF Sensor state."""
+
+    INITIALIZING = (0,)
+    IDLE = 1
+    MEASURING = 2
+    ERROR = 3
+
+
+class TOFSensorMode(Enum):
+    """The mode the sensor is in."""
+
+    UNKNOWN = 0
+    BOOTLOADER = 1
+    MEASURE = 2
 
 
 @dataclass
@@ -162,6 +194,17 @@ class PlatformStatus:
             "extent": self.E,
             "retract": self.R,
         }
+
+
+@dataclass
+class TOFSensorStatus:
+    """Stacker TOF sensor status."""
+
+    sensor: TOFSensor
+    state: TOFSensorState
+    mode: TOFSensorMode
+    enabled: bool
+    ready: bool
 
 
 @dataclass

--- a/api/src/opentrons/drivers/flex_stacker/types.py
+++ b/api/src/opentrons/drivers/flex_stacker/types.py
@@ -132,18 +132,19 @@ class Direction(Enum):
 class TOFSensorState(Enum):
     """TOF Sensor state."""
 
-    INITIALIZING = 0
-    IDLE = 1
-    MEASURING = 2
-    ERROR = 3
+    DISABLED = 0
+    INITIALIZING = 1
+    IDLE = 2
+    MEASURING = 3
+    ERROR = 4
 
 
 class TOFSensorMode(Enum):
     """The mode the sensor is in."""
 
     UNKNOWN = 0
-    BOOTLOADER = 1
-    MEASURE = 2
+    MEASURE = 0x03
+    BOOTLOADER = 0x80
 
 
 @dataclass
@@ -203,8 +204,7 @@ class TOFSensorStatus:
     sensor: TOFSensor
     state: TOFSensorState
     mode: TOFSensorMode
-    enabled: bool
-    ready: bool
+    ok: bool
 
 
 @dataclass

--- a/api/src/opentrons/drivers/flex_stacker/types.py
+++ b/api/src/opentrons/drivers/flex_stacker/types.py
@@ -68,27 +68,19 @@ class StackerInfo:
         }
 
 
-class StackerAxis(Enum):
+class StackerAxis(str, Enum):
     """Stacker Axis."""
 
     X = "X"
     Z = "Z"
     L = "L"
 
-    def __str__(self) -> str:
-        """Name."""
-        return self.name
 
-
-class TOFSensor(Enum):
+class TOFSensor(str, Enum):
     """Stacker TOF sensor."""
 
     X = "X"
     Z = "Z"
-
-    def __str__(self) -> str:
-        """Name."""
-        return self.name
 
 
 class LEDColor(Enum):


### PR DESCRIPTION
# Overview

Adds support for interfacing with the TMF8820/21/28 dToF (direct Time Of Flight) sensors for the Flex Stacker, this pull request goes in conjunction with this opentrons-modules pull request [Opentrons/opentrons-modules#503](https://github.com/Opentrons/opentrons-modules/pull/503).

Adds the following GCodes.

```
M215 - Get TOF Sensor Status
M222 - Get TOF Driver Register
M223 - Set TOF Driver Register
M224 - Enable TOF Driver
```

Closes: [EXEC-971](https://opentrons.atlassian.net/browse/EXEC-971) [EXEC-1166](https://opentrons.atlassian.net/browse/EXEC-1166) [EXEC-1170](https://opentrons.atlassian.net/browse/EXEC-1170) [EXEC-1171](https://opentrons.atlassian.net/browse/EXEC-1171) [EXEC-1172](https://opentrons.atlassian.net/browse/EXEC-1172)

## Test Plan and Hands on Testing

- [x] Make sure you can get the TOF sensor status for both sensors
- [x] Make sure you can set and get the registers for each TOF sensor
- [x] Make sure you can enable/disable the TOF sensor

## Changelog

- add M215 - Get TOF Sensor Status Gcode
- add M222 - Get TOF Driver Register Gcode
- add M223 - Set TOF Driver Register Gcode
- add M224 - Enable TOF Driver Gcode

## Risk assessment

Low, unreleased

[EXEC-971]: https://opentrons.atlassian.net/browse/EXEC-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-1166]: https://opentrons.atlassian.net/browse/EXEC-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-1170]: https://opentrons.atlassian.net/browse/EXEC-1170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-1171]: https://opentrons.atlassian.net/browse/EXEC-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-1172]: https://opentrons.atlassian.net/browse/EXEC-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ