### PR TITLE
fix(protocol-designer): fix OffDeckDetails container flicker

### DIFF
--- a/protocol-designer/src/pages/Designer/OffDeck/OffDeckDetails.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/OffDeckDetails.tsx
@@ -69,7 +69,7 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
       borderRadius={BORDERS.borderRadius12}
       width="100%"
       height="100%"
-      padding={`${SPACING.spacing24} ${paddingRight} ${SPACING.spacing24} 0`}
+      padding={`${SPACING.spacing40} ${paddingRight} ${SPACING.spacing40} 0`}
       gridGap={SPACING.spacing24}
       alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_FLEX_END}

--- a/protocol-designer/src/pages/Designer/OffDeck/OffDeckDetails.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/OffDeckDetails.tsx
@@ -12,6 +12,7 @@ import {
   EmptySelectorButton,
   Flex,
   JUSTIFY_CENTER,
+  JUSTIFY_FLEX_END,
   LabwareRender,
   OVERFLOW_AUTO,
   RobotWorkSpace,
@@ -59,16 +60,8 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
   )
   const containerWidth = tab === 'startingDeck' ? '100vw' : '75vw'
 
-  const paddingLeftWithHover =
-    hoverSlot == null
-      ? `calc((${containerWidth} - (${SPACING.spacing24}  * 2) - ${OFF_DECK_MAP_WIDTH}) / 2)`
-      : SPACING.spacing24
-  const paddingLeft = tab === 'startingDeck' ? paddingLeftWithHover : undefined
-  const padding =
-    tab === 'protocolSteps'
-      ? SPACING.spacing24
-      : `${SPACING.spacing40} ${paddingLeft}`
   const stepDetailsContainerWidth = `calc(((${containerWidth} - ${OFF_DECK_MAP_WIDTH}) / 2) - (${SPACING.spacing24}  * 3))`
+  const paddingRight = `calc((100% - ${OFF_DECK_MAP_WIDTH}) / 2)`
 
   return (
     <Flex
@@ -76,10 +69,10 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
       borderRadius={BORDERS.borderRadius12}
       width="100%"
       height="100%"
-      padding={padding}
+      padding={`${SPACING.spacing24} ${paddingRight} ${SPACING.spacing24} 0`}
       gridGap={SPACING.spacing24}
       alignItems={ALIGN_CENTER}
-      justifyContent={JUSTIFY_CENTER}
+      justifyContent={JUSTIFY_FLEX_END}
     >
       {hoverSlot != null ? (
         <Flex width={stepDetailsContainerWidth} height="6.25rem">


### PR DESCRIPTION
# Overview

Refactors padding logic in PD `OffDeckDetails` outer container to justify right with padding, rather than justifying center and dynamically calculating left padding based on the presence of the details element. This prevents flickering when hovering an added offdeck labware

Closes RQA-3953

## Test Plan and Hands on Testing

- create a protocol and add some off-deck labware
- hover the added labware to produce hover details, and verify that no bouncing happens

#### Before

https://github.com/user-attachments/assets/17ab1290-b57f-4c0b-808c-8121c5247a97

#### After
https://github.com/user-attachments/assets/83e0f9b5-6073-4504-9e2a-122a7845354f

## Changelog

- fix `OffDeckDetails` alignment and padding

## Review requests

see test plan

## Risk assessment

low