### PR TITLE
fix(shared-data): Restore "lid" display category missing from labware schema 3

### DIFF
--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -77,11 +77,9 @@ describe(`test labware definitions with schema v3`, () => {
 
       // FIXME(mm, 2025-02-04): These new definitions have a displayCategory that
       // the schema does not recognize. Either they need to change or the schema does.
-      const expectFailure = [
-        'opentrons_flex_tiprack_lid',
-        'opentrons_tough_pcr_auto_sealing_lid',
-        'protocol_engine_lid_stack_object',
-      ].includes(labwareDef.parameters.loadName)
+      const expectFailure = ['protocol_engine_lid_stack_object'].includes(
+        labwareDef.parameters.loadName
+      )
 
       if (expectFailure) expect(validationErrors).not.toBe(null)
       else expect(validationErrors).toBe(null)

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -41,7 +41,8 @@
         "wellPlate",
         "aluminumBlock",
         "adapter",
-        "other"
+        "other",
+        "lid"
       ]
     },
     "safeString": {


### PR DESCRIPTION
## Overview

PR #16410 added `"displayCategory": "lid"` in-place to labware schema 2, but did not also add it to the yet-to-be-released labware schema 3. That seems like it was just an accidental omission, so this PR adds the same thing to schema 3.

## Test Plan and Hands on Testing

None.

## Review requests

None.

## Risk assessment

Low.
