### PR TITLE
fix(protocol-designer): set form field value if 1 option, add newLocation error

### DIFF
--- a/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import {
@@ -78,6 +79,12 @@ export function DropdownStepFormField(
       )
     }
   }
+
+  useEffect(() => {
+    if (options.length === 1) {
+      updateValue(options[0].value)
+    }
+  }, [options.length])
 
   return (
     <Flex padding={padding ?? SPACING.spacing16}>

--- a/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/molecules/DropdownStepFormField/index.tsx
@@ -145,6 +145,11 @@ export function DropdownStepFormField(
               </Flex>
             </Flex>
           </ListItem>
+          {errorToShow != null ? (
+            <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.red50}>
+              {errorToShow}
+            </StyledText>
+          ) : null}
         </Flex>
       )}
     </Flex>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/__tests__/MagnetTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/__tests__/MagnetTools.test.tsx
@@ -59,6 +59,15 @@ describe('MagnetTools', () => {
           updateValue: vi.fn(),
           value: 'engage',
         },
+        moduleId: {
+          onFieldFocus: vi.fn(),
+          onFieldBlur: vi.fn(),
+          errorToShow: null,
+          disabled: false,
+          name: 'magnetAction',
+          updateValue: vi.fn(),
+          value: 'engage',
+        },
         engageHeight: {
           onFieldFocus: vi.fn(),
           onFieldBlur: vi.fn(),


### PR DESCRIPTION
# Overview

In `DropdownStepFormField`, if the length of `options` passed in changes to 1, we need to set the form field value for this component to the single value

Closes RQA-3955

## Test Plan and Hands on Testing

- import or create a protocol that will provide 1 single location for moving labware ([example](https://github.com/user-attachments/files/18751160/untitled.3.json))

- verify that the single option is selected, and saving the step form is not blocked

https://github.com/user-attachments/assets/4f49b0b1-6fb9-4811-87dd-77de9e617de0


## Changelog

- add useEffect to select the single option of a `DropDownStepFormField` if `options`'s length === 1

## Review requests

see test plan

## Risk assessment

low