### PR TITLE
feat(protocol-designer): loadAdapter and loadLabware python file

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -129,7 +129,10 @@ requirements = {
 }
 
 def run(protocol: protocol_api.ProtocolContext):
-    pass
+    # Load Labware:
+    mockPythonName = protocol.load_labware("fixture_trash", "12")
+    mockPythonName = protocol.load_labware("fixture_tiprack_10_ul", "1")
+    mockPythonName = protocol.load_labware("fixture_96_plate", "7")
 `.trimStart()
     )
   })

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -92,15 +92,15 @@ const mockModuleEntities: ModuleEntities = {
     pythonName: 'magnetic_block_2',
   },
 }
-const labwareId = 'labwareId1'
+const labwareId1 = 'labwareId1'
 const labwareId2 = 'labwareId2'
 const labwareId3 = 'labwareId3'
 const labwareId4 = 'labwareId4'
 const labwareId5 = 'labwareId5'
 
 const mockLabwareEntities: LabwareEntities = {
-  [labwareId]: {
-    id: labwareId,
+  [labwareId1]: {
+    id: labwareId1,
     labwareDefURI: 'fixture/fixture_flex_96_tiprack_adapter/1',
     def: fixtureTiprackAdapter as LabwareDefinition2,
     pythonName: 'adapter_1',
@@ -133,7 +133,7 @@ const mockLabwareEntities: LabwareEntities = {
 
 const labwareRobotState: TimelineFrame['labware'] = {
   //  adapter on a module
-  [labwareId]: { slot: moduleId },
+  [labwareId1]: { slot: moduleId },
   //  adapter on a slot
   [labwareId2]: { slot: 'B2' },
   //  labware on an adapter on a slot
@@ -153,10 +153,11 @@ describe('getLoadModules', () => {
     }
 
     expect(getLoadModules(mockModuleEntities, modules)).toBe(
-      `# Load Modules:
+      `
+# Load Modules:
 magnetic_block_1 = protocol.load_module("magneticBlockV1", "B1")
 heater_shaker_1 = protocol.load_module("heaterShakerModuleV1", "A1")
-magnetic_block_2 = protocol.load_module("magneticBlockV1", "A2")`
+magnetic_block_2 = protocol.load_module("magneticBlockV1", "A2")`.trimStart()
     )
   })
 })
@@ -170,9 +171,10 @@ describe('getLoadAdapters', () => {
         labwareRobotState
       )
     ).toBe(
-      `# Load Adapters:
+      `
+# Load Adapters:
 adapter_1 = magnetic_block_1.load_adapter("fixture_flex_96_tiprack_adapter")
-adapter_2 = protocol.load_adapter("fixture_flex_96_tiprack_adapter", "B2")`
+adapter_2 = protocol.load_adapter("fixture_flex_96_tiprack_adapter", "B2")`.trimStart()
     )
   })
 })
@@ -182,10 +184,11 @@ describe('getLoadLabware', () => {
     expect(
       getLoadLabware(mockModuleEntities, mockLabwareEntities, labwareRobotState)
     ).toBe(
-      `# Load Labware:
+      `
+# Load Labware:
 well_plate_1 = adapter_2.load_labware("fixture_96_plate")
 well_plate_2 = magnetic_block_2.load_labware("fixture_96_plate")
-well_plate_3 = protocol.load_labware("fixture_96_plate", "C2")`
+well_plate_3 = protocol.load_labware("fixture_96_plate", "C2")`.trimStart()
     )
   })
 })

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -6,13 +6,18 @@ import {
   MAGNETIC_BLOCK_TYPE,
   MAGNETIC_BLOCK_V1,
   OT2_ROBOT_TYPE,
+  fixture96Plate,
+  fixtureTiprackAdapter,
 } from '@opentrons/shared-data'
 import {
+  getLoadAdapters,
+  getLoadLabware,
   getLoadModules,
   pythonMetadata,
   pythonRequirements,
 } from '../selectors/pythonFile'
-import type { TimelineFrame } from '@opentrons/step-generation'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareEntities, TimelineFrame } from '@opentrons/step-generation'
 import type { ModuleEntities } from '../../step-forms'
 
 describe('pythonMetadata', () => {
@@ -64,31 +69,83 @@ requirements = {
   })
 })
 
+const moduleId = '1'
+const moduleId2 = '2'
+const moduleId3 = '3'
+const mockModuleEntities: ModuleEntities = {
+  [moduleId]: {
+    id: moduleId,
+    model: MAGNETIC_BLOCK_V1,
+    type: MAGNETIC_BLOCK_TYPE,
+    pythonName: 'magnetic_block_1',
+  },
+  [moduleId2]: {
+    id: moduleId2,
+    model: HEATERSHAKER_MODULE_V1,
+    type: HEATERSHAKER_MODULE_TYPE,
+    pythonName: 'heater_shaker_1',
+  },
+  [moduleId3]: {
+    id: moduleId3,
+    model: MAGNETIC_BLOCK_V1,
+    type: MAGNETIC_BLOCK_TYPE,
+    pythonName: 'magnetic_block_2',
+  },
+}
+const labwareId = 'labwareId1'
+const labwareId2 = 'labwareId2'
+const labwareId3 = 'labwareId3'
+const labwareId4 = 'labwareId4'
+const labwareId5 = 'labwareId5'
+
+const mockLabwareEntities: LabwareEntities = {
+  [labwareId]: {
+    id: labwareId,
+    labwareDefURI: 'fixture/fixture_flex_96_tiprack_adapter/1',
+    def: fixtureTiprackAdapter as LabwareDefinition2,
+    pythonName: 'adapter_1',
+  },
+  [labwareId2]: {
+    id: labwareId2,
+    labwareDefURI: 'fixture/fixture_flex_96_tiprack_adapter/1',
+    def: fixtureTiprackAdapter as LabwareDefinition2,
+    pythonName: 'adapter_2',
+  },
+  [labwareId3]: {
+    id: labwareId3,
+    labwareDefURI: 'fixture/fixture_96_plate/1',
+    def: fixture96Plate as LabwareDefinition2,
+    pythonName: 'well_plate_1',
+  },
+  [labwareId4]: {
+    id: labwareId4,
+    labwareDefURI: 'fixture/fixture_96_plate/1',
+    def: fixture96Plate as LabwareDefinition2,
+    pythonName: 'well_plate_2',
+  },
+  [labwareId5]: {
+    id: labwareId5,
+    labwareDefURI: 'fixture/fixture_96_plate/1',
+    def: fixture96Plate as LabwareDefinition2,
+    pythonName: 'well_plate_3',
+  },
+}
+
+const labwareRobotState: TimelineFrame['labware'] = {
+  //  adapter on a module
+  [labwareId]: { slot: moduleId },
+  //  adapter on a slot
+  [labwareId2]: { slot: 'B2' },
+  //  labware on an adapter on a slot
+  [labwareId3]: { slot: labwareId2 },
+  //  labware on a module
+  [labwareId4]: { slot: moduleId3 },
+  //  labware on a slot
+  [labwareId5]: { slot: 'C2' },
+}
+
 describe('getLoadModules', () => {
   it('should generate loadModules', () => {
-    const moduleId = '1'
-    const moduleId2 = '2'
-    const moduleId3 = '3'
-    const mockModuleEntities: ModuleEntities = {
-      [moduleId]: {
-        id: moduleId,
-        model: MAGNETIC_BLOCK_V1,
-        type: MAGNETIC_BLOCK_TYPE,
-        pythonName: 'magnetic_block_1',
-      },
-      [moduleId2]: {
-        id: moduleId2,
-        model: HEATERSHAKER_MODULE_V1,
-        type: HEATERSHAKER_MODULE_TYPE,
-        pythonName: 'heater_shaker_1',
-      },
-      [moduleId3]: {
-        id: moduleId3,
-        model: MAGNETIC_BLOCK_V1,
-        type: MAGNETIC_BLOCK_TYPE,
-        pythonName: 'magnetic_block_2',
-      },
-    }
     const modules: TimelineFrame['modules'] = {
       [moduleId]: { slot: 'B1', moduleState: {} as any },
       [moduleId2]: { slot: 'A1', moduleState: {} as any },
@@ -100,6 +157,35 @@ describe('getLoadModules', () => {
 magnetic_block_1 = protocol.load_module("magneticBlockV1", "B1")
 heater_shaker_1 = protocol.load_module("heaterShakerModuleV1", "A1")
 magnetic_block_2 = protocol.load_module("magneticBlockV1", "A2")`
+    )
+  })
+})
+
+describe('getLoadAdapters', () => {
+  it('should generate loadAdapters for 2 adapters', () => {
+    expect(
+      getLoadAdapters(
+        mockModuleEntities,
+        mockLabwareEntities,
+        labwareRobotState
+      )
+    ).toBe(
+      `# Load Adapters:
+adapter_1 = magnetic_block_1.load_adapter("fixture_flex_96_tiprack_adapter")
+adapter_2 = protocol.load_adapter("fixture_flex_96_tiprack_adapter", "B2")`
+    )
+  })
+})
+
+describe('getLoadLabware', () => {
+  it('should generate loadLabware for 3 labware', () => {
+    expect(
+      getLoadLabware(mockModuleEntities, mockLabwareEntities, labwareRobotState)
+    ).toBe(
+      `# Load Labware:
+well_plate_1 = adapter_2.load_labware("fixture_96_plate")
+well_plate_2 = magnetic_block_2.load_labware("fixture_96_plate")
+well_plate_3 = protocol.load_labware("fixture_96_plate", "C2")`
     )
   })
 })

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -9,6 +9,7 @@ import {
 } from '@opentrons/step-generation'
 import type {
   InvariantContext,
+  LabwareEntities,
   ModuleEntities,
   TimelineFrame,
 } from '@opentrons/step-generation'
@@ -77,17 +78,89 @@ export function getLoadModules(
   return hasModules ? `# Load Modules:\n${pythonModules}` : ''
 }
 
+export function getLoadAdapters(
+  moduleEntities: ModuleEntities,
+  labwareEntities: LabwareEntities,
+  labwareRobotState: TimelineFrame['labware']
+): string {
+  const adapterEntities = Object.values(labwareEntities).filter(lw =>
+    lw.def.allowedRoles?.includes('adapter')
+  )
+  const hasAdapters = Object.keys(adapterEntities).length > 0
+
+  const pythonAdapters = hasAdapters
+    ? Object.values(adapterEntities)
+        .map(adapter => {
+          const adapterSlot = labwareRobotState[adapter.id].slot
+          const onModule = moduleEntities[adapterSlot] != null
+          const location = onModule
+            ? moduleEntities[adapterSlot].pythonName
+            : PROTOCOL_CONTEXT_NAME
+          const slotInfo = onModule ? '' : `, ${formatPyStr(adapterSlot)}`
+
+          return `${
+            adapter.pythonName
+          } = ${location}.load_adapter(${formatPyStr(
+            adapter.def.parameters.loadName
+          )}${slotInfo})`
+        })
+        .join('\n')
+    : ''
+
+  return hasAdapters ? `# Load Adapters:\n${pythonAdapters}` : ''
+}
+
+export function getLoadLabware(
+  moduleEntities: ModuleEntities,
+  allLabwareEntities: LabwareEntities,
+  labwareRobotState: TimelineFrame['labware']
+): string {
+  const labwareEntities = Object.values(allLabwareEntities).filter(
+    lw => !lw.def.allowedRoles?.includes('adapter')
+  )
+  const hasLabware = Object.keys(labwareEntities).length > 0
+
+  const pythonLabware = hasLabware
+    ? Object.values(labwareEntities)
+        .map(labware => {
+          const labwareSlot = labwareRobotState[labware.id].slot
+          const onModule = moduleEntities[labwareSlot] != null
+          const onAdapter = allLabwareEntities[labwareSlot] != null
+          let location = PROTOCOL_CONTEXT_NAME
+          if (onAdapter) {
+            location = allLabwareEntities[labwareSlot].pythonName
+          } else if (onModule) {
+            location = moduleEntities[labwareSlot].pythonName
+          }
+          const slotInfo =
+            onModule || onAdapter ? '' : `, ${formatPyStr(labwareSlot)}`
+
+          return `${
+            labware.pythonName
+          } = ${location}.load_labware(${formatPyStr(
+            labware.def.parameters.loadName
+          )}${slotInfo})`
+        })
+        .join('\n')
+    : ''
+
+  return hasLabware ? `# Load Labware:\n${pythonLabware}` : ''
+}
+
 export function pythonDefRun(
   invariantContext: InvariantContext,
   robotState: TimelineFrame
 ): string {
-  const { moduleEntities } = invariantContext
-
-  const loadModules = getLoadModules(moduleEntities, robotState.modules)
+  const { moduleEntities, labwareEntities } = invariantContext
+  const { modules, labware } = robotState
+  const loadModules = getLoadModules(moduleEntities, modules)
+  const loadAdapters = getLoadAdapters(moduleEntities, labwareEntities, labware)
+  const loadLabware = getLoadLabware(moduleEntities, labwareEntities, labware)
 
   const sections: string[] = [
     loadModules,
-    // loadLabware(),
+    loadAdapters,
+    loadLabware,
     // loadInstruments(),
     // defineLiquids(),
     // loadLiquids(),

--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -77,7 +77,7 @@ export const createContainer: (
   const labwareDef = labwareDefSelectors.getLabwareDefsByURI(state)[
     args.labwareDefURI
   ]
-  const displayCategory = labwareDef.metadata.displayCategory
+  const labwareDisplayCategory = labwareDef.metadata.displayCategory
   const slot =
     args.slot ||
     getNextAvailableDeckSlot(initialDeckSetup, robotType, labwareDef)
@@ -90,6 +90,9 @@ export const createContainer: (
         : null
 
     if (adapterId != null && args.adapterUnderLabwareDefURI != null) {
+      const adapterDef = labwareDefSelectors.getLabwareDefsByURI(state)[
+        args.adapterUnderLabwareDefURI
+      ]
       dispatch({
         type: 'CREATE_CONTAINER',
         payload: {
@@ -97,7 +100,7 @@ export const createContainer: (
           labwareDefURI: args.adapterUnderLabwareDefURI,
           id: adapterId,
           slot,
-          displayCategory,
+          displayCategory: adapterDef.metadata.displayCategory,
         },
       })
       dispatch({
@@ -106,13 +109,13 @@ export const createContainer: (
           ...args,
           id,
           slot: adapterId,
-          displayCategory,
+          displayCategory: labwareDisplayCategory,
         },
       })
     } else {
       dispatch({
         type: 'CREATE_CONTAINER',
-        payload: { ...args, id, slot, displayCategory },
+        payload: { ...args, id, slot, displayCategory: labwareDisplayCategory },
       })
     }
     if (isTiprack) {


### PR DESCRIPTION
partially addresses AUTH-1092

# Overview

This pr creates the `load_adapter` and `load_labware` api commands in the python export file. This also fixes a bug with generating the `pythonNames` for adapters in the `createContainer` redux action where the `displayCategory` for the adapter was incorrectly the `displayCategory` for the labware

Here is an example of what it would look like 

```
def run(protocol: protocol_api.ProtocolContext):
    # Load Modules:
    heater_shaker_module_1 = protocol.load_module("heaterShakerModuleV1", "D1")
    thermocycler_module_1 = protocol.load_module("thermocyclerModuleV2", "B1")

    # Load Adapters:
    adapter_1 = heater_shaker_module_1.load_adapter("opentrons_96_flat_bottom_adapter")
    adapter_2 = protocol.load_adapter("opentrons_96_deep_well_temp_mod_adapter", "B3")

    # Load Labware:
    tip_rack_1 = protocol.load_labware("opentrons_flex_96_filtertiprack_200ul", "C2")
    well_plate_1 = adapter_1.load_labware("nest_96_wellplate_200ul_flat")
    well_plate_2 = thermocycler_module_1.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt")
    well_plate_3 = adapter_2.load_labware("nest_96_wellplate_2ml_deep")
```

## Test Plan and Hands on Testing

Test various combinations and make sure the python blob looks correct. Here are the combos: (NOTE: i tested each combo in the unit test)

- adapter on a slot
- adapter on a module on a slot
- labware on a slot
- labware on a module on a slot
- labware on an adapater on a module on a slot

## Changelog

- create `getLoadLabware` and `getLoadAdapters` functions and add unit tests for them
- fix a bug with generating the adapter `pythonNames` in the redux action

## Risk assessment

low, behind ff
