### PR TITLE
feat(protocol-designer): add placeholder for step commands to generated Python

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -106,7 +106,8 @@ describe('createFile selector', () => {
       fileMetadata,
       OT2_ROBOT_TYPE,
       entities,
-      v7Fixture.initialRobotState
+      v7Fixture.initialRobotState,
+      v7Fixture.robotStateTimeline
     )
     // This is just a quick smoke test to make sure createPythonFile() produces
     // something that looks like a Python file. The individual sections of the
@@ -129,6 +130,9 @@ requirements = {
 }
 
 def run(protocol: protocol_api.ProtocolContext):
+    # PROTOCOL STEPS
+
+    # Step 1:
     pass
 `.trimStart()
     )

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -310,14 +310,21 @@ export const createPythonFile: Selector<string> = createSelector(
   getRobotType,
   stepFormSelectors.getInvariantContext,
   getInitialRobotState,
-  (fileMetadata, robotType, invariantContext, robotState) => {
+  getRobotStateTimeline,
+  (
+    fileMetadata,
+    robotType,
+    invariantContext,
+    robotState,
+    robotStateTimeline
+  ) => {
     return (
       [
         // Here are the sections of the Python file:
         pythonImports(),
         pythonMetadata(fileMetadata),
         pythonRequirements(robotType),
-        pythonDefRun(invariantContext, robotState),
+        pythonDefRun(invariantContext, robotState, robotStateTimeline),
       ]
         .filter(section => section) // skip any blank sections
         .join('\n\n') + '\n'

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -10,6 +10,7 @@ import {
 import type {
   InvariantContext,
   ModuleEntities,
+  Timeline,
   TimelineFrame,
 } from '@opentrons/step-generation'
 import type { RobotType } from '@opentrons/shared-data'
@@ -77,9 +78,22 @@ export function getLoadModules(
   return hasModules ? `# Load Modules:\n${pythonModules}` : ''
 }
 
+export function stepCommands(robotStateTimeline: Timeline): string {
+  return (
+    '# PROTOCOL STEPS\n\n' +
+    robotStateTimeline.timeline
+      .map(
+        (timelineFrame, idx) =>
+          `# Step ${idx + 1}:\n${timelineFrame.python || 'pass'}`
+      )
+      .join('\n\n')
+  )
+}
+
 export function pythonDefRun(
   invariantContext: InvariantContext,
-  robotState: TimelineFrame
+  robotState: TimelineFrame,
+  robotStateTimeline: Timeline
 ): string {
   const { moduleEntities } = invariantContext
 
@@ -91,7 +105,7 @@ export function pythonDefRun(
     // loadInstruments(),
     // defineLiquids(),
     // loadLiquids(),
-    // stepCommands(),
+    stepCommands(robotStateTimeline),
   ]
   const functionBody =
     sections


### PR DESCRIPTION
# Overview

This adds the Python output from `step-generation` into the generated Python file so that we can see our progress as we work. AUTH-1385

Right now, it just emits a placeholder that looks like:
```
def run(protocol: protocol_api.ProtocolContext):
    # PROTOCOL STEPS

    # Step 1:
    pass

    # Step 2:
    pass
```

## Test Plan and Hands on Testing

Updated unit test, and tested exporting a Python protocol by hand.

## Risk assessment

Low. Python export is hidden under a feature flag, so this should have no observable impact to users.