### PR TITLE
refactor(shared-data): Clean up Python types for labware definitions

### DIFF
--- a/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
@@ -4,7 +4,7 @@ import pytest
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
     LabwareRole,
-    OverlapOffset,
+    OffsetVector,
     Parameters,
 )
 
@@ -64,13 +64,13 @@ def test_validate_definition_is_adapter(
     [
         (
             LabwareDefinition.model_construct(  # type: ignore[call-arg]
-                stackingOffsetWithLabware={"labware123": OverlapOffset(x=4, y=5, z=6)}
+                stackingOffsetWithLabware={"labware123": OffsetVector(x=4, y=5, z=6)}
             ),
             True,
         ),
         (
             LabwareDefinition.model_construct(  # type: ignore[call-arg]
-                stackingOffsetWithLabware={"labwareXYZ": OverlapOffset(x=4, y=5, z=6)}
+                stackingOffsetWithLabware={"labwareXYZ": OffsetVector(x=4, y=5, z=6)}
             ),
             False,
         ),

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
@@ -4,7 +4,7 @@ import pytest
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
     LabwareRole,
-    OffsetVector,
+    Vector,
     Parameters,
 )
 
@@ -64,13 +64,13 @@ def test_validate_definition_is_adapter(
     [
         (
             LabwareDefinition.model_construct(  # type: ignore[call-arg]
-                stackingOffsetWithLabware={"labware123": OffsetVector(x=4, y=5, z=6)}
+                stackingOffsetWithLabware={"labware123": Vector(x=4, y=5, z=6)}
             ),
             True,
         ),
         (
             LabwareDefinition.model_construct(  # type: ignore[call-arg]
-                stackingOffsetWithLabware={"labwareXYZ": OffsetVector(x=4, y=5, z=6)}
+                stackingOffsetWithLabware={"labwareXYZ": Vector(x=4, y=5, z=6)}
             ),
             False,
         ),

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -31,7 +31,7 @@ from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.labware.labware_definition import (
     Dimensions as LabwareDimensions,
     Parameters as LabwareDefinitionParameters,
-    CornerOffsetFromSlot,
+    OffsetVector as LabwareDefinitionOffsetVector,
     ConicalFrustum,
 )
 
@@ -2953,7 +2953,9 @@ def test_check_gripper_labware_tip_collision(
             isTiprack=True,
             isMagneticModuleCompatible=False,
         ),
-        cornerOffsetFromSlot=CornerOffsetFromSlot.model_construct(x=1, y=2, z=3),
+        cornerOffsetFromSlot=LabwareDefinitionOffsetVector.model_construct(
+            x=1, y=2, z=3
+        ),
         ordering=[],
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -31,7 +31,7 @@ from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.labware.labware_definition import (
     Dimensions as LabwareDimensions,
     Parameters as LabwareDefinitionParameters,
-    OffsetVector as LabwareDefinitionOffsetVector,
+    Vector as LabwareDefinitionVector,
     ConicalFrustum,
 )
 
@@ -2953,9 +2953,7 @@ def test_check_gripper_labware_tip_collision(
             isTiprack=True,
             isMagneticModuleCompatible=False,
         ),
-        cornerOffsetFromSlot=LabwareDefinitionOffsetVector.model_construct(
-            x=1, y=2, z=3
-        ),
+        cornerOffsetFromSlot=LabwareDefinitionVector.model_construct(x=1, y=2, z=3),
         ordering=[],
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -18,7 +18,6 @@ from opentrons_shared_data.labware.labware_definition import (
     Parameters,
     LabwareDefinition,
     LabwareRole,
-    OverlapOffset as SharedDataOverlapOffset,
     GripperOffsets,
     OffsetVector,
 )
@@ -698,7 +697,7 @@ def test_get_labware_overlap_offsets() -> None:
     result = subject.get_labware_overlap_offsets(
         definition=LabwareDefinition.model_construct(  # type: ignore[call-arg]
             stackingOffsetWithLabware={
-                "bottom-labware-name": SharedDataOverlapOffset(x=1, y=2, z=3)
+                "bottom-labware-name": OffsetVector(x=1, y=2, z=3)
             }
         ),
         below_labware_name="bottom-labware-name",
@@ -712,7 +711,7 @@ class ModuleOverlapSpec(NamedTuple):
 
     spec_deck_definition: DeckDefinitionV5
     module_model: ModuleModel
-    stacking_offset_with_module: Dict[str, SharedDataOverlapOffset]
+    stacking_offset_with_module: Dict[str, OffsetVector]
     expected_offset: OverlapOffset
 
 
@@ -722,9 +721,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
         spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
         module_model=ModuleModel.TEMPERATURE_MODULE_V2,
         stacking_offset_with_module={
-            str(ModuleModel.TEMPERATURE_MODULE_V2.value): SharedDataOverlapOffset(
-                x=1, y=2, z=3
-            ),
+            str(ModuleModel.TEMPERATURE_MODULE_V2.value): OffsetVector(x=1, y=2, z=3),
         },
         expected_offset=OverlapOffset(x=1, y=2, z=3),
     ),
@@ -733,7 +730,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
         spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
         module_model=ModuleModel.THERMOCYCLER_MODULE_V1,
         stacking_offset_with_module={
-            str(ModuleModel.THERMOCYCLER_MODULE_V1.value): SharedDataOverlapOffset(
+            str(ModuleModel.THERMOCYCLER_MODULE_V1.value): OffsetVector(
                 x=11, y=22, z=33
             ),
         },
@@ -758,7 +755,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
         spec_deck_definition=load_deck(STANDARD_OT3_DECK, 5),
         module_model=ModuleModel.THERMOCYCLER_MODULE_V2,
         stacking_offset_with_module={
-            str(ModuleModel.THERMOCYCLER_MODULE_V2.value): SharedDataOverlapOffset(
+            str(ModuleModel.THERMOCYCLER_MODULE_V2.value): OffsetVector(
                 x=111, y=222, z=333
             ),
         },
@@ -774,7 +771,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
 def test_get_module_overlap_offsets(
     spec_deck_definition: DeckDefinitionV5,
     module_model: ModuleModel,
-    stacking_offset_with_module: Dict[str, SharedDataOverlapOffset],
+    stacking_offset_with_module: Dict[str, OffsetVector],
     expected_offset: OverlapOffset,
 ) -> None:
     """It should get the labware overlap offsets."""
@@ -1408,9 +1405,7 @@ def test_raise_if_labware_cannot_be_stacked_on_module_not_adapter() -> None:
         subject.raise_if_labware_cannot_be_stacked(
             top_labware_definition=LabwareDefinition.model_construct(  # type: ignore[call-arg]
                 parameters=Parameters.model_construct(loadName="name"),  # type: ignore[call-arg]
-                stackingOffsetWithLabware={
-                    "test": SharedDataOverlapOffset(x=0, y=0, z=0)
-                },
+                stackingOffsetWithLabware={"test": OffsetVector(x=0, y=0, z=0)},
             ),
             bottom_labware_id="labware-id",
         )
@@ -1450,9 +1445,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
         subject.raise_if_labware_cannot_be_stacked(
             top_labware_definition=LabwareDefinition.model_construct(  # type: ignore[call-arg]
                 parameters=Parameters.model_construct(loadName="name"),  # type: ignore[call-arg]
-                stackingOffsetWithLabware={
-                    "test": SharedDataOverlapOffset(x=0, y=0, z=0)
-                },
+                stackingOffsetWithLabware={"test": OffsetVector(x=0, y=0, z=0)},
             ),
             bottom_labware_id="labware-id",
         )
@@ -1533,9 +1526,7 @@ def test_labware_stacking_height_passes_or_raises(
                     loadName="name",
                     isMagneticModuleCompatible=False,
                 ),
-                stackingOffsetWithLabware={
-                    "test": SharedDataOverlapOffset(x=0, y=0, z=0)
-                },
+                stackingOffsetWithLabware={"test": OffsetVector(x=0, y=0, z=0)},
                 stackLimit=stack_limit,
             ),
             bottom_labware_id="labware-id4",

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -19,7 +19,7 @@ from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
     LabwareRole,
     GripperOffsets,
-    OffsetVector,
+    Vector,
 )
 
 from opentrons.protocols.api_support.deck_type import (
@@ -696,9 +696,7 @@ def test_get_labware_overlap_offsets() -> None:
     subject = get_labware_view()
     result = subject.get_labware_overlap_offsets(
         definition=LabwareDefinition.model_construct(  # type: ignore[call-arg]
-            stackingOffsetWithLabware={
-                "bottom-labware-name": OffsetVector(x=1, y=2, z=3)
-            }
+            stackingOffsetWithLabware={"bottom-labware-name": Vector(x=1, y=2, z=3)}
         ),
         below_labware_name="bottom-labware-name",
     )
@@ -711,7 +709,7 @@ class ModuleOverlapSpec(NamedTuple):
 
     spec_deck_definition: DeckDefinitionV5
     module_model: ModuleModel
-    stacking_offset_with_module: Dict[str, OffsetVector]
+    stacking_offset_with_module: Dict[str, Vector]
     expected_offset: OverlapOffset
 
 
@@ -721,7 +719,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
         spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
         module_model=ModuleModel.TEMPERATURE_MODULE_V2,
         stacking_offset_with_module={
-            str(ModuleModel.TEMPERATURE_MODULE_V2.value): OffsetVector(x=1, y=2, z=3),
+            str(ModuleModel.TEMPERATURE_MODULE_V2.value): Vector(x=1, y=2, z=3),
         },
         expected_offset=OverlapOffset(x=1, y=2, z=3),
     ),
@@ -730,9 +728,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
         spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
         module_model=ModuleModel.THERMOCYCLER_MODULE_V1,
         stacking_offset_with_module={
-            str(ModuleModel.THERMOCYCLER_MODULE_V1.value): OffsetVector(
-                x=11, y=22, z=33
-            ),
+            str(ModuleModel.THERMOCYCLER_MODULE_V1.value): Vector(x=11, y=22, z=33),
         },
         expected_offset=OverlapOffset(x=11, y=22, z=33),
     ),
@@ -755,9 +751,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
         spec_deck_definition=load_deck(STANDARD_OT3_DECK, 5),
         module_model=ModuleModel.THERMOCYCLER_MODULE_V2,
         stacking_offset_with_module={
-            str(ModuleModel.THERMOCYCLER_MODULE_V2.value): OffsetVector(
-                x=111, y=222, z=333
-            ),
+            str(ModuleModel.THERMOCYCLER_MODULE_V2.value): Vector(x=111, y=222, z=333),
         },
         expected_offset=OverlapOffset(x=111, y=222, z=333),
     ),
@@ -771,7 +765,7 @@ module_overlap_specs: List[ModuleOverlapSpec] = [
 def test_get_module_overlap_offsets(
     spec_deck_definition: DeckDefinitionV5,
     module_model: ModuleModel,
-    stacking_offset_with_module: Dict[str, OffsetVector],
+    stacking_offset_with_module: Dict[str, Vector],
     expected_offset: OverlapOffset,
 ) -> None:
     """It should get the labware overlap offsets."""
@@ -1405,7 +1399,7 @@ def test_raise_if_labware_cannot_be_stacked_on_module_not_adapter() -> None:
         subject.raise_if_labware_cannot_be_stacked(
             top_labware_definition=LabwareDefinition.model_construct(  # type: ignore[call-arg]
                 parameters=Parameters.model_construct(loadName="name"),  # type: ignore[call-arg]
-                stackingOffsetWithLabware={"test": OffsetVector(x=0, y=0, z=0)},
+                stackingOffsetWithLabware={"test": Vector(x=0, y=0, z=0)},
             ),
             bottom_labware_id="labware-id",
         )
@@ -1445,7 +1439,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
         subject.raise_if_labware_cannot_be_stacked(
             top_labware_definition=LabwareDefinition.model_construct(  # type: ignore[call-arg]
                 parameters=Parameters.model_construct(loadName="name"),  # type: ignore[call-arg]
-                stackingOffsetWithLabware={"test": OffsetVector(x=0, y=0, z=0)},
+                stackingOffsetWithLabware={"test": Vector(x=0, y=0, z=0)},
             ),
             bottom_labware_id="labware-id",
         )
@@ -1526,7 +1520,7 @@ def test_labware_stacking_height_passes_or_raises(
                     loadName="name",
                     isMagneticModuleCompatible=False,
                 ),
-                stackingOffsetWithLabware={"test": OffsetVector(x=0, y=0, z=0)},
+                stackingOffsetWithLabware={"test": Vector(x=0, y=0, z=0)},
                 stackLimit=stack_limit,
             ),
             bottom_labware_id="labware-id4",
@@ -1587,8 +1581,8 @@ def test_get_labware_gripper_offsets_default_no_slots(
             "some-labware-uri": LabwareDefinition.model_construct(  # type: ignore[call-arg]
                 gripperOffsets={
                     "default": GripperOffsets(
-                        pickUpOffset=OffsetVector(x=1, y=2, z=3),
-                        dropOffset=OffsetVector(x=4, y=5, z=6),
+                        pickUpOffset=Vector(x=1, y=2, z=3),
+                        dropOffset=Vector(x=4, y=5, z=6),
                     )
                 }
             ),

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -9,7 +9,7 @@ from opentrons_shared_data.labware.labware_definition import (
     Metadata,
     DisplayCategory,
     BrandData,
-    OffsetVector as SD_Labware_OffsetVector,
+    Vector as SD_Labware_Vector,
     Dimensions,
     Group,
     GroupMetadata,
@@ -692,7 +692,7 @@ def _load_labware_definition_data() -> LabwareDefinition:
             )
         },
         dimensions=Dimensions(yDimension=85.5, zDimension=100, xDimension=127.75),
-        cornerOffsetFromSlot=SD_Labware_OffsetVector(x=0, y=0, z=0),
+        cornerOffsetFromSlot=SD_Labware_Vector(x=0, y=0, z=0),
         innerLabwareGeometry={
             "welldefinition1111": InnerWellGeometry(
                 sections=[

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -9,7 +9,7 @@ from opentrons_shared_data.labware.labware_definition import (
     Metadata,
     DisplayCategory,
     BrandData,
-    OffsetVector,
+    OffsetVector as SD_Labware_OffsetVector,
     Dimensions,
     Group,
     GroupMetadata,
@@ -692,7 +692,7 @@ def _load_labware_definition_data() -> LabwareDefinition:
             )
         },
         dimensions=Dimensions(yDimension=85.5, zDimension=100, xDimension=127.75),
-        cornerOffsetFromSlot=OffsetVector(x=0, y=0, z=0),
+        cornerOffsetFromSlot=SD_Labware_OffsetVector(x=0, y=0, z=0),
         innerLabwareGeometry={
             "welldefinition1111": InnerWellGeometry(
                 sections=[

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -12,7 +12,7 @@ from opentrons_shared_data.labware.labware_definition import (
     CornerOffsetFromSlot,
     Dimensions,
     Group,
-    Metadata1,
+    GroupMetadata,
     WellDefinition,
     CuboidalFrustum,
     InnerWellGeometry,
@@ -680,7 +680,7 @@ def _load_labware_definition_data() -> LabwareDefinition:
         namespace="example",
         schemaVersion=2,
         ordering=[["A1", "B1", "C1", "D1"], ["A2", "B2", "C2", "D2"]],
-        groups=[Group(wells=["A1"], metadata=Metadata1())],
+        groups=[Group(wells=["A1"], metadata=GroupMetadata())],
         wells={
             "A1": WellDefinition(
                 depth=25,

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -9,7 +9,7 @@ from opentrons_shared_data.labware.labware_definition import (
     Metadata,
     DisplayCategory,
     BrandData,
-    CornerOffsetFromSlot,
+    OffsetVector,
     Dimensions,
     Group,
     GroupMetadata,
@@ -692,7 +692,7 @@ def _load_labware_definition_data() -> LabwareDefinition:
             )
         },
         dimensions=Dimensions(yDimension=85.5, zDimension=100, xDimension=127.75),
-        cornerOffsetFromSlot=CornerOffsetFromSlot(x=0, y=0, z=0),
+        cornerOffsetFromSlot=OffsetVector(x=0, y=0, z=0),
         innerLabwareGeometry={
             "welldefinition1111": InnerWellGeometry(
                 sections=[

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -332,13 +332,19 @@ def minimal_labware_def() -> LabwareDefinition:
 @pytest.fixture
 def custom_tiprack_def() -> LabwareDefinition:
     return {
-        "metadata": {"displayName": "minimal labware"},
+        "metadata": {
+            "displayName": "minimal labware",
+            "displayCategory": "tipRack",
+            "displayVolumeUnits": "µL",
+        },
         "cornerOffsetFromSlot": {"x": 10, "y": 10, "z": 5},
         "parameters": {
             "isTiprack": True,
             "tipLength": 55.3,
             "tipOverlap": 2.8,
             "loadName": "minimal_labware_def",
+            "format": "96Standard",
+            "isMagneticModuleCompatible": False,
         },
         "ordering": [["A1"], ["A2"]],
         "wells": {

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -50,7 +50,7 @@
       "type": "string",
       "pattern": "^[a-z0-9._]+$"
     },
-    "coordinates": {
+    "vector": {
       "type": "object",
       "additionalProperties": false,
       "required": ["x", "y", "z"],
@@ -71,11 +71,11 @@
       "required": ["pickUpOffset", "dropOffset"],
       "properties": {
         "pickUpOffset": {
-          "$ref": "#/definitions/coordinates",
+          "$ref": "#/definitions/vector",
           "description": "Offset added to calculate pick-up coordinates."
         },
         "dropOffset": {
-          "$ref": "#/definitions/coordinates",
+          "$ref": "#/definitions/vector",
           "description": "Offset added to calculate drop coordinates."
         }
       }
@@ -203,7 +203,7 @@
     },
     "cornerOffsetFromSlot": {
       "description": "Distance from left-front-bottom corner of slot to left-front-bottom corner of labware bounding box. Used for labware that spans multiple slots. For labware that does not span multiple slots, x/y/z should all be zero.",
-      "$ref": "#/definitions/coordinates"
+      "$ref": "#/definitions/vector"
     },
     "dimensions": {
       "type": "object",
@@ -345,14 +345,14 @@
       "type": "object",
       "description": "Supported labware that can be stacked upon, with overlap height between both labware.",
       "additionalProperties": {
-        "$ref": "#/definitions/coordinates"
+        "$ref": "#/definitions/vector"
       }
     },
     "stackingOffsetWithModule": {
       "type": "object",
       "description": "Supported module that can be stacked upon, with overlap height between labware and module.",
       "additionalProperties": {
-        "$ref": "#/definitions/coordinates"
+        "$ref": "#/definitions/vector"
       }
     },
     "gripperOffsets": {

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -202,15 +202,8 @@
       }
     },
     "cornerOffsetFromSlot": {
-      "type": "object",
-      "additionalProperties": false,
       "description": "Distance from left-front-bottom corner of slot to left-front-bottom corner of labware bounding box. Used for labware that spans multiple slots. For labware that does not span multiple slots, x/y/z should all be zero.",
-      "required": ["x", "y", "z"],
-      "properties": {
-        "x": { "type": "number" },
-        "y": { "type": "number" },
-        "z": { "type": "number" }
-      }
+      "$ref": "#/definitions/coordinates"
     },
     "dimensions": {
       "type": "object",

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -50,7 +50,7 @@
       "type": "string",
       "pattern": "^[a-z0-9._]+$"
     },
-    "coordinates": {
+    "vector": {
       "type": "object",
       "additionalProperties": false,
       "required": ["x", "y", "z"],
@@ -71,11 +71,11 @@
       "required": ["pickUpOffset", "dropOffset"],
       "properties": {
         "pickUpOffset": {
-          "$ref": "#/definitions/coordinates",
+          "$ref": "#/definitions/vector",
           "description": "Offset added to calculate pick-up coordinates."
         },
         "dropOffset": {
-          "$ref": "#/definitions/coordinates",
+          "$ref": "#/definitions/vector",
           "description": "Offset added to calculate drop coordinates."
         }
       }
@@ -430,7 +430,7 @@
     },
     "cornerOffsetFromSlot": {
       "description": "Distance from left-front-bottom corner of slot to left-front-bottom corner of labware bounding box. Used for labware that spans multiple slots. For labware that does not span multiple slots, x/y/z should all be zero.",
-      "$ref": "#/definitions/coordinates"
+      "$ref": "#/definitions/vector"
     },
     "dimensions": {
       "type": "object",
@@ -576,14 +576,14 @@
       "type": "object",
       "description": "Supported labware that can be stacked upon, with overlap height between both labware.",
       "additionalProperties": {
-        "$ref": "#/definitions/coordinates"
+        "$ref": "#/definitions/vector"
       }
     },
     "stackingOffsetWithModule": {
       "type": "object",
       "description": "Supported module that can be stacked upon, with overlap height between labware and module.",
       "additionalProperties": {
-        "$ref": "#/definitions/coordinates"
+        "$ref": "#/definitions/vector"
       }
     },
     "stackLimit": {

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -429,15 +429,8 @@
       }
     },
     "cornerOffsetFromSlot": {
-      "type": "object",
-      "additionalProperties": false,
       "description": "Distance from left-front-bottom corner of slot to left-front-bottom corner of labware bounding box. Used for labware that spans multiple slots. For labware that does not span multiple slots, x/y/z should all be zero.",
-      "required": ["x", "y", "z"],
-      "properties": {
-        "x": { "type": "number" },
-        "y": { "type": "number" },
-        "z": { "type": "number" }
-      }
+      "$ref": "#/definitions/coordinates"
     },
     "dimensions": {
       "type": "object",

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -588,8 +588,7 @@
     },
     "stackLimit": {
       "type": "number",
-      "description": "The limit representing the maximum stack size for a given labware.",
-      "additionalProperties": false
+      "description": "The limit representing the maximum stack size for a given labware."
     },
     "compatibleParentLabware": {
       "type": "array",

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -667,12 +667,13 @@ class Group(BaseModel):
     )
 
 
-WellSegment = Union[
-    ConicalFrustum,
-    CuboidalFrustum,
-    SquaredConeSegment,
-    RoundedCuboidSegment,
-    SphericalSegment,
+WellSegment = Annotated[
+    ConicalFrustum
+    | CuboidalFrustum
+    | SquaredConeSegment
+    | RoundedCuboidSegment
+    | SphericalSegment,
+    Field(discriminator="shape"),
 ]
 
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -639,7 +639,7 @@ class RoundedCuboidSegment(BaseModel):
     model_config = ConfigDict(ignored_types=(cached_property,))
 
 
-class Metadata1(BaseModel):
+class GroupMetadata(BaseModel):
     """
     Metadata specific to a grid of wells in a labware
     """
@@ -659,7 +659,7 @@ class Group(BaseModel):
     wells: List[str] = Field(
         ..., description="An array of wells that contain the same metadata"
     )
-    metadata: Metadata1 = Field(
+    metadata: GroupMetadata = Field(
         ..., description="Metadata specific to a grid of wells in a labware"
     )
     brand: Optional[BrandData] = Field(

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -50,18 +50,6 @@ _NonNegativeNumber = Union[_StrictNonNegativeInt, _StrictNonNegativeFloat]
 """Non-negative JSON number type, written to preserve lack of decimal point."""
 
 
-class CornerOffsetFromSlot(BaseModel):
-    """
-    Distance from left-front-bottom corner of slot to left-front-bottom corner
-     of labware bounding box. Used for labware that spans multiple slots. For
-      labware that does not span multiple slots, x/y/z should all be zero.
-    """
-
-    x: _Number
-    y: _Number
-    z: _Number
-
-
 class OverlapOffset(BaseModel):
     """
     Overlap dimensions of labware with another labware/module that it can be stacked on top of.
@@ -713,7 +701,7 @@ class LabwareDefinition(BaseModel):
         description="Generated array that keeps track of how wells should be "
         "ordered in a labware",
     )
-    cornerOffsetFromSlot: CornerOffsetFromSlot = Field(
+    cornerOffsetFromSlot: OffsetVector = Field(
         ...,
         description="Distance from left-front-bottom corner of slot to "
         "left-front-bottom corner of labware bounding box. Used for "

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -50,7 +50,7 @@ _NonNegativeNumber = Union[_StrictNonNegativeInt, _StrictNonNegativeFloat]
 """Non-negative JSON number type, written to preserve lack of decimal point."""
 
 
-class OffsetVector(BaseModel):
+class Vector(BaseModel):
     """
     A generic 3-D offset vector.
     """
@@ -65,8 +65,8 @@ class GripperOffsets(BaseModel):
     Offsets used when calculating coordinates for gripping labware during labware movement.
     """
 
-    pickUpOffset: OffsetVector
-    dropOffset: OffsetVector
+    pickUpOffset: Vector
+    dropOffset: Vector
 
 
 class BrandData(BaseModel):
@@ -691,7 +691,7 @@ class LabwareDefinition(BaseModel):
         description="Generated array that keeps track of how wells should be "
         "ordered in a labware",
     )
-    cornerOffsetFromSlot: OffsetVector = Field(
+    cornerOffsetFromSlot: Vector = Field(
         ...,
         description="Distance from left-front-bottom corner of slot to "
         "left-front-bottom corner of labware bounding box. Used for "
@@ -713,12 +713,12 @@ class LabwareDefinition(BaseModel):
         default_factory=list,
         description="Allowed behaviors and usage of a labware in a protocol.",
     )
-    stackingOffsetWithLabware: Dict[str, OffsetVector] = Field(
+    stackingOffsetWithLabware: Dict[str, Vector] = Field(
         default_factory=dict,
         description="Supported labware that can be stacked upon,"
         " with overlap vector offset between both labware.",
     )
-    stackingOffsetWithModule: Dict[str, OffsetVector] = Field(
+    stackingOffsetWithModule: Dict[str, Vector] = Field(
         default_factory=dict,
         description="Supported module that can be stacked upon,"
         " with overlap vector offset between labware and module.",

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -50,16 +50,6 @@ _NonNegativeNumber = Union[_StrictNonNegativeInt, _StrictNonNegativeFloat]
 """Non-negative JSON number type, written to preserve lack of decimal point."""
 
 
-class OverlapOffset(BaseModel):
-    """
-    Overlap dimensions of labware with another labware/module that it can be stacked on top of.
-    """
-
-    x: _Number
-    y: _Number
-    z: _Number
-
-
 class OffsetVector(BaseModel):
     """
     A generic 3-D offset vector.
@@ -723,12 +713,12 @@ class LabwareDefinition(BaseModel):
         default_factory=list,
         description="Allowed behaviors and usage of a labware in a protocol.",
     )
-    stackingOffsetWithLabware: Dict[str, OverlapOffset] = Field(
+    stackingOffsetWithLabware: Dict[str, OffsetVector] = Field(
         default_factory=dict,
         description="Supported labware that can be stacked upon,"
         " with overlap vector offset between both labware.",
     )
-    stackingOffsetWithModule: Dict[str, OverlapOffset] = Field(
+    stackingOffsetWithModule: Dict[str, OffsetVector] = Field(
         default_factory=dict,
         description="Supported module that can be stacked upon,"
         " with overlap vector offset between labware and module.",

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -106,7 +106,7 @@ class RectangularWellDefinition(TypedDict):
     z: float
     xDimension: float
     yDimension: float
-    geometryDefinitionId: NotRequired[str]
+    geometryDefinitionId: NotRequired[str | None]
 
 
 WellDefinition = CircularWellDefinition | RectangularWellDefinition
@@ -142,6 +142,6 @@ class LabwareDefinition(TypedDict):
     gripperOffsets: NotRequired[dict[str, GripperOffsets]]
     gripForce: NotRequired[float]
     gripHeightFromLabwareBottom: NotRequired[float]
-    innerLabwareGeometry: NotRequired[dict[str, InnerWellGeometry]]
+    innerLabwareGeometry: NotRequired[dict[str, InnerWellGeometry] | None]
     compatibleParentLabware: NotRequired[list[str]]
     stackLimit: NotRequired[int]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -13,34 +13,34 @@ from .constants import (
 
 LabwareUri = NewType("LabwareUri", str)
 
-LabwareDisplayCategory = Union[
-    Literal["tipRack"],
-    Literal["tubeRack"],
-    Literal["reservoir"],
-    Literal["trash"],
-    Literal["wellPlate"],
-    Literal["aluminumBlock"],
-    Literal["adapter"],
-    Literal["other"],
-    Literal["lid"],
-    Literal["system"],
+LabwareDisplayCategory = Literal[
+    "tipRack",
+    "tubeRack",
+    "reservoir",
+    "trash",
+    "wellPlate",
+    "aluminumBlock",
+    "adapter",
+    "other",
+    "lid",
+    "system",
 ]
 
-LabwareFormat = Union[
-    Literal["96Standard"],
-    Literal["384Standard"],
-    Literal["trough"],
-    Literal["irregular"],
-    Literal["trash"],
+LabwareFormat = Literal[
+    "96Standard",
+    "384Standard",
+    "trough",
+    "irregular",
+    "trash",
 ]
 
-LabwareRoles = Union[
-    Literal["labware"],
-    Literal["fixture"],
-    Literal["adapter"],
-    Literal["maintenance"],
-    Literal["lid"],
-    Literal["system"],
+LabwareRoles = Literal[
+    "labware",
+    "fixture",
+    "adapter",
+    "maintenance",
+    "lid",
+    "system",
 ]
 
 
@@ -76,7 +76,7 @@ class LabwareBrandData(TypedDict, total=False):
 class LabwareMetadata(TypedDict, total=False):
     displayName: str
     displayCategory: LabwareDisplayCategory
-    displayVolumeUnits: Union[Literal["µL"], Literal["mL"], Literal["L"]]
+    displayVolumeUnits: Literal["µL", "mL", "L"]
     tags: List[str]
 
 
@@ -115,7 +115,7 @@ WellDefinition = Union[CircularWellDefinition, RectangularWellDefinition]
 class WellGroupMetadata(TypedDict, total=False):
     displayName: str
     displayCategory: LabwareDisplayCategory
-    wellBottomShape: Union[Literal["flat"], Literal["u"], Literal["v"]]
+    wellBottomShape: Literal["flat", "u", "v"]
 
 
 class WellGroup(TypedDict, total=False):

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -44,15 +44,15 @@ LabwareRoles = Literal[
 ]
 
 
-class NamedOffset(TypedDict):
+class Vector(TypedDict):
     x: float
     y: float
     z: float
 
 
 class GripperOffsets(TypedDict):
-    pickUpOffset: NamedOffset
-    dropOffset: NamedOffset
+    pickUpOffset: Vector
+    dropOffset: Vector
 
 
 class LabwareParameters(TypedDict):
@@ -131,13 +131,13 @@ class LabwareDefinition(TypedDict):
     metadata: LabwareMetadata
     brand: LabwareBrandData
     parameters: LabwareParameters
-    cornerOffsetFromSlot: NamedOffset
+    cornerOffsetFromSlot: Vector
     ordering: list[list[str]]
     dimensions: LabwareDimensions
     wells: dict[str, WellDefinition]
     groups: list[WellGroup]
-    stackingOffsetWithLabware: NotRequired[dict[str, NamedOffset]]
-    stackingOffsetWithModule: NotRequired[dict[str, NamedOffset]]
+    stackingOffsetWithLabware: NotRequired[dict[str, Vector]]
+    stackingOffsetWithModule: NotRequired[dict[str, Vector]]
     allowedRoles: NotRequired[list[LabwareRoles]]
     gripperOffsets: NotRequired[dict[str, GripperOffsets]]
     gripForce: NotRequired[float]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -3,7 +3,7 @@
 types in this file by and large require the use of typing_extensions.
 this module shouldn't be imported unless typing.TYPE_CHECKING is true.
 """
-from typing import Dict, List, NewType, Union
+from typing import NewType
 from typing_extensions import Literal, TypedDict, NotRequired
 from .labware_definition import InnerWellGeometry
 from .constants import (
@@ -55,29 +55,29 @@ class GripperOffsets(TypedDict):
     dropOffset: NamedOffset
 
 
-class LabwareParameters(TypedDict, total=False):
+class LabwareParameters(TypedDict):
     format: LabwareFormat
     isTiprack: bool
     loadName: str
     isMagneticModuleCompatible: bool
-    isDeckSlotCompatible: bool
-    quirks: List[str]
-    tipLength: float
-    tipOverlap: float
-    magneticModuleEngageHeight: float
+    isDeckSlotCompatible: NotRequired[bool]
+    quirks: NotRequired[list[str]]
+    tipLength: NotRequired[float]
+    tipOverlap: NotRequired[float]
+    magneticModuleEngageHeight: NotRequired[float]
 
 
-class LabwareBrandData(TypedDict, total=False):
+class LabwareBrandData(TypedDict):
     brand: str
-    brandId: List[str]
-    links: List[str]
+    brandId: NotRequired[list[str]]
+    links: NotRequired[list[str]]
 
 
-class LabwareMetadata(TypedDict, total=False):
+class LabwareMetadata(TypedDict):
     displayName: str
     displayCategory: LabwareDisplayCategory
     displayVolumeUnits: Literal["µL", "mL", "L"]
-    tags: List[str]
+    tags: NotRequired[list[str]]
 
 
 class LabwareDimensions(TypedDict):
@@ -109,19 +109,19 @@ class RectangularWellDefinition(TypedDict):
     geometryDefinitionId: NotRequired[str]
 
 
-WellDefinition = Union[CircularWellDefinition, RectangularWellDefinition]
+WellDefinition = CircularWellDefinition | RectangularWellDefinition
 
 
-class WellGroupMetadata(TypedDict, total=False):
-    displayName: str
-    displayCategory: LabwareDisplayCategory
-    wellBottomShape: Literal["flat", "u", "v"]
+class WellGroupMetadata(TypedDict):
+    displayName: NotRequired[str]
+    displayCategory: NotRequired[LabwareDisplayCategory]
+    wellBottomShape: NotRequired[Literal["flat", "u", "v"]]
 
 
-class WellGroup(TypedDict, total=False):
-    wells: List[str]
+class WellGroup(TypedDict):
+    wells: list[str]
     metadata: WellGroupMetadata
-    brand: LabwareBrandData
+    brand: NotRequired[LabwareBrandData]
 
 
 class LabwareDefinition(TypedDict):
@@ -132,16 +132,16 @@ class LabwareDefinition(TypedDict):
     brand: LabwareBrandData
     parameters: LabwareParameters
     cornerOffsetFromSlot: NamedOffset
-    ordering: List[List[str]]
+    ordering: list[list[str]]
     dimensions: LabwareDimensions
-    wells: Dict[str, WellDefinition]
-    groups: List[WellGroup]
-    stackingOffsetWithLabware: NotRequired[Dict[str, NamedOffset]]
-    stackingOffsetWithModule: NotRequired[Dict[str, NamedOffset]]
-    allowedRoles: NotRequired[List[LabwareRoles]]
-    gripperOffsets: NotRequired[Dict[str, GripperOffsets]]
+    wells: dict[str, WellDefinition]
+    groups: list[WellGroup]
+    stackingOffsetWithLabware: NotRequired[dict[str, NamedOffset]]
+    stackingOffsetWithModule: NotRequired[dict[str, NamedOffset]]
+    allowedRoles: NotRequired[list[LabwareRoles]]
+    gripperOffsets: NotRequired[dict[str, GripperOffsets]]
     gripForce: NotRequired[float]
     gripHeightFromLabwareBottom: NotRequired[float]
-    innerLabwareGeometry: NotRequired[Dict[str, InnerWellGeometry]]
-    compatibleParentLabware: NotRequired[List[str]]
+    innerLabwareGeometry: NotRequired[dict[str, InnerWellGeometry]]
+    compatibleParentLabware: NotRequired[list[str]]
     stackLimit: NotRequired[int]


### PR DESCRIPTION
## Overview

Refactors and minor corrections to our Python types for labware definitions.

Goes towards EXEC-1206.

## Test Plan and Hands on Testing

Just automated tests.

## Changelog

See the commit messages. It's easiest to go commit-by-commit to see what changed.

## Review requests

None.

## Risk assessment

Low.
