### PR TITLE
feat(protocol-designer): python instrument and liquid load commands

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -107,7 +107,8 @@ describe('createFile selector', () => {
       OT2_ROBOT_TYPE,
       entities,
       v7Fixture.initialRobotState,
-      v7Fixture.robotStateTimeline
+      v7Fixture.robotStateTimeline,
+      ingredLocations
     )
     // This is just a quick smoke test to make sure createPythonFile() produces
     // something that looks like a Python file. The individual sections of the
@@ -122,6 +123,7 @@ metadata = {
     "author": "The Author",
     "description": "Protocol description",
     "created": "2020-02-25T21:48:32.515Z",
+    "protocolDesigner": "fake_PD_version",
 }
 
 requirements = {
@@ -134,6 +136,9 @@ def run(protocol: protocol_api.ProtocolContext):
     mockPythonName = protocol.load_labware("fixture_trash", "12")
     mockPythonName = protocol.load_labware("fixture_tiprack_10_ul", "1")
     mockPythonName = protocol.load_labware("fixture_96_plate", "7")
+
+    # Load Pipettes:
+    mockPythonName = protocol.load_instrument("p10_single", "left", tip_racks=[mockPythonName])
 
     # PROTOCOL STEPS
 

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -7,18 +7,30 @@ import {
   MAGNETIC_BLOCK_V1,
   OT2_ROBOT_TYPE,
   fixture96Plate,
+  fixtureP1000SingleV2Specs,
+  fixtureP300MultiV2Specs,
+  fixtureTiprack1000ul,
   fixtureTiprackAdapter,
 } from '@opentrons/shared-data'
 import {
+  getDefineLiquids,
   getLoadAdapters,
   getLoadLabware,
+  getLoadLiquids,
   getLoadModules,
+  getLoadPipettes,
   pythonMetadata,
   pythonRequirements,
 } from '../selectors/pythonFile'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type { LabwareEntities, TimelineFrame } from '@opentrons/step-generation'
-import type { ModuleEntities } from '../../step-forms'
+import type {
+  LabwareEntities,
+  LabwareLiquidState,
+  LiquidEntities,
+  ModuleEntities,
+  PipetteEntities,
+  TimelineFrame,
+} from '@opentrons/step-generation'
 
 describe('pythonMetadata', () => {
   it('should generate metadata section', () => {
@@ -44,6 +56,7 @@ metadata = {
     "category": "PCR",
     "subcategory": "PCR Prep",
     "tags": "wombat, kangaroo, wallaby",
+    "protocolDesigner": "fake_PD_version",
 }`.trimStart()
     )
   })
@@ -189,6 +202,124 @@ describe('getLoadLabware', () => {
 well_plate_1 = adapter_2.load_labware("fixture_96_plate")
 well_plate_2 = magnetic_block_2.load_labware("fixture_96_plate")
 well_plate_3 = protocol.load_labware("fixture_96_plate", "C2")`.trimStart()
+    )
+  })
+})
+
+describe('getLoadPipettes', () => {
+  it('should generate loadPipette for 2 pipettes using the same tiprack', () => {
+    const mockTiprackDefURI = 'fixture/fixture_flex_96_tiprack_1000ul/1'
+    const tiprack1 = 'tiprack1'
+    const pipette1 = 'pipette1'
+    const pipette2 = 'pipette2'
+    const mockPipetteEntities: PipetteEntities = {
+      [pipette1]: {
+        id: pipette1,
+        pythonName: 'pipette_left',
+        name: 'p300_multi_gen2',
+        tiprackDefURI: [mockTiprackDefURI],
+        spec: fixtureP300MultiV2Specs,
+        tiprackLabwareDef: [fixtureTiprack1000ul as LabwareDefinition2],
+      },
+      [pipette2]: {
+        id: pipette2,
+        pythonName: 'pipette_left',
+        name: 'p1000_single_flex',
+        tiprackDefURI: [mockTiprackDefURI],
+        spec: fixtureP1000SingleV2Specs,
+        tiprackLabwareDef: [fixtureTiprack1000ul as LabwareDefinition2],
+      },
+    }
+    const mockTiprackEntities: LabwareEntities = {
+      [tiprack1]: {
+        id: tiprack1,
+        def: fixtureTiprack1000ul as LabwareDefinition2,
+        labwareDefURI: mockTiprackDefURI,
+        pythonName: 'tip_rack_1',
+      },
+    }
+    const pipetteRobotState: TimelineFrame['pipettes'] = {
+      [pipette1]: { mount: 'left' },
+      [pipette2]: { mount: 'right' },
+    }
+
+    expect(
+      getLoadPipettes(
+        mockPipetteEntities,
+        mockTiprackEntities,
+        pipetteRobotState
+      )
+    ).toBe(
+      `
+# Load Pipettes:
+pipette_left = protocol.load_instrument("p300_multi_gen2", "left", tip_racks=[tip_rack_1])
+pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks=[tip_rack_1])`.trimStart()
+    )
+  })
+})
+
+const liquid1 = 'liquid1'
+const liquid2 = 'liquid2'
+const mockLiquidEntities: LiquidEntities = {
+  [liquid1]: {
+    liquidGroupId: liquid1,
+    pythonName: 'liquid_1',
+    displayName: 'water',
+    description: 'mock description',
+    displayColor: 'mock display color',
+  },
+  [liquid2]: {
+    liquidGroupId: liquid2,
+    pythonName: 'liquid_2',
+    description: null,
+    displayName: 'sulfur',
+    displayColor: 'mock display color 2',
+  },
+}
+
+describe('getDefineLiquids', () => {
+  it('should generate 2 liquids, 1 with description, 1 without', () => {
+    expect(getDefineLiquids(mockLiquidEntities)).toBe(
+      `
+# Define Liquids:
+liquid_1 = protocol.define_liquid(
+    name="water"
+    description="mock description"
+    display_color="mock display color"
+)
+liquid_2 = protocol.define_liquid(
+    name="sulfur"
+    display_color="mock display color 2"
+)`.trimStart()
+    )
+  })
+})
+
+describe('getLoadLiquids', () => {
+  it('should generate 2 liquids in 2 labware in 4 wells', () => {
+    const mockLiquidsBylabwareId: LabwareLiquidState = {
+      [labwareId3]: {
+        A1: { [liquid1]: { volume: 10 } },
+        A2: { [liquid1]: { volume: 10 } },
+        A3: { [liquid2]: { volume: 50 } },
+      },
+      [labwareId4]: {
+        D1: { [liquid2]: { volume: 180 } },
+      },
+    }
+    expect(
+      getLoadLiquids(
+        mockLiquidsBylabwareId,
+        mockLiquidEntities,
+        mockLabwareEntities
+      )
+    ).toBe(
+      `
+# Load Liquids:
+well_plate_1["A1"].load_liquid(liquid=liquid_1, volume=10)
+well_plate_1["A2"].load_liquid(liquid=liquid_1, volume=10)
+well_plate_1["A3"].load_liquid(liquid=liquid_2, volume=50)
+well_plate_2["D1"].load_liquid(liquid=liquid_2, volume=180)`.trimStart()
     )
   })
 })

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -313,12 +313,12 @@ describe('getDefineLiquids', () => {
       `
 # Define Liquids:
 liquid_1 = protocol.define_liquid(
-    name="water",
-    display_color="mock display color",
+    "water",
     description="mock description",
+    display_color="mock display color",
 )
 liquid_2 = protocol.define_liquid(
-    name="sulfur",
+    "sulfur",
     display_color="mock display color 2",
 )`.trimStart()
     )
@@ -346,10 +346,10 @@ describe('getLoadLiquids', () => {
     ).toBe(
       `
 # Load Liquids:
-well_plate_1["A1"].load_liquid(liquid=liquid_1, volume=10)
-well_plate_1["A2"].load_liquid(liquid=liquid_1, volume=10)
-well_plate_1["A3"].load_liquid(liquid=liquid_2, volume=50)
-well_plate_2["D1"].load_liquid(liquid=liquid_2, volume=180)`.trimStart()
+well_plate_1["A1"].load_liquid(liquid_1, 10)
+well_plate_1["A2"].load_liquid(liquid_1, 10)
+well_plate_1["A3"].load_liquid(liquid_2, 50)
+well_plate_2["D1"].load_liquid(liquid_2, 180)`.trimStart()
     )
   })
 })

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -256,6 +256,36 @@ pipette_left = protocol.load_instrument("p300_multi_gen2", "left", tip_racks=[ti
 pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks=[tip_rack_1])`.trimStart()
     )
   })
+
+  it('should generate loadPipette for 1 pipette with no tiprack', () => {
+    const pipette1 = 'pipette1'
+    const mockPipetteEntities: PipetteEntities = {
+      [pipette1]: {
+        id: pipette1,
+        pythonName: 'pipette_left',
+        name: 'p300_multi_gen2',
+        tiprackDefURI: [],
+        spec: fixtureP300MultiV2Specs,
+        tiprackLabwareDef: [],
+      },
+    }
+    const mockTiprackEntities: LabwareEntities = {}
+    const pipetteRobotState: TimelineFrame['pipettes'] = {
+      [pipette1]: { mount: 'left' },
+    }
+
+    expect(
+      getLoadPipettes(
+        mockPipetteEntities,
+        mockTiprackEntities,
+        pipetteRobotState
+      )
+    ).toBe(
+      `
+# Load Pipettes:
+pipette_left = protocol.load_instrument("p300_multi_gen2", "left")`.trimStart()
+    )
+  })
 })
 
 const liquid1 = 'liquid1'
@@ -284,8 +314,8 @@ describe('getDefineLiquids', () => {
 # Define Liquids:
 liquid_1 = protocol.define_liquid(
     name="water",
-    description="mock description",
     display_color="mock display color",
+    description="mock description",
 )
 liquid_2 = protocol.define_liquid(
     name="sulfur",

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -283,13 +283,13 @@ describe('getDefineLiquids', () => {
       `
 # Define Liquids:
 liquid_1 = protocol.define_liquid(
-    name="water"
-    description="mock description"
-    display_color="mock display color"
+    name="water",
+    description="mock description",
+    display_color="mock display color",
 )
 liquid_2 = protocol.define_liquid(
-    name="sulfur"
-    display_color="mock display color 2"
+    name="sulfur",
+    display_color="mock display color 2",
 )`.trimStart()
     )
   })

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -311,12 +311,14 @@ export const createPythonFile: Selector<string> = createSelector(
   stepFormSelectors.getInvariantContext,
   getInitialRobotState,
   getRobotStateTimeline,
+  ingredSelectors.getLiquidsByLabwareId,
   (
     fileMetadata,
     robotType,
     invariantContext,
     robotState,
-    robotStateTimeline
+    robotStateTimeline,
+    liquidsByLabwareId
   ) => {
     return (
       [
@@ -324,7 +326,12 @@ export const createPythonFile: Selector<string> = createSelector(
         pythonImports(),
         pythonMetadata(fileMetadata),
         pythonRequirements(robotType),
-        pythonDefRun(invariantContext, robotState, robotStateTimeline),
+        pythonDefRun(
+          invariantContext,
+          robotState,
+          robotStateTimeline,
+          liquidsByLabwareId
+        ),
       ]
         .filter(section => section) // skip any blank sections
         .join('\n\n') + '\n'

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -194,13 +194,13 @@ export function getDefineLiquids(liquidEntities: LiquidEntities): string {
       const { pythonName, displayColor, displayName, description } = liquid
       const pythonDescription =
         description != null
-          ? `\n${indentPyLines(`description=${formatPyStr(description)}`)}`
+          ? `\n${indentPyLines(`description=${formatPyStr(description)}`)},`
           : ''
 
       return `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.define_liquid(\n${indentPyLines(
-        `name=${formatPyStr(displayName)}`
+        `name=${formatPyStr(displayName)},`
       )}${pythonDescription}\n${indentPyLines(
-        `display_color=${formatPyStr(displayColor)}`
+        `display_color=${formatPyStr(displayColor)},`
       )}\n)`
     })
     .join('\n')

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -178,10 +178,12 @@ export function getLoadPipettes(
         )
         .map(tiprack => tiprack.pythonName)
         .join(', ')
+      const pythonTipRacks =
+        tiprackDefURI.length === 0 ? '' : `, tip_racks=[${tiprackPythonNames}]`
 
       return `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_instrument(${formatPyStr(
         pipetteName
-      )}, ${mount}, tip_racks=[${tiprackPythonNames}])`
+      )}, ${mount}${pythonTipRacks})`
     })
     .join('\n')
 
@@ -192,16 +194,19 @@ export function getDefineLiquids(liquidEntities: LiquidEntities): string {
   const pythonDefineLiquids = Object.values(liquidEntities)
     .map(liquid => {
       const { pythonName, displayColor, displayName, description } = liquid
-      const pythonDescription =
-        description != null
-          ? `\n${indentPyLines(`description=${formatPyStr(description)}`)},`
-          : ''
+      const liquidArgs = [
+        `name=${formatPyStr(displayName)}`,
+        `display_color=${formatPyStr(displayColor)}`,
+        ...(description != null
+          ? [`description=${formatPyStr(description)}`]
+          : []),
+      ].join(',\n')
 
-      return `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.define_liquid(\n${indentPyLines(
-        `name=${formatPyStr(displayName)},`
-      )}${pythonDescription}\n${indentPyLines(
-        `display_color=${formatPyStr(displayColor)},`
-      )}\n)`
+      return (
+        `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.define_liquid(\n` +
+        `${indentPyLines(liquidArgs)},\n` +
+        `)`
+      )
     })
     .join('\n')
   return pythonDefineLiquids ? `# Define Liquids:\n${pythonDefineLiquids}` : ''

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -1,16 +1,24 @@
 /** Generate sections of the Python file for fileCreator.ts */
 
-import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import {
+  FLEX_ROBOT_TYPE,
+  OT2_ROBOT_TYPE,
+  isFlexPipette,
+} from '@opentrons/shared-data'
 import {
   formatPyDict,
   formatPyStr,
   indentPyLines,
   PROTOCOL_CONTEXT_NAME,
 } from '@opentrons/step-generation'
+import { getFlexNameConversion } from './utils'
 import type {
   InvariantContext,
   LabwareEntities,
+  LabwareLiquidState,
+  LiquidEntities,
   ModuleEntities,
+  PipetteEntities,
   Timeline,
   TimelineFrame,
 } from '@opentrons/step-generation'
@@ -41,6 +49,7 @@ export function pythonMetadata(fileMetadata: FileMetadataFields): string {
       category: fileMetadata.category,
       subcategory: fileMetadata.subcategory,
       tags: fileMetadata.tags?.length && fileMetadata.tags.join(', '),
+      protocolDesigner: process.env.OT_PD_VERSION,
     }).filter(([key, value]) => value) // drop blank entries
   )
   return `metadata = ${formatPyDict(stringifiedMetadata)}`
@@ -148,24 +157,103 @@ export function stepCommands(robotStateTimeline: Timeline): string {
   )
 }
 
+export function getLoadPipettes(
+  pipetteEntities: PipetteEntities,
+  labwareEntities: LabwareEntities,
+  pipetteRobotState: TimelineFrame['pipettes']
+): string {
+  const pythonPipette = Object.values(pipetteEntities)
+    .map(pipette => {
+      const { name, id, spec, pythonName, tiprackDefURI } = pipette
+      const mount =
+        spec.channels === 96 ? '' : formatPyStr(pipetteRobotState[id].mount)
+      const pipetteName = isFlexPipette(name)
+        ? getFlexNameConversion(spec)
+        : name
+      const tiprackPythonNames = tiprackDefURI
+        .flatMap(defURI =>
+          Object.values(labwareEntities).filter(
+            lw => lw.labwareDefURI === defURI
+          )
+        )
+        .map(tiprack => tiprack.pythonName)
+        .join(', ')
+
+      return `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_instrument(${formatPyStr(
+        pipetteName
+      )}, ${mount}, tip_racks=[${tiprackPythonNames}])`
+    })
+    .join('\n')
+
+  return pythonPipette ? `# Load Pipettes:\n${pythonPipette}` : ''
+}
+
+export function getDefineLiquids(liquidEntities: LiquidEntities): string {
+  const pythonDefineLiquids = Object.values(liquidEntities)
+    .map(liquid => {
+      const { pythonName, displayColor, displayName, description } = liquid
+      const pythonDescription =
+        description != null
+          ? `\n${indentPyLines(`description=${formatPyStr(description)}`)}`
+          : ''
+
+      return `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.define_liquid(\n${indentPyLines(
+        `name=${formatPyStr(displayName)}`
+      )}${pythonDescription}\n${indentPyLines(
+        `display_color=${formatPyStr(displayColor)}`
+      )}\n)`
+    })
+    .join('\n')
+  return pythonDefineLiquids ? `# Define Liquids:\n${pythonDefineLiquids}` : ''
+}
+
+export function getLoadLiquids(
+  liquidsByLabwareId: LabwareLiquidState,
+  liquidEntities: LiquidEntities,
+  labwareEntities: LabwareEntities
+): string {
+  const pythonLoadLiquids = Object.entries(liquidsByLabwareId)
+    .flatMap(([labwareId, liquidState]) => {
+      const labwarePythonName = labwareEntities[labwareId].pythonName
+
+      return Object.entries(liquidState).flatMap(([well, locationState]) =>
+        Object.entries(locationState)
+          .map(([liquidGroupId, volume]) => {
+            const liquidPythonName = liquidEntities[liquidGroupId].pythonName
+            return `${labwarePythonName}[${formatPyStr(
+              well
+            )}].load_liquid(liquid=${liquidPythonName}, volume=${
+              volume.volume
+            })`
+          })
+          .join('\n')
+      )
+    })
+    .join('\n')
+  return pythonLoadLiquids ? `# Load Liquids:\n${pythonLoadLiquids}` : ''
+}
+
 export function pythonDefRun(
   invariantContext: InvariantContext,
   robotState: TimelineFrame,
-  robotStateTimeline: Timeline
+  robotStateTimeline: Timeline,
+  liquidsByLabwareId: LabwareLiquidState
 ): string {
-  const { moduleEntities, labwareEntities } = invariantContext
-  const { modules, labware } = robotState
-  const loadModules = getLoadModules(moduleEntities, modules)
-  const loadAdapters = getLoadAdapters(moduleEntities, labwareEntities, labware)
-  const loadLabware = getLoadLabware(moduleEntities, labwareEntities, labware)
+  const {
+    moduleEntities,
+    labwareEntities,
+    pipetteEntities,
+    liquidEntities,
+  } = invariantContext
+  const { modules, labware, pipettes } = robotState
 
   const sections: string[] = [
-    loadModules,
-    loadAdapters,
-    loadLabware,
-    // loadInstruments(),
-    // defineLiquids(),
-    // loadLiquids(),
+    getLoadModules(moduleEntities, modules),
+    getLoadAdapters(moduleEntities, labwareEntities, labware),
+    getLoadLabware(moduleEntities, labwareEntities, labware),
+    getLoadPipettes(pipetteEntities, labwareEntities, pipettes),
+    getDefineLiquids(liquidEntities),
+    getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),
     stepCommands(robotStateTimeline),
   ]
   const functionBody =

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -195,11 +195,11 @@ export function getDefineLiquids(liquidEntities: LiquidEntities): string {
     .map(liquid => {
       const { pythonName, displayColor, displayName, description } = liquid
       const liquidArgs = [
-        `name=${formatPyStr(displayName)}`,
-        `display_color=${formatPyStr(displayColor)}`,
+        `${formatPyStr(displayName)}`,
         ...(description != null
           ? [`description=${formatPyStr(description)}`]
           : []),
+        `display_color=${formatPyStr(displayColor)}`,
       ].join(',\n')
 
       return (
@@ -227,9 +227,7 @@ export function getLoadLiquids(
             const liquidPythonName = liquidEntities[liquidGroupId].pythonName
             return `${labwarePythonName}[${formatPyStr(
               well
-            )}].load_liquid(liquid=${liquidPythonName}, volume=${
-              volume.volume
-            })`
+            )}].load_liquid(${liquidPythonName}, ${volume.volume})`
           })
           .join('\n')
       )

--- a/protocol-designer/src/file-data/selectors/utils.ts
+++ b/protocol-designer/src/file-data/selectors/utils.ts
@@ -242,6 +242,7 @@ export const getLabwareLoadInfo = (
 const DEFAULT_LIQUID_TYPE = 'default'
 //  Flex pipette api names are different from pipetteName
 //  p1000_multi_flex -> flex_8channel_1000
+//  we do not need to worry about -_em pipette in PD
 export const getFlexNameConversion = (pipetteSpec: PipetteV2Specs): string => {
   const channels = pipetteSpec.channels
   const maxVolume = pipetteSpec.liquids[DEFAULT_LIQUID_TYPE].maxVolume

--- a/protocol-designer/src/file-data/selectors/utils.ts
+++ b/protocol-designer/src/file-data/selectors/utils.ts
@@ -240,6 +240,8 @@ export const getLabwareLoadInfo = (
 }
 
 const DEFAULT_LIQUID_TYPE = 'default'
+//  Flex pipette api names are different from pipetteName
+//  p1000_multi_flex -> flex_8channel_1000
 export const getFlexNameConversion = (pipetteSpec: PipetteV2Specs): string => {
   const channels = pipetteSpec.channels
   const maxVolume = pipetteSpec.liquids[DEFAULT_LIQUID_TYPE].maxVolume

--- a/protocol-designer/src/file-data/selectors/utils.ts
+++ b/protocol-designer/src/file-data/selectors/utils.ts
@@ -11,6 +11,7 @@ import type {
   LoadModuleCreateCommand,
   LoadPipetteCreateCommand,
   PipetteName,
+  PipetteV2Specs,
 } from '@opentrons/shared-data'
 import type {
   LabwareEntities,
@@ -236,4 +237,11 @@ export const getLabwareLoadInfo = (
     }),
     {}
   )
+}
+
+const DEFAULT_LIQUID_TYPE = 'default'
+export const getFlexNameConversion = (pipetteSpec: PipetteV2Specs): string => {
+  const channels = pipetteSpec.channels
+  const maxVolume = pipetteSpec.liquids[DEFAULT_LIQUID_TYPE].maxVolume
+  return `flex_${channels}channel_${maxVolume}`
 }


### PR DESCRIPTION
closes AUTH-1092 AUTH-1444

# Overview

This PR adds `load_instrument`, `define_liquid`, and `load_liquid` commands to python export in PD. And `metadata` is expanded to include the ProtocolDesigner version.

## Test Plan and Hands on Testing

Review the code and smoke test. There is unit testing to make sure it works as well.

Here is a sample:

```
from contextlib import nullcontext as pd_step
from opentrons import protocol_api

metadata = {
    "protocolName": "python export test",
    "author": "Hopia",
    "created": "2025-02-12T13:31:03.341Z",
    "lastModified": "2025-02-12T13:32:18.838Z",
    "protocolDesigner": "8.4.0-alpha.0",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.23",
}

def run(protocol: protocol_api.ProtocolContext):
    # Load Modules:
    heater_shaker_module_1 = protocol.load_module("heaterShakerModuleV1", "D3")
    heater_shaker_module_2 = protocol.load_module("heaterShakerModuleV1", "C1")
    heater_shaker_module_3 = protocol.load_module("heaterShakerModuleV1", "D1")

    # Load Adapters:
    adapter_1 = heater_shaker_module_3.load_adapter("opentrons_96_flat_bottom_adapter")

    # Load Labware:
    tip_rack_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "C2")
    well_plate_1 = adapter_1.load_labware("nest_96_wellplate_200ul_flat")
    reservoir_1 = protocol.load_labware("nest_12_reservoir_15ml", "B3")

    # Load Pipettes:
    pipette_left = protocol.load_instrument("flex_8channel_1000", "left", tip_racks=[tip_rack_1])

    # Define Liquids:
    liquid_1 = protocol.define_liquid(
        name="water",
        description="h20",
        display_color="#b925ff",
    )
    liquid_2 = protocol.define_liquid(
        name="h2s04",
        description="sulfuric acid",
        display_color="#ffd600",
    )
    liquid_3 = protocol.define_liquid(
        name="sample",
        display_color="#9dffd8",
    )

    # Load Liquids:
    well_plate_1["A1"].load_liquid(liquid=liquid_3, volume=10)
    well_plate_1["B1"].load_liquid(liquid=liquid_3, volume=10)
    well_plate_1["C1"].load_liquid(liquid=liquid_3, volume=10)
    well_plate_1["D1"].load_liquid(liquid=liquid_3, volume=10)
    well_plate_1["E1"].load_liquid(liquid=liquid_3, volume=10)
    reservoir_1["A1"].load_liquid(liquid=liquid_1, volume=10000)
    reservoir_1["A2"].load_liquid(liquid=liquid_1, volume=10000)
    reservoir_1["A3"].load_liquid(liquid=liquid_1, volume=10000)
    reservoir_1["A11"].load_liquid(liquid=liquid_2, volume=10000)
    reservoir_1["A12"].load_liquid(liquid=liquid_2, volume=10000)

    # PROTOCOL STEPS
```

## Changelog

- create `getLoadPipettes()`, `getDefineLiquids()`, and `getLoadLiquids()`
- add unit tests for each
- expand metadata to include `protocolDesigner` version

## Review requests

- RIght now for `load_liquid`, it doesn't take into account anything fancy like a for loop to loop through a bunch of wells to minimize the python lines. It will make a `load_liquid` command for every well that is assigned a liquid. So if you have a 96 well plate where each well has a liquid, it will emit `load_liquid` 96 times. I looked at customer protocols and they tend to use for loops instead to loop through. The tricky part about implementing that here is what if the user has liquids only in every other well or something? But would like to know your thoughts @ddcc4 .
- i added `tip_racks` arg to `load_instrument` based off of the assigned tipracks to that pipette in PD. Does that make sense to you? Does it work if both pipettes use the same tip rack?

## Risk assessment

low, behind a feature flag