### PR TITLE
fix(shared-data): Fix schema version of opentrons_tough_pcr_auto_sealing_lid

### DIFF
--- a/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/2.json
+++ b/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/2.json
@@ -37,7 +37,7 @@
   },
   "namespace": "opentrons",
   "version": 2,
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "stackingOffsetWithModule": {
     "thermocyclerModuleV2": {
       "x": 0,


### PR DESCRIPTION
## Overview

This labware definition is in the directory for definitions that conform to schema 3, and it mostly conforms to schema 3, except that it says `"schemaVersion": 2`. Fix it so it says `"schemaVersion": 3`.

## Test Plan and Hands on Testing

* [x] Automated tests for this aren't working in `chore_release-8.3.0`, but they are working in `edge`. Do a test-merge of this into `edge` and make sure it passes the tests there.

## Review requests

None.

## Risk assessment

Low. This isn't actually intended to be used in the v8.3.0 release. It's just in the v8.3.0 release branch incidentally.
