### PR TITLE
feat(protocol-designer): Python generation for the Pause step.

### DIFF
--- a/step-generation/src/__tests__/delay.test.ts
+++ b/step-generation/src/__tests__/delay.test.ts
@@ -24,6 +24,7 @@ describe('delay', () => {
         },
       },
     ])
+    expect(res.python).toEqual(`protocol.pause("delay indefinitely message")`)
   })
 
   it('should delay for a given duration', () => {
@@ -45,5 +46,24 @@ describe('delay', () => {
         },
       },
     ])
+    expect(res.python).toEqual(
+      `protocol.delay(seconds=95.5, msg="delay 95.5 secs message")`
+    )
+  })
+
+  it('should delay with no message', () => {
+    const robotInitialState = getRobotInitialState()
+    const result = delay({ seconds: 12.3 }, invariantContext, robotInitialState)
+    const res = getSuccessResult(result)
+    expect(res.commands).toEqual([
+      {
+        commandType: 'waitForDuration',
+        key: expect.any(String),
+        params: {
+          seconds: 12.3,
+        },
+      },
+    ])
+    expect(res.python).toEqual(`protocol.delay(seconds=12.3)`)
   })
 })

--- a/step-generation/src/commandCreators/atomic/delay.ts
+++ b/step-generation/src/commandCreators/atomic/delay.ts
@@ -1,4 +1,4 @@
-import { uuid } from '../../utils'
+import { formatPyStr, PROTOCOL_CONTEXT_NAME, uuid } from '../../utils'
 import type {
   WaitForDurationCreateCommand,
   WaitForDurationParams,
@@ -13,20 +13,30 @@ export const delay: CommandCreator<
   const { message } = args
   //  delay is deprecated and now is either waitForResume or waitForDuration
   let command: WaitForResumeCreateCommand | WaitForDurationCreateCommand
+  let python: string
   if ('seconds' in args) {
     command = {
       commandType: 'waitForDuration',
       key: uuid(),
       params: { seconds: args.seconds, message },
     }
+    const pythonArgs = [
+      `seconds=${args.seconds}`,
+      ...(message ? [`msg=${formatPyStr(message)}`] : []),
+    ]
+    python = `${PROTOCOL_CONTEXT_NAME}.delay(${pythonArgs.join(', ')})`
   } else {
     command = {
       commandType: 'waitForResume',
       key: uuid(),
       params: { message },
     }
+    python = `${PROTOCOL_CONTEXT_NAME}.pause(${
+      message ? formatPyStr(message) : ''
+    })`
   }
   return {
     commands: [command],
+    python: python,
   }
 }


### PR DESCRIPTION
# Overview

This emits Python code for the `WaitForDuration`/`WaitForResume` commands. AUTH-1096

I picked this one because it's the simplest step that a user can add in PD.

With this and @jerader's PR, we should be able to generate a complete and simulatable/runnable Python protocol, so that we can see what the whole Python generation process looks like as we build it out.

## Test Plan and Hands on Testing

I added unit tests.

Here's the complete Python protocol that demonstrates all 4 variants of delaying/pausing:
```
from contextlib import nullcontext as pd_step
from opentrons import protocol_api

metadata = {
    "protocolName": "Delay A Lot",
    "created": "2025-02-11T23:04:46.106Z",
    "lastModified": "2025-02-12T17:39:47.049Z",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.23",
}

def run(protocol: protocol_api.ProtocolContext):
    # PROTOCOL STEPS

    # Step 1:
    protocol.pause()

    # Step 2:
    protocol.pause("Pause with message")

    # Step 3:
    protocol.delay(seconds=3723)

    # Step 4:
    protocol.delay(seconds=3723, msg="Delay for 1h2m3s with message")
```

## Review requests

Note that this is not the final form of the Pause step. We haven't implemented the decorator that lets us annotate each set with the step name and description yet.

## Risk assessment

Low. This is all hidden behind a feature flag.