### PR TITLE
feat(api): allow moving labware with lids

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -266,7 +266,7 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
         )
 
         # Check that labware and destination do not have labware on top
-        self._state_view.labware.raise_if_labware_has_labware_on_top(
+        self._state_view.labware.raise_if_labware_has_non_lid_labware_on_top(
             labware_id=params.labwareId
         )
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -209,23 +209,23 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
                 version=loaded_labware_update.definition.version,
             )
 
-            self._state.definitions_by_uri[definition_uri] = (
-                loaded_labware_update.definition
-            )
+            self._state.definitions_by_uri[
+                definition_uri
+            ] = loaded_labware_update.definition
 
             location = loaded_labware_update.new_location
 
             display_name = loaded_labware_update.display_name
 
-            self._state.labware_by_id[loaded_labware_update.labware_id] = (
-                LoadedLabware.model_construct(
-                    id=loaded_labware_update.labware_id,
-                    location=location,
-                    loadName=loaded_labware_update.definition.parameters.loadName,
-                    definitionUri=definition_uri,
-                    offsetId=loaded_labware_update.offset_id,
-                    displayName=display_name,
-                )
+            self._state.labware_by_id[
+                loaded_labware_update.labware_id
+            ] = LoadedLabware.model_construct(
+                id=loaded_labware_update.labware_id,
+                location=location,
+                loadName=loaded_labware_update.definition.parameters.loadName,
+                definitionUri=definition_uri,
+                offsetId=loaded_labware_update.offset_id,
+                displayName=display_name,
             )
 
     def _add_loaded_lid_stack(self, state_update: update_types.StateUpdate) -> None:
@@ -237,18 +237,18 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
                 load_name=loaded_lid_stack_update.stack_object_definition.parameters.loadName,
                 version=loaded_lid_stack_update.stack_object_definition.version,
             )
-            self.state.definitions_by_uri[stack_definition_uri] = (
-                loaded_lid_stack_update.stack_object_definition
-            )
-            self._state.labware_by_id[loaded_lid_stack_update.stack_id] = (
-                LoadedLabware.construct(
-                    id=loaded_lid_stack_update.stack_id,
-                    location=loaded_lid_stack_update.stack_location,
-                    loadName=loaded_lid_stack_update.stack_object_definition.parameters.loadName,
-                    definitionUri=stack_definition_uri,
-                    offsetId=None,
-                    displayName=None,
-                )
+            self.state.definitions_by_uri[
+                stack_definition_uri
+            ] = loaded_lid_stack_update.stack_object_definition
+            self._state.labware_by_id[
+                loaded_lid_stack_update.stack_id
+            ] = LoadedLabware.construct(
+                id=loaded_lid_stack_update.stack_id,
+                location=loaded_lid_stack_update.stack_location,
+                loadName=loaded_lid_stack_update.stack_object_definition.parameters.loadName,
+                definitionUri=stack_definition_uri,
+                offsetId=None,
+                displayName=None,
             )
 
             # Add the Lids on top of the stack object
@@ -263,9 +263,9 @@ class LabwareStore(HasState[LabwareState], HandlesActions):
                     version=loaded_lid_stack_update.definition.version,
                 )
 
-                self._state.definitions_by_uri[definition_uri] = (
-                    loaded_lid_stack_update.definition
-                )
+                self._state.definitions_by_uri[
+                    definition_uri
+                ] = loaded_lid_stack_update.definition
 
                 location = loaded_lid_stack_update.new_locations_by_id[labware_id]
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -138,7 +138,9 @@ async def test_manual_move_labware_implementation(
     result = await subject.execute(data)
     decoy.verify(await run_control.wait_for_resume(), times=times_pause_called)
     decoy.verify(
-        state_view.labware.raise_if_labware_has_labware_on_top("my-cool-labware-id")
+        state_view.labware.raise_if_labware_has_non_lid_labware_on_top(
+            "my-cool-labware-id"
+        )
     )
     assert result == SuccessData(
         public=MoveLabwareResult(
@@ -221,7 +223,9 @@ async def test_move_labware_implementation_on_labware(
 
     result = await subject.execute(data)
     decoy.verify(
-        state_view.labware.raise_if_labware_has_labware_on_top("my-cool-labware-id"),
+        state_view.labware.raise_if_labware_has_non_lid_labware_on_top(
+            "my-cool-labware-id"
+        ),
         state_view.labware.raise_if_labware_has_labware_on_top(
             "my-even-cooler-labware-id"
         ),
@@ -329,7 +333,9 @@ async def test_gripper_move_labware_implementation(
 
     result = await subject.execute(data)
     decoy.verify(
-        state_view.labware.raise_if_labware_has_labware_on_top("my-cool-labware-id"),
+        state_view.labware.raise_if_labware_has_non_lid_labware_on_top(
+            "my-cool-labware-id"
+        ),
         await labware_movement.move_labware_with_gripper(
             labware_id="my-cool-labware-id",
             current_location=sentinel.from_location_validated_for_gripper,
@@ -621,7 +627,9 @@ async def test_gripper_move_to_waste_chute_implementation(
 
     result = await subject.execute(data)
     decoy.verify(
-        state_view.labware.raise_if_labware_has_labware_on_top("my-cool-labware-id"),
+        state_view.labware.raise_if_labware_has_non_lid_labware_on_top(
+            "my-cool-labware-id"
+        ),
         await labware_movement.move_labware_with_gripper(
             labware_id="my-cool-labware-id",
             current_location=from_location,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom.ts
@@ -58,6 +58,13 @@ function getDisplayNameFromUri({
   const matchedDef = labwareDefs?.find(
     def => getLabwareDefURI(def) === uri
   ) as LabwareDefinition2
+  if (!!!matchedDef) {
+    console.warn(
+      `Could not get labware def for uri ${uri} from list of defs with uri ${
+        labwareDefs?.map(getLabwareDefURI) ?? '<no list provided>'
+      }`
+    )
+  }
 
   return getLabwareDisplayName(matchedDef)
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -59,10 +59,12 @@ export function useLPCFlows({
   const currentOffsets = runRecord?.data?.labwareOffsets ?? []
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
 
-  const labwareDefs = useMemo(
-    () => getLabwareDefinitionsFromCommands(mostRecentAnalysis?.commands ?? []),
-    [mostRecentAnalysis != null]
-  )
+  const labwareDefs = useMemo(() => {
+    const labwareDefsFromCommands = getLabwareDefinitionsFromCommands(
+      mostRecentAnalysis?.commands ?? []
+    )
+    return labwareDefsFromCommands
+  }, [mostRecentAnalysis != null])
   const labwareInfo = useLPCLabwareInfo({
     currentOffsets,
     labwareDefs,

--- a/app/src/transformations/analysis/getLabwareRenderInfo.ts
+++ b/app/src/transformations/analysis/getLabwareRenderInfo.ts
@@ -23,9 +23,8 @@ export const getLabwareRenderInfo = (
   deckDef: DeckDefinition
 ): LabwareRenderInfoById =>
   protocolData.commands
-    .filter(
-      (command): command is LoadLabwareRunTimeCommand =>
-        command.commandType === 'loadLabware'
+    .filter((command): command is LoadLabwareRunTimeCommand =>
+      ['loadLabware', 'loadLid'].includes(command.commandType)
     )
     .reduce((acc, command) => {
       const labwareId = command.result?.labwareId

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
@@ -8,13 +8,13 @@ export function getLabwareDefinitionsFromCommands(
 ): LabwareDefinition2[] {
   return commands.reduce<LabwareDefinition2[]>((acc, command) => {
     const isLoadingNewDef =
-      command.commandType === 'loadLabware' &&
+      (command.commandType === 'loadLabware' ||
+        command.commandType === 'loadLid') &&
       !acc.some(
         def =>
           command.result?.definition != null &&
           getLabwareDefURI(def) === getLabwareDefURI(command.result?.definition)
       )
-
     return isLoadingNewDef && command.result?.definition != null
       ? [...acc, command.result?.definition]
       : acc

--- a/components/src/organisms/ProtocolTimelineScrubber/utils.ts
+++ b/components/src/organisms/ProtocolTimelineScrubber/utils.ts
@@ -152,7 +152,8 @@ export function getLabwareDefinitionsFromCommands(
 ): LabwareDefinition2[] {
   return commands.reduce<LabwareDefinition2[]>((acc, command) => {
     const isLoadingNewDef =
-      command.commandType === 'loadLabware' &&
+      (command.commandType === 'loadLabware' ||
+        command.commandType === 'loadLid') &&
       !acc.some(
         def =>
           command.result?.definition != null &&

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -47,6 +47,8 @@ export const LABWAREV2_DO_NOT_LIST = [
   //  temporarily blocking evotips until it is out of beta
   'evotips_flex_96_tiprack_adapter',
   'evotips_opentrons_96_labware',
+  //  temporarily block tiprack lids until stacker launches
+  'opentrons_flex_tiprack_lid',
 ]
 // NOTE(sa, 2020-7-14): in PD we do not want to list calibration blocks
 // or the adapter/labware combos since we migrated to splitting them up
@@ -66,6 +68,8 @@ export const PD_DO_NOT_LIST = [
   //  temporarily blocking evotips until it is supported in PD
   'evotips_flex_96_tiprack_adapter',
   'evotips_opentrons_96_labware',
+  // temporarily blocking tiprack lids until stacker launches
+  'opentrons_flex_tiprack_lid',
 ]
 
 export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -123,6 +123,7 @@ import usascientific12Reservoir22MlV1Uncasted from '../labware/definitions/2/usa
 import usascientific96Wellplate24MlDeepV1Uncasted from '../labware/definitions/2/usascientific_96_wellplate_2.4ml_deep/1.json'
 import evotipsFlex96TiprackAdapterV1Uncasted from '../labware/definitions/2/evotips_flex_96_tiprack_adapter/1.json'
 import evotipsOpentrons96LabwareV1Uncasted from '../labware/definitions/2/evotips_opentrons_96_labware/1.json'
+import opentronsFlexTiprackLidV1Uncasted from '../labware/definitions/3/opentrons_flex_tiprack_lid/1.json'
 
 // v1 legacy labware definitions
 
@@ -301,6 +302,7 @@ const usascientific12Reservoir22MlV1 = usascientific12Reservoir22MlV1Uncasted as
 const usascientific96Wellplate24MlDeepV1 = usascientific96Wellplate24MlDeepV1Uncasted as LabwareDefinition2
 const evotipsFlex96TiprackAdapterV1 = evotipsFlex96TiprackAdapterV1Uncasted as LabwareDefinition2
 const evotipsOpentrons96LabwareV1 = evotipsOpentrons96LabwareV1Uncasted as LabwareDefinition2
+const opentronsFlexTiprackLidV1 = opentronsFlexTiprackLidV1Uncasted as LabwareDefinition2
 
 // cast v1 defs
 
@@ -472,6 +474,7 @@ const latestDefs = {
   usascientific96Wellplate24MlDeepV1,
   evotipsFlex96TiprackAdapterV1,
   evotipsOpentrons96LabwareV1,
+  opentronsFlexTiprackLidV1,
 }
 
 // labware definitions


### PR DESCRIPTION
Allow moving a labware (labware-bottom) with another labware (labware-top) on top of it, as long as labware-top is labware-bottom's lid by its lid id.

## Testing
- [x] try and move a tiprack that has a lid on it

```
metadata = {
    "protocolName": "Move tiprack with lid",
}

requirements = {
    "robotType": "OT-3",
    "apiLevel": "2.23",
}


def run(protocol):
    trash = protocol.load_trash_bin(location="A3")
    plate = protocol.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "C1")

    tiprack = protocol.load_labware(
        "opentrons_flex_96_tiprack_1000ul", "D1", lid="opentrons_flex_tiprack_lid"
    )
    adapter = protocol.load_adapter("opentrons_flex_96_tiprack_adapter", "D2")

    p1000 = protocol.load_instrument("flex_96channel_1000", "left", tip_racks=[tiprack])
    protocol.move_labware(tiprack, adapter, use_gripper=True)
    protocol.move_lid(tiprack, trash, use_gripper=True)
    p1000.pick_up_tip()
    p1000.aspirate(200, plate["A1"])
    p1000.dispense(200, plate["A1"])
    p1000.drop_tip()
```

Closes EXEC-1116
