### PR TITLE
refactor(protocol-designer): add label, namespace, version args to lo…

### DIFF
--- a/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
@@ -36,19 +36,19 @@ export const labwareEntities: LabwareEntities = {
     labwareDefURI: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
     id: 'fixedTrash',
     def: fixtureTrash,
-    pythonName: 'mockPythonName',
+    pythonName: 'mock_python_name_1',
   },
   tiprackId: {
     labwareDefURI: 'opentrons/opentrons_96_tiprack_10ul/1',
     id: 'tiprackId',
     def: fixtureTiprack10ul,
-    pythonName: 'mockPythonName',
+    pythonName: 'mock_python_name_2',
   },
   plateId: {
     labwareDefURI: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
     id: 'plateId',
     def: fixture96Plate,
-    pythonName: 'mockPythonName',
+    pythonName: 'mock_python_name_3',
   },
 }
 export const pipetteEntities: PipetteEntities = {
@@ -58,7 +58,7 @@ export const pipetteEntities: PipetteEntities = {
     spec: fixtureP10SingleV2Specs,
     tiprackDefURI: ['opentrons/opentrons_96_tiprack_10ul/1'],
     tiprackLabwareDef: [fixtureTiprack10ul],
-    pythonName: 'mockPythonName',
+    pythonName: 'mock_python_name_1',
   },
 }
 export const labwareNicknamesById: Record<string, string> = {

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -134,30 +134,30 @@ requirements = {
 
 def run(protocol: protocol_api.ProtocolContext):
     # Load Labware:
-    mockPythonName = protocol.load_labware(
+    mock_python_name_1 = protocol.load_labware(
         "fixture_trash",
         "12",
         label="Trash",
         namespace="fixture",
-        version="1",
+        version=1,
     )
-    mockPythonName = protocol.load_labware(
+    mock_python_name_2 = protocol.load_labware(
         "fixture_tiprack_10_ul",
         "1",
         label="Opentrons 96 Tip Rack 10 µL",
         namespace="fixture",
-        version="1",
+        version=1,
     )
-    mockPythonName = protocol.load_labware(
+    mock_python_name_3 = protocol.load_labware(
         "fixture_96_plate",
         "7",
         label="NEST 96 Well Plate 100 µL PCR Full Skirt",
         namespace="fixture",
-        version="1",
+        version=1,
     )
 
     # Load Pipettes:
-    mockPythonName = protocol.load_instrument("p10_single", "left", tip_racks=[mockPythonName])
+    mock_python_name_1 = protocol.load_instrument("p10_single", "left", tip_racks=[mock_python_name_2])
 
     # PROTOCOL STEPS
 

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -108,7 +108,8 @@ describe('createFile selector', () => {
       entities,
       v7Fixture.initialRobotState,
       v7Fixture.robotStateTimeline,
-      ingredLocations
+      ingredLocations,
+      labwareNicknamesById
     )
     // This is just a quick smoke test to make sure createPythonFile() produces
     // something that looks like a Python file. The individual sections of the
@@ -133,9 +134,27 @@ requirements = {
 
 def run(protocol: protocol_api.ProtocolContext):
     # Load Labware:
-    mockPythonName = protocol.load_labware("fixture_trash", "12")
-    mockPythonName = protocol.load_labware("fixture_tiprack_10_ul", "1")
-    mockPythonName = protocol.load_labware("fixture_96_plate", "7")
+    mockPythonName = protocol.load_labware(
+        "fixture_trash",
+        "12",
+        label="Trash",
+        namespace="fixture",
+        version="1",
+    )
+    mockPythonName = protocol.load_labware(
+        "fixture_tiprack_10_ul",
+        "1",
+        label="Opentrons 96 Tip Rack 10 µL",
+        namespace="fixture",
+        version="1",
+    )
+    mockPythonName = protocol.load_labware(
+        "fixture_96_plate",
+        "7",
+        label="NEST 96 Well Plate 100 µL PCR Full Skirt",
+        namespace="fixture",
+        version="1",
+    )
 
     # Load Pipettes:
     mockPythonName = protocol.load_instrument("p10_single", "left", tip_racks=[mockPythonName])

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -31,6 +31,7 @@ import type {
   PipetteEntities,
   TimelineFrame,
 } from '@opentrons/step-generation'
+import { string } from 'yup'
 
 describe('pythonMetadata', () => {
   it('should generate metadata section', () => {
@@ -157,6 +158,13 @@ const labwareRobotState: TimelineFrame['labware'] = {
   [labwareId5]: { slot: 'C2' },
 }
 
+const mockLabwareNicknames: Record<string, string> = {
+  [labwareId1]: fixtureTiprackAdapter.metadata.displayName,
+  [labwareId2]: fixtureTiprackAdapter.metadata.displayName,
+  [labwareId3]: 'reagent plate',
+  [labwareId4]: fixture96Plate.metadata.displayName,
+  [labwareId5]: 'sample plate',
+}
 describe('getLoadModules', () => {
   it('should generate loadModules', () => {
     const modules: TimelineFrame['modules'] = {
@@ -186,8 +194,17 @@ describe('getLoadAdapters', () => {
     ).toBe(
       `
 # Load Adapters:
-adapter_1 = magnetic_block_1.load_adapter("fixture_flex_96_tiprack_adapter")
-adapter_2 = protocol.load_adapter("fixture_flex_96_tiprack_adapter", "B2")`.trimStart()
+adapter_1 = magnetic_block_1.load_adapter(
+    "fixture_flex_96_tiprack_adapter",
+    namespace="fixture",
+    version="1",
+)
+adapter_2 = protocol.load_adapter(
+    "fixture_flex_96_tiprack_adapter",
+    "B2",
+    namespace="fixture",
+    version="1",
+)`.trimStart()
     )
   })
 })
@@ -195,13 +212,33 @@ adapter_2 = protocol.load_adapter("fixture_flex_96_tiprack_adapter", "B2")`.trim
 describe('getLoadLabware', () => {
   it('should generate loadLabware for 3 labware', () => {
     expect(
-      getLoadLabware(mockModuleEntities, mockLabwareEntities, labwareRobotState)
+      getLoadLabware(
+        mockModuleEntities,
+        mockLabwareEntities,
+        labwareRobotState,
+        mockLabwareNicknames
+      )
     ).toBe(
       `
 # Load Labware:
-well_plate_1 = adapter_2.load_labware("fixture_96_plate")
-well_plate_2 = magnetic_block_2.load_labware("fixture_96_plate")
-well_plate_3 = protocol.load_labware("fixture_96_plate", "C2")`.trimStart()
+well_plate_1 = adapter_2.load_labware(
+    "fixture_96_plate",
+    label="reagent plate",
+    namespace="fixture",
+    version="1",
+)
+well_plate_2 = magnetic_block_2.load_labware(
+    "fixture_96_plate",
+    namespace="fixture",
+    version="1",
+)
+well_plate_3 = protocol.load_labware(
+    "fixture_96_plate",
+    "C2",
+    label="sample plate",
+    namespace="fixture",
+    version="1",
+)`.trimStart()
     )
   })
 })

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -31,7 +31,6 @@ import type {
   PipetteEntities,
   TimelineFrame,
 } from '@opentrons/step-generation'
-import { string } from 'yup'
 
 describe('pythonMetadata', () => {
   it('should generate metadata section', () => {
@@ -197,13 +196,13 @@ describe('getLoadAdapters', () => {
 adapter_1 = magnetic_block_1.load_adapter(
     "fixture_flex_96_tiprack_adapter",
     namespace="fixture",
-    version="1",
+    version=1,
 )
 adapter_2 = protocol.load_adapter(
     "fixture_flex_96_tiprack_adapter",
     "B2",
     namespace="fixture",
-    version="1",
+    version=1,
 )`.trimStart()
     )
   })
@@ -225,19 +224,19 @@ well_plate_1 = adapter_2.load_labware(
     "fixture_96_plate",
     label="reagent plate",
     namespace="fixture",
-    version="1",
+    version=1,
 )
 well_plate_2 = magnetic_block_2.load_labware(
     "fixture_96_plate",
     namespace="fixture",
-    version="1",
+    version=1,
 )
 well_plate_3 = protocol.load_labware(
     "fixture_96_plate",
     "C2",
     label="sample plate",
     namespace="fixture",
-    version="1",
+    version=1,
 )`.trimStart()
     )
   })

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -312,13 +312,15 @@ export const createPythonFile: Selector<string> = createSelector(
   getInitialRobotState,
   getRobotStateTimeline,
   ingredSelectors.getLiquidsByLabwareId,
+  uiLabwareSelectors.getLabwareNicknamesById,
   (
     fileMetadata,
     robotType,
     invariantContext,
     robotState,
     robotStateTimeline,
-    liquidsByLabwareId
+    liquidsByLabwareId,
+    labwareNicknamesById
   ) => {
     return (
       [
@@ -330,7 +332,8 @@ export const createPythonFile: Selector<string> = createSelector(
           invariantContext,
           robotState,
           robotStateTimeline,
-          liquidsByLabwareId
+          liquidsByLabwareId,
+          labwareNicknamesById
         ),
       ]
         .filter(section => section) // skip any blank sections

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -111,7 +111,7 @@ export function getLoadAdapters(
         `${formatPyStr(parameters.loadName)}`,
         ...(!onModule ? [`${formatPyStr(adapterSlot)}`] : []),
         `namespace=${formatPyStr(namespace)}`,
-        `version=${formatPyStr(version.toString())}`,
+        `version=${version}`,
       ].join(',\n')
 
       return (
@@ -142,7 +142,6 @@ export function getLoadLabware(
       const labwareSlot = labwareRobotState[id].slot
       const onModule = moduleEntities[labwareSlot] != null
       const onAdapter = allLabwareEntities[labwareSlot] != null
-
       let location = PROTOCOL_CONTEXT_NAME
       if (onAdapter) {
         location = allLabwareEntities[labwareSlot].pythonName
@@ -157,7 +156,7 @@ export function getLoadLabware(
           ? [`label=${formatPyStr(labwareNicknamesById[id])}`]
           : []),
         `namespace=${formatPyStr(namespace)}`,
-        `version=${formatPyStr(version.toString())}`,
+        `version=${version}`,
       ].join(',\n')
 
       return (

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -87,7 +87,8 @@ export function getLoadModules(
     : ''
   return hasModules ? `# Load Modules:\n${pythonModules}` : ''
 }
-
+//  note: label arg is not needed since PD does not support giving an adapter
+//  a nickname
 export function getLoadAdapters(
   moduleEntities: ModuleEntities,
   labwareEntities: LabwareEntities,
@@ -98,16 +99,26 @@ export function getLoadAdapters(
   )
   const pythonAdapters = Object.values(adapterEntities)
     .map(adapter => {
-      const adapterSlot = labwareRobotState[adapter.id].slot
+      const { id, def, pythonName } = adapter
+      const { parameters, namespace, version } = def
+      const adapterSlot = labwareRobotState[id].slot
       const onModule = moduleEntities[adapterSlot] != null
       const location = onModule
         ? moduleEntities[adapterSlot].pythonName
         : PROTOCOL_CONTEXT_NAME
-      const slotInfo = onModule ? '' : `, ${formatPyStr(adapterSlot)}`
 
-      return `${adapter.pythonName} = ${location}.load_adapter(${formatPyStr(
-        adapter.def.parameters.loadName
-      )}${slotInfo})`
+      const adapterArgs = [
+        `${formatPyStr(parameters.loadName)}`,
+        ...(!onModule ? [`${formatPyStr(adapterSlot)}`] : []),
+        `namespace=${formatPyStr(namespace)}`,
+        `version=${formatPyStr(version.toString())}`,
+      ].join(',\n')
+
+      return (
+        `${pythonName} = ${location}.load_adapter(\n` +
+        `${indentPyLines(adapterArgs)},\n` +
+        `)`
+      )
     })
     .join('\n')
 
@@ -117,28 +128,43 @@ export function getLoadAdapters(
 export function getLoadLabware(
   moduleEntities: ModuleEntities,
   allLabwareEntities: LabwareEntities,
-  labwareRobotState: TimelineFrame['labware']
+  labwareRobotState: TimelineFrame['labware'],
+  labwareNicknamesById: Record<string, string>
 ): string {
   const labwareEntities = Object.values(allLabwareEntities).filter(
     lw => !lw.def.allowedRoles?.includes('adapter')
   )
   const pythonLabware = Object.values(labwareEntities)
     .map(labware => {
-      const labwareSlot = labwareRobotState[labware.id].slot
+      const { id, def, pythonName } = labware
+      const { metadata, parameters, namespace, version } = def
+      const hasNickname = labwareNicknamesById[id] !== metadata.displayName
+      const labwareSlot = labwareRobotState[id].slot
       const onModule = moduleEntities[labwareSlot] != null
       const onAdapter = allLabwareEntities[labwareSlot] != null
+
       let location = PROTOCOL_CONTEXT_NAME
       if (onAdapter) {
         location = allLabwareEntities[labwareSlot].pythonName
       } else if (onModule) {
         location = moduleEntities[labwareSlot].pythonName
       }
-      const slotInfo =
-        onModule || onAdapter ? '' : `, ${formatPyStr(labwareSlot)}`
 
-      return `${labware.pythonName} = ${location}.load_labware(${formatPyStr(
-        labware.def.parameters.loadName
-      )}${slotInfo})`
+      const labwareArgs = [
+        `${formatPyStr(parameters.loadName)}`,
+        ...(!onModule && !onAdapter ? [`${formatPyStr(labwareSlot)}`] : []),
+        ...(hasNickname
+          ? [`label=${formatPyStr(labwareNicknamesById[id])}`]
+          : []),
+        `namespace=${formatPyStr(namespace)}`,
+        `version=${formatPyStr(version.toString())}`,
+      ].join(',\n')
+
+      return (
+        `${pythonName} = ${location}.load_labware(\n` +
+        `${indentPyLines(labwareArgs)},\n` +
+        `)`
+      )
     })
     .join('\n')
 
@@ -240,7 +266,8 @@ export function pythonDefRun(
   invariantContext: InvariantContext,
   robotState: TimelineFrame,
   robotStateTimeline: Timeline,
-  liquidsByLabwareId: LabwareLiquidState
+  liquidsByLabwareId: LabwareLiquidState,
+  labwareNicknamesById: Record<string, string>
 ): string {
   const {
     moduleEntities,
@@ -253,7 +280,12 @@ export function pythonDefRun(
   const sections: string[] = [
     getLoadModules(moduleEntities, modules),
     getLoadAdapters(moduleEntities, labwareEntities, labware),
-    getLoadLabware(moduleEntities, labwareEntities, labware),
+    getLoadLabware(
+      moduleEntities,
+      labwareEntities,
+      labware,
+      labwareNicknamesById
+    ),
     getLoadPipettes(pipetteEntities, labwareEntities, pipettes),
     getDefineLiquids(liquidEntities),
     getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),


### PR DESCRIPTION
…ad_labware & load_adapter

closes AUTH-1453

# Overview

This PR adds the optional `load_adapter()` and `load_labware()` args: `label`, `namespace`, and `version`

## Test Plan and Hands on Testing

Review code and smoke test

## Changelog

- extended `getLoadLabware` and `getLoadAdapters` to include optional args of `label`, `namespace`, and `version` 
- add onto unit tests

## Risk assessment

low, behind ff