### PR TITLE
refactor(shared-data): Split `TypedDict`-based bindings for labware schemas 2 and 3

### DIFF
--- a/api/src/opentrons/calibration_storage/ot2/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot2/tip_length.py
@@ -16,7 +16,7 @@ from opentrons.util.helpers import utc_now
 from .models import v1
 
 if typing.TYPE_CHECKING:
-    from opentrons_shared_data.labware.types import LabwareDefinition
+    from opentrons_shared_data.labware.types import LabwareDefinition2
 
 
 log = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ def tip_lengths_for_pipette(
 
 
 def load_tip_length_calibration(
-    pip_id: str, definition: "LabwareDefinition"
+    pip_id: str, definition: "LabwareDefinition2"
 ) -> v1.TipLengthModel:
     """
     Function used to grab the current tip length associated
@@ -127,7 +127,7 @@ def get_all_tip_length_calibrations() -> typing.List[v1.TipLengthCalibration]:
     return all_tip_lengths_available
 
 
-def get_custom_tiprack_definition_for_tlc(labware_uri: str) -> "LabwareDefinition":
+def get_custom_tiprack_definition_for_tlc(labware_uri: str) -> "LabwareDefinition2":
     """
     Return the custom tiprack definition saved in the custom tiprack directory
     during tip length calibration
@@ -137,7 +137,7 @@ def get_custom_tiprack_definition_for_tlc(labware_uri: str) -> "LabwareDefinitio
     try:
         with open(custom_tiprack_path, "rb") as f:
             return typing.cast(
-                "LabwareDefinition",
+                "LabwareDefinition2",
                 json.loads(f.read().decode("utf-8")),
             )
     except FileNotFoundError:
@@ -213,7 +213,7 @@ def clear_tip_length_calibration() -> None:
 
 
 def create_tip_length_data(
-    definition: "LabwareDefinition",
+    definition: "LabwareDefinition2",
     length: float,
     cal_status: typing.Optional[
         typing.Union[local_types.CalibrationStatus, v1.CalibrationStatus]
@@ -251,7 +251,7 @@ def create_tip_length_data(
 
 def _save_custom_tiprack_definition(
     labware_uri: str,
-    definition: "LabwareDefinition",
+    definition: "LabwareDefinition2",
 ) -> None:
     namespace, load_name, version = labware_uri.split("/")
     custom_tr_dir_path = config.get_custom_tiprack_def_path()

--- a/api/src/opentrons/hardware_control/instruments/ot2/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/instrument_calibration.py
@@ -14,7 +14,7 @@ from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 if typing.TYPE_CHECKING:
     from opentrons_shared_data.pipette.types import LabwareUri
     from opentrons_shared_data.labware.types import (
-        LabwareDefinition as TypeDictLabwareDef,
+        LabwareDefinition2 as TypeDictLabwareDef2,
     )
 
 # These type aliases aid typechecking in tests that work the same on this and
@@ -119,12 +119,19 @@ def save_pipette_offset_calibration(
 # TODO (lc 09-26-2022) We should ensure that only LabwareDefinition models are passed
 # into this function instead of a mixture of TypeDicts and BaseModels
 def load_tip_length_for_pipette(
-    pipette_id: str, tiprack: typing.Union["TypeDictLabwareDef", LabwareDefinition]
+    pipette_id: str, tiprack: typing.Union["TypeDictLabwareDef2", LabwareDefinition]
 ) -> TipLengthCalibration:
     if isinstance(tiprack, LabwareDefinition):
+        # todo(mm, 2025-02-13): This is only correct for schema 2 labware.
+        # The LabwareDefinition union member needs to be narrowed to LabwareDefinition2,
+        # which doesn't exist yet (https://opentrons.atlassian.net/browse/EXEC-1206).
         tiprack = typing.cast(
-            "TypeDictLabwareDef",
-            tiprack.model_dump(exclude_none=True, exclude_unset=True),
+            "TypeDictLabwareDef2",
+            tiprack.model_dump(
+                exclude_none=True,
+                exclude_unset=True
+                # todo(mm, 2025-02-13): Do we need by_alias=True here?
+            ),
         )
 
     tip_length_data = calibration_storage.load_tip_length_calibration(

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -3,7 +3,8 @@
 from typing import List, Optional, cast, Dict
 
 from opentrons_shared_data.labware.types import (
-    LabwareParameters as LabwareParametersDict,
+    LabwareParameters2 as LabwareParameters2Dict,
+    LabwareParameters3 as LabwareParameters3Dict,
     LabwareDefinition as LabwareDefinitionDict,
 )
 
@@ -27,6 +28,9 @@ from ..._liquid import Liquid
 from ..labware import AbstractLabware, LabwareLoadParams
 
 from .well import WellCore
+
+
+_LabwareParametersDict = LabwareParameters2Dict | LabwareParameters3Dict
 
 
 class LabwareCore(AbstractLabware[WellCore]):
@@ -96,9 +100,9 @@ class LabwareCore(AbstractLabware[WellCore]):
             LabwareDefinitionDict, self._definition.model_dump(exclude_none=True)
         )
 
-    def get_parameters(self) -> LabwareParametersDict:
+    def get_parameters(self) -> _LabwareParametersDict:
         return cast(
-            LabwareParametersDict,
+            _LabwareParametersDict,
             self._definition.parameters.model_dump(exclude_none=True),
         )
 

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -7,7 +7,8 @@ from typing import Any, Generic, List, NamedTuple, Optional, TypeVar, Dict
 
 from opentrons_shared_data.labware.types import (
     LabwareUri,
-    LabwareParameters as LabwareParametersDict,
+    LabwareParameters2,
+    LabwareParameters3,
     LabwareDefinition as LabwareDefinitionDict,
 )
 
@@ -15,6 +16,9 @@ from opentrons.types import DeckSlotName, Point, NozzleMapInterface
 from .._liquid import Liquid
 
 from .well import WellCoreType
+
+
+_LabwareParametersDict = LabwareParameters2 | LabwareParameters3
 
 
 class LabwareLoadParams(NamedTuple):
@@ -75,7 +79,7 @@ class AbstractLabware(ABC, Generic[WellCoreType]):
         """Get the labware's definition as a plain dictionary."""
 
     @abstractmethod
-    def get_parameters(self) -> LabwareParametersDict:
+    def get_parameters(self) -> _LabwareParametersDict:
         """Get the labware's definition's `parameters` field as a plain dictionary."""
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
@@ -6,7 +6,7 @@ from opentrons.protocols.api_support.tip_tracker import TipTracker
 
 from opentrons.types import DeckSlotName, Location, Point, NozzleMapInterface
 
-from opentrons_shared_data.labware.types import LabwareParameters, LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareParameters2, LabwareDefinition2
 
 from ..._liquid import Liquid
 from ..labware import AbstractLabware, LabwareLoadParams
@@ -36,7 +36,7 @@ class LegacyLabwareCore(AbstractLabware[LegacyWellCore]):
 
     def __init__(
         self,
-        definition: LabwareDefinition,
+        definition: LabwareDefinition2,
         parent: Location,
         label: Optional[str] = None,
     ) -> None:
@@ -106,10 +106,10 @@ class LegacyLabwareCore(AbstractLabware[LegacyWellCore]):
     def set_name(self, new_name: str) -> None:
         self._name = new_name
 
-    def get_definition(self) -> LabwareDefinition:
+    def get_definition(self) -> LabwareDefinition2:
         return self._definition
 
-    def get_parameters(self) -> LabwareParameters:
+    def get_parameters(self) -> LabwareParameters2:
         return self._parameters
 
     def get_quirks(self) -> List[str]:

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
@@ -36,6 +36,10 @@ class LegacyLabwareCore(AbstractLabware[LegacyWellCore]):
 
     def __init__(
         self,
+        # We need labware schema 2, specifically, because schema 3 changes how positions
+        # are calculated, and we don't attempt to handle that here in
+        # `opentrons.protocol_api.core.legacy`. We do handle it in
+        # `opentrons.protocol_api.core.engine` and `opentrons.protocol_engine`.
         definition: LabwareDefinition2,
         parent: Location,
         label: Optional[str] = None,

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -209,6 +209,10 @@ class LegacyProtocolCore(
             bundled_defs=self._bundled_labware,
             extra_defs=self._extra_labware,
         )
+        # For type checking. This should always pass because
+        # opentrons.protocol_api.core.legacy should only load labware with schema 2.
+        assert labware_def["schemaVersion"] == 2
+
         labware_core = LegacyLabwareCore(
             definition=labware_def,
             parent=parent,

--- a/api/src/opentrons/protocol_api/core/legacy/load_info.py
+++ b/api/src/opentrons/protocol_api/core/legacy/load_info.py
@@ -18,8 +18,6 @@ from opentrons.types import Mount, DeckSlotName
 class LabwareLoadInfo:
     """Information about a successful labware load.
 
-    :meta private:
-
     This is a separate class from the main user-facing `Labware` class
     because this is easier to construct in unit tests.
     """
@@ -47,10 +45,7 @@ class LabwareLoadInfo:
 
 @dataclass(frozen=True)
 class InstrumentLoadInfo:
-    """Like `LabwareLoadInfo`, but for instruments (pipettes).
-
-    :meta private:
-    """
+    """Like `LabwareLoadInfo`, but for instruments (pipettes)."""
 
     instrument_load_name: str
     mount: Mount
@@ -59,10 +54,7 @@ class InstrumentLoadInfo:
 
 @dataclass(frozen=True)
 class ModuleLoadInfo:
-    """Like `LabwareLoadInfo`, but for hardware modules.
-
-    :meta private:
-    """
+    """Like `LabwareLoadInfo`, but for hardware modules."""
 
     requested_model: ModuleModel
     loaded_model: ModuleModel

--- a/api/src/opentrons/protocol_api/core/legacy/load_info.py
+++ b/api/src/opentrons/protocol_api/core/legacy/load_info.py
@@ -7,7 +7,7 @@ It's only for internal Opentrons use.
 
 from dataclasses import dataclass
 from typing import Optional, Union
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.modules.types import ModuleModel
@@ -22,7 +22,7 @@ class LabwareLoadInfo:
     because this is easier to construct in unit tests.
     """
 
-    labware_definition: LabwareDefinition
+    labware_definition: LabwareDefinition2
 
     # todo(mm, 2021-10-11): Namespace, load name, and version can be derived from the
     # definition. Should they be removed from here?

--- a/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
+++ b/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
@@ -273,8 +273,13 @@ class ThermocyclerGeometry(ModuleGeometry):
             LegacyLabwareCore,
         )
 
-        # Block first three columns from being accessed
         definition = labware._core.get_definition()
+
+        # For type checking. This should always pass because
+        # opentrons.protocol_api.core.legacy should only load labware with schema 2.
+        assert definition["schemaVersion"] == 2
+
+        # Block first three columns from being accessed
         definition["ordering"] = definition["ordering"][2::]
         return Labware(
             core=LegacyLabwareCore(definition, super().location),

--- a/api/src/opentrons/protocol_api/core/legacy/well_geometry.py
+++ b/api/src/opentrons/protocol_api/core/legacy/well_geometry.py
@@ -4,9 +4,9 @@ from typing import Optional, cast, TYPE_CHECKING
 
 from opentrons.types import Point
 from opentrons_shared_data.labware.types import (
-    WellDefinition,
-    CircularWellDefinition,
-    RectangularWellDefinition,
+    WellDefinition2 as WellDefinition,
+    CircularWellDefinition2 as CircularWellDefinition,
+    RectangularWellDefinition2 as RectangularWellDefinition,
 )
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional, Any
 
 from opentrons_shared_data.labware.types import (
-    LabwareDefinition as LabwareDefinitionDict,
+    LabwareDefinition2 as LabwareDefinition2Dict,
 )
 
 from opentrons import types
@@ -56,7 +56,7 @@ def validate_blowout_location(
 
 
 def tip_length_for(
-    pipette: PipetteDict, tip_rack_definition: LabwareDefinitionDict
+    pipette: PipetteDict, tip_rack_definition: LabwareDefinition2Dict
 ) -> float:
     """Get the tip length, including overlap, for a tip from this rack"""
     try:

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -154,8 +154,7 @@ def verify_definition(  # noqa: C901
     If the definition is invalid, an exception is raised; otherwise parse the
     json and return the valid definition.
 
-    :raises json.JsonDecodeError: If the definition is not valid json
-    :raises jsonschema.ValidationError: If the definition is not valid.
+    :raises NotALabwareError:
     :returns: The parsed definition
     """
     schemata_by_version = {

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -4,7 +4,7 @@ import logging
 import json
 import os
 from pathlib import Path
-from typing import Any, AnyStr, Dict, Optional, Union, List, Sequence, Literal
+from typing import Any, AnyStr, Dict, Mapping, Optional, Union, List, Sequence, Literal
 
 import jsonschema  # type: ignore
 
@@ -46,8 +46,8 @@ def get_labware_definition(
     load_name: str,
     namespace: Optional[str] = None,
     version: Optional[int] = None,
-    bundled_defs: Optional[Dict[str, LabwareDefinition]] = None,
-    extra_defs: Optional[Dict[str, LabwareDefinition]] = None,
+    bundled_defs: Optional[Mapping[str, LabwareDefinition]] = None,
+    extra_defs: Optional[Mapping[str, LabwareDefinition]] = None,
 ) -> LabwareDefinition:
     """
     Look up and return a definition by load_name + namespace + version and
@@ -191,7 +191,7 @@ def verify_definition(  # noqa: C901
 
 
 def _get_labware_definition_from_bundle(
-    bundled_labware: Dict[str, LabwareDefinition],
+    bundled_labware: Mapping[str, LabwareDefinition],
     load_name: str,
     namespace: Optional[str] = None,
     version: Optional[int] = None,

--- a/api/tests/opentrons/calibration_storage/test_tip_length_ot2.py
+++ b/api/tests/opentrons/calibration_storage/test_tip_length_ot2.py
@@ -20,14 +20,14 @@ from opentrons.calibration_storage.ot2 import (
 from opentrons_shared_data.pipette.types import LabwareUri
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.types import LabwareDefinition
+    from opentrons_shared_data.labware.types import LabwareDefinition2
 
 
 @pytest.fixture
 def starting_calibration_data(
     ot_config_tempdir: Any,
-    minimal_labware_def: "LabwareDefinition",
-    minimal_labware_def2: "LabwareDefinition",
+    minimal_labware_def: "LabwareDefinition2",
+    minimal_labware_def2: "LabwareDefinition2",
 ) -> None:
     """
     Starting calibration data fixture.
@@ -55,7 +55,7 @@ def starting_calibration_data(
 
 
 def test_save_tip_length_calibration(
-    ot_config_tempdir: Any, minimal_labware_def: "LabwareDefinition"
+    ot_config_tempdir: Any, minimal_labware_def: "LabwareDefinition2"
 ) -> None:
     """
     Test saving tip length calibrations.
@@ -72,7 +72,7 @@ def test_save_tip_length_calibration(
 
 
 def test_get_tip_length_calibration(
-    starting_calibration_data: Any, minimal_labware_def: "LabwareDefinition"
+    starting_calibration_data: Any, minimal_labware_def: "LabwareDefinition2"
 ) -> None:
     """
     Test ability to get a tip length calibration model.
@@ -91,7 +91,7 @@ def test_get_tip_length_calibration(
 
 
 def test_delete_specific_tip_calibration(
-    starting_calibration_data: Any, minimal_labware_def: "LabwareDefinition"
+    starting_calibration_data: Any, minimal_labware_def: "LabwareDefinition2"
 ) -> None:
     """
     Test delete a specific tip length calibration.

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -36,7 +36,7 @@ except (OSError, ModuleNotFoundError):
 
 from opentrons_shared_data.robot.types import RobotTypeEnum
 from opentrons_shared_data.protocol.types import JsonProtocol
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition, LabwareDefinition2
 from opentrons_shared_data.module.types import ModuleDefinitionV3
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
@@ -606,7 +606,7 @@ def get_bundle_fixture() -> Callable[[str], Bundle]:
 
 
 @pytest.fixture()
-def minimal_labware_def() -> LabwareDefinition:
+def minimal_labware_def() -> LabwareDefinition2:
     return {
         "metadata": {
             "displayName": "minimal labware",
@@ -652,7 +652,7 @@ def minimal_labware_def() -> LabwareDefinition:
 
 
 @pytest.fixture()
-def minimal_labware_def2() -> LabwareDefinition:
+def minimal_labware_def2() -> LabwareDefinition2:
     return {
         "metadata": {
             "displayName": "other test labware",
@@ -733,14 +733,14 @@ def minimal_labware_def2() -> LabwareDefinition:
 
 
 @pytest.fixture()
-def min_lw_impl(minimal_labware_def: LabwareDefinition) -> LegacyLabwareCore:
+def min_lw_impl(minimal_labware_def: LabwareDefinition2) -> LegacyLabwareCore:
     return LegacyLabwareCore(
         definition=minimal_labware_def, parent=Location(Point(0, 0, 0), "deck")
     )
 
 
 @pytest.fixture()
-def min_lw2_impl(minimal_labware_def2: LabwareDefinition) -> LegacyLabwareCore:
+def min_lw2_impl(minimal_labware_def2: LabwareDefinition2) -> LegacyLabwareCore:
     return LegacyLabwareCore(
         definition=minimal_labware_def2, parent=Location(Point(0, 0, 0), "deck")
     )

--- a/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
@@ -8,7 +8,7 @@ from decoy import Decoy
 
 from opentrons_shared_data.labware.types import (
     LabwareUri,
-    LabwareDefinition as LabwareDefDict,
+    LabwareDefinition2 as LabwareDef2Dict,
 )
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
@@ -44,10 +44,10 @@ def _use_mock_calibration_storage(
 
 
 @pytest.fixture
-def tip_rack_dict() -> LabwareDefDict:
+def tip_rack_dict() -> LabwareDef2Dict:
     """Get a tip rack dictionary definition value object."""
     return cast(
-        LabwareDefDict,
+        LabwareDef2Dict,
         {"namespace": "test", "version": 1, "parameters": {"loadName": "cool-labware"}},
     )
 
@@ -74,8 +74,8 @@ def tip_rack_model() -> LabwareDefinition:
 )
 def test_load_tip_length(
     decoy: Decoy,
-    tip_rack_dict: LabwareDefDict,
-    tip_rack_definition: Union[LabwareDefDict, LabwareDefinition],
+    tip_rack_dict: LabwareDef2Dict,
+    tip_rack_definition: Union[LabwareDef2Dict, LabwareDefinition],
 ) -> None:
     """Test that a tip length can be laoded for a pipette / tiprack combination."""
     tip_length_data = v1_models.TipLengthModel(

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -7,7 +7,6 @@ from decoy import Decoy
 
 from opentrons_shared_data.labware.types import (
     LabwareDefinition as LabwareDefDict,
-    LabwareParameters as LabwareParamsDict,
     LabwareUri,
 )
 from opentrons_shared_data.labware.labware_definition import (
@@ -192,7 +191,9 @@ def test_get_definition(subject: LabwareCore) -> None:
             "gripperOffsets": {},
         },
     )
-    assert subject.get_parameters() == cast(LabwareParamsDict, {"loadName": "world"})
+    assert subject.get_parameters() == {  # type: ignore[comparison-overlap]
+        "loadName": "world"
+    }
 
 
 def test_get_user_display_name(decoy: Decoy, mock_engine_client: EngineClient) -> None:

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, cast
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.types import LabwareDefinition2 as LabwareDefDict
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.module.types import ModuleDefinitionV3
 
@@ -204,6 +204,7 @@ def test_load_labware(
     labware_definition_dict = cast(
         LabwareDefDict,
         {
+            "schemaVersion": 2,
             "namespace": "super cool namespace",
             "parameters": {"loadName": "super cool load name"},
             "version": 42,
@@ -301,6 +302,7 @@ def test_load_labware_on_module(
     labware_definition_dict = cast(
         LabwareDefDict,
         {
+            "schemaVersion": 2,
             "namespace": "super cool namespace",
             "parameters": {"loadName": "super cool load name"},
             "version": 42,

--- a/api/tests/opentrons/protocol_api_old/core/simulator/conftest.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/conftest.py
@@ -21,7 +21,7 @@ from opentrons.protocol_api.core.legacy_simulator.legacy_protocol_core import (
     LegacyProtocolCoreSimulator,
 )
 
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 from opentrons_shared_data.pipette.types import PipetteNameType
 
 
@@ -101,7 +101,7 @@ def second_simulating_instrument_context(
 
 
 @pytest.fixture
-def labware(minimal_labware_def: LabwareDefinition) -> LegacyLabwareCore:
+def labware(minimal_labware_def: LabwareDefinition2) -> LegacyLabwareCore:
     """Labware fixture."""
     return LegacyLabwareCore(
         definition=minimal_labware_def,
@@ -110,7 +110,7 @@ def labware(minimal_labware_def: LabwareDefinition) -> LegacyLabwareCore:
 
 
 @pytest.fixture
-def tip_rack(minimal_labware_def: LabwareDefinition) -> LegacyLabwareCore:
+def tip_rack(minimal_labware_def: LabwareDefinition2) -> LegacyLabwareCore:
     tip_rack_definition = minimal_labware_def.copy()
     tip_rack_parameters = minimal_labware_def["parameters"].copy()
 
@@ -128,7 +128,7 @@ def tip_rack(minimal_labware_def: LabwareDefinition) -> LegacyLabwareCore:
 
 
 @pytest.fixture
-def second_labware(minimal_labware_def: LabwareDefinition) -> LegacyLabwareCore:
+def second_labware(minimal_labware_def: LabwareDefinition2) -> LegacyLabwareCore:
     """Labware fixture."""
     return LegacyLabwareCore(
         definition=minimal_labware_def,

--- a/api/tests/opentrons/protocol_api_old/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api_old/test_accessor_fn.py
@@ -1,13 +1,13 @@
 from opentrons.types import Point
 from opentrons.protocol_api import Labware
 from opentrons.protocol_api.core.legacy.legacy_labware_core import LegacyLabwareCore
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 
 
 def test_wells_accessor(
     min_lw: Labware,
     min_lw_impl: LegacyLabwareCore,
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinition2,
 ) -> None:
     depth1 = minimal_labware_def["wells"]["A1"]["depth"]
     depth2 = minimal_labware_def["wells"]["A2"]["depth"]
@@ -23,7 +23,7 @@ def test_wells_accessor(
 def test_wells_name_accessor(
     min_lw: Labware,
     min_lw_impl: LegacyLabwareCore,
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinition2,
 ) -> None:
     depth1 = minimal_labware_def["wells"]["A1"]["depth"]
     depth2 = minimal_labware_def["wells"]["A2"]["depth"]
@@ -45,7 +45,7 @@ def test_deprecated_index_accessors(min_lw: Labware) -> None:
 def test_dict_accessor(
     min_lw: Labware,
     min_lw_impl: LegacyLabwareCore,
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinition2,
 ) -> None:
     depth1 = minimal_labware_def["wells"]["A1"]["depth"]
     depth2 = minimal_labware_def["wells"]["A2"]["depth"]
@@ -61,7 +61,7 @@ def test_dict_accessor(
 def test_rows_accessor(
     min_lw2_impl: LegacyLabwareCore,
     min_lw2: Labware,
-    minimal_labware_def2: LabwareDefinition,
+    minimal_labware_def2: LabwareDefinition2,
 ) -> None:
     depth1 = minimal_labware_def2["wells"]["A1"]["depth"]
     x1 = minimal_labware_def2["wells"]["A1"]["x"]
@@ -79,7 +79,7 @@ def test_rows_accessor(
 def test_row_name_accessor(
     min_lw2_impl: LegacyLabwareCore,
     min_lw2: Labware,
-    minimal_labware_def2: LabwareDefinition,
+    minimal_labware_def2: LabwareDefinition2,
 ) -> None:
     depth1 = minimal_labware_def2["wells"]["A1"]["depth"]
     x1 = minimal_labware_def2["wells"]["A1"]["x"]
@@ -97,7 +97,7 @@ def test_row_name_accessor(
 def test_cols_accessor(
     min_lw_impl: LegacyLabwareCore,
     min_lw: Labware,
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinition2,
 ) -> None:
     depth1 = minimal_labware_def["wells"]["A1"]["depth"]
     depth2 = minimal_labware_def["wells"]["A2"]["depth"]
@@ -113,7 +113,7 @@ def test_cols_accessor(
 def test_col_name_accessor(
     min_lw: Labware,
     min_lw_impl: LegacyLabwareCore,
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinition2,
 ) -> None:
     depth1 = minimal_labware_def["wells"]["A1"]["depth"]
     depth2 = minimal_labware_def["wells"]["A2"]["depth"]

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -1096,7 +1096,7 @@ def test_tip_length_for_caldata(
     assert (
         instrument_support.tip_length_for(
             pipette=instr.hw_pipette,
-            tip_rack_definition=tip_rack._core.get_definition(),
+            tip_rack_definition=tip_rack._core.get_definition(),  # type: ignore[arg-type]
         )
         == 2
     )
@@ -1107,7 +1107,7 @@ def test_tip_length_for_caldata(
 
     assert instrument_support.tip_length_for(
         pipette=instr.hw_pipette,
-        tip_rack_definition=tip_rack._core.get_definition(),
+        tip_rack_definition=tip_rack._core.get_definition(),  # type: ignore[arg-type]
     ) == (
         tip_rack._core.get_definition()["parameters"]["tipLength"]
         - instr.hw_pipette["tip_overlap"]["opentrons/geb_96_tiprack_10ul/1"]

--- a/api/tests/opentrons/protocol_api_old/test_labware.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware.py
@@ -3,8 +3,7 @@ from typing import Dict
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.types import WellDefinition
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2, WellDefinition2
 from opentrons.protocol_api import Labware
 
 from opentrons.hardware_control.modules.types import (
@@ -27,7 +26,7 @@ from opentrons.protocol_api.core.legacy.well_geometry import WellGeometry
 from opentrons.calibration_storage import helpers
 from opentrons.types import Point, Location
 
-test_data: Dict[str, WellDefinition] = {
+test_data: Dict[str, WellDefinition2] = {
     "circular_well_json": {
         "shape": "circular",
         "depth": 40,
@@ -212,14 +211,16 @@ def test_from_center_cartesian() -> None:
 
 
 @pytest.fixture
-def corning_96_wellplate_360ul_flat_def() -> LabwareDefinition:
+def corning_96_wellplate_360ul_flat_def() -> LabwareDefinition2:
     labware_name = "corning_96_wellplate_360ul_flat"
-    return labware.get_labware_definition(labware_name)
+    result = labware.get_labware_definition(labware_name)
+    assert result["schemaVersion"] == 2
+    return result
 
 
 @pytest.fixture
 def corning_96_wellplate_360ul_flat(
-    corning_96_wellplate_360ul_flat_def: LabwareDefinition,
+    corning_96_wellplate_360ul_flat_def: LabwareDefinition2,
 ) -> Labware:
     return labware.Labware(
         core=LegacyLabwareCore(
@@ -233,14 +234,16 @@ def corning_96_wellplate_360ul_flat(
 
 
 @pytest.fixture
-def opentrons_96_tiprack_300ul_def() -> LabwareDefinition:
+def opentrons_96_tiprack_300ul_def() -> LabwareDefinition2:
     labware_name = "opentrons_96_tiprack_300ul"
-    return labware.get_labware_definition(labware_name)
+    result = labware.get_labware_definition(labware_name)
+    assert result["schemaVersion"] == 2
+    return result
 
 
 @pytest.fixture
 def opentrons_96_tiprack_300ul(
-    opentrons_96_tiprack_300ul_def: LabwareDefinition,
+    opentrons_96_tiprack_300ul_def: LabwareDefinition2,
 ) -> Labware:
     return labware.Labware(
         core=LegacyLabwareCore(
@@ -379,7 +382,7 @@ def test_use_tips(opentrons_96_tiprack_300ul: Labware) -> None:
 
 def test_select_next_tip(
     opentrons_96_tiprack_300ul: Labware,
-    opentrons_96_tiprack_300ul_def: LabwareDefinition,
+    opentrons_96_tiprack_300ul_def: LabwareDefinition2,
 ) -> None:
     tiprack = opentrons_96_tiprack_300ul
     well_list = tiprack.wells()
@@ -521,6 +524,7 @@ def test_module_load_labware(module_name: str) -> None:
         None,
     )
     old_z = mod.highest_z
+    assert labware_def["schemaVersion"] == 2  # load_from_definition() expects this.
     lw = labware.load_from_definition(labware_def, mod.location)
     mod.add_labware(lw)
     assert mod.labware == lw
@@ -539,6 +543,7 @@ def test_module_load_labware(module_name: str) -> None:
 def test_tiprack_list() -> None:
     labware_name = "opentrons_96_tiprack_300ul"
     labware_def = labware.get_labware_definition(labware_name)
+    assert labware_def["schemaVersion"] == 2  # LegacyLabwareCore expects this.
     tiprack = labware.Labware(
         core=LegacyLabwareCore(labware_def, Location(Point(0, 0, 0), "Test Slot")),
         api_version=APIVersion(2, 13),
@@ -585,6 +590,7 @@ def test_uris() -> None:
     defn = labware.get_labware_definition(
         details[1], details[0], details[2]  # type: ignore[arg-type]
     )
+    assert defn["schemaVersion"] == 2  # LegacyLabwareCore expects this.
     assert helpers.uri_from_definition(defn) == uri
     lw = labware.Labware(
         core=LegacyLabwareCore(defn, Location(Point(0, 0, 0), "Test Slot")),
@@ -596,7 +602,7 @@ def test_uris() -> None:
 
 
 def test_labware_hash_func_same_implementation(
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinition2,
 ) -> None:
     """Test that multiple Labware objects with same implementation and version
     have the same __hash__"""
@@ -614,7 +620,7 @@ def test_labware_hash_func_same_implementation(
 
 
 def test_labware_hash_func_same_implementation_different_version(
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinition2,
 ) -> None:
     """Test that multiple Labware objects with same implementation yet
     different version have different __hash__"""
@@ -637,7 +643,7 @@ def test_labware_hash_func_same_implementation_different_version(
 
 
 def test_labware_hash_func_diff_implementation_same_version(
-    minimal_labware_def: LabwareDefinition,
+    minimal_labware_def: LabwareDefinition2,
 ) -> None:
     """Test that multiple Labware objects with different implementation yet
     sane version have different __hash__"""

--- a/api/tests/opentrons/protocol_api_old/test_offsets.py
+++ b/api/tests/opentrons/protocol_api_old/test_offsets.py
@@ -5,10 +5,10 @@ from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import Point, Location
 
 if typing.TYPE_CHECKING:
-    from opentrons_shared_data.labware.types import LabwareDefinition
+    from opentrons_shared_data.labware.types import LabwareDefinition2
 
 
-def test_wells_rebuilt_with_offset(minimal_labware_def: "LabwareDefinition") -> None:
+def test_wells_rebuilt_with_offset(minimal_labware_def: "LabwareDefinition2") -> None:
     test_labware = labware.Labware(
         core=LegacyLabwareCore(minimal_labware_def, Location(Point(0, 0, 0), "deck")),
         api_version=APIVersion(2, 13),  # set_offset() is not implemented in 2.14.

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -1,15 +1,16 @@
 """Test equipment command execution side effects."""
 
-import pytest
-from _pytest.fixtures import SubRequest
+from unittest.mock import sentinel
 import inspect
 from datetime import datetime
 from decoy import Decoy, matchers
 from typing import Any, Optional, cast, Dict
 
+import pytest
+from _pytest.fixtures import SubRequest
+
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.pipette import pipette_definition
-from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.types import LabwareUri
 
 from opentrons.calibration_storage.helpers import uri_from_details
@@ -217,7 +218,6 @@ async def test_load_labware(
     model_utils: ModelUtils,
     state_store: StateStore,
     labware_data_provider: LabwareDataProvider,
-    minimal_labware_def: LabwareDefinition,
     subject: EquipmentHandler,
 ) -> None:
     """It should load labware definition and offset data and generate an ID."""
@@ -233,7 +233,7 @@ async def test_load_labware(
             namespace="opentrons-test",
             version=1,
         )
-    ).then_return(minimal_labware_def)
+    ).then_return(sentinel.labware_def)
     decoy.when(
         state_store.geometry.get_projected_offset_location(
             DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
@@ -276,7 +276,7 @@ async def test_load_labware(
 
     assert result == LoadedLabwareData(
         labware_id="unique-id",
-        definition=minimal_labware_def,
+        definition=sentinel.labware_def,
         offsetId="labware-offset-id",
     )
 
@@ -285,7 +285,6 @@ async def test_load_labware_off_deck(
     decoy: Decoy,
     model_utils: ModelUtils,
     state_store: StateStore,
-    minimal_labware_def: LabwareDefinition,
     subject: EquipmentHandler,
 ) -> None:
     """It should load labware definition and offset data and generate an ID."""
@@ -295,7 +294,7 @@ async def test_load_labware_off_deck(
         state_store.labware.get_definition_by_uri(
             cast("LabwareUri", "opentrons-test/load-name/1")
         )
-    ).then_return(minimal_labware_def)
+    ).then_return(sentinel.labware_def)
 
     result = await subject.load_labware(
         location=OFF_DECK_LOCATION,
@@ -307,7 +306,7 @@ async def test_load_labware_off_deck(
 
     assert result == LoadedLabwareData(
         labware_id="unique-id",
-        definition=minimal_labware_def,
+        definition=sentinel.labware_def,
         offsetId=None,
     )
 
@@ -316,7 +315,6 @@ async def test_load_labware_uses_provided_id(
     decoy: Decoy,
     state_store: StateStore,
     labware_data_provider: LabwareDataProvider,
-    minimal_labware_def: LabwareDefinition,
     subject: EquipmentHandler,
 ) -> None:
     """It should use the provided ID rather than generating an ID for the labware."""
@@ -330,7 +328,7 @@ async def test_load_labware_uses_provided_id(
             namespace="opentrons-test",
             version=1,
         )
-    ).then_return(minimal_labware_def)
+    ).then_return(sentinel.labware_def)
     decoy.when(
         state_store.geometry.get_projected_offset_location(
             DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
@@ -358,7 +356,7 @@ async def test_load_labware_uses_provided_id(
     )
 
     assert result == LoadedLabwareData(
-        labware_id="my-labware-id", definition=minimal_labware_def, offsetId=None
+        labware_id="my-labware-id", definition=sentinel.labware_def, offsetId=None
     )
 
 
@@ -367,7 +365,6 @@ async def test_load_labware_uses_loaded_labware_def(
     model_utils: ModelUtils,
     state_store: StateStore,
     labware_data_provider: LabwareDataProvider,
-    minimal_labware_def: LabwareDefinition,
     subject: EquipmentHandler,
 ) -> None:
     """Loading labware should use the labware definition already in state."""
@@ -380,7 +377,7 @@ async def test_load_labware_uses_loaded_labware_def(
     decoy.when(model_utils.generate_id()).then_return("unique-id")
 
     decoy.when(state_store.labware.get_definition_by_uri(expected_uri)).then_return(
-        minimal_labware_def
+        sentinel.labware_def
     )
 
     decoy.when(
@@ -412,7 +409,7 @@ async def test_load_labware_uses_loaded_labware_def(
 
     assert result == LoadedLabwareData(
         labware_id="unique-id",
-        definition=minimal_labware_def,
+        definition=sentinel.labware_def,
         offsetId=None,
     )
 
@@ -430,7 +427,6 @@ async def test_load_labware_on_module(
     decoy: Decoy,
     model_utils: ModelUtils,
     state_store: StateStore,
-    minimal_labware_def: LabwareDefinition,
     subject: EquipmentHandler,
 ) -> None:
     """It should load labware definition and offset data and generate an ID."""
@@ -438,7 +434,7 @@ async def test_load_labware_on_module(
 
     decoy.when(
         state_store.labware.get_definition_by_uri(matchers.IsA(str))
-    ).then_return(minimal_labware_def)
+    ).then_return(sentinel.labware_def)
 
     decoy.when(state_store.modules.get_requested_model("module-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V1
@@ -503,7 +499,7 @@ async def test_load_labware_on_module(
 
     assert result == LoadedLabwareData(
         labware_id="unique-id",
-        definition=minimal_labware_def,
+        definition=sentinel.labware_def,
         offsetId="labware-offset-id",
     )
 

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -41,7 +41,7 @@ from opentrons.protocol_runner.legacy_command_mapper import (
     LegacyContextCommandError,
     LegacyCommandMapper,
 )
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 from opentrons_shared_data.module.types import ModuleDefinitionV3
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import DeckSlotName, Mount, MountType
@@ -267,7 +267,7 @@ def test_command_stack() -> None:
     ]
 
 
-def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
+def test_map_labware_load(minimal_labware_def: LabwareDefinition2) -> None:
     """It should correctly map a labware load."""
     input = LegacyLabwareLoadInfo(
         labware_definition=minimal_labware_def,
@@ -468,7 +468,7 @@ def test_map_module_load(
     assert result_succeed == expected_succeed
 
 
-def test_map_module_labware_load(minimal_labware_def: LabwareDefinition) -> None:
+def test_map_module_labware_load(minimal_labware_def: LabwareDefinition2) -> None:
     """It should correctly map a labware load on module."""
     load_input = LegacyLabwareLoadInfo(
         labware_definition=minimal_labware_def,

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -26,7 +26,7 @@ from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
 from opentrons.types import DeckSlotName
 
 from opentrons_shared_data.labware.types import (
-    LabwareDefinition as LabwareDefinitionDict,
+    LabwareDefinition2 as LabwareDefinition2Dict,
 )
 
 
@@ -181,7 +181,7 @@ async def test_equipment_broker_messages(
     mock_legacy_command_mapper: LegacyCommandMapper,
     mock_action_dispatcher: pe_actions.ActionDispatcher,
     subject: LegacyContextPlugin,
-    minimal_labware_def: LabwareDefinitionDict,
+    minimal_labware_def: LabwareDefinition2Dict,
 ) -> None:
     """It should dispatch commands from equipment broker messages."""
     # Capture the function that the plugin sets up as its labware load callback.

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -10,16 +10,18 @@ from opentrons.types import Location, Point
 from opentrons.protocol_api.labware import Labware
 from opentrons.protocol_api.core.legacy.module_geometry import ModuleGeometry
 
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 
 
 @pytest.fixture(scope="session")
-def trough_definition() -> LabwareDefinition:
-    return labware.get_labware_definition("usascientific_12_reservoir_22ml")
+def trough_definition() -> LabwareDefinition2:
+    result = labware.get_labware_definition("usascientific_12_reservoir_22ml")
+    assert result["schemaVersion"] == 2  # For type checking.
+    return result
 
 
 @pytest.fixture(scope="session")
-def trough(trough_definition: LabwareDefinition) -> Labware:
+def trough(trough_definition: LabwareDefinition2) -> Labware:
     deck = Deck(deck_type=STANDARD_OT2_DECK)
     return labware.load_from_definition(trough_definition, deck.position_for(1))
 
@@ -38,7 +40,9 @@ def module() -> ModuleGeometry:
 
 
 @pytest.fixture(scope="session")
-def mod_trough(trough_definition: LabwareDefinition, module: ModuleGeometry) -> Labware:
+def mod_trough(
+    trough_definition: LabwareDefinition2, module: ModuleGeometry
+) -> Labware:
     mod_trough = module.add_labware(
         labware.load_from_definition(trough_definition, module.location)
     )

--- a/api/tests/opentrons/protocols/api_support/test_util.py
+++ b/api/tests/opentrons/protocols/api_support/test_util.py
@@ -59,6 +59,7 @@ def test_max_speeds_userdict() -> None:
 
 def test_build_edges() -> None:
     lw_def = get_labware_definition("corning_96_wellplate_360ul_flat")
+    assert lw_def["schemaVersion"] == 2  # LegacyLabwareCore expects this.
     test_lw = Labware(
         core=LegacyLabwareCore(lw_def, Location(Point(0, 0, 0), None)),
         api_version=MAX_SUPPORTED_VERSION,

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, List, Tuple
 import typing
 from opentrons.protocol_api.core.well import AbstractWellCore
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 from opentrons_shared_data.protocol.types import (
     BlowoutParams,
     DelayParams,
@@ -65,7 +65,7 @@ def test_load_pipettes_from_json() -> None:
     assert result == {"aID": ("p10_single", "left"), "bID": ("p50_single", "right")}  # type: ignore[comparison-overlap]
 
 
-def test_get_well(minimal_labware_def2: LabwareDefinition) -> None:
+def test_get_well(minimal_labware_def2: LabwareDefinition2) -> None:
     deck = Location(Point(0, 0, 0), "deck")
     mock_core = mock.create_autospec(AbstractWellCore)
     mock_map = mock.create_autospec(LoadedCoreMap)
@@ -142,7 +142,7 @@ def test_get_location_with_offset(min_lw2: labware.Labware) -> None:
 
 
 def test_get_location_with_offset_fixed_trash(
-    minimal_labware_def2: LabwareDefinition,
+    minimal_labware_def2: LabwareDefinition2,
 ) -> None:
     deck = Location(Point(0, 0, 0), "deck")
     mock_core = mock.create_autospec(AbstractWellCore)
@@ -244,7 +244,7 @@ def test_drop_tip() -> None:
     assert pipette_mock.mock_calls == [mock.call.drop_tip(mock_labware.__getitem__())]
 
 
-def test_air_gap(minimal_labware_def2: LabwareDefinition) -> None:
+def test_air_gap(minimal_labware_def2: LabwareDefinition2) -> None:
     m = mock.MagicMock()
     m.pipette_mock = mock.create_autospec(InstrumentContext)
     m.mock_set_flow_rate = mock.MagicMock()

--- a/robot-server/robot_server/robot/calibration/check/models.py
+++ b/robot-server/robot_server/robot/calibration/check/models.py
@@ -104,6 +104,9 @@ class SessionCreateParams(BaseModel):
         description="Whether to use a calibration block in the"
         "calibration health check flow.",
     )
+    # todo(mm, 2025-02-13): This should restrict input to labware schema 2 to protect
+    # robot_server.robot.calibration legacy internals.
+    # https://opentrons.atlassian.net/browse/EXEC-1230
     tipRacks: List[Dict[str, Any]] = Field(
         [],
         description="A list of labware definitions to use in"

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -35,7 +35,7 @@ from opentrons.protocols.api_support.deck_type import (
     guess_from_global_config as guess_deck_type_from_global_config,
 )
 
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 
 from robot_server.robot.calibration.constants import (
     MOVE_TO_DECK_SAFETY_BUFFER,
@@ -100,7 +100,7 @@ class CheckCalibrationUserFlow:
         self,
         hardware: HardwareControlAPI,
         has_calibration_block: bool = False,
-        tip_rack_defs: Optional[List[LabwareDefinition]] = None,
+        tip_rack_defs: Optional[List[LabwareDefinition2]] = None,
     ):
         self._hardware = hardware
         self._state_machine = CalibrationCheckStateMachine()
@@ -125,7 +125,7 @@ class CheckCalibrationUserFlow:
         ) = self._get_current_calibrations()
         self._check_valid_calibrations()
 
-        self._tip_racks: Optional[List[LabwareDefinition]] = tip_rack_defs
+        self._tip_racks: Optional[List[LabwareDefinition2]] = tip_rack_defs
         self._active_pipette, self._pip_info = self._select_starting_pipette()
 
         self._has_calibration_block = has_calibration_block
@@ -209,7 +209,7 @@ class CheckCalibrationUserFlow:
     def supported_commands(self) -> List[str]:
         return self._supported_commands.supported()
 
-    async def transition(self, tiprackDefinition: Optional[LabwareDefinition] = None):
+    async def transition(self, tiprackDefinition: Optional[LabwareDefinition2] = None):
         pass
 
     async def change_active_pipette(self):
@@ -363,6 +363,8 @@ class CheckCalibrationUserFlow:
         details = helpers.details_from_uri(pip_offset.uri)
         position = self._deck.position_for(TIPRACK_SLOT)
         if details.namespace == OPENTRONS_NAMESPACE:
+            # todo(mm, 2025-02-13): This can probably replaced with a load from
+            # shared-data. We don't need a whole Labware object.
             tiprack = labware.load(
                 load_name=details.load_name,
                 namespace=details.namespace,
@@ -372,6 +374,9 @@ class CheckCalibrationUserFlow:
             tiprack_def = tiprack._core.get_definition()
         else:
             tiprack_def = get_custom_tiprack_definition_for_tlc(pip_offset.uri)
+        # todo(mm, 2025-02-13): Unclear if this assert is actually always safe.
+        # https://opentrons.atlassian.net/browse/EXEC-1230
+        assert tiprack_def["schemaVersion"] == 2
         return load_tip_length_calibration(pipette.pipette_id, tiprack_def)
 
     def _check_valid_calibrations(self):
@@ -405,7 +410,7 @@ class CheckCalibrationUserFlow:
     def _is_checking_both_mounts(self):
         return len(self._pip_info) == 2
 
-    def _get_volume_from_tiprack_def(self, tip_rack_def: LabwareDefinition) -> float:
+    def _get_volume_from_tiprack_def(self, tip_rack_def: LabwareDefinition2) -> float:
         first_well = tip_rack_def["wells"]["A1"]
         return float(first_well["totalLiquidVolume"])
 
@@ -432,7 +437,7 @@ class CheckCalibrationUserFlow:
 
     @staticmethod
     def _get_tr_lw(
-        tip_rack_def: Optional[LabwareDefinition],
+        tip_rack_def: Optional[LabwareDefinition2],
         existing_calibration: models.v1.InstrumentOffsetModel,
         volume: float,
         position: Location,
@@ -685,6 +690,9 @@ class CheckCalibrationUserFlow:
                 self._tip_lengths[active_mount], cal_types.SourceType.calibration_check
             )
             tip_definition = self.active_tiprack._core.get_definition()
+            # Assert for type checking. This should always pass because
+            # self._get_tr_lw() should only deal with labware schema 2.
+            assert tip_definition["schemaVersion"] == 2
             tip_length_dict = create_tip_length_data(
                 definition=tip_definition,
                 length=calibration.tip_length,
@@ -845,11 +853,12 @@ class CheckCalibrationUserFlow:
         pip_id = self.hw_pipette.pipette_id
         assert pip_id
         assert self.active_tiprack
+        definition = self.active_tiprack._core.get_definition()
+        # Assert for type checking. This should always pass because
+        # self._get_tr_lw() should only deal with labware schema 2.
+        assert definition["schemaVersion"] == 2
         try:
-            return load_tip_length_calibration(
-                pip_id,
-                self.active_tiprack._core.get_definition(),
-            ).tipLength
+            return load_tip_length_calibration(pip_id, definition).tipLength
         except cal_types.TipLengthCalNotFound:
             tip_overlap = self.hw_pipette.tip_overlap["v0"].get(
                 self.active_tiprack.uri, self.hw_pipette.tip_overlap["v0"]["default"]

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -5,7 +5,7 @@ from enum import Enum
 from dataclasses import dataclass, fields
 from pydantic import BaseModel, Field
 
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 from opentrons.protocol_api import labware
 from opentrons.types import DeckLocation
 
@@ -62,7 +62,7 @@ class PipetteInfo:
     max_volume: int
     channels: int
     tip_rack: labware.Labware
-    default_tipracks: typing.List[LabwareDefinition]
+    default_tipracks: typing.List[LabwareDefinition2]
 
 
 @dataclass
@@ -128,6 +128,9 @@ class RequiredLabware(BaseModel):
     namespace: str
     version: str
     isTiprack: bool
+    # todo(mm, 2025-02-13): This should restrict input to labware schema 2 to protect
+    # robot_server.robot.calibration legacy internals.
+    # https://opentrons.atlassian.net/browse/EXEC-1230
     definition: typing.Dict[str, typing.Any]
 
     @classmethod

--- a/robot-server/robot_server/robot/calibration/models.py
+++ b/robot-server/robot_server/robot/calibration/models.py
@@ -20,6 +20,9 @@ class SessionCreateParams(BaseModel):
         "is performed, this is ignored, but it should always be "
         "specified.",
     )
+    # todo(mm, 2025-02-13): This should restrict input to labware schema 2 to protect
+    # robot_server.robot.calibration legacy internals.
+    # https://opentrons.atlassian.net/browse/EXEC-1230
     tipRackDefinition: Optional[Dict[str, Any]] = Field(
         None,
         description="The full labware definition of the tip rack to "

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -56,7 +56,7 @@ from .state_machine import (
     PipetteOffsetWithTipLengthStateMachine,
 )
 
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition2
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -84,9 +84,8 @@ class PipetteOffsetCalibrationUserFlow:
         mount: Mount = Mount.RIGHT,
         recalibrate_tip_length: bool = False,
         has_calibration_block: bool = False,
-        tip_rack_def: Optional[LabwareDefinition] = None,
+        tip_rack_def: Optional[LabwareDefinition2] = None,
     ):
-
         self._hardware = hardware
         self._mount = mount
 
@@ -259,11 +258,17 @@ class PipetteOffsetCalibrationUserFlow:
 
     async def load_labware(
         self,
-        tiprackDefinition: Optional[LabwareDefinition] = None,
+        # tiprackDefinition comes from the HTTP client and is not validated by the time
+        # it reaches here, hence us calling labware.verify_definition() below.
+        tiprackDefinition: Optional[LabwareDefinition2] = None,
     ):
         self._supported_commands.loadLabware = False
         if tiprackDefinition:
             verified_definition = labware.verify_definition(tiprackDefinition)
+            # todo(mm, 2025-02-13): Move schema validation to the FastAPI layer and turn
+            # this schemaVersion assertion into a proper HTTP API 422 error.
+            # https://opentrons.atlassian.net/browse/EXEC-1230
+            assert verified_definition["schemaVersion"] == 2
             existing_offset_calibration = self._get_stored_pipette_offset_cal()
             self._load_tip_rack(verified_definition, existing_offset_calibration)
 
@@ -311,9 +316,12 @@ class PipetteOffsetCalibrationUserFlow:
 
     def _get_stored_tip_length_cal(self) -> Optional[float]:
         try:
+            definition = self._tip_rack._core.get_definition()
+            # Assert for type checking. This should always pass because
+            # self._get_tr_lw() limits itself to schema 2.
+            assert definition["schemaVersion"] == 2
             return load_tip_length_calibration(
-                self._hw_pipette.pipette_id or "",
-                self._tip_rack._core.get_definition(),
+                self._hw_pipette.pipette_id or "", definition
             ).tipLength
         except TipLengthCalNotFound:
             return None
@@ -346,7 +354,7 @@ class PipetteOffsetCalibrationUserFlow:
 
     @staticmethod
     def _get_tr_lw(
-        tip_rack_def: Optional[LabwareDefinition],
+        tip_rack_def: Optional[LabwareDefinition2],
         existing_calibration: Optional[models.v1.InstrumentOffsetModel],
         volume: float,
         position: Location,
@@ -375,7 +383,7 @@ class PipetteOffsetCalibrationUserFlow:
 
     def _load_tip_rack(
         self,
-        tip_rack_def: Optional[LabwareDefinition],
+        tip_rack_def: Optional[LabwareDefinition2],
         existing_calibration: Optional[models.v1.InstrumentOffsetModel],
     ):
         """

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -193,9 +193,6 @@ def get_reference_location(
 def save_tip_length_calibration(
     pipette_id: str, tip_length_offset: float, tip_rack: labware.Labware
 ):
-    # TODO: 07-22-2020 parent slot is not important when tracking
-    # tip length data, hence the empty string, we should remove it
-    # from create_tip_length_data in a refactor
     tip_length_data = ot2_cal_storage.create_tip_length_data(
         tip_rack._core.get_definition(), tip_length_offset
     )

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -239,6 +239,7 @@ def set_up_tip_length_temp_directory(server_temp_directory: str) -> None:
     attached_pip_list = ["123", "321"]
     tip_length_list = [30.5, 31.5]
     definition = labware.get_labware_definition("opentrons_96_filtertiprack_200ul")
+    assert definition["schemaVersion"] == 2  # Required by create_tip_length_data().
     for pip, tip_len in zip(attached_pip_list, tip_length_list):
         cal_data = create_tip_length_data(definition, tip_len)
         save_tip_length_calibration(pip, cal_data)

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -153,6 +153,7 @@ class LabwareDefinition2(TypedDict):
     gripperOffsets: NotRequired[dict[str, GripperOffsets]]
     gripForce: NotRequired[float]
     gripHeightFromLabwareBottom: NotRequired[float]
+    stackLimit: NotRequired[int]
 
 
 class LabwareDefinition3(TypedDict):

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -5,7 +5,6 @@ this module shouldn't be imported unless typing.TYPE_CHECKING is true.
 """
 from typing import NewType
 from typing_extensions import Literal, TypedDict, NotRequired
-from .labware_definition import InnerWellGeometry
 from .constants import (
     CircularType,
     RectangularType,
@@ -142,6 +141,9 @@ class LabwareDefinition(TypedDict):
     gripperOffsets: NotRequired[dict[str, GripperOffsets]]
     gripForce: NotRequired[float]
     gripHeightFromLabwareBottom: NotRequired[float]
-    innerLabwareGeometry: NotRequired[dict[str, InnerWellGeometry] | None]
+    # The innerLabwareGeometry dict values are not currently modeled in these
+    # TypedDict-based bindings. The only code that cares about them
+    # currentlyuses our Pydantic-based bindings instead.
+    innerLabwareGeometry: NotRequired[dict[str, object] | None]
     compatibleParentLabware: NotRequired[list[str]]
     stackLimit: NotRequired[int]

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -54,16 +54,19 @@ class GripperOffsets(TypedDict):
     dropOffset: Vector
 
 
-class LabwareParameters(TypedDict):
+class LabwareParameters2(TypedDict):
     format: LabwareFormat
     isTiprack: bool
     loadName: str
     isMagneticModuleCompatible: bool
-    isDeckSlotCompatible: NotRequired[bool]
     quirks: NotRequired[list[str]]
     tipLength: NotRequired[float]
     tipOverlap: NotRequired[float]
     magneticModuleEngageHeight: NotRequired[float]
+
+
+class LabwareParameters3(LabwareParameters2, TypedDict):
+    isDeckSlotCompatible: NotRequired[bool]
 
 
 class LabwareBrandData(TypedDict):
@@ -85,7 +88,7 @@ class LabwareDimensions(TypedDict):
     xDimension: float
 
 
-class CircularWellDefinition(TypedDict):
+class CircularWellDefinition2(TypedDict):
     shape: CircularType
     depth: float
     totalLiquidVolume: float
@@ -93,10 +96,9 @@ class CircularWellDefinition(TypedDict):
     y: float
     z: float
     diameter: float
-    geometryDefinitionId: NotRequired[str]
 
 
-class RectangularWellDefinition(TypedDict):
+class RectangularWellDefinition2(TypedDict):
     shape: RectangularType
     depth: float
     totalLiquidVolume: float
@@ -105,10 +107,20 @@ class RectangularWellDefinition(TypedDict):
     z: float
     xDimension: float
     yDimension: float
+
+
+WellDefinition2 = CircularWellDefinition2 | RectangularWellDefinition2
+
+
+class CircularWellDefinition3(CircularWellDefinition2, TypedDict):
+    geometryDefinitionId: NotRequired[str]
+
+
+class RectangularWellDefinition3(RectangularWellDefinition2, TypedDict):
     geometryDefinitionId: NotRequired[str | None]
 
 
-WellDefinition = CircularWellDefinition | RectangularWellDefinition
+WellDefinition3 = CircularWellDefinition3 | RectangularWellDefinition3
 
 
 class WellGroupMetadata(TypedDict):
@@ -123,17 +135,37 @@ class WellGroup(TypedDict):
     brand: NotRequired[LabwareBrandData]
 
 
-class LabwareDefinition(TypedDict):
-    schemaVersion: Literal[2, 3]
+class LabwareDefinition2(TypedDict):
+    schemaVersion: Literal[2]
     version: int
     namespace: str
     metadata: LabwareMetadata
     brand: LabwareBrandData
-    parameters: LabwareParameters
+    parameters: LabwareParameters2
     cornerOffsetFromSlot: Vector
     ordering: list[list[str]]
     dimensions: LabwareDimensions
-    wells: dict[str, WellDefinition]
+    wells: dict[str, WellDefinition2]
+    groups: list[WellGroup]
+    stackingOffsetWithLabware: NotRequired[dict[str, Vector]]
+    stackingOffsetWithModule: NotRequired[dict[str, Vector]]
+    allowedRoles: NotRequired[list[LabwareRoles]]
+    gripperOffsets: NotRequired[dict[str, GripperOffsets]]
+    gripForce: NotRequired[float]
+    gripHeightFromLabwareBottom: NotRequired[float]
+
+
+class LabwareDefinition3(TypedDict):
+    schemaVersion: Literal[3]
+    version: int
+    namespace: str
+    metadata: LabwareMetadata
+    brand: LabwareBrandData
+    parameters: LabwareParameters3
+    cornerOffsetFromSlot: Vector
+    ordering: list[list[str]]
+    dimensions: LabwareDimensions
+    wells: dict[str, WellDefinition3]
     groups: list[WellGroup]
     stackingOffsetWithLabware: NotRequired[dict[str, Vector]]
     stackingOffsetWithModule: NotRequired[dict[str, Vector]]
@@ -147,3 +179,6 @@ class LabwareDefinition(TypedDict):
     innerLabwareGeometry: NotRequired[dict[str, object] | None]
     compatibleParentLabware: NotRequired[list[str]]
     stackLimit: NotRequired[int]
+
+
+LabwareDefinition = LabwareDefinition2 | LabwareDefinition3

--- a/shared-data/python/opentrons_shared_data/protocol/types.py
+++ b/shared-data/python/opentrons_shared_data/protocol/types.py
@@ -7,7 +7,7 @@ from enum import Enum
 
 from typing_extensions import TypedDict, Literal
 from ..pipette.types import PipetteName
-from ..labware.types import LabwareDefinition
+from ..labware.types import LabwareDefinition2
 from ..module.types import ModuleModel
 
 SlotSpan = Literal["span7_8_10_11"]
@@ -392,7 +392,7 @@ JsonProtocolV4 = TypedDict(
         "robot": RobotRequirement,
         "pipettes": Dict[str, PipetteRequirement],
         "labware": Dict[str, LabwareRequirement],
-        "labwareDefinitions": Dict[str, LabwareDefinition],
+        "labwareDefinitions": Dict[str, LabwareDefinition2],
         "modules": Dict[str, ModuleRequirement],
         "commands": List[Command],
         "commandAnnotations": Dict[str, Any],
@@ -410,7 +410,7 @@ JsonProtocolV5 = TypedDict(
         "robot": RobotRequirement,
         "pipettes": Dict[str, PipetteRequirement],
         "labware": Dict[str, LabwareRequirement],
-        "labwareDefinitions": Dict[str, LabwareDefinition],
+        "labwareDefinitions": Dict[str, LabwareDefinition2],
         "modules": Dict[str, ModuleRequirement],
         "commands": List[Command],
         "commandAnnotations": Dict[str, Any],
@@ -426,7 +426,7 @@ class JsonProtocolV3(TypedDict, total=False):
     robot: RobotRequirement
     pipettes: Dict[str, PipetteRequirement]
     labware: Dict[str, LabwareRequirement]
-    labwareDefinitions: Dict[str, LabwareDefinition]
+    labwareDefinitions: Dict[str, LabwareDefinition2]
     commands: List[V3Command]
     commandAnnotations: Dict[str, Any]
     designerApplication: DesignerApplication

--- a/shared-data/python/tests/labware/__init__.py
+++ b/shared-data/python/tests/labware/__init__.py
@@ -3,14 +3,17 @@ from typing import List, Tuple
 from pathlib import Path
 
 
-def get_ot_defs() -> List[Tuple[str, int]]:
+def get_ot_defs(schema: int) -> List[Tuple[str, int]]:
     def_files = (
-        Path(__file__).parent / ".." / ".." / ".." / "labware" / "definitions" / "2"
+        Path(__file__).parent
+        / ".."
+        / ".."
+        / ".."
+        / "labware"
+        / "definitions"
+        / str(schema)
     ).glob("**/*.json")
 
     # example filename
     # shared-data/labware/definitions/2/opentrons_96_tiprack_300ul/1.json
     return [(f.parent.name, int(f.stem)) for f in def_files]
-
-
-# TODO(cm): add python validation once labware definitions are added

--- a/shared-data/python/tests/labware/test_typechecks.py
+++ b/shared-data/python/tests/labware/test_typechecks.py
@@ -1,13 +1,30 @@
+"""Test that our `TypedDict`-based bindings can hold our standard labware definitions."""
+
+
 import pytest
 import typeguard
 
 from opentrons_shared_data.labware import load_definition
-from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.labware.types import (
+    LabwareDefinition,
+    LabwareDefinition2,
+    LabwareDefinition3,
+)
 
 from . import get_ot_defs
 
 
-@pytest.mark.parametrize("loadname,version", get_ot_defs())
-def test_opentrons_definition_types(loadname: str, version: int) -> None:
-    defdict = load_definition(loadname, version)
+@pytest.mark.parametrize("loadname,version", get_ot_defs(schema=2))
+def test_schema_2_types(loadname: str, version: int) -> None:
+    defdict = load_definition(loadname, version, schema=2)
+
+    typeguard.check_type(defdict, LabwareDefinition2)
+    typeguard.check_type(defdict, LabwareDefinition)
+
+
+@pytest.mark.parametrize("loadname,version", get_ot_defs(schema=3))
+def test_schema_3_types(loadname: str, version: int) -> None:
+    defdict = load_definition(loadname, version, schema=3)
+
+    typeguard.check_type(defdict, LabwareDefinition3)
     typeguard.check_type(defdict, LabwareDefinition)

--- a/shared-data/python/tests/labware/test_validations.py
+++ b/shared-data/python/tests/labware/test_validations.py
@@ -8,14 +8,14 @@ from . import get_ot_defs
 
 
 def test_loadname_regex_applied() -> None:
-    defdict = load_definition(*get_ot_defs()[0])
+    defdict = load_definition(*get_ot_defs(schema=2)[0])
     defdict["parameters"]["loadName"] = "ALSJHDAKJLA"
     with pytest.raises(ValidationError):
         LabwareDefinition.model_validate(defdict)
 
 
 def test_namespace_regex_applied() -> None:
-    defdict = load_definition(*get_ot_defs()[0])
+    defdict = load_definition(*get_ot_defs(schema=2)[0])
     defdict["namespace"] = "ALSJHDAKJLA"
     with pytest.raises(ValidationError):
         LabwareDefinition.model_validate(defdict)


### PR DESCRIPTION
## Overview

Goes towards EXEC-1206. See that ticket for background.

## Changelog

Split the `opentrons_shared_data.labware.types.LabwareDefinition` `TypedDict` into `LabwareDefinition2` and `LabwareDefinition3`.

Then, audit the consuming code and try to find boundaries between code that needs to handle both schemas vs. code that should limit itself to schema 2:

* `opentrons.protocol_api.core.legacy`, which handles Python protocols with `apiLevel` ≤2.13 and JSON protocols with protocol schema ≤5, is limited to labware schema 2 for scope reasons.

  Labware schema 3 entails major changes in the way we represent labware geometry, including moving a labware's origin from the bottom-left to the top-left. Coping with this will involve a good amount of changes just for new `apiLevel`s (EXEC-78), and I doubt we want to spend time duplicating those changes for old `apiLevel`s too.
* `opentrons.calibration_storage` is limited to labware schema 2 because allowing schema 3 would break users' ability to downgrade, without further changes to `calibration_storage`. In theory, at least.
* OT-2 calibration (`robot_server.robot.calibration` and `robot_server.sessions`) is limited to labware schema 2 because it is built on the two packages above.

All of those restrictions could be lifted in the future, if we have reason to.

Implementing those restrictions, for now, basically means littering the code with `assert schemaVersion == 2`. In at least some cases, this is not correct. A user can still load a schema 3 labware, and it will only hit one of these `assert`s later on, causing a confusing internal error. Ideally, we'd prevent the user from loading the schema 3 labware *at our API boundaries*, *before* it reaches our innards and hits one of these `assert`s. Improving this is ticketed as EXEC-1210 and EXEC-1230.

## Next steps

To fully close EXEC-1206, will need to do the same thing for our Pydantic-based models (`opentrons_shared_data.labware.labware_definition.LabwareDefinition`), and that will happen in another PR.

Also EXEC-1210 and EXEC-1230, as described above.

## Test Plan and Hands on Testing

* [ ] Run some OT-2 calibration sessions and make sure they don't raise any internal `AssertionError`s now.

## Review requests

* Does everything I described in the changelog sound like a good idea?
* At the code level, do my boundaries between schema-2–specific code and schema-agnostic code seem correct?

## Risk assessment

Medium. There's a risk of something like this happening:

1. For OT-2 calibration, some piece of code loads the latest version of a tip rack.
2. The latest version of the tip rack happens to be defined in schema 3 now.
3. The schema 3 definition makes its way through our code, eventually hits one of these new `assert`s, and causes a confusing error.

I have not found anything that does that, specifically—it seems like labware loads generally default to the first version, not the latest version—but that gives you an idea of what can go wrong with this.