### PR TITLE
chore(app): dont show stacked icon when showing labware on a module

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -106,8 +106,7 @@ export function LabwareListItem(
 
   const isStacked =
     labwareQuantity > 1 ||
-    bottomLabwareId !== topLabwareId ||
-    moduleModel != null
+    bottomLabwareId !== topLabwareId
 
   const { i18n, t } = useTranslation('protocol_setup')
   const [

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -104,9 +104,7 @@ export function LabwareListItem(
     adapterName: bottomLabwareName,
   } = getLocationInfoNames(topLabwareId, commands)
 
-  const isStacked =
-    labwareQuantity > 1 ||
-    bottomLabwareId !== topLabwareId
+  const isStacked = labwareQuantity > 1 || bottomLabwareId !== topLabwareId
 
   const { i18n, t } = useTranslation('protocol_setup')
   const [

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -64,13 +64,15 @@ export function SetupLabwareMap({
   const protocolModulesInfo = getProtocolModulesInfo(protocolAnalysis, deckDef)
 
   const modulesOnDeck = protocolModulesInfo.map(module => {
-    const isLabwareStacked =
-      module.nestedLabwareId != null && module.nestedLabwareDef != null
+
     const {
       topLabwareId,
       topLabwareDefinition,
       topLabwareDisplayName,
     } = getTopLabwareInfo(module.nestedLabwareId ?? '', loadLabwareCommands)
+
+    const isLabwareStacked =
+    module.nestedLabwareId != null && module.nestedLabwareId != topLabwareId
 
     return {
       moduleModel: module.moduleDef.model,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -64,7 +64,6 @@ export function SetupLabwareMap({
   const protocolModulesInfo = getProtocolModulesInfo(protocolAnalysis, deckDef)
 
   const modulesOnDeck = protocolModulesInfo.map(module => {
-
     const {
       topLabwareId,
       topLabwareDefinition,
@@ -72,7 +71,7 @@ export function SetupLabwareMap({
     } = getTopLabwareInfo(module.nestedLabwareId ?? '', loadLabwareCommands)
 
     const isLabwareStacked =
-    module.nestedLabwareId != null && module.nestedLabwareId != topLabwareId
+      module.nestedLabwareId != null && module.nestedLabwareId != topLabwareId
 
     return {
       moduleModel: module.moduleDef.model,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -71,7 +71,7 @@ export function SetupLabwareMap({
     } = getTopLabwareInfo(module.nestedLabwareId ?? '', loadLabwareCommands)
 
     const isLabwareStacked =
-      module.nestedLabwareId != null && module.nestedLabwareId != topLabwareId
+      module.nestedLabwareId != null && module.nestedLabwareId !== topLabwareId
 
     return {
       moduleModel: module.moduleDef.model,

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
@@ -52,11 +52,13 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
 
   const modulesOnDeck = attachedProtocolModuleMatches.map(module => {
     const { moduleDef, nestedLabwareDef, nestedLabwareId, slotName } = module
-    const isLabwareStacked = nestedLabwareId != null && nestedLabwareDef != null
     const { topLabwareId, topLabwareDefinition } = getTopLabwareInfo(
       module.nestedLabwareId ?? '',
       loadLabwareCommands
     )
+
+    const isLabwareStacked =
+      nestedLabwareId != null && nestedLabwareId !== topLabwareId
 
     return {
       moduleModel: moduleDef.model,

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
@@ -51,7 +51,7 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
       : {}
 
   const modulesOnDeck = attachedProtocolModuleMatches.map(module => {
-    const { moduleDef, nestedLabwareDef, nestedLabwareId, slotName } = module
+    const { moduleDef, nestedLabwareId, slotName } = module
     const { topLabwareId, topLabwareDefinition } = getTopLabwareInfo(
       module.nestedLabwareId ?? '',
       loadLabwareCommands

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -464,8 +464,7 @@ function RowLabware({
     matchedModule.attachedModuleMatch.moduleType === HEATERSHAKER_MODULE_TYPE
       ? matchedModule.attachedModuleMatch
       : null
-  const isStacked =
-    topLabwareQuantity > 1 || adapterName != null || matchedModule != null
+  const isStacked = topLabwareQuantity > 1 || adapterName != null
 
   let slotName: string = slot
   let location: JSX.Element = <DeckInfoLabel deckLabel={slotName} />


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-1141.
Do not show stacked icon when there is only one labware on top of a module. 

## Test Plan and Hands on Testing

load the following protocol to the flex and start setup.
Make sure ODD and Desktop app do not show the stacked icon on the module/labware combo.
**OOD**
<img width="1142" alt="Screenshot 2025-02-13 at 2 15 07 PM" src="https://github.com/user-attachments/assets/c71b75d4-7ef0-4605-9954-b6f0ce36cbd4" />
<img width="1144" alt="Screenshot 2025-02-13 at 2 15 16 PM" src="https://github.com/user-attachments/assets/a2ab6bb7-0b66-45cc-8c9b-57d8e3ca9c43" />
**DESKTOP**
<img width="921" alt="Screenshot 2025-02-13 at 2 15 22 PM" src="https://github.com/user-attachments/assets/8cfd1f22-4849-4e29-abf0-25f66da13578" />
<img width="1008" alt="Screenshot 2025-02-13 at 2 15 32 PM" src="https://github.com/user-attachments/assets/d77b6226-aac1-40ea-9076-b78e5236c2bc" />

## Review requests

changes make sense? did I miss anything? 

## Risk assessment

low.
