### PR TITLE
feat(api): add optional user_grip_force param to LabwareMovementHandl…

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -90,6 +90,7 @@ class LabwareMovementHandler:
         new_location: OnDeckLabwareLocation,
         user_offset_data: LabwareMovementOffsetData,
         post_drop_slide_offset: Optional[Point],
+        user_grip_force: float | None = None,
     ) -> None:
         ...
 
@@ -102,6 +103,7 @@ class LabwareMovementHandler:
         new_location: OnDeckLabwareLocation,
         user_offset_data: LabwareMovementOffsetData,
         post_drop_slide_offset: Optional[Point],
+        user_grip_force: float | None = None,
     ) -> None:
         ...
 
@@ -114,6 +116,7 @@ class LabwareMovementHandler:
         new_location: OnDeckLabwareLocation,
         user_offset_data: LabwareMovementOffsetData,
         post_drop_slide_offset: Optional[Point],
+        user_grip_force: float | None = None,
     ) -> None:
         """Physically move a labware from one location to another using the gripper.
 
@@ -195,9 +198,19 @@ class LabwareMovementHandler:
                 offset_data=final_offsets,
                 post_drop_slide_offset=post_drop_slide_offset,
             )
-            labware_grip_force = self._state_store.labware.get_grip_force(
-                labware_definition
-            )
+
+            if user_grip_force is None:
+                labware_grip_force = self._state_store.labware.get_grip_force(
+                    labware_definition
+                )
+            else:
+                MAX_GRIP_FORCE = 25
+                if user_grip_force > MAX_GRIP_FORCE:
+                    raise CannotPerformGripperAction(
+                        f"User-specified grip force of {user_grip_force} N exceeds maximum grip force of {MAX_GRIP_FORCE} N."
+                    )
+                labware_grip_force = user_grip_force
+
             holding_labware = False
             for waypoint_data in movement_waypoints:
                 if waypoint_data.jaw_open:


### PR DESCRIPTION
…er.move_labware_with_gripper

The user_grip_force parameter allows the grip force to be set based off a user-specified parameter, instead of the default value for the labware.

# Overview

This pull request is not complete--I'm opening it because this is a feature I'd like to have, and I want to start a discussion to see how feasible it would be before I get too far in the weeds with implementing it.

I would like to be able to manually specify the gripping force the gripper uses when moving labware. I'm not too familiar with the codebase, but it looks like the core of this change would be to add a `user_grip_force` parameter to the `LabwareMovementHandler.move_labware_with_gripper` function, so I've gone ahead and done that.

## Test Plan and Hands on Testing

Because this is just an initial idea, I have not yet tested this change.

## Changelog

- Added `user_grip_force parameter to LabwareMovementHandler.move_labware_with_gripper`

## Review requests

- Before I spend more time on this, I'd like to hear if this looks feasible, and if I'm on the right track.
- Additionally, I'm not familiar with the structure of how the `LabwareMovementHandler` class is translated into the [`ProtocolContext.move_labware`](https://docs.opentrons.com/v2/new_protocol_api.html#opentrons.protocol_api.ProtocolContext.move_labware) function in the Python API, so I'd appreciate some pointers on how to propagate the feature up to that level.
- In my code, I limit the grip force from being set to too high of a value. I couldn't find any specifications online as to what the upper limit is of the force the gripper can exert, but looking through the `gripForce` parameter for the labware definitions in [opentrons/tree/edge/shared-data/labware/definitions/](https://github.com/Opentrons/opentrons/tree/edge/shared-data/labware/definitions), the highest value I saw was 21 N, so I guessed and set a limit of 25 N in my code. If you have an official value for that limit, that would be good to know.

## Risk assessment

For users who don't use this new parameter, this feature would not change anything, because the default is just to execute the command in the way it's currently done.

The user-specified grip force needs to be limited from being set to too high of a value. I have included a structure for such a limitation into my code.