### PR TITLE
fix(components): commandText loadLabware to display labware nickname

### DIFF
--- a/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -558,7 +558,7 @@ describe('CommandText', () => {
       { i18nInstance: i18n }
     )
     screen.getByText(
-      'Load NEST 96 Well Plate 100 µL PCR Full Skirt in Magnetic Module GEN2 in Slot 1'
+      'Load NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1'
     )
   })
   it('renders correct text for loadLabware in adapter', () => {
@@ -627,7 +627,9 @@ describe('CommandText', () => {
       />,
       { i18nInstance: i18n }
     )
-    screen.getByText('Load NEST 96 Well Plate 100 µL PCR Full Skirt off deck')
+    screen.getByText(
+      'Load NEST 96 Well Plate 100 µL PCR Full Skirt (2) off deck'
+    )
   })
   it('renders correct text for reloadLabware', () => {
     const reloadLabwareCommand = mockCommandTextData.commands.find(

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
@@ -56,7 +56,9 @@ export const getLoadCommandText = ({
         loadedModules: commandTextData?.modules ?? [],
         t,
       })
-      const labwareName = command.result?.definition.metadata.displayName
+      const labwareName =
+        command.params.displayName ??
+        command.result?.definition.metadata.displayName
       // use in preposition for modules and slots, on for labware and adapters
       let displayLocation = t('in_location', { location })
       if (


### PR DESCRIPTION
# Overview

Noticed this bug.

The api docs say: "If 'label' is specified, this is how the labware will appear in the run log, Labware Position Check, and elsewhere in the Opentrons App and on the touchscreen." The label is the user defined labware name. 

see more info on slack here: https://opentrons.slack.com/archives/C06M9F26YGH/p1739452405482199

## Test Plan and Hands on Testing

Check a render of command text, either in run log or the timeline tab behind a ff of protocol details. There is also unit testing that displays the labware nick name

## Changelog

- display nickname if it exists

## Risk assessment

low