### PR TITLE
fix(app): translate continue button in network

### DIFF
--- a/app/src/organisms/ODD/RobotSettingsDashboard/NetworkSettings/RobotSettingsJoinOtherNetwork.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/NetworkSettings/RobotSettingsJoinOtherNetwork.tsx
@@ -21,7 +21,7 @@ export function RobotSettingsJoinOtherNetwork({
   setCurrentOption,
   setSelectedSsid,
 }: RobotSettingsJoinOtherNetworkProps): JSX.Element {
-  const { i18n, t } = useTranslation('device_settings')
+  const { i18n, t } = useTranslation(['device_settings', 'shared'])
 
   const [inputSsid, setInputSsid] = useState<string>('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -38,7 +38,7 @@ export function RobotSettingsJoinOtherNetwork({
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <ChildNavigation
-        buttonText={i18n.format(t('continue'), 'capitalize')}
+        buttonText={i18n.format(t('shared:continue'), 'capitalize')}
         header={t('join_other_network')}
         onClickBack={() => {
           setCurrentOption('RobotSettingsWifi')

--- a/app/src/organisms/ODD/RobotSettingsDashboard/NetworkSettings/RobotSettingsSelectAuthenticationType.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/NetworkSettings/RobotSettingsSelectAuthenticationType.tsx
@@ -25,12 +25,12 @@ export function RobotSettingsSelectAuthenticationType({
   setCurrentOption,
   setSelectedAuthType,
 }: RobotSettingsSelectAuthenticationTypeProps): JSX.Element {
-  const { i18n, t } = useTranslation('device_settings')
+  const { i18n, t } = useTranslation(['device_settings', 'shared'])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <ChildNavigation
-        buttonText={i18n.format(t('continue'), 'capitalize')}
+        buttonText={i18n.format(t('shared:continue'), 'capitalize')}
         header={t('select_a_security_type')}
         onClickBack={() => {
           setCurrentOption('RobotSettingsWifi')

--- a/app/src/pages/ODD/ConnectViaEthernet/index.tsx
+++ b/app/src/pages/ODD/ConnectViaEthernet/index.tsx
@@ -21,7 +21,7 @@ import type { State, Dispatch } from '/app/redux/types'
 const STATUS_REFRESH_MS = 5000
 
 export function ConnectViaEthernet(): JSX.Element {
-  const { t } = useTranslation('device_settings')
+  const { t } = useTranslation(['device_settings', 'shared'])
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
   const dispatch = useDispatch<Dispatch>()

--- a/app/src/pages/ODD/ConnectViaWifi/JoinOtherNetwork.tsx
+++ b/app/src/pages/ODD/ConnectViaWifi/JoinOtherNetwork.tsx
@@ -18,7 +18,7 @@ export function JoinOtherNetwork({
   setCurrentOption,
   setSelectedSsid,
 }: JoinOtherNetworkProps): JSX.Element {
-  const { i18n, t } = useTranslation('device_settings')
+  const { i18n, t } = useTranslation(['device_settings', 'shared'])
 
   const [inputSsid, setInputSsid] = useState<string>('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -35,7 +35,7 @@ export function JoinOtherNetwork({
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <RobotSetupHeader
-        buttonText={i18n.format(t('continue'), 'capitalize')}
+        buttonText={i18n.format(t('shared:continue'), 'capitalize')}
         header={t('join_other_network')}
         onClickBack={() => {
           setCurrentOption('WifiList')

--- a/app/src/pages/ODD/ConnectViaWifi/SelectAuthenticationType.tsx
+++ b/app/src/pages/ODD/ConnectViaWifi/SelectAuthenticationType.tsx
@@ -21,12 +21,12 @@ export function SelectAuthenticationType({
   setCurrentOption,
   setSelectedAuthType,
 }: SelectAuthenticationTypeProps): JSX.Element {
-  const { i18n, t } = useTranslation('device_settings')
+  const { i18n, t } = useTranslation(['device_settings', 'shared'])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <RobotSetupHeader
-        buttonText={i18n.format(t('continue'), 'capitalize')}
+        buttonText={i18n.format(t('shared:continue'), 'capitalize')}
         header={t('select_a_security_type')}
         onClickBack={() => {
           setCurrentOption('WifiList')


### PR DESCRIPTION
The continue button "continue" text in various network settings panels needs to come from the shared i18n source, which is where it is, not the device_settings i18n source, which is where it isn't. By knowing where continue isn't, we know where continue is, and by subtracting where continue isn't from where continue is we know where continue should be, and by making where continue should be go from where continue isn't to where continue is, eventually we end up where continue is.

## testing
- put this odd on a robot
- from the settings screen, connect to wifi and check that continue is localized. This should now happen in the "join other network" screen and in the "select authentication type" screen
- from the first-run experience, try to connect via ethernet while an ethernet cable is unplugged and note that "no data" is now localized
- from the first-run experience, try to connect via wifi and note that the same things are now localized as in the setup screen

Closes RQA-3960
