### PR TITLE
chore(app): extend props of intervention modal

### DIFF
--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -70,6 +70,7 @@ type Story = StoryObj<typeof InterventionInfo>
 
 export const MoveBetweenSlots: Story = {
   args: {
+    layout: 'default',
     type: 'location-arrow-location',
     labwareName: 'Plate',
     currentLocationProps: {
@@ -83,6 +84,7 @@ export const MoveBetweenSlots: Story = {
 
 export const Refill: Story = {
   args: {
+    layout: 'default',
     type: 'location',
     labwareName: 'Tip Rack',
     currentLocationProps: {
@@ -93,6 +95,7 @@ export const Refill: Story = {
 
 export const Select: Story = {
   args: {
+    layout: 'default',
     type: 'location-colon-location',
     labwareName: 'Well',
     currentLocationProps: {

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -108,13 +108,10 @@ export const LabwareWithLidAndQuantity: Story = {
   args: {
     type: 'location-colon-location',
     labwareName: 'Labware with lid',
-    subtext: 'lid id',
+    subtext: 'With Tip Rack Lid',
     tagtext: '3',
     currentLocationProps: {
-      slotName: 'A1',
-    },
-    newLocationProps: {
-      slotName: 'B1',
+      slotName: 'STACKER A',
     },
   },
 }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -103,3 +103,18 @@ export const Select: Story = {
     },
   },
 }
+
+export const LabwareWithLidAndQountaty: Story = {
+  args: {
+    type: 'location-colon-location',
+    labwareName: 'Labware with lid',
+    subtext: 'lid id',
+    tagtext: '3',
+    currentLocationProps: {
+      slotName: 'A1',
+    },
+    newLocationProps: {
+      slotName: 'B1',
+    },
+  },
+}

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -106,10 +106,11 @@ export const Select: Story = {
 
 export const LabwareWithLidAndQuantity: Story = {
   args: {
+    layout: 'stacked',
     type: 'location-colon-location',
     labwareName: 'Labware with lid',
-    subtext: 'With Tip Rack Lid',
-    tagtext: 'Quantity: 3',
+    subText: 'With Tip Rack Lid',
+    tagText: 'Quantity: 3',
     currentLocationProps: {
       deckLabel: 'STACKER A',
     },

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -109,7 +109,7 @@ export const LabwareWithLidAndQuantity: Story = {
     type: 'location-colon-location',
     labwareName: 'Labware with lid',
     subtext: 'With Tip Rack Lid',
-    tagtext: '3',
+    tagtext: 'Quantity: 3',
     currentLocationProps: {
       deckLabel: 'STACKER A',
     },

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -104,7 +104,7 @@ export const Select: Story = {
   },
 }
 
-export const LabwareWithLidAndQountaty: Story = {
+export const LabwareWithLidAndQuantity: Story = {
   args: {
     type: 'location-colon-location',
     labwareName: 'Labware with lid',

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -110,12 +110,15 @@ export const Select: Story = {
 export const LabwareWithLidAndQuantity: Story = {
   args: {
     layout: 'stacked',
-    type: 'location-colon-location',
+    type: 'location',
     labwareName: 'Labware with lid',
     subText: 'With Tip Rack Lid',
     tagText: 'Quantity: 3',
     currentLocationProps: {
       deckLabel: 'STACKER A',
+    },
+    newLocationProps: {
+      deckLabel: 'OFF-DECK',
     },
   },
 }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -73,10 +73,10 @@ export const MoveBetweenSlots: Story = {
     type: 'location-arrow-location',
     labwareName: 'Plate',
     currentLocationProps: {
-      slotName: 'A1',
+      deckLabel: 'A1',
     },
     newLocationProps: {
-      slotName: 'B2',
+      deckLabel: 'B2',
     },
   },
 }
@@ -86,7 +86,7 @@ export const Refill: Story = {
     type: 'location',
     labwareName: 'Tip Rack',
     currentLocationProps: {
-      slotName: 'A1',
+      deckLabel: 'A1',
     },
   },
 }
@@ -96,10 +96,10 @@ export const Select: Story = {
     type: 'location-colon-location',
     labwareName: 'Well',
     currentLocationProps: {
-      slotName: 'A1',
+      deckLabel: 'A1',
     },
     newLocationProps: {
-      slotName: 'B1',
+      deckLabel: 'B1',
     },
   },
 }
@@ -111,7 +111,7 @@ export const LabwareWithLidAndQuantity: Story = {
     subtext: 'With Tip Rack Lid',
     tagtext: '3',
     currentLocationProps: {
-      slotName: 'STACKER A',
+      deckLabel: 'STACKER A',
     },
   },
 }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -18,15 +18,25 @@ import { Divider } from '/app/atoms/structure/Divider'
 
 import type { DeckInfoLabelProps } from '@opentrons/components'
 
-export interface InterventionInfoProps {
+export interface InterventionInfoDefaultProps {
+  layout: 'default'
   type: 'location-arrow-location' | 'location-colon-location' | 'location'
   labwareName: string
   labwareNickname?: string
-  subtext?: string
-  tagtext?: string
   currentLocationProps: DeckInfoLabelProps
   newLocationProps?: DeckInfoLabelProps
 }
+
+export interface InterventionInfoStackedProps
+  extends Omit<InterventionInfoDefaultProps, 'layout'> {
+  layout: 'stacked'
+  subText: string
+  tagText: string
+}
+
+export type InterventionInfoProps =
+  | InterventionInfoDefaultProps
+  | InterventionInfoStackedProps
 
 export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
   const content = buildContent(props)
@@ -45,36 +55,34 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
         >
           {props.labwareNickname ?? props.labwareName}
         </StyledText>
-        {props.subtext != null ? (
-          <StyledText
-            oddStyle="hidden"
-            desktopStyle="bodyDefaultRegular"
-            color={COLORS.grey60}
-            css={css`
-              ${LINE_CLAMP_STYLE}
-              margin-bottom: ${SPACING_1}
+        {props.layout === 'stacked' ? (
+          <>
+            <StyledText
+              oddStyle="hidden"
+              desktopStyle="bodyDefaultRegular"
+              color={COLORS.grey60}
+              css={css`
+                ${LINE_CLAMP_STYLE}
+                margin-bottom: ${SPACING_1}
               @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                display: none;
-              }
-            `}
-          >
-            {props.subtext}
-          </StyledText>
-        ) : null}
-        {props.tagtext != null ? (
-          <Tag type="default" text={props.tagtext} shrinkToContent={true} />
+                  display: none;
+                }
+              `}
+            >
+              {props.subText}
+            </StyledText>
+            <Tag type="default" text={props.tagText} shrinkToContent={true} />
+            <Divider
+              borderColor={COLORS.grey35}
+              css={`
+                @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                  display: none;
+                }
+              `}
+            />
+          </>
         ) : null}
       </Flex>
-      {props.tagtext != null && (
-        <Divider
-          borderColor={COLORS.grey35}
-          css={`
-            @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-              display: none;
-            }
-          `}
-        />
-      )}
       {content}
     </Flex>
   )

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -52,7 +52,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
             color={COLORS.grey60}
             css={css`
               ${LINE_CLAMP_STYLE}
-              maring-bottom: ${SPACING_1}
+              margin-bottom: ${SPACING_1}
               @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                 display: none;
               }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -55,7 +55,33 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
         >
           {props.labwareNickname ?? props.labwareName}
         </StyledText>
-        {props.layout === 'stacked' ? (
+        {props.layout === 'default' ? (
+          <>
+            {props.labwareNickname != null ? (
+              <StyledText
+                oddStyle="hidden"
+                desktopStyle="bodyDefaultRegular"
+                color={COLORS.grey60}
+                css={css`
+                  ${LINE_CLAMP_STYLE}
+                  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                    display: none;
+                  }
+                `}
+              >
+                {props.labwareNickname}{' '}
+              </StyledText>
+            ) : null}
+            <Divider
+              borderColor={COLORS.grey35}
+              css={`
+                @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                  display: none;
+                }
+              `}
+            />
+          </>
+        ) : (
           <>
             <StyledText
               oddStyle="hidden"
@@ -64,7 +90,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               css={css`
                 ${LINE_CLAMP_STYLE}
                 margin-bottom: ${SPACING_1}
-              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                   display: none;
                 }
               `}
@@ -81,7 +107,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               `}
             />
           </>
-        ) : null}
+        )}
       </Flex>
       {content}
     </Flex>

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -13,7 +13,7 @@ import {
   RESPONSIVENESS,
   Tag,
   SPACING_1,
-  TYPOGRAPHY
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { Divider } from '/app/atoms/structure/Divider'
 
@@ -56,35 +56,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
         >
           {props.labwareNickname ?? props.labwareName}
         </StyledText>
-        {props.layout === 'default' ? (
-          <>
-            {props.labwareNickname != null ? (
-              <>
-                <StyledText
-                  oddStyle="hidden"
-                  desktopStyle="bodyDefaultRegular"
-                  color={COLORS.grey60}
-                  css={css`
-                    ${LINE_CLAMP_STYLE}
-                    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                      display: none;
-                    }
-                  `}
-                >
-                  {props.labwareNickname}{' '}
-                </StyledText>
-                <Divider
-                  borderColor={COLORS.grey35}
-                  css={`
-                    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                      display: none;
-                    }
-                  `}
-                />
-              </>
-            ) : null}
-          </>
-        ) : (
+        {props.layout === 'stacked' ? (
           <>
             <StyledText
               oddStyle="hidden"
@@ -94,7 +66,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
                 ${LINE_CLAMP_STYLE}
                 margin: ${SPACING_1} 0;
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                  font-size: ${TYPOGRAPHY.fontSize22}
+                  font-size: ${TYPOGRAPHY.fontSize22};
                 }
               `}
             >
@@ -105,12 +77,12 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               borderColor={COLORS.grey35}
               css={`
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                  border-bottom-color: ${COLORS.grey60}
+                  border-bottom-color: ${COLORS.grey60};
                 }
               `}
             />
           </>
-        )}
+        ) : null}
       </Flex>
       {content}
     </Flex>

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -13,6 +13,7 @@ import {
   RESPONSIVENESS,
   Tag,
   SPACING_1,
+  SPACING_3,
   TYPOGRAPHY,
 } from '@opentrons/components'
 import { Divider } from '/app/atoms/structure/Divider'
@@ -76,6 +77,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
             <Divider
               borderColor={COLORS.grey35}
               css={`
+                margin-top: ${SPACING_3};
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                   border-bottom-color: ${COLORS.grey60};
                 }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -63,7 +63,11 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
           </StyledText>
         ) : null}
         {props.tagtext != null ? (
-            <Tag type="default" text={t('labware_quantity', { quantity: props.tagtext })} shrinkToContent={true}/>
+          <Tag
+            type="default"
+            text={t('labware_quantity', { quantity: props.tagtext })}
+            shrinkToContent={true}
+          />
         ) : null}
       </Flex>
       <Divider

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -20,6 +20,8 @@ export interface InterventionInfoProps {
   type: 'location-arrow-location' | 'location-colon-location' | 'location'
   labwareName: string
   labwareNickname?: string
+  subtext?: string
+  tagtext?: string
   currentLocationProps: DeckInfoLabelProps
   newLocationProps?: DeckInfoLabelProps
 }
@@ -39,9 +41,9 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
           desktopStyle="bodyDefaultSemiBold"
           css={LINE_CLAMP_STYLE}
         >
-          {props.labwareName}
+          {props.labwareNickname ?? props.labwareName}
         </StyledText>
-        {props.labwareNickname != null ? (
+        {props.subtext != null ? (
           <StyledText
             oddStyle="hidden"
             desktopStyle="bodyDefaultRegular"
@@ -53,7 +55,22 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               }
             `}
           >
-            {props.labwareNickname}{' '}
+            {props.subtext}{' '}
+          </StyledText>
+        ) : null}
+        {props.tagtext != null ? (
+          <StyledText
+            oddStyle="hidden"
+            desktopStyle="bodyDefaultRegular"
+            color={COLORS.grey60}
+            css={css`
+              ${LINE_CLAMP_STYLE}
+              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                display: none;
+              }
+            `}
+          >
+            {props.tagtext}{' '}
           </StyledText>
         ) : null}
       </Flex>

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -13,7 +13,7 @@ import {
   RESPONSIVENESS,
   Tag,
   SPACING_1,
-  TYPOGRAPHY,
+  TYPOGRAPHY
 } from '@opentrons/components'
 import { Divider } from '/app/atoms/structure/Divider'
 
@@ -94,7 +94,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
                 ${LINE_CLAMP_STYLE}
                 margin: ${SPACING_1} 0;
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                  font-size: ${TYPOGRAPHY.fontSize22};
+                  font-size: ${TYPOGRAPHY.fontSize22}
                 }
               `}
             >
@@ -105,7 +105,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               borderColor={COLORS.grey35}
               css={`
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                  border-bottom-color: ${COLORS.grey60};
+                  border-bottom-color: ${COLORS.grey60}
                 }
               `}
             />

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -11,6 +11,7 @@ import {
   StyledText,
   ALIGN_CENTER,
   RESPONSIVENESS,
+  Tag,
 } from '@opentrons/components'
 import { Divider } from '/app/atoms/structure/Divider'
 
@@ -59,19 +60,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
           </StyledText>
         ) : null}
         {props.tagtext != null ? (
-          <StyledText
-            oddStyle="hidden"
-            desktopStyle="bodyDefaultRegular"
-            color={COLORS.grey60}
-            css={css`
-              ${LINE_CLAMP_STYLE}
-              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                display: none;
-              }
-            `}
-          >
-            {props.tagtext}{' '}
-          </StyledText>
+            <Tag type="default" text={'Quantity: ' + props.tagtext} shrinkToContent={true}/>
         ) : null}
       </Flex>
       <Divider

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -58,7 +58,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               }
             `}
           >
-            {props.subtext}{' '}
+            {props.subtext}
           </StyledText>
         ) : null}
         {props.tagtext != null ? (

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -12,8 +12,7 @@ import {
   ALIGN_CENTER,
   RESPONSIVENESS,
   Tag,
-  SPACING_1,
-  SPACING_3,
+  SPACING_2,
   TYPOGRAPHY,
 } from '@opentrons/components'
 import { Divider } from '/app/atoms/structure/Divider'
@@ -65,7 +64,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               color={COLORS.grey60}
               css={css`
                 ${LINE_CLAMP_STYLE}
-                margin: ${SPACING_1} 0;
+                margin: ${SPACING_2} 0;
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                   font-size: ${TYPOGRAPHY.fontSize22};
                 }
@@ -77,7 +76,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
             <Divider
               borderColor={COLORS.grey35}
               css={`
-                margin-top: ${SPACING_3};
+                margin: ${SPACING_2} 0 0 0;
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                   border-bottom-color: ${COLORS.grey60};
                 }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
@@ -29,6 +30,7 @@ export interface InterventionInfoProps {
 
 export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
   const content = buildContent(props)
+  const { t } = useTranslation('protocol_setup')
 
   return (
     <Flex
@@ -61,7 +63,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
           </StyledText>
         ) : null}
         {props.tagtext != null ? (
-            <Tag type="default" text={'Quantity: ' + props.tagtext} shrinkToContent={true}/>
+            <Tag type="default" text={t('labware_quantity', { quantity: props.tagtext })} shrinkToContent={true}/>
         ) : null}
       </Flex>
       <Divider

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -12,6 +12,7 @@ import {
   ALIGN_CENTER,
   RESPONSIVENESS,
   Tag,
+  SPACING_1,
   SPACING_2,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -64,9 +65,10 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               color={COLORS.grey60}
               css={css`
                 ${LINE_CLAMP_STYLE}
-                margin: ${SPACING_2} 0;
+                margin: 0 0.125rem ${SPACING_2} 0;
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                   font-size: ${TYPOGRAPHY.fontSize22};
+                  margin: 0 ${SPACING_1} ${SPACING_2} 0;
                 }
               `}
             >

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -53,7 +53,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
             color={COLORS.grey60}
             css={css`
               ${LINE_CLAMP_STYLE}
-              maring-bottom: 0.25rem
+              margin-bottom: 0.25rem
               @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                 display: none;
               }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -13,6 +13,7 @@ import {
   RESPONSIVENESS,
   Tag,
   SPACING_1,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import { Divider } from '/app/atoms/structure/Divider'
 
@@ -58,28 +59,30 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
         {props.layout === 'default' ? (
           <>
             {props.labwareNickname != null ? (
-              <StyledText
-                oddStyle="hidden"
-                desktopStyle="bodyDefaultRegular"
-                color={COLORS.grey60}
-                css={css`
-                  ${LINE_CLAMP_STYLE}
-                  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                    display: none;
-                  }
-                `}
-              >
-                {props.labwareNickname}{' '}
-              </StyledText>
+              <>
+                <StyledText
+                  oddStyle="hidden"
+                  desktopStyle="bodyDefaultRegular"
+                  color={COLORS.grey60}
+                  css={css`
+                    ${LINE_CLAMP_STYLE}
+                    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                      display: none;
+                    }
+                  `}
+                >
+                  {props.labwareNickname}{' '}
+                </StyledText>
+                <Divider
+                  borderColor={COLORS.grey35}
+                  css={`
+                    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                      display: none;
+                    }
+                  `}
+                />
+              </>
             ) : null}
-            <Divider
-              borderColor={COLORS.grey35}
-              css={`
-                @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                  display: none;
-                }
-              `}
-            />
           </>
         ) : (
           <>
@@ -89,9 +92,9 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               color={COLORS.grey60}
               css={css`
                 ${LINE_CLAMP_STYLE}
-                margin-bottom: ${SPACING_1}
-            @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                  display: none;
+                margin: ${SPACING_1} 0;
+                @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                  font-size: ${TYPOGRAPHY.fontSize22};
                 }
               `}
             >
@@ -102,7 +105,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               borderColor={COLORS.grey35}
               css={`
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                  display: none;
+                  border-bottom-color: ${COLORS.grey60};
                 }
               `}
             />

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
@@ -13,6 +12,7 @@ import {
   ALIGN_CENTER,
   RESPONSIVENESS,
   Tag,
+  SPACING_1,
 } from '@opentrons/components'
 import { Divider } from '/app/atoms/structure/Divider'
 
@@ -30,7 +30,6 @@ export interface InterventionInfoProps {
 
 export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
   const content = buildContent(props)
-  const { t } = useTranslation('protocol_setup')
 
   return (
     <Flex
@@ -53,7 +52,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
             color={COLORS.grey60}
             css={css`
               ${LINE_CLAMP_STYLE}
-              margin-bottom: 0.25rem
+              maring-bottom: ${SPACING_1}
               @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                 display: none;
               }
@@ -63,21 +62,19 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
           </StyledText>
         ) : null}
         {props.tagtext != null ? (
-          <Tag
-            type="default"
-            text={t('labware_quantity', { quantity: props.tagtext })}
-            shrinkToContent={true}
-          />
+          <Tag type="default" text={props.tagtext} shrinkToContent={true} />
         ) : null}
       </Flex>
-      <Divider
-        borderColor={COLORS.grey35}
-        css={`
-          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-            display: none;
-          }
-        `}
-      />
+      {props.tagtext != null && (
+        <Divider
+          borderColor={COLORS.grey35}
+          css={`
+            @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+              display: none;
+            }
+          `}
+        />
+      )}
       {content}
     </Flex>
   )

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -51,6 +51,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
             color={COLORS.grey60}
             css={css`
               ${LINE_CLAMP_STYLE}
+              maring-bottom: 0.25rem
               @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                 display: none;
               }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -65,10 +65,10 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
               color={COLORS.grey60}
               css={css`
                 ${LINE_CLAMP_STYLE}
-                margin: 0 0.125rem ${SPACING_2} 0;
+                margin: 0.125rem 0 ${SPACING_2} 0;
                 @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
                   font-size: ${TYPOGRAPHY.fontSize22};
-                  margin: 0 ${SPACING_1} ${SPACING_2} 0;
+                  margin: ${SPACING_1} 0 ${SPACING_2} 0;
                 }
               `}
             >

--- a/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
@@ -35,6 +35,7 @@ export function LeftColumnLabwareInfo({
     <InterventionContent
       headline={title}
       infoProps={{
+        layout: 'default',
         type,
         labwareName: failedLabwareName ?? '',
         labwareNickname: failedLabwareNickname ?? '',

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
@@ -49,6 +49,7 @@ describe('LeftColumnLabwareInfo', () => {
       expect.objectContaining({
         headline: 'MOCK_TITLE',
         infoProps: {
+          layout: 'default',
           type: 'location',
           labwareName: 'MOCK_LW_NAME',
           labwareNickname: 'MOCK_LW_NICKNAME',


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-1224.
Add subtext and tagtext props to intervention modal. 

## Test Plan and Hands on Testing

Can follow storybook for changes. (not passing these props yet so can only view in storybook).
https://s3-us-west-2.amazonaws.com/opentrons-components/EXEC-1224-component-update-intervention-info-component/index.html?path=/docs/app-molecules-interventionmodal-interventioncontent-interventioninfo--docs

## Changelog

Added 2 new props to intervention modal. subtext and tagtext.
Added conditional display.
fixed bug in storybook where it didnt show the location label.

## Review requests

changes make sense? do we want to fix storybook rendering the slots?

## Risk assessment

low. added 2 optional props. 
