### PR TITLE
refactor(robot-server): Type-check robot_server.robot

### DIFF
--- a/api/src/opentrons/calibration_storage/ot2/mark_bad_calibration.py
+++ b/api/src/opentrons/calibration_storage/ot2/mark_bad_calibration.py
@@ -10,7 +10,9 @@ from .models import v1
 CalibrationType = typing.TypeVar(
     "CalibrationType",
     v1.PipetteOffsetCalibration,
+    v1.InstrumentOffsetModel,
     v1.TipLengthCalibration,
+    v1.TipLengthModel,
     v1.DeckCalibrationModel,
 )
 

--- a/robot-server/.flake8
+++ b/robot-server/.flake8
@@ -28,7 +28,7 @@ per-file-ignores =
     robot_server/dependencies.py:ANN,D
     robot_server/util.py:ANN,D
     robot_server/settings.py:ANN,D
-    robot_server/robot/*:ANN,D
+    robot_server/robot/*:D
     robot_server/service/*:ANN,D
     tests/integration/*:ANN,D
     tests/robot/*:ANN,D

--- a/robot-server/mypy.ini
+++ b/robot-server/mypy.ini
@@ -60,12 +60,6 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-robot_server.robot.calibration.*]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
-disallow_incomplete_defs = False
-warn_return_any = False
-
 [mypy-tests.service.json_api.*]
 disallow_any_generics = False
 disallow_untyped_defs = False

--- a/robot-server/robot_server/robot/calibration/check/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/check/state_machine.py
@@ -71,12 +71,12 @@ CALIBRATION_CHECK_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
 
 
 class CalibrationCheckStateMachine:
-    def __init__(self):
+    def __init__(self) -> None:
         self._state_machine = SimpleStateMachine(
             states=set(s for s in State), transitions=CALIBRATION_CHECK_TRANSITIONS
         )
 
-    def get_next_state(self, from_state: State, command: CommandDefinition):
+    def get_next_state(self, from_state: State, command: CommandDefinition) -> State:
         next_state = self._state_machine.get_next_state(from_state, command)
         if next_state:
             return next_state

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -19,7 +19,7 @@ from opentrons.calibration_storage.ot2 import (
     save_tip_length_calibration,
 )
 
-from opentrons.calibration_storage.ot2 import models
+from opentrons.calibration_storage.ot2.models import v1 as cal_models
 from opentrons.types import Mount, Point, Location
 from opentrons.hardware_control import (
     HardwareControlAPI,
@@ -347,9 +347,9 @@ class CheckCalibrationUserFlow:
     def _get_current_calibrations(
         self,
     ) -> tuple[
-        models.v1.DeckCalibrationModel | None,
-        dict[Mount, models.v1.InstrumentOffsetModel | None],
-        dict[Mount, models.v1.TipLengthModel | None],
+        cal_models.DeckCalibrationModel | None,
+        dict[Mount, cal_models.InstrumentOffsetModel | None],
+        dict[Mount, cal_models.TipLengthModel | None],
     ]:
         deck = get_robot_deck_attitude()
         pipette_offsets = {
@@ -365,7 +365,7 @@ class CheckCalibrationUserFlow:
 
     def _get_tip_length_from_pipette(
         self, mount: Mount, pipette: Pipette
-    ) -> Optional[models.v1.TipLengthModel]:
+    ) -> Optional[cal_models.TipLengthModel]:
         if not pipette.pipette_id:
             return None
         pip_offset = get_pipette_offset(pipette.pipette_id, mount)
@@ -431,7 +431,7 @@ class CheckCalibrationUserFlow:
         self,
         pipette: Optional[Pipette] = None,
         mount: Optional[Mount] = None,
-    ) -> models.v1.InstrumentOffsetModel:
+    ) -> cal_models.InstrumentOffsetModel:
         if not pipette or not mount:
             pip_offset = get_pipette_offset(
                 self.hw_pipette.pipette_id or "", self.mount
@@ -444,7 +444,7 @@ class CheckCalibrationUserFlow:
     @staticmethod
     def _get_tr_lw(
         tip_rack_def: Optional[LabwareDefinition],
-        existing_calibration: models.v1.InstrumentOffsetModel,
+        existing_calibration: cal_models.InstrumentOffsetModel,
         volume: float,
         position: Location,
     ) -> labware.Labware:
@@ -497,7 +497,7 @@ class CheckCalibrationUserFlow:
         return tr_lw
 
     def _get_tiprack_by_pipette_volume(
-        self, volume: float, existing_calibration: models.v1.InstrumentOffsetModel
+        self, volume: float, existing_calibration: cal_models.InstrumentOffsetModel
     ) -> labware.Labware:
         tip_rack_def = None
         if self._tip_racks:

--- a/robot-server/robot_server/robot/calibration/check/util.py
+++ b/robot-server/robot_server/robot/calibration/check/util.py
@@ -33,7 +33,7 @@ class ComparisonStatePerCalibration:
         self,
         name: str,
         value: Union[TipComparisonMap, PipetteOffsetComparisonMap, DeckComparisonMap],
-    ):
+    ) -> None:
         setattr(self, name, value)
 
 
@@ -42,7 +42,7 @@ class ComparisonStatePerPipette:
     first: ComparisonStatePerCalibration
     second: ComparisonStatePerCalibration
 
-    def set_value(self, name: str, value: ComparisonStatePerCalibration):
+    def set_value(self, name: str, value: ComparisonStatePerCalibration) -> None:
         setattr(self, name, value)
 
 

--- a/robot-server/robot_server/robot/calibration/constants.py
+++ b/robot-server/robot_server/robot/calibration/constants.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, Final, Set
 from dataclasses import dataclass
 from opentrons.types import Point, Mount
 
-if TYPE_CHECKING:
-    from typing_extensions import Final
 
-
-STATE_WILDCARD = "*"
+STATE_WILDCARD: Final = "*"
 
 _lw_fmt = "opentrons_96_{}_{}ul"
 _filtertiprack = "filtertiprack"

--- a/robot-server/robot_server/robot/calibration/deck/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/deck/state_machine.py
@@ -51,12 +51,12 @@ DECK_CALIBRATION_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
 
 
 class DeckCalibrationStateMachine:
-    def __init__(self):
+    def __init__(self) -> None:
         self._state_machine = SimpleStateMachine(
             states=set(s for s in State), transitions=DECK_CALIBRATION_TRANSITIONS
         )
 
-    def get_next_state(self, from_state: State, command: CommandDefinition):
+    def get_next_state(self, from_state: State, command: CommandDefinition) -> State:
         next_state = self._state_machine.get_next_state(from_state, command)
         if next_state:
             return next_state

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -1,4 +1,5 @@
 import typing
+from typing_extensions import Self
 
 from opentrons.types import Mount
 from enum import Enum
@@ -14,7 +15,7 @@ class RobotHealthCheck(Enum):
     IN_THRESHOLD = "IN_THRESHOLD"
     OUTSIDE_THRESHOLD = "OUTSIDE_THRESHOLD"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
     @classmethod
@@ -31,26 +32,29 @@ class PipetteRank(str, Enum):
     first = "first"
     second = "second"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def __ge__(self, other):
-        if self.__class__ is other.__class__:
+    # todo(mm, 2025-02-14): PipetteRank ordering relies on the fact that the
+    # string "first" comes alphabetically before the string "second"? D:
+
+    def __ge__(self, other: object) -> bool:
+        if isinstance(other, PipetteRank):
             return self.value >= other.value
         return NotImplemented
 
-    def __gt__(self, other):
-        if self.__class__ is other.__class__:
+    def __gt__(self, other: object) -> bool:
+        if isinstance(other, PipetteRank):
             return self.value > other.value
         return NotImplemented
 
-    def __le__(self, other):
-        if self.__class__ is other.__class__:
+    def __le__(self, other: object) -> bool:
+        if isinstance(other, PipetteRank):
             return self.value <= other.value
         return NotImplemented
 
-    def __lt__(self, other):
-        if self.__class__ is other.__class__:
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, PipetteRank):
             return self.value < other.value
         return NotImplemented
 
@@ -74,11 +78,11 @@ class SupportedCommands:
 
     loadLabware: bool = False
 
-    def __init__(self, namespace: str):
+    def __init__(self, namespace: str) -> None:
         self._namespace = namespace
 
-    def supported(self):
-        commands = []
+    def supported(self) -> list[str]:
+        commands: list[str] = []
         for field in fields(self):
             result = getattr(self, field.name)
             if result:
@@ -112,9 +116,9 @@ class AttachedPipette(BaseModel):
     serial: typing.Optional[str] = Field(
         None, description="The serial number of the attached pipette"
     )
-    defaultTipracks: typing.Optional[typing.List[typing.Dict[str, typing.Any]]] = Field(
-        None, description="A list of default tipracks for this pipette"
-    )
+    defaultTipracks: typing.Optional[
+        typing.Sequence[typing.Mapping[str, typing.Any]]
+    ] = Field(None, description="A list of default tipracks for this pipette")
 
 
 class RequiredLabware(BaseModel):
@@ -131,7 +135,9 @@ class RequiredLabware(BaseModel):
     definition: typing.Dict[str, typing.Any]
 
     @classmethod
-    def from_lw(cls, lw: labware.Labware, slot: typing.Optional[DeckLocation] = None):
+    def from_lw(
+        cls, lw: labware.Labware, slot: typing.Optional[DeckLocation] = None
+    ) -> Self:
         if not slot:
             # TODO(mc, 2021-09-08): lw.parent is not necessarily a slot
             slot = lw.parent  # type: ignore[assignment]

--- a/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
@@ -93,7 +93,7 @@ PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
 
 
 class PipetteOffsetCalibrationStateMachine:
-    def __init__(self):
+    def __init__(self) -> None:
         self._state_machine = SimpleStateMachine(
             states=set(s for s in POCState), transitions=PIP_OFFSET_CAL_TRANSITIONS
         )
@@ -108,10 +108,12 @@ class PipetteOffsetCalibrationStateMachine:
     def current_state(self) -> POCState:
         return self._current_state
 
-    def set_state(self, state: POCState):
+    def set_state(self, state: POCState) -> None:
         self._current_state = state
 
-    def get_next_state(self, from_state: POCState, command: CommandDefinition):
+    def get_next_state(
+        self, from_state: POCState, command: CommandDefinition
+    ) -> POCState:
         next_state = self._state_machine.get_next_state(from_state, command)
         if next_state:
             return next_state
@@ -120,7 +122,7 @@ class PipetteOffsetCalibrationStateMachine:
 
 
 class PipetteOffsetWithTipLengthStateMachine:
-    def __init__(self):
+    def __init__(self) -> None:
         self._state_machine = SimpleStateMachine(
             states=set(s for s in POWTState),
             transitions=PIP_OFFSET_WITH_TL_TRANSITIONS,
@@ -136,10 +138,12 @@ class PipetteOffsetWithTipLengthStateMachine:
     def current_state(self) -> POWTState:
         return self._current_state
 
-    def set_state(self, state: POWTState):
+    def set_state(self, state: POWTState) -> None:
         self._current_state = state
 
-    def get_next_state(self, from_state: POWTState, command: CommandDefinition):
+    def get_next_state(
+        self, from_state: POWTState, command: CommandDefinition
+    ) -> POWTState:
         next_state = self._state_machine.get_next_state(from_state, command)
         if next_state:
             return next_state

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -5,6 +5,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    NoReturn,
     Optional,
     Union,
     Tuple,
@@ -85,8 +86,7 @@ class PipetteOffsetCalibrationUserFlow:
         recalibrate_tip_length: bool = False,
         has_calibration_block: bool = False,
         tip_rack_def: Optional[LabwareDefinition] = None,
-    ):
-
+    ) -> None:
         self._hardware = hardware
         self._mount = mount
 
@@ -189,7 +189,7 @@ class PipetteOffsetCalibrationUserFlow:
         return self._should_perform_tip_length
 
     @should_perform_tip_length.setter
-    def should_perform_tip_length(self, value: bool):
+    def should_perform_tip_length(self, value: bool) -> None:
         self._should_perform_tip_length = value
 
     def get_pipette(self) -> AttachedPipette:
@@ -200,7 +200,7 @@ class PipetteOffsetCalibrationUserFlow:
             tipLength=self._hw_pipette.active_tip_settings.default_tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            defaultTipracks=self._default_tipracks,  # type: ignore[arg-type]
+            defaultTipracks=self._default_tipracks,
         )
 
     def get_required_labware(self) -> List[RequiredLabware]:
@@ -211,7 +211,7 @@ class PipetteOffsetCalibrationUserFlow:
             for s, lw in lw_by_slot.items()
         ]
 
-    async def set_has_calibration_block(self, hasBlock: bool):
+    async def set_has_calibration_block(self, hasBlock: bool) -> None:
         if self._has_calibration_block and not hasBlock:
             self._remove_calibration_block()
         elif hasBlock and not self._has_calibration_block:
@@ -223,7 +223,7 @@ class PipetteOffsetCalibrationUserFlow:
         lw_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(pip_vol)].load_name
         return labware.load(lw_load_name, self._deck.position_for(TIP_RACK_SLOT))
 
-    async def handle_command(self, name: Any, data: Dict[Any, Any]):
+    async def handle_command(self, name: Any, data: Dict[Any, Any]) -> None:
         """
         Handle a client command
 
@@ -240,7 +240,11 @@ class PipetteOffsetCalibrationUserFlow:
         handler = self._command_map.get(name)
         if handler is not None:
             await handler(**data)
-        self._sm.set_state(next_state)
+        self._sm.set_state(
+            # This `type: ignore` is because self._sm can be one of two types.
+            # This should be safe in practice since we got next_state from self._sm.
+            next_state  # type: ignore[arg-type]
+        )
         MODULE_LOG.debug(
             f"PipetteOffsetCalUserFlow handled command {name}, transitioned"
             f"from {self._sm.current_state} to {next_state}"
@@ -260,14 +264,14 @@ class PipetteOffsetCalibrationUserFlow:
     async def load_labware(
         self,
         tiprackDefinition: Optional[LabwareDefinition] = None,
-    ):
+    ) -> None:
         self._supported_commands.loadLabware = False
         if tiprackDefinition:
             verified_definition = labware.verify_definition(tiprackDefinition)
             existing_offset_calibration = self._get_stored_pipette_offset_cal()
             self._load_tip_rack(verified_definition, existing_offset_calibration)
 
-    async def jog(self, vector):
+    async def jog(self, vector: tuple[float, float, float]) -> None:
         await self._hardware.move_rel(mount=self._mount, delta=Point(*vector))
 
     @property
@@ -280,17 +284,17 @@ class PipetteOffsetCalibrationUserFlow:
             )
 
     @tip_origin.setter
-    def tip_origin(self, new_val: Point):
+    def tip_origin(self, new_val: Point) -> None:
         self._tip_origin_pt = new_val
 
-    def reset_tip_origin(self):
+    def reset_tip_origin(self) -> None:
         self._tip_origin_pt = None
 
     @property
     def supported_commands(self) -> List[str]:
         return self._supported_commands.supported()
 
-    async def move_to_tip_rack(self):
+    async def move_to_tip_rack(self) -> None:
         if (
             self._sm.current_state == self._sm.state.labwareLoaded
             and not self.has_calibrated_tip_length
@@ -334,13 +338,13 @@ class PipetteOffsetCalibrationUserFlow:
         else:
             return stored_tip_length_cal
 
-    def _load_calibration_block(self):
+    def _load_calibration_block(self) -> None:
         cb_setup = CAL_BLOCK_SETUP_BY_MOUNT[self._mount]
         self._deck[cb_setup.slot] = labware.load(
             cb_setup.load_name, self._deck.position_for(cb_setup.slot)
         )
 
-    def _remove_calibration_block(self):
+    def _remove_calibration_block(self) -> None:
         cb_setup = CAL_BLOCK_SETUP_BY_MOUNT[self._mount]
         del self._deck[cb_setup.slot]
 
@@ -377,7 +381,7 @@ class PipetteOffsetCalibrationUserFlow:
         self,
         tip_rack_def: Optional[LabwareDefinition],
         existing_calibration: Optional[models.v1.InstrumentOffsetModel],
-    ):
+    ) -> None:
         """
         load onto the deck the default opentrons tip rack labware for this
         pipette and return the tip rack labware. If tip_rack_def is supplied,
@@ -393,7 +397,9 @@ class PipetteOffsetCalibrationUserFlow:
             del self._deck[TIP_RACK_SLOT]
         self._deck[TIP_RACK_SLOT] = self._tip_rack
 
-    def _flag_unmet_transition_req(self, command_handler: str, unmet_condition: str):
+    def _flag_unmet_transition_req(
+        self, command_handler: str, unmet_condition: str
+    ) -> NoReturn:
         raise RobotServerError(
             definition=CalibrationError.UNMET_STATE_TRANSITION_REQ,
             handler=command_handler,
@@ -401,7 +407,7 @@ class PipetteOffsetCalibrationUserFlow:
             condition=unmet_condition,
         )
 
-    async def move_to_deck(self):
+    async def move_to_deck(self) -> None:
         current_state = self._sm.current_state
         if (
             not self.has_calibrated_tip_length
@@ -430,7 +436,7 @@ class PipetteOffsetCalibrationUserFlow:
         await self._move(to_loc)
         self._should_perform_tip_length = False
 
-    async def move_to_point_one(self):
+    async def move_to_point_one(self) -> None:
         assert (
             self._z_height_reference is not None
         ), "saveOffset has not been called yet"
@@ -438,7 +444,7 @@ class PipetteOffsetCalibrationUserFlow:
         target = target_loc.move(point=Point(0, 0, self._z_height_reference))
         await self._move(target)
 
-    async def save_offset(self):
+    async def save_offset(self) -> None:
         cur_pt = await self.get_current_point(critical_point=None)
         current_state = self._sm.current_state
         if current_state == self._sm.state.joggingToDeck:
@@ -487,7 +493,7 @@ class PipetteOffsetCalibrationUserFlow:
             )
             await self.hardware.retract(self._mount, 20)
 
-    async def move_to_reference_point(self):
+    async def move_to_reference_point(self) -> None:
         if not self.should_perform_tip_length and self._sm.current_state in (
             self._sm.state.labwareLoaded,
             self._sm.state.inspectingTip,
@@ -508,7 +514,7 @@ class PipetteOffsetCalibrationUserFlow:
         )
         await self._move(ref_loc)
 
-    async def invalidate_last_action(self):
+    async def invalidate_last_action(self) -> None:
         if self._sm.current_state == POWTState.measuringNozzleOffset:
             await self._hardware.home()
             await self._hardware.gantry_position(self.mount, refresh=True)
@@ -527,19 +533,19 @@ class PipetteOffsetCalibrationUserFlow:
             await self.hardware.drop_tip(self.mount)
             await self.move_to_tip_rack()
 
-    async def pick_up_tip(self):
+    async def pick_up_tip(self) -> None:
         await util.pick_up_tip(self, tip_length=self._get_tip_length())
 
-    async def invalidate_tip(self):
+    async def invalidate_tip(self) -> None:
         await util.invalidate_tip(self)
 
-    async def return_tip(self):
+    async def return_tip(self) -> None:
         await util.return_tip(self, tip_length=self._get_tip_length())
 
-    async def _move(self, to_loc: Location):
+    async def _move(self, to_loc: Location) -> None:
         await util.move(self, to_loc)
 
-    async def exit_session(self):
+    async def exit_session(self) -> None:
         if self.hw_pipette.has_tip:
             await self.move_to_tip_rack()
             await self.return_tip()

--- a/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
@@ -40,12 +40,12 @@ TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
 
 
 class TipCalibrationStateMachine:
-    def __init__(self):
+    def __init__(self) -> None:
         self._state_machine = SimpleStateMachine(
             states=set(s for s in State), transitions=TIP_LENGTH_TRANSITIONS
         )
 
-    def get_next_state(self, from_state: State, command: CommandDefinition):
+    def get_next_state(self, from_state: State, command: CommandDefinition) -> State:
         next_state = self._state_machine.get_next_state(from_state, command)
         if next_state:
             return next_state

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -1,5 +1,13 @@
 import logging
-from typing import Set, Dict, Any, Union, List, Optional, TYPE_CHECKING
+from typing import (
+    Generic,
+    Mapping,
+    TypeVar,
+    Union,
+    List,
+    Optional,
+    TYPE_CHECKING,
+)
 
 from opentrons.hardware_control.util import plan_arc
 from opentrons.hardware_control.types import CriticalPoint
@@ -47,7 +55,7 @@ ValidState = Union[
 
 
 class StateTransitionError(RobotServerError):
-    def __init__(self, action: CommandDefinition, state: ValidState):
+    def __init__(self, action: CommandDefinition, state: ValidState) -> None:
         super().__init__(
             definition=CalibrationError.BAD_STATE_TRANSITION,
             action=action,
@@ -55,12 +63,25 @@ class StateTransitionError(RobotServerError):
         )
 
 
-TransitionMap = Dict[Any, Dict[Any, Any]]
 MODULE_LOG = logging.getLogger(__name__)
 
 
-class SimpleStateMachine:
-    def __init__(self, states: Set[Any], transitions: TransitionMap):
+_StateT = TypeVar("_StateT")
+_TransitionT = TypeVar("_TransitionT")
+
+
+class SimpleStateMachine(Generic[_StateT, _TransitionT]):
+    def __init__(
+        self,
+        states: set[_StateT],
+        transitions: Mapping[
+            _StateT,
+            Mapping[
+                _TransitionT,
+                _StateT,
+            ],
+        ],
+    ) -> None:
         """
         Construct a simple state machine
 
@@ -71,7 +92,11 @@ class SimpleStateMachine:
         self._states = states
         self._transitions = transitions
 
-    def get_next_state(self, from_state, command):
+    def get_next_state(
+        self,
+        from_state: _StateT,
+        command: _TransitionT,
+    ) -> _StateT | None:
         """
         Trigger a state transition
 
@@ -80,12 +105,17 @@ class SimpleStateMachine:
         :param to_state: The desired state
         :return: desired state if successful, None if fails
         """
+        try:
+            wc_transitions = self._transitions[STATE_WILDCARD]  # type: ignore[index]
+            wc_to_state = wc_transitions[command]
+        except KeyError:
+            wc_to_state = None
 
-        wc_transitions = self._transitions.get(STATE_WILDCARD, {})
-        wc_to_state = wc_transitions.get(command, {})
-
-        fs_transitions = self._transitions.get(from_state, {})
-        fs_to_state = fs_transitions.get(command, {})
+        try:
+            fs_transitions = self._transitions[from_state]
+            fs_to_state = fs_transitions[command]
+        except KeyError:
+            fs_to_state = None
 
         if wc_to_state:
             return wc_to_state
@@ -103,7 +133,7 @@ CalibrationUserFlow = Union[
 ]
 
 
-async def invalidate_tip(user_flow: CalibrationUserFlow):
+async def invalidate_tip(user_flow: CalibrationUserFlow) -> None:
     await user_flow.return_tip()
     user_flow.reset_tip_origin()
     await user_flow.hardware.update_nozzle_configuration_for_mount(
@@ -112,7 +142,7 @@ async def invalidate_tip(user_flow: CalibrationUserFlow):
     await user_flow.move_to_tip_rack()
 
 
-async def pick_up_tip(user_flow: CalibrationUserFlow, tip_length: float):
+async def pick_up_tip(user_flow: CalibrationUserFlow, tip_length: float) -> None:
     # grab position of active nozzle for ref when returning tip later
     cp = user_flow.critical_point_override
     user_flow.tip_origin = await user_flow.hardware.gantry_position(
@@ -128,7 +158,7 @@ async def pick_up_tip(user_flow: CalibrationUserFlow, tip_length: float):
     await user_flow.hardware.pick_up_tip(user_flow.mount, tip_length)
 
 
-async def return_tip(user_flow: CalibrationUserFlow, tip_length: float):
+async def return_tip(user_flow: CalibrationUserFlow, tip_length: float) -> None:
     """
     Move pipette with tip to tip rack well, such that
     the tip is inside the well, but not so deep that
@@ -154,7 +184,7 @@ async def move(
     user_flow: CalibrationUserFlow,
     to_loc: Location,
     this_move_cp: Optional[CriticalPoint] = None,
-):
+) -> None:
     from_pt = await user_flow.get_current_point(None)
     from_loc = Location(from_pt, None)
     cp = this_move_cp or user_flow.critical_point_override
@@ -192,7 +222,7 @@ def get_reference_location(
 
 def save_tip_length_calibration(
     pipette_id: str, tip_length_offset: float, tip_rack: labware.Labware
-):
+) -> None:
     # TODO: 07-22-2020 parent slot is not important when tracking
     # tip length data, hence the empty string, we should remove it
     # from create_tip_length_data in a refactor

--- a/robot-server/robot_server/service/session/models/command_definitions.py
+++ b/robot-server/robot_server/service/session/models/command_definitions.py
@@ -5,6 +5,7 @@ Definitions should be grouped into thematic namespaces.
 """
 import typing
 from enum import Enum
+from typing_extensions import Self
 
 
 class CommandDefinition(str, Enum):
@@ -12,7 +13,7 @@ class CommandDefinition(str, Enum):
 
     """The base of command definition enumerations."""
 
-    def __new__(cls, value):
+    def __new__(cls, value: str) -> Self:
         """Create a string enum."""
         # https://docs.python.org/3/library/enum.html#when-to-use-new-vs-init
         namespace = cls.namespace()
@@ -23,16 +24,16 @@ class CommandDefinition(str, Enum):
         return obj
 
     @staticmethod
-    def namespace():
+    def namespace() -> str | None:
         """
-        Override to create a namespoce for the member definitions. The
-         name.space will be used to make the value of the enum. It will
+        Override to create a namespace for the member definitions. The
+         namespace will be used to make the value of the enum. It will
          be "{namespace}.{value}"
         """
         return None
 
     @property
-    def localname(self):
+    def localname(self) -> str:
         """Get the name of the command without the namespace"""
         return self._localname
 


### PR DESCRIPTION
## Overview

`robot_server.robot.*` is old code that was excluded from type-checking. This removes the exclusion and fixes the type-checking errors, to the extent that I could without disturbing the code too much.

This helps with EXEC-1206 and EXEC-1230.

## Test Plan and Hands on Testing

I think we're good with CI and careful code review, but if that makes anyone nervous, I can smoke-test the OT-2's calibration flows next week.

## Review requests

`robot-server/robot_server/robot/calibration/check/user_flow.py` was pretty bad. There are a lot of things there that look like they're forgetting to handle the possibility of a `None` value, and a lot of things that look like they're accessing properties that don't exist (!). I don't know how, or even if, it was working at all.

I’ve left comments in the code for those problems, and a GitHub review comment below. Anyone have insight into them?

## Risk assessment

Low—I tried to avoid disrupting the code too much.

I added a number of `assert foo is not None`s, but only where we were accessing properties like `foo.bar`, so at worst, it will turn an `AttributeError` into an `AssertionError`.