### PR TITLE
feat(protocol-designer): Python generation for the Comment step

### DIFF
--- a/step-generation/src/__tests__/comment.test.ts
+++ b/step-generation/src/__tests__/comment.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { comment } from '../commandCreators/atomic/comment'
+import { getSuccessResult } from '../fixtures'
+
+describe('comment', () => {
+  it('should generate comment command', () => {
+    // InvariantContext and RobotState don't matter for comment.
+    const invariantContext: any = {}
+    const robotInitialState: any = {}
+
+    const message = 'I am a comment'
+    const result = comment({ message }, invariantContext, robotInitialState)
+    const res = getSuccessResult(result)
+    expect(res.commands).toEqual([
+      {
+        commandType: 'comment',
+        key: expect.any(String),
+        params: { message },
+      },
+    ])
+    expect(res.python).toEqual(`protocol.comment("I am a comment")`)
+  })
+})

--- a/step-generation/src/commandCreators/atomic/comment.ts
+++ b/step-generation/src/commandCreators/atomic/comment.ts
@@ -1,4 +1,4 @@
-import { uuid } from '../../utils'
+import { uuid, formatPyStr, PROTOCOL_CONTEXT_NAME } from '../../utils'
 import type { CommentParams } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
 
@@ -18,7 +18,9 @@ export const comment: CommandCreator<CommentParams> = (
       },
     },
   ]
+  const python = `${PROTOCOL_CONTEXT_NAME}.comment(${formatPyStr(message)})`
   return {
     commands,
+    python,
   }
 }


### PR DESCRIPTION
# Overview

This adds Python generation for the Comment step in PD. The Comment step has not been publicly released yet, but this was easy to implement, so I might as well get it out of the way.

## Test Plan and Hands on Testing

Added unit tests (for the JSON implementation as well, which didn't seem to have tests before). Confirmed the output when running from my branch. Also checked that the generated Python file passes simulation.

## Risk assessment

Very low. Both comments and Python generation are hidden behind feature flags.