### PR TITLE
fix(protocol-designer): don't emit define_liquid(description="") if it's empty string

### DIFF
--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -337,7 +337,7 @@ const mockLiquidEntities: LiquidEntities = {
   [liquid2]: {
     liquidGroupId: liquid2,
     pythonName: 'liquid_2',
-    description: null,
+    description: '',
     displayName: 'sulfur',
     displayColor: 'mock display color 2',
   },

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -221,9 +221,7 @@ export function getDefineLiquids(liquidEntities: LiquidEntities): string {
       const { pythonName, displayColor, displayName, description } = liquid
       const liquidArgs = [
         `${formatPyStr(displayName)}`,
-        ...(description != null
-          ? [`description=${formatPyStr(description)}`]
-          : []),
+        ...(description ? [`description=${formatPyStr(description)}`] : []),
         `display_color=${formatPyStr(displayColor)}`,
       ].join(',\n')
 


### PR DESCRIPTION
# Overview

The liquid description in the `LiquidEntities` seems to be the empty string sometimes. We don't want to emit that into the Python code if it's empty.

Before:
```
# Define Liquids:
liquid_1 = protocol.define_liquid(
    "Ketchup",
    description="",
    display_color="#ff4f4fff",
)
```

After:
```
# Define Liquids:
liquid_1 = protocol.define_liquid(
    "Ketchup",
    display_color="#ff4f4fff",
)
```
AUTH-1092

## Test Plan and Hands on Testing

Updated unit test to test the empty-string case.

## Risk assessment

Low. No one is relying on the generated Python code yet.