### PR TITLE
feat(api): return tip for liquid class based transfer functions

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1304,7 +1304,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     home_after=False,
                     alternate_drop_location=False,
                 )
-            if isinstance(trash_location, (TrashBin, WasteChute)):
+            elif isinstance(trash_location, (TrashBin, WasteChute)):
                 self.drop_tip_in_disposal_location(
                     disposal_location=trash_location,
                     home_after=False,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1072,6 +1072,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[Location, LabwareCore]],
         trash_location: Union[Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """Execute transfer using liquid class properties.
 
@@ -1225,6 +1226,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[Location, LabwareCore]],
         trash_location: Union[Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         pass
 
@@ -1237,6 +1239,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[Location, LabwareCore]],
         trash_location: Union[Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         if not tip_racks:
             raise RuntimeError(

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1117,8 +1117,18 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             ),
         )
 
+        last_tip_picked_up_from: Optional[WellCore] = None
+
         def _drop_tip() -> None:
-            if isinstance(trash_location, (TrashBin, WasteChute)):
+            if return_tip:
+                assert last_tip_picked_up_from is not None
+                self.drop_tip(
+                    location=None,
+                    well_core=last_tip_picked_up_from,
+                    home_after=False,
+                    alternate_drop_location=False,
+                )
+            elif isinstance(trash_location, (TrashBin, WasteChute)):
                 self.drop_tip_in_disposal_location(
                     disposal_location=trash_location,
                     home_after=False,
@@ -1132,7 +1142,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     alternate_drop_location=True,
                 )
 
-        def _pick_up_tip() -> None:
+        def _pick_up_tip() -> WellCore:
             next_tip = self.get_next_tip(
                 tip_racks=[core for loc, core in tip_racks],
                 starting_well=None,
@@ -1157,9 +1167,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 presses=None,
                 increment=None,
             )
+            return tip_well
 
         if new_tip == TransferTipPolicyV2.ONCE:
-            _pick_up_tip()
+            last_tip_picked_up_from = _pick_up_tip()
 
         prev_src: Optional[Tuple[Location, WellCore]] = None
         post_disp_tip_contents = [
@@ -1186,7 +1197,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             ):
                 if prev_src is not None:
                     _drop_tip()
-                _pick_up_tip()
+                last_tip_picked_up_from = _pick_up_tip()
                 post_disp_tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1282,7 +1293,17 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             max_volume=max_volume,
         )
 
+        last_tip_picked_up_from: Optional[WellCore] = None
+
         def _drop_tip() -> None:
+            if return_tip:
+                assert last_tip_picked_up_from is not None
+                self.drop_tip(
+                    location=None,
+                    well_core=last_tip_picked_up_from,
+                    home_after=False,
+                    alternate_drop_location=False,
+                )
             if isinstance(trash_location, (TrashBin, WasteChute)):
                 self.drop_tip_in_disposal_location(
                     disposal_location=trash_location,
@@ -1297,7 +1318,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     alternate_drop_location=True,
                 )
 
-        def _pick_up_tip() -> None:
+        def _pick_up_tip() -> WellCore:
             next_tip = self.get_next_tip(
                 tip_racks=[core for loc, core in tip_racks],
                 starting_well=None,
@@ -1322,9 +1343,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 presses=None,
                 increment=None,
             )
+            return tip_well
 
         if new_tip == TransferTipPolicyV2.ONCE:
-            _pick_up_tip()
+            last_tip_picked_up_from = _pick_up_tip()
 
         prev_src: Optional[Tuple[Location, WellCore]] = None
         tip_contents = [
@@ -1351,7 +1373,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             if new_tip == TransferTipPolicyV2.ALWAYS:
                 if prev_src is not None:
                     _drop_tip()
-                _pick_up_tip()
+                last_tip_picked_up_from = _pick_up_tip()
                 tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -360,6 +360,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LabwareCoreType]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """Transfer a liquid from source to dest according to liquid class properties."""
         ...
@@ -374,6 +375,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LabwareCoreType]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """
         Distribute a liquid from single source to multiple destinations
@@ -391,6 +393,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LabwareCoreType]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """
         Consolidate liquid from multiple sources to a single destination

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -625,6 +625,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23"""
         assert False, "transfer_liquid is not supported in legacy context"
@@ -638,6 +639,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
@@ -651,6 +653,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -517,6 +517,7 @@ class LegacyInstrumentCoreSimulator(
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "transfer_liquid is not supported in legacy context"
@@ -530,6 +531,7 @@ class LegacyInstrumentCoreSimulator(
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
@@ -543,6 +545,7 @@ class LegacyInstrumentCoreSimulator(
         new_tip: TransferTipPolicyV2,
         tip_racks: List[Tuple[types.Location, LegacyLabwareCore]],
         trash_location: Union[types.Location, TrashBin, WasteChute],
+        return_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1528,6 +1528,7 @@ class InstrumentContext(publisher.CommandPublisher):
         trash_location: Optional[
             Union[types.Location, labware.Well, TrashBin, WasteChute]
         ] = None,
+        return_tip: bool = False,
     ) -> InstrumentContext:
         """Transfer liquid from source to dest using the specified liquid class properties.
 
@@ -1599,6 +1600,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 for rack in tip_racks
             ],
             trash_location=checked_trash_location,
+            return_tip=return_tip,
         )
         return self
 
@@ -1615,6 +1617,7 @@ class InstrumentContext(publisher.CommandPublisher):
         trash_location: Optional[
             Union[types.Location, labware.Well, TrashBin, WasteChute]
         ] = None,
+        return_tip: bool = False,
     ) -> InstrumentContext:
         """
         Distribute liquid from a single source to multiple destinations
@@ -1678,6 +1681,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 for rack in tip_racks
             ],
             trash_location=checked_trash_location,
+            return_tip=return_tip,
         )
         return self
 
@@ -1694,6 +1698,7 @@ class InstrumentContext(publisher.CommandPublisher):
         trash_location: Optional[
             Union[types.Location, labware.Well, TrashBin, WasteChute]
         ] = None,
+        return_tip: bool = False,
     ) -> InstrumentContext:
         """
         Consolidate liquid from multiple sources to a single destination
@@ -1765,6 +1770,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 for rack in tip_racks
             ],
             trash_location=checked_trash_location,
+            return_tip=return_tip,
         )
         return self
 

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1948,6 +1948,7 @@ def test_transfer_liquid_delegates_to_engine_core(
         dest=[mock_well],
         new_tip="never",
         trash_location=trash_location,
+        return_tip=True,
     )
     decoy.verify(
         mock_instrument_core.transfer_liquid(
@@ -1958,6 +1959,7 @@ def test_transfer_liquid_delegates_to_engine_core(
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
             trash_location=trash_location.move(Point(1, 2, 3)),
+            return_tip=True,
         )
     )
 
@@ -2178,6 +2180,7 @@ def test_distribute_liquid_delegates_to_engine_core(
         dest=[mock_well],
         new_tip="never",
         trash_location=trash_location,
+        return_tip=True,
     )
     decoy.verify(
         mock_instrument_core.distribute_liquid(
@@ -2188,6 +2191,7 @@ def test_distribute_liquid_delegates_to_engine_core(
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
             trash_location=trash_location.move(Point(1, 2, 3)),
+            return_tip=True,
         )
     )
 
@@ -2433,6 +2437,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
         dest=mock_well,
         new_tip="never",
         trash_location=trash_location,
+        return_tip=True,
     )
     decoy.verify(
         mock_instrument_core.consolidate_liquid(
@@ -2443,5 +2448,6 @@ def test_consolidate_liquid_delegates_to_engine_core(
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
             trash_location=trash_location.move(Point(1, 2, 3)),
+            return_tip=True,
         )
     )

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -236,6 +236,159 @@ def test_order_of_water_transfer_steps(
 @pytest.mark.parametrize(
     "simulated_protocol_context", [("2.23", "Flex")], indirect=True
 )
+def test_order_of_water_transfer_steps_with_return_tip(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should run the transfer steps without any errors and return tips.
+
+    This test only checks that various supported configurations for a transfer
+    analyze successfully. It doesn't check whether the steps are as expected.
+    That will be covered in analysis snapshot tests.
+    """
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_50ul", "D1"
+    )
+    pipette_50 = simulated_protocol_context.load_instrument(
+        "flex_1channel_50", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+
+    water = simulated_protocol_context.define_liquid_class("water")
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "load_liquid_class",
+            side_effect=InstrumentCore.load_liquid_class,
+            autospec=True,
+        ) as patched_load_liquid_class,
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "aspirate_liquid_class",
+            side_effect=InstrumentCore.aspirate_liquid_class,
+            autospec=True,
+        ) as patched_aspirate,
+        mock.patch.object(
+            InstrumentCore,
+            "dispense_liquid_class",
+            side_effect=InstrumentCore.dispense_liquid_class,
+            autospec=True,
+        ) as patched_dispense,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip",
+            side_effect=InstrumentCore.drop_tip,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_load_liquid_class, "load_liquid_class")
+        mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
+        mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip")
+        pipette_50.transfer_liquid(
+            liquid_class=water,
+            volume=40,
+            source=nest_plate.rows()[0][:2],
+            dest=arma_plate.rows()[0][:2],
+            new_tip="always",
+            trash_location=trash,
+            return_tip=True,
+        )
+        expected_calls = [
+            mock.call.load_liquid_class(
+                mock.ANY,
+                name="water",
+                transfer_properties=mock.ANY,
+                tiprack_uri="opentrons/opentrons_flex_96_tiprack_50ul/1",
+            ),
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+            mock.call.aspirate_liquid_class(
+                mock.ANY,
+                volume=40,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_ONE,
+                tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
+            ),
+            mock.call.dispense_liquid_class(
+                mock.ANY,
+                volume=40,
+                dest=mock.ANY,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_ONE,
+                tip_contents=[LiquidAndAirGapPair(liquid=40, air_gap=0.1)],
+                add_final_air_gap=True,
+                trash_location=mock.ANY,
+            ),
+            mock.call.drop_tip(
+                mock.ANY,
+                location=None,
+                well_core=mock.ANY,
+                home_after=False,
+                alternate_drop_location=False,
+            ),
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+            mock.call.aspirate_liquid_class(
+                mock.ANY,
+                volume=40,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_ONE,
+                tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
+            ),
+            mock.call.dispense_liquid_class(
+                mock.ANY,
+                volume=40,
+                dest=mock.ANY,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_ONE,
+                tip_contents=[LiquidAndAirGapPair(liquid=40, air_gap=0.1)],
+                add_final_air_gap=True,
+                trash_location=mock.ANY,
+            ),
+            mock.call.drop_tip(
+                mock.ANY,
+                location=None,
+                well_core=mock.ANY,
+                home_after=False,
+                alternate_drop_location=False,
+            ),
+        ]
+        assert len(mock_manager.mock_calls) == 9
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+)
 def test_order_of_water_transfer_steps_with_no_new_tips(
     simulated_protocol_context: ProtocolContext,
 ) -> None:
@@ -744,4 +897,132 @@ def test_order_of_water_consolidate_steps_with_no_new_tips(
             ),
         ]
         assert len(mock_manager.mock_calls) == 4
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+)
+def test_order_of_water_consolidate_steps_with_return_tip(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should run the consolidate steps without any errors and return tips.
+
+    This test only checks that various supported configurations for a consolidation
+    analyze successfully. It doesn't check whether the steps are as expected.
+    That will be covered in analysis snapshot tests.
+    """
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_50ul", "D1"
+    )
+    pipette_50 = simulated_protocol_context.load_instrument(
+        "flex_1channel_50", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+
+    water = simulated_protocol_context.define_liquid_class("water")
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "load_liquid_class",
+            side_effect=InstrumentCore.load_liquid_class,
+            autospec=True,
+        ) as patched_load_liquid_class,
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "aspirate_liquid_class",
+            side_effect=InstrumentCore.aspirate_liquid_class,
+            autospec=True,
+        ) as patched_aspirate,
+        mock.patch.object(
+            InstrumentCore,
+            "dispense_liquid_class",
+            side_effect=InstrumentCore.dispense_liquid_class,
+            autospec=True,
+        ) as patched_dispense,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip",
+            side_effect=InstrumentCore.drop_tip,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_load_liquid_class, "load_liquid_class")
+        mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
+        mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip")
+        pipette_50.consolidate_liquid(
+            liquid_class=water,
+            volume=25,
+            source=nest_plate.rows()[0][:2],
+            dest=arma_plate.wells()[0],
+            new_tip="once",
+            trash_location=trash,
+            return_tip=True,
+        )
+        expected_calls = [
+            mock.call.load_liquid_class(
+                mock.ANY,
+                name="water",
+                transfer_properties=mock.ANY,
+                tiprack_uri="opentrons/opentrons_flex_96_tiprack_50ul/1",
+            ),
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+            mock.call.aspirate_liquid_class(
+                mock.ANY,
+                volume=25,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.MANY_TO_ONE,
+                tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
+            ),
+            mock.call.aspirate_liquid_class(
+                mock.ANY,
+                volume=25,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.MANY_TO_ONE,
+                tip_contents=[LiquidAndAirGapPair(liquid=25, air_gap=0.1)],
+            ),
+            mock.call.dispense_liquid_class(
+                mock.ANY,
+                volume=50,
+                dest=mock.ANY,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.MANY_TO_ONE,
+                tip_contents=[LiquidAndAirGapPair(liquid=50, air_gap=0)],
+                add_final_air_gap=True,
+                trash_location=mock.ANY,
+            ),
+            mock.call.drop_tip(
+                mock.ANY,
+                location=None,
+                well_core=mock.ANY,
+                home_after=False,
+                alternate_drop_location=False,
+            ),
+        ]
+        assert len(mock_manager.mock_calls) == 6
         assert mock_manager.mock_calls == expected_calls


### PR DESCRIPTION
# Overview

Closes AUTH-1403.

This PR adds the ability to have tips be returned during a `transfer_liquid`, `consolidate_liquid` and adds the boilerplate for `distribute_liquid` so it can be added when that function is finished.

This is accomplished by adding a new `return_tip` boolean argument to the `InstrumentContext` methods, that are then passed to the engine core. By default these are set to `False`, so it is not required to be set if tips will be dropped in the trash. This is then passed to the core, where we now keep track of the `WellCore` of the last tip to be picked up. If `return_tip` is set to `True`, we then drop the tip with that `WellCore` argument, using the same arguments as the `InstrumentContext` `return_tip()` method (hence the `location` argument being set to `None`).

There was some discussion of how this should be added to the API. The older legacy transfers had a `trash` boolean argument where if set to `True` it would drop the tips in the default `InstrumentContext.trash_container` (with no option to drop them in something else without changing that variable), and if set to `False` it would return tips. `return_tip` seems the most straightforward name for it. Another option would have been to allow the `trash_location` to be set to a tip rack, but then that introduces the problem of where to blowout if the blowout location is chosen to be trash, so that was a non-viable option.

## Test Plan and Hands on Testing

On robot testing with the following protocol, along with protocol api integration tests.

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.23"
}

metadata = {
    "protocolName":'Transfer with tip return',
}

def run(protocol_context):
	# Define labware, trash and pipette
	tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_200ul", "C2")
	trash = protocol_context.load_trash_bin('A3')
	pipette_1k = protocol_context.load_instrument("flex_1channel_1000", "left", tip_racks=[tiprack])
	nest_plate = protocol_context.load_labware("nest_96_wellplate_2ml_deep", "D1")
	arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "D3")

	# Define water liquid class
	water_class = protocol_context.define_liquid_class("water")

	pipette_1k.transfer_liquid(
		liquid_class=water_class,
		volume=100,
		source=nest_plate.columns()[0][:2],
		dest=arma_plate.columns()[0][:2],
		new_tip="always",
		trash_location=trash,
		return_tip=True,
	)

	pipette_1k.consolidate_liquid(
		liquid_class=water_class,
		volume=100,
		source=nest_plate.columns()[0][:2],
		dest=arma_plate.wells()[0],
		new_tip="once",
		trash_location=trash,
		return_tip=True,
	)
```

## Changelog

- added `return_tip` boolean argument to `transfer_liquid`, `consolidate_liquid`, and `distribute_liquid`
- added engine core logic for returning tip to `transfer_liquid` and `consolidate_liquid`

## Review requests

Usual request to double check the logical correctness of the return tip logic

## Risk assessment

Low.