### PR TITLE
fix(shared-data): remove command schema 11 changes

### DIFF
--- a/shared-data/command/schemas/11.json
+++ b/shared-data/command/schemas/11.json
@@ -337,73 +337,6 @@
       "title": "AspirateProperties",
       "type": "object"
     },
-    "AspirateWhileTrackingCreate": {
-      "description": "Create aspirateWhileTracking command request model.",
-      "properties": {
-        "commandType": {
-          "const": "aspirateWhileTracking",
-          "default": "aspirateWhileTracking",
-          "enum": ["aspirateWhileTracking"],
-          "title": "Commandtype",
-          "type": "string"
-        },
-        "intent": {
-          "$ref": "#/$defs/CommandIntent",
-          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
-          "title": "Intent"
-        },
-        "key": {
-          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
-          "title": "Key",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/$defs/AspirateWhileTrackingParams"
-        }
-      },
-      "required": ["params"],
-      "title": "AspirateWhileTrackingCreate",
-      "type": "object"
-    },
-    "AspirateWhileTrackingParams": {
-      "description": "Parameters required to aspirate from a specific well.",
-      "properties": {
-        "flowRate": {
-          "description": "Speed in \u00b5L/s configured for the pipette",
-          "exclusiveMinimum": 0.0,
-          "title": "Flowrate",
-          "type": "number"
-        },
-        "labwareId": {
-          "description": "Identifier of labware to use.",
-          "title": "Labwareid",
-          "type": "string"
-        },
-        "pipetteId": {
-          "description": "Identifier of pipette to use for liquid handling.",
-          "title": "Pipetteid",
-          "type": "string"
-        },
-        "volume": {
-          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
-          "minimum": 0.0,
-          "title": "Volume",
-          "type": "number"
-        },
-        "wellLocation": {
-          "$ref": "#/$defs/LiquidHandlingWellLocation",
-          "description": "Relative well location at which to perform the operation"
-        },
-        "wellName": {
-          "description": "Name of well to use in labware.",
-          "title": "Wellname",
-          "type": "string"
-        }
-      },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
-      "title": "AspirateWhileTrackingParams",
-      "type": "object"
-    },
     "BlowOutCreate": {
       "description": "Create blow-out command request model.",
       "properties": {
@@ -811,34 +744,6 @@
       "title": "CommentParams",
       "type": "object"
     },
-    "ConfigureCreate": {
-      "description": "A request to execute a Flex Stacker Configure command.",
-      "properties": {
-        "commandType": {
-          "const": "flexStacker/configure",
-          "default": "flexStacker/configure",
-          "enum": ["flexStacker/configure"],
-          "title": "Commandtype",
-          "type": "string"
-        },
-        "intent": {
-          "$ref": "#/$defs/CommandIntent",
-          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
-          "title": "Intent"
-        },
-        "key": {
-          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
-          "title": "Key",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/$defs/ConfigureParams"
-        }
-      },
-      "required": ["params"],
-      "title": "ConfigureCreate",
-      "type": "object"
-    },
     "ConfigureForVolumeCreate": {
       "description": "Configure for volume command creation request model.",
       "properties": {
@@ -950,32 +855,6 @@
       },
       "required": ["pipetteId", "configurationParams"],
       "title": "ConfigureNozzleLayoutParams",
-      "type": "object"
-    },
-    "ConfigureParams": {
-      "description": "Input parameters for a configure command.",
-      "properties": {
-        "moduleId": {
-          "description": "Unique ID of the Flex Stacker.",
-          "title": "Moduleid",
-          "type": "string"
-        },
-        "static": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Whether the Flex Stacker should be in static mode.",
-          "title": "Static"
-        }
-      },
-      "required": ["moduleId"],
-      "title": "ConfigureParams",
       "type": "object"
     },
     "Coordinate": {
@@ -1531,78 +1410,6 @@
       },
       "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "DispenseParams",
-      "type": "object"
-    },
-    "DispenseWhileTrackingCreate": {
-      "description": "Create dispenseWhileTracking command request model.",
-      "properties": {
-        "commandType": {
-          "const": "dispenseWhileTracking",
-          "default": "dispenseWhileTracking",
-          "enum": ["dispenseWhileTracking"],
-          "title": "Commandtype",
-          "type": "string"
-        },
-        "intent": {
-          "$ref": "#/$defs/CommandIntent",
-          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
-          "title": "Intent"
-        },
-        "key": {
-          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
-          "title": "Key",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/$defs/DispenseWhileTrackingParams"
-        }
-      },
-      "required": ["params"],
-      "title": "DispenseWhileTrackingCreate",
-      "type": "object"
-    },
-    "DispenseWhileTrackingParams": {
-      "description": "Payload required to dispense to a specific well.",
-      "properties": {
-        "flowRate": {
-          "description": "Speed in \u00b5L/s configured for the pipette",
-          "exclusiveMinimum": 0.0,
-          "title": "Flowrate",
-          "type": "number"
-        },
-        "labwareId": {
-          "description": "Identifier of labware to use.",
-          "title": "Labwareid",
-          "type": "string"
-        },
-        "pipetteId": {
-          "description": "Identifier of pipette to use for liquid handling.",
-          "title": "Pipetteid",
-          "type": "string"
-        },
-        "pushOut": {
-          "description": "push the plunger a small amount farther than necessary for accurate low-volume dispensing",
-          "title": "Pushout",
-          "type": "number"
-        },
-        "volume": {
-          "description": "The amount of liquid to dispense, in \u00b5L. Must not be greater than the currently aspirated volume. There is some tolerance for floating point rounding errors.",
-          "minimum": 0.0,
-          "title": "Volume",
-          "type": "number"
-        },
-        "wellLocation": {
-          "$ref": "#/$defs/LiquidHandlingWellLocation",
-          "description": "Relative well location at which to perform the operation"
-        },
-        "wellName": {
-          "description": "Name of well to use in labware.",
-          "title": "Wellname",
-          "type": "string"
-        }
-      },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
-      "title": "DispenseWhileTrackingParams",
       "type": "object"
     },
     "DropTipCreate": {
@@ -2441,11 +2248,6 @@
               "type": "string"
             },
             {
-              "const": "systemLocation",
-              "enum": ["systemLocation"],
-              "type": "string"
-            },
-            {
               "$ref": "#/$defs/AddressableAreaLocation"
             }
           ],
@@ -2520,11 +2322,6 @@
               "type": "string"
             },
             {
-              "const": "systemLocation",
-              "enum": ["systemLocation"],
-              "type": "string"
-            },
-            {
               "$ref": "#/$defs/AddressableAreaLocation"
             }
           ],
@@ -2577,14 +2374,6 @@
     "LoadLidStackParams": {
       "description": "Payload required to load a lid stack onto a location.",
       "properties": {
-        "labwareIds": {
-          "description": "An optional list of IDs to assign to the lids in the stack.If None, an ID will be generated.",
-          "items": {
-            "type": "string"
-          },
-          "title": "Labwareids",
-          "type": "array"
-        },
         "loadName": {
           "description": "Name used to reference a lid labware definition.",
           "title": "Loadname",
@@ -2607,11 +2396,6 @@
               "type": "string"
             },
             {
-              "const": "systemLocation",
-              "enum": ["systemLocation"],
-              "type": "string"
-            },
-            {
               "$ref": "#/$defs/AddressableAreaLocation"
             }
           ],
@@ -2627,11 +2411,6 @@
           "description": "The quantity of lids to load.",
           "title": "Quantity",
           "type": "integer"
-        },
-        "stackLabwareId": {
-          "description": "An optional ID to assign to the lid stack labware object created.If None, an ID will be generated.",
-          "title": "Stacklabwareid",
-          "type": "string"
         },
         "version": {
           "description": "The lid labware definition version.",
@@ -2933,8 +2712,7 @@
         "thermocyclerModuleV2",
         "heaterShakerModuleV1",
         "magneticBlockV1",
-        "absorbanceReaderV1",
-        "flexStackerModuleV1"
+        "absorbanceReaderV1"
       ],
       "title": "ModuleModel",
       "type": "string"
@@ -3121,11 +2899,6 @@
             {
               "const": "offDeck",
               "enum": ["offDeck"],
-              "type": "string"
-            },
-            {
-              "const": "systemLocation",
-              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -4337,47 +4110,6 @@
       "title": "RetractDispense",
       "type": "object"
     },
-    "RetrieveCreate": {
-      "description": "A request to execute a Flex Stacker retrieve command.",
-      "properties": {
-        "commandType": {
-          "const": "flexStacker/retrieve",
-          "default": "flexStacker/retrieve",
-          "enum": ["flexStacker/retrieve"],
-          "title": "Commandtype",
-          "type": "string"
-        },
-        "intent": {
-          "$ref": "#/$defs/CommandIntent",
-          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
-          "title": "Intent"
-        },
-        "key": {
-          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
-          "title": "Key",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/$defs/RetrieveParams"
-        }
-      },
-      "required": ["params"],
-      "title": "RetrieveCreate",
-      "type": "object"
-    },
-    "RetrieveParams": {
-      "description": "Input parameters for a labware retrieval command.",
-      "properties": {
-        "moduleId": {
-          "description": "Unique ID of the Flex Stacker.",
-          "title": "Moduleid",
-          "type": "string"
-        }
-      },
-      "required": ["moduleId"],
-      "title": "RetrieveParams",
-      "type": "object"
-    },
     "RowNozzleLayoutConfiguration": {
       "description": "Minimum information required for a new nozzle configuration.",
       "properties": {
@@ -4986,47 +4718,6 @@
       "enum": ["idle", "confirm", "updating", "disco", "off"],
       "title": "StatusBarAnimation",
       "type": "string"
-    },
-    "StoreCreate": {
-      "description": "A request to execute a Flex Stacker store command.",
-      "properties": {
-        "commandType": {
-          "const": "flexStacker/store",
-          "default": "flexStacker/store",
-          "enum": ["flexStacker/store"],
-          "title": "Commandtype",
-          "type": "string"
-        },
-        "intent": {
-          "$ref": "#/$defs/CommandIntent",
-          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
-          "title": "Intent"
-        },
-        "key": {
-          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
-          "title": "Key",
-          "type": "string"
-        },
-        "params": {
-          "$ref": "#/$defs/StoreParams"
-        }
-      },
-      "required": ["params"],
-      "title": "StoreCreate",
-      "type": "object"
-    },
-    "StoreParams": {
-      "description": "Input parameters for a labware storage command.",
-      "properties": {
-        "moduleId": {
-          "description": "Unique ID of the flex stacker.",
-          "title": "Moduleid",
-          "type": "string"
-        }
-      },
-      "required": ["moduleId"],
-      "title": "StoreParams",
-      "type": "object"
     },
     "Submerge": {
       "description": "Shared properties for the submerge function before aspiration or dispense.",
@@ -6230,7 +5921,6 @@
       "airGapInPlace": "#/$defs/AirGapInPlaceCreate",
       "aspirate": "#/$defs/AspirateCreate",
       "aspirateInPlace": "#/$defs/AspirateInPlaceCreate",
-      "aspirateWhileTracking": "#/$defs/AspirateWhileTrackingCreate",
       "blowOutInPlace": "#/$defs/BlowOutInPlaceCreate",
       "blowout": "#/$defs/BlowOutCreate",
       "calibration/calibrateGripper": "#/$defs/CalibrateGripperCreate",
@@ -6243,12 +5933,8 @@
       "custom": "#/$defs/CustomCreate",
       "dispense": "#/$defs/DispenseCreate",
       "dispenseInPlace": "#/$defs/DispenseInPlaceCreate",
-      "dispenseWhileTracking": "#/$defs/DispenseWhileTrackingCreate",
       "dropTip": "#/$defs/DropTipCreate",
       "dropTipInPlace": "#/$defs/DropTipInPlaceCreate",
-      "flexStacker/configure": "#/$defs/ConfigureCreate",
-      "flexStacker/retrieve": "#/$defs/RetrieveCreate",
-      "flexStacker/store": "#/$defs/StoreCreate",
       "evotipDispense": "#/$defs/EvotipDispenseCreate",
       "evotipSealPipette": "#/$defs/EvotipSealPipetteCreate",
       "evotipUnsealPipette": "#/$defs/EvotipUnsealPipetteCreate",
@@ -6326,9 +6012,6 @@
       "$ref": "#/$defs/AspirateCreate"
     },
     {
-      "$ref": "#/$defs/AspirateWhileTrackingCreate"
-    },
-    {
       "$ref": "#/$defs/AspirateInPlaceCreate"
     },
     {
@@ -6348,9 +6031,6 @@
     },
     {
       "$ref": "#/$defs/DispenseInPlaceCreate"
-    },
-    {
-      "$ref": "#/$defs/DispenseWhileTrackingCreate"
     },
     {
       "$ref": "#/$defs/BlowOutCreate"
@@ -6537,15 +6217,6 @@
     },
     {
       "$ref": "#/$defs/ReadAbsorbanceCreate"
-    },
-    {
-      "$ref": "#/$defs/ConfigureCreate"
-    },
-    {
-      "$ref": "#/$defs/RetrieveCreate"
-    },
-    {
-      "$ref": "#/$defs/StoreCreate"
     },
     {
       "$ref": "#/$defs/CalibrateGripperCreate"


### PR DESCRIPTION
Changes relative to the release are not allowed in command schema 11, since it will ship in 8.3.0. Changes should only be made to command schema 12.

These changes come from:
- #17286 ( 48a028ab17bbd491936a6a2451bc36f4a68f7eab ) which added aspirate and dispense while tracking commands
- #17300 ( 35686bc7e7c391d45a4a03573425afcd9030fc01 ) and #17206 ( cec46ef0d6c3eca8c802f56cb1f543b340e1a84a) which added initial stacker EVT commands 
- #17259 ( 7393c92cefcd97b2e9354428084f6888ec5161ec) which added a move lid command

These are all covered in schema 12 by subsequent schema generation exports.
