### PR TITLE
fix(protocol-designer,-shared-data): update command schema to v10

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -42,7 +42,7 @@ import type {
 } from '@opentrons/step-generation'
 import type {
   CommandAnnotationV1Mixin,
-  CommandV8Mixin,
+  CommandV10Mixin,
   CreateCommand,
   LabwareV2Mixin,
   LiquidV1Mixin,
@@ -243,8 +243,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       liquids,
     }
 
-    const commandv8Mixin: CommandV8Mixin = {
-      commandSchemaId: 'opentronsCommandSchemaV8',
+    const commandv10Mixin: CommandV10Mixin = {
+      commandSchemaId: 'opentronsCommandSchemaV10',
       commands,
     }
 
@@ -299,7 +299,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       ...deckStructure,
       ...labwareV2Mixin,
       ...liquidV1Mixin,
-      ...commandv8Mixin,
+      ...commandv10Mixin,
       ...commandAnnotionaV1Mixin,
     }
   }

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -27,6 +27,11 @@ export interface CommandV9Mixin {
   commands: CreateCommand[]
 }
 
+export interface CommandV10Mixin {
+  commandSchemaId: 'opentronsCommandSchemaV10'
+  commands: CreateCommand[]
+}
+
 export interface CommandAnnotationsStructure {
   commandAnnotationSchemaId: string
   commandAnnotations: any[]
@@ -115,7 +120,7 @@ export type ProtocolFile<
   (OT2RobotMixin | OT3RobotMixin) &
   LabwareV2Mixin &
   LiquidV1Mixin &
-  (CommandV8Mixin | CommandV9Mixin) &
+  (CommandV8Mixin | CommandV9Mixin | CommandV10Mixin) &
   CommandAnnotationV1Mixin
 
 export type ProtocolStructure = ProtocolBase<{}> &


### PR DESCRIPTION
# Overview

As an oversight, PD 8.4.0 maintained exporting protocols with command schema v8. This PR updates the command schema to v10.

## Test Plan and Hands on Testing


## Changelog


## Review requests


## Risk assessment

low-med