### PR TITLE
refactor(api): Delete obsolete todo comments

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -175,9 +175,6 @@ class LoadLabwareImplementation(
             display_name=params.displayName,
         )
 
-        # TODO(jbl 2023-06-23) these validation checks happen after the labware is loaded, because they rely on
-        #   on the definition. In practice this will not cause any issues since they will raise protocol ending
-        #   exception, but for correctness should be refactored to do this check beforehand.
         if isinstance(verified_location, OnLabwareLocation):
             self._state_view.labware.raise_if_labware_cannot_be_stacked(
                 top_labware_definition=loaded_labware.definition,

--- a/api/src/opentrons/protocol_engine/commands/load_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_lid.py
@@ -87,9 +87,6 @@ class LoadLidImplementation(
             labware_id=None,
         )
 
-        # TODO(chb 2024-12-12) these validation checks happen after the labware is loaded, because they rely on
-        #   on the definition. In practice this will not cause any issues since they will raise protocol ending
-        #   exception, but for correctness should be refactored to do this check beforehand.
         if not labware_validation.validate_definition_is_lid(loaded_labware.definition):
             raise LabwareCannotBeStackedError(
                 f"Labware {params.loadName} is not a Lid and cannot be loaded onto {self._state_view.labware.get_display_name(params.location.labwareId)}."


### PR DESCRIPTION
## Overview

Delete some todo comments in the `loadLabware` and `loadLid` Protocol Engine command implementations.

Emphasis mine:

> **these validation checks happen after the labware is loaded,** because they rely on the definition. In practice this will not cause any issues since they will raise protocol ending exception, but for correctness should be refactored to do this check beforehand.

As far as I can tell, this is not true. These checks happen inside Protocol Engine command implementations, which, architecturally, commit all their changes only at the very end, once they've completed without errors.

These comments may have been inherited from `opentrons.protocol_api`-level code, [which *does* still have this problem.](https://github.com/Opentrons/opentrons/blob/909c8468fbdebc4a0caaa865e3d6dd14e6c778bc/api/src/opentrons/protocol_api/core/engine/protocol.py#L243-L265) They may also have been inherited from older hacky Protocol Engine code that *did* directly modify state in the middle of a command, code that I believe and hope we've stamped out by now.

## Test Plan and Hands on Testing

None needed.

## Review requests

Am I correct, or is there something weird about these commands where they *do* modify Protocol Engine state before they complete?

## Risk assessment

No risk.
