### PR TITLE
refactor(api, shared-data): update command-schema make target to not require version

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -213,6 +213,6 @@ term:
 plot-session:
 	$(python) util/plot_session.py $(plot_type) $(plot_type).pdf
 
-PHONY: command-schema
+.PHONY: command-schema
 command-schema: 
-	$(python) src/opentrons/protocol_engine/commands/generate_command_schema.py $(COMMAND_SCHEMA_VERSION) > ../shared-data/command/schemas/$(COMMAND_SCHEMA_VERSION).json
+	$(python) src/opentrons/protocol_engine/commands/generate_command_schema.py --overwrite-shared-data

--- a/api/tests/opentrons/protocol_engine/commands/test_command_schema_snapshot.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_command_schema_snapshot.py
@@ -1,4 +1,4 @@
-"""Test that the command schema is in sync with it's source models."""
+"""Test that the command schema is in sync with its source models."""
 from opentrons_shared_data.command import load_schema_string, get_newest_schema_version
 from opentrons.protocol_engine.commands import generate_command_schema
 
@@ -10,7 +10,7 @@ If this change is accidental, undo the changes to our Python models.
 
 Or, if this change is intentional, update the shared JSON schema by running this from the monorepo root:
 
-    make -C api command-schema COMMAND_SCHEMA_VERSION=<version number>
+    make -C api command-schema
     make format
 
 ...and include the updated JSON schema file in your pull request.


### PR DESCRIPTION
# Overview

In response to the recent command schema issues with older schema versions having newer commands added, the `command-schema` Make target and corresponding `generate_command_schema.py` script have been updated as to not need a version be manually entered. Instead, the script will automatically detect the most recent command schema version in `shared-data` and automatically update and overwrite that command schema JSON file. This way, as long as a new command schema is made when a chore release branch is made, there is no opportunity for human error when updating the command schema.

In a probably unnecessary goal to preserve backwards compatibility with the script, you can still give a version as a positional argument and by default it will still print to standard out. The version will be automatically detected if you don't provided a positional argument, and the flag `--overwrite-shared-data` needs to be included for the file to be overwritten. This way, any outside source relying on this script will still function the same way.

## Test Plan and Hands on Testing

Changed some protocol engine commands and ensured that the new make target correctly modifies the most recent command schema

## Changelog

- Updated `generate_command_schema.py` to allow automatic detection of most recent command schema version and write to the JSON file in python
- Updated the Makefile target to use new argument and not need a version to be manually entered
- Fixed the `.PHONY` label missing the initial period

## Review requests

While the `generate_command_schema.py` maintains backwards compatibility, I've removed the ability to target a non-most recent version using `make command-schema`. You can still do this by calling the script manually, but if we want to keep that functionality from the make target please let your voice be heard.

## Risk assessment

Low, not touching any production code.