### PR TITLE
chore(js): Disable @typescript-eslint/consistent-indexed-object-style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     'import/no-default-export': 'error',
     '@typescript-eslint/promise-function-async': 'off',
     '@typescript-eslint/default-param-last': 'off',
+    '@typescript-eslint/consistent-indexed-object-style': 'off',
 
     // TODO(mc, 2021-01-29): fix these and remove warning overrides
     'lines-between-class-members': 'warn',


### PR DESCRIPTION
## Overview

This disables [this eslint warning](https://typescript-eslint.io/rules/consistent-indexed-object-style/).

It seems like a lot of our code makes the deliberate choice to use the `[key: string]: T` syntax, for readability. [Example 1](https://github.com/Opentrons/opentrons/blob/b5f11c7a9b4c165e3ee549e9d7333c184948ba6e/shared-data/protocol/types/schemaV8/index.ts#L40-L70), [example 2](https://github.com/Opentrons/opentrons/pull/17279#discussion_r1920787751). So it doesn't seem like this is going to change any time soon.

## Test Plan and Hands on Testing

Just CI.

## Review requests

Good idea or bad idea?

## Risk assessment

No risk.