### PR TITLE
feat(app,protocol-designer,shared-data): Allow JSON protocols to mix labware schemas

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -20,7 +20,7 @@ import type {
   CommandV8Mixin,
   CreateCommand,
   CutoutId,
-  LabwareV2Mixin,
+  LabwareMixin,
   LiquidV1Mixin,
   LoadLabwareCreateCommand,
   LoadPipetteCreateCommand,
@@ -222,8 +222,8 @@ export function createQuickTransferFile(
     return { ...acc, [entity.labwareDefURI]: entity.def }
   }, {})
 
-  const labwareV2Mixin: LabwareV2Mixin = {
-    labwareDefinitionSchemaId: 'opentronsLabwareSchemaV2',
+  const labwareMixin: LabwareMixin = {
+    labwareDefinitionSchemaId: '', // Deliberate empty string. See schema documentation.
     labwareDefinitions,
   }
 
@@ -244,7 +244,7 @@ export function createQuickTransferFile(
   const protocolContents = JSON.stringify({
     ...protocolBase,
     ...flexDeckSpec,
-    ...labwareV2Mixin,
+    ...labwareMixin,
     ...liquidV1Mixin,
     ...commandv8Mixin,
     ...commandAnnotionaV1Mixin,

--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -286,7 +286,7 @@
     "model": "OT-2 Standard",
     "deckId": "ot2_standard"
   },
-  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitionSchemaId": "",
   "labwareDefinitions": {
     "opentrons/opentrons_96_tiprack_300ul/1": {
       "ordering": [

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -315,7 +315,7 @@
     "model": "OT-2 Standard",
     "deckId": "ot2_standard"
   },
-  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitionSchemaId": "",
   "labwareDefinitions": {
     "opentrons/opentrons_96_tiprack_300ul/1": {
       "ordering": [

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -452,7 +452,7 @@
     "model": "OT-3 Standard",
     "deckId": "ot3_standard"
   },
-  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitionSchemaId": "",
   "labwareDefinitions": {
     "opentrons/opentrons_flex_96_filtertiprack_50ul/1": {
       "ordering": [

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -388,7 +388,7 @@
     "model": "OT-3 Standard",
     "deckId": "ot3_standard"
   },
-  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitionSchemaId": "",
   "labwareDefinitions": {
     "opentrons/opentrons_flex_96_tiprack_1000ul/1": {
       "ordering": [

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -257,7 +257,7 @@
     "model": "OT-2 Standard",
     "deckId": "ot2_standard"
   },
-  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitionSchemaId": "",
   "labwareDefinitions": {
     "opentrons/opentrons_96_tiprack_10ul/1": {
       "ordering": [

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -218,7 +218,7 @@
     "model": "OT-3 Standard",
     "deckId": "ot3_standard"
   },
-  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitionSchemaId": "",
   "labwareDefinitions": {
     "opentrons/opentrons_flex_96_tiprack_50ul/1": {
       "ordering": [

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -209,7 +209,7 @@
     "model": "OT-3 Standard",
     "deckId": "ot3_standard"
   },
-  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitionSchemaId": "",
   "labwareDefinitions": {
     "opentrons/opentrons_flex_96_tiprack_50ul/1": {
       "ordering": [

--- a/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
@@ -203,7 +203,7 @@
     "model": "OT-2 Standard",
     "deckId": "ot2_standard"
   },
-  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitionSchemaId": "",
   "labwareDefinitions": {
     "opentrons/opentrons_96_tiprack_20ul/1": {
       "ordering": [

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -44,7 +44,7 @@ import type {
   CommandAnnotationV1Mixin,
   CommandV8Mixin,
   CreateCommand,
-  LabwareV2Mixin,
+  LabwareMixin,
   LiquidV1Mixin,
   OT2RobotMixin,
   OT3RobotMixin,
@@ -233,8 +233,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
     const deckStructure =
       robotType === FLEX_ROBOT_TYPE ? flexDeckSpec : ot2DeckSpec
 
-    const labwareV2Mixin: LabwareV2Mixin = {
-      labwareDefinitionSchemaId: 'opentronsLabwareSchemaV2',
+    const labwareMixin: LabwareMixin = {
+      labwareDefinitionSchemaId: '', // Deliberate empty string. See schema documentation.
       labwareDefinitions,
     }
 
@@ -297,7 +297,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
     return {
       ...protocolBase,
       ...deckStructure,
-      ...labwareV2Mixin,
+      ...labwareMixin,
       ...liquidV1Mixin,
       ...commandv8Mixin,
       ...commandAnnotionaV1Mixin,

--- a/protocol-designer/src/load-file/migration/8_0_0.ts
+++ b/protocol-designer/src/load-file/migration/8_0_0.ts
@@ -15,7 +15,7 @@ import type {
   CommandAnnotationV1Mixin,
   CommandV8Mixin,
   CreateCommand as CreateCommandV8,
-  LabwareV2Mixin,
+  LabwareMixin,
   LiquidV1Mixin,
   LoadPipetteCreateCommand,
   OT2RobotMixin,
@@ -180,8 +180,8 @@ export const migrateFile = (
     },
   }
 
-  const labwareV2Mixin: LabwareV2Mixin = {
-    labwareDefinitionSchemaId: 'opentronsLabwareSchemaV2',
+  const labwareMixin: LabwareMixin = {
+    labwareDefinitionSchemaId: '', // Deliberate empty string. See schema documentation.
     labwareDefinitions: {
       ...appData.labwareDefinitions,
     },
@@ -205,7 +205,7 @@ export const migrateFile = (
   return {
     ...protocolBase,
     ...deckStructure,
-    ...labwareV2Mixin,
+    ...labwareMixin,
     ...liquidV1Mixin,
     ...commandv8Mixin,
     ...commandAnnotionaV1Mixin,

--- a/protocol-designer/src/load-file/migration/utils/getEquipmentLoadInfoFromCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getEquipmentLoadInfoFromCommands.ts
@@ -1,6 +1,7 @@
 import type {
   CreateCommand,
   LabwareDefinition2,
+  LabwareDefinition3,
   LoadLabwareCreateCommand,
   LoadModuleCreateCommand,
   LoadPipetteCreateCommand,
@@ -16,7 +17,7 @@ export interface EquipmentLoadInfoFromCommands {
 export const getEquipmentLoadInfoFromCommands = (
   commands: CreateCommand[],
   labwareDefinitions: {
-    [definitionId: string]: LabwareDefinition2
+    [definitionId: string]: LabwareDefinition2 | LabwareDefinition3
   }
 ): EquipmentLoadInfoFromCommands => {
   const loadPipetteCommands = commands.filter(

--- a/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
+++ b/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
@@ -1,5 +1,6 @@
 import type {
   LabwareDefinition2,
+  LabwareDefinition3,
   LoadLabwareCreateCommand,
 } from '@opentrons/shared-data'
 
@@ -7,7 +8,7 @@ import type { MoveLiquidPrefixType } from '../../../resources/types'
 
 export const getMigratedPositionFromTop = (
   labwareDefinitions: {
-    [definitionId: string]: LabwareDefinition2
+    [definitionId: string]: LabwareDefinition2 | LabwareDefinition3
   },
   loadLabwareCommands: LoadLabwareCreateCommand[],
   labware: string,

--- a/shared-data/js/__tests__/protocolValidation.test.ts
+++ b/shared-data/js/__tests__/protocolValidation.test.ts
@@ -32,12 +32,12 @@ describe('check that all fixtures can validate', () => {
     ...protocolFixtures7,
     ...protocolFixtures8,
   ]
-  protocolPaths.forEach(protocolPath =>
+  protocolPaths.forEach(protocolPath => {
     it(`${path.relative(relRoot, protocolPath)}`, () => {
       const protocol = require(protocolPath)
       return validate(protocol)
     })
-  )
+  })
 })
 
 describe('test that mutating v8 fixtures causes failure', () => {

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -6,6 +6,7 @@ import standardFlexDeckDef from '../../deck/definitions/5/ot3_standard.json'
 import type {
   DeckDefinition,
   LabwareDefinition2,
+  LabwareDefinition3,
   ModuleModel,
   RobotType,
   ThermalAdapterName,
@@ -41,10 +42,13 @@ export * from './formatRunTimeParameterMinMax'
 export * from './orderRuntimeParameterRangeOptions'
 export * from './sortRunTimeParameters'
 
-export const getLabwareDefIsStandard = (def: LabwareDefinition2): boolean =>
-  def?.namespace === OPENTRONS_LABWARE_NAMESPACE
+export const getLabwareDefIsStandard = (
+  def: LabwareDefinition2 | LabwareDefinition3
+): boolean => def?.namespace === OPENTRONS_LABWARE_NAMESPACE
 
-export const getLabwareDefURI = (def: LabwareDefinition2): string =>
+export const getLabwareDefURI = (
+  def: LabwareDefinition2 | LabwareDefinition3
+): string =>
   constructLabwareDefURI(
     def.namespace,
     def.parameters.loadName,
@@ -78,7 +82,7 @@ export const RETIRED_LABWARE = [
 ]
 
 export const getLabwareDisplayName = (
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition2 | LabwareDefinition3
 ): string => {
   const { displayName } = labwareDef.metadata
 
@@ -92,7 +96,9 @@ export const getLabwareDisplayName = (
   return displayName
 }
 
-export const getTiprackVolume = (labwareDef: LabwareDefinition2): number => {
+export const getTiprackVolume = (
+  labwareDef: LabwareDefinition2 | LabwareDefinition3
+): number => {
   console.assert(
     labwareDef.parameters.isTiprack,
     `getTiprackVolume expected a tiprack labware ${getLabwareDefURI(
@@ -109,7 +115,7 @@ export const getTiprackVolume = (labwareDef: LabwareDefinition2): number => {
 }
 
 export function getLabwareHasQuirk(
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition2 | LabwareDefinition3,
   quirk: string
 ): boolean {
   const quirks = labwareDef.parameters.quirks
@@ -186,7 +192,7 @@ export function splitWellsOnColumn(sortedArray: string[]): string[][] {
 }
 
 export const getWellDepth = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition2 | LabwareDefinition3,
   well: string
 ): number => labwareDef.wells[well].depth
 
@@ -194,7 +200,7 @@ export const getWellDepth = (
 // Assumes all wells have same offset because multi-offset not yet supported.
 // TODO: Ian 2019-07-13 return {[string: well]: offset} to support multi-offset
 export const getWellsDepth = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition2 | LabwareDefinition3,
   wells: string[]
 ): number => {
   const offsets = wells.map(well => getWellDepth(labwareDef, well))
@@ -213,7 +219,7 @@ export const getWellsDepth = (
 }
 
 export const getWellDimension = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition2 | LabwareDefinition3,
   wells: string[],
   position: 'x' | 'y'
 ): number => {
@@ -322,7 +328,7 @@ export const getAreSlotsAdjacent = (
   getAreSlotsVerticallyAdjacent(slotNameA, slotNameB)
 
 export const getIsLabwareAboveHeight = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition2 | LabwareDefinition3,
   height: number
 ): boolean => labwareDef.dimensions.zDimension > height
 

--- a/shared-data/js/protocols.ts
+++ b/shared-data/js/protocols.ts
@@ -11,6 +11,7 @@ import commandSchema7 from '../command/schemas/7.json'
 import commandAnnotationSchema1 from '../commandAnnotation/schemas/1.json'
 import liquidSchema1 from '../liquid/schemas/1.json'
 import labwareSchema2 from '../labware/schemas/2.json'
+import labwareSchema3 from '../labware/schemas/3.json'
 
 import protocolSchema8 from '../protocol/schemas/8.json'
 import protocolSchema7 from '../protocol/schemas/7.json'
@@ -154,39 +155,21 @@ const validateLabware8 = (
   toValidate: ProtocolSchemas.ProtocolStructureV8
 ): Promise<ProtocolSchemas.ProtocolFileV8['labwareDefinitions']> =>
   new Promise((resolve, reject) => {
-    const requestedSchema = toValidate.labwareDefinitionSchemaId
-    switch (requestedSchema) {
-      case 'opentronsLabwareSchemaV2':
-        resolve(labwareSchema2)
-        break
-      default:
-        // eslint-disable-next-line prefer-promise-reject-errors
-        reject([
-          {
-            keyword: 'Invalid labware schema requested',
-            dataPath: requestedSchema,
-            schemaPath: '#/properties/labwareSchemaId',
-            params: { allowedValues: ['opentronsLabwareSchemaV2'] },
-          },
-        ])
+    const generatedSchema = {
+      type: 'object',
+      patternProperties: {
+        '.+': { anyOf: [labwareSchema2, labwareSchema3] },
+      },
     }
-  }).then(
-    schema =>
-      new Promise((resolve, reject) => {
-        const generatedSchema = {
-          type: 'object',
-          patternProperties: { '.+': schema },
-        }
-        const labwareAjv = new Ajv({ allErrors: true, jsonPointers: true })
-        const validateLabware = labwareAjv.compile(generatedSchema)
-        const ok = validateLabware(toValidate.labwareDefinitions)
-        if (ok == null || ok === false) {
-          // eslint-disable-next-line prefer-promise-reject-errors
-          reject(validateLabware.errors)
-        }
-        resolve(toValidate.labwareDefinitions)
-      })
-  )
+    const labwareAjv = new Ajv({ allErrors: true, jsonPointers: true })
+    const validateLabware = labwareAjv.compile(generatedSchema)
+    const ok = validateLabware(toValidate.labwareDefinitions)
+    if (ok == null || ok === false) {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      reject(validateLabware.errors)
+    }
+    resolve(toValidate.labwareDefinitions)
+  })
 
 const validate8 = (toValidate: any): Promise<ProtocolSchemas.ProtocolFileV8> =>
   new Promise<ProtocolSchemas.ProtocolStructureV8>((resolve, reject) => {

--- a/shared-data/protocol/fixtures/8/mixedLabwareSchemas.json
+++ b/shared-data/protocol/fixtures/8/mixedLabwareSchemas.json
@@ -1,0 +1,124 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Simple test protocol",
+    "author": "engineering <engineering@opentrons.com>",
+    "description": "A short test protocol",
+    "created": 1223131231,
+    "tags": ["unitTest"]
+  },
+  "robot": {
+    "model": "OT-3 Standard",
+    "deckId": "ot3_standard"
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {},
+  "labwareDefinitionSchemaId": "",
+  "labwareDefinitions": {
+    "labware-in-schema-2": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "reservoir",
+        "displayVolumeUnits": "mL",
+        "displayName": "Labware in Schema 2",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trough",
+        "isTiprack": false,
+        "loadName": "labware_in_schema_2",
+        "isMagneticModuleCompatible": false,
+        "quirks": []
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 77,
+          "x": 82.84,
+          "y": 53.56,
+          "z": 5
+        }
+      },
+      "brand": {
+        "brand": "Opentrons"
+      },
+      "groups": [
+        {
+          "wells": ["A1"],
+          "metadata": {}
+        }
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "labware-in-schema-3": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "reservoir",
+        "displayVolumeUnits": "mL",
+        "displayName": "Labware in Schema 3",
+        "tags": []
+      },
+      "schemaVersion": 3,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trough",
+        "isTiprack": false,
+        "loadName": "labware_in_schema_3",
+        "isMagneticModuleCompatible": false,
+        "quirks": []
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 77,
+          "x": 82.84,
+          "y": 53.56,
+          "z": 5
+        }
+      },
+      "brand": {
+        "brand": "Opentrons"
+      },
+      "groups": [
+        {
+          "wells": ["A1"],
+          "metadata": {}
+        }
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commands": [],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": []
+}

--- a/shared-data/protocol/schemas/8.json
+++ b/shared-data/protocol/schemas/8.json
@@ -111,7 +111,7 @@
     },
 
     "labwareDefinitionSchemaId": {
-      "description": "The schema to use for labware definitions.",
+      "description": "This should be the empty string, for historical reasons. This was formerly the labware schema version of the objects in `labwareDefinitions`, but that imposed an unnecessary restriction of using the same labware schema version for all labware. The schema version is now declared per-definition, inside the definition.",
       "type": "string"
     },
 

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -7,7 +7,11 @@ import type {
   RunTimeParameter,
 } from '../../../js'
 import type { CommandAnnotation } from '../../../commandAnnotation/types'
-import type { LabwareDefinition2, RobotType } from '../../../js/types'
+import type {
+  LabwareDefinition2,
+  LabwareDefinition3,
+  RobotType,
+} from '../../../js/types'
 import type { RunTimeCommand } from '../schemaV8'
 
 export * from '../../../command/types'
@@ -44,10 +48,10 @@ export interface LabwareStructure {
   }
 }
 
-export interface LabwareV2Mixin {
-  labwareDefinitionSchemaId: 'opentronsLabwareSchemaV2'
+export interface LabwareMixin {
+  labwareDefinitionSchemaId: string
   labwareDefinitions: {
-    [definitionId: string]: LabwareDefinition2
+    [definitionId: string]: LabwareDefinition2 | LabwareDefinition3
   }
 }
 
@@ -113,7 +117,7 @@ export type ProtocolFile<
   DesignerApplicationData = {}
 > = ProtocolBase<DesignerApplicationData> &
   (OT2RobotMixin | OT3RobotMixin) &
-  LabwareV2Mixin &
+  LabwareMixin &
   LiquidV1Mixin &
   (CommandV8Mixin | CommandV9Mixin) &
   CommandAnnotationV1Mixin

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
@@ -46,7 +46,7 @@ class ProtocolSchemaV8(BaseModel):
     robot: Robot
     liquidSchemaId: Literal["opentronsLiquidSchemaV1"]
     liquids: Dict[str, Liquid]
-    labwareDefinitionSchemaId: Literal["opentronsLabwareSchemaV2"]
+    labwareDefinitionSchemaId: str
     labwareDefinitions: Dict[str, LabwareDefinition]
     commandSchemaId: CommandSchemaId
     commands: List[Command]


### PR DESCRIPTION
## Overview

This allows JSON protocol files to contain a mixture of labware defined in labware schema 2 and labware defined in labware schema 3.

I think this is necessary because schemas 2 and 3 are mutually incompatible, and someone might want to use, for example, their existing schema-2 custom labware alongside our new schema-3 standard labware.

Closes EXEC-1236.

## Test Plan and Hands on Testing

So far, just CI.

## Changelog

Done:

* In the underlying JSON schema, basically deprecate the `labwareDefinitionSchemaId` property.

  It was already accepting arbitrary strings, and that hasn't changed. However, in the human-readable description, we now say that it should just contain the empty string (`""`), instead of a labware schema ID like `"opentronsLabwareSchemaV2"`.
* Protocol Designer now emits JSON protocols with `labwareDefinitionSchemaId` set to `""`.
* The on-device display's Quick Transfer code now emits JSON protocols with `labwareDefinitionSchemaId` set to `""`.
* Update TypeScript types to reflect that a protocol's `labware` contains `LabwareDefinition2 | LabwareDefinition3`, not just `LabwareDefinition2`.
* Update the JSON Schema validation code in shared-data to ignore `labwareDefinitionSchemaId`. Instead, it validates each labware individually into a `<labware schema 2> | <labware schema 3>` union.

Not done:

* No treatment needed for Python in this PR. Our Python parsing code has never relied on `labwareDefinitionSchemaId`. It already accepts labware schemas 2 and 3 (though it doesn't yet handle schema 3 fully correctly).
* Getting presentation-layer TypeScript code to correctly handle schema-3 labware—for example, rendering the wells in the correct place even though the location of the origin has changed—is out of scope for this PR.

## Review requests

* Fundamentally, does all of the above seem like a good idea, and is the `""` thing a good approach?
* I haven't worked with PD or Quick Transfer much, so I'm not aware of any gotchas. Is there anything in particular I need to manually test?
* See comments below.

## Risk assessment

Low?