### PR TITLE
fix(shared-data): Do not accept `"schemaVersion": 1` when parsing into a `LabwareDefinition2`

### DIFF
--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -484,8 +484,7 @@ class InnerWellGeometry(BaseModel):
 
 
 class LabwareDefinition2(BaseModel):
-    # todo(mm, 2025-02-18): Is it correct to accept schemaVersion==1 here?
-    schemaVersion: Literal[1, 2]
+    schemaVersion: Literal[2]
     version: Annotated[int, Field(ge=1)]
     namespace: Annotated[str, Field(pattern=SAFE_STRING_REGEX)]
     metadata: Metadata


### PR DESCRIPTION
## Overview

An easy follow-up from https://github.com/Opentrons/opentrons/pull/17563#discussion_r1965565503.

Our `LabwareDefinition2` Pydantic model accepted `schemaVersion: 1 | 2` instead of just the expected `schemaVersion: 2`.

Could a single Pydantic model theoretically represent both schemas? No—labware schemas 1 and 2 are fundamentally incompatible with each other. For example, here's schema 1:

https://github.com/Opentrons/opentrons/blob/87596c701aa97cb17dd6822aea592841cac45b14/shared-data/js/schema.ts#L15-L16

And here's schema 2:

https://github.com/Opentrons/opentrons/blob/87596c701aa97cb17dd6822aea592841cac45b14/shared-data/labware/schemas/2.json#L85-L98

## Test Plan and Hands on Testing

Just automated tests.

## Review requests

None.

## Risk assessment

Low. I don't see how schema 1 labware definitions would have *ever* successfully parsed into this model, so this shouldn't change anything.
