### PR TITLE
feat(api): show air gap volume in simulate log

### DIFF
--- a/api/src/opentrons/legacy_commands/commands.py
+++ b/api/src/opentrons/legacy_commands/commands.py
@@ -234,9 +234,25 @@ def touch_tip(instrument: InstrumentContext) -> command_types.TouchTipCommand:
     }
 
 
-def air_gap() -> command_types.AirGapCommand:
-    text = "Air gap"
-    return {"name": command_types.AIR_GAP, "payload": {"text": text}}
+def air_gap(
+    instrument: InstrumentContext,
+    volume: float | None,
+    height: float | None,
+) -> command_types.AirGapCommand:
+    text = (
+        "Air gap"
+        + (f" of {volume} uL" if volume is not None else "")
+        + (f" at height {height}" if height is not None else "")
+    )
+    return {
+        "name": command_types.AIR_GAP,
+        "payload": {
+            "instrument": instrument,
+            "volume": volume,
+            "height": height,
+            "text": text,
+        },
+    }
 
 
 def return_tip() -> command_types.ReturnTipCommand:

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -472,8 +472,9 @@ class TouchTipCommand(TypedDict):
     payload: TouchTipCommandPayload
 
 
-class AirGapCommandPayload(TextOnlyPayload):
-    pass
+class AirGapCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
+    volume: Union[float, None]
+    height: Union[float, None]
 
 
 class AirGapCommand(TypedDict):


### PR DESCRIPTION
# Overview

When `simulate`-ing a protocol, the logs just show this for an `AIR_GAP` command:
```
Air gap
Logs from this command:
INFO (publisher): command.AIR_GAP: 
```
 whereas the other commands have useful info. I want to see how much air we're aspirating for the air gap. After this change, the logs will look like this:
```
Air gap of 11.5 uL
Logs from this command:
INFO (publisher): command.AIR_GAP: instrument: Flex 1-Channel 50 µL on right mount, volume: 11.5, height: None
```

## Test Plan and Hands on Testing

I'm mainly relying on the CI tests. I did run `simulate` with this change and checked the output manually.

## Review requests

I am not too familiar with this part of the code.
- Why is the implementation of the simulate logger in `legacy_commands`? What does "legacy" refer to?
- I don't quite understand how arguments are passed to the functions in `legacy_commands/commands.py`. How was the code able to work when the function was declared as `def air_gap()` with no arguments before this change?

## Risk assessment

Medium? I don't know if there are consumers of the simulate log who expect the payload never to change.