### PR TITLE
feat(api): Add stacker fill, empy, set_stored_labware

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -1,4 +1,5 @@
 """Protocol API module implementation logic."""
+
 from __future__ import annotations
 
 from typing import Optional, List, Dict, Union
@@ -17,7 +18,7 @@ from opentrons.drivers.types import (
 )
 
 from opentrons.protocol_engine import commands as cmd
-from opentrons.protocol_engine.types import ABSMeasureMode
+from opentrons.protocol_engine.types import ABSMeasureMode, StackerFillEmptyStrategy
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
 from opentrons.protocol_engine.errors.exceptions import (
@@ -40,6 +41,7 @@ from ..module import (
     AbstractFlexStackerCore,
 )
 from .exceptions import InvalidMagnetEngageHeightError
+from . import load_labware_params
 
 
 # Valid wavelength range for absorbance reader
@@ -727,5 +729,88 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore):
         self._engine_client.execute_command(
             cmd.flex_stacker.StoreParams(
                 moduleId=self.module_id,
+            )
+        )
+
+    def fill(self, message: str, count: int | None) -> None:
+        """Pause the protocol to add more labware to the Flex Stacker's hopper."""
+        self._engine_client.execute_command(
+            cmd.flex_stacker.FillParams(
+                moduleId=self.module_id,
+                strategy=StackerFillEmptyStrategy.MANUAL_WITH_PAUSE,
+                message=message,
+                count=count,
+            )
+        )
+
+    def empty(self, message: str) -> None:
+        """Pause the protocol to remove labware from the Flex Stacker's hopper."""
+        self._engine_client.execute_command(
+            cmd.flex_stacker.EmptyParams(
+                moduleId=self.module_id,
+                strategy=StackerFillEmptyStrategy.MANUAL_WITH_PAUSE,
+                message=message,
+                count=0,
+            )
+        )
+
+    def set_stored_labware(
+        self,
+        main_load_name: str,
+        main_namespace: str | None,
+        main_version: int | None,
+        lid_load_name: str | None,
+        lid_namespace: str | None,
+        lid_version: int | None,
+        adapter_load_name: str | None,
+        adapter_namespace: str | None,
+        adapter_version: int | None,
+        count: int | None,
+    ) -> None:
+        """Configure the kind of labware that the stacker stores."""
+
+        custom_labware_params = (
+            self._engine_client.state.labware.find_custom_labware_load_params()
+        )
+
+        main_namespace, main_version = load_labware_params.resolve(
+            main_load_name, main_namespace, main_version, custom_labware_params
+        )
+        main_labware = cmd.flex_stacker.StackerStoredLabwareDetails(
+            loadName=main_load_name, namespace=main_namespace, version=main_version
+        )
+
+        lid_labware: cmd.flex_stacker.StackerStoredLabwareDetails | None = None
+
+        if lid_load_name:
+            lid_namespace, lid_version = load_labware_params.resolve(
+                lid_load_name, lid_namespace, lid_version, custom_labware_params
+            )
+            lid_labware = cmd.flex_stacker.StackerStoredLabwareDetails(
+                loadName=lid_load_name, namespace=lid_namespace, version=lid_version
+            )
+
+        adapter_labware: cmd.flex_stacker.StackerStoredLabwareDetails | None = None
+
+        if adapter_load_name:
+            adapter_namespace, adapter_version = load_labware_params.resolve(
+                adapter_load_name,
+                adapter_namespace,
+                adapter_version,
+                custom_labware_params,
+            )
+            adapter_labware = cmd.flex_stacker.StackerStoredLabwareDetails(
+                loadName=adapter_load_name,
+                namespace=adapter_namespace,
+                version=adapter_version,
+            )
+
+        self._engine_client.execute_command(
+            cmd.flex_stacker.SetStoredLabwareParams(
+                moduleId=self.module_id,
+                initialCount=count,
+                primaryLabware=main_labware,
+                lidLabware=lid_labware,
+                adapterLabware=adapter_labware,
             )
         )

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -1,4 +1,5 @@
 """Core module control interfaces."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -401,3 +402,27 @@ class AbstractFlexStackerCore(AbstractModuleCore):
     @abstractmethod
     def store(self) -> None:
         """Store a labware in the stacker hopper."""
+
+    @abstractmethod
+    def fill(self, message: str, count: int | None) -> None:
+        """Pause the protocol to allow for filling the stacker."""
+
+    @abstractmethod
+    def empty(self, message: str) -> None:
+        """Pause the protocol to allow for emptying the stacker."""
+
+    @abstractmethod
+    def set_stored_labware(
+        self,
+        main_load_name: str,
+        main_namespace: str | None,
+        main_version: int | None,
+        lid_load_name: str | None,
+        lid_namespace: str | None,
+        lid_version: int | None,
+        adapter_load_name: str | None,
+        adapter_namespace: str | None,
+        adapter_version: int | None,
+        count: int | None,
+    ) -> None:
+        """Configure the kind of labware that the stacker stores."""

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1188,3 +1188,78 @@ class FlexStackerContext(ModuleContext):
         """
         assert labware._core is not None
         self._core.store()
+
+    @requires_version(2, 23)
+    def set_stored_labware(
+        self,
+        load_name: str,
+        namespace: str | None = None,
+        version: int | None = None,
+        adapter: str | None = None,
+        lid: str | None = None,
+        count: int | None = None,
+    ) -> None:
+        """Configure what kind of labware the Flex Stacker will store.
+
+        :param str load_name: A string to use for looking up a labware definition.
+            You can find the ``load_name`` for any Opentrons-verified labware on the
+            `Labware Library <https://labware.opentrons.com>`__.
+        :param str namespace: The namespace that the labware definition belongs to.
+            If unspecified, the API will automatically search two namespaces:
+
+              - ``"opentrons"``, to load standard Opentrons labware definitions.
+              - ``"custom_beta"``, to load custom labware definitions created with the
+                `Custom Labware Creator <https://labware.opentrons.com/create>`__.
+
+            You might need to specify an explicit ``namespace`` if you have a custom
+            definition whose ``load_name`` is the same as an Opentrons-verified
+            definition, and you want to explicitly choose one or the other.
+        :param version: The version of the labware definition. You should normally
+            leave this unspecified to let ``load_labware()`` choose a version
+            automatically.
+        :param adapter: An adapter to load the labware on top of. Accepts the same
+            values as the ``load_name`` parameter of :py:meth:`.load_adapter`. The
+            adapter will use the same namespace as the labware, and the API will
+            choose the adapter's version automatically.
+        :param lid: A lid to load the on top of the main labware. Accepts the same
+            values as the ``load_name`` parameter of :py:meth:`.load_lid_stack`. The
+            lid will use the same namespace as the labware, and the API will
+            choose the lid's version automatically.
+        :param count: The number of labware that the Flex Stacker should start the protocol
+            storing. If not specified, this will be the maximum amount of this kind of
+            labware that the Flex Stacker is capable of storing.
+
+        """
+        self._core.set_stored_labware(
+            main_load_name=load_name,
+            main_namespace=namespace,
+            main_version=version,
+            lid_load_name=lid,
+            lid_namespace=namespace,
+            lid_version=version,
+            adapter_load_name=adapter,
+            adapter_namespace=namespace,
+            adapter_version=version,
+            count=count,
+        )
+
+    @requires_version(2, 23)
+    def fill(self, message: str, count: int | None = None) -> None:
+        """Pause the protocol to add more labware to the Flex Stacker.
+
+        :param message: A message to display in the Opentrons App to note what kind of labware to add.
+        :param count: The amount of labware the Flex Stacker should hold after this command is executed.
+                      If not specified, the Flex Stacker should be full after this command is executed.
+        """
+        self._core.fill(message, count)
+
+    @requires_version(2, 23)
+    def empty(self, message: str) -> None:
+        """Pause the protocol to remove labware from the Flex Stacker.
+
+        :param message: A message to display in the Opentrons App to note what should be removed from
+                        the Flex Stacker.
+        """
+        self._core.empty(
+            message,
+        )

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/__init__.py
@@ -30,6 +30,7 @@ from .set_stored_labware import (
     SetStoredLabwareResult,
     SetStoredLabware,
     SetStoredLabwareCreate,
+    StackerStoredLabwareDetails,
 )
 
 from .fill import FillCommandType, FillParams, FillResult, Fill, FillCreate
@@ -62,6 +63,7 @@ __all__ = [
     "SetStoredLabwareResult",
     "SetStoredLabware",
     "SetStoredLabwareCreate",
+    "StackerStoredLabwareDetails",
     # flexStacker/fill
     "FillCommandType",
     "FillParams",

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -87,6 +87,7 @@ from .exceptions import (
     LiquidClassRedefinitionError,
     OffsetLocationInvalidError,
     FlexStackerLabwarePoolNotYetDefinedError,
+    FlexStackerNotLogicallyEmptyError,
 )
 
 from .error_occurrence import ErrorOccurrence, ProtocolCommandFailedError
@@ -169,6 +170,7 @@ __all__ = [
     "NotSupportedOnRobotType",
     "OffsetLocationInvalidError",
     "FlexStackerLabwarePoolNotYetDefinedError",
+    "FlexStackerNotLogicallyEmptyError",
     # error occurrence models
     "ErrorOccurrence",
     "CommandNotAllowedError",

--- a/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
@@ -1,4 +1,8 @@
 """Tests for Flex Stacker Engine Core."""
+
+import inspect
+from unittest.mock import sentinel
+
 import pytest
 from decoy import Decoy
 
@@ -8,7 +12,9 @@ from opentrons.hardware_control.modules.types import (
     ModuleType,
 )
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_api.core.engine.module_core import FlexStackerCore
+from opentrons.protocol_api.core.engine import load_labware_params
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 
 SyncFlexStackerHardware = SynchronousAdapter[FlexStacker]
@@ -24,6 +30,15 @@ def mock_engine_client(decoy: Decoy) -> EngineClient:
 def mock_sync_module_hardware(decoy: Decoy) -> SyncFlexStackerHardware:
     """Get a mock synchronous module hardware."""
     return decoy.mock(name="SyncFlexStackerHardware")  # type: ignore[no-any-return]
+
+
+@pytest.fixture(autouse=True)
+def patch_mock_load_labware_params(
+    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mock out load_labware_params.py functions."""
+    for name, func in inspect.getmembers(load_labware_params, inspect.isfunction):
+        monkeypatch.setattr(load_labware_params, name, decoy.mock(func=func))
 
 
 @pytest.fixture
@@ -55,3 +70,103 @@ def test_create(
 
     assert result.module_id == "1234"
     assert result.MODULE_TYPE == ModuleType.FLEX_STACKER
+
+
+def test_set_stored_labware_all_elements(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: FlexStackerCore
+) -> None:
+    """It should gather labware into objects appropriately when specifying all of lid, labware, and adapter."""
+    decoy.when(
+        mock_engine_client.state.labware.find_custom_labware_load_params()
+    ).then_return(sentinel.custom_labware_load_params)
+    decoy.when(
+        load_labware_params.resolve(
+            "main-name", "main-namespace", 1, sentinel.custom_labware_load_params
+        )
+    ).then_return(("main-namespace-verified", 10))
+    decoy.when(
+        load_labware_params.resolve(
+            "adapter-name", "adapter-namespace", 2, sentinel.custom_labware_load_params
+        )
+    ).then_return(("adapter-namespace-verified", 20))
+    decoy.when(
+        load_labware_params.resolve(
+            "lid-name", "lid-namespace", 3, sentinel.custom_labware_load_params
+        )
+    ).then_return(("lid-namespace-verified", 30))
+
+    subject.set_stored_labware(
+        main_load_name="main-name",
+        main_namespace="main-namespace",
+        main_version=1,
+        lid_load_name="lid-name",
+        lid_namespace="lid-namespace",
+        lid_version=3,
+        adapter_load_name="adapter-name",
+        adapter_namespace="adapter-namespace",
+        adapter_version=2,
+        count=5,
+    )
+    decoy.verify(
+        mock_engine_client.execute_command(
+            cmd.flex_stacker.SetStoredLabwareParams(
+                moduleId="1234",
+                initialCount=5,
+                primaryLabware=cmd.flex_stacker.StackerStoredLabwareDetails(
+                    loadName="main-name",
+                    namespace="main-namespace-verified",
+                    version=10,
+                ),
+                lidLabware=cmd.flex_stacker.StackerStoredLabwareDetails(
+                    loadName="lid-name", namespace="lid-namespace-verified", version=30
+                ),
+                adapterLabware=cmd.flex_stacker.StackerStoredLabwareDetails(
+                    loadName="adapter-name",
+                    namespace="adapter-namespace-verified",
+                    version=20,
+                ),
+            )
+        )
+    )
+
+
+def test_set_stored_labware_only_checks_load_name_for_lid_and_adapter_valid(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: FlexStackerCore
+) -> None:
+    """It should specify lid and adapter if and only if their load names are specified."""
+    decoy.when(
+        mock_engine_client.state.labware.find_custom_labware_load_params()
+    ).then_return(sentinel.custom_labware_load_params)
+    decoy.when(
+        load_labware_params.resolve(
+            "main-name", "main-namespace", 1, sentinel.custom_labware_load_params
+        )
+    ).then_return(("main-namespace-verified", 10))
+
+    subject.set_stored_labware(
+        main_load_name="main-name",
+        main_namespace="main-namespace",
+        main_version=1,
+        lid_load_name=None,
+        lid_namespace="lid-namespace",
+        lid_version=3,
+        adapter_load_name=None,
+        adapter_namespace="adapter-namespace",
+        adapter_version=2,
+        count=5,
+    )
+    decoy.verify(
+        mock_engine_client.execute_command(
+            cmd.flex_stacker.SetStoredLabwareParams(
+                moduleId="1234",
+                initialCount=5,
+                primaryLabware=cmd.flex_stacker.StackerStoredLabwareDetails(
+                    loadName="main-name",
+                    namespace="main-namespace-verified",
+                    version=10,
+                ),
+                lidLabware=None,
+                adapterLabware=None,
+            )
+        )
+    )

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -1,4 +1,5 @@
 """Tests for Protocol API Flex Stacker contexts."""
+
 import pytest
 from decoy import Decoy
 
@@ -121,4 +122,41 @@ def test_load_labware_with_lid_to_hopper(
             lid="some-lid-name",
         ),
         times=1,
+    )
+
+
+def test_fill(
+    decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
+) -> None:
+    """It should pass args to the core."""
+    subject.fill("hello", 2)
+    decoy.verify(mock_core.fill("hello", 2))
+
+
+def test_empty(
+    decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
+) -> None:
+    """It should pass args to the core."""
+    subject.empty("goodbye")
+    decoy.verify(mock_core.empty("goodbye"))
+
+
+def test_set_stored_labware(
+    decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
+) -> None:
+    """It should route arguments appropriately."""
+    subject.set_stored_labware("load_name", "namespace", 1, "adapter", "lid", 2)
+    decoy.verify(
+        mock_core.set_stored_labware(
+            main_load_name="load_name",
+            main_namespace="namespace",
+            main_version=1,
+            lid_load_name="lid",
+            lid_namespace="namespace",
+            lid_version=1,
+            adapter_load_name="adapter",
+            adapter_namespace="namespace",
+            adapter_version=1,
+            count=2,
+        )
     )

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
@@ -1,0 +1,260 @@
+"""Test Flex Stacker set stored labware command implementation."""
+
+import pytest
+from decoy import Decoy
+from typing import Any, cast
+from unittest.mock import sentinel
+
+from opentrons.protocol_engine.state.update_types import (
+    StateUpdate,
+    FlexStackerStateUpdate,
+    FlexStackerPoolConstraint,
+)
+
+from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.state.module_substates import (
+    FlexStackerSubState,
+    FlexStackerId,
+)
+from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.flex_stacker.set_stored_labware import (
+    SetStoredLabwareImpl,
+    SetStoredLabwareParams,
+    SetStoredLabwareResult,
+    StackerStoredLabwareDetails,
+)
+
+from opentrons.protocol_engine.errors import (
+    FlexStackerNotLogicallyEmptyError,
+)
+
+
+@pytest.fixture
+def subject(state_view: StateView, equipment: EquipmentHandler) -> SetStoredLabwareImpl:
+    """A FillImpl for testing."""
+    return SetStoredLabwareImpl(state_view=state_view, equipment=equipment)
+
+
+@pytest.mark.parametrize(
+    "adapter_labware,lid_labware,pool_definition",
+    [
+        pytest.param(
+            StackerStoredLabwareDetails(
+                loadName="adapter-name", namespace="adapter-namespace", version=2
+            ),
+            StackerStoredLabwareDetails(
+                loadName="lid-name", namespace="lid-namespace", version=3
+            ),
+            FlexStackerPoolConstraint(
+                primary_definition=sentinel.primary_definition,
+                lid_definition=sentinel.lid_definition,
+                adapter_definition=sentinel.adapter_definition,
+            ),
+            id="all-specified",
+        ),
+        pytest.param(
+            None,
+            None,
+            FlexStackerPoolConstraint(
+                primary_definition=sentinel.primary_definition,
+                lid_definition=None,
+                adapter_definition=None,
+            ),
+            id="none-specified",
+        ),
+        pytest.param(
+            None,
+            StackerStoredLabwareDetails(
+                loadName="lid-name", namespace="lid-namespace", version=3
+            ),
+            FlexStackerPoolConstraint(
+                primary_definition=sentinel.primary_definition,
+                lid_definition=sentinel.lid_definition,
+                adapter_definition=None,
+            ),
+            id="lid-only",
+        ),
+        pytest.param(
+            StackerStoredLabwareDetails(
+                loadName="adapter-name", namespace="adapter-namespace", version=2
+            ),
+            None,
+            FlexStackerPoolConstraint(
+                primary_definition=sentinel.primary_definition,
+                lid_definition=None,
+                adapter_definition=sentinel.adapter_definition,
+            ),
+            id="adapter-only",
+        ),
+    ],
+)
+async def test_set_stored_labware_happypath(
+    adapter_labware: StackerStoredLabwareDetails | None,
+    lid_labware: StackerStoredLabwareDetails | None,
+    pool_definition: FlexStackerPoolConstraint,
+    decoy: Decoy,
+    subject: SetStoredLabwareImpl,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+) -> None:
+    """It should load all possible main/lid/adapter combos."""
+    module_id = "module-id"
+    lid_definition: Any = None
+    adapter_definition: Any = None
+    params = SetStoredLabwareParams(
+        moduleId=module_id,
+        primaryLabware=StackerStoredLabwareDetails(
+            loadName="main-name", namespace="main-namespace", version=1
+        ),
+        lidLabware=lid_labware,
+        adapterLabware=adapter_labware,
+        initialCount=3,
+    )
+    decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
+        FlexStackerSubState(
+            module_id=cast(FlexStackerId, module_id),
+            in_static_mode=False,
+            hopper_labware_ids=[],
+            pool_primary_definition=None,
+            pool_adapter_definition=None,
+            pool_lid_definition=None,
+            pool_count=0,
+        )
+    )
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="main-name",
+            namespace="main-namespace",
+            version=1,
+        )
+    ).then_return((sentinel.primary_definition, sentinel.unused))
+    if lid_labware:
+        decoy.when(
+            await equipment.load_definition_for_details(
+                load_name=lid_labware.loadName,
+                namespace=lid_labware.namespace,
+                version=lid_labware.version,
+            )
+        ).then_return((sentinel.lid_definition, sentinel.unused))
+        lid_definition = sentinel.lid_definition
+    if adapter_labware:
+        decoy.when(
+            await equipment.load_definition_for_details(
+                load_name=adapter_labware.loadName,
+                namespace=adapter_labware.namespace,
+                version=adapter_labware.version,
+            )
+        ).then_return((sentinel.adapter_definition, sentinel.unused))
+        adapter_definition = sentinel.adapter_definition
+    result = await subject.execute(params)
+    assert result == SuccessData(
+        public=SetStoredLabwareResult.model_construct(
+            primaryLabwareDefinition=sentinel.primary_definition,
+            lidLabwareDefinition=lid_definition,
+            adapterLabwareDefinition=adapter_definition,
+            count=3,
+        ),
+        state_update=StateUpdate(
+            flex_stacker_state_update=FlexStackerStateUpdate(
+                module_id=module_id, pool_constraint=pool_definition, pool_count=3
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "hopper_labware,pool_count", [([], 1), (["fake-id"], 0), (["fake-id"], 1)]
+)
+async def test_set_stored_labware_requires_empty_hopper(
+    hopper_labware: list[str],
+    pool_count: int,
+    decoy: Decoy,
+    state_view: StateView,
+    subject: SetStoredLabwareImpl,
+) -> None:
+    """It should fail if the hopper is not empty."""
+    module_id = "module-id"
+    decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
+        FlexStackerSubState(
+            module_id=cast(FlexStackerId, module_id),
+            in_static_mode=False,
+            hopper_labware_ids=hopper_labware,
+            pool_primary_definition=None,
+            pool_adapter_definition=None,
+            pool_lid_definition=None,
+            pool_count=pool_count,
+        )
+    )
+    with pytest.raises(FlexStackerNotLogicallyEmptyError):
+        await subject.execute(
+            SetStoredLabwareParams(
+                moduleId=module_id,
+                primaryLabware=StackerStoredLabwareDetails(
+                    loadName="main-name", namespace="main-namespace", version=1
+                ),
+                lidLabware=None,
+                adapterLabware=None,
+                initialCount=3,
+            )
+        )
+
+
+@pytest.mark.parametrize("input_count,output_count", [(None, 5), (2, 2), (6, 5)])
+async def test_set_stored_labware_limits_count(
+    input_count: int | None,
+    output_count: int,
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+    subject: SetStoredLabwareImpl,
+) -> None:
+    """It should default and limit the input count."""
+    module_id = "module-id"
+    params = SetStoredLabwareParams(
+        moduleId=module_id,
+        primaryLabware=StackerStoredLabwareDetails(
+            loadName="main-name", namespace="main-namespace", version=1
+        ),
+        lidLabware=None,
+        adapterLabware=None,
+        initialCount=input_count,
+    )
+    decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
+        FlexStackerSubState(
+            module_id=cast(FlexStackerId, module_id),
+            in_static_mode=False,
+            hopper_labware_ids=[],
+            pool_primary_definition=None,
+            pool_adapter_definition=None,
+            pool_lid_definition=None,
+            pool_count=0,
+        )
+    )
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="main-name",
+            namespace="main-namespace",
+            version=1,
+        )
+    ).then_return((sentinel.primary_definition, sentinel.unused))
+    result = await subject.execute(params)
+    assert result == SuccessData(
+        public=SetStoredLabwareResult.model_construct(
+            primaryLabwareDefinition=sentinel.primary_definition,
+            lidLabwareDefinition=None,
+            adapterLabwareDefinition=None,
+            count=output_count,
+        ),
+        state_update=StateUpdate(
+            flex_stacker_state_update=FlexStackerStateUpdate(
+                module_id=module_id,
+                pool_constraint=FlexStackerPoolConstraint(
+                    primary_definition=sentinel.primary_definition,
+                    lid_definition=None,
+                    adapter_definition=None,
+                ),
+                pool_count=output_count,
+            )
+        ),
+    )

--- a/shared-data/command/schemas/12.json
+++ b/shared-data/command/schemas/12.json
@@ -5007,10 +5007,18 @@
           "description": "The details of the adapter under the primary labware, if any."
         },
         "initialCount": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The number of labware that should be initially stored in the stacker. This number will be silently clamped to the maximum number of labware that will fit; do not rely on the parameter to know how many labware are in the stacker.",
-          "minimum": 0,
-          "title": "Initialcount",
-          "type": "integer"
+          "title": "Initialcount"
         },
         "lidLabware": {
           "anyOf": [
@@ -5034,7 +5042,7 @@
           "description": "The details of the primary labware (i.e. not the lid or adapter, if any) stored in the stacker."
         }
       },
-      "required": ["moduleId", "initialCount", "primaryLabware"],
+      "required": ["moduleId", "primaryLabware"],
       "title": "SetStoredLabwareParams",
       "type": "object"
     },


### PR DESCRIPTION
Add a protocol API binding for fill, empty, and set_stored_labware.
These functions are used to configure the stacker labware pool and to
empty or fill the hopper interactively while a protocol is paused.


Also, add tests and a slight defaulting change to the engine setStoredLabware command.

## testing
- [x] run a protocol and test that fill, empty, and set_stored_labware run

Closes EXEC-1217
Closes EXEC-1216