### PR TITLE
refactor(shared-data): Disallow empty labware geometries

### DIFF
--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_generic_2ml_screwcap/3.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_generic_2ml_screwcap/3.json
@@ -36,8 +36,7 @@
       "totalLiquidVolume": 2000,
       "x": 20.75,
       "y": 16.88,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "C1": {
       "shape": "circular",
@@ -46,8 +45,7 @@
       "totalLiquidVolume": 2000,
       "x": 20.75,
       "y": 34.13,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "B1": {
       "shape": "circular",
@@ -56,8 +54,7 @@
       "totalLiquidVolume": 2000,
       "x": 20.75,
       "y": 51.38,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "A1": {
       "shape": "circular",
@@ -66,8 +63,7 @@
       "totalLiquidVolume": 2000,
       "x": 20.75,
       "y": 68.63,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "D2": {
       "shape": "circular",
@@ -76,8 +72,7 @@
       "totalLiquidVolume": 2000,
       "x": 38,
       "y": 16.88,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "C2": {
       "shape": "circular",
@@ -86,8 +81,7 @@
       "totalLiquidVolume": 2000,
       "x": 38,
       "y": 34.13,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "B2": {
       "shape": "circular",
@@ -96,8 +90,7 @@
       "totalLiquidVolume": 2000,
       "x": 38,
       "y": 51.38,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "A2": {
       "shape": "circular",
@@ -106,8 +99,7 @@
       "totalLiquidVolume": 2000,
       "x": 38,
       "y": 68.63,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "D3": {
       "shape": "circular",
@@ -116,8 +108,7 @@
       "totalLiquidVolume": 2000,
       "x": 55.25,
       "y": 16.88,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "C3": {
       "shape": "circular",
@@ -126,8 +117,7 @@
       "totalLiquidVolume": 2000,
       "x": 55.25,
       "y": 34.13,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "B3": {
       "shape": "circular",
@@ -136,8 +126,7 @@
       "totalLiquidVolume": 2000,
       "x": 55.25,
       "y": 51.38,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "A3": {
       "shape": "circular",
@@ -146,8 +135,7 @@
       "totalLiquidVolume": 2000,
       "x": 55.25,
       "y": 68.63,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "D4": {
       "shape": "circular",
@@ -156,8 +144,7 @@
       "totalLiquidVolume": 2000,
       "x": 72.5,
       "y": 16.88,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "C4": {
       "shape": "circular",
@@ -166,8 +153,7 @@
       "totalLiquidVolume": 2000,
       "x": 72.5,
       "y": 34.13,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "B4": {
       "shape": "circular",
@@ -176,8 +162,7 @@
       "totalLiquidVolume": 2000,
       "x": 72.5,
       "y": 51.38,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "A4": {
       "shape": "circular",
@@ -186,8 +171,7 @@
       "totalLiquidVolume": 2000,
       "x": 72.5,
       "y": 68.63,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "D5": {
       "shape": "circular",
@@ -196,8 +180,7 @@
       "totalLiquidVolume": 2000,
       "x": 89.75,
       "y": 16.88,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "C5": {
       "shape": "circular",
@@ -206,8 +189,7 @@
       "totalLiquidVolume": 2000,
       "x": 89.75,
       "y": 34.13,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "B5": {
       "shape": "circular",
@@ -216,8 +198,7 @@
       "totalLiquidVolume": 2000,
       "x": 89.75,
       "y": 51.38,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "A5": {
       "shape": "circular",
@@ -226,8 +207,7 @@
       "totalLiquidVolume": 2000,
       "x": 89.75,
       "y": 68.63,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "D6": {
       "shape": "circular",
@@ -236,8 +216,7 @@
       "totalLiquidVolume": 2000,
       "x": 107,
       "y": 16.88,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "C6": {
       "shape": "circular",
@@ -246,8 +225,7 @@
       "totalLiquidVolume": 2000,
       "x": 107,
       "y": 34.13,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "B6": {
       "shape": "circular",
@@ -256,8 +234,7 @@
       "totalLiquidVolume": 2000,
       "x": 107,
       "y": 51.38,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     },
     "A6": {
       "shape": "circular",
@@ -266,8 +243,7 @@
       "totalLiquidVolume": 2000,
       "x": 107,
       "y": 68.63,
-      "z": 6.7,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.7
     }
   },
   "brand": {
@@ -321,11 +297,6 @@
     "x": 0,
     "y": 0,
     "z": 0
-  },
-  "innerLabwareGeometry": {
-    "conicalWell": {
-      "sections": []
-    }
   },
   "$otSharedSchema": "#/labware/schemas/3"
 }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap_acrylic/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap_acrylic/2.json
@@ -31,8 +31,7 @@
       "totalLiquidVolume": 2000,
       "x": 15.28,
       "y": 13.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "C1": {
       "depth": 38.58,
@@ -41,8 +40,7 @@
       "totalLiquidVolume": 2000,
       "x": 15.28,
       "y": 33.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "B1": {
       "depth": 38.58,
@@ -51,8 +49,7 @@
       "totalLiquidVolume": 2000,
       "x": 15.28,
       "y": 52.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "A1": {
       "depth": 38.58,
@@ -61,8 +58,7 @@
       "totalLiquidVolume": 2000,
       "x": 15.28,
       "y": 72.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "D2": {
       "depth": 38.58,
@@ -71,8 +67,7 @@
       "totalLiquidVolume": 2000,
       "x": 34.78,
       "y": 13.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "C2": {
       "depth": 38.58,
@@ -81,8 +76,7 @@
       "totalLiquidVolume": 2000,
       "x": 34.78,
       "y": 33.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "B2": {
       "depth": 38.58,
@@ -91,8 +85,7 @@
       "totalLiquidVolume": 2000,
       "x": 34.78,
       "y": 52.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "A2": {
       "depth": 38.58,
@@ -101,8 +94,7 @@
       "totalLiquidVolume": 2000,
       "x": 34.78,
       "y": 72.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "D3": {
       "depth": 38.58,
@@ -111,8 +103,7 @@
       "totalLiquidVolume": 2000,
       "x": 54.28,
       "y": 13.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "C3": {
       "depth": 38.58,
@@ -121,8 +112,7 @@
       "totalLiquidVolume": 2000,
       "x": 54.28,
       "y": 33.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "B3": {
       "depth": 38.58,
@@ -131,8 +121,7 @@
       "totalLiquidVolume": 2000,
       "x": 54.28,
       "y": 52.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "A3": {
       "depth": 38.58,
@@ -141,8 +130,7 @@
       "totalLiquidVolume": 2000,
       "x": 54.28,
       "y": 72.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "D4": {
       "depth": 38.58,
@@ -151,8 +139,7 @@
       "totalLiquidVolume": 2000,
       "x": 73.78,
       "y": 13.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "C4": {
       "depth": 38.58,
@@ -161,8 +148,7 @@
       "totalLiquidVolume": 2000,
       "x": 73.78,
       "y": 33.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "B4": {
       "depth": 38.58,
@@ -171,8 +157,7 @@
       "totalLiquidVolume": 2000,
       "x": 73.78,
       "y": 52.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "A4": {
       "depth": 38.58,
@@ -181,8 +166,7 @@
       "totalLiquidVolume": 2000,
       "x": 73.78,
       "y": 72.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "D5": {
       "depth": 38.58,
@@ -191,8 +175,7 @@
       "totalLiquidVolume": 2000,
       "x": 93.28,
       "y": 13.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "C5": {
       "depth": 38.58,
@@ -201,8 +184,7 @@
       "totalLiquidVolume": 2000,
       "x": 93.28,
       "y": 33.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "B5": {
       "depth": 38.58,
@@ -211,8 +193,7 @@
       "totalLiquidVolume": 2000,
       "x": 93.28,
       "y": 52.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "A5": {
       "depth": 38.58,
@@ -221,8 +202,7 @@
       "totalLiquidVolume": 2000,
       "x": 93.28,
       "y": 72.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "D6": {
       "depth": 38.58,
@@ -231,8 +211,7 @@
       "totalLiquidVolume": 2000,
       "x": 112.78,
       "y": 13.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "C6": {
       "depth": 38.58,
@@ -241,8 +220,7 @@
       "totalLiquidVolume": 2000,
       "x": 112.78,
       "y": 33.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "B6": {
       "depth": 38.58,
@@ -251,8 +229,7 @@
       "totalLiquidVolume": 2000,
       "x": 112.78,
       "y": 52.9,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     },
     "A6": {
       "depth": 38.58,
@@ -261,8 +238,7 @@
       "totalLiquidVolume": 2000,
       "x": 112.78,
       "y": 72.4,
-      "z": 13.42,
-      "geometryDefinitionId": "conicalWell"
+      "z": 13.42
     }
   },
   "parameters": {
@@ -329,11 +305,6 @@
     "x": 0,
     "y": 0,
     "z": 0
-  },
-  "innerLabwareGeometry": {
-    "conicalWell": {
-      "sections": []
-    }
   },
   "$otSharedSchema": "#/labware/schemas/3"
 }

--- a/shared-data/labware/definitions/3/opentrons_24_tuberack_generic_0.75ml_snapcap_acrylic/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_tuberack_generic_0.75ml_snapcap_acrylic/2.json
@@ -31,8 +31,7 @@
       "totalLiquidVolume": 750,
       "x": 16.76,
       "y": 11.94,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "C1": {
       "depth": 20,
@@ -41,8 +40,7 @@
       "totalLiquidVolume": 750,
       "x": 16.76,
       "y": 31.5,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "B1": {
       "depth": 20,
@@ -51,8 +49,7 @@
       "totalLiquidVolume": 750,
       "x": 16.76,
       "y": 51.06,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "A1": {
       "depth": 20,
@@ -61,8 +58,7 @@
       "totalLiquidVolume": 750,
       "x": 16.76,
       "y": 70.62,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "D2": {
       "depth": 20,
@@ -71,8 +67,7 @@
       "totalLiquidVolume": 750,
       "x": 36.32,
       "y": 11.94,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "C2": {
       "depth": 20,
@@ -81,8 +76,7 @@
       "totalLiquidVolume": 750,
       "x": 36.32,
       "y": 31.5,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "B2": {
       "depth": 20,
@@ -91,8 +85,7 @@
       "totalLiquidVolume": 750,
       "x": 36.32,
       "y": 51.06,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "A2": {
       "depth": 20,
@@ -101,8 +94,7 @@
       "totalLiquidVolume": 750,
       "x": 36.32,
       "y": 70.62,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "D3": {
       "depth": 20,
@@ -111,8 +103,7 @@
       "totalLiquidVolume": 750,
       "x": 55.88,
       "y": 11.94,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "C3": {
       "depth": 20,
@@ -121,8 +112,7 @@
       "totalLiquidVolume": 750,
       "x": 55.88,
       "y": 31.5,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "B3": {
       "depth": 20,
@@ -131,8 +121,7 @@
       "totalLiquidVolume": 750,
       "x": 55.88,
       "y": 51.06,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "A3": {
       "depth": 20,
@@ -141,8 +130,7 @@
       "totalLiquidVolume": 750,
       "x": 55.88,
       "y": 70.62,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "D4": {
       "depth": 20,
@@ -151,8 +139,7 @@
       "totalLiquidVolume": 750,
       "x": 75.44,
       "y": 11.94,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "C4": {
       "depth": 20,
@@ -161,8 +148,7 @@
       "totalLiquidVolume": 750,
       "x": 75.44,
       "y": 31.5,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "B4": {
       "depth": 20,
@@ -171,8 +157,7 @@
       "totalLiquidVolume": 750,
       "x": 75.44,
       "y": 51.06,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "A4": {
       "depth": 20,
@@ -181,8 +166,7 @@
       "totalLiquidVolume": 750,
       "x": 75.44,
       "y": 70.62,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "D5": {
       "depth": 20,
@@ -191,8 +175,7 @@
       "totalLiquidVolume": 750,
       "x": 95,
       "y": 11.94,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "C5": {
       "depth": 20,
@@ -201,8 +184,7 @@
       "totalLiquidVolume": 750,
       "x": 95,
       "y": 31.5,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "B5": {
       "depth": 20,
@@ -211,8 +193,7 @@
       "totalLiquidVolume": 750,
       "x": 95,
       "y": 51.06,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "A5": {
       "depth": 20,
@@ -221,8 +202,7 @@
       "totalLiquidVolume": 750,
       "x": 95,
       "y": 70.62,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "D6": {
       "depth": 20,
@@ -231,8 +211,7 @@
       "totalLiquidVolume": 750,
       "x": 114.56,
       "y": 11.94,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "C6": {
       "depth": 20,
@@ -241,8 +220,7 @@
       "totalLiquidVolume": 750,
       "x": 114.56,
       "y": 31.5,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "B6": {
       "depth": 20,
@@ -251,8 +229,7 @@
       "totalLiquidVolume": 750,
       "x": 114.56,
       "y": 51.06,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     },
     "A6": {
       "depth": 20,
@@ -261,8 +238,7 @@
       "totalLiquidVolume": 750,
       "x": 114.56,
       "y": 70.62,
-      "z": 35,
-      "geometryDefinitionId": "conicalWell"
+      "z": 35
     }
   },
   "parameters": {
@@ -318,11 +294,6 @@
     "x": 0,
     "y": 0,
     "z": 0
-  },
-  "innerLabwareGeometry": {
-    "conicalWell": {
-      "sections": []
-    }
   },
   "$otSharedSchema": "#/labware/schemas/3"
 }

--- a/shared-data/labware/definitions/3/opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/2.json
+++ b/shared-data/labware/definitions/3/opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/2.json
@@ -7,8 +7,7 @@
       "depth": 20.3,
       "x": 5,
       "y": 74.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "B1": {
       "totalLiquidVolume": 200,
@@ -17,8 +16,7 @@
       "depth": 20.3,
       "x": 5,
       "y": 65.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "C1": {
       "totalLiquidVolume": 200,
@@ -27,8 +25,7 @@
       "depth": 20.3,
       "x": 5,
       "y": 56.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "D1": {
       "totalLiquidVolume": 200,
@@ -37,8 +34,7 @@
       "depth": 20.3,
       "x": 5,
       "y": 47.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "E1": {
       "totalLiquidVolume": 200,
@@ -47,8 +43,7 @@
       "depth": 20.3,
       "x": 5,
       "y": 38.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "F1": {
       "totalLiquidVolume": 200,
@@ -57,8 +52,7 @@
       "depth": 20.3,
       "x": 5,
       "y": 29.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "G1": {
       "totalLiquidVolume": 200,
@@ -67,8 +61,7 @@
       "depth": 20.3,
       "x": 5,
       "y": 20.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "H1": {
       "totalLiquidVolume": 200,
@@ -77,8 +70,7 @@
       "depth": 20.3,
       "x": 5,
       "y": 11.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "A3": {
       "totalLiquidVolume": 2000,
@@ -87,8 +79,7 @@
       "depth": 42,
       "x": 15.13,
       "y": 72,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "B3": {
       "totalLiquidVolume": 2000,
@@ -97,8 +88,7 @@
       "depth": 42,
       "x": 15.13,
       "y": 52.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "C3": {
       "totalLiquidVolume": 2000,
@@ -107,8 +97,7 @@
       "depth": 42,
       "x": 15.13,
       "y": 33,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "D3": {
       "totalLiquidVolume": 2000,
@@ -117,8 +106,7 @@
       "depth": 42,
       "x": 15.13,
       "y": 13.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "A4": {
       "totalLiquidVolume": 2000,
@@ -127,8 +115,7 @@
       "depth": 42,
       "x": 34.63,
       "y": 72,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "B4": {
       "totalLiquidVolume": 2000,
@@ -137,8 +124,7 @@
       "depth": 42,
       "x": 34.63,
       "y": 52.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "C4": {
       "totalLiquidVolume": 2000,
@@ -147,8 +133,7 @@
       "depth": 42,
       "x": 34.63,
       "y": 33,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "D4": {
       "totalLiquidVolume": 2000,
@@ -157,8 +142,7 @@
       "depth": 42,
       "x": 34.63,
       "y": 13.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "A5": {
       "totalLiquidVolume": 2000,
@@ -167,8 +151,7 @@
       "depth": 42,
       "x": 54.13,
       "y": 72,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "B5": {
       "totalLiquidVolume": 2000,
@@ -177,8 +160,7 @@
       "depth": 42,
       "x": 54.13,
       "y": 52.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "C5": {
       "totalLiquidVolume": 2000,
@@ -187,8 +169,7 @@
       "depth": 42,
       "x": 54.13,
       "y": 33,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "D5": {
       "totalLiquidVolume": 2000,
@@ -197,8 +178,7 @@
       "depth": 42,
       "x": 54.13,
       "y": 13.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "A6": {
       "totalLiquidVolume": 2000,
@@ -207,8 +187,7 @@
       "depth": 42,
       "x": 73.63,
       "y": 72,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "B6": {
       "totalLiquidVolume": 2000,
@@ -217,8 +196,7 @@
       "depth": 42,
       "x": 73.63,
       "y": 52.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "C6": {
       "totalLiquidVolume": 2000,
@@ -227,8 +205,7 @@
       "depth": 42,
       "x": 73.63,
       "y": 33,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "D6": {
       "totalLiquidVolume": 2000,
@@ -237,8 +214,7 @@
       "depth": 42,
       "x": 73.63,
       "y": 13.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "A7": {
       "totalLiquidVolume": 2000,
@@ -247,8 +223,7 @@
       "depth": 42,
       "x": 93.13,
       "y": 72,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "B7": {
       "totalLiquidVolume": 2000,
@@ -257,8 +232,7 @@
       "depth": 42,
       "x": 93.13,
       "y": 52.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "C7": {
       "totalLiquidVolume": 2000,
@@ -267,8 +241,7 @@
       "depth": 42,
       "x": 93.13,
       "y": 33,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "D7": {
       "totalLiquidVolume": 2000,
@@ -277,8 +250,7 @@
       "depth": 42,
       "x": 93.13,
       "y": 13.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "A8": {
       "totalLiquidVolume": 2000,
@@ -287,8 +259,7 @@
       "depth": 42,
       "x": 112.63,
       "y": 72,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "B8": {
       "totalLiquidVolume": 2000,
@@ -297,8 +268,7 @@
       "depth": 42,
       "x": 112.63,
       "y": 52.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "C8": {
       "totalLiquidVolume": 2000,
@@ -307,8 +277,7 @@
       "depth": 42,
       "x": 112.63,
       "y": 33,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "D8": {
       "totalLiquidVolume": 2000,
@@ -317,8 +286,7 @@
       "depth": 42,
       "x": 112.63,
       "y": 13.5,
-      "z": 6.26,
-      "geometryDefinitionId": "conicalWell"
+      "z": 6.26
     },
     "A13": {
       "totalLiquidVolume": 200,
@@ -327,8 +295,7 @@
       "depth": 20.3,
       "x": 122.75,
       "y": 74.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "B13": {
       "totalLiquidVolume": 200,
@@ -337,8 +304,7 @@
       "depth": 20.3,
       "x": 122.75,
       "y": 65.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "C13": {
       "totalLiquidVolume": 200,
@@ -347,8 +313,7 @@
       "depth": 20.3,
       "x": 122.75,
       "y": 56.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "D13": {
       "totalLiquidVolume": 200,
@@ -357,8 +322,7 @@
       "depth": 20.3,
       "x": 122.75,
       "y": 47.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "E13": {
       "totalLiquidVolume": 200,
@@ -367,8 +331,7 @@
       "depth": 20.3,
       "x": 122.75,
       "y": 38.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "F13": {
       "totalLiquidVolume": 200,
@@ -377,8 +340,7 @@
       "depth": 20.3,
       "x": 122.75,
       "y": 29.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "G13": {
       "totalLiquidVolume": 200,
@@ -387,8 +349,7 @@
       "depth": 20.3,
       "x": 122.75,
       "y": 20.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     },
     "H13": {
       "totalLiquidVolume": 200,
@@ -397,8 +358,7 @@
       "depth": 20.3,
       "x": 122.75,
       "y": 11.25,
-      "z": 28.92,
-      "geometryDefinitionId": "conicalWell"
+      "z": 28.92
     }
   },
   "brand": {
@@ -517,11 +477,6 @@
     "x": 0,
     "y": 0,
     "z": 0
-  },
-  "innerLabwareGeometry": {
-    "conicalWell": {
-      "sections": []
-    }
   },
   "$otSharedSchema": "#/labware/schemas/3"
 }

--- a/shared-data/labware/definitions/3/opentrons_96_aluminumblock_generic_pcr_strip_200ul/3.json
+++ b/shared-data/labware/definitions/3/opentrons_96_aluminumblock_generic_pcr_strip_200ul/3.json
@@ -42,8 +42,7 @@
       "totalLiquidVolume": 200,
       "x": 14.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G1": {
       "shape": "circular",
@@ -52,8 +51,7 @@
       "totalLiquidVolume": 200,
       "x": 14.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F1": {
       "shape": "circular",
@@ -62,8 +60,7 @@
       "totalLiquidVolume": 200,
       "x": 14.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E1": {
       "shape": "circular",
@@ -72,8 +69,7 @@
       "totalLiquidVolume": 200,
       "x": 14.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D1": {
       "shape": "circular",
@@ -82,8 +78,7 @@
       "totalLiquidVolume": 200,
       "x": 14.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C1": {
       "shape": "circular",
@@ -92,8 +87,7 @@
       "totalLiquidVolume": 200,
       "x": 14.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B1": {
       "shape": "circular",
@@ -102,8 +96,7 @@
       "totalLiquidVolume": 200,
       "x": 14.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A1": {
       "shape": "circular",
@@ -112,8 +105,7 @@
       "totalLiquidVolume": 200,
       "x": 14.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H2": {
       "shape": "circular",
@@ -122,8 +114,7 @@
       "totalLiquidVolume": 200,
       "x": 23.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G2": {
       "shape": "circular",
@@ -132,8 +123,7 @@
       "totalLiquidVolume": 200,
       "x": 23.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F2": {
       "shape": "circular",
@@ -142,8 +132,7 @@
       "totalLiquidVolume": 200,
       "x": 23.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E2": {
       "shape": "circular",
@@ -152,8 +141,7 @@
       "totalLiquidVolume": 200,
       "x": 23.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D2": {
       "shape": "circular",
@@ -162,8 +150,7 @@
       "totalLiquidVolume": 200,
       "x": 23.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C2": {
       "shape": "circular",
@@ -172,8 +159,7 @@
       "totalLiquidVolume": 200,
       "x": 23.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B2": {
       "shape": "circular",
@@ -182,8 +168,7 @@
       "totalLiquidVolume": 200,
       "x": 23.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A2": {
       "shape": "circular",
@@ -192,8 +177,7 @@
       "totalLiquidVolume": 200,
       "x": 23.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H3": {
       "shape": "circular",
@@ -202,8 +186,7 @@
       "totalLiquidVolume": 200,
       "x": 32.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G3": {
       "shape": "circular",
@@ -212,8 +195,7 @@
       "totalLiquidVolume": 200,
       "x": 32.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F3": {
       "shape": "circular",
@@ -222,8 +204,7 @@
       "totalLiquidVolume": 200,
       "x": 32.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E3": {
       "shape": "circular",
@@ -232,8 +213,7 @@
       "totalLiquidVolume": 200,
       "x": 32.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D3": {
       "shape": "circular",
@@ -242,8 +222,7 @@
       "totalLiquidVolume": 200,
       "x": 32.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C3": {
       "shape": "circular",
@@ -252,8 +231,7 @@
       "totalLiquidVolume": 200,
       "x": 32.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B3": {
       "shape": "circular",
@@ -262,8 +240,7 @@
       "totalLiquidVolume": 200,
       "x": 32.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A3": {
       "shape": "circular",
@@ -272,8 +249,7 @@
       "totalLiquidVolume": 200,
       "x": 32.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H4": {
       "shape": "circular",
@@ -282,8 +258,7 @@
       "totalLiquidVolume": 200,
       "x": 41.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G4": {
       "shape": "circular",
@@ -292,8 +267,7 @@
       "totalLiquidVolume": 200,
       "x": 41.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F4": {
       "shape": "circular",
@@ -302,8 +276,7 @@
       "totalLiquidVolume": 200,
       "x": 41.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E4": {
       "shape": "circular",
@@ -312,8 +285,7 @@
       "totalLiquidVolume": 200,
       "x": 41.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D4": {
       "shape": "circular",
@@ -322,8 +294,7 @@
       "totalLiquidVolume": 200,
       "x": 41.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C4": {
       "shape": "circular",
@@ -332,8 +303,7 @@
       "totalLiquidVolume": 200,
       "x": 41.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B4": {
       "shape": "circular",
@@ -342,8 +312,7 @@
       "totalLiquidVolume": 200,
       "x": 41.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A4": {
       "shape": "circular",
@@ -352,8 +321,7 @@
       "totalLiquidVolume": 200,
       "x": 41.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H5": {
       "shape": "circular",
@@ -362,8 +330,7 @@
       "totalLiquidVolume": 200,
       "x": 50.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G5": {
       "shape": "circular",
@@ -372,8 +339,7 @@
       "totalLiquidVolume": 200,
       "x": 50.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F5": {
       "shape": "circular",
@@ -382,8 +348,7 @@
       "totalLiquidVolume": 200,
       "x": 50.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E5": {
       "shape": "circular",
@@ -392,8 +357,7 @@
       "totalLiquidVolume": 200,
       "x": 50.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D5": {
       "shape": "circular",
@@ -402,8 +366,7 @@
       "totalLiquidVolume": 200,
       "x": 50.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C5": {
       "shape": "circular",
@@ -412,8 +375,7 @@
       "totalLiquidVolume": 200,
       "x": 50.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B5": {
       "shape": "circular",
@@ -422,8 +384,7 @@
       "totalLiquidVolume": 200,
       "x": 50.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A5": {
       "shape": "circular",
@@ -432,8 +393,7 @@
       "totalLiquidVolume": 200,
       "x": 50.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H6": {
       "shape": "circular",
@@ -442,8 +402,7 @@
       "totalLiquidVolume": 200,
       "x": 59.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G6": {
       "shape": "circular",
@@ -452,8 +411,7 @@
       "totalLiquidVolume": 200,
       "x": 59.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F6": {
       "shape": "circular",
@@ -462,8 +420,7 @@
       "totalLiquidVolume": 200,
       "x": 59.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E6": {
       "shape": "circular",
@@ -472,8 +429,7 @@
       "totalLiquidVolume": 200,
       "x": 59.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D6": {
       "shape": "circular",
@@ -482,8 +438,7 @@
       "totalLiquidVolume": 200,
       "x": 59.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C6": {
       "shape": "circular",
@@ -492,8 +447,7 @@
       "totalLiquidVolume": 200,
       "x": 59.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B6": {
       "shape": "circular",
@@ -502,8 +456,7 @@
       "totalLiquidVolume": 200,
       "x": 59.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A6": {
       "shape": "circular",
@@ -512,8 +465,7 @@
       "totalLiquidVolume": 200,
       "x": 59.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H7": {
       "shape": "circular",
@@ -522,8 +474,7 @@
       "totalLiquidVolume": 200,
       "x": 68.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G7": {
       "shape": "circular",
@@ -532,8 +483,7 @@
       "totalLiquidVolume": 200,
       "x": 68.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F7": {
       "shape": "circular",
@@ -542,8 +492,7 @@
       "totalLiquidVolume": 200,
       "x": 68.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E7": {
       "shape": "circular",
@@ -552,8 +501,7 @@
       "totalLiquidVolume": 200,
       "x": 68.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D7": {
       "shape": "circular",
@@ -562,8 +510,7 @@
       "totalLiquidVolume": 200,
       "x": 68.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C7": {
       "shape": "circular",
@@ -572,8 +519,7 @@
       "totalLiquidVolume": 200,
       "x": 68.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B7": {
       "shape": "circular",
@@ -582,8 +528,7 @@
       "totalLiquidVolume": 200,
       "x": 68.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A7": {
       "shape": "circular",
@@ -592,8 +537,7 @@
       "totalLiquidVolume": 200,
       "x": 68.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H8": {
       "shape": "circular",
@@ -602,8 +546,7 @@
       "totalLiquidVolume": 200,
       "x": 77.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G8": {
       "shape": "circular",
@@ -612,8 +555,7 @@
       "totalLiquidVolume": 200,
       "x": 77.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F8": {
       "shape": "circular",
@@ -622,8 +564,7 @@
       "totalLiquidVolume": 200,
       "x": 77.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E8": {
       "shape": "circular",
@@ -632,8 +573,7 @@
       "totalLiquidVolume": 200,
       "x": 77.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D8": {
       "shape": "circular",
@@ -642,8 +582,7 @@
       "totalLiquidVolume": 200,
       "x": 77.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C8": {
       "shape": "circular",
@@ -652,8 +591,7 @@
       "totalLiquidVolume": 200,
       "x": 77.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B8": {
       "shape": "circular",
@@ -662,8 +600,7 @@
       "totalLiquidVolume": 200,
       "x": 77.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A8": {
       "shape": "circular",
@@ -672,8 +609,7 @@
       "totalLiquidVolume": 200,
       "x": 77.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H9": {
       "shape": "circular",
@@ -682,8 +618,7 @@
       "totalLiquidVolume": 200,
       "x": 86.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G9": {
       "shape": "circular",
@@ -692,8 +627,7 @@
       "totalLiquidVolume": 200,
       "x": 86.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F9": {
       "shape": "circular",
@@ -702,8 +636,7 @@
       "totalLiquidVolume": 200,
       "x": 86.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E9": {
       "shape": "circular",
@@ -712,8 +645,7 @@
       "totalLiquidVolume": 200,
       "x": 86.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D9": {
       "shape": "circular",
@@ -722,8 +654,7 @@
       "totalLiquidVolume": 200,
       "x": 86.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C9": {
       "shape": "circular",
@@ -732,8 +663,7 @@
       "totalLiquidVolume": 200,
       "x": 86.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B9": {
       "shape": "circular",
@@ -742,8 +672,7 @@
       "totalLiquidVolume": 200,
       "x": 86.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A9": {
       "shape": "circular",
@@ -752,8 +681,7 @@
       "totalLiquidVolume": 200,
       "x": 86.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H10": {
       "shape": "circular",
@@ -762,8 +690,7 @@
       "totalLiquidVolume": 200,
       "x": 95.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G10": {
       "shape": "circular",
@@ -772,8 +699,7 @@
       "totalLiquidVolume": 200,
       "x": 95.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F10": {
       "shape": "circular",
@@ -782,8 +708,7 @@
       "totalLiquidVolume": 200,
       "x": 95.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E10": {
       "shape": "circular",
@@ -792,8 +717,7 @@
       "totalLiquidVolume": 200,
       "x": 95.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D10": {
       "shape": "circular",
@@ -802,8 +726,7 @@
       "totalLiquidVolume": 200,
       "x": 95.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C10": {
       "shape": "circular",
@@ -812,8 +735,7 @@
       "totalLiquidVolume": 200,
       "x": 95.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B10": {
       "shape": "circular",
@@ -822,8 +744,7 @@
       "totalLiquidVolume": 200,
       "x": 95.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A10": {
       "shape": "circular",
@@ -832,8 +753,7 @@
       "totalLiquidVolume": 200,
       "x": 95.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H11": {
       "shape": "circular",
@@ -842,8 +762,7 @@
       "totalLiquidVolume": 200,
       "x": 104.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G11": {
       "shape": "circular",
@@ -852,8 +771,7 @@
       "totalLiquidVolume": 200,
       "x": 104.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F11": {
       "shape": "circular",
@@ -862,8 +780,7 @@
       "totalLiquidVolume": 200,
       "x": 104.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E11": {
       "shape": "circular",
@@ -872,8 +789,7 @@
       "totalLiquidVolume": 200,
       "x": 104.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D11": {
       "shape": "circular",
@@ -882,8 +798,7 @@
       "totalLiquidVolume": 200,
       "x": 104.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C11": {
       "shape": "circular",
@@ -892,8 +807,7 @@
       "totalLiquidVolume": 200,
       "x": 104.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B11": {
       "shape": "circular",
@@ -902,8 +816,7 @@
       "totalLiquidVolume": 200,
       "x": 104.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A11": {
       "shape": "circular",
@@ -912,8 +825,7 @@
       "totalLiquidVolume": 200,
       "x": 104.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "H12": {
       "shape": "circular",
@@ -922,8 +834,7 @@
       "totalLiquidVolume": 200,
       "x": 113.38,
       "y": 11.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "G12": {
       "shape": "circular",
@@ -932,8 +843,7 @@
       "totalLiquidVolume": 200,
       "x": 113.38,
       "y": 20.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "F12": {
       "shape": "circular",
@@ -942,8 +852,7 @@
       "totalLiquidVolume": 200,
       "x": 113.38,
       "y": 29.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "E12": {
       "shape": "circular",
@@ -952,8 +861,7 @@
       "totalLiquidVolume": 200,
       "x": 113.38,
       "y": 38.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "D12": {
       "shape": "circular",
@@ -962,8 +870,7 @@
       "totalLiquidVolume": 200,
       "x": 113.38,
       "y": 47.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "C12": {
       "shape": "circular",
@@ -972,8 +879,7 @@
       "totalLiquidVolume": 200,
       "x": 113.38,
       "y": 56.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "B12": {
       "shape": "circular",
@@ -982,8 +888,7 @@
       "totalLiquidVolume": 200,
       "x": 113.38,
       "y": 65.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     },
     "A12": {
       "shape": "circular",
@@ -992,8 +897,7 @@
       "totalLiquidVolume": 200,
       "x": 113.38,
       "y": 74.25,
-      "z": 5.31,
-      "geometryDefinitionId": "conicalWell"
+      "z": 5.31
     }
   },
   "brand": {
@@ -1119,11 +1023,6 @@
     "x": 0,
     "y": 0,
     "z": 0
-  },
-  "innerLabwareGeometry": {
-    "conicalWell": {
-      "sections": []
-    }
   },
   "$otSharedSchema": "#/labware/schemas/3"
 }

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -415,6 +415,7 @@
         "sections": {
           "description": "A list of all of the sections of the well that have a contiguous shape. Must be ordered from top (highest z) to bottom (lowest z).",
           "type": "array",
+          "minItems": 1,
           "items": {
             "oneOf": [
               {

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -480,7 +480,7 @@ WellSegment = Annotated[
 
 
 class InnerWellGeometry(BaseModel):
-    sections: list[WellSegment]
+    sections: Annotated[list[WellSegment], Field(min_length=1)]
 
 
 class LabwareDefinition2(BaseModel):


### PR DESCRIPTION
## Overview

In labware schema v3:

* A labware has wells (of course).
* A well can refer to a geometry definition, *if* we have detailed information about the shape of the well's interior.
* Each geometry definition has a list of vertically-stacked sections.

Some definitions were providing a well geometry, but with an empty list of sections. This was adding an edge case to the tests and production code. This PR forbids that, so geometries either need to have real data, or they need to be omitted.

## Test Plan and Hands on Testing

Just automated tests.

## Changelog

* In the JSON schema, require the `sections` array to have at least one element.
* In any labware definitions that were supplying an empty geometry, just delete the geometry.
    * Four of these are for "generic" labware. By definition, it doesn't seem like we could ever have detailed geometry info for these.
      * `definitions/3/opentrons_24_aluminumblock_generic_2ml_screwcap/3.json`
      * `definitions/3/opentrons_24_tuberack_generic_0.75ml_snapcap_acrylic/2.json`
      * `definitions/3/opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/2.json`
      * `definitions/3/opentrons_96_aluminumblock_generic_pcr_strip_200ul/3.json`
    * The remaining one is `definitions/3/opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap_acrylic/2.json`. This labware is very old, apparently [predating](https://docs.opentrons.com/v1/labware.html#deprecated-labware-load-names) the [4-in-1 tube rack set](https://opentrons.com/products/4-in-1-tube-rack-set). It [does not appear in Labware Library](https://github.com/Opentrons/opentrons/blob/469e03b12a23fbd4cd834437a7c6454348fbdc5a/shared-data/js/getLabware.ts#L19-L26) and does not have geometry measurements in the "LLD GEOMETRY LIBRARY" sheet. I think it's safe to say we're never going to care about getting good geometry info for it. I think it's questionable whether a schema 3 definition should exist for it at all, let alone one with `innerLabwareGeometry`.

## Review requests

Does my thinking in the changelog above sound correct?

## Risk assessment

Low.