### PR TITLE
fix(protocol-designer): fix whitescreen after deleting labware

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -114,7 +114,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       const mixLabwareDisplayName = labwareNicknamesById[mixLabwareId]
       const mixWellsDisplay = getWellsForStepSummary(
         mix_wells as string[],
-        flatten(labwareEntities[mixLabware].def.ordering)
+        flatten(labwareEntities[mixLabware]?.def.ordering)
       )
 
       stepSummaryContent = (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -137,8 +137,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         engageHeight,
         magnetAction,
       } = currentStep
+      const moduleModel = modules[magneticModuleId]?.model
       const magneticModuleDisplayName =
-        getModuleDisplayName(modules[magneticModuleId]?.model) ?? unknownModule
+        moduleModel != null ? getModuleDisplayName(moduleModel) : unknownModule
       stepSummaryContent =
         magnetAction === 'engage' ? (
           <StyledTrans
@@ -239,8 +240,11 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           )
           break
         case 'untilTemperature':
+          const moduleModel = modules[pauseModuleId]?.model
           const pauseModuleDisplayName =
-            getModuleDisplayName(modules[pauseModuleId]?.model) ?? unknownModule
+            modules[pauseModuleId]?.model != null
+              ? getModuleDisplayName(moduleModel)
+              : unknownModule
           stepSummaryContent = (
             <StyledTrans
               i18nKey="protocol_steps:pause.untilTemperature"
@@ -269,8 +273,11 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       } = currentStep
       const isSettingTemperature =
         setTemperature != null && JSON.parse(String(setTemperature ?? false))
+      const moduleModel = modules[tempModuleId]?.model
       const tempModuleDisplayName =
-        getModuleDisplayName(modules[tempModuleId]?.model) ?? unknownModule
+        moduleModel != null
+          ? getModuleDisplayName(modules[tempModuleId]?.model)
+          : unknownModule
       stepSummaryContent = isSettingTemperature ? (
         <StyledTrans
           i18nKey={'protocol_steps:temperature_module.active'}
@@ -291,7 +298,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       const labwareName = labwareNicknamesById[labware]
       let newLocationName = newLocation
       if (newLocation in modules) {
-        newLocationName = getModuleDisplayName(modules[newLocation]?.model)
+        newLocationName = getModuleDisplayName(modules[newLocation].model)
       } else if (newLocation in labwareEntities) {
         newLocationName = labwareNicknamesById[newLocation]
       } else if (newLocation === 'offDeck') {
@@ -378,9 +385,9 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         targetHeaterShakerTemperature,
         targetSpeed,
       } = currentStep
+      const moduleModel = modules[heaterShakerModuleId]?.model
       const moduleDisplayName =
-        getModuleDisplayName(modules[heaterShakerModuleId]?.model) ??
-        unknownModule
+        moduleModel != null ? getModuleDisplayName(moduleModel) : unknownModule
       stepSummaryContent = (
         <StepSummaryContainer>
           <StyledTrans

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepSummary.tsx
@@ -291,7 +291,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
       const labwareName = labwareNicknamesById[labware]
       let newLocationName = newLocation
       if (newLocation in modules) {
-        newLocationName = getModuleDisplayName(modules[newLocation].model)
+        newLocationName = getModuleDisplayName(modules[newLocation]?.model)
       } else if (newLocation in labwareEntities) {
         newLocationName = labwareNicknamesById[newLocation]
       } else if (newLocation === 'offDeck') {


### PR DESCRIPTION
# Overview

This PR fixes a whitescreen produced by the `StepSummary` component for mix steps whose target labware was deleted. There was a missing optional chaining when attempting to access the labware definition's ordering. If the labware entity is null, we should not check the definition.

TODO: confirm with design whether to show StepSummary at all if some data is missing

Closes RQA-3916
Closes AUTH-1377

## Test Plan and Hands on Testing

- create or upload a protocol that utilizes a mix step on a certain labware
- delete that labware and navigate back to timeline
- hover that mix step and verify that no whitescreen occurs

before:

https://github.com/user-attachments/assets/254901a6-e8d2-4c81-b8ff-10819fb3f742


after:

https://github.com/user-attachments/assets/41190b4e-8399-45b6-8bd8-dc8f32f1162c


## Changelog

- null check labware definition in mix case of StepSummary

## Review requests

- see test plan

## Risk assessment

low