### PR TITLE
fix(protocol-designer): prevent liquid handling steps if no compatible labware

### DIFF
--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -193,3 +193,5 @@ export const ABSORBANCE_READER_COLOR_BY_WAVELENGTH: Record<number, string> = {
   600: 'Orange',
   650: 'Red',
 }
+
+export const OFFDECK: 'offDeck' = 'offDeck'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -12,25 +12,91 @@ import {
 } from '@opentrons/shared-data'
 import { renderWithProviders } from '../../../../../__testing-utils__'
 import { i18n } from '../../../../../assets/localization'
-import { AddStepButton } from '../AddStepButton'
+import { OFFDECK } from '../../../../../constants'
 import { getEnableComment } from '../../../../../feature-flags/selectors'
+import {
+  getInitialRobotState,
+  getRobotStateTimeline,
+} from '../../../../../file-data/selectors'
 import {
   getCurrentFormIsPresaved,
   getInitialDeckSetup,
+  getLabwareEntities,
 } from '../../../../../step-forms/selectors'
 import { getIsMultiSelectMode } from '../../../../../ui/steps'
+import { AddStepButton } from '../AddStepButton'
+
+import type {
+  LabwareDefinition2,
+  LabwareParameters,
+} from '@opentrons/shared-data'
 
 import type { ComponentProps } from 'react'
+import type { LabwareEntity, RobotState } from '@opentrons/step-generation'
 
 vi.mock('../../../../../feature-flags/selectors')
-vi.mock('../../../../../ui/steps')
+vi.mock('../../../../../file-data/selectors')
 vi.mock('../../../../../step-forms/selectors')
+vi.mock('../../../../../ui/steps')
 
 const render = (props: ComponentProps<typeof AddStepButton>) => {
   return renderWithProviders(<AddStepButton {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
+
+const MOCK_TIPRACK_ID = 'mockTiprackId'
+const MOCK_TUBERACK_ID = 'mockTuberackId'
+const MOCK_TIPRACK_ENTITY = {
+  id: MOCK_TIPRACK_ID,
+  def: {
+    parameters: {
+      isTiprack: true,
+    } as LabwareParameters,
+  } as LabwareDefinition2,
+} as LabwareEntity
+const MOCK_TIPRACK_LABWARE = {
+  slot: 'C2',
+}
+const MOCK_TUBERACK_LABWARE_ONDECK = {
+  slot: 'C2',
+}
+const MOCK_TUBERACK_LABWARE_OFFDECK = {
+  slot: OFFDECK,
+}
+
+const MOCK_INITIAL_ROBOT_STATE = {
+  labware: {
+    [MOCK_TIPRACK_ID]: MOCK_TIPRACK_LABWARE,
+    [MOCK_TUBERACK_ID]: MOCK_TUBERACK_LABWARE_ONDECK,
+  },
+  modules: {},
+  pipettes: {
+    'a212ebf2-bbd7-4946-a0e7-894a55e730ce': {
+      mount: 'left',
+    },
+  },
+  liquidState: {
+    pipettes: {},
+    labware: {},
+    additionalEquipment: {},
+  },
+  tipState: {
+    pipettes: {},
+    tipracks: {},
+  },
+} as RobotState
+
+const MOCK_TUBERACK_ENTITY = {
+  labwareDefURI:
+    'opentrons/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical/1',
+  id: MOCK_TUBERACK_ID,
+  def: {
+    parameters: {
+      isTiprack: false,
+    } as LabwareParameters,
+  } as LabwareDefinition2,
+} as LabwareEntity
 
 describe('AddStepButton', () => {
   let props: ComponentProps<typeof AddStepButton>
@@ -77,6 +143,12 @@ describe('AddStepButton', () => {
       additionalEquipmentOnDeck: {},
       pipettes: {},
     })
+    vi.mocked(getRobotStateTimeline).mockReturnValue({ timeline: [] })
+    vi.mocked(getLabwareEntities).mockReturnValue({
+      [MOCK_TIPRACK_ID]: MOCK_TIPRACK_ENTITY,
+      [MOCK_TUBERACK_ID]: MOCK_TUBERACK_ENTITY,
+    })
+    vi.mocked(getInitialRobotState).mockReturnValue(MOCK_INITIAL_ROBOT_STATE)
   })
 
   it('renders add step button and clicking on it renders the overflow menu with all modules', () => {
@@ -97,5 +169,41 @@ describe('AddStepButton', () => {
     render(props)
     const text = screen.queryByText('Add Step')
     expect(text).toBeNull()
+  })
+
+  it('should not render liquid handling steps if no compatible labware is present in entities', () => {
+    vi.mocked(getLabwareEntities).mockReturnValue({
+      [MOCK_TIPRACK_ID]: MOCK_TIPRACK_ENTITY,
+    })
+    render(props)
+    fireEvent.click(screen.getByText('Add Step'))
+    screen.getByText('Comment')
+    expect(screen.queryByText('Transfer')).not.toBeInTheDocument()
+    expect(screen.queryByText('Mix')).not.toBeInTheDocument()
+    screen.getByText('Pause')
+    screen.getByText('Thermocycler')
+    screen.getByText('Heater-Shaker')
+    screen.getByText('Temperature')
+    screen.getByText('Magnet')
+  })
+
+  it('should not render liquid handling steps if no compatible labware on deck', () => {
+    vi.mocked(getInitialRobotState).mockReturnValue({
+      ...MOCK_INITIAL_ROBOT_STATE,
+      labware: {
+        ...MOCK_INITIAL_ROBOT_STATE.labware,
+        [MOCK_TUBERACK_ID]: MOCK_TUBERACK_LABWARE_OFFDECK,
+      },
+    })
+    render(props)
+    fireEvent.click(screen.getByText('Add Step'))
+    screen.getByText('Comment')
+    expect(screen.queryByText('Transfer')).not.toBeInTheDocument()
+    expect(screen.queryByText('Mix')).not.toBeInTheDocument()
+    screen.getByText('Pause')
+    screen.getByText('Thermocycler')
+    screen.getByText('Heater-Shaker')
+    screen.getByText('Temperature')
+    screen.getByText('Magnet')
   })
 })

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -21,6 +21,7 @@ import type {
   CutoutFixtureId,
   RobotType,
   SupportedTip,
+  LabwareDefinition2,
 } from '@opentrons/shared-data'
 import type { WellGroup } from '@opentrons/components'
 import type { BoundingRect, GenericRect } from '../collision-types'
@@ -129,10 +130,11 @@ export const getIsAdapter = (
   labwareEntities: LabwareEntities
 ): boolean => {
   if (labwareEntities[labwareId] == null) return false
-  return (
-    labwareEntities[labwareId].def.allowedRoles?.includes('adapter') ?? false
-  )
+  return getIsAdapterFromDef(labwareEntities[labwareId].def)
 }
+
+export const getIsAdapterFromDef = (labwareDef: LabwareDefinition2): boolean =>
+  labwareDef.allowedRoles?.includes('adapter') ?? false
 
 export const getStagingAreaSlots = (
   stagingAreas?: AdditionalEquipmentEntity[]


### PR DESCRIPTION
# Overview

This PR refines `AddStepButton`'s supported steps logic for mix and moveLiquid, by checking the presence of compatible labware during the creation of the step. These two liquid handling options should only be shown if:
1) the labware is on deck
2) the labware is not an adapter
3) the labware is not a tiprack

Closes RQA-3409

## Test Plan and Hands on Testing

#### Case 1 - labware available
- create or import a protocol whose final state includes liquid handling-compatible labware on deck
- verify that the add step button menu shows transfer and mix steps

#### Case 2 - labware unavailable
- delete or move all liquid handling-compatible labware off deck
- verify that the add step button menu does not show transfer and mix steps
- navigate to starting deck state, and add an adapter to the deck
- verify that the add step button menu still does not show transfer and mix steps
- navigate to starting deck state, and add a tiprack to the deck
- verify that the add step button menu still does not show transfer and mix steps

## Changelog

- update `AddStepButton` logic for enabled steps
- update util, constants, and tests

## Review requests

see test plan

## Risk assessment

low-medium. want to be sure we don't accidentally hide those two steps unintentionally