### PR TITLE
feat(protocol-designer, step-generation): add `prepareToAspirate`

### DIFF
--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -135,7 +135,8 @@ export const substepTimelineSingleChannel = (
         }
       } else if (
         command.commandType === 'dispenseInPlace' ||
-        command.commandType === 'aspirateInPlace'
+        command.commandType === 'aspirateInPlace' ||
+        command.commandType === 'airGapInPlace'
       ) {
         const { volume } = command.params
         const prevMoveToAddressableAreaCommand = getPreviousMoveToAddressableAreaCommand(
@@ -287,7 +288,8 @@ export const substepTimelineMultiChannel = (
         }
       } else if (
         command.commandType === 'dispenseInPlace' ||
-        command.commandType === 'aspirateInPlace'
+        command.commandType === 'aspirateInPlace' ||
+        command.commandType === 'airGapInPlace'
       ) {
         const { volume } = command.params
         const prevMoveToAddressableAreaCommand = getPreviousMoveToAddressableAreaCommand(

--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -11,6 +11,8 @@ import {
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import { getCutoutIdByAddressableArea } from '../utils'
+import { getPreviousMoveToAddressableAreaCommand } from './utils/getPreviousMoveToAddressableAreaCommand'
+
 import type { Channels } from '@opentrons/components'
 import type {
   AddressableAreaName,
@@ -136,32 +138,28 @@ export const substepTimelineSingleChannel = (
         command.commandType === 'aspirateInPlace'
       ) {
         const { volume } = command.params
-        const prevCommand =
-          'commands' in nextFrame ? nextFrame.commands[index - 1] : null
-
-        const moveToAddressableAreaCommand =
-          prevCommand?.commandType === 'moveToAddressableArea'
-            ? prevCommand
-            : null
-        if (moveToAddressableAreaCommand == null) {
+        const prevMoveToAddressableAreaCommand = getPreviousMoveToAddressableAreaCommand(
+          nextFrame
+        )
+        if (prevMoveToAddressableAreaCommand == null) {
           console.error(
             `expected to find moveToAddressableArea command assosciated with the ${command.commandType} but could not`
           )
         }
         const trashCutoutFixture =
-          moveToAddressableAreaCommand?.params.addressableAreaName ===
+          prevMoveToAddressableAreaCommand?.params.addressableAreaName ===
           'fixedTrash'
             ? 'fixedTrashSlot'
             : 'trashBinAdapter'
 
         const cutoutFixture = wasteChuteddressableAreaNamesPipette.includes(
-          moveToAddressableAreaCommand?.params.addressableAreaName ?? ''
+          prevMoveToAddressableAreaCommand?.params.addressableAreaName ?? ''
         )
           ? 'wasteChuteRightAdapterNoCover'
           : trashCutoutFixture
 
         const cutoutId = getCutoutIdByAddressableArea(
-          moveToAddressableAreaCommand?.params
+          prevMoveToAddressableAreaCommand?.params
             .addressableAreaName as AddressableAreaName,
           cutoutFixture,
           trashCutoutFixture === 'fixedTrashSlot'

--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -290,35 +290,31 @@ export const substepTimelineMultiChannel = (
         command.commandType === 'aspirateInPlace'
       ) {
         const { volume } = command.params
-        const prevCommand =
-          'commands' in nextFrame ? nextFrame.commands[index - 1] : null
-
-        const moveToAddressableAreaCommand =
-          prevCommand?.commandType === 'moveToAddressableArea'
-            ? prevCommand
-            : null
-        if (moveToAddressableAreaCommand == null) {
+        const prevMoveToAddressableAreaCommand = getPreviousMoveToAddressableAreaCommand(
+          nextFrame
+        )
+        if (prevMoveToAddressableAreaCommand == null) {
           console.error(
             `expected to find moveToAddressableArea command assosciated with the ${command.commandType} but could not`
           )
         }
         const trashCutoutFixture =
-          moveToAddressableAreaCommand?.params.addressableAreaName ===
+          prevMoveToAddressableAreaCommand?.params.addressableAreaName ===
           'fixedTrash'
             ? 'fixedTrashSlot'
             : 'trashBinAdapter'
 
         const cutoutFixture =
           wasteChuteddressableAreaNamesPipette.includes(
-            moveToAddressableAreaCommand?.params.addressableAreaName ?? ''
+            prevMoveToAddressableAreaCommand?.params.addressableAreaName ?? ''
           ) ||
-          moveToAddressableAreaCommand?.params.addressableAreaName ===
+          prevMoveToAddressableAreaCommand?.params.addressableAreaName ===
             '96ChannelWasteChute'
             ? 'wasteChuteRightAdapterNoCover'
             : trashCutoutFixture
 
         const cutoutId = getCutoutIdByAddressableArea(
-          moveToAddressableAreaCommand?.params
+          prevMoveToAddressableAreaCommand?.params
             .addressableAreaName as AddressableAreaName,
           cutoutFixture,
           trashCutoutFixture === 'fixedTrashSlot'

--- a/protocol-designer/src/steplist/test/getPreviousMoveToAddressableAreaCommand.test.ts
+++ b/protocol-designer/src/steplist/test/getPreviousMoveToAddressableAreaCommand.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { getPreviousMoveToAddressableAreaCommand } from '../utils/getPreviousMoveToAddressableAreaCommand'
+import type {
+  CreateCommand,
+  MoveToAddressableAreaCreateCommand,
+} from '@opentrons/shared-data'
+
+const PIPETTE_ID = 'mockPipetteId'
+const DUMMY_COMMANDS = [
+  {} as CreateCommand,
+  {} as CreateCommand,
+  {} as CreateCommand,
+  {} as CreateCommand,
+]
+const MOVE_TO_TRASH_BIN_COMMAND: MoveToAddressableAreaCreateCommand = {
+  commandType: 'moveToAddressableArea',
+  params: {
+    pipetteId: PIPETTE_ID,
+    addressableAreaName: 'movableTrashD1',
+    offset: { x: 0, y: 0, z: 0 },
+  },
+}
+const MOVE_TO_WASTE_CHUTE_COMMAND: MoveToAddressableAreaCreateCommand = {
+  commandType: 'moveToAddressableArea',
+  params: {
+    pipetteId: PIPETTE_ID,
+    addressableAreaName: '8ChannelWasteChute',
+    offset: { x: 0, y: 0, z: 0 },
+  },
+}
+const BASE_COMMANDS: CreateCommand[] = [
+  ...DUMMY_COMMANDS,
+  {
+    commandType: 'aspirateInPlace',
+    params: { pipetteId: PIPETTE_ID, volume: 10, flowRate: 100 },
+  },
+]
+
+describe('getPreviousMoveToAddressableAreaCommand', () => {
+  it('returns moveToAddressableAreaCommand if one previous exists', () => {
+    const frame = {
+      commands: [MOVE_TO_TRASH_BIN_COMMAND, ...BASE_COMMANDS],
+    }
+    expect(getPreviousMoveToAddressableAreaCommand(frame)).toEqual({
+      commandType: 'moveToAddressableArea',
+      params: {
+        pipetteId: PIPETTE_ID,
+        addressableAreaName: 'movableTrashD1',
+        offset: { x: 0, y: 0, z: 0 },
+      },
+    })
+  })
+
+  it('returns closest previous moveToAddressableAreaCommand if multiple exist', () => {
+    const frame = {
+      commands: [
+        MOVE_TO_TRASH_BIN_COMMAND,
+        MOVE_TO_WASTE_CHUTE_COMMAND,
+        ...BASE_COMMANDS,
+      ],
+    }
+    expect(getPreviousMoveToAddressableAreaCommand(frame)).toEqual({
+      commandType: 'moveToAddressableArea',
+      params: {
+        pipetteId: PIPETTE_ID,
+        addressableAreaName: '8ChannelWasteChute',
+        offset: { x: 0, y: 0, z: 0 },
+      },
+    })
+  })
+  it('returns null if no previous moveToAddressableAreaCommand exists', () => {
+    const frame = {
+      commands: BASE_COMMANDS,
+    }
+    expect(getPreviousMoveToAddressableAreaCommand(frame)).toEqual(null)
+  })
+})

--- a/protocol-designer/src/steplist/utils/getPreviousMoveToAddressableAreaCommand.ts
+++ b/protocol-designer/src/steplist/utils/getPreviousMoveToAddressableAreaCommand.ts
@@ -9,15 +9,13 @@ import type { CommandCreatorResult } from '@opentrons/step-generation'
 export const getPreviousMoveToAddressableAreaCommand = (
   frame: CommandCreatorResult
 ): MoveToAddressableAreaCreateCommand | null => {
-  let prevMoveToAddressableAreaCommand: MoveToAddressableAreaCreateCommand | null = null
   if ('commands' in frame) {
     for (let i = frame.commands.length - 1; i >= 0; i--) {
       const command = frame.commands[i]
       if (command.commandType === 'moveToAddressableArea') {
-        prevMoveToAddressableAreaCommand = command
-        break
+        return command
       }
     }
   }
-  return prevMoveToAddressableAreaCommand
+  return null
 }

--- a/protocol-designer/src/steplist/utils/getPreviousMoveToAddressableAreaCommand.ts
+++ b/protocol-designer/src/steplist/utils/getPreviousMoveToAddressableAreaCommand.ts
@@ -1,0 +1,23 @@
+import type { MoveToAddressableAreaCreateCommand } from '@opentrons/shared-data'
+import type { CommandCreatorResult } from '@opentrons/step-generation'
+
+/**
+ * finds and returns last moveToAddressableArea command if it exists
+ * @param {CommandCreatorResult} frame next frame from command creator
+ * @returns {MoveToAddressableAreaCreateCommand | null} previous moveToAddressableArea command
+ */
+export const getPreviousMoveToAddressableAreaCommand = (
+  frame: CommandCreatorResult
+): MoveToAddressableAreaCreateCommand | null => {
+  let prevMoveToAddressableAreaCommand: MoveToAddressableAreaCreateCommand | null = null
+  if ('commands' in frame) {
+    for (let i = frame.commands.length - 1; i >= 0; i--) {
+      const command = frame.commands[i]
+      if (command.commandType === 'moveToAddressableArea') {
+        prevMoveToAddressableAreaCommand = command
+        break
+      }
+    }
+  }
+  return prevMoveToAddressableAreaCommand
+}

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -247,6 +247,7 @@ export type BlowoutParams = FlowRateParams &
 export type TouchTipParams = PipetteAccessParams & WellLocationParam
 export type DropTipParams = PipetteAccessParams & DropTipWellLocationParam
 export type PickUpTipParams = TouchTipParams
+export type PrepareToAspirateParams = PipetteIdentityParams
 
 interface AddressableOffsetVector {
   x: number

--- a/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
@@ -3,7 +3,7 @@ import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 import { curryCommandCreator } from '../utils'
 import { movableTrashCommandsUtil } from '../utils/movableTrashCommandsUtil'
 import {
-  aspirateInPlace,
+  airGapInPlace,
   blowOutInPlace,
   dispenseInPlace,
   dropTipInPlace,
@@ -115,7 +115,7 @@ describe('movableTrashCommandsUtil', () => {
     expect(curryCommandCreator).toHaveBeenCalledWith(prepareToAspirate, {
       pipetteId: mockId,
     })
-    expect(curryCommandCreator).toHaveBeenCalledWith(aspirateInPlace, {
+    expect(curryCommandCreator).toHaveBeenCalledWith(airGapInPlace, {
       pipetteId: mockId,
       volume: 10,
       flowRate: 10,

--- a/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
@@ -9,6 +9,7 @@ import {
   dropTipInPlace,
   moveToAddressableArea,
   moveToAddressableAreaForDropTip,
+  prepareToAspirate,
 } from '../commandCreators/atomic'
 import type { PipetteEntities } from '../types'
 
@@ -111,6 +112,9 @@ describe('movableTrashCommandsUtil', () => {
       moveToAddressableArea,
       mockMoveToAddressableAreaParams
     )
+    expect(curryCommandCreator).toHaveBeenCalledWith(prepareToAspirate, {
+      pipetteId: mockId,
+    })
     expect(curryCommandCreator).toHaveBeenCalledWith(aspirateInPlace, {
       pipetteId: mockId,
       volume: 10,

--- a/step-generation/src/__tests__/prepareToAspirate.test.ts
+++ b/step-generation/src/__tests__/prepareToAspirate.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, it, expect } from 'vitest'
+import {
+  makeContext,
+  getRobotStateWithTipStandard,
+  getSuccessResult,
+} from '../fixtures'
+import { prepareToAspirate } from '../commandCreators/atomic'
+import type { PrepareToAspirateParams } from '@opentrons/shared-data'
+import type { RobotState, InvariantContext } from '../types'
+
+describe('prepareToAspirate', () => {
+  let invariantContext: InvariantContext
+  let robotStateWithTip: RobotState
+
+  const mockId = 'mockId'
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
+  })
+  it('aspirate in place', () => {
+    const params: PrepareToAspirateParams = {
+      pipetteId: mockId,
+    }
+    const result = prepareToAspirate(
+      params,
+      invariantContext,
+      robotStateWithTip
+    )
+    const res = getSuccessResult(result)
+    expect(res.commands).toEqual([
+      {
+        commandType: 'prepareToAspirate',
+        key: expect.any(String),
+        params: {
+          pipetteId: mockId,
+        },
+      },
+    ])
+  })
+})

--- a/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
@@ -5,7 +5,7 @@ import { curryCommandCreator } from '../utils'
 import { wasteChuteCommandsUtil } from '../utils/wasteChuteCommandsUtil'
 import type { PipetteEntities } from '../types'
 import {
-  aspirateInPlace,
+  airGapInPlace,
   blowOutInPlace,
   dispenseInPlace,
   dropTipInPlace,
@@ -114,7 +114,7 @@ describe('wasteChuteCommandsUtil', () => {
     expect(curryCommandCreator).toHaveBeenCalledWith(prepareToAspirate, {
       pipetteId: mockId,
     })
-    expect(curryCommandCreator).toHaveBeenCalledWith(aspirateInPlace, {
+    expect(curryCommandCreator).toHaveBeenCalledWith(airGapInPlace, {
       pipetteId: mockId,
       volume: 10,
       flowRate: 10,

--- a/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
@@ -10,6 +10,7 @@ import {
   dispenseInPlace,
   dropTipInPlace,
   moveToAddressableArea,
+  prepareToAspirate,
 } from '../commandCreators/atomic'
 
 vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
@@ -110,6 +111,9 @@ describe('wasteChuteCommandsUtil', () => {
       moveToAddressableArea,
       mockMoveToAddressableAreaParams
     )
+    expect(curryCommandCreator).toHaveBeenCalledWith(prepareToAspirate, {
+      pipetteId: mockId,
+    })
     expect(curryCommandCreator).toHaveBeenCalledWith(aspirateInPlace, {
       pipetteId: mockId,
       volume: 10,

--- a/step-generation/src/commandCreators/atomic/index.ts
+++ b/step-generation/src/commandCreators/atomic/index.ts
@@ -23,6 +23,7 @@ import { moveToAddressableArea } from './moveToAddressableArea'
 import { moveToAddressableAreaForDropTip } from './moveToAddressableAreaForDropTip'
 import { moveToWell } from './moveToWell'
 import { pickUpTip } from './pickUpTip'
+import { prepareToAspirate } from './prepareToAspirate'
 import { setTemperature } from './setTemperature'
 import { touchTip } from './touchTip'
 import { waitForTemperature } from './waitForTemperature'
@@ -53,6 +54,7 @@ export {
   moveToAddressableAreaForDropTip,
   moveToWell,
   pickUpTip,
+  prepareToAspirate,
   setTemperature,
   touchTip,
   waitForTemperature,

--- a/step-generation/src/commandCreators/atomic/prepareToAspirate.ts
+++ b/step-generation/src/commandCreators/atomic/prepareToAspirate.ts
@@ -1,0 +1,20 @@
+import { uuid } from '../../utils'
+import type { CommandCreator } from '../../types'
+import type { PrepareToAspirateParams } from '@opentrons/shared-data'
+
+export const prepareToAspirate: CommandCreator<PrepareToAspirateParams> = args => {
+  const { pipetteId } = args
+
+  const commands = [
+    {
+      commandType: 'prepareToAspirate' as const,
+      key: uuid(),
+      params: {
+        pipetteId,
+      },
+    },
+  ]
+  return {
+    commands,
+  }
+}

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -123,6 +123,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'custom': // fall-back
     case 'comment':
     case 'airGapInPlace':
+    case 'prepareToAspirate':
       break
 
     case 'loadLiquid':

--- a/step-generation/src/utils/movableTrashCommandsUtil.ts
+++ b/step-generation/src/utils/movableTrashCommandsUtil.ts
@@ -4,12 +4,13 @@ import {
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import {
-  aspirateInPlace,
+  airGapInPlace,
   blowOutInPlace,
   dispenseInPlace,
   dropTipInPlace,
   moveToAddressableArea,
   moveToAddressableAreaForDropTip,
+  prepareToAspirate,
 } from '../commandCreators/atomic'
 import { ZERO_OFFSET } from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
@@ -93,7 +94,10 @@ export const movableTrashCommandsUtil = (
                   addressableAreaName,
                   offset,
                 }),
-                curryCommandCreator(aspirateInPlace, {
+                curryCommandCreator(prepareToAspirate, {
+                  pipetteId,
+                }),
+                curryCommandCreator(airGapInPlace, {
                   pipetteId,
                   volume,
                   flowRate,

--- a/step-generation/src/utils/wasteChuteCommandsUtil.ts
+++ b/step-generation/src/utils/wasteChuteCommandsUtil.ts
@@ -1,9 +1,10 @@
 import {
-  aspirateInPlace,
+  airGapInPlace,
   blowOutInPlace,
   dispenseInPlace,
   dropTipInPlace,
   moveToAddressableArea,
+  prepareToAspirate,
 } from '../commandCreators/atomic'
 import { ZERO_OFFSET } from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
@@ -99,7 +100,10 @@ export const wasteChuteCommandsUtil = (
                 addressableAreaName,
                 offset,
               }),
-              curryCommandCreator(aspirateInPlace, {
+              curryCommandCreator(prepareToAspirate, {
+                pipetteId,
+              }),
+              curryCommandCreator(airGapInPlace, {
                 pipetteId,
                 flowRate,
                 volume,


### PR DESCRIPTION
# Overview

Here, I introduce and wire up the `prepareToAspirate` atomic command in step generation. This command is necessary for our in place commands: `airGapInPlace` and `aspirateInPlace`, which are curried  when implementing air gap at a trash bin or waste chute addressable area.

Implicated by this introduction of `prepareToAspirate` between `moveToAddressableArea` and `airGapInPlace` are is `protocol-designer/src/steplist/substepTimeline.ts`. Previously, we gleaned information from accessing the `moveToAddressableArea` command preceding the inPlace command, presuming it was the direct preceding command. Now, those commands are separated by a `prepareToAspirate` command, so I introduce a utility to get the most recent `moveToAddressableArea` command relatvie to the inPlace command, and wire up in `substepTimeline.ts`

Note that `prepareToAspirate` does not affect robot state.

Closes RQA-3968

## Test Plan and Hands on Testing

- create or import a protocol that uses a single-channel pipette to dispense to the trash or waste chute, ensuring a post-dispense blowout and air gap is configured.
- verify that the protocol emits 3 commands following this dispense: 1) moveToAddressableArea (trash entity) 2) prepareToAspirate, 3) airGapInPlace
- repeat with 8/96-channel pipettes

## Changelog

- introduce and wire up `prepareToAspirate` atomic command in step generation
- fix logic for getting previous `moveToAddressableArea` command for inPlace commands

## Review requests

see test plan

## Risk assessment

medium. touches step generation commands