### PR TITLE
fix(protocol-designer, shared-data): update command schema to v10

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -2521,7 +2521,7 @@
       "displayColor": "#b925ff"
     }
   },
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "5eb673b3-81d8-47d4-8e0e-b4b82ada5a02",

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -2631,7 +2631,7 @@
       "displayColor": "#b925ff"
     }
   },
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "4863af21-c51a-4773-836e-69d2b5e37260",

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -3859,7 +3859,7 @@
       "displayColor": "#ffd600"
     }
   },
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "eea399e6-ccb5-4c81-9434-806b4694d527",

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -3419,7 +3419,7 @@
       "displayColor": "#ffd600"
     }
   },
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "613fa8b3-d474-4588-ac4d-a9a2919258d6",

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -3341,7 +3341,7 @@
     },
     "1": { "displayName": "dna", "description": "", "displayColor": "#ffd600" }
   },
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "f9ad5d77-d29a-420b-bd45-fe1d86b6cceb",

--- a/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
+++ b/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
@@ -2126,7 +2126,7 @@
   },
   "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {},
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "d66aa1db-df76-492d-ab2c-533b982522aa",

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -3583,7 +3583,7 @@
   },
   "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {},
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "5d17baa4-7738-4f3f-a33d-d4401cef44e7",

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -2242,7 +2242,7 @@
   },
   "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {},
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "1370b9a4-1e65-4203-9106-896db3db3bd3",

--- a/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
@@ -2193,7 +2193,7 @@
   "liquids": {
     "0": { "displayName": "123", "description": "", "displayColor": "#b925ff" }
   },
-  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
       "key": "b0cb75c2-d745-44fc-9132-d0614153db4f",

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -41,7 +41,7 @@ import type {
   LabwareLocation,
   AddressableAreaName,
   CommandAnnotationV1Mixin,
-  CommandV8Mixin,
+  CommandV10Mixin,
   CreateCommand,
   LabwareV2Mixin,
   LiquidV1Mixin,
@@ -380,8 +380,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       liquids,
     }
 
-    const commandv8Mixin: CommandV8Mixin = {
-      commandSchemaId: 'opentronsCommandSchemaV8',
+    const commandv10Mixin: CommandV10Mixin = {
+      commandSchemaId: 'opentronsCommandSchemaV10',
       commands,
     }
 
@@ -436,7 +436,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       ...deckStructure,
       ...labwareV2Mixin,
       ...liquidV1Mixin,
-      ...commandv8Mixin,
+      ...commandv10Mixin,
       ...commandAnnotionaV1Mixin,
     }
   }

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -27,6 +27,11 @@ export interface CommandV9Mixin {
   commands: CreateCommand[]
 }
 
+export interface CommandV10Mixin {
+  commandSchemaId: 'opentronsCommandSchemaV10'
+  commands: CreateCommand[]
+}
+
 export interface CommandAnnotationsStructure {
   commandAnnotationSchemaId: string
   commandAnnotations: any[]
@@ -115,7 +120,7 @@ export type ProtocolFile<
   (OT2RobotMixin | OT3RobotMixin) &
   LabwareV2Mixin &
   LiquidV1Mixin &
-  (CommandV8Mixin | CommandV9Mixin) &
+  (CommandV8Mixin | CommandV9Mixin | CommandV10Mixin) &
   CommandAnnotationV1Mixin
 
 export type ProtocolStructure = ProtocolBase<{}> &


### PR DESCRIPTION
# Overview

As an oversight, PD 8.4.0 maintained exporting protocols with command schema v8. This PR updates the command schema to v10.

## Test Plan and Hands on Testing

- ensure exporting a protocol on this branch produces command schema v10

## Changelog

- update command schema to v10
- update fixtures

## Review requests

see test plan

## Risk assessment

lowish