### PR TITLE
feat(protocol-designer): emit Python for aspirate command

### DIFF
--- a/step-generation/src/__tests__/aspirate.test.ts
+++ b/step-generation/src/__tests__/aspirate.test.ts
@@ -98,6 +98,14 @@ describe('aspirate', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      `
+mockPythonName.aspirate(
+    volume=50,
+    location=mockPythonName["A1"].bottom(z=5),
+    rate=6 / mockPythonName.flow_rate.aspirate,
+)`.trimStart()
+    )
   })
   it('aspirate with volume > tip max volume should throw error', () => {
     invariantContext.pipetteEntities[DEFAULT_PIPETTE].tiprackDefURI = [

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -14,6 +14,9 @@ import {
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
   uuid,
   getIsSafePipetteMovement,
+  formatPyStr,
+  formatPyWellLocation,
+  indentPyLines,
 } from '../../utils'
 import { COLUMN_4_SLOTS } from '../../constants'
 import type {
@@ -257,7 +260,26 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
       },
     },
   ]
+
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const labwarePythonName =
+    invariantContext.labwareEntities[labwareId].pythonName
+  const pythonArgs = [
+    `volume=${volume}`,
+    `location=${labwarePythonName}[${formatPyStr(
+      wellName
+    )}]${formatPyWellLocation(wellLocation)}`,
+    // rate= is a ratio in the PAPI, and we have no good way to figure out what
+    // flowrate the PAPI has set the pipette to, so we just have to do a division:
+    `rate=${flowRate} / ${pipettePythonName}.flow_rate.aspirate`,
+  ]
+  const python = `${pipettePythonName}.aspirate(\n${indentPyLines(
+    pythonArgs.join(',\n')
+  )},\n)`
+
   return {
     commands,
+    python,
   }
 }


### PR DESCRIPTION
# Overview

This implements Python code generation for the PD atomic `aspirate` command. AUTH-1094

The generated code looks like this:
```
pipette_left.aspirate(
    volume=75,
    location=well_plate_2["B2"].bottom(z=1),
    rate=716 / pipette_left.flow_rate.aspirate,
)
```

## Test Plan and Hands on Testing

Added unit tests.

I also took the generated code and added it to a Python protocol and confirmed that it is understandable by `simulate`.

## Review requests

PD has its own code to load the default flow rates for a particular pipette/tip/volume: https://github.com/Opentrons/opentrons/blob/8fe0be18a49512640b2ebabce49f585ce26ff4f1/protocol-designer/src/utils/index.ts#L211-L215

I was trying really hard to use those default flow rates to compute the ratio in JavaScript to pass to `aspirate(rate=...)`. E.g., if we knew that the default flow rate is 700 uL/s, and the PD user wants a flow rate of 350 uL/s, I wanted to generate code like `aspirate(rate=0.5)`.

But that turned out to be unworkable. PD has a very specific algorithm for picking the default flow rates, which is **not** the same as what the PAPI implements. Furthermore, we discovered that the current implementation for default flow rates in the PAPI is just wrong.

So in this PR, I had to emit an explicit division expression to generate the `aspirate(rate=...)` argument.

## Risk assessment

Low. Python export in PD is not available to external users yet.