### PR TITLE
feat(protocol-designer): emit Python for dispense command

### DIFF
--- a/step-generation/src/__tests__/dispense.test.ts
+++ b/step-generation/src/__tests__/dispense.test.ts
@@ -84,6 +84,14 @@ describe('dispense', () => {
           },
         },
       ])
+      expect(getSuccessResult(result).python).toBe(
+        `
+mockPythonName.dispense(
+    volume=50,
+    location=mockPythonName["A1"].bottom(z=5),
+    rate=6 / mockPythonName.flow_rate.dispense,
+)`.trimStart()
+      )
     })
     it('dispensing without tip should throw error', () => {
       const result = dispense(params, invariantContext, initialRobotState)

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -13,6 +13,9 @@ import {
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
   uuid,
   getIsSafePipetteMovement,
+  formatPyStr,
+  formatPyWellLocation,
+  indentPyLines,
 } from '../../utils'
 import { COLUMN_4_SLOTS } from '../../constants'
 import type {
@@ -229,7 +232,28 @@ export const dispense: CommandCreator<DispenseAtomicCommandParams> = (
       ...(isAirGap && { meta: { isAirGap } }),
     },
   ]
+
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const labwarePythonName =
+    invariantContext.labwareEntities[labwareId].pythonName
+  const pythonArgs = [
+    `volume=${volume}`,
+    `location=${labwarePythonName}[${formatPyStr(
+      wellName
+    )}]${formatPyWellLocation(wellLocation)}`,
+    // rate= is a ratio in the PAPI, and we have no good way to figure out what
+    // flowrate the PAPI has set the pipette to, so we just have to emit a division:
+    `rate=${flowRate} / ${pipettePythonName}.flow_rate.dispense`,
+    // PAPI has no way to indicate that we're dispensing air, so we don't do anything
+    // with the isAirGap parameter.
+  ]
+  const python = `${pipettePythonName}.dispense(\n${indentPyLines(
+    pythonArgs.join(',\n')
+  )},\n)`
+
   return {
     commands,
+    python,
   }
 }


### PR DESCRIPTION
# Overview

This generates the Python code for the PD atomic `dispense` command. AUTH-1094

As with the `aspirate` command, for the `dispense(rate=...)`, we have to emit a literal division expression in the Python code because the PAPI takes a **ratio**, and we don't know what the PAPI default flow rate for the pipette is.

## Test Plan and Hands on Testing

Added unit tests.

I also took the generated Python and used `simulate` to confirm that it's well-formed.

## Review requests

The JSON command has a `{ meta: { isAirGap } }` to indicate that we're dispensing air. There is no corresponding way to indicate that in the Python API. So we're supposed to just use the `dispense()` API for both liquid and air, right?

## Risk assessment

Low. Python code generation is not used externally yet.