### PR TITLE
fix(shared-data): Keep inner well geometries of sibling labware in sync with each other

### DIFF
--- a/shared-data/js/__tests__/sharedGeometryGroups.ts
+++ b/shared-data/js/__tests__/sharedGeometryGroups.ts
@@ -1,0 +1,72 @@
+/** Labware that are expected to have the exact same inner well geometry. */
+export const SHARED_GEOMETRY_GROUPS: SharedGeometryGroups = {
+  falcon_15ml_conical: [
+    {
+      loadName: 'opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical',
+      geometryKey: '15mlconicalWell',
+    },
+    'opentrons_15_tuberack_falcon_15ml_conical',
+  ],
+  falcon_50ml_conical: [
+    {
+      loadName: 'opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical',
+      geometryKey: '50mlconicalWell',
+    },
+    'opentrons_6_tuberack_falcon_50ml_conical',
+  ],
+  generic_2ml_screwcap: [
+    'opentrons_24_aluminumblock_generic_2ml_screwcap',
+    'opentrons_24_tuberack_generic_2ml_screwcap',
+  ],
+  'nest_0.5ml_screwcap': [
+    'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
+    'opentrons_24_tuberack_nest_0.5ml_screwcap',
+  ],
+  'nest_1.5ml_screwcap': [
+    'opentrons_24_aluminumblock_nest_1.5ml_screwcap',
+    'opentrons_24_tuberack_nest_1.5ml_screwcap',
+  ],
+  'nest_1.5ml_snapcap': [
+    'opentrons_24_aluminumblock_nest_1.5ml_snapcap',
+    'opentrons_24_tuberack_nest_1.5ml_snapcap',
+  ],
+  nest_2ml_screwcap: [
+    'opentrons_24_aluminumblock_nest_2ml_screwcap',
+    'opentrons_24_tuberack_nest_2ml_screwcap',
+  ],
+  nest_2ml_snapcap: [
+    'opentrons_24_aluminumblock_nest_2ml_snapcap',
+    'opentrons_24_tuberack_nest_2ml_snapcap',
+  ],
+  nest_15ml_conical: [
+    {
+      loadName: 'opentrons_10_tuberack_nest_4x50ml_6x15ml_conical',
+      geometryKey: 'conicalWell15mL',
+    },
+    'opentrons_15_tuberack_nest_15ml_conical',
+  ],
+  nest_50ml_conical: [
+    {
+      loadName: 'opentrons_10_tuberack_nest_4x50ml_6x15ml_conical',
+      geometryKey: 'conicalWell50mL',
+    },
+    'opentrons_6_tuberack_nest_50ml_conical',
+  ],
+}
+
+interface SharedGeometryGroups {
+  [humanReadableGroupName: string]: SharedGeometryEntry[]
+}
+
+/**
+ * If a plain string, the string is the load name of the labware. In this case, the
+ * labware must have exactly one key within innerLabwareGeometry.
+ *
+ * If an object, the object contains the load name and the specific key within
+ * innerLabwareGeometry. */
+export type SharedGeometryEntry =
+  | string
+  | {
+      loadName: string
+      geometryKey: string
+    }

--- a/shared-data/labware/definitions/3/opentrons_15_tuberack_nest_15ml_conical/2.json
+++ b/shared-data/labware/definitions/3/opentrons_15_tuberack_nest_15ml_conical/2.json
@@ -227,22 +227,28 @@
         {
           "shape": "conical",
           "topDiameter": 15.5,
-          "bottomDiameter": 14.78,
+          "bottomDiameter": 14.56,
           "topHeight": 117.8,
-          "bottomHeight": 109.03
+          "bottomHeight": 113.8
         },
         {
           "shape": "conical",
-          "topDiameter": 14.78,
+          "topDiameter": 14.56,
           "bottomDiameter": 13.8,
-          "topHeight": 109.03,
+          "topHeight": 113.8,
           "bottomHeight": 22.55
         },
         {
           "shape": "conical",
           "topDiameter": 13.8,
-          "bottomDiameter": 2.5,
+          "bottomDiameter": 2.38,
           "topHeight": 22.55,
+          "bottomHeight": 0.92
+        },
+        {
+          "shape": "spherical",
+          "radiusOfCurvature": 1.235,
+          "topHeight": 0.92,
           "bottomHeight": 0.0
         }
       ]

--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_generic_2ml_screwcap/3.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_generic_2ml_screwcap/3.json
@@ -36,7 +36,8 @@
       "totalLiquidVolume": 2000,
       "x": 20.75,
       "y": 16.88,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "C1": {
       "shape": "circular",
@@ -45,7 +46,8 @@
       "totalLiquidVolume": 2000,
       "x": 20.75,
       "y": 34.13,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "B1": {
       "shape": "circular",
@@ -54,7 +56,8 @@
       "totalLiquidVolume": 2000,
       "x": 20.75,
       "y": 51.38,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "A1": {
       "shape": "circular",
@@ -63,7 +66,8 @@
       "totalLiquidVolume": 2000,
       "x": 20.75,
       "y": 68.63,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "D2": {
       "shape": "circular",
@@ -72,7 +76,8 @@
       "totalLiquidVolume": 2000,
       "x": 38,
       "y": 16.88,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "C2": {
       "shape": "circular",
@@ -81,7 +86,8 @@
       "totalLiquidVolume": 2000,
       "x": 38,
       "y": 34.13,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "B2": {
       "shape": "circular",
@@ -90,7 +96,8 @@
       "totalLiquidVolume": 2000,
       "x": 38,
       "y": 51.38,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "A2": {
       "shape": "circular",
@@ -99,7 +106,8 @@
       "totalLiquidVolume": 2000,
       "x": 38,
       "y": 68.63,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "D3": {
       "shape": "circular",
@@ -108,7 +116,8 @@
       "totalLiquidVolume": 2000,
       "x": 55.25,
       "y": 16.88,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "C3": {
       "shape": "circular",
@@ -117,7 +126,8 @@
       "totalLiquidVolume": 2000,
       "x": 55.25,
       "y": 34.13,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "B3": {
       "shape": "circular",
@@ -126,7 +136,8 @@
       "totalLiquidVolume": 2000,
       "x": 55.25,
       "y": 51.38,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "A3": {
       "shape": "circular",
@@ -135,7 +146,8 @@
       "totalLiquidVolume": 2000,
       "x": 55.25,
       "y": 68.63,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "D4": {
       "shape": "circular",
@@ -144,7 +156,8 @@
       "totalLiquidVolume": 2000,
       "x": 72.5,
       "y": 16.88,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "C4": {
       "shape": "circular",
@@ -153,7 +166,8 @@
       "totalLiquidVolume": 2000,
       "x": 72.5,
       "y": 34.13,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "B4": {
       "shape": "circular",
@@ -162,7 +176,8 @@
       "totalLiquidVolume": 2000,
       "x": 72.5,
       "y": 51.38,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "A4": {
       "shape": "circular",
@@ -171,7 +186,8 @@
       "totalLiquidVolume": 2000,
       "x": 72.5,
       "y": 68.63,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "D5": {
       "shape": "circular",
@@ -180,7 +196,8 @@
       "totalLiquidVolume": 2000,
       "x": 89.75,
       "y": 16.88,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "C5": {
       "shape": "circular",
@@ -189,7 +206,8 @@
       "totalLiquidVolume": 2000,
       "x": 89.75,
       "y": 34.13,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "B5": {
       "shape": "circular",
@@ -198,7 +216,8 @@
       "totalLiquidVolume": 2000,
       "x": 89.75,
       "y": 51.38,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "A5": {
       "shape": "circular",
@@ -207,7 +226,8 @@
       "totalLiquidVolume": 2000,
       "x": 89.75,
       "y": 68.63,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "D6": {
       "shape": "circular",
@@ -216,7 +236,8 @@
       "totalLiquidVolume": 2000,
       "x": 107,
       "y": 16.88,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "C6": {
       "shape": "circular",
@@ -225,7 +246,8 @@
       "totalLiquidVolume": 2000,
       "x": 107,
       "y": 34.13,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "B6": {
       "shape": "circular",
@@ -234,7 +256,8 @@
       "totalLiquidVolume": 2000,
       "x": 107,
       "y": 51.38,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     },
     "A6": {
       "shape": "circular",
@@ -243,7 +266,8 @@
       "totalLiquidVolume": 2000,
       "x": 107,
       "y": 68.63,
-      "z": 6.7
+      "z": 6.7,
+      "geometryDefinitionId": "conicalWell"
     }
   },
   "brand": {
@@ -297,6 +321,33 @@
     "x": 0,
     "y": 0,
     "z": 0
+  },
+  "innerLabwareGeometry": {
+    "conicalWell": {
+      "sections": [
+        {
+          "shape": "conical",
+          "topDiameter": 8.5,
+          "bottomDiameter": 8.14,
+          "topHeight": 42.0,
+          "bottomHeight": 3.04
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.14,
+          "bottomDiameter": 6.5,
+          "topHeight": 3.04,
+          "bottomHeight": 2.08
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 6.5,
+          "bottomDiameter": 1.21,
+          "topHeight": 2.08,
+          "bottomHeight": 0.0
+        }
+      ]
+    }
   },
   "$otSharedSchema": "#/labware/schemas/3"
 }

--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_1.5ml_snapcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_1.5ml_snapcap/2.json
@@ -327,22 +327,29 @@
       "sections": [
         {
           "shape": "conical",
-          "topDiameter": 9.28,
-          "bottomDiameter": 8.9,
+          "topDiameter": 9.9,
+          "bottomDiameter": 9.28,
           "topHeight": 37.9,
-          "bottomHeight": 17.7
+          "bottomHeight": 35.4
         },
         {
           "shape": "conical",
-          "topDiameter": 8.9,
+          "topDiameter": 9.28,
+          "bottomDiameter": 8.98,
+          "topHeight": 35.4,
+          "bottomHeight": 17.4
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.98,
           "bottomDiameter": 3.69,
-          "topHeight": 17.7,
-          "bottomHeight": 1.57
+          "topHeight": 17.4,
+          "bottomHeight": 1.56
         },
         {
           "shape": "spherical",
-          "radiusOfCurvature": 2.72,
-          "topHeight": 1.57,
+          "radiusOfCurvature": 1.87,
+          "topHeight": 1.56,
           "bottomHeight": 0.0
         }
       ]

--- a/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_2ml_snapcap/2.json
+++ b/shared-data/labware/definitions/3/opentrons_24_aluminumblock_nest_2ml_snapcap/2.json
@@ -327,43 +327,50 @@
       "sections": [
         {
           "shape": "conical",
-          "bottomDiameter": 8.9,
           "topDiameter": 9.28,
+          "bottomDiameter": 8.9,
           "topHeight": 39.28,
           "bottomHeight": 15.04
         },
         {
           "shape": "conical",
-          "bottomDiameter": 8,
           "topDiameter": 8.9,
-          "topHeight": 15.05,
-          "bottomHeight": 3.89
+          "bottomDiameter": 8.74,
+          "topHeight": 15.04,
+          "bottomHeight": 6.26
         },
         {
           "shape": "conical",
+          "topDiameter": 8.74,
+          "bottomDiameter": 8.0,
+          "topHeight": 6.26,
+          "bottomHeight": 3.98
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 8.0,
           "bottomDiameter": 7.2,
-          "topDiameter": 8,
-          "topHeight": 3.89,
+          "topHeight": 3.98,
           "bottomHeight": 2.74
         },
         {
           "shape": "conical",
-          "bottomDiameter": 7,
           "topDiameter": 7.2,
+          "bottomDiameter": 7.0,
           "topHeight": 2.74,
           "bottomHeight": 2.59
         },
         {
           "shape": "conical",
-          "bottomDiameter": 6,
-          "topDiameter": 7,
+          "topDiameter": 7.0,
+          "bottomDiameter": 6.0,
           "topHeight": 2.59,
           "bottomHeight": 1.83
         },
         {
           "shape": "conical",
-          "bottomDiameter": 5,
-          "topDiameter": 6,
+          "topDiameter": 6.0,
+          "bottomDiameter": 5.0,
           "topHeight": 1.83,
           "bottomHeight": 1.21
         },

--- a/shared-data/labware/definitions/3/opentrons_6_tuberack_nest_50ml_conical/2.json
+++ b/shared-data/labware/definitions/3/opentrons_6_tuberack_nest_50ml_conical/2.json
@@ -118,23 +118,30 @@
       "sections": [
         {
           "shape": "conical",
-          "topDiameter": 27.45,
-          "bottomDiameter": 27.0,
-          "topHeight": 113.3,
-          "bottomHeight": 109.0
+          "topDiameter": 28.18,
+          "bottomDiameter": 27.95,
+          "topHeight": 113.1,
+          "bottomHeight": 109.1
         },
         {
           "shape": "conical",
-          "topDiameter": 27.0,
+          "topDiameter": 27.95,
+          "bottomDiameter": 27.69,
+          "topHeight": 109.1,
+          "bottomHeight": 108.8
+        },
+        {
+          "shape": "conical",
+          "topDiameter": 27.69,
           "bottomDiameter": 26.0,
-          "topHeight": 109.0,
-          "bottomHeight": 14.28
+          "topHeight": 108.8,
+          "bottomHeight": 14.35
         },
         {
           "shape": "conical",
           "topDiameter": 26.0,
-          "bottomDiameter": 6.0,
-          "topHeight": 14.28,
+          "bottomDiameter": 4.5,
+          "topHeight": 14.35,
           "bottomHeight": 0.0
         }
       ]


### PR DESCRIPTION
## Overview

This fixes some out-of-date labware geometry definitions and tries to prevent similar problems in the future.

Some of our labware definitions ought to share well geometries with each other. For example, `opentrons_24_aluminumblock_nest_0.5ml_screwcap` and `opentrons_24_tuberack_nest_0.5ml_screwcap` have the same NEST 0.5 mL screwcap tubes.

It's proving to be challenging to keep all of these in sync. The underlying spreadsheets from the hardware team don't necessarily enumerate every single definition. So, some labware seem like they were accidentally omitted from the updates in #17082, and other labware just never had any geometry definitions to begin with.

This PR fixes the discrepancies that I found. Then, to mitigate the problem going forward, this PR hard-codes list of labware that belong to the same "shared geometry groups." In the tests, we assert that each group has consistent geometry.

## Test Plan and Hands on Testing

None.

## Changelog

* Hard-code lists of labware that should share well geometry with each other. Test that they actually do.
* Fix several discrepancies caught by those tests. See the commit messages for exact details.

## Review requests

* **Am I reconciling each group in the correct direction?**
* **Are any labware groups missing?**
* Are all the labware groups correct (i.e. they actually share the same physical tubes)?

## Risk assessment

Medium. This might reconcile a group in the wrong direction.