### PR TITLE
chore(js): Disable @typescript-eslint/consistent-indexed-object-style, for real this time

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,7 +104,6 @@ module.exports = {
         '@typescript-eslint/no-floating-promises': 'warn',
         '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
         '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
-        '@typescript-eslint/consistent-indexed-object-style': 'warn',
         '@typescript-eslint/ban-types': 'warn',
         '@typescript-eslint/non-nullable-type-assertion-style': 'warn',
         '@typescript-eslint/await-thenable': 'warn',


### PR DESCRIPTION
## Overview

https://github.com/Opentrons/opentrons/pull/17557 did not quite do the trick, because in addition to the top-level `rules` config, we also need to update `overrides`.

Sorry—I swear I tested it before merging and it seemed like it was working! 🤦 

## Test Plan and Hands on Testing

* [x] Run `make lint-js` before and after this PR, grep for `consistent`, and make sure the fix actually works this time.

## Review requests

My understanding of `overrides` is that you can narrow them down to specific sets of files. But these overrides are written to apply to every .ts and .tsx file, so...what's the point? Anyone know why we wouldn't just define these in the top-level `rules`?

## Risk assessment

No risk.
