### PR TITLE
feat(shared-data, api): add stacker max fill height in shared-data definition

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
@@ -86,8 +86,12 @@ class FillImpl(AbstractCommandImpl[FillParams, SuccessData[FillResult]]):
                 message=f"The Flex Stacker in {location} has not been configured yet and cannot be filled."
             )
 
-        count = params.count if params.count is not None else stacker_state.max_pool_count
-        new_count = min(stacker_state.max_pool_count, max(stacker_state.pool_count, count))
+        count = (
+            params.count if params.count is not None else stacker_state.max_pool_count
+        )
+        new_count = min(
+            stacker_state.max_pool_count, max(stacker_state.pool_count, count)
+        )
 
         state_update = (
             update_types.StateUpdate().update_flex_stacker_labware_pool_count(

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
@@ -86,15 +86,8 @@ class FillImpl(AbstractCommandImpl[FillParams, SuccessData[FillResult]]):
                 message=f"The Flex Stacker in {location} has not been configured yet and cannot be filled."
             )
 
-        pool_height = self._state_view.geometry.get_height_of_stacker_labware_pool(
-            params.moduleId
-        )
-        max_pool_count = self._state_view.modules.stacker_max_pool_count_by_height(
-            params.moduleId, pool_height
-        )
-
-        count = params.count if params.count is not None else max_pool_count
-        new_count = min(max_pool_count, max(stacker_state.pool_count, count))
+        count = params.count if params.count is not None else stacker_state.max_pool_count
+        new_count = min(stacker_state.max_pool_count, max(stacker_state.pool_count, count))
 
         state_update = (
             update_types.StateUpdate().update_flex_stacker_labware_pool_count(

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
@@ -86,9 +86,15 @@ class FillImpl(AbstractCommandImpl[FillParams, SuccessData[FillResult]]):
                 message=f"The Flex Stacker in {location} has not been configured yet and cannot be filled."
             )
 
-        # TODO: propagate the limit on max height of the stacker
-        count = params.count if params.count is not None else 5
-        new_count = min(5, max(stacker_state.pool_count, count))
+        pool_height = self._state_view.geometry.get_height_of_stacker_labware_pool(
+            params.moduleId
+        )
+        max_pool_count = self._state_view.modules.stacker_max_pool_count_by_height(
+            params.moduleId, pool_height
+        )
+
+        count = params.count if params.count is not None else max_pool_count
+        new_count = min(max_pool_count, max(stacker_state.pool_count, count))
 
         state_update = (
             update_types.StateUpdate().update_flex_stacker_labware_pool_count(

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -1,7 +1,7 @@
 """Command models to configure the stored labware pool of a Flex Stacker.."""
 
 from __future__ import annotations
-from typing import List, Optional, Literal, TYPE_CHECKING
+from typing import Optional, Literal, TYPE_CHECKING
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -159,7 +159,7 @@ class SetStoredLabwareImpl(
         state_update = (
             update_types.StateUpdate()
             .update_flex_stacker_labware_pool_definition(
-                params.moduleId, labware_def, adapter_def, lid_def
+                params.moduleId, max_pool_count, labware_def, adapter_def, lid_def
             )
             .update_flex_stacker_labware_pool_count(params.moduleId, count)
         )

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -134,7 +134,7 @@ class StoreImpl(AbstractCommandImpl[StoreParams, SuccessData[StoreResult]]):
                 "Cannot store labware in Flex Stacker while in static mode"
             )
 
-        if stacker_state.pool_count == 5:
+        if stacker_state.pool_count == stacker_state.max_pool_count:
             raise CannotPerformModuleAction(
                 "Cannot store labware in Flex Stacker while it is full"
             )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -2027,3 +2027,11 @@ class GeometryView:
             total_height += upper_def.dimensions.zDimension - overlap
             upper_def = lower_def
         return total_height + upper_def.dimensions.zDimension
+
+    def get_height_of_stacker_labware_pool(self, module_id: str) -> float:
+        """Get the overall height of a stack of labware in a Stacker module."""
+        stacker = self._modules.get_flex_stacker_substate(module_id)
+        pool_list = stacker.get_pool_definition_ordered_list()
+        if not pool_list:
+            return 0.0
+        return self.get_height_of_labware_stack(pool_list)

--- a/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
@@ -30,6 +30,7 @@ class FlexStackerSubState:
     pool_adapter_definition: LabwareDefinition | None
     pool_lid_definition: LabwareDefinition | None
     pool_count: int
+    max_pool_count: int
 
     def new_from_state_change(
         self, update: FlexStackerStateUpdate
@@ -42,7 +43,9 @@ class FlexStackerSubState:
         pool_primary_definition = self.pool_primary_definition
         pool_adapter_definition = self.pool_adapter_definition
         pool_lid_definition = self.pool_lid_definition
+        max_pool_count = self.max_pool_count
         if update.pool_constraint != NO_CHANGE:
+            max_pool_count = update.pool_constraint.max_pool_count
             pool_primary_definition = update.pool_constraint.primary_definition
             pool_adapter_definition = update.pool_constraint.adapter_definition
             pool_lid_definition = update.pool_constraint.lid_definition
@@ -74,6 +77,7 @@ class FlexStackerSubState:
             pool_adapter_definition=pool_adapter_definition,
             pool_lid_definition=pool_lid_definition,
             pool_count=pool_count,
+            max_pool_count=max_pool_count,
         )
 
     def get_pool_definition_ordered_list(self) -> list[LabwareDefinition] | None:

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -390,6 +390,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 pool_adapter_definition=None,
                 pool_lid_definition=None,
                 pool_count=0,
+                max_pool_count=0,
             )
 
     def _update_additional_slots_occupied_by_thermocycler(

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1418,7 +1418,7 @@ class ModuleView:
         )
         return lid_dock_area
 
-    def get_stacker_max_fill_height(self, module_id: str):
+    def get_stacker_max_fill_height(self, module_id: str) -> float:
         """Get the maximum fill height for the Flex Stacker."""
         definition = self.get_definition(module_id)
 
@@ -1438,4 +1438,5 @@ class ModuleView:
     ) -> int:
         """Get the maximum stack count for the Flex Stacker by stack height."""
         max_fill_height = self.get_stacker_max_fill_height(module_id)
+        assert max_fill_height > 0
         return math.floor(max_fill_height / pool_height)

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -14,6 +14,7 @@ from typing import (
     Union,
     overload,
 )
+import math
 from numpy import array, dot, double as npdouble
 from numpy.typing import NDArray
 
@@ -1416,3 +1417,25 @@ class ModuleView:
             addressableAreaName="absorbanceReaderV1LidDock" + lid_doc_slot.value
         )
         return lid_dock_area
+
+    def get_stacker_max_fill_height(self, module_id: str):
+        """Get the maximum fill height for the Flex Stacker."""
+        definition = self.get_definition(module_id)
+
+        if (
+            definition.moduleType == ModuleType.FLEX_STACKER
+            and hasattr(definition.dimensions, "maxStackerFillHeight")
+            and definition.dimensions.maxStackerFillHeight is not None
+        ):
+            return definition.dimensions.maxStackerFillHeight
+        else:
+            raise errors.WrongModuleTypeError(
+                f"Cannot get max fill height of {definition.moduleType}"
+            )
+
+    def stacker_max_pool_count_by_height(
+        self, module_id: str, pool_height: float
+    ) -> int:
+        """Get the maximum stack count for the Flex Stacker by stack height."""
+        max_fill_height = self.get_stacker_max_fill_height(module_id)
+        return math.floor(max_fill_height / pool_height)

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -371,7 +371,6 @@ class FlexStackerPoolConstraint:
     primary_definition: LabwareDefinition
     lid_definition: LabwareDefinition | None
     adapter_definition: LabwareDefinition | None
-    # if the pool is changed we must also update the max pool count
 
 
 @dataclasses.dataclass

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -367,9 +367,11 @@ class FlexStackerStoreLabware:
 class FlexStackerPoolConstraint:
     """The labware definitions that are contained in the pool."""
 
+    max_pool_count: int
     primary_definition: LabwareDefinition
     lid_definition: LabwareDefinition | None
     adapter_definition: LabwareDefinition | None
+    # if the pool is changed we must also update the max pool count
 
 
 @dataclasses.dataclass
@@ -894,6 +896,7 @@ class StateUpdate:
     def update_flex_stacker_labware_pool_definition(
         self,
         module_id: str,
+        max_count: int,
         primary_definition: LabwareDefinition,
         adapter_definition: LabwareDefinition | None,
         lid_definition: LabwareDefinition | None,
@@ -904,6 +907,7 @@ class StateUpdate:
                 self.flex_stacker_state_update, module_id
             ),
             pool_constraint=FlexStackerPoolConstraint(
+                max_pool_count=max_count,
                 primary_definition=primary_definition,
                 lid_definition=lid_definition,
                 adapter_definition=adapter_definition,

--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -125,6 +125,8 @@ class ModuleDimensions(BaseModel):
     bareOverallHeight: float
     overLabwareHeight: float
     lidHeight: Optional[float] = None
+    maxStackerFillHeight: Optional[float] = None
+    maxStackerRetrievableHeight: Optional[float] = None
 
 
 # TODO(mm, 2022-11-07): Deduplicate with Vec3f.

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_empty.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_empty.py
@@ -65,6 +65,7 @@ async def test_empty_happypath(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=current_count,
+        max_pool_count=5,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state
@@ -115,6 +116,7 @@ async def test_empty_requires_constrained_pool(
         pool_lid_definition=None,
         pool_adapter_definition=None,
         pool_count=3,
+        max_pool_count=5,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state
@@ -155,6 +157,7 @@ async def test_pause_strategy_pauses(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=current_count,
+        max_pool_count=5,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -95,6 +95,7 @@ async def test_retrieve_raises_when_static(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=1,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -126,6 +127,7 @@ async def test_retrieve_raises_when_empty(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=0,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -158,6 +160,7 @@ async def test_retrieve_primary_only(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=1,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -237,6 +240,7 @@ async def test_retrieve_primary_and_lid(
         pool_adapter_definition=None,
         pool_lid_definition=tiprack_lid_def,
         pool_count=1,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -352,6 +356,7 @@ async def test_retrieve_primary_and_adapter(
         pool_adapter_definition=tiprack_adapter_def,
         pool_lid_definition=None,
         pool_count=1,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -460,6 +465,7 @@ async def test_retrieve_primary_adapter_and_lid(
         pool_adapter_definition=tiprack_adapter_def,
         pool_lid_definition=tiprack_lid_def,
         pool_count=1,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
@@ -47,6 +47,7 @@ def subject(state_view: StateView, equipment: EquipmentHandler) -> SetStoredLabw
                 loadName="lid-name", namespace="lid-namespace", version=3
             ),
             FlexStackerPoolConstraint(
+                max_pool_count=10,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=sentinel.lid_definition,
                 adapter_definition=sentinel.adapter_definition,
@@ -57,6 +58,7 @@ def subject(state_view: StateView, equipment: EquipmentHandler) -> SetStoredLabw
             None,
             None,
             FlexStackerPoolConstraint(
+                max_pool_count=10,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=None,
                 adapter_definition=None,
@@ -69,6 +71,7 @@ def subject(state_view: StateView, equipment: EquipmentHandler) -> SetStoredLabw
                 loadName="lid-name", namespace="lid-namespace", version=3
             ),
             FlexStackerPoolConstraint(
+                max_pool_count=10,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=sentinel.lid_definition,
                 adapter_definition=None,
@@ -81,6 +84,7 @@ def subject(state_view: StateView, equipment: EquipmentHandler) -> SetStoredLabw
             ),
             None,
             FlexStackerPoolConstraint(
+                max_pool_count=10,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=None,
                 adapter_definition=sentinel.adapter_definition,
@@ -120,6 +124,7 @@ async def test_set_stored_labware_happypath(
             pool_adapter_definition=None,
             pool_lid_definition=None,
             pool_count=0,
+            max_pool_count=0,
         )
     )
     decoy.when(
@@ -147,6 +152,26 @@ async def test_set_stored_labware_happypath(
             )
         ).then_return((sentinel.adapter_definition, sentinel.unused))
         adapter_definition = sentinel.adapter_definition
+
+    decoy.when(
+        state_view.geometry.get_height_of_labware_stack(
+            [
+                x
+                for x in [
+                    lid_definition,
+                    sentinel.primary_definition,
+                    adapter_definition,
+                ]
+                if x is not None
+            ]
+        )
+    ).then_return(sentinel.pool_height)
+    decoy.when(
+        state_view.modules.stacker_max_pool_count_by_height(
+            module_id, sentinel.pool_height
+        )
+    ).then_return(10)
+
     result = await subject.execute(params)
     decoy.verify(
         state_view.labware.raise_if_stacker_labware_pool_is_not_valid(
@@ -190,6 +215,7 @@ async def test_set_stored_labware_requires_empty_hopper(
             pool_adapter_definition=None,
             pool_lid_definition=None,
             pool_count=pool_count,
+            max_pool_count=pool_count,
         )
     )
     with pytest.raises(FlexStackerNotLogicallyEmptyError):
@@ -235,6 +261,7 @@ async def test_set_stored_labware_limits_count(
             pool_adapter_definition=None,
             pool_lid_definition=None,
             pool_count=0,
+            max_pool_count=0,
         )
     )
     decoy.when(
@@ -244,6 +271,15 @@ async def test_set_stored_labware_limits_count(
             version=1,
         )
     ).then_return((sentinel.primary_definition, sentinel.unused))
+    decoy.when(
+        state_view.geometry.get_height_of_labware_stack([sentinel.primary_definition])
+    ).then_return(sentinel.pool_height)
+    decoy.when(
+        state_view.modules.stacker_max_pool_count_by_height(
+            module_id, sentinel.pool_height
+        )
+    ).then_return(5)
+
     result = await subject.execute(params)
     assert result == SuccessData(
         public=SetStoredLabwareResult.model_construct(
@@ -256,6 +292,7 @@ async def test_set_stored_labware_limits_count(
             flex_stacker_state_update=FlexStackerStateUpdate(
                 module_id=module_id,
                 pool_constraint=FlexStackerPoolConstraint(
+                    max_pool_count=5,
                     primary_definition=sentinel.primary_definition,
                     lid_definition=None,
                     adapter_definition=None,

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -57,6 +57,7 @@ async def test_store_raises_in_static_mode(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=0,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -87,6 +88,7 @@ async def test_store_raises_if_full(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=5,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -117,6 +119,7 @@ async def test_store_raises_if_carriage_logically_empty(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=1,
+        max_pool_count=5,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -148,6 +151,7 @@ async def test_store_raises_if_not_configured(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=1,
+        max_pool_count=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -268,6 +272,7 @@ async def test_store_raises_if_labware_does_not_match(
         pool_adapter_definition=pool_adapter,
         pool_lid_definition=pool_lid,
         pool_count=0,
+        max_pool_count=5,
     )
 
     decoy.when(
@@ -336,6 +341,7 @@ async def test_store(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=0,
+        max_pool_count=5,
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -321,6 +321,7 @@ async def test_load_labware_in_flex_stacker(
             pool_adapter_definition=None,
             pool_lid_definition=None,
             pool_count=0,
+            max_pool_count=0,
         )
     )
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/state/test_flex_stacker_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_flex_stacker_state.py
@@ -124,6 +124,7 @@ def test_add_module_action(
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=0,
+        max_pool_count=0,
     )
 
 
@@ -172,5 +173,6 @@ def test_get_labware_definition_list(
         pool_adapter_definition=adapter_def,
         pool_lid_definition=lid_def,
         pool_count=0,
+        max_pool_count=5,
     )
     assert subject.get_pool_definition_ordered_list() == result

--- a/shared-data/module/definitions/3/flexStackerModuleV1.json
+++ b/shared-data/module/definitions/3/flexStackerModuleV1.json
@@ -17,7 +17,7 @@
     "labwareInterfaceXDimension": 128,
     "labwareInterfaceYDimension": 86,
     "maxStackerFillHeight": 612.75,
-    "maxStackerRetrievableHeight": 120.0
+    "maxStackerRetrievableHeight": 106.5
   },
   "cornerOffsetFromSlot": {
     "x": -18,

--- a/shared-data/module/definitions/3/flexStackerModuleV1.json
+++ b/shared-data/module/definitions/3/flexStackerModuleV1.json
@@ -15,7 +15,9 @@
     "footprintXDimension": 128,
     "footprintYDimension": 86,
     "labwareInterfaceXDimension": 128,
-    "labwareInterfaceYDimension": 86
+    "labwareInterfaceYDimension": 86,
+    "maxStackerFillHeight": 612.75,
+    "maxStackerRetrievableHeight": 120.0
   },
   "cornerOffsetFromSlot": {
     "x": -18,

--- a/shared-data/module/schemas/3.json
+++ b/shared-data/module/schemas/3.json
@@ -110,7 +110,9 @@
         "footprintXDimension": { "type": "number" },
         "footprintYDimension": { "type": "number" },
         "labwareInterfaceXDimension": { "type": "number" },
-        "labwareInterfaceYDimension": { "type": "number" }
+        "labwareInterfaceYDimension": { "type": "number" },
+        "maxStackerFillHeight": { "type": "number" },
+        "maxStackerRetrievableHeight": { "type": "number" }
       }
     },
     "cornerOffsetFromSlot": {

--- a/shared-data/python/opentrons_shared_data/module/types.py
+++ b/shared-data/python/opentrons_shared_data/module/types.py
@@ -69,6 +69,8 @@ ModuleDimensions = TypedDict(
         "footprintYDimension": float,
         "labwareInterfaceXDimension": float,
         "labwareInterfaceYDimension": float,
+        "maxStackerFillHeight": float,
+        "maxStackerRetrievableHeight": float
     },
     total=False,
 )

--- a/shared-data/python/opentrons_shared_data/module/types.py
+++ b/shared-data/python/opentrons_shared_data/module/types.py
@@ -70,7 +70,7 @@ ModuleDimensions = TypedDict(
         "labwareInterfaceXDimension": float,
         "labwareInterfaceYDimension": float,
         "maxStackerFillHeight": float,
-        "maxStackerRetrievableHeight": float
+        "maxStackerRetrievableHeight": float,
     },
     total=False,
 )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The stacker's stackable labware count is limited by the interior height of the stacker. 
This PR adds this property as the `maxStackerFillHeight` in the module definition. 

The `flex_stacker/fill` and `flex_stacker/set_stored_labware` commands are updated to use this property to calculate the actual max labware count based on the height of labware pool. 

