### PR TITLE
feat(protocol-designer): generate Python for pickUpTip command

### DIFF
--- a/step-generation/src/__tests__/pickUpTip.test.ts
+++ b/step-generation/src/__tests__/pickUpTip.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  getRobotStateWithTipStandard,
+  makeContext,
+  getSuccessResult,
+  DEFAULT_PIPETTE,
+  TIPRACK_1,
+} from '../fixtures'
+import type { InvariantContext, RobotState } from '../types'
+import { pickUpTip } from '../commandCreators/atomic'
+
+describe('pickUpTip', () => {
+  let robotStateWithTip: RobotState
+  let invariantContext: InvariantContext
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
+  })
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+  it('pick up tip', () => {
+    const params = {
+      pipetteId: DEFAULT_PIPETTE,
+      labwareId: TIPRACK_1,
+      wellName: 'B1',
+    }
+    const result = pickUpTip(params, invariantContext, robotStateWithTip)
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'pickUpTip',
+        key: expect.any(String),
+        params: {
+          pipetteId: DEFAULT_PIPETTE,
+          labwareId: TIPRACK_1,
+          wellName: 'B1',
+        },
+      },
+    ])
+    expect(getSuccessResult(result).python).toBe(
+      `mockPythonName.pick_up_tip(location=mockPythonName)`
+    )
+  })
+})

--- a/step-generation/src/commandCreators/atomic/pickUpTip.ts
+++ b/step-generation/src/commandCreators/atomic/pickUpTip.ts
@@ -53,6 +53,15 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
     }
   }
 
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const tiprackPythonName =
+    invariantContext.labwareEntities[labwareId].pythonName
+  // We don't specify the tip well because it would make it hard for users to modify
+  // the Python protocol. We do specify the tip rack because multiple tip racks could be
+  // assigned to the pipette, and the UI makes the user choose which tip rack to use.
+  const python = `${pipettePythonName}.pick_up_tip(location=${tiprackPythonName})`
+
   if (errors.length > 0) {
     return { errors }
   }
@@ -68,5 +77,6 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
         },
       },
     ],
+    python,
   }
 }


### PR DESCRIPTION
# Overview

This emits Python for the PD atomic pickUpTip command. The Python code looks like this:
```
pipette_left.pick_up_tip(location=tip_rack_1)
```

PD implements its own tip tracking and calculates exactly which tip to pick up. However, we don't want to emit the exact tip well in the Python code because it would make it painful for someone to edit the Python code to add or remove steps.

We do emit the tiprack ID in the Python code because PD makes the user choose which tiprack to use for each transfer. If we didn't emit the tiprack ID, the PAPI would pick the next available tiprack, which may not match the tiprack that the user chose in PD.

AUTH-1093

## Test Plan and Hands on Testing

There was no existing unit test for the JSON `pickUpTip` command, so I added one.

With this change, we can now generate a runnable Python protocol for a simple PD transfer. I checked that the protocol passes with `simulate`.

## Risk assessment

Low. Python generation is not used externally yet.