### PR TITLE
chore(api): return stall/collision defined error from stacker store

### DIFF
--- a/api/src/opentrons/hardware_control/modules/errors.py
+++ b/api/src/opentrons/hardware_control/modules/errors.py
@@ -1,5 +1,11 @@
+from typing import Optional, Dict, Sequence
+
 from opentrons.drivers.flex_stacker.types import StackerAxis
-from opentrons_shared_data.errors import EnumeratedError
+from opentrons_shared_data.errors import (
+    EnumeratedError,
+    RoboticsControlError,
+    ErrorCodes,
+)
 
 
 class UpdateError(RuntimeError):
@@ -11,7 +17,18 @@ class AbsorbanceReaderDisconnectedError(RuntimeError):
         self.serial = serial
 
 
-class FlexStackerStallError(EnumeratedError):
-    def __init__(self, serial: str, axis: StackerAxis):
+class FlexStackerStallError(RoboticsControlError):
+    def __init__(
+        self,
+        serial: str,
+        axis: StackerAxis,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, str]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a StallOrCollisionDetectedError."""
         self.serial = serial
         self.axis = axis
+        super().__init__(
+            ErrorCodes.STALL_OR_COLLISION_DETECTED, message, detail, wrapping
+        )

--- a/api/src/opentrons/hardware_control/modules/errors.py
+++ b/api/src/opentrons/hardware_control/modules/errors.py
@@ -1,4 +1,5 @@
 from opentrons.drivers.flex_stacker.types import StackerAxis
+from opentrons_shared_data.errors import EnumeratedError
 
 
 class UpdateError(RuntimeError):
@@ -10,7 +11,7 @@ class AbsorbanceReaderDisconnectedError(RuntimeError):
         self.serial = serial
 
 
-class FlexStackerStallError(RuntimeError):
+class FlexStackerStallError(EnumeratedError):
     def __init__(self, serial: str, axis: StackerAxis):
         self.serial = serial
         self.axis = axis

--- a/api/src/opentrons/hardware_control/modules/errors.py
+++ b/api/src/opentrons/hardware_control/modules/errors.py
@@ -26,7 +26,7 @@ class FlexStackerStallError(RoboticsControlError):
         detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build a StallOrCollisionDetectedError."""
+        """Build a FlexStallOrCollisionDetectedError."""
         self.serial = serial
         self.axis = axis
         super().__init__(

--- a/api/src/opentrons/hardware_control/modules/errors.py
+++ b/api/src/opentrons/hardware_control/modules/errors.py
@@ -30,5 +30,5 @@ class FlexStackerStallError(RoboticsControlError):
         self.serial = serial
         self.axis = axis
         super().__init__(
-            ErrorCodes.STALL_OR_COLLISION_DETECTED, message, detail, wrapping
+            ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED, message, detail, wrapping
         )

--- a/api/src/opentrons/hardware_control/modules/errors.py
+++ b/api/src/opentrons/hardware_control/modules/errors.py
@@ -1,13 +1,3 @@
-from typing import Optional, Dict, Sequence
-
-from opentrons.drivers.flex_stacker.types import StackerAxis
-from opentrons_shared_data.errors import (
-    EnumeratedError,
-    RoboticsControlError,
-    ErrorCodes,
-)
-
-
 class UpdateError(RuntimeError):
     pass
 
@@ -15,20 +5,3 @@ class UpdateError(RuntimeError):
 class AbsorbanceReaderDisconnectedError(RuntimeError):
     def __init__(self, serial: str):
         self.serial = serial
-
-
-class FlexStackerStallError(RoboticsControlError):
-    def __init__(
-        self,
-        serial: str,
-        axis: StackerAxis,
-        message: Optional[str] = None,
-        detail: Optional[Dict[str, str]] = None,
-        wrapping: Optional[Sequence[EnumeratedError]] = None,
-    ) -> None:
-        """Build a FlexStallOrCollisionDetectedError."""
-        self.serial = serial
-        self.axis = axis
-        super().__init__(
-            ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED, message, detail, wrapping
-        )

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -21,7 +21,6 @@ from opentrons.drivers.flex_stacker.driver import (
 from opentrons.drivers.flex_stacker.abstract import AbstractFlexStackerDriver
 from opentrons.drivers.flex_stacker.simulator import SimulatingDriver
 from opentrons.hardware_control.execution_manager import ExecutionManager
-from opentrons.hardware_control.modules.errors import FlexStackerStallError
 from opentrons.hardware_control.poller import Reader, Poller
 from opentrons.hardware_control.modules import mod_abc, update
 from opentrons.hardware_control.modules.types import (
@@ -36,6 +35,8 @@ from opentrons.hardware_control.modules.types import (
     LiveData,
     FlexStackerData,
 )
+
+from opentrons_shared_data.errors.exceptions import FlexStackerStallError
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -13,7 +13,8 @@ from .pipetting_common import (
     LiquidNotFoundError,
     TipPhysicallyAttachedError,
 )
-from .movement_common import StallOrCollisionError, FlexStackerStallOrCollisionError
+from .movement_common import StallOrCollisionError
+from .flex_stacker.common import FlexStackerStallOrCollisionError
 
 from . import absorbance_reader
 from . import flex_stacker

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -13,7 +13,7 @@ from .pipetting_common import (
     LiquidNotFoundError,
     TipPhysicallyAttachedError,
 )
-from .movement_common import StallOrCollisionError
+from .movement_common import StallOrCollisionError, FlexStackerStallOrCollisionError
 
 from . import absorbance_reader
 from . import flex_stacker
@@ -908,6 +908,7 @@ CommandDefinedErrorData = Union[
     DefinedErrorData[LiquidNotFoundError],
     DefinedErrorData[GripperMovementError],
     DefinedErrorData[StallOrCollisionError],
+    DefinedErrorData[FlexStackerStallOrCollisionError],
 ]
 
 

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -1,0 +1,14 @@
+from typing import Literal
+
+from opentrons.protocol_engine import ErrorOccurrence
+from opentrons_shared_data.errors import ErrorCodes
+
+
+class FlexStackerStallOrCollisionError(ErrorOccurrence):
+    """Returned when the motor driver detects a stall."""
+
+    isDefined: bool = True
+    errorType: Literal["flexStackerStallOrCollision"] = "flexStackerStallOrCollision"
+
+    errorCode: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.code
+    detail: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.detail

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -1,6 +1,7 @@
+"""Common flex stacker base models."""
 from typing import Literal
 
-from opentrons.protocol_engine import ErrorOccurrence
+from ...errors import ErrorOccurrence
 from opentrons_shared_data.errors import ErrorCodes
 
 

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -10,5 +10,5 @@ class FlexStackerStallOrCollisionError(ErrorOccurrence):
     isDefined: bool = True
     errorType: Literal["flexStackerStallOrCollision"] = "flexStackerStallOrCollision"
 
-    errorCode: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.code
-    detail: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.detail
+    errorCode: str = ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED.value.code
+    detail: str = ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED.value.detail

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
@@ -5,8 +5,8 @@ from typing import Optional, Literal, TYPE_CHECKING, Any, Dict, Union
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
-from opentrons.hardware_control.modules.errors import FlexStackerStallError
 from ..command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -30,7 +30,7 @@ from ...types import (
     LabwareLocation,
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from pydantic.json_schema import SkipJsonSchema
+from opentrons_shared_data.errors.exceptions import FlexStackerStallError
 from opentrons.calibration_storage.helpers import uri_from_details
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
@@ -14,7 +14,7 @@ from ..command import (
     SuccessData,
     DefinedErrorData,
 )
-from ..movement_common import FlexStackerStallOrCollisionError
+from ..flex_stacker.common import FlexStackerStallOrCollisionError
 from ...errors import (
     ErrorOccurrence,
     CannotPerformModuleAction,

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -13,7 +13,7 @@ from ..command import (
     SuccessData,
     DefinedErrorData,
 )
-from ..movement_common import FlexStackerStallOrCollisionError
+from ..flex_stacker.common import FlexStackerStallOrCollisionError
 from ...errors import (
     ErrorOccurrence,
     CannotPerformModuleAction,

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -195,7 +195,6 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
                         )
                     ],
                 ),
-                # state_update=StateUpdate().set_fluid_unknown(pipette_id=pipette_id),
             )
 
         id_list = [

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -5,7 +5,6 @@ from typing import Optional, Literal, TYPE_CHECKING, Type, Union
 
 from pydantic import BaseModel, Field
 
-from opentrons.hardware_control.modules.errors import FlexStackerStallError
 from ..command import (
     AbstractCommandImpl,
     BaseCommand,
@@ -26,6 +25,8 @@ from ...types import (
     LabwareLocationSequence,
     InStackerHopperLocation,
 )
+
+from opentrons_shared_data.errors.exceptions import FlexStackerStallError
 
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_engine/commands/movement_common.py
+++ b/api/src/opentrons/protocol_engine/commands/movement_common.py
@@ -115,6 +115,22 @@ class StallOrCollisionError(ErrorOccurrence):
     detail: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.detail
 
 
+class FlexStackerStallOrCollisionError(ErrorOccurrence):
+    """Returned when the machine detects that axis encoders are reading a different position than expected.
+
+    All axes are stopped at the point where the error was encountered.
+
+    The next thing to move the machine must account for the robot not having a valid estimate
+    of its position. It should be a `home` or `unsafe/updatePositionEstimators`.
+    """
+
+    isDefined: bool = True
+    errorType: Literal["flexStackerStallOrCollision"] = "flexStackerStallOrCollision"
+
+    errorCode: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.code
+    detail: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.detail
+
+
 class DestinationPositionResult(BaseModel):
     """Mixin for command results that move a pipette."""
 

--- a/api/src/opentrons/protocol_engine/commands/movement_common.py
+++ b/api/src/opentrons/protocol_engine/commands/movement_common.py
@@ -115,22 +115,6 @@ class StallOrCollisionError(ErrorOccurrence):
     detail: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.detail
 
 
-class FlexStackerStallOrCollisionError(ErrorOccurrence):
-    """Returned when the motor driver detects a stall."""
-
-    All axes are stopped at the point where the error was encountered.
-
-    The next thing to move the machine must account for the robot not having a valid estimate
-    of its position. It should be a `home` or `unsafe/updatePositionEstimators`.
-    """
-
-    isDefined: bool = True
-    errorType: Literal["flexStackerStallOrCollision"] = "flexStackerStallOrCollision"
-
-    errorCode: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.code
-    detail: str = ErrorCodes.STALL_OR_COLLISION_DETECTED.value.detail
-
-
 class DestinationPositionResult(BaseModel):
     """Mixin for command results that move a pipette."""
 

--- a/api/src/opentrons/protocol_engine/commands/movement_common.py
+++ b/api/src/opentrons/protocol_engine/commands/movement_common.py
@@ -116,7 +116,7 @@ class StallOrCollisionError(ErrorOccurrence):
 
 
 class FlexStackerStallOrCollisionError(ErrorOccurrence):
-    """Returned when the machine detects that axis encoders are reading a different position than expected.
+    """Returned when the motor driver detects a stall."""
 
     All axes are stopped at the point where the error was encountered.
 

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -7,7 +7,7 @@ from decoy import Decoy, matchers
 from opentrons.drivers.flex_stacker.types import StackerAxis
 from opentrons.hardware_control.modules import FlexStacker
 from opentrons.hardware_control.modules.errors import FlexStackerStallError
-from opentrons.protocol_engine.commands.movement_common import (
+from opentrons.protocol_engine.commands.flex_stacker.common import (
     FlexStackerStallOrCollisionError,
 )
 from opentrons.protocol_engine.resources import ModelUtils

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -6,7 +6,6 @@ from decoy import Decoy, matchers
 
 from opentrons.drivers.flex_stacker.types import StackerAxis
 from opentrons.hardware_control.modules import FlexStacker
-from opentrons.hardware_control.modules.errors import FlexStackerStallError
 from opentrons.protocol_engine.commands.flex_stacker.common import (
     FlexStackerStallOrCollisionError,
 )
@@ -48,6 +47,7 @@ from opentrons.protocol_engine.execution import LoadedLabwareData
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
 )
+from opentrons_shared_data.errors.exceptions import FlexStackerStallError
 
 
 def _prep_stacker_own_location(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -4,6 +4,7 @@ import pytest
 from decoy import Decoy
 
 from opentrons.hardware_control.modules import FlexStacker
+from opentrons.protocol_engine.resources import ModelUtils
 
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state.update_types import (
@@ -76,15 +77,25 @@ def _stacker_base_loc_seq(stacker_id: str) -> LabwareLocationSequence:
     ]
 
 
+@pytest.fixture
+def subject(
+    state_view: StateView, equipment: EquipmentHandler, model_utils: ModelUtils
+) -> RetrieveImpl:
+    """Subject under tests."""
+    return RetrieveImpl(
+        state_view=state_view, equipment=equipment, model_utils=model_utils
+    )
+
+
 async def test_retrieve_raises_when_static(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    subject: RetrieveImpl,
     flex_50uL_tiprack: LabwareDefinition,
     stacker_id: FlexStackerId,
 ) -> None:
     """It should raise an exception when called in static mode."""
-    subject = RetrieveImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.RetrieveParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -111,11 +122,11 @@ async def test_retrieve_raises_when_empty(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    subject: RetrieveImpl,
     flex_50uL_tiprack: LabwareDefinition,
     stacker_id: FlexStackerId,
 ) -> None:
     """It should raise an exception when called on an empty pool."""
-    subject = RetrieveImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.RetrieveParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -142,12 +153,12 @@ async def test_retrieve_primary_only(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    subject: RetrieveImpl,
     flex_50uL_tiprack: LabwareDefinition,
     stacker_id: FlexStackerId,
     stacker_hardware: FlexStacker,
 ) -> None:
     """It should be able to retrieve a labware."""
-    subject = RetrieveImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.RetrieveParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -220,13 +231,13 @@ async def test_retrieve_primary_and_lid(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    subject: RetrieveImpl,
     flex_50uL_tiprack: LabwareDefinition,
     tiprack_lid_def: LabwareDefinition,
     stacker_id: FlexStackerId,
     stacker_hardware: FlexStacker,
 ) -> None:
     """It should be able to retrieve a labware with a lid on it."""
-    subject = RetrieveImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.RetrieveParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -335,13 +346,13 @@ async def test_retrieve_primary_and_adapter(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    subject: RetrieveImpl,
     flex_50uL_tiprack: LabwareDefinition,
     tiprack_adapter_def: LabwareDefinition,
     stacker_id: FlexStackerId,
     stacker_hardware: FlexStacker,
 ) -> None:
     """It should be able to retrieve a labware on an adapter."""
-    subject = RetrieveImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.RetrieveParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -442,6 +453,7 @@ async def test_retrieve_primary_adapter_and_lid(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    subject: RetrieveImpl,
     flex_50uL_tiprack: LabwareDefinition,
     tiprack_adapter_def: LabwareDefinition,
     tiprack_lid_def: LabwareDefinition,
@@ -449,7 +461,6 @@ async def test_retrieve_primary_adapter_and_lid(
     stacker_hardware: FlexStacker,
 ) -> None:
     """It should be able to retrieve a labware on an adapter."""
-    subject = RetrieveImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.RetrieveParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -7,7 +7,6 @@ from decoy import Decoy, matchers
 
 from opentrons.drivers.flex_stacker.types import StackerAxis
 from opentrons.hardware_control.modules import FlexStacker
-from opentrons.hardware_control.modules.errors import FlexStackerStallError
 from opentrons.protocol_engine.commands.flex_stacker.common import (
     FlexStackerStallOrCollisionError,
 )
@@ -42,6 +41,7 @@ from opentrons.protocol_engine.errors import (
 )
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+from opentrons_shared_data.errors.exceptions import FlexStackerStallError
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -8,7 +8,7 @@ from decoy import Decoy, matchers
 from opentrons.drivers.flex_stacker.types import StackerAxis
 from opentrons.hardware_control.modules import FlexStacker
 from opentrons.hardware_control.modules.errors import FlexStackerStallError
-from opentrons.protocol_engine.commands.movement_common import (
+from opentrons.protocol_engine.commands.flex_stacker.common import (
     FlexStackerStallOrCollisionError,
 )
 from opentrons.protocol_engine.resources import ModelUtils

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -6,6 +6,7 @@ import pytest
 from decoy import Decoy
 
 from opentrons.hardware_control.modules import FlexStacker
+from opentrons.protocol_engine.resources import ModelUtils
 
 from opentrons.protocol_engine.state.update_types import (
     StateUpdate,
@@ -38,15 +39,27 @@ from opentrons.protocol_engine.errors import (
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 
+@pytest.fixture
+def subject(
+    equipment: EquipmentHandler,
+    state_view: StateView,
+    model_utils: ModelUtils,
+) -> StoreImpl:
+    return StoreImpl(
+        state_view=state_view, equipment=equipment, model_utils=model_utils
+    )
+
+
 async def test_store_raises_in_static_mode(
     decoy: Decoy,
     equipment: EquipmentHandler,
     state_view: StateView,
+    model_utils: ModelUtils,
+    subject: StoreImpl,
     stacker_id: FlexStackerId,
     flex_50uL_tiprack: LabwareDefinition,
 ) -> None:
     """It should raise if called when the stacker is static."""
-    subject = StoreImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.StoreParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -72,11 +85,11 @@ async def test_store_raises_if_full(
     decoy: Decoy,
     equipment: EquipmentHandler,
     state_view: StateView,
+    subject: StoreImpl,
     stacker_id: FlexStackerId,
     flex_50uL_tiprack: LabwareDefinition,
 ) -> None:
     """It should raise if called when the stacker is full."""
-    subject = StoreImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.StoreParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -102,11 +115,11 @@ async def test_store_raises_if_carriage_logically_empty(
     decoy: Decoy,
     equipment: EquipmentHandler,
     state_view: StateView,
+    subject: StoreImpl,
     stacker_id: FlexStackerId,
     flex_50uL_tiprack: LabwareDefinition,
 ) -> None:
     """It should raise if called with a known-empty carriage."""
-    subject = StoreImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.StoreParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -135,10 +148,10 @@ async def test_store_raises_if_not_configured(
     decoy: Decoy,
     equipment: EquipmentHandler,
     state_view: StateView,
+    subject: StoreImpl,
     stacker_id: FlexStackerId,
 ) -> None:
     """It should raise if called before the stacker is configured."""
-    subject = StoreImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.StoreParams(moduleId=stacker_id)
     fs_module_substate = FlexStackerSubState(
         module_id=stacker_id,
@@ -249,6 +262,7 @@ async def test_store_raises_if_labware_does_not_match(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    subject: StoreImpl,
     stacker_id: FlexStackerId,
     stacker_hardware: FlexStacker,
     pool_adapter: LabwareDefinition | None,
@@ -257,7 +271,6 @@ async def test_store_raises_if_labware_does_not_match(
     param_lid: LabwareDefinition | None,
 ) -> None:
     """It should raise if the labware to be stored does not match the labware pool parameters."""
-    subject = StoreImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.StoreParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(
@@ -321,11 +334,10 @@ async def test_store(
     state_view: StateView,
     equipment: EquipmentHandler,
     stacker_id: FlexStackerId,
+    subject: StoreImpl,
     stacker_hardware: FlexStacker,
     flex_50uL_tiprack: LabwareDefinition,
 ) -> None:
-    """It should be able to store a labware."""
-    subject = StoreImpl(state_view=state_view, equipment=equipment)
     data = flex_stacker.StoreParams(moduleId=stacker_id)
 
     fs_module_substate = FlexStackerSubState(

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -130,6 +130,10 @@
       "detail": "Tip Hit Well Bottom",
       "category": "roboticsControlError"
     },
+    "2019": {
+      "detail": "Flex Stacker Stall or Collision Detected",
+      "category": "roboticsControlError"
+    },
     "3000": {
       "detail": "A robotics interaction error occurred.",
       "category": "roboticsInteractionError"

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -62,6 +62,7 @@ class ErrorCodes(Enum):
     MOTOR_DRIVER_ERROR = _code_from_dict_entry("2016")
     PIPETTE_LIQUID_NOT_FOUND = _code_from_dict_entry("2017")
     TIP_HIT_WELL_BOTTOM = _code_from_dict_entry("2018")
+    FLEX_STACKER_STALL_OR_COLLISION_DETECTED = _code_from_dict_entry("2019")
     ROBOTICS_INTERACTION_ERROR = _code_from_dict_entry("3000")
     LABWARE_DROPPED = _code_from_dict_entry("3001")
     LABWARE_NOT_PICKED_UP = _code_from_dict_entry("3002")

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -6,6 +6,7 @@ from traceback import format_exception_only, format_tb
 import inspect
 import sys
 
+from opentrons.drivers.flex_stacker.types import StackerAxis
 from .codes import ErrorCodes
 from .categories import ErrorCategories
 
@@ -380,6 +381,25 @@ class StallOrCollisionDetectedError(RoboticsControlError):
         """Build a StallOrCollisionDetectedError."""
         super().__init__(
             ErrorCodes.STALL_OR_COLLISION_DETECTED, message, detail, wrapping
+        )
+
+
+class FlexStackerStallError(RoboticsControlError):
+    """An error indicating that a stall or collision occurred in the flex stacker."""
+
+    def __init__(
+        self,
+        serial: str,
+        axis: StackerAxis,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, str]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a StallOrCollisionDetectedError."""
+        self.serial = serial
+        self.axis = axis
+        super().__init__(
+            ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED, message, detail, wrapping
         )
 
 

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -395,7 +395,7 @@ class FlexStackerStallError(RoboticsControlError):
         detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build a StallOrCollisionDetectedError."""
+        """Build a FlexStackerStallError."""
         self.serial = serial
         self.axis = axis
         super().__init__(

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -6,7 +6,6 @@ from traceback import format_exception_only, format_tb
 import inspect
 import sys
 
-from opentrons.drivers.flex_stacker.types import StackerAxis
 from .codes import ErrorCodes
 from .categories import ErrorCategories
 
@@ -390,7 +389,7 @@ class FlexStackerStallError(RoboticsControlError):
     def __init__(
         self,
         serial: str,
-        axis: StackerAxis,
+        axis: str,
         message: Optional[str] = None,
         detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
@@ -399,7 +398,10 @@ class FlexStackerStallError(RoboticsControlError):
         self.serial = serial
         self.axis = axis
         super().__init__(
-            ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED, message, detail, wrapping
+            ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED,
+            message,
+            detail,
+            wrapping,
         )
 
 


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-1198.
return a defined error from store and retrive when encountering a stall. 

## Test Plan and Hands on Testing

upload a protocol to the flex and trigger a stall upon store + retrive.
make sure the server is returning a defined error and not propagating the stall collision error. 

*** will add a protocol soon and will test locally as well

## Changelog

- `retreive` and `store` now catch a `FlexStackerStallError` and return a defined error for ER. 
- added `FlexStackerStallOrCollisionError` to the defined errors union. 

## Review requests

1. should we update the state when there is a stall?
2. do we need to add a new error code for the stacker stall?
3. do we need the `axis` and `serial` as props to the error? 
4. did I miss anything?

## Risk assessment

low. return a defined error instead of the error propagating. 
