### PR TITLE
fix(api): move plunger to top during evotip

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/evotip_seal_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/evotip_seal_pipette.py
@@ -253,7 +253,7 @@ class EvotipSealPipetteImplementation(
             # of 25.15. Applying a 5% safety factor makes it work.
             target_position = (
                 pipette_dict["plunger_positions"]["bottom"]
-                + _SAFE_TOP_VOLUME * pipette_dict["shaft_ul_per_mm"] * 1.05
+                - (_SAFE_TOP_VOLUME / pipette_dict["shaft_ul_per_mm"]) * 1.05
             )
             await self._hardware_api.move_axes(
                 {Axis.of_main_tool_actuator(hw_mount): target_position}

--- a/api/src/opentrons/protocol_engine/commands/evotip_seal_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/evotip_seal_pipette.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type, Union
-from opentrons.types import MountType
+from opentrons.types import MountType, Mount
 from opentrons.protocol_engine.types import MotorAxis
 from typing_extensions import Literal
 
@@ -237,19 +237,32 @@ class EvotipSealPipetteImplementation(
         if isinstance(move_result, DefinedErrorData):
             return move_result
 
+        mount = self._state_view.pipettes.get_mount(pipette_id)
+
         # Aspirate to move plunger to a maximum volume position per pipette type
         tip_geometry = self._state_view.geometry.get_nominal_tip_geometry(
             pipette_id, labware_id, well_name
         )
-        if self._state_view.pipettes.get_mount(pipette_id) == MountType.LEFT:
-            await self._hardware_api.home(axes=[Axis.P_L])
-        else:
-            await self._hardware_api.home(axes=[Axis.P_R])
+        # TODO: Make this less awful when there's a little more time to do so
+        if self._state_view.config.use_virtual_pipettes is False:
+            hw_mount = Mount.RIGHT if mount == MountType.RIGHT else Mount.LEFT
+            await self._hardware_api.home(axes=[Axis.of_main_tool_actuator(hw_mount)])
+            pipette_dict = self._hardware_api.get_attached_pipettes()[hw_mount]
+            # the actual ul/mm at 400ul for a 96 channel 1000ul 3.5 is 15.215 implying a plunger
+            # position of 26.29; the shaft nominal value is 15.904 implying a plunger position
+            # of 25.15. Applying a 5% safety factor makes it work.
+            target_position = (
+                pipette_dict["plunger_positions"]["bottom"]
+                + _SAFE_TOP_VOLUME * pipette_dict["shaft_ul_per_mm"] * 1.05
+            )
+            await self._hardware_api.move_axes(
+                {Axis.of_main_tool_actuator(hw_mount): target_position}
+            )
 
         # Begin relative pickup steps for the resin tips
 
         channels = self._state_view.tips.get_pipette_active_channels(pipette_id)
-        mount = self._state_view.pipettes.get_mount(pipette_id)
+
         tip_pick_up_params = params.tipPickUpParams
         if tip_pick_up_params is None:
             tip_pick_up_params = TipPickUpParams(


### PR DESCRIPTION
We were setting the max allowed volume of an evotip dispense, which means that the system won't allow you to dispense more than 400ul. The thing is, that when you dispense say 100ul, what the system does is take current volume (400) minus dispense volume (to equal 300) and move the plunger to the appropriate position for 300ul, _not_ move the plunger down 100ul. That means that at the moment you call that evotips dispense call, the plunger moves from the top to 300ul, which is a big swing that will inappropriately overdispense and will cause a pressure spike.

One way to fix this might be to keep the plunger starting from the top, and change evotips_dispense to move the plunger down by 100ul when you tell it to dispense 100ul. The problem there is that you're compressing a bigger air column under the pipette, which will change the behavior.

The right way to fix this is to move the plunger to +400ul right before doing the tip seal actions. This is unfortunately hard because we don't have the tips yet, and we don't have code to project settings based on what the tip _will_ be, and we don't have code to get the hardware to move like that. So let's do the ugly thing in the short term:
- Pick a position based on the nominal ul/mm with a bit of a margin, since the nominal ul/mm may be below the ul/mm at 400ul for the tip that we chose
- Move to that position before doing the pickup tip

This ain't no good!


## testing
- [x] do the protocol and check that the plunger moves right

Closes EXEC-1264