### PR TITLE
feat(protocol-designer): add off-deck variable for python

### DIFF
--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -9,6 +9,7 @@ import {
   formatPyDict,
   formatPyStr,
   indentPyLines,
+  OFF_DECK,
   PROTOCOL_CONTEXT_NAME,
 } from '@opentrons/step-generation'
 import { getFlexNameConversion } from './utils'
@@ -109,7 +110,13 @@ export function getLoadAdapters(
 
       const adapterArgs = [
         `${formatPyStr(parameters.loadName)}`,
-        ...(!onModule ? [`${formatPyStr(adapterSlot)}`] : []),
+        ...(!onModule
+          ? [
+              `${formatPyStr(
+                adapterSlot === 'offDeck' ? OFF_DECK : adapterSlot
+              )}`,
+            ]
+          : []),
         `namespace=${formatPyStr(namespace)}`,
         `version=${version}`,
       ].join(',\n')
@@ -151,7 +158,13 @@ export function getLoadLabware(
 
       const labwareArgs = [
         `${formatPyStr(parameters.loadName)}`,
-        ...(!onModule && !onAdapter ? [`${formatPyStr(labwareSlot)}`] : []),
+        ...(!onModule && !onAdapter
+          ? [
+              `${formatPyStr(
+                labwareSlot === 'offDeck' ? OFF_DECK : labwareSlot
+              )}`,
+            ]
+          : []),
         ...(hasNickname
           ? [`label=${formatPyStr(labwareNicknamesById[id])}`]
           : []),

--- a/step-generation/src/utils/pythonFormat.ts
+++ b/step-generation/src/utils/pythonFormat.ts
@@ -9,7 +9,7 @@ import type { WellLocation } from '@opentrons/shared-data/command/types/support'
 export const PROTOCOL_CONTEXT_NAME = 'protocol'
 
 /** The variable name for defining a labware that is off-deck or being moved to off-deck */
-export const OFF_DECK = 'OFF_DECK'
+export const OFF_DECK = 'protocol_api.OFF_DECK'
 
 const INDENT = '    '
 

--- a/step-generation/src/utils/pythonFormat.ts
+++ b/step-generation/src/utils/pythonFormat.ts
@@ -8,7 +8,7 @@ import type { WellLocation } from '@opentrons/shared-data/command/types/support'
  */
 export const PROTOCOL_CONTEXT_NAME = 'protocol'
 
-/** The variable name for defining a labware of moving a labware to a location off-deck */
+/** The variable name for defining a labware that is off-deck or being moved to off-deck */
 export const OFF_DECK = 'OFF_DECK'
 
 const INDENT = '    '

--- a/step-generation/src/utils/pythonFormat.ts
+++ b/step-generation/src/utils/pythonFormat.ts
@@ -8,6 +8,9 @@ import type { WellLocation } from '@opentrons/shared-data/command/types/support'
  */
 export const PROTOCOL_CONTEXT_NAME = 'protocol'
 
+/** The variable name for defining a labware of moving a labware to a location off-deck */
+export const OFF_DECK = 'OFF_DECK'
+
 const INDENT = '    '
 
 /** Indent each of the lines in `text`. */


### PR DESCRIPTION
# Overview

when calling `offDeck` location, it should use this varible `OFF_DECK`. This will be used in `move_labware` in addition to `load_labware`

see reference in the api doc here: https://docs.opentrons.com/v2/new_protocol_api.html?highlight=use_gripper#opentrons.protocol_api.OFF_DECK

## Test Plan and Hands on Testing

Review the code, smoke test uploading a labware loaded off-deck to the app

## Changelog

- add `OFF_DECK` variable and plug in

## Risk assessment

low, behind ff