### PR TITLE
feat(abr-testing): update stacker protocols for new api

### DIFF
--- a/abr-testing/abr_testing/protocols/helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers.py
@@ -514,7 +514,7 @@ def find_liquid_height(pipette: InstrumentContext, well_to_probe: Well) -> float
         )
     except PipetteLiquidNotFoundError:
         liquid_height = 0
-    return liquid_height
+    return liquid_height if isinstance(liquid_height, (float, int)) else 0
 
 
 def load_wells_with_custom_liquids(

--- a/abr-testing/abr_testing/protocols/test_protocols/IDT xGen 96ch.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/IDT xGen 96ch.py
@@ -1,4 +1,5 @@
 """IDT xGEn 96x with Flex Stacker."""
+
 from opentrons.protocol_api import ProtocolContext, ParameterContext
 from abr_testing.protocols import helpers
 from typing import List
@@ -106,18 +107,18 @@ def run(protocol: ProtocolContext) -> None:
     stacker_200_ul_tips: FlexStackerContext = protocol.load_module(
         "flexStackerModuleV1", "B4"
     )  # type: ignore[assignment]
-    stacker_200_ul_tips.load_labware_to_hopper(
+    stacker_200_ul_tips.set_stored_labware(
         load_name="opentrons_flex_96_tiprack_200ul",
-        quantity=6,
         lid="opentrons_flex_tiprack_lid",
+        count=6,
     )
     stacker_50_ul_tips: FlexStackerContext = protocol.load_module(
         "flexStackerModuleV1", "C4"
     )  # type: ignore[assignment]
-    stacker_50_ul_tips.load_labware_to_hopper(
+    stacker_50_ul_tips.set_stored_labware(
         load_name="opentrons_flex_96_tiprack_50ul",
-        quantity=6,
         lid="opentrons_flex_tiprack_lid",
+        count=6,
     )
 
     # ========== FIRST ROW ===========

--- a/abr-testing/abr_testing/protocols/test_protocols/Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/Illumina RNA all parts.py
@@ -1,4 +1,5 @@
 """Illumina RNA Enrichment 96x Flex Stacker."""
+
 from opentrons.protocol_api import ProtocolContext, ParameterContext, OFF_DECK
 from opentrons import types
 from opentrons.protocol_api import COLUMN, ALL, Labware
@@ -228,7 +229,7 @@ def run(protocol: ProtocolContext) -> None:
     )  # type: ignore[assignment]
     stacker_200_1.set_stored_labware(
         load_name="opentrons_flex_96_tiprack_200ul",
-        lid="opentrons_flex_tiprack_lid"
+        lid="opentrons_flex_tiprack_lid",
         count=6,
     )
     tiprack_A3_adapter = protocol.load_adapter(
@@ -245,7 +246,7 @@ def run(protocol: ProtocolContext) -> None:
     )  # type: ignore[assignment]
     stacker_200_2.set_stored_labware(
         load_name="opentrons_flex_96_tiprack_200ul",
-        lid="opentrons_flex_tiprack_lid"
+        lid="opentrons_flex_tiprack_lid",
         count=6,
     )
     lids = protocol.load_lid_stack("opentrons_tough_pcr_auto_sealing_lid", "B3", 5)
@@ -256,7 +257,7 @@ def run(protocol: ProtocolContext) -> None:
     )  # type: ignore[assignment]
     stacker_50_1.set_stored_labware(
         load_name="opentrons_flex_96_tiprack_50ul",
-        lid="opentrons_flex_tiprack_lid"
+        lid="opentrons_flex_tiprack_lid",
         count=6,
     )
     if ONDECK_TEMP:
@@ -283,8 +284,8 @@ def run(protocol: ProtocolContext) -> None:
     )  # type: ignore[assignment]
     stacker_50_2.set_stored_labware(
         load_name="opentrons_flex_96_tiprack_50ul",
-         lid="opentrons_flex_tiprack_lid",
-        quantity=6,
+        lid="opentrons_flex_tiprack_lid",
+        count=6,
     )
     TRASH = protocol.load_waste_chute()
     LW_reservoir = protocol.load_labware(

--- a/abr-testing/abr_testing/protocols/test_protocols/Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/Illumina RNA all parts.py
@@ -226,8 +226,10 @@ def run(protocol: ProtocolContext) -> None:
     stacker_200_1: FlexStackerContext = protocol.load_module(
         "flexStackerModuleV1", "A4"
     )  # type: ignore[assignment]
-    stacker_200_1.load_labware_to_hopper(
-        "opentrons_flex_96_tiprack_200ul", quantity=6, lid="opentrons_flex_tiprack_lid"
+    stacker_200_1.set_stored_labware(
+        load_name="opentrons_flex_96_tiprack_200ul",
+        lid="opentrons_flex_tiprack_lid"
+        count=6,
     )
     tiprack_A3_adapter = protocol.load_adapter(
         "opentrons_flex_96_tiprack_adapter", "A3"
@@ -241,8 +243,10 @@ def run(protocol: ProtocolContext) -> None:
     stacker_200_2: FlexStackerContext = protocol.load_module(
         "flexStackerModuleV1", "B4"
     )  # type: ignore[assignment]
-    stacker_200_2.load_labware_to_hopper(
-        "opentrons_flex_96_tiprack_200ul", quantity=6, lid="opentrons_flex_tiprack_lid"
+    stacker_200_2.set_stored_labware(
+        load_name="opentrons_flex_96_tiprack_200ul",
+        lid="opentrons_flex_tiprack_lid"
+        count=6,
     )
     lids = protocol.load_lid_stack("opentrons_tough_pcr_auto_sealing_lid", "B3", 5)
 
@@ -250,8 +254,10 @@ def run(protocol: ProtocolContext) -> None:
     stacker_50_1: FlexStackerContext = protocol.load_module(
         "flexStackerModuleV1", "C4"
     )  # type: ignore[assignment]
-    stacker_50_1.load_labware_to_hopper(
-        "opentrons_flex_96_tiprack_50ul", quantity=6, lid="opentrons_flex_tiprack_lid"
+    stacker_50_1.set_stored_labware(
+        load_name="opentrons_flex_96_tiprack_50ul",
+        lid="opentrons_flex_tiprack_lid"
+        count=6,
     )
     if ONDECK_TEMP:
         temp_block: TemperatureModuleContext = protocol.load_module(
@@ -275,8 +281,10 @@ def run(protocol: ProtocolContext) -> None:
     stacker_50_2: FlexStackerContext = protocol.load_module(
         "flexStackerModuleV1", "D4"
     )  # type: ignore[assignment]
-    stacker_50_2.load_labware_to_hopper(
-        "opentrons_flex_96_tiprack_50ul", quantity=6, lid="opentrons_flex_tiprack_lid"
+    stacker_50_2.set_stored_labware(
+        load_name="opentrons_flex_96_tiprack_50ul",
+         lid="opentrons_flex_tiprack_lid",
+        quantity=6,
     )
     TRASH = protocol.load_waste_chute()
     LW_reservoir = protocol.load_labware(
@@ -288,7 +296,6 @@ def run(protocol: ProtocolContext) -> None:
     CleanupPlate_1 = mag_block.load_labware(
         "nest_96_wellplate_2ml_deep", "Cleanup Plate 1"
     )
-    stacker_50_2.enter_static_mode()
     CleanupPlate_2 = stacker_50_2.load_labware(
         "nest_96_wellplate_2ml_deep", "Cleanup Plate 2"
     )
@@ -458,7 +465,6 @@ def run(protocol: ProtocolContext) -> None:
             )
         protocol.comment("MOVING: tiprack_50_SCP_2 = D4 --> SCP_Position")
         protocol.move_labware(CleanupPlate_2, stacker_200_1, use_gripper=True)
-        stacker_50_2.exit_static_mode()
         tiprack_50_SCP_2 = stacker_50_2.retrieve()
         protocol.move_lid(tiprack_50_SCP_2, TRASH, use_gripper=True)
         protocol.move_labware(
@@ -606,7 +612,6 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("MOVING: CleanupPlate_1 = mag_block --> D4")
-        stacker_50_2.enter_static_mode()
         protocol.move_labware(
             labware=CleanupPlate_1,
             new_location=stacker_50_2,
@@ -911,12 +916,10 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("MOVING: CleanupPlate_1 = D4 --> A4")
-        stacker_200_1.enter_static_mode()
         protocol.move_labware(
             labware=CleanupPlate_1, new_location=stacker_200_1, use_gripper=True
         )
         protocol.comment("MOVING: tiprack_200_X = SCP_Position --> B4")
-        stacker_200_2.enter_static_mode()
         protocol.move_labware(
             labware=tiprack_200_X,
             new_location=tiprack_A3_adapter,
@@ -924,7 +927,6 @@ def run(protocol: ProtocolContext) -> None:
         )
 
         protocol.comment("DISPENSING: tiprack_50_SCP_4 = #3--> D4")
-        stacker_50_2.exit_static_mode()
         tiprack_50_SCP_4 = stacker_50_2.retrieve()
         protocol.move_lid(tiprack_50_SCP_4, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_50_SCP_4 = D4 --> tiprack_A3_adapter")
@@ -1165,7 +1167,6 @@ def run(protocol: ProtocolContext) -> None:
             drop_offset=deck_drop_offset,
         )
         protocol.comment("MOVING: CleanupPlate_1 = A4 --> D4")
-        # stacker_50_2.enter_static_mode()
         protocol.move_labware(
             labware=CleanupPlate_1,
             new_location=stacker_50_2,
@@ -1174,9 +1175,7 @@ def run(protocol: ProtocolContext) -> None:
             drop_offset=deck_drop_offset,
         )
         protocol.comment("DISPENSING: tiprack_200_5 = #3--> A4")
-        stacker_200_1.enter_static_mode()
         protocol.move_labware(CleanupPlate_2, stacker_200_1, use_gripper=True)
-        stacker_200_2.exit_static_mode()
         tiprack_200_5 = stacker_200_2.retrieve()
         protocol.move_lid(tiprack_200_5, TRASH, use_gripper=True)
         protocol.move_labware(
@@ -1243,9 +1242,7 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_200_6 = #4--> A4")
-        stacker_200_2.enter_static_mode()
         protocol.move_labware(CleanupPlate_2, stacker_200_2, use_gripper=True)
-        stacker_200_1.exit_static_mode()
         tiprack_200_6 = stacker_200_1.retrieve()
         protocol.move_lid(tiprack_200_6, TRASH, use_gripper=True)
         protocol.move_labware(
@@ -1312,7 +1309,6 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_200_7 = #5--> A4")
-        stacker_200_1.exit_static_mode()
         tiprack_200_7 = stacker_200_1.retrieve()
         protocol.move_lid(tiprack_200_7, TRASH, use_gripper=True)
         protocol.move_labware(
@@ -1377,7 +1373,6 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_200_8 = #6--> A4")
-        stacker_200_1.exit_static_mode()
         tiprack_200_8 = stacker_200_1.retrieve()
         protocol.move_lid(tiprack_200_8, TRASH, use_gripper=True)
         protocol.move_labware(
@@ -1426,7 +1421,6 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("MOVING: CleanupPlate_1 = D4 --> A4")
-        stacker_200_1.enter_static_mode()
         protocol.move_labware(
             labware=CleanupPlate_1,
             new_location=stacker_200_1,
@@ -1435,7 +1429,6 @@ def run(protocol: ProtocolContext) -> None:
             drop_offset=deck_drop_offset,
         )
         protocol.comment("DISPENSING: tiprack_50_7 = #6--> D4")
-        stacker_50_2.exit_static_mode()
         tiprack_50_7 = stacker_50_2.retrieve()
         protocol.move_lid(tiprack_50_7, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_50_7 = D4 --> tiprack_A3_adapter")
@@ -1503,7 +1496,6 @@ def run(protocol: ProtocolContext) -> None:
             pick_up_offset=deck_pick_up_offset,
             drop_offset=mb_drop_offset,
         )
-        stacker_50_2.exit_static_mode()
         # ============================================================================================
 
         protocol.comment("--> TRANSFERRING AND ADDING AMPure (0.8x)")
@@ -1549,9 +1541,7 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_200_9 = #2--> B4")
-        stacker_200_1.enter_static_mode()
         protocol.move_labware(CleanupPlate_2, stacker_200_1, use_gripper=True)
-        stacker_200_2.exit_static_mode()
         tiprack_200_9 = stacker_200_2.retrieve()
         protocol.move_lid(tiprack_200_9, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_200_9 = B4 --> tiprack_A3_adapter")
@@ -1614,7 +1604,6 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_200_10 = #3--> B4")
-        stacker_200_2.exit_static_mode()
         tiprack_200_10 = stacker_200_2.retrieve()
         protocol.move_lid(tiprack_200_10, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_200_10 = B4 --> tiprack_A3_adapter")
@@ -1677,7 +1666,6 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_200_11 = #4--> B4")
-        stacker_200_2.exit_static_mode()
         tiprack_200_11 = stacker_200_2.retrieve()
         protocol.move_lid(tiprack_200_11, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_200_11 = B4 --> tiprack_A3_adapter")
@@ -1733,7 +1721,6 @@ def run(protocol: ProtocolContext) -> None:
         )
 
         protocol.comment("MOVING: CleanupPlate_2 = C4 --> A4")
-        stacker_50_2.enter_static_mode()
         protocol.move_labware(
             labware=CleanupPlate_2,
             new_location=stacker_50_2,
@@ -1742,7 +1729,6 @@ def run(protocol: ProtocolContext) -> None:
             drop_offset=deck_drop_offset,
         )
         protocol.comment("DISPENSING: tiprack_50_SCP_9 = #3--> C4")
-        stacker_50_1.exit_static_mode()
         tiprack_50_SCP_9 = stacker_50_1.retrieve()
         protocol.move_lid(tiprack_50_SCP_9, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_50_SCP_9 = C4 --> SCP_Position")
@@ -1794,9 +1780,7 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_50_SCP_10 = #4--> C4")
-        stacker_200_1.enter_static_mode()
         protocol.move_labware(CleanupPlate_2, stacker_200_1, use_gripper=True)
-        stacker_50_1.exit_static_mode()
         tiprack_50_SCP_10 = stacker_50_1.retrieve()
         protocol.move_lid(tiprack_50_SCP_10, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_50_SCP_10 = C4 --> SCP_Position")
@@ -1876,7 +1860,6 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_50_SCP_10 = #5--> C4")
-        stacker_50_1.exit_static_mode()
         tiprack_50_X = stacker_50_1.retrieve()
         protocol.move_lid(tiprack_50_X, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_50_X = C4 --> SCP_Position")
@@ -1986,7 +1969,6 @@ def run(protocol: ProtocolContext) -> None:
                 thermocycler.set_lid_temperature(58)
         # ============================================================================================
         protocol.comment("MOVING: tiprack_50_X = SCP_Position --> C4")
-        stacker_50_1.enter_static_mode()
         protocol.move_labware(
             labware=tiprack_50_X,
             new_location=stacker_50_1,
@@ -2175,7 +2157,6 @@ def run(protocol: ProtocolContext) -> None:
                 use_gripper=False,
             )
         protocol.comment("DISPENSING: tiprack_200_XX = #5--> B4")
-        stacker_200_2.exit_static_mode()
         tiprack_200_XX = stacker_200_2.retrieve()
         protocol.move_lid(tiprack_200_XX, TRASH, use_gripper=True)
         protocol.comment("MOVING: tiprack_200_XX = B4 --> SCP_Position")
@@ -2346,7 +2327,6 @@ def run(protocol: ProtocolContext) -> None:
 
         # ============================================================================================
         protocol.comment("MOVING: tiprack_200_XX = SCP_Position --> A4")
-        stacker_200_1.enter_static_mode()
         protocol.move_labware(
             labware=tiprack_200_XX,
             new_location=stacker_200_1,
@@ -2522,7 +2502,6 @@ def run(protocol: ProtocolContext) -> None:
 
         # ============================================================================================
         protocol.comment("MOVING: tiprack_50_X = SCP_Position --> B4")
-        stacker_200_2.enter_static_mode()
         protocol.move_labware(
             labware=tiprack_50_X,
             new_location=stacker_200_2,
@@ -2670,7 +2649,6 @@ def run(protocol: ProtocolContext) -> None:
 
         # ============================================================================================
         protocol.comment("MOVING: tiprack_200_XX = SCP_Position --> A4")
-        stacker_200_1.enter_static_mode()
         protocol.move_labware(
             labware=tiprack_200_XX,
             new_location=stacker_200_1,


### PR DESCRIPTION
Updates the two ABR stacker protocols for the new api by
- Switching all the load labwares to `set_stored_labware`
- remove all the static mode stuff
- That's actually pretty much it since they don't store or refill the stackers


## testing
- [x] run em