### PR TITLE
feat(protocol-designer): load_trash_bin and load_waste_chute for Flex

### DIFF
--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -19,11 +19,14 @@ import {
   getLoadLiquids,
   getLoadModules,
   getLoadPipettes,
+  getLoadTrashBins,
+  getLoadWasteChute,
   pythonMetadata,
   pythonRequirements,
 } from '../selectors/pythonFile'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type {
+  AdditionalEquipmentEntities,
   LabwareEntities,
   LabwareLiquidState,
   LiquidEntities,
@@ -386,6 +389,51 @@ well_plate_1["A1"].load_liquid(liquid_1, 10)
 well_plate_1["A2"].load_liquid(liquid_1, 10)
 well_plate_1["A3"].load_liquid(liquid_2, 50)
 well_plate_2["D1"].load_liquid(liquid_2, 180)`.trimStart()
+    )
+  })
+})
+
+const trash1 = 'trash1'
+const trash2 = 'trash2'
+const wasteChute = 'wasteChute'
+const mockAdditionalEquipmentEntities: AdditionalEquipmentEntities = {
+  [trash1]: {
+    name: 'trashBin',
+    pythonName: 'trash_bin_1',
+    location: 'A3',
+    id: trash1,
+  },
+  [trash2]: {
+    name: 'trashBin',
+    pythonName: 'trash_bin_2',
+    location: 'C3',
+    id: trash2,
+  },
+  [wasteChute]: {
+    name: 'wasteChute',
+    pythonName: 'waste_chute',
+    location: 'D3',
+    id: wasteChute,
+  },
+}
+
+describe('getTrashBins', () => {
+  it('should generate 2 trash bins', () => {
+    expect(getLoadTrashBins(mockAdditionalEquipmentEntities)).toBe(
+      `
+# Load Trash Bins:
+trash_bin_1 = protocol.load_trash_bin(location = "A3")
+trash_bin_2 = protocol.load_trash_bin(location = "C3")`.trimStart()
+    )
+  })
+})
+
+describe('getLoadWasteChute', () => {
+  it('should generate a waste chute', () => {
+    expect(getLoadWasteChute(mockAdditionalEquipmentEntities)).toBe(
+      `
+# Load Waste Chute:
+waste_chute = protocol.load_waste_chute()`.trimStart()
     )
   })
 })

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -422,8 +422,8 @@ describe('getTrashBins', () => {
     expect(getLoadTrashBins(mockAdditionalEquipmentEntities)).toBe(
       `
 # Load Trash Bins:
-trash_bin_1 = protocol.load_trash_bin(location = "A3")
-trash_bin_2 = protocol.load_trash_bin(location = "C3")`.trimStart()
+trash_bin_1 = protocol.load_trash_bin("A3")
+trash_bin_2 = protocol.load_trash_bin("C3")`.trimStart()
     )
   })
 })

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -333,7 +333,8 @@ export const createPythonFile: Selector<string> = createSelector(
           robotState,
           robotStateTimeline,
           liquidsByLabwareId,
-          labwareNicknamesById
+          labwareNicknamesById,
+          robotType
         ),
       ]
         .filter(section => section) // skip any blank sections

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -271,7 +271,7 @@ export function getLoadTrashBins(
         trashBin.location != null
           ? formatPyStr(getCutoutDisplayName(trashBin.location as CutoutId))
           : 'unknown trash location' // note: should never hit unknown trash location since location is always defined for trashBin entity
-      return `${trashBin.pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_trash_bin(location = ${location})`
+      return `${trashBin.pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_trash_bin(${location})`
     })
     .join('\n')
 
@@ -319,14 +319,14 @@ export function pythonDefRun(
       labwareNicknamesById
     ),
     getLoadPipettes(pipetteEntities, labwareEntities, pipettes),
-    getDefineLiquids(liquidEntities),
-    getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),
     ...(robotType === FLEX_ROBOT_TYPE
       ? [
           getLoadTrashBins(additionalEquipmentEntities),
           getLoadWasteChute(additionalEquipmentEntities),
         ]
       : []),
+    getDefineLiquids(liquidEntities),
+    getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),
     stepCommands(robotStateTimeline),
   ]
   const functionBody =

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -288,7 +288,7 @@ export function getLoadWasteChute(
         `${wasteChute.pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_waste_chute()`
     )
 
-  return pythonLoadWasteChute
+  return pythonLoadWasteChute.length > 0
     ? `# Load Waste Chute:\n${pythonLoadWasteChute}`
     : ''
 }
@@ -309,7 +309,6 @@ export function pythonDefRun(
     additionalEquipmentEntities,
   } = invariantContext
   const { modules, labware, pipettes } = robotState
-
   const sections: string[] = [
     getLoadModules(moduleEntities, modules),
     getLoadAdapters(moduleEntities, labwareEntities, labware),

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1331,7 +1331,8 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
       action: CreateDeckFixtureAction
     ): NormalizedAdditionalEquipmentById => {
       const { location, id, name } = action.payload
-      const count = Object.values(state).filter(aE => aE.name === name).length
+      const typeCount = Object.values(state).filter(aE => aE.name === name)
+        .length
 
       return {
         ...state,
@@ -1342,7 +1343,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           pythonName:
             name === 'stagingArea'
               ? undefined
-              : getAdditionalEquipmentPythonName(name, count),
+              : getAdditionalEquipmentPythonName(name, typeCount + 1),
         },
       }
     },

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1250,14 +1250,21 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
       }
       let trashBin
       if (Object.keys(trashBinLocationUpdate).length > 0) {
-        const id = Object.keys(trashBinLocationUpdate)[0]
-        trashBin = {
-          [id]: {
-            name: 'trashBin' as const,
-            id,
-            location: Object.values(trashBinLocationUpdate)[0],
-          },
-        }
+        trashBin = Object.entries(trashBinLocationUpdate).reduce(
+          (acc, [id, location], index) => ({
+            ...acc,
+            [id]: {
+              name: 'trashBin' as const,
+              id,
+              location,
+              pythonName: getAdditionalEquipmentPythonName(
+                'trashBin',
+                index + 1
+              ),
+            },
+          }),
+          {}
+        )
       }
       let wasteChute
       if (Object.keys(wasteChuteLocationUpdate).length > 0) {
@@ -1267,6 +1274,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
             name: 'wasteChute' as const,
             id,
             location: Object.values(wasteChuteLocationUpdate)[0],
+            pythonName: getAdditionalEquipmentPythonName('wasteChute', 1),
           },
         }
       }

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -22,7 +22,11 @@ import {
 import { PRESAVED_STEP_ID } from '../../steplist/types'
 import { getLabwareIsCompatible } from '../../utils/labwareModuleCompatibility'
 import { getLabwareOnModule } from '../../ui/modules/utils'
-import { getLabwarePythonName, getModulePythonName } from '../../utils'
+import {
+  getAdditionalEquipmentPythonName,
+  getLabwarePythonName,
+  getModulePythonName,
+} from '../../utils'
 import { nestedCombineReducers } from './nestedCombineReducers'
 import {
   _getPipetteEntitiesRootState,
@@ -1319,12 +1323,18 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
       action: CreateDeckFixtureAction
     ): NormalizedAdditionalEquipmentById => {
       const { location, id, name } = action.payload
+      const count = Object.values(state).filter(aE => aE.name === name).length
+
       return {
         ...state,
         [id]: {
           name,
           id,
           location,
+          pythonName:
+            name === 'stagingArea'
+              ? undefined
+              : getAdditionalEquipmentPythonName(name, count),
         },
       }
     },

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -306,3 +306,12 @@ export const getLabwarePythonName = (
 ): string => {
   return `${snakeCase(labwareDisplayCategory)}_${typeCount}`
 }
+
+export const getAdditionalEquipmentPythonName = (
+  fixtureName: 'wasteChute' | 'trashBin',
+  typeCount: number
+): string => {
+  return fixtureName === 'wasteChute'
+    ? snakeCase(fixtureName)
+    : `${snakeCase(fixtureName)}_${typeCount}`
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -150,6 +150,9 @@ export interface NormalizedAdditionalEquipmentById {
     name: AdditionalEquipmentName
     id: string
     location?: string
+    //  Note: leaving as optional since gripper and stagingArea
+    //  will never need a pythonName
+    pythonName?: string
   }
 }
 


### PR DESCRIPTION
closes AUTH-1510

# Overview

1st, this PR creates the `pythonName` for trash bins and waste chutes in the additional equipment entities when they're created from `create_deck_fixture` redux action and the reducer

2nd, this PR emits `load_trash_bin` and `load_waste_chute` for exporting python for Flex protocols (since OT-2 has fixed trash always available - see https://docs.opentrons.com/v2/new_protocol_api.html?highlight=waste#opentrons.protocol_api.ProtocolContext.fixed_trash)

NOTE: this already supports multiple trash bins even though we do not support selecting multiple trash bins in the UI yet.

## Test Plan and Hands on Testing

Test creating a trash bin and waste chute for a flex and observe the python protocol generated, should include the load commands for trash bin and waste chute. then test creating an ot-2 protocol and see that there is no trash bin command generated

## Changelog

- create `getLoadTrashBin` and `getLoadWasteChute` and wire up for flex protocols, generate based off of trash bin and waste chute entities created

## Risk assessment

low, behind ff
