### PR TITLE
fix(api): Add ready-to-aspirate into engine state so analysis correctly fails

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1077,6 +1077,7 @@ class API(
         rate: float = 1.0,
         push_out: Optional[float] = None,
         correction_volume: float = 0.0,
+        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid in microliters(uL) using this pipette.

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -607,6 +607,7 @@ class OT3PipetteHandler:
         volume: Optional[float],
         rate: float,
         push_out: Optional[float],
+        is_full_dispense: bool,
         correction_volume: float = 0.0,
     ) -> Optional[LiquidActionSpec]:
         """Check preconditions for dispense, parse args, and calculate positions.
@@ -644,7 +645,21 @@ class OT3PipetteHandler:
         # of the OT-2 version of this class. Protocol Engine does its own clamping,
         # so we don't expect this to trigger in practice.
         disp_vol = min(instrument.current_volume, disp_vol)
-        is_full_dispense = numpy.isclose(instrument.current_volume - disp_vol, 0)
+
+        # TODO (Ryan): Remove this check in the future.
+        # we moved this logic up to protocol_engine but replacing with this check to make sure
+        # we don't accidentally call this incorrectly from somewhere else.
+        if not is_full_dispense and numpy.isclose(
+            instrument.current_volume - disp_vol, 0
+        ):
+            raise CommandPreconditionViolated(
+                message="Command created a full-dispense without the full dispense argument",
+                detail={
+                    "command": "dispense",
+                    "current-volume": str(instrument.current_volume),
+                    "dispense-volume": str(disp_vol),
+                },
+            )
 
         if disp_vol == 0:
             return None

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2100,6 +2100,7 @@ class OT3API(
         rate: float = 1.0,
         push_out: Optional[float] = None,
         correction_volume: float = 0.0,
+        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid in microliters(uL) using this pipette."""
@@ -2109,6 +2110,7 @@ class OT3API(
             volume=volume,
             rate=rate,
             push_out=push_out,
+            is_full_dispense=is_full_dispense,
             correction_volume=correction_volume,
         )
         if not dispense_spec:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -3051,6 +3051,7 @@ class OT3API(
         volume: float,
         push_out: Optional[float],
         flow_rate: float = 1.0,
+        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid (in microliters/uL) while moving the z axis synchronously.
@@ -3062,7 +3063,7 @@ class OT3API(
         """
         realmount = OT3Mount.from_mount(mount)
         dispense_spec = self._pipette_handler.plan_check_dispense(
-            realmount, volume, flow_rate, push_out
+            realmount, volume, flow_rate, push_out, is_full_dispense
         )
         if not dispense_spec:
             return

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -168,6 +168,7 @@ class LiquidHandler(
         volume: float,
         push_out: Optional[float],
         flow_rate: float = 1.0,
+        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid (in microliters/uL) while moving the z axis synchronously.

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -146,6 +146,7 @@ class LiquidHandler(
         rate: float = 1.0,
         push_out: Optional[float] = None,
         correction_volume: float = 0.0,
+        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid in microliters(uL) using this pipette

--- a/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
@@ -86,7 +86,7 @@ class AirGapInPlaceImplementation(
         """
         ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
             pipette_id=params.pipetteId
-        ) and self._state_view.pipettes.get_ready_to_aspirate(params.pipetteId)
+        )
         if not ready_to_aspirate:
             raise PipetteNotReadyToAspirateError(
                 "Pipette cannot air gap in place because of a previous blow out."

--- a/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
@@ -84,10 +84,9 @@ class AirGapInPlaceImplementation(
             TipNotAttachedError: if no tip is attached to the pipette.
             PipetteNotReadyToAirGapError: pipette plunger is not ready.
         """
-        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
-            pipette_id=params.pipetteId,
-        )
-
+        ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
+            pipette_id=params.pipetteId
+        ) and self._pipetting.get_is_ready_to_aspirate(pipette_id=params.pipetteId)
         if not ready_to_aspirate:
             raise PipetteNotReadyToAspirateError(
                 "Pipette cannot air gap in place because of a previous blow out."

--- a/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/air_gap_in_place.py
@@ -84,9 +84,9 @@ class AirGapInPlaceImplementation(
             TipNotAttachedError: if no tip is attached to the pipette.
             PipetteNotReadyToAirGapError: pipette plunger is not ready.
         """
-        ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
+        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
             pipette_id=params.pipetteId
-        ) and self._pipetting.get_is_ready_to_aspirate(pipette_id=params.pipetteId)
+        ) and self._state_view.pipettes.get_ready_to_aspirate(params.pipetteId)
         if not ready_to_aspirate:
             raise PipetteNotReadyToAspirateError(
                 "Pipette cannot air gap in place because of a previous blow out."

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -111,9 +111,9 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
             pipette_id=pipette_id,
         )
 
-        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
-            pipette_id=pipette_id
-        )
+        ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
+            pipette_id
+        ) and self._pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)
 
         current_well = None
 

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -113,7 +113,7 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
 
         ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
             pipette_id=pipette_id
-        ) and self._state_view.pipettes.get_ready_to_aspirate(pipette_id)
+        )
 
         current_well = None
 

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -111,9 +111,9 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
             pipette_id=pipette_id,
         )
 
-        ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
-            pipette_id
-        ) and self._pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)
+        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
+            pipette_id=pipette_id
+        ) and self._state_view.pipettes.get_ready_to_aspirate(pipette_id)
 
         current_well = None
 

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -82,9 +82,9 @@ class AspirateInPlaceImplementation(
             TipNotAttachedError: if no tip is attached to the pipette.
             PipetteNotReadyToAspirateError: pipette plunger is not ready.
         """
-        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
-            pipette_id=params.pipetteId,
-        )
+        ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
+            pipette_id=params.pipetteId
+        ) and self._pipetting.get_is_ready_to_aspirate(pipette_id=params.pipetteId)
         if not ready_to_aspirate:
             raise PipetteNotReadyToAspirateError(
                 "Pipette cannot aspirate in place because of a previous blow out."

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -82,9 +82,9 @@ class AspirateInPlaceImplementation(
             TipNotAttachedError: if no tip is attached to the pipette.
             PipetteNotReadyToAspirateError: pipette plunger is not ready.
         """
-        ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
+        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
             pipette_id=params.pipetteId
-        ) and self._pipetting.get_is_ready_to_aspirate(pipette_id=params.pipetteId)
+        ) and self._state_view.pipettes.get_ready_to_aspirate(params.pipetteId)
         if not ready_to_aspirate:
             raise PipetteNotReadyToAspirateError(
                 "Pipette cannot aspirate in place because of a previous blow out."

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -84,7 +84,7 @@ class AspirateInPlaceImplementation(
         """
         ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
             pipette_id=params.pipetteId
-        ) and self._state_view.pipettes.get_ready_to_aspirate(params.pipetteId)
+        )
         if not ready_to_aspirate:
             raise PipetteNotReadyToAspirateError(
                 "Pipette cannot aspirate in place because of a previous blow out."

--- a/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
@@ -91,9 +91,9 @@ class AspirateWhileTrackingImplementation(
             TipNotAttachedError: if no tip is attached to the pipette.
             PipetteNotReadyToAspirateError: pipette plunger is not ready.
         """
-        ready_to_aspirate = self._pipetting.get_is_ready_to_aspirate(
-            pipette_id=params.pipetteId,
-        )
+        ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
+            pipette_id=params.pipetteId
+        ) and self._pipetting.get_is_ready_to_aspirate(pipette_id=params.pipetteId)
         if not ready_to_aspirate:
             raise PipetteNotReadyToAspirateError(
                 "Pipette cannot aspirate while tracking because of a previous blow out."

--- a/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
@@ -93,7 +93,7 @@ class AspirateWhileTrackingImplementation(
         """
         ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
             pipette_id=params.pipetteId
-        ) and self._pipetting.get_is_ready_to_aspirate(pipette_id=params.pipetteId)
+        )
         if not ready_to_aspirate:
             raise PipetteNotReadyToAspirateError(
                 "Pipette cannot aspirate while tracking because of a previous blow out."

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -115,7 +115,7 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, _ExecuteReturn]):
                 public=BlowOutResult(position=move_result.public.position),
                 state_update=StateUpdate.reduce(
                     move_result.state_update, blow_out_result.state_update
-                ).set_pipette_ready_to_aspireate(
+                ).set_pipette_ready_to_aspirate(
                     pipette_id=params.pipetteId, ready_to_aspirate=False
                 ),
             )

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -115,6 +115,8 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, _ExecuteReturn]):
                 public=BlowOutResult(position=move_result.public.position),
                 state_update=StateUpdate.reduce(
                     move_result.state_update, blow_out_result.state_update
+                ).set_pipette_ready_to_aspireate(
+                    pipette_id=params.pipetteId, ready_to_aspirate=False
                 ),
             )
 

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -89,7 +89,10 @@ class BlowOutInPlaceImplementation(
         if isinstance(result, DefinedErrorData):
             return result
         return SuccessData(
-            public=BlowOutInPlaceResult(), state_update=result.state_update
+            public=BlowOutInPlaceResult(),
+            state_update=result.state_update.set_pipette_ready_to_aspireate(
+                pipette_id=params.pipetteId, ready_to_aspirate=False
+            ),
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -90,7 +90,7 @@ class BlowOutInPlaceImplementation(
             return result
         return SuccessData(
             public=BlowOutInPlaceResult(),
-            state_update=result.state_update.set_pipette_ready_to_aspireate(
+            state_update=result.state_update.set_pipette_ready_to_aspirate(
                 pipette_id=params.pipetteId, ready_to_aspirate=False
             ),
         )

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -74,6 +74,9 @@ class ConfigureForVolumeImplementation(
             config=pipette_result.static_config,
             serial_number=pipette_result.serial_number,
         )
+        state_update.set_pipette_ready_to_aspireate(
+            pipette_result.pipette_id, ready_to_aspirate=False
+        )
 
         return SuccessData(
             public=ConfigureForVolumeResult(),

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -74,7 +74,7 @@ class ConfigureForVolumeImplementation(
             config=pipette_result.static_config,
             serial_number=pipette_result.serial_number,
         )
-        state_update.set_pipette_ready_to_aspireate(
+        state_update.set_pipette_ready_to_aspirate(
             pipette_result.pipette_id, ready_to_aspirate=False
         )
 

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type, Union, Any
 from typing_extensions import Literal
-import numpy
 
 from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
@@ -150,14 +149,6 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
                 volume_added *= self._state_view.geometry.get_nozzles_per_well(
                     labware_id, well_name, params.pipetteId
                 )
-            # The current volume won't be none since it passed validation
-            current_volume = (
-                self._state_view.pipettes.get_aspirated_volume(params.pipetteId) or 0.0
-            )
-            auto_pushout = numpy.isclose(current_volume - params.volume, 0)
-            ready = (
-                params.pushOut == 0 if params.pushOut is not None else not auto_pushout
-            )
             return SuccessData(
                 public=DispenseResult(
                     volume=dispense_result.public.volume,
@@ -166,8 +157,7 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
                 state_update=(
                     StateUpdate.reduce(
                         move_result.state_update, dispense_result.state_update
-                    )
-                    .set_liquid_operated(
+                    ).set_liquid_operated(
                         labware_id=labware_id,
                         well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
                             labware_id, well_name, params.pipetteId
@@ -175,9 +165,6 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
                         volume_added=volume_added
                         if volume_added is not None
                         else CLEAR,
-                    )
-                    .set_pipette_ready_to_aspireate(
-                        pipette_id=params.pipetteId, ready_to_aspirate=ready
                     )
                 ),
             )

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -154,9 +154,9 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
             current_volume = (
                 self._state_view.pipettes.get_aspirated_volume(params.pipetteId) or 0.0
             )
-            auto_blowout = numpy.isclose(current_volume - params.volume, 0)
+            auto_pushout = numpy.isclose(current_volume - params.volume, 0)
             ready = (
-                params.pushOut == 0 if params.pushOut is not None else not auto_blowout
+                params.pushOut == 0 if params.pushOut is not None else not auto_pushout
             )
             return SuccessData(
                 public=DispenseResult(

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -124,9 +124,9 @@ class DispenseInPlaceImplementation(
             current_volume = (
                 self._state_view.pipettes.get_aspirated_volume(params.pipetteId) or 0.0
             )
-            auto_blowout = numpy.isclose(current_volume - params.volume, 0)
+            auto_pushout = numpy.isclose(current_volume - params.volume, 0)
             ready = (
-                params.pushOut == 0 if params.pushOut is not None else not auto_blowout
+                params.pushOut == 0 if params.pushOut is not None else not auto_pushout
             )
             result.state_update.set_pipette_ready_to_aspireate(
                 pipette_id=params.pipetteId, ready_to_aspirate=ready

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type, Union, Any
 from typing_extensions import Literal
+import numpy
 from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
 
@@ -119,6 +120,17 @@ class DispenseInPlaceImplementation(
             else:
                 return result
         else:
+            # The current volume won't be none since it passed validation
+            current_volume = (
+                self._state_view.pipettes.get_aspirated_volume(params.pipetteId) or 0.0
+            )
+            auto_blowout = numpy.isclose(current_volume - params.volume, 0)
+            ready = (
+                params.pushOut == 0 if params.pushOut is not None else not auto_blowout
+            )
+            result.state_update.set_pipette_ready_to_aspireate(
+                pipette_id=params.pipetteId, ready_to_aspirate=ready
+            )
             if (
                 isinstance(current_location, CurrentWell)
                 and current_location.pipette_id == params.pipetteId

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type, Union, Any
 from typing_extensions import Literal
-import numpy
+
 from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
 
@@ -120,17 +120,6 @@ class DispenseInPlaceImplementation(
             else:
                 return result
         else:
-            # The current volume won't be none since it passed validation
-            current_volume = (
-                self._state_view.pipettes.get_aspirated_volume(params.pipetteId) or 0.0
-            )
-            auto_pushout = numpy.isclose(current_volume - params.volume, 0)
-            ready = (
-                params.pushOut == 0 if params.pushOut is not None else not auto_pushout
-            )
-            result.state_update.set_pipette_ready_to_aspireate(
-                pipette_id=params.pipetteId, ready_to_aspirate=ready
-            )
             if (
                 isinstance(current_location, CurrentWell)
                 and current_location.pipette_id == params.pipetteId

--- a/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
@@ -145,6 +145,10 @@ class DispenseWhileTrackingImplementation(
             else:
                 return dispense_result
         else:
+            ready = params.pushOut is None or params.pushOut == 0
+            dispense_result.state_update.set_pipette_ready_to_aspireate(
+                pipette_id=params.pipetteId, ready_to_aspirate=ready
+            )
             if (
                 isinstance(current_location, CurrentWell)
                 and current_location.pipette_id == params.pipetteId

--- a/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
@@ -145,10 +145,6 @@ class DispenseWhileTrackingImplementation(
             else:
                 return dispense_result
         else:
-            ready = params.pushOut is None or params.pushOut == 0
-            dispense_result.state_update.set_pipette_ready_to_aspireate(
-                pipette_id=params.pipetteId, ready_to_aspirate=ready
-            )
             if (
                 isinstance(current_location, CurrentWell)
                 and current_location.pipette_id == params.pipetteId

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -190,6 +190,9 @@ async def _execute_common(  # noqa: C901
             well_location=params.wellLocation,
         )
     except PipetteLiquidNotFoundError as exception:
+        move_result.state_update.set_pipette_ready_to_aspireate(
+            pipette_id=pipette_id, ready_to_aspirate=True
+        )
         return _ExecuteCommonResult(
             z_pos_or_error=exception,
             state_update=move_result.state_update,
@@ -223,6 +226,9 @@ async def _execute_common(  # noqa: C901
             ),
         )
     else:
+        move_result.state_update.set_pipette_ready_to_aspireate(
+            pipette_id=pipette_id, ready_to_aspirate=True
+        )
         return _ExecuteCommonResult(
             z_pos_or_error=z_pos,
             state_update=move_result.state_update,

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -190,7 +190,7 @@ async def _execute_common(  # noqa: C901
             well_location=params.wellLocation,
         )
     except PipetteLiquidNotFoundError as exception:
-        move_result.state_update.set_pipette_ready_to_aspireate(
+        move_result.state_update.set_pipette_ready_to_aspirate(
             pipette_id=pipette_id, ready_to_aspirate=True
         )
         return _ExecuteCommonResult(
@@ -226,7 +226,7 @@ async def _execute_common(  # noqa: C901
             ),
         )
     else:
-        move_result.state_update.set_pipette_ready_to_aspireate(
+        move_result.state_update.set_pipette_ready_to_aspirate(
             pipette_id=pipette_id, ready_to_aspirate=True
         )
         return _ExecuteCommonResult(

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -138,6 +138,9 @@ class LoadPipetteImplementation(
             config=loaded_pipette.static_config,
         )
         state_update.set_fluid_unknown(pipette_id=loaded_pipette.pipette_id)
+        state_update.set_pipette_ready_to_aspireate(
+            pipette_id=loaded_pipette.pipette_id, ready_to_aspirate=False
+        ),
 
         return SuccessData(
             public=LoadPipetteResult(pipetteId=loaded_pipette.pipette_id),

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -138,7 +138,7 @@ class LoadPipetteImplementation(
             config=loaded_pipette.static_config,
         )
         state_update.set_fluid_unknown(pipette_id=loaded_pipette.pipette_id)
-        state_update.set_pipette_ready_to_aspireate(
+        state_update.set_pipette_ready_to_aspirate(
             pipette_id=loaded_pipette.pipette_id, ready_to_aspirate=False
         ),
 

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -189,7 +189,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                     pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
                 )
                 .set_fluid_empty(pipette_id=pipette_id)
-                .set_pipette_ready_to_aspireate(
+                .set_pipette_ready_to_aspirate(
                     pipette_id=pipette_id, ready_to_aspirate=True
                 )
             )

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -189,6 +189,9 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                     pipette_id=pipette_id, labware_id=labware_id, well_name=well_name
                 )
                 .set_fluid_empty(pipette_id=pipette_id)
+                .set_pipette_ready_to_aspireate(
+                    pipette_id=pipette_id, ready_to_aspirate=True
+                )
             )
             return SuccessData(
                 public=PickUpTipResult(

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -296,7 +296,7 @@ async def dispense_while_tracking(
     current_volume = (
         pipetting.get_state_view().pipettes.get_aspirated_volume(pipette_id) or 0.0
     )
-    is_full_dispense = numpy.isclose(current_volume - volume, 0)
+    is_full_dispense = bool(numpy.isclose(current_volume - volume, 0))
     ready = push_out == 0 if push_out is not None else not is_full_dispense
     try:
         volume_dispensed = await pipetting.dispense_while_tracking(
@@ -306,6 +306,7 @@ async def dispense_while_tracking(
             volume=volume,
             flow_rate=flow_rate,
             push_out=push_out,
+            is_full_dispense=is_full_dispense,
         )
     except PipetteOverpressureError as e:
         return DefinedErrorData(

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -359,7 +359,6 @@ async def dispense_in_place(
         pipetting.get_state_view().pipettes.get_aspirated_volume(pipette_id) or 0.0
     )
     is_full_dispense = bool(numpy.isclose(current_volume - volume, 0))
-    print(f"Current volume {current_volume}")
     ready: bool = push_out == 0 if push_out is not None else not is_full_dispense
     try:
         volume = await pipetting.dispense_in_place(
@@ -367,6 +366,7 @@ async def dispense_in_place(
             volume=volume,
             flow_rate=flow_rate,
             push_out=push_out,
+            is_full_dispense=is_full_dispense,
             correction_volume=correction_volume,
         )
     except PipetteOverpressureError as e:

--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -84,7 +84,9 @@ class PrepareToAspirateImplementation(
         else:
             return SuccessData(
                 public=PrepareToAspirateResult(),
-                state_update=prepare_result.state_update,
+                state_update=prepare_result.state_update.set_pipette_ready_to_aspireate(
+                    pipette_id=params.pipetteId, ready_to_aspirate=True
+                ),
             )
 
 

--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -84,7 +84,7 @@ class PrepareToAspirateImplementation(
         else:
             return SuccessData(
                 public=PrepareToAspirateResult(),
-                state_update=prepare_result.state_update.set_pipette_ready_to_aspireate(
+                state_update=prepare_result.state_update.set_pipette_ready_to_aspirate(
                     pipette_id=params.pipetteId, ready_to_aspirate=True
                 ),
             )

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
@@ -69,7 +69,7 @@ class UnsafeBlowOutInPlaceImplementation(
         )
         state_update = update_types.StateUpdate()
         state_update.set_fluid_empty(pipette_id=params.pipetteId)
-        state_update.set_pipette_ready_to_aspireate(
+        state_update.set_pipette_ready_to_aspirate(
             pipette_id=params.pipetteId, ready_to_aspirate=False
         )
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
@@ -69,7 +69,9 @@ class UnsafeBlowOutInPlaceImplementation(
         )
         state_update = update_types.StateUpdate()
         state_update.set_fluid_empty(pipette_id=params.pipetteId)
-
+        state_update.set_pipette_ready_to_aspireate(
+            pipette_id=params.pipetteId, ready_to_aspirate=False
+        )
         return SuccessData(
             public=UnsafeBlowOutInPlaceResult(), state_update=state_update
         )

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -252,6 +252,7 @@ class HardwarePipettingHandler(PipettingHandler):
                 volume=adjusted_volume,
                 push_out=push_out,
                 correction_volume=correction_volume,
+                is_full_dispense=is_full_dispense,
             )
 
         return adjusted_volume

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -72,6 +72,7 @@ class PipettingHandler(TypingProtocol):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
+        is_full_dispense: bool = False,
     ) -> float:
         """Set flow-rate and dispense while tracking."""
 
@@ -196,6 +197,7 @@ class HardwarePipettingHandler(PipettingHandler):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
+        is_full_dispense: bool = False,
     ) -> float:
         """Set flow-rate and dispense.
 
@@ -438,6 +440,7 @@ class VirtualPipettingHandler(PipettingHandler):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
+        is_full_dispense: bool = False,
     ) -> float:
         """Virtually dispense (no-op)."""
         # TODO (tz, 8-23-23): add a check for push_out not larger that the max volume allowed when working on this https://opentrons.atlassian.net/browse/RSS-329

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -34,6 +34,9 @@ _VOLUME_ROUNDING_ERROR_TOLERANCE = 1e-9
 class PipettingHandler(TypingProtocol):
     """Liquid handling commands."""
 
+    def get_state_view(self) -> StateView:
+        """Get the stateview associated with this handler."""
+
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:
         """Get whether a pipette is ready to aspirate."""
 
@@ -78,6 +81,7 @@ class PipettingHandler(TypingProtocol):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
+        is_full_dispense: bool,
         correction_volume: float = 0.0,
     ) -> float:
         """Set flow-rate and dispense."""
@@ -106,6 +110,10 @@ class HardwarePipettingHandler(PipettingHandler):
         """Initialize a PipettingHandler instance."""
         self._state_view = state_view
         self._hardware_api = hardware_api
+
+    def get_state_view(self) -> StateView:
+        """Get the stateview associated with this handler."""
+        return self._state_view
 
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:
         """Get whether a pipette is ready to aspirate."""
@@ -228,6 +236,7 @@ class HardwarePipettingHandler(PipettingHandler):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
+        is_full_dispense: bool,
         correction_volume: float = 0.0,
     ) -> float:
         """Dispense liquid without moving the pipette."""
@@ -327,6 +336,10 @@ class VirtualPipettingHandler(PipettingHandler):
         """Initialize a PipettingHandler instance."""
         self._state_view = state_view
 
+    def get_state_view(self) -> StateView:
+        """Get the stateview associated with this handler."""
+        return self._state_view
+
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:
         """Get whether a pipette is ready to aspirate."""
         return self._state_view.pipettes.get_aspirated_volume(pipette_id) is not None
@@ -358,6 +371,7 @@ class VirtualPipettingHandler(PipettingHandler):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
+        is_full_dispense: bool,
         correction_volume: float = 0.0,
     ) -> float:
         """Virtually dispense (no-op)."""

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -332,6 +332,7 @@ class VirtualPipettingHandler(PipettingHandler):
 
     async def prepare_for_aspirate(self, pipette_id: str) -> None:
         """Virtually prepare to aspirate (no-op)."""
+        self._validate_tip_attached(pipette_id=pipette_id, command_name="aspirate")
 
     async def aspirate_in_place(
         self,

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -116,6 +116,7 @@ class HardwarePipettingHandler(PipettingHandler):
         return (
             self._state_view.pipettes.get_aspirated_volume(pipette_id) is not None
             and hw_pipette.config["ready_to_aspirate"]
+            and self._state_view.pipettes.get_ready_to_aspirate(pipette_id)
         )
 
     async def prepare_for_aspirate(self, pipette_id: str) -> None:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -835,7 +835,7 @@ class PipetteView:
         """Get the plunger position provided for the given pipette id."""
         return self.get_config(pipette_id).plunger_positions[position_name]
 
-    def get_ready_to_aspirate(self, pipette_id: str) -> float:
+    def get_ready_to_aspirate(self, pipette_id: str) -> bool:
         """Get if the provided pipette is ready to aspirate for the given pipette id."""
         try:
             return self._state.ready_to_aspirate_by_id[pipette_id]

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -863,7 +863,7 @@ class StateUpdate:
         )
         return self
 
-    def set_pipette_ready_to_aspireate(
+    def set_pipette_ready_to_aspirate(
         self, pipette_id: str, ready_to_aspirate: bool
     ) -> Self:
         """Set the ready to aspirate state for a pipette."""

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -239,6 +239,14 @@ class PipetteTipStateUpdate:
 
 
 @dataclasses.dataclass
+class PipetteAspirateReadyUpdate:
+    """Update pipette ready state."""
+
+    pipette_id: str
+    ready_to_aspirate: bool
+
+
+@dataclasses.dataclass
 class TipsUsedUpdate:
     """Represents an update that marks tips in a tip rack as used."""
 
@@ -459,6 +467,8 @@ class StateUpdate:
     files_added: FilesAddedUpdate | NoChangeType = NO_CHANGE
 
     addressable_area_used: AddressableAreaUsedUpdate | NoChangeType = NO_CHANGE
+
+    ready_to_aspirate: PipetteAspirateReadyUpdate | NoChangeType = NO_CHANGE
 
     def append(self, other: Self) -> Self:
         """Apply another `StateUpdate` "on top of" this one.
@@ -850,5 +860,14 @@ class StateUpdate:
                 self.flex_stacker_state_update, module_id
             ),
             pool_count=count,
+        )
+        return self
+
+    def set_pipette_ready_to_aspireate(
+        self, pipette_id: str, ready_to_aspirate: bool
+    ) -> Self:
+        """Set the ready to aspirate state for a pipette."""
+        self.ready_to_aspirate = PipetteAspirateReadyUpdate(
+            pipette_id=pipette_id, ready_to_aspirate=ready_to_aspirate
         )
         return self

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -585,7 +585,7 @@ async def test_dispense_ot3(
     with pytest.raises(CommandPreconditionViolated):
         await hw_api.dispense(mount, 5, push_out=10)
 
-    await hw_api.dispense(mount, rate=2, push_out=10)
+    await hw_api.dispense(mount, rate=2, push_out=10, is_full_dispense=True)
     plunger_pos_2 = 72.2715
     assert (await hw_api.current_position(mount))[Axis.B] == pytest.approx(
         plunger_pos_2, 0.1
@@ -832,7 +832,7 @@ async def test_dispense_flow_rate(
         assert_move_called(mock_move, 10)
 
     with mock.patch.object(hw_api, "_move") as mock_move:
-        await hw_api.dispense(types.Mount.LEFT, 1, rate=0.5)
+        await hw_api.dispense(types.Mount.LEFT, 1, rate=0.5, is_full_dispense=True)
         assert_move_called(mock_move, 5)
 
 

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1871,9 +1871,13 @@ async def test_dispense_while_tracking(
 
     if not tip_present:
         with pytest.raises(UnexpectedTipRemovalError):
-            await ot3_hardware.dispense_while_tracking(mount, 8.0, 80.0, push_out=None, is_full_dispense=is_ready)
+            await ot3_hardware.dispense_while_tracking(
+                mount, 8.0, 80.0, push_out=None, is_full_dispense=is_ready
+            )
     else:
-        await ot3_hardware.dispense_while_tracking(mount, 8.0, 80.0, push_out=None, is_full_dispense=is_ready)
+        await ot3_hardware.dispense_while_tracking(
+            mount, 8.0, 80.0, push_out=None, is_full_dispense=True
+        )
         if is_ready:
             # make sure the move planning math stays the same
             expected_target_pos = {

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1871,9 +1871,9 @@ async def test_dispense_while_tracking(
 
     if not tip_present:
         with pytest.raises(UnexpectedTipRemovalError):
-            await ot3_hardware.dispense_while_tracking(mount, 8.0, 80.0, push_out=None)
+            await ot3_hardware.dispense_while_tracking(mount, 8.0, 80.0, push_out=None, is_full_dispense=is_ready)
     else:
-        await ot3_hardware.dispense_while_tracking(mount, 8.0, 80.0, push_out=None)
+        await ot3_hardware.dispense_while_tracking(mount, 8.0, 80.0, push_out=None, is_full_dispense=is_ready)
         if is_ready:
             # make sure the move planning math stays the same
             expected_target_pos = {

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1783,7 +1783,9 @@ async def test_plunger_ready_to_aspirate_after_dispense(
     assert ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate
 
     await ot3_hardware.aspirate(OT3Mount.LEFT, asp_vol)
-    await ot3_hardware.dispense(OT3Mount.LEFT, disp_vol, push_out=push_out)
+    await ot3_hardware.dispense(
+        OT3Mount.LEFT, disp_vol, push_out=push_out, is_full_dispense=disp_vol == asp_vol
+    )
     assert (
         ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate == is_ready
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_air_gap_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_air_gap_in_place.py
@@ -120,6 +120,9 @@ async def test_air_gap_in_place_implementation(
         )
     ).then_return(123)
 
+    decoy.when(
+        state_store.pipettes.get_ready_to_aspirate("pipette-id-abc")
+    ).then_return(True)
     decoy.when(state_store.pipettes.get_current_location()).then_return(location)
 
     result = await subject.execute(params=data)
@@ -178,6 +181,7 @@ async def test_handle_air_gap_in_place_request_not_ready_to_aspirate(
 async def test_aspirate_raises_volume_error(
     decoy: Decoy,
     pipetting: PipettingHandler,
+    state_store: StateStore,
     subject: AirGapInPlaceImplementation,
     mock_command_note_adder: CommandNoteAdder,
 ) -> None:
@@ -189,6 +193,7 @@ async def test_aspirate_raises_volume_error(
     )
 
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id="abc")).then_return(True)
+    decoy.when(state_store.pipettes.get_ready_to_aspirate("abc")).then_return(True)
 
     decoy.when(
         await pipetting.aspirate_in_place(
@@ -264,6 +269,7 @@ async def test_overpressure_error(
     decoy.when(model_utils.get_timestamp()).then_return(error_timestamp)
     decoy.when(await gantry_mover.get_position(pipette_id)).then_return(position)
     decoy.when(state_store.pipettes.get_current_location()).then_return(location)
+    decoy.when(state_store.pipettes.get_ready_to_aspirate(pipette_id)).then_return(True)
 
     result = await subject.execute(data)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -92,6 +92,8 @@ async def test_aspirate_implementation_no_prep(
         True
     )
 
+    decoy.when(state_view.pipettes.get_ready_to_aspirate(pipette_id)).then_return(True)
+
     decoy.when(
         state_view.geometry.get_nozzles_per_well(
             labware_id=labware_id,
@@ -185,6 +187,7 @@ async def test_aspirate_implementation_with_prep(
         False
     )
 
+    decoy.when(state_view.pipettes.get_ready_to_aspirate(pipette_id)).then_return(False)
     decoy.when(
         state_view.geometry.get_nozzles_per_well(
             labware_id=labware_id,
@@ -294,6 +297,7 @@ async def test_aspirate_raises_volume_error(
         True
     )
 
+    decoy.when(state_view.pipettes.get_ready_to_aspirate(pipette_id)).then_return(True)
     decoy.when(
         state_view.geometry.get_nozzles_per_well(
             labware_id=labware_id,
@@ -384,6 +388,7 @@ async def test_overpressure_error(
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
         True
     )
+    decoy.when(state_view.pipettes.get_ready_to_aspirate(pipette_id)).then_return(True)
 
     decoy.when(
         await movement.move_to_well(
@@ -485,6 +490,7 @@ async def test_aspirate_implementation_meniscus(
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
         True
     )
+    decoy.when(state_view.pipettes.get_ready_to_aspirate(pipette_id)).then_return(True)
 
     decoy.when(
         await movement.move_to_well(
@@ -556,6 +562,7 @@ async def test_stall_during_final_movement(
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
         True
     )
+    decoy.when(state_view.pipettes.get_ready_to_aspirate(pipette_id)).then_return(True)
 
     params = AspirateParams(
         pipetteId=pipette_id,
@@ -601,6 +608,7 @@ async def test_stall_during_preparation(
     pipetting: PipettingHandler,
     subject: AspirateImplementation,
     model_utils: ModelUtils,
+    state_view: StateView,
 ) -> None:
     """It should propagate a stall error that happens during the prepare-to-aspirate part."""
     pipette_id = "pipette-id"
@@ -625,6 +633,7 @@ async def test_stall_during_preparation(
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
         False
     )
+    decoy.when(state_view.pipettes.get_ready_to_aspirate(pipette_id)).then_return(False)
 
     decoy.when(
         await movement.move_to_well(
@@ -685,6 +694,7 @@ async def test_overpressure_during_preparation(
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
         False
     )
+    decoy.when(state_view.pipettes.get_ready_to_aspirate(pipette_id)).then_return(False)
 
     retry_location = Point(1, 2, 3)
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
@@ -124,6 +124,9 @@ async def test_aspirate_in_place_implementation(
     ).then_return(True)
 
     decoy.when(
+        state_store.pipettes.get_ready_to_aspirate("pipette-id-abc")
+    ).then_return(True)
+    decoy.when(
         await pipetting.aspirate_in_place(
             pipette_id="pipette-id-abc",
             volume=123,
@@ -191,6 +194,9 @@ async def test_handle_aspirate_in_place_request_not_ready_to_aspirate(
         )
     ).then_return(False)
 
+    decoy.when(
+        state_store.pipettes.get_ready_to_aspirate("pipette-id-abc")
+    ).then_return(False)
     with pytest.raises(
         PipetteNotReadyToAspirateError,
         match="Pipette cannot aspirate in place because of a previous blow out."
@@ -204,6 +210,7 @@ async def test_aspirate_raises_volume_error(
     decoy: Decoy,
     pipetting: PipettingHandler,
     subject: AspirateInPlaceImplementation,
+    state_store: StateStore,
     mock_command_note_adder: CommandNoteAdder,
     gantry_mover: GantryMover,
 ) -> None:
@@ -215,6 +222,7 @@ async def test_aspirate_raises_volume_error(
     )
     decoy.when(await gantry_mover.get_position("abc")).then_return(Point(x=1, y=2, z=3))
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id="abc")).then_return(True)
+    decoy.when(state_store.pipettes.get_ready_to_aspirate("abc")).then_return(True)
 
     decoy.when(
         await pipetting.aspirate_in_place(
@@ -288,6 +296,7 @@ async def test_overpressure_error(
         True
     )
 
+    decoy.when(state_store.pipettes.get_ready_to_aspirate(pipette_id)).then_return(True)
     decoy.when(
         await pipetting.aspirate_in_place(
             pipette_id=pipette_id,

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_while_tracking.py
@@ -139,6 +139,10 @@ async def test_aspirate_while_tracking_implementation(
     ).then_return(True)
 
     decoy.when(
+        state_store.pipettes.get_ready_to_aspirate("pipette-id-abc")
+    ).then_return(True)
+
+    decoy.when(
         await pipetting.aspirate_while_tracking(
             pipette_id="pipette-id-abc",
             volume=123,
@@ -218,6 +222,9 @@ async def test_handle_aspirate_while_tracking_request_not_ready_to_aspirate(
         )
     ).then_return(False)
 
+    decoy.when(
+        state_store.pipettes.get_ready_to_aspirate("pipette-id-abc")
+    ).then_return(False)
     with pytest.raises(
         PipetteNotReadyToAspirateError,
         match="Pipette cannot aspirate while tracking because of a previous blow out."
@@ -255,6 +262,9 @@ async def test_aspirate_raises_volume_error(
         pipetting.get_is_ready_to_aspirate(pipette_id="pipette-id-abc")
     ).then_return(True)
 
+    decoy.when(
+        state_store.pipettes.get_ready_to_aspirate("pipette-id-abc")
+    ).then_return(True)
     decoy.when(
         await pipetting.aspirate_while_tracking(
             pipette_id="pipette-id-abc",
@@ -334,6 +344,8 @@ async def test_overpressure_error(
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
         True
     )
+
+    decoy.when(state_store.pipettes.get_ready_to_aspirate(pipette_id)).then_return(True)
 
     decoy.when(
         await pipetting.aspirate_while_tracking(

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -99,6 +99,9 @@ async def test_blow_out_implementation(
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="pipette-id"
             ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id", ready_to_aspirate=False
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
@@ -62,7 +62,10 @@ async def test_blow_out_in_place_implementation(
         state_update=update_types.StateUpdate(
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="pipette-id"
-            )
+            ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id", ready_to_aspirate=False
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -1,8 +1,5 @@
 """Test load pipette commands."""
-from opentrons.protocol_engine.state.update_types import (
-    PipetteConfigUpdate,
-    StateUpdate,
-)
+import opentrons.protocol_engine.state.update_types as update_types
 import pytest
 from decoy import Decoy
 
@@ -102,9 +99,12 @@ async def test_configure_for_volume_implementation(
 
     assert result == SuccessData(
         public=ConfigureForVolumeResult(),
-        state_update=StateUpdate(
-            pipette_config=PipetteConfigUpdate(
+        state_update=update_types.StateUpdate(
+            pipette_config=update_types.PipetteConfigUpdate(
                 pipette_id="pipette-id", serial_number="some number", config=config
-            )
+            ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id", ready_to_aspirate=False
+            ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -133,6 +133,9 @@ async def test_dispense_implementation(
             pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
                 pipette_id="pipette-id-abc123", volume=42
             ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id-abc123", ready_to_aspirate=True
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -98,11 +98,18 @@ async def test_dispense_implementation(
     ).then_return(["A3", "A4"])
 
     decoy.when(
+        state_view.pipettes.get_aspirated_volume("pipette-id-abc123")
+    ).then_return(100)
+
+    decoy.when(pipetting.get_state_view()).then_return(state_view)
+
+    decoy.when(
         await pipetting.dispense_in_place(
             pipette_id="pipette-id-abc123",
             volume=50,
             flow_rate=1.23,
             push_out=None,
+            is_full_dispense=False,
             correction_volume=0,
         )
     ).then_return(42)
@@ -198,12 +205,15 @@ async def test_overpressure_error(
         ),
     ).then_return(position)
 
+    decoy.when(pipetting.get_state_view()).then_return(state_view)
+
     decoy.when(
         await pipetting.dispense_in_place(
             pipette_id=pipette_id,
             volume=50,
             flow_rate=1.23,
             push_out=None,
+            is_full_dispense=False,
             correction_volume=0,
         ),
     ).then_raise(PipetteOverpressureError())
@@ -236,6 +246,9 @@ async def test_overpressure_error(
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="pipette-id"
+            ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id", ready_to_aspirate=False
             ),
         ),
         state_update_if_false_positive=update_types.StateUpdate(

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
@@ -124,6 +124,9 @@ async def test_dispense_in_place_implementation(
                     well_names=["A3", "A4"],
                     volume_added=68,
                 ),
+                ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                    pipette_id="pipette-id-abc", ready_to_aspirate=True
+                ),
             ),
         )
     else:
@@ -132,7 +135,10 @@ async def test_dispense_in_place_implementation(
             state_update=update_types.StateUpdate(
                 pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
                     pipette_id="pipette-id-abc", volume=42
-                )
+                ),
+                ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                    pipette_id="pipette-id-abc", ready_to_aspirate=True
+                ),
             ),
         )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
@@ -141,6 +141,9 @@ async def test_dispense_while_tracking_implementation(
                     well_names=["A3", "A4"],
                     volume_added=68,
                 ),
+                ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                    pipette_id="pipette-id-abc", ready_to_aspirate=True
+                ),
             ),
         )
     else:
@@ -151,7 +154,10 @@ async def test_dispense_while_tracking_implementation(
             state_update=update_types.StateUpdate(
                 pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
                     pipette_id="pipette-id-abc", volume=42
-                )
+                ),
+                ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                    pipette_id="pipette-id-abc", ready_to_aspirate=True
+                ),
             ),
         )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
@@ -98,9 +98,10 @@ async def test_dispense_while_tracking_implementation(
             push_out=None,
             well_name=stateupdateWell,
             labware_id=stateupdateLabware,
+            is_full_dispense=True,
         )
     ).then_return(42)
-    decoy.when(state_view.pipettes.get_aspirated_volume("pipette-id")).then_return(123)
+    decoy.when(state_view.pipettes.get_aspirated_volume("pipette-id-abc")).then_return(123)
 
     decoy.when(pipetting.get_state_view()).then_return(state_view)
 
@@ -145,7 +146,7 @@ async def test_dispense_while_tracking_implementation(
                     volume_added=68,
                 ),
                 ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
-                    pipette_id="pipette-id-abc", ready_to_aspirate=True
+                    pipette_id="pipette-id-abc", ready_to_aspirate=False
                 ),
             ),
         )
@@ -159,7 +160,7 @@ async def test_dispense_while_tracking_implementation(
                     pipette_id="pipette-id-abc", volume=42
                 ),
                 ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
-                    pipette_id="pipette-id-abc", ready_to_aspirate=True
+                    pipette_id="pipette-id-abc", ready_to_aspirate=False
                 ),
             ),
         )
@@ -240,6 +241,7 @@ async def test_overpressure_error(
             push_out=10,
             well_name=stateupdateWell,
             labware_id=stateupdateLabware,
+            is_full_dispense=True,
         ),
     ).then_raise(PipetteOverpressureError())
 

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
@@ -100,6 +100,9 @@ async def test_dispense_while_tracking_implementation(
             labware_id=stateupdateLabware,
         )
     ).then_return(42)
+    decoy.when(state_view.pipettes.get_aspirated_volume("pipette-id")).then_return(123)
+
+    decoy.when(pipetting.get_state_view()).then_return(state_view)
 
     decoy.when(state_view.pipettes.get_current_location()).then_return(location)
     decoy.when(
@@ -226,7 +229,9 @@ async def test_overpressure_error(
             stateupdateLabware, stateupdateWell, "pipette-id"
         )
     ).then_return(["A3", "A4"])
+    decoy.when(state_view.pipettes.get_aspirated_volume("pipette-id")).then_return(50)
 
+    decoy.when(pipetting.get_state_view()).then_return(state_view)
     decoy.when(
         await pipetting.dispense_while_tracking(
             pipette_id=pipette_id,
@@ -262,6 +267,9 @@ async def test_overpressure_error(
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="pipette-id"
                 ),
+                ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                    pipette_id="pipette-id", ready_to_aspirate=False
+                ),
             ),
         )
     else:
@@ -275,6 +283,9 @@ async def test_overpressure_error(
             state_update=update_types.StateUpdate(
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="pipette-id"
-                )
+                ),
+                ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                    pipette_id="pipette-id", ready_to_aspirate=False
+                ),
             ),
         )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
@@ -101,7 +101,9 @@ async def test_dispense_while_tracking_implementation(
             is_full_dispense=True,
         )
     ).then_return(42)
-    decoy.when(state_view.pipettes.get_aspirated_volume("pipette-id-abc")).then_return(123)
+    decoy.when(state_view.pipettes.get_aspirated_volume("pipette-id-abc")).then_return(
+        123
+    )
 
     decoy.when(pipetting.get_state_view()).then_return(state_view)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_dispense.py
@@ -100,6 +100,11 @@ async def test_evotip_dispense_implementation(
     decoy.when(state_view.labware.get_definition("labware-id-abc123")).then_return(
         evotips_definition
     )
+    decoy.when(
+        state_view.pipettes.get_aspirated_volume("pipette-id-abc123")
+    ).then_return(100)
+
+    decoy.when(pipetting.get_state_view()).then_return(state_view)
 
     decoy.when(
         await pipetting.dispense_in_place(
@@ -107,6 +112,7 @@ async def test_evotip_dispense_implementation(
             volume=100.0,
             flow_rate=456.0,
             push_out=None,
+            is_full_dispense=True,
             correction_volume=0,
         )
     ).then_return(100)
@@ -130,6 +136,9 @@ async def test_evotip_dispense_implementation(
             ),
             pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
                 pipette_id="pipette-id-abc123", volume=100
+            ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id-abc123", ready_to_aspirate=False
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -257,6 +257,9 @@ async def test_liquid_probe_implementation(
                 volume=30.0,
                 last_probed=timestamp,
             ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="abc", ready_to_aspirate=True
+            ),
         ),
     )
 
@@ -368,6 +371,9 @@ async def test_liquid_not_found_error(
             height=update_types.CLEAR,
             volume=update_types.CLEAR,
             last_probed=error_timestamp,
+        ),
+        ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+            pipette_id=pipette_id, ready_to_aspirate=True
         ),
     )
     if isinstance(subject, LiquidProbeImplementation):

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -4,6 +4,7 @@ from opentrons.protocol_engine.state.update_types import (
     PipetteConfigUpdate,
     StateUpdate,
     PipetteUnknownFluidUpdate,
+    PipetteAspirateReadyUpdate,
 )
 import pytest
 from decoy import Decoy
@@ -119,6 +120,9 @@ async def test_load_pipette_implementation(
                 config=config_data,
             ),
             pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="some id"),
+            ready_to_aspirate=PipetteAspirateReadyUpdate(
+                pipette_id="some id", ready_to_aspirate=False
+            ),
         ),
     )
 
@@ -194,6 +198,9 @@ async def test_load_pipette_implementation_96_channel(
                 config=config_data,
             ),
             pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="pipette-id"),
+            ready_to_aspirate=PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id", ready_to_aspirate=False
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -110,6 +110,9 @@ async def test_success(
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="pipette-id"
             ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id", ready_to_aspirate=True
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_prepare_to_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_prepare_to_aspirate.py
@@ -54,7 +54,10 @@ async def test_prepare_to_aspirate_implementation(
         state_update=update_types.StateUpdate(
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="some id"
-            )
+            ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="some id", ready_to_aspirate=True
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_blow_out_in_place.py
@@ -47,7 +47,10 @@ async def test_blow_out_in_place_implementation(
         state_update=update_types.StateUpdate(
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="pipette-id"
-            )
+            ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id="pipette-id", ready_to_aspirate=False
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -179,7 +179,7 @@ async def test_hw_dispense_in_place(
             mount=Mount.RIGHT, aspirate=None, dispense=2.5, blow_out=None
         ),
         await mock_hardware_api.dispense(
-            mount=Mount.RIGHT, volume=25, push_out=None, correction_volume=0
+            mount=Mount.RIGHT, volume=25, push_out=None, correction_volume=0, is_full_dispense=True
         ),
         mock_hardware_api.set_flow_rate(
             mount=Mount.RIGHT, aspirate=1.23, dispense=4.56, blow_out=7.89

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -179,7 +179,11 @@ async def test_hw_dispense_in_place(
             mount=Mount.RIGHT, aspirate=None, dispense=2.5, blow_out=None
         ),
         await mock_hardware_api.dispense(
-            mount=Mount.RIGHT, volume=25, push_out=None, correction_volume=0, is_full_dispense=True
+            mount=Mount.RIGHT,
+            volume=25,
+            push_out=None,
+            correction_volume=0,
+            is_full_dispense=True,
         ),
         mock_hardware_api.set_flow_rate(
             mount=Mount.RIGHT, aspirate=1.23, dispense=4.56, blow_out=7.89

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -71,6 +71,7 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
         flow_rates_by_id={},
         nozzle_configuration_by_id={},
         liquid_presence_detection_by_id={},
+        ready_to_aspirate_by_id={},
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
@@ -84,6 +84,7 @@ def get_pipette_view(
     flow_rates_by_id: Optional[Dict[str, FlowRates]] = None,
     nozzle_layout_by_id: Optional[Dict[str, NozzleMap]] = None,
     liquid_presence_detection_by_id: Optional[Dict[str, bool]] = None,
+    ready_to_aspirate_by_id: Optional[Dict[str, bool]] = None,
     pipette_contents_by_id: Optional[
         Dict[str, Optional[fluid_stack.FluidStack]]
     ] = None,
@@ -100,6 +101,7 @@ def get_pipette_view(
         flow_rates_by_id=flow_rates_by_id or {},
         nozzle_configuration_by_id=nozzle_layout_by_id or {},
         liquid_presence_detection_by_id=liquid_presence_detection_by_id or {},
+        ready_to_aspirate_by_id=ready_to_aspirate_by_id or {},
     )
 
     return PipetteView(state=state)

--- a/hardware-testing/hardware_testing/examples/plunger_ot3.py
+++ b/hardware-testing/hardware_testing/examples/plunger_ot3.py
@@ -24,7 +24,7 @@ async def _main(is_simulating: bool) -> None:
     max_vol = pipette.working_volume
     for vol in [max_vol, max_vol / 2, max_vol / 10]:
         await api.aspirate(mount, volume=vol)
-        await api.dispense(mount, volume=vol)
+        await api.dispense(mount, volume=vol, is_full_dispense=True)
         await api.prepare_for_aspirate(mount)
     api.remove_tip(mount)
 

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
@@ -129,7 +129,7 @@ async def aspirate_and_wait(
     await api.move_to(
         OT3Mount.LEFT, reservoir + Point(z=DEPTH_INTO_RESERVOIR_FOR_DISPENSE)
     )
-    await api.dispense(OT3Mount.LEFT)
+    await api.dispense(OT3Mount.LEFT, is_full_dispense=True)
     return result, duration_seconds
 
 

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_pressure.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_pressure.py
@@ -156,7 +156,7 @@ async def run(
 
         # DISPENSE-Pa
         dispense_pa = 0.0
-        await api.dispense(OT3Mount.LEFT, ASPIRATE_VOLUME)
+        await api.dispense(OT3Mount.LEFT, ASPIRATE_VOLUME, is_full_dispense=True)
         if not api.is_simulator:
             try:
                 dispense_pa = await _read_from_sensor(

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -462,7 +462,7 @@ async def _aspirate_and_look_for_droplets(
         leak_test_passed = _get_operator_answer_to_question("did it pass? no leaking?")
     print("dispensing back into reservoir")
     await api.move_rel(mount, Point(z=-LEAK_HOVER_ABOVE_LIQUID_MM))
-    await api.dispense(mount, pipette_volume)
+    await api.dispense(mount, pipette_volume, is_full_dispense=True)
     await api.blow_out(mount)
     await api.move_rel(mount, Point(z=ASPIRATE_SUBMERGE_MM))
     return leak_test_passed
@@ -648,7 +648,7 @@ async def _fixture_check_pressure(
     )
     results.append(r)
     # dispense
-    await api.dispense(mount, PRESSURE_FIXTURE_ASPIRATE_VOLUME[pip_vol])
+    await api.dispense(mount, PRESSURE_FIXTURE_ASPIRATE_VOLUME[pip_vol], is_full_dispense=True)
     r, _ = await _read_pressure_and_check_results(
         api,
         pip_channels,
@@ -1125,7 +1125,7 @@ async def _test_diagnostics_pressure(
     if not api.is_simulator:
         _get_operator_answer_to_question('REMOVE your finger, enter "y" when ready')
     print("moving plunger back down to BOTTOM position")
-    await api.dispense(mount)
+    await api.dispense(mount, is_full_dispense=True)
     await api.prepare_for_aspirate(mount)
 
     await _drop_tip_in_trash(api, mount)

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -648,7 +648,9 @@ async def _fixture_check_pressure(
     )
     results.append(r)
     # dispense
-    await api.dispense(mount, PRESSURE_FIXTURE_ASPIRATE_VOLUME[pip_vol], is_full_dispense=True)
+    await api.dispense(
+        mount, PRESSURE_FIXTURE_ASPIRATE_VOLUME[pip_vol], is_full_dispense=True
+    )
     r, _ = await _read_pressure_and_check_results(
         api,
         pip_channels,

--- a/hardware-testing/hardware_testing/protocols/liquid_sense/lld_test_liquid_height.py
+++ b/hardware-testing/hardware_testing/protocols/liquid_sense/lld_test_liquid_height.py
@@ -238,8 +238,9 @@ def _get_tip_z_error(
 def _get_height_of_liquid_in_well(
     pipette: InstrumentContext,
     well: Well,
+    simulating: bool,
 ) -> float:
-    if pipette.detect_liquid_presence(well):
+    if pipette.detect_liquid_presence(well) and not simulating:
         height = pipette.measure_liquid_height(well) - well.bottom().point.z
     else:
         height = 0.0
@@ -316,7 +317,9 @@ def _test_for_finding_liquid_height(
         liquid_pipette.blow_out(well.top(z=-9)).prepare_to_aspirate()
         # get height of liquid
         if probe_yes_or_no == "yes":
-            height = _get_height_of_liquid_in_well(probing_pipette, well)
+            height = _get_height_of_liquid_in_well(
+                probing_pipette, well, ctx.is_simulating()
+            )
         else:
             height = 0
         corrected_height = height + tip_z_error

--- a/hardware-testing/hardware_testing/protocols/liquid_sense/lld_test_liquid_height_3mm.py
+++ b/hardware-testing/hardware_testing/protocols/liquid_sense/lld_test_liquid_height_3mm.py
@@ -1,4 +1,5 @@
 """Measure Liquid Height 3mm."""
+# mypy: ignore-error
 import math
 from typing import List, Tuple, Optional
 from opentrons.protocol_api import (

--- a/hardware-testing/hardware_testing/protocols/liquid_sense/lld_test_liquid_height_3mm.py
+++ b/hardware-testing/hardware_testing/protocols/liquid_sense/lld_test_liquid_height_3mm.py
@@ -1,5 +1,4 @@
 """Measure Liquid Height 3mm."""
-# mypy: ignore-error
 import math
 from typing import List, Tuple, Optional
 from opentrons.protocol_api import (
@@ -455,7 +454,8 @@ def _test_for_finding_liquid_height(  # noqa: C901
                 0.0 if is_empty else -9999
             )  # some obviously fake number so we know it failed
         corrected_height = height + tip_z_error
-        all_corrected_heights.append(corrected_height)  # type: ignore[arg-type]
+        if not ctx.is_simulating():
+            all_corrected_heights.append(corrected_height)  # type: ignore[arg-type]
         ctx.pause("CHECK LABWARE")
         # drop tips
         if not SAME_TIP:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The "ready to aspirate" state was previously only known to the hardware control layer, this adds the state updates to the protocol engine so that commands will fail analysis when steps would produce an error at runtime without removing any of the hardware layer checks.

This stems from a scenario where the following steps would produce a "not ready to aspirate" error at runtime but pass analysis.

1. Pipette picks up tips
2. Does an air gap
3. Does an aspirate
4. does a dispense with push out
5. does an airgap command

Since we automatically do a prepare-to-aspirate as part of the aspirate command and the pick up tip, it successfully passes step 2 but we don't automatically do it during dispense or air gap so when the hardware attempts to start step 5, and step 4 leaves it in an "not-ready" state the hardware controller fails at runtime.

This PR updates all of the various protocol engine command that effect the "ready" state to have a new StateUpdate element that stores the current state in the state view. this way analysis will fail when a particular order of calls would result in an illegal move.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
