### PR TITLE
chore(app): add stacker/retrieve command handling and fix lpc crash

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom.ts
@@ -26,6 +26,12 @@ function getLabwareInfoRecords(
   const labwareDetails: LPCLabwareInfo['labware'] = {}
 
   params.lwURIs.forEach(uri => {
+    if (!labwareUriKnown({ ...params, uri })) {
+      console.warn(
+        `getLPCLabwareInfoFrom: No information about labware uri ${uri}, is there a command that loads labware that we're not handling?`
+      )
+      return
+    }
     if (!(uri in labwareDetails)) {
       labwareDetails[uri] = {
         id: getALabwareIdFromUri({ ...params, uri }),
@@ -49,6 +55,13 @@ function getALabwareIdFromUri({
   return (
     lwLocationCombos.find(combo => combo.definitionUri === uri)?.labwareId ?? ''
   )
+}
+
+function labwareUriKnown({
+  uri,
+  labwareDefs,
+}: GetLPCLabwareInfoForURI): boolean {
+  return labwareDefs?.find(def => getLabwareDefURI(def) === uri) != null
 }
 
 function getDisplayNameFromUri({

--- a/app/src/organisms/LegacyApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
@@ -136,6 +136,37 @@ export function getLabwareLocationCombos(
             labwareId: command.params.labwareId,
           })
         }
+      } else if (command.commandType === 'flexStacker/retrieve') {
+        if (command?.result == null) {
+          return acc
+        }
+        const modLocation = resolveModuleLocation(
+          modules,
+          command.params.moduleId
+        )
+        if (modLocation == null) {
+          return acc
+        }
+
+        if (command.result.adapterId != null) {
+          return appendLocationComboIfUniq(acc, {
+            location: {
+              ...modLocation,
+              definitionUri: command.result.adapterLabwareURI,
+            },
+            definitionUri: command.result.primaryLabwareURI,
+            labwareId: command.result.labwareId,
+            moduleId: command.params.moduleId,
+            adapterId: command.result.adapterId,
+          })
+        } else {
+          return appendLocationComboIfUniq(acc, {
+            location: modLocation,
+            definitionUri: command.result.primaryLabwareURI,
+            labwareId: command.result.labwareId,
+            moduleId: command.params.moduleId,
+          })
+        }
       } else {
         return acc
       }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
@@ -1,6 +1,11 @@
 import { getLabwareDefURI } from '@opentrons/shared-data'
 
-import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition2,
+  RunTimeCommand,
+  LoadLabwareRunTimeCommand,
+  LoadLidRunTimeCommand,
+} from '@opentrons/shared-data'
 
 // Note: This is an O(n) operation.
 export function getLabwareDefinitionsFromCommands(
@@ -29,15 +34,15 @@ function getNewLabwareDefinitions(
 }
 
 const isLoadCommand = (
-  commandType: string
-): commandType is 'loadLabware' | 'loadLid' =>
-  ['loadLabware', 'loadLid'].includes(commandType)
+  command: RunTimeCommand
+): command is LoadLabwareRunTimeCommand | LoadLidRunTimeCommand =>
+  ['loadLabware', 'loadLid'].includes(command.commandType)
 
 function getLabwareDefinitionFromCommand(
   command: RunTimeCommand,
   known: LabwareDefinition2[]
 ): LabwareDefinition2[] {
-  if (isLoadCommand(command.commandType)) {
+  if (isLoadCommand(command)) {
     return getNewLabwareDefinitions([command.result?.definition], known)
   }
   if (command.commandType === 'flexStacker/setStoredLabware') {

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
@@ -50,5 +50,5 @@ function getLabwareDefinitionFromCommand(
       known
     )
   }
-  return known
+  return []
 }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
@@ -6,17 +6,49 @@ import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
 export function getLabwareDefinitionsFromCommands(
   commands: RunTimeCommand[]
 ): LabwareDefinition2[] {
-  return commands.reduce<LabwareDefinition2[]>((acc, command) => {
-    const isLoadingNewDef =
-      (command.commandType === 'loadLabware' ||
-        command.commandType === 'loadLid') &&
-      !acc.some(
-        def =>
-          command.result?.definition != null &&
-          getLabwareDefURI(def) === getLabwareDefURI(command.result?.definition)
+  return commands.reduce<LabwareDefinition2[]>(
+    (acc, command) => [
+      ...getLabwareDefinitionFromCommand(command, acc),
+      ...acc,
+    ],
+    []
+  )
+}
+
+function getNewLabwareDefinitions(
+  newDefinitions: Array<LabwareDefinition2 | null | undefined>,
+  knownDefinitions: LabwareDefinition2[]
+): LabwareDefinition2[] {
+  return newDefinitions.filter(
+    (maybeNewDef): maybeNewDef is LabwareDefinition2 =>
+      maybeNewDef != null &&
+      !knownDefinitions.some(
+        knownDef => getLabwareDefURI(knownDef) === getLabwareDefURI(maybeNewDef)
       )
-    return isLoadingNewDef && command.result?.definition != null
-      ? [...acc, command.result?.definition]
-      : acc
-  }, [])
+  )
+}
+
+const isLoadCommand = (
+  commandType: string
+): commandType is 'loadLabware' | 'loadLid' =>
+  ['loadLabware', 'loadLid'].includes(commandType)
+
+function getLabwareDefinitionFromCommand(
+  command: RunTimeCommand,
+  known: LabwareDefinition2[]
+): LabwareDefinition2[] {
+  if (isLoadCommand(command.commandType)) {
+    return getNewLabwareDefinitions([command.result?.definition], known)
+  }
+  if (command.commandType === 'flexStacker/setStoredLabware') {
+    return getNewLabwareDefinitions(
+      [
+        command.result?.primaryLabwareDefinition,
+        command.result?.adapterLabwareDefinition,
+        command.result?.lidLabwareDefinition,
+      ],
+      known
+    )
+  }
+  return known
 }

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -1,4 +1,5 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+import type { LabwareLocationSequence } from './setup'
 import type { LabwareDefinition2 } from '../../js'
 
 export type ModuleRunTimeCommand =
@@ -30,6 +31,7 @@ export type ModuleRunTimeCommand =
   | AbsorbanceReaderInitializeRunTimeCommand
   | AbsorbanceReaderReadRunTimeCommand
   | FlexStackerSetStoredLabwareRunTimeCommand
+  | FlexStackerRetrieveRunTimeCommand
 
 export type ModuleCreateCommand =
   | MagneticModuleEngageMagnetCreateCommand
@@ -60,6 +62,7 @@ export type ModuleCreateCommand =
   | AbsorbanceReaderInitializeCreateCommand
   | AbsorbanceReaderReadCreateCommand
   | FlexStackerSetStoredLabwareCreateCommand
+  | FlexStackerRetrieveCreateCommand
 
 export interface MagneticModuleEngageMagnetCreateCommand
   extends CommonCommandCreateInfo {
@@ -411,4 +414,52 @@ export interface FlexStackerSetStoredLabwareRunTimeCommand
     adapterLabwareDefinition?: LabwareDefinition2 | null
     count: number
   }
+}
+
+export interface FlexStackerRetrieveCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'flexStacker/retrieve'
+  params: {
+    moduleId: string
+  }
+}
+
+interface RetrieveResultPrimary {
+  labwareId: string
+  primaryLocationSequence: LabwareLocationSequence
+  primaryLabwareURI: string
+}
+
+interface RetrieveResultNoLid {
+  lidId?: null
+  lidLocationSequence?: null
+  lidLabwareURI?: null
+}
+
+interface RetrieveResultLid {
+  lidId: string
+  lidLocationSequence: LabwareLocationSequence
+  lidLabwareURI: string
+}
+
+interface RetrieveResultAdapter {
+  adapterId: string
+  adapterLocationSequence: LabwareLocationSequence
+  adapterLabwareURI: string
+}
+
+interface RetrieveResultNoAdapter {
+  adapterId?: null
+  adapterLocationSequence?: null
+  adapterLabwareURI?: null
+}
+
+export interface FlexStackerRetrieveRunTimeCommand
+  extends FlexStackerRetrieveCreateCommand,
+    CommonCommandRunTimeInfo {
+  result?:
+    | (RetrieveResultPrimary & RetrieveResultNoLid & RetrieveResultNoAdapter)
+    | (RetrieveResultPrimary & RetrieveResultLid & RetrieveResultNoAdapter)
+    | (RetrieveResultPrimary & RetrieveResultNoLid & RetrieveResultAdapter)
+    | (RetrieveResultPrimary & RetrieveResultAdapter & RetrieveResultLid)
 }


### PR DESCRIPTION
Add the app-side changes from #17620 that handle
- Adding the retrieve command to some of the command parse utilities (but almost certainly not all of them)
- Fixing an LPC whitescreen when there are any unknown definitions, which really makes the problems with forgetting the locations of some of the command parsing stuff much worse
- Adding retrieve types


## Review requests
- cohesive enough when separated from the other pr?

## testing
- [x] we should no longer crash when looking at a protocol that loads labware in a way we don't know about. instead that labware just isn't shown.