### PR TITLE
feat(step-generation): python commands for disengage and engage magnet

### DIFF
--- a/step-generation/src/__tests__/disengageMagnet.test.ts
+++ b/step-generation/src/__tests__/disengageMagnet.test.ts
@@ -17,7 +17,7 @@ describe('disengageMagnet', () => {
       id: moduleId,
       type: MAGNETIC_MODULE_TYPE,
       model: MAGNETIC_MODULE_V1,
-      pythonName: 'mockPythonName',
+      pythonName: 'mock_magnetic_module_1',
     }
     robotState = getInitialRobotStateStandard(invariantContext)
     robotState.modules[moduleId] = {
@@ -46,6 +46,7 @@ describe('disengageMagnet', () => {
           },
         },
       ],
+      python: 'mock_magnetic_module_1.disengage()',
     })
   })
 })

--- a/step-generation/src/__tests__/engageMagnet.test.ts
+++ b/step-generation/src/__tests__/engageMagnet.test.ts
@@ -17,7 +17,7 @@ describe('engageMagnet', () => {
       id: moduleId,
       type: MAGNETIC_MODULE_TYPE,
       model: MAGNETIC_MODULE_V1,
-      pythonName: 'mockPythonName',
+      pythonName: 'mock_magnetic_module_1',
     }
     robotState = getInitialRobotStateStandard(invariantContext)
     robotState.modules[moduleId] = {
@@ -49,6 +49,7 @@ describe('engageMagnet', () => {
           },
         },
       ],
+      python: `mock_magnetic_module_1.engage(height_from_base=${height})`,
     })
   })
 })

--- a/step-generation/src/commandCreators/atomic/disengageMagnet.ts
+++ b/step-generation/src/commandCreators/atomic/disengageMagnet.ts
@@ -12,6 +12,7 @@ export const disengageMagnet: CommandCreator<ModuleOnlyParams> = (
   prevRobotState
 ) => {
   const { moduleId } = args
+  const { moduleEntities } = invariantContext
   const commandType = 'magneticModule/disengage'
 
   if (moduleId === null) {
@@ -21,9 +22,12 @@ export const disengageMagnet: CommandCreator<ModuleOnlyParams> = (
   }
 
   assert(
-    invariantContext.moduleEntities[moduleId]?.type === MAGNETIC_MODULE_TYPE,
-    `expected module ${moduleId} to be magdeck, got ${invariantContext.moduleEntities[moduleId]?.type}`
+    moduleEntities[moduleId]?.type === MAGNETIC_MODULE_TYPE,
+    `expected module ${moduleId} to be magdeck, got ${moduleEntities[moduleId]?.type}`
   )
+
+  const pythonName = moduleEntities[moduleId].pythonName
+
   return {
     commands: [
       {
@@ -34,5 +38,6 @@ export const disengageMagnet: CommandCreator<ModuleOnlyParams> = (
         },
       },
     ],
+    python: `${pythonName}.disengage()`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/engageMagnet.ts
+++ b/step-generation/src/commandCreators/atomic/engageMagnet.ts
@@ -12,6 +12,7 @@ export const engageMagnet: CommandCreator<EngageMagnetParams> = (
   prevRobotState
 ) => {
   const { moduleId, height } = args
+  const { moduleEntities } = invariantContext
   const commandType = 'magneticModule/engage'
 
   if (moduleId === null) {
@@ -21,9 +22,12 @@ export const engageMagnet: CommandCreator<EngageMagnetParams> = (
   }
 
   assert(
-    invariantContext.moduleEntities[moduleId]?.type === MAGNETIC_MODULE_TYPE,
-    `expected module ${moduleId} to be magdeck, got ${invariantContext.moduleEntities[moduleId]?.type}`
+    moduleEntities[moduleId]?.type === MAGNETIC_MODULE_TYPE,
+    `expected module ${moduleId} to be magdeck, got ${moduleEntities[moduleId]?.type}`
   )
+
+  const pythonName = moduleEntities[moduleId].pythonName
+
   return {
     commands: [
       {
@@ -35,5 +39,6 @@ export const engageMagnet: CommandCreator<EngageMagnetParams> = (
         },
       },
     ],
+    python: `${pythonName}.engage(height_from_base=${height})`,
   }
 }


### PR DESCRIPTION
closes AUTH-1103

# Overview

Wire up the python generation for `disengageMagnet` and `engageMagnet` that is used for the OT-2 magnetic modules

## Test Plan and Hands on Testing

I added unit test coverage but smoke test as well 😄 

## Changelog

- add python generation for disengage and engage magnet
- add test coverage

## Risk assessment

low, behind ff