### PR TITLE
feat(step-generation): plate reader python commands

### DIFF
--- a/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
@@ -35,7 +35,6 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
       sampleWavelengths: [450],
       name: 'some name',
       description: 'some descirption',
-      referenceWavelength: 450,
     }
     invariantContext = {
       ...makeContext(),
@@ -91,7 +90,7 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
     )
 
     const result = absorbanceReaderCloseInitialize(
-      absorbanceReaderCloseInitializeArgs,
+      { ...absorbanceReaderCloseInitializeArgs, referenceWavelength: 450 },
       invariantContext,
       robotState
     )
@@ -116,7 +115,9 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
       },
     ])
     expect(getSuccessResult(result).python).toBe(
-      `mock_absorbance_plate_reader_1.close_lid()\nmock_absorbance_plate_reader_1.initialize("single", [450], reference_wavelength=450)`
+      `
+mock_absorbance_plate_reader_1.close_lid()
+mock_absorbance_plate_reader_1.initialize("single", [450], reference_wavelength=450)`.trimStart()
     )
   })
   it('should emit close and intalize commands if multi mode', () => {
@@ -150,12 +151,13 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
           moduleId: 'absorbanceReaderModuleId',
           sampleWavelengths: [450, 600],
           measureMode: 'multi',
-          referenceWavelength: 450,
         },
       },
     ])
     expect(getSuccessResult(result).python).toBe(
-      `mock_absorbance_plate_reader_1.close_lid()\nmock_absorbance_plate_reader_1.initialize("multi", [450, 600], reference_wavelength=450)`
+      `
+mock_absorbance_plate_reader_1.close_lid()
+mock_absorbance_plate_reader_1.initialize("multi", [450, 600])`.trimStart()
     )
   })
 })

--- a/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
@@ -155,7 +155,7 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
       },
     ])
     expect(getSuccessResult(result).python).toBe(
-      `mock_absorbance_plate_reader_1.close_lid()\nmock_absorbance_plate_reader_1.initialize("multi", [450,600], reference_wavelength=450)`
+      `mock_absorbance_plate_reader_1.close_lid()\nmock_absorbance_plate_reader_1.initialize("multi", [450, 600], reference_wavelength=450)`
     )
   })
 })

--- a/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
@@ -35,6 +35,7 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
       sampleWavelengths: [450],
       name: 'some name',
       description: 'some descirption',
+      referenceWavelength: 450,
     }
     invariantContext = {
       ...makeContext(),
@@ -43,7 +44,7 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
           id: ABSORBANCE_READER_MODULE_ID,
           type: ABSORBANCE_READER_TYPE,
           model: ABSORBANCE_READER_V1,
-          pythonName: 'mockPythonName',
+          pythonName: 'mock_absorbance_plate_reader_1',
         },
       },
       additionalEquipmentEntities: {
@@ -110,9 +111,13 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
           moduleId: 'absorbanceReaderModuleId',
           sampleWavelengths: [450],
           measureMode: 'single',
+          referenceWavelength: 450,
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      `mock_absorbance_plate_reader_1.close_lid()\nmock_absorbance_plate_reader_1.initialize("single", [450], reference_wavelength=450)`
+    )
   })
   it('should emit close and intalize commands if multi mode', () => {
     absorbanceReaderCloseInitializeArgs = {
@@ -145,8 +150,12 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
           moduleId: 'absorbanceReaderModuleId',
           sampleWavelengths: [450, 600],
           measureMode: 'multi',
+          referenceWavelength: 450,
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      `mock_absorbance_plate_reader_1.close_lid()\nmock_absorbance_plate_reader_1.initialize("multi", [450,600], reference_wavelength=450)`
+    )
   })
 })

--- a/step-generation/src/__tests__/absorbanceReaderCloseLid.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseLid.test.ts
@@ -28,7 +28,7 @@ describe('absorbanceReaderCloseLid', () => {
       id: moduleId,
       type: ABSORBANCE_READER_TYPE,
       model: ABSORBANCE_READER_V1,
-      pythonName: 'mockPythonName',
+      pythonName: 'mock_absorbance_plate_reader_1',
     }
     invariantContext.additionalEquipmentEntities = {
       gripperId: {
@@ -67,6 +67,7 @@ describe('absorbanceReaderCloseLid', () => {
           },
         },
       ],
+      python: 'mock_absorbance_plate_reader_1.close_lid()',
     })
   })
   it('creates returns error if bad module state', () => {

--- a/step-generation/src/__tests__/absorbanceReaderCloseRead.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseRead.test.ts
@@ -43,7 +43,7 @@ describe('absorbanceReaderCloseRead compound command creator', () => {
           id: ABSORBANCE_READER_MODULE_ID,
           type: ABSORBANCE_READER_TYPE,
           model: ABSORBANCE_READER_V1,
-          pythonName: 'mockPythonName',
+          pythonName: 'mock_absorbance_plate_reader_1',
         },
       },
       additionalEquipmentEntities: {
@@ -79,12 +79,12 @@ describe('absorbanceReaderCloseRead compound command creator', () => {
     )
     vi.mocked(absorbanceReaderStateGetter).mockReturnValue(null)
 
-    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors).toHaveLength(2)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'MISSING_MODULE',
     })
   })
-  it.only('should emit close and read commands without fileName param', () => {
+  it('should emit close and read commands without fileName param', () => {
     vi.mocked(absorbanceReaderStateGetter).mockReturnValue({
       initialization: {},
     } as AbsorbanceReaderState)
@@ -110,8 +110,11 @@ describe('absorbanceReaderCloseRead compound command creator', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mock_absorbance_plate_reader_1.close_lid()\nmock_absorbance_plate_reader_1.read()'
+    )
   })
-  it.only('should emit close and read commands with fileName param', () => {
+  it('should emit close and read commands with fileName param', () => {
     vi.mocked(absorbanceReaderStateGetter).mockReturnValue({
       initialization: {},
     } as AbsorbanceReaderState)
@@ -142,5 +145,8 @@ describe('absorbanceReaderCloseRead compound command creator', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      `mock_absorbance_plate_reader_1.close_lid()\nmock_absorbance_plate_reader_1.read(export_filename="${ABSORBANCE_READER_OUTPUT_PATH}")`
+    )
   })
 })

--- a/step-generation/src/__tests__/absorbanceReaderOpenLid.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderOpenLid.test.ts
@@ -28,7 +28,7 @@ describe('absorbanceReaderOpenLid', () => {
       id: moduleId,
       type: ABSORBANCE_READER_TYPE,
       model: ABSORBANCE_READER_V1,
-      pythonName: 'mockPythonName',
+      pythonName: 'mock_absorbance_plate_reader_1',
     }
     invariantContext.additionalEquipmentEntities = {
       gripperId: {
@@ -68,6 +68,7 @@ describe('absorbanceReaderOpenLid', () => {
           },
         },
       ],
+      python: 'mock_absorbance_plate_reader_1.open_lid()',
     })
   })
   it('creates returns error if bad module state', () => {

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderCloseLid.ts
@@ -7,6 +7,7 @@ import type { CommandCreator, CommandCreatorError } from '../../types'
 export const absorbanceReaderCloseLid: CommandCreator<
   AbsorbanceReaderCloseLidCreateCommand['params']
 > = (args, invariantContext, prevRobotState) => {
+  const { additionalEquipmentEntities, moduleEntities } = invariantContext
   const absorbanceReaderState = absorbanceReaderStateGetter(
     prevRobotState,
     args.moduleId
@@ -16,7 +17,7 @@ export const absorbanceReaderCloseLid: CommandCreator<
     errors.push(errorCreators.missingModuleError())
   }
   if (
-    !Object.values(invariantContext.additionalEquipmentEntities).some(
+    !Object.values(additionalEquipmentEntities).some(
       ({ name }) => name === 'gripper'
     )
   ) {
@@ -25,6 +26,7 @@ export const absorbanceReaderCloseLid: CommandCreator<
   if (errors.length > 0) {
     return { errors }
   }
+  const pythonName = moduleEntities[args.moduleId].pythonName
 
   return {
     commands: [
@@ -36,5 +38,6 @@ export const absorbanceReaderCloseLid: CommandCreator<
         },
       },
     ],
+    python: `${pythonName}.close_lid()`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderInitialize.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderInitialize.ts
@@ -1,4 +1,4 @@
-import { uuid } from '../../utils'
+import { formatPyStr, uuid } from '../../utils'
 import type { CommandCreator } from '../../types'
 import type { AbsorbanceReaderInitializeCreateCommand } from '@opentrons/shared-data'
 
@@ -6,6 +6,11 @@ export const absorbanceReaderInitialize: CommandCreator<
   AbsorbanceReaderInitializeCreateCommand['params']
 > = (args, invariantContext, prevRobotState) => {
   const { moduleId, sampleWavelengths, measureMode, referenceWavelength } = args
+  const pythonName = invariantContext.moduleEntities[moduleId].pythonName
+  const referenceWavelengthPython =
+    referenceWavelength != null
+      ? `reference_wavelength=${referenceWavelength}`
+      : ''
   return {
     commands: [
       {
@@ -19,5 +24,8 @@ export const absorbanceReaderInitialize: CommandCreator<
         },
       },
     ],
+    python: `${pythonName}.initialize(${formatPyStr(
+      measureMode
+    )}, [${sampleWavelengths}], ${referenceWavelengthPython})`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderInitialize.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderInitialize.ts
@@ -9,7 +9,7 @@ export const absorbanceReaderInitialize: CommandCreator<
   const pythonName = invariantContext.moduleEntities[moduleId].pythonName
   const referenceWavelengthPython =
     referenceWavelength != null
-      ? `reference_wavelength=${referenceWavelength}`
+      ? `, reference_wavelength=${referenceWavelength}`
       : ''
   return {
     commands: [
@@ -26,6 +26,6 @@ export const absorbanceReaderInitialize: CommandCreator<
     ],
     python: `${pythonName}.initialize(${formatPyStr(
       measureMode
-    )}, ${formatPyList(sampleWavelengths)}, ${referenceWavelengthPython})`,
+    )}, ${formatPyList(sampleWavelengths)}${referenceWavelengthPython})`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderInitialize.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderInitialize.ts
@@ -1,4 +1,4 @@
-import { formatPyStr, uuid } from '../../utils'
+import { formatPyList, formatPyStr, uuid } from '../../utils'
 import type { CommandCreator } from '../../types'
 import type { AbsorbanceReaderInitializeCreateCommand } from '@opentrons/shared-data'
 
@@ -26,6 +26,6 @@ export const absorbanceReaderInitialize: CommandCreator<
     ],
     python: `${pythonName}.initialize(${formatPyStr(
       measureMode
-    )}, [${sampleWavelengths}], ${referenceWavelengthPython})`,
+    )}, ${formatPyList(sampleWavelengths)}, ${referenceWavelengthPython})`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderOpenLid.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderOpenLid.ts
@@ -7,6 +7,7 @@ import type { CommandCreator, CommandCreatorError } from '../../types'
 export const absorbanceReaderOpenLid: CommandCreator<
   AbsorbanceReaderOpenLidCreateCommand['params']
 > = (args, invariantContext, prevRobotState) => {
+  const { additionalEquipmentEntities, moduleEntities } = invariantContext
   const absorbanceReaderState = absorbanceReaderStateGetter(
     prevRobotState,
     args.moduleId
@@ -17,7 +18,7 @@ export const absorbanceReaderOpenLid: CommandCreator<
   }
 
   if (
-    !Object.values(invariantContext.additionalEquipmentEntities).some(
+    !Object.values(additionalEquipmentEntities).some(
       ({ name }) => name === 'gripper'
     )
   ) {
@@ -26,6 +27,7 @@ export const absorbanceReaderOpenLid: CommandCreator<
   if (errors.length > 0) {
     return { errors }
   }
+  const pythonName = moduleEntities[args.moduleId].pythonName
 
   return {
     commands: [
@@ -37,5 +39,6 @@ export const absorbanceReaderOpenLid: CommandCreator<
         },
       },
     ],
+    python: `${pythonName}.open_lid()`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/absorbanceReaderRead.ts
+++ b/step-generation/src/commandCreators/atomic/absorbanceReaderRead.ts
@@ -1,6 +1,6 @@
 import * as errorCreators from '../../errorCreators'
 import { absorbanceReaderStateGetter } from '../../robotStateSelectors'
-import { uuid } from '../../utils'
+import { formatPyStr, uuid } from '../../utils'
 import type { CommandCreator, CommandCreatorError } from '../../types'
 import type { AbsorbanceReaderReadCreateCommand } from '@opentrons/shared-data'
 
@@ -23,6 +23,10 @@ export const absorbanceReaderRead: CommandCreator<
     errors.push(errorCreators.absorbanceReaderLidClosed())
   }
 
+  const pythonName = invariantContext.moduleEntities[moduleId].pythonName
+  const pythonfileName =
+    fileName != null ? `export_filename=${formatPyStr(fileName)}` : ''
+
   return errors.length > 0
     ? { errors }
     : {
@@ -36,5 +40,6 @@ export const absorbanceReaderRead: CommandCreator<
             },
           },
         ],
+        python: `${pythonName}.read(${pythonfileName})`,
       }
 }


### PR DESCRIPTION
closes AUTH-1512

# Overview

this PR creates the python commands for the 4 plate reader commands: open lid, close lid, initialize, and read. For reading, the output is a CSV file and not imbedded in the python protocol, since PD only supports outputting into a CSV file right now.

## Test Plan and Hands on Testing

Review the unit tests and smoke test!

## Changelog

- add python command for the 4 plate reader commands
- add unit test coverage

## Risk assessment

low, behind ff