### PR TITLE
feat(step-generation): python command generation for heater-shaker co…

### DIFF
--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -39,7 +39,7 @@ describe('heaterShaker compound command creator', () => {
           id: HEATER_SHAKER_ID,
           type: HEATERSHAKER_MODULE_TYPE,
           model: HEATERSHAKER_MODULE_V1,
-          pythonName: 'mockPythonName',
+          pythonName: 'mock_heater_shaker_1',
         },
       },
     }
@@ -128,6 +128,9 @@ describe('heaterShaker compound command creator', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mock_heater_shaker_1.close_labware_latch()\nmock_heater_shaker_1.set_target_temperature(80)\nmock_heater_shaker_1.set_and_wait_for_shake_speed(444)\nprotocol.delay(seconds=30)\nmock_heater_shaker_1.deactivate_shaker()\nmock_heater_shaker_1.deactivate_heater()'
+    )
   })
   it('should NOT delay and deactivate the heater shaker when a user specificies a timer that is 0 seconds', () => {
     heaterShakerArgs = {
@@ -164,6 +167,9 @@ describe('heaterShaker compound command creator', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mock_heater_shaker_1.close_labware_latch()\nmock_heater_shaker_1.set_target_temperature(80)\nmock_heater_shaker_1.set_and_wait_for_shake_speed(444)'
+    )
   })
   it('should delay and emit open latch last if open latch is specified', () => {
     heaterShakerArgs = {
@@ -233,6 +239,9 @@ describe('heaterShaker compound command creator', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mock_heater_shaker_1.set_target_temperature(80)\nmock_heater_shaker_1.set_and_wait_for_shake_speed(444)\nprotocol.delay(seconds=20)\nmock_heater_shaker_1.deactivate_shaker()\nmock_heater_shaker_1.deactivate_heater()\nmock_heater_shaker_1.open_labware_latch()'
+    )
   })
   it('should not call deactivateShaker when it is not shaking but call activate temperature when setting target temp', () => {
     heaterShakerArgs = {
@@ -276,6 +285,9 @@ describe('heaterShaker compound command creator', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mock_heater_shaker_1.close_labware_latch()\nmock_heater_shaker_1.set_target_temperature(80)'
+    )
   })
   it('should call to open latch last', () => {
     heaterShakerArgs = {
@@ -313,5 +325,8 @@ describe('heaterShaker compound command creator', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mock_heater_shaker_1.deactivate_heater()\nmock_heater_shaker_1.open_labware_latch()'
+    )
   })
 })

--- a/step-generation/src/__tests__/heaterShakerOpenLatch.test.ts
+++ b/step-generation/src/__tests__/heaterShakerOpenLatch.test.ts
@@ -41,6 +41,12 @@ describe('heaterShakerOpenLatch', () => {
           pythonName: 'mockPythonName',
         },
       },
+      moduleEntities: {
+        ...context.moduleEntities,
+        [HEATER_SHAKER_ID]: {
+          pythonName: 'mock_heater_shaker_1',
+        } as any,
+      },
     }
     const state = getInitialRobotStateStandard(invariantContext)
 
@@ -100,6 +106,7 @@ describe('heaterShakerOpenLatch', () => {
           params: { moduleId: 'heaterShakerId' },
         },
       ],
+      python: 'mock_heater_shaker_1.open_labware_latch()',
     })
   })
   it('should return an open latch command when there is no labware that is too tall east/west of the heater shaker', () => {
@@ -125,6 +132,7 @@ describe('heaterShakerOpenLatch', () => {
           params: { moduleId: 'heaterShakerId' },
         },
       ],
+      python: 'mock_heater_shaker_1.open_labware_latch()',
     })
   })
 })

--- a/step-generation/src/__tests__/setTemperature.test.ts
+++ b/step-generation/src/__tests__/setTemperature.test.ts
@@ -40,6 +40,7 @@ describe('setTemperature', () => {
             },
           },
         ],
+        python: 'mock_temperature_module_1.set_target_temperature(42)',
       },
     },
     {

--- a/step-generation/src/commandCreators/atomic/heaterShakerCloseLatch.ts
+++ b/step-generation/src/commandCreators/atomic/heaterShakerCloseLatch.ts
@@ -6,6 +6,7 @@ export const heaterShakerCloseLatch: CommandCreator<ModuleOnlyParams> = (
   invariantContext,
   prevRobotState
 ) => {
+  const pythonName = invariantContext.moduleEntities[args.moduleId].pythonName
   return {
     commands: [
       {
@@ -16,5 +17,6 @@ export const heaterShakerCloseLatch: CommandCreator<ModuleOnlyParams> = (
         },
       },
     ],
+    python: `${pythonName}.close_labware_latch()`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/heaterShakerDeactivateHeater.ts
+++ b/step-generation/src/commandCreators/atomic/heaterShakerDeactivateHeater.ts
@@ -6,6 +6,7 @@ export const heaterShakerDeactivateHeater: CommandCreator<ModuleOnlyParams> = (
   invariantContext,
   prevRobotState
 ) => {
+  const pythonName = invariantContext.moduleEntities[args.moduleId].pythonName
   return {
     commands: [
       {
@@ -16,5 +17,6 @@ export const heaterShakerDeactivateHeater: CommandCreator<ModuleOnlyParams> = (
         },
       },
     ],
+    python: `${pythonName}.deactivate_heater()`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/heaterShakerOpenLatch.ts
+++ b/step-generation/src/commandCreators/atomic/heaterShakerOpenLatch.ts
@@ -9,10 +9,10 @@ export const heaterShakerOpenLatch: CommandCreator<ModuleOnlyParams> = (
   invariantContext,
   prevRobotState
 ) => {
+  const { pipetteEntities, labwareEntities, moduleEntities } = invariantContext
   const heaterShakerSlot = prevRobotState.modules[args.moduleId].slot
-  const firstPipetteId = Object.keys(invariantContext.pipetteEntities)[0]
-  const firstPipetteSpec =
-    invariantContext.pipetteEntities[firstPipetteId]?.spec
+  const firstPipetteId = Object.keys(pipetteEntities)[0]
+  const firstPipetteSpec = pipetteEntities[firstPipetteId]?.spec
 
   const isFlexPipette =
     (firstPipetteSpec?.displayCategory === 'FLEX' ||
@@ -23,7 +23,7 @@ export const heaterShakerOpenLatch: CommandCreator<ModuleOnlyParams> = (
     !isFlexPipette &&
     getIsTallLabwareEastWestOfHeaterShaker(
       prevRobotState.labware,
-      invariantContext.labwareEntities,
+      labwareEntities,
       heaterShakerSlot
     )
   ) {
@@ -33,6 +33,8 @@ export const heaterShakerOpenLatch: CommandCreator<ModuleOnlyParams> = (
       errors: [errorCreators.tallLabwareEastWestOfHeaterShaker(leftOrRight)],
     }
   }
+  const pythonName = moduleEntities[args.moduleId].pythonName
+
   return {
     commands: [
       {
@@ -43,5 +45,6 @@ export const heaterShakerOpenLatch: CommandCreator<ModuleOnlyParams> = (
         },
       },
     ],
+    python: `${pythonName}.open_labware_latch()`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/heaterShakerSetTargetShakeSpeed.ts
+++ b/step-generation/src/commandCreators/atomic/heaterShakerSetTargetShakeSpeed.ts
@@ -7,6 +7,7 @@ import type { CommandCreator } from '../../types'
 export const heaterShakerSetTargetShakeSpeed: CommandCreator<
   HeaterShakerSetAndWaitForShakeSpeedCreateCommand['params']
 > = (args, invariantContext, prevRobotState) => {
+  const { moduleEntities } = invariantContext
   const { moduleId, rpm } = args
 
   if (moduleId === null) {
@@ -16,10 +17,10 @@ export const heaterShakerSetTargetShakeSpeed: CommandCreator<
   }
 
   assert(
-    invariantContext.moduleEntities[moduleId]?.type ===
-      HEATERSHAKER_MODULE_TYPE,
-    `expected module ${moduleId} to be heaterShaker, got ${invariantContext.moduleEntities[moduleId]?.type}`
+    moduleEntities[moduleId]?.type === HEATERSHAKER_MODULE_TYPE,
+    `expected module ${moduleId} to be heaterShaker, got ${moduleEntities[moduleId]?.type}`
   )
+  const pythonName = moduleEntities[moduleId].pythonName
 
   return {
     commands: [
@@ -32,5 +33,6 @@ export const heaterShakerSetTargetShakeSpeed: CommandCreator<
         },
       },
     ],
+    python: `${pythonName}.set_and_wait_for_shake_speed(${rpm})`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/heaterShakerStopShake.ts
+++ b/step-generation/src/commandCreators/atomic/heaterShakerStopShake.ts
@@ -6,6 +6,7 @@ export const heaterShakerStopShake: CommandCreator<ModuleOnlyParams> = (
   invariantContext,
   prevRobotState
 ) => {
+  const pythonName = invariantContext.moduleEntities[args.moduleId].pythonName
   return {
     commands: [
       {
@@ -16,5 +17,6 @@ export const heaterShakerStopShake: CommandCreator<ModuleOnlyParams> = (
         },
       },
     ],
+    python: `${pythonName}.deactivate_shaker()`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/setTemperature.ts
+++ b/step-generation/src/commandCreators/atomic/setTemperature.ts
@@ -15,14 +15,14 @@ export const setTemperature: CommandCreator<TemperatureParams> = (
   prevRobotState
 ) => {
   const { moduleId, celsius } = args
-
   if (moduleId === null) {
     return {
       errors: [errorCreators.missingModuleError()],
     }
   }
-
-  const moduleType = invariantContext.moduleEntities[moduleId]?.type
+  const module = invariantContext.moduleEntities[moduleId]
+  const moduleType = module?.type
+  const pythonCommand = `${module?.pythonName}.set_target_temperature(${celsius})`
 
   if (moduleType === TEMPERATURE_MODULE_TYPE) {
     return {
@@ -36,6 +36,7 @@ export const setTemperature: CommandCreator<TemperatureParams> = (
           },
         },
       ],
+      python: pythonCommand,
     }
   } else if (moduleType === THERMOCYCLER_MODULE_TYPE) {
     // TODO: Ian 2019-01-24 implement setting thermocycler temp: block vs lid
@@ -55,6 +56,7 @@ export const setTemperature: CommandCreator<TemperatureParams> = (
           },
         },
       ],
+      python: pythonCommand,
     }
   } else {
     console.error(

--- a/step-generation/src/fixtures/robotStateFixtures.ts
+++ b/step-generation/src/fixtures/robotStateFixtures.ts
@@ -384,11 +384,13 @@ export const getStateAndContextTempTCModules = ({
       id: temperatureModuleId,
       type: TEMPERATURE_MODULE_TYPE,
       model: 'foo',
+      pythonName: 'mock_temperature_module_1',
     },
     [thermocyclerId]: {
       id: thermocyclerId,
       type: THERMOCYCLER_MODULE_TYPE,
       model: 'foo',
+      pythonName: 'mock_thermocycler',
     },
   }
   const robotState = makeState({


### PR DESCRIPTION
…mmands

closes AUTH-1102

# Overview

This PR adds python support for the majority of heater-shaker commands + `setTemperature` since it is used for heater-shaker (as well as temperature module commands)

## Test Plan and Hands on Testing

I added unit test coverage but also review the code and smoke test

## Changelog

- add python command generation for each of the heater-shaker commands and add unit test coverage to the exiting heater-shaker tests

## Risk assessment

low, behind ff