### PR TITLE
fix(protocol-designer): overhaul highlight logic for modules + labware

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -14,7 +14,7 @@ import {
   getModuleType,
 } from '@opentrons/shared-data'
 
-import { getStagingAreaAddressableAreas } from '../../../utils'
+import { getIsAdapter, getStagingAreaAddressableAreas } from '../../../utils'
 import {
   getLabwareIsCompatible,
   getLabwareIsCustom,
@@ -43,7 +43,9 @@ import type {
   AllTemporalPropertiesForTimelineFrame,
   InitialDeckSetup,
   LabwareOnDeck,
+  ModuleOnDeck,
 } from '../../../step-forms'
+import type { Selection } from '../../../ui/steps'
 import type { Fixture } from './constants'
 
 const OT2_TC_SLOTS = ['7', '8', '10', '11']
@@ -490,4 +492,100 @@ export const getOT2HoverDimensions = (
     x,
     y: hasTCOnSlot ? y - 72 : y,
   }
+}
+
+interface HighlightItemsByType {
+  highlightModuleItems: Array<{
+    selection: Selection
+    module: ModuleOnDeck
+    isSelected?: boolean
+  }>
+  highlightLabwareItems: Array<{
+    selection: Selection
+    labware: LabwareOnDeck
+    isSelected?: boolean
+  }>
+}
+
+export function getHighlightLabwareAndModules(
+  hoveredItem: Selection,
+  selectedDropdownItems: Selection[],
+  labware: Record<string, LabwareOnDeck>,
+  modules: Record<string, ModuleOnDeck>
+): HighlightItemsByType {
+  const _getReducedHighlightItemsById = (
+    items: Selection[],
+    isSelected: boolean
+  ): Record<string, { item: Selection; isSelected: boolean }> => {
+    return items.reduce((acc, item) => {
+      if (item.id != null) {
+        const moduleIdUnderLabwareToUse =
+          item.id != null &&
+          labware[item.id] != null &&
+          getIsAdapter(item.id, labware)
+            ? modules[labware[item.id].slot]?.id
+            : null
+
+        const updatedItem =
+          moduleIdUnderLabwareToUse != null
+            ? { ...item, id: moduleIdUnderLabwareToUse }
+            : item
+
+        return updatedItem.id != null
+          ? { ...acc, [updatedItem.id]: { item: updatedItem, isSelected } }
+          : acc
+      }
+      return acc
+    }, {})
+  }
+
+  const reducedHoveredItemsById = _getReducedHighlightItemsById(
+    [hoveredItem],
+    false
+  )
+  const reducedSelectedItemsById = _getReducedHighlightItemsById(
+    selectedDropdownItems,
+    true
+  )
+  const dropdownModulesAndLabwareItemsById = {
+    ...reducedHoveredItemsById,
+    ...reducedSelectedItemsById,
+  }
+
+  const highlightItems = Object.values(
+    dropdownModulesAndLabwareItemsById
+  ).reduce<HighlightItemsByType>(
+    (acc, { item, isSelected }) => {
+      const { id } = item
+      if (id == null) {
+        return acc
+      }
+      if (id in modules) {
+        const moduleOnDeck = modules[id]
+        return {
+          ...acc,
+          highlightModuleItems: [
+            ...acc.highlightModuleItems,
+            { module: moduleOnDeck, selection: item, isSelected },
+          ],
+        }
+      }
+      if (id in labware) {
+        const labwareOnDeck = labware[id]
+        return {
+          ...acc,
+          highlightLabwareItems: [
+            ...acc.highlightLabwareItems,
+            { labware: labwareOnDeck, selection: item, isSelected },
+          ],
+        }
+      }
+      return acc
+    },
+    {
+      highlightModuleItems: [],
+      highlightLabwareItems: [],
+    }
+  )
+  return highlightItems
 }

--- a/protocol-designer/src/ui/steps/actions/actions.ts
+++ b/protocol-designer/src/ui/steps/actions/actions.ts
@@ -196,7 +196,8 @@ const setSelection = (
     formData.stepType === 'heaterShaker' ||
     formData.stepType === 'temperature' ||
     formData.stepType === 'thermocycler' ||
-    formData.stepType === 'magnet'
+    formData.stepType === 'magnet' ||
+    formData.stepType === 'absorbanceReader'
   ) {
     dispatch({
       type: 'SELECT_DROPDOWN_ITEM',

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -121,7 +121,6 @@ export const addAndSelectStep: (arg: {
       abosrbanceReaderModules.length === 1
         ? abosrbanceReaderModules[0][0]
         : null
-    console.log({ absorbanceReaderId, abosrbanceReaderModules })
     if (abosrbanceReaderModules != null) {
       dispatch(
         selectDropdownItem({

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -1,5 +1,6 @@
 import last from 'lodash/last'
 import {
+  ABSORBANCE_READER_TYPE,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
@@ -105,6 +106,27 @@ export const addAndSelectStep: (arg: {
         selectDropdownItem({
           selection: {
             id: hsId,
+            text: 'Selected',
+            field: '1',
+          },
+          mode: 'add',
+        })
+      )
+    }
+  } else if (payload.stepType === 'absorbanceReader') {
+    const abosrbanceReaderModules = Object.entries(modules).filter(
+      ([, module]) => module.type === ABSORBANCE_READER_TYPE
+    )
+    const absorbanceReaderId =
+      abosrbanceReaderModules.length === 1
+        ? abosrbanceReaderModules[0][0]
+        : null
+    console.log({ absorbanceReaderId, abosrbanceReaderModules })
+    if (abosrbanceReaderModules != null) {
+      dispatch(
+        selectDropdownItem({
+          selection: {
+            id: absorbanceReaderId,
             text: 'Selected',
             field: '1',
           },


### PR DESCRIPTION
# Overview

This PR updates logic for which labware/module entities to highlight, whether they be selected or hovered, and moves the logic into a utility for code cleanliness. The logic includes checking whether a selected or hovered labware item is a bare adapter on top of a module, in which case we actually highlight the parent module rather than the adapter. I also fix a bug where absorbance reader module highlights were  not correctly taken into account when opening a new or old plate reader step with pre-selected moduleId.

Closes AUTH-1450, Closes RQA-3954, Closes RQA-3951

## Test Plan and Hands on Testing

- create or import a protocol with a full range of labware + module + adapter combos and step types [example](https://github.com/user-attachments/files/19099267/master.json)
- navigate through the timeline, opening steps, and hovering and selecting the various labware/module dropdown fields. Ensure the highlights work as expected

Specifically:
- open an absorbance reader step and verify that the absorbance reader module is correctly highlighted. Changing the module in the dropdown updates the highlights accordingly (RQA-3954)
- open a move step with source or destination set to heater shaker (step 19 in example, RQA-3951)

## Changelog

- create utility for consolidating module and labware highlight items
- fix bug with absorbance reader selection dispatch when opening a step

## Review requests

See test plan. Please ping me if you'd like to walk through the utility logic live!

## Risk assessment

low