### PR TITLE
fix(protocol-designer): disallow touchtip if destination is trash

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -494,6 +494,11 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
           tooltipText={
             propsForFields[`${tab}_touchTip_checkbox`].tooltipContent
           }
+          disabled={
+            (destinationLabwareType === 'trashBin' ||
+              destinationLabwareType === 'wasteChute') &&
+            tab === 'dispense'
+          }
         >
           {formData[`${tab}_touchTip_checkbox`] === true ? (
             <PositionField


### PR DESCRIPTION
# Overview

If destination type is trash bin or waste chute, disable touch tip field in moveLiquid form.

Closes AUTH-1480

## Test Plan and Hands on Testing

- create or open moveLiquid form
- ensure destination is set to trash bin
- move to advanced dispense settings
- verify that touch tip is disabled
- repeat with waste chute

## Changelog

- disable tooltip field if destination is waste chute or trash bin

## Review requests

see test plan

## Risk assessment

low