### PR TITLE
feat(api): support an "experimental" api version

### DIFF
--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -1,4 +1,5 @@
 """ProtocolContext factory."""
+
 import asyncio
 from typing import Any, Dict, Optional, Union, cast
 
@@ -83,7 +84,7 @@ def create_protocol_context(
     Returns:
         A ready-to-use ProtocolContext.
     """
-    if api_version > MAX_SUPPORTED_VERSION:
+    if api_version > MAX_SUPPORTED_VERSION and not api_version.experimental:
         raise ValueError(
             f"API version {api_version} is not supported by this robot software."
             f" Please reduce your API version to {MAX_SUPPORTED_VERSION} or below"

--- a/api/src/opentrons/protocol_reader/file_identifier.py
+++ b/api/src/opentrons/protocol_reader/file_identifier.py
@@ -265,7 +265,7 @@ def _analyze_python_protocol(
         parsed, PythonProtocol
     ), "Parsing a Python file returned something other than a Python protocol."
 
-    if parsed.api_level > MAX_SUPPORTED_VERSION:
+    if parsed.api_level > MAX_SUPPORTED_VERSION and not parsed.api_level.experimental:
         raise FileIdentificationError(
             message=(
                 f"API version {parsed.api_level} is not supported by this "

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,18 +1,12 @@
-from .types import APIVersion
+from .types import (
+    MAX_SUPPORTED_VERSION,
+    MIN_SUPPORTED_VERSION,
+    MIN_SUPPORTED_VERSION_FOR_FLEX,
+)
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 23)
-"""The maximum supported protocol API version in this release."""
 
-MIN_SUPPORTED_VERSION = APIVersion(2, 0)
-"""The minimum supported protocol API version in this release, across all robot types."""
-
-MIN_SUPPORTED_VERSION_FOR_FLEX = APIVersion(2, 15)
-"""The minimum protocol API version supported by the Opentrons Flex.
-
-It's an infrastructural requirement for this to be at least newer than 2.14. Before then,
-the protocol API is backed by the legacy non-Protocol-engine backend, which is not prepared to
-handle anything but OT-2s.
-
-The additional bump to 2.15 is because that's what we tested on, and because it adds all the
-Flex-specific features.
-"""
+__all__ = [
+    "MAX_SUPPORTED_VERSION",
+    "MIN_SUPPORTED_VERSION",
+    "MIN_SUPPORTED_VERSION_FOR_FLEX",
+]

--- a/api/src/opentrons/protocols/api_support/types.py
+++ b/api/src/opentrons/protocols/api_support/types.py
@@ -1,22 +1,68 @@
 from __future__ import annotations
+import re
 from typing import NamedTuple, TypedDict
+from functools import total_ordering
+
+# match e.g. "2.0" but not "hi", "2", "2.0.1"
+_API_VERSION_RE = re.compile(r"^(\d+)\.(\d+)$")
 
 
+class BadAPIVersionError(Exception):
+    def __init__(self, bad_string: str) -> None:
+        self.bad_string = bad_string
+
+
+@total_ordering
 class APIVersion(NamedTuple):
     major: int
     minor: int
+    experimental: bool = False
 
     @classmethod
     def from_string(cls, inp: str) -> APIVersion:
-        parts = inp.split(".")
-        if len(parts) != 2:
-            raise ValueError(inp)
-        intparts = [int(p) for p in parts]
+        if inp == "experimental":
+            return cls.as_experimental()
+        elif inp == "1":
+            return cls(major=1, minor=0, experimental=False)
 
-        return cls(major=intparts[0], minor=intparts[1])
+        matches = _API_VERSION_RE.match(inp)
+        if not matches:
+            raise BadAPIVersionError(inp)
+
+        return cls(
+            major=int(matches.group(1)), minor=int(matches.group(2)), experimental=False
+        )
+
+    @classmethod
+    def as_experimental(cls) -> APIVersion:
+        return cls(
+            major=MAX_SUPPORTED_VERSION.major,
+            minor=MAX_SUPPORTED_VERSION.minor,
+            experimental=True,
+        )
 
     def __str__(self) -> str:
-        return f"{self.major}.{self.minor}"
+        return f"{self.major}.{self.minor}" if not self.experimental else "experimental"
+
+    def __le__(self, other: tuple[int, int, bool] | tuple[int, int]) -> bool:  # type: ignore[override]
+        # this __le__ supports calling it against a version raw tuple or an API version;
+        # the type ignore happens because NamedTuple says its parent is tuple[int...] in this
+        # case, not tuple[int, int, bool]
+        b_maj = other[0]
+        b_min = other[1]
+        b_exp = other[2] if len(other) > 2 else False
+        # when you do a <= b, interpreter calls a.__le__(b)
+        if self.experimental and b_exp:
+            # both a and b are experimental: same version
+            return True
+        elif self.experimental:
+            # a is experimental, and b is not: a > b, a !<= b
+            return False
+        elif b_exp:
+            # a is not experimental, and b is: a < b, a <= b
+            return True
+        # both are not experimental, standard version compare
+        return (self.major, self.minor) <= (b_maj, b_min)
 
 
 class ThermocyclerStepBase(TypedDict):
@@ -30,3 +76,21 @@ class ThermocyclerStep(ThermocyclerStepBase, total=False):
 
     hold_time_seconds: float
     hold_time_minutes: float
+
+
+MAX_SUPPORTED_VERSION = APIVersion(2, 23)
+"""The maximum supported protocol API version in this release."""
+
+MIN_SUPPORTED_VERSION = APIVersion(2, 0)
+"""The minimum supported protocol API version in this release, across all robot types."""
+
+MIN_SUPPORTED_VERSION_FOR_FLEX = APIVersion(2, 15)
+"""The minimum protocol API version supported by the Opentrons Flex.
+
+It's an infrastructural requirement for this to be at least newer than 2.14. Before then,
+the protocol API is backed by the legacy non-Protocol-engine backend, which is not prepared to
+handle anything but OT-2s.
+
+The additional bump to 2.15 is because that's what we tested on, and because it adds all the
+Flex-specific features.
+"""

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -1,6 +1,5 @@
 """Test cli execution."""
 
-
 import json
 import tempfile
 import textwrap
@@ -128,6 +127,12 @@ def _get_deck_definition_test_source(api_level: str, robot_type: str) -> str:
             "OT-3",
             "(227.88, 42.785, 44.04)",
             marks=pytest.mark.ot3_only,  # Analyzing an OT-3 protocol requires an OT-3 hardware API.
+        ),
+        pytest.param(
+            "experimental",
+            "Flex",
+            "(227.88, 42.785, 44.04)",
+            marks=pytest.mark.ot3_only,
         ),
     ],
 )

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -1,4 +1,5 @@
 """HTTP routes and handlers for /health endpoints."""
+
 from dataclasses import dataclass
 from fastapi import APIRouter, Depends, status
 from typing import Annotated, Dict, cast
@@ -168,8 +169,8 @@ async def get_health(
         board_revision=hardware.board_revision,
         logs=logs,
         system_version=versions.system_version,
-        maximum_protocol_api_version=list(protocol_api.MAX_SUPPORTED_VERSION),
-        minimum_protocol_api_version=list(minimum_protocol_api_version),
+        maximum_protocol_api_version=list(protocol_api.MAX_SUPPORTED_VERSION[:2]),
+        minimum_protocol_api_version=list(minimum_protocol_api_version[:2]),
         robot_model=robot_type,
         links=health_links,
         robot_serial=(await hardware.get_serial_number()),

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -1,4 +1,5 @@
 """Tests for the /health router."""
+
 import pytest
 from typing import Dict, Iterator
 from mock import MagicMock, patch
@@ -32,8 +33,8 @@ def test_get_health(
             "/logs/update_server.log",
         ],
         "system_version": "mytestsystemversion",
-        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION),
-        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
+        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION[:2]),
+        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION[:2]),
         "robot_model": "OT-2 Standard",
         "links": {
             "apiLog": "/logs/api.log",
@@ -75,8 +76,8 @@ def test_get_health_with_none_version(
             "/logs/update_server.log",
         ],
         "system_version": "mytestsystemversion",
-        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION),
-        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
+        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION[:2]),
+        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION[:2]),
         "robot_model": "OT-2 Standard",
         "links": {
             "apiLog": "/logs/api.log",

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -1,6 +1,5 @@
 """Fixtures to be used by Tavern tests."""
 
-
 from box import Box
 from requests import Response
 from opentrons.protocol_api import (
@@ -26,8 +25,8 @@ def check_health_response(response: Response) -> None:
         ],
         "system_version": config.OT_SYSTEM_VERSION,
         "robot_model": "OT-2 Standard",
-        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION),
-        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
+        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION[:2]),
+        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION[:2]),
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",
@@ -58,8 +57,8 @@ def check_ot3_health_response(response: Response) -> None:
         ],
         "system_version": config.OT_SYSTEM_VERSION,
         "robot_model": "OT-3 Standard",
-        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION_FOR_FLEX),
-        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
+        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION_FOR_FLEX[:2]),
+        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION[:2]),
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",


### PR DESCRIPTION
Add the ability to specify a protocol's API level as "experimental", and to specify API calls as experimental.

The experimental API level is greater than any named API level. That means that
- An api method that is experimental can only be used if the protocol requests the experimental api level
- This will remain true as the max supported api version changes

## review requests
- is this a thing we want to do?

## to come out of draft
- decide which APIs should be marked as experimental, and mark them that way