### PR TITLE
feat(step-generation): python commands for configure_

### DIFF
--- a/step-generation/src/__tests__/configureForVolume.test.ts
+++ b/step-generation/src/__tests__/configureForVolume.test.ts
@@ -11,6 +11,7 @@ const invariantContext: any = {
     [mockId]: {
       name: 'p50_single_flex',
       id: mockId,
+      pythonName: 'mock_pipette_left',
     },
   },
 }
@@ -35,5 +36,6 @@ describe('configureForVolume', () => {
         },
       },
     ])
+    expect(res.python).toBe('mock_pipette_left.configure_for_volume(1)')
   })
 })

--- a/step-generation/src/__tests__/configureNozzleLayout.test.ts
+++ b/step-generation/src/__tests__/configureNozzleLayout.test.ts
@@ -7,9 +7,17 @@ const getRobotInitialState = (): any => {
   return {}
 }
 
-const invariantContext: any = {}
-const robotInitialState = getRobotInitialState()
 const mockPipette = 'mockPipette'
+const invariantContext: any = {
+  pipetteEntities: {
+    [mockPipette]: {
+      name: 'p1000_96',
+      id: mockPipette,
+      pythonName: 'mock_pipette',
+    },
+  },
+}
+const robotInitialState = getRobotInitialState()
 
 describe('configureNozzleLayout', () => {
   it('should call configureNozzleLayout with correct params for full tip', () => {
@@ -35,6 +43,7 @@ describe('configureNozzleLayout', () => {
         },
       },
     ])
+    expect(res.python).toBe('mock_pipette.configure_nozzle_layout(ALL)')
   })
   it('should call configureNozzleLayout with correct params for column tip', () => {
     const result = configureNozzleLayout(
@@ -59,5 +68,8 @@ describe('configureNozzleLayout', () => {
         },
       },
     ])
+    expect(res.python).toBe(
+      'mock_pipette.configure_nozzle_layout(COLUMN, start="A12")'
+    )
   })
 })

--- a/step-generation/src/__tests__/configureNozzleLayout.test.ts
+++ b/step-generation/src/__tests__/configureNozzleLayout.test.ts
@@ -43,7 +43,9 @@ describe('configureNozzleLayout', () => {
         },
       },
     ])
-    expect(res.python).toBe('mock_pipette.configure_nozzle_layout(ALL)')
+    expect(res.python).toBe(
+      'mock_pipette.configure_nozzle_layout(protocol_api.ALL)'
+    )
   })
   it('should call configureNozzleLayout with correct params for column tip', () => {
     const result = configureNozzleLayout(
@@ -69,7 +71,7 @@ describe('configureNozzleLayout', () => {
       },
     ])
     expect(res.python).toBe(
-      'mock_pipette.configure_nozzle_layout(COLUMN, start="A12")'
+      'mock_pipette.configure_nozzle_layout(protocol_api.COLUMN, start="A12")'
     )
   })
 })

--- a/step-generation/src/commandCreators/atomic/configureForVolume.ts
+++ b/step-generation/src/commandCreators/atomic/configureForVolume.ts
@@ -8,9 +8,9 @@ export const configureForVolume: CommandCreator<ConfigureForVolumeParams> = (
   prevRobotState
 ) => {
   const { pipetteId, volume } = args
-
+  const pipette = invariantContext.pipetteEntities[pipetteId]
   // No-op if there is no pipette
-  if (!invariantContext.pipetteEntities[pipetteId]) {
+  if (!pipette) {
     return {
       commands: [],
     }
@@ -28,5 +28,6 @@ export const configureForVolume: CommandCreator<ConfigureForVolumeParams> = (
   ]
   return {
     commands,
+    python: `${pipette.pythonName}.configure_for_volume(${volume})`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/configureNozzleLayout.ts
+++ b/step-generation/src/commandCreators/atomic/configureNozzleLayout.ts
@@ -25,6 +25,6 @@ export const configureNozzleLayout: CommandCreator<ConfigureNozzleLayoutParams> 
 
   return {
     commands,
-    python: `${pythonName}.configure_nozzle_layout(${style}${startArg})`,
+    python: `${pythonName}.configure_nozzle_layout(protocol_api.${style}${startArg})`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/configureNozzleLayout.ts
+++ b/step-generation/src/commandCreators/atomic/configureNozzleLayout.ts
@@ -1,4 +1,4 @@
-import { uuid } from '../../utils'
+import { formatPyStr, uuid } from '../../utils'
 import type { ConfigureNozzleLayoutParams } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
 
@@ -8,7 +8,7 @@ export const configureNozzleLayout: CommandCreator<ConfigureNozzleLayoutParams> 
   prevRobotState
 ) => {
   const { pipetteId, configurationParams } = args
-
+  const { style, primaryNozzle } = configurationParams
   const commands = [
     {
       commandType: 'configureNozzleLayout' as const,
@@ -19,7 +19,12 @@ export const configureNozzleLayout: CommandCreator<ConfigureNozzleLayoutParams> 
       },
     },
   ]
+  const pythonName = invariantContext.pipetteEntities[pipetteId].pythonName
+  const startArg =
+    primaryNozzle != null ? `, start=${formatPyStr(primaryNozzle)}` : ''
+
   return {
     commands,
+    python: `${pythonName}.configure_nozzle_layout(${style}${startArg})`,
   }
 }


### PR DESCRIPTION
closes AUTH-1521

# Overview

This PR adds python generation support for `configure_nozzle_layout()` and `configure_for_volume()`

## Test Plan and Hands on Testing

Review code and unit tests

Example with configure nozzle layout:
```

from contextlib import nullcontext as pd_step
from opentrons import protocol_api, types

metadata = {
    "created": "2025-03-07T20:02:35.249Z",
    "lastModified": "2025-03-07T20:03:16.136Z",
    "protocolDesigner": "8.4.0",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.23",
}

def run(protocol: protocol_api.ProtocolContext):
    # Load Adapters:
    adapter_1 = protocol.load_adapter(
        "opentrons_flex_96_tiprack_adapter",
        "C2",
        namespace="opentrons",
        version=1,
    )

    # Load Labware:
    tip_rack_1 = adapter_1.load_labware(
        "opentrons_flex_96_filtertiprack_1000ul",
        namespace="opentrons",
        version=1,
    )
    well_plate_1 = protocol.load_labware(
        "biorad_96_wellplate_200ul_pcr",
        "B3",
        namespace="opentrons",
        version=2,
    )
    tip_rack_2 = protocol.load_labware(
        "opentrons_flex_96_filtertiprack_1000ul",
        "D1",
        label="Opentrons Flex 96 Filter Tip Rack 1000 µL (1)",
        namespace="opentrons",
        version=1,
    )

    # Load Pipettes:
    pipette_left = protocol.load_instrument("flex_96channel_1000", tip_racks=[tip_rack_1, tip_rack_2])

    # Load Trash Bins:
    trash_bin_1 = protocol.load_trash_bin("A3")

    # PROTOCOL STEPS

    # Step 1:
    pipette_left.configure_nozzle_layout(protocol_api.ALL)
    pipette_left.pick_up_tip(location=tip_rack_1)
    pipette_left.aspirate(
        volume=10,
        location=well_plate_1["A1"].bottom(z=1),
        rate=160 / pipette_left.flow_rate.aspirate,
    )
    pipette_left.drop_tip()
```

## Changelog

- add python generation for `configure_nozzle_layout()` and `configure_for_volume()`
- add unit test coverage

## Risk assessment

low