### PR TITLE
fix(api): fix float conversion issue when truncating absorbance values.

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1346,7 +1346,7 @@ class ModuleView:
                 col = (i % 12) + 1  # Convert index to column (1-12)
                 well_key = f"{row}{col}"
                 truncated_value = float(
-                    "{:.5}".format(str(value))
+                    "%.3f" % value
                 )  # Truncate the returned value to the third decimal place
                 well_map[well_key] = truncated_value
             return well_map

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1333,22 +1333,20 @@ class ModuleView:
         else:
             return False
 
-    def convert_absorbance_reader_data_points(
-        self, data: List[float]
-    ) -> Dict[str, float]:
+    @staticmethod
+    def convert_absorbance_reader_data_points(data: List[float]) -> Dict[str, float]:
         """Return the data from the Absorbance Reader module in a map of wells for each read value."""
         if len(data) == 96:
             # We have to reverse the reader values because the Opentrons Absorbance Reader is rotated 180 degrees on the deck
-            data.reverse()
+            raw_data = data.copy()
+            raw_data.reverse()
             well_map: Dict[str, float] = {}
-            for i, value in enumerate(data):
+            for i, value in enumerate(raw_data):
                 row = chr(ord("A") + i // 12)  # Convert index to row (A-H)
                 col = (i % 12) + 1  # Convert index to column (1-12)
                 well_key = f"{row}{col}"
-                truncated_value = float(
-                    "%.3f" % value
-                )  # Truncate the returned value to the third decimal place
-                well_map[well_key] = truncated_value
+                # Truncate the value to the third decimal place
+                well_map[well_key] = math.floor(value * 1000) / 1000
             return well_map
         else:
             raise ValueError(


### PR DESCRIPTION
# Overview

Converting a float in scientific notation to a string with `str` gives you a string of the scientific notation of the value. We then truncate that string by 5 characters using string formatting, which keeps the one's place, floating point, and 3 decimal places converted back to a float giving us invalid values. Here is a snippet showcasing this behavior

```
>>> value = float(-1.708423405943904e-05)
>>> value
-1.708423405943904e-05
>>> str(value)
'-1.708423405943904e-05'
>>> "{:.5}".format(str(value))
'-1.70'
```

Closes: [EXEC-1295](https://opentrons.atlassian.net/browse/EXEC-1295)

## Test Plan and Hands on Testing

- [x] Make sure we produce correct values when reading absorbance
- [x] Make sure near 0 values expressed in scientific notation are truncated properly

## Changelog

- Don't use string formatting when truncating the absorbance values, use math.floor instead.

## Review requests

- Makes sense?

## Risk assessment
Low

[EXEC-1295]: https://opentrons.atlassian.net/browse/EXEC-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ