### PR TITLE
fix(protocol-designer): route to overview if importing with settings open

### DIFF
--- a/protocol-designer/src/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/organisms/Navigation/index.tsx
@@ -30,6 +30,7 @@ export function Navigation(): JSX.Element | null {
   const loadFile = (fileChangeEvent: ChangeEvent<HTMLInputElement>): void => {
     dispatch(loadFileActions.loadProtocolFile(fileChangeEvent))
     dispatch(toggleNewProtocolModal(false))
+    navigate('/overview')
   }
   const hasUnsavedChanges = useSelector(getHasUnsavedChanges)
 


### PR DESCRIPTION
# Overview

This PR adds navigation to protocol overview page when importing a protocol when on the Settings page. Previously, the import would happen silently in the background, with the Settings page still showing.

Closes AUTH-1198

## Test Plan and Hands on Testing

- open or create a protocol, and open settings page (top right of navbar)
- with settings open, import a protocol (navbar), and verify that you are directed to the protocol overview page

### Before:

https://github.com/user-attachments/assets/637ac53e-9ebd-4a41-899a-6fd985dbf44f

### After:

https://github.com/user-attachments/assets/312d9379-fb25-4f50-b9c2-7537ac4bf6f4

## Changelog

- add navigation to protocol overview on `loadFile` in `Navigation`

## Review requests

see test plan

## Risk assessment

low