### PR TITLE
feat(robot-server): Support multiple filters in `GET /labwareOffsets`

### DIFF
--- a/api-client/src/labwareOffsets/getLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/getLabwareOffsets.ts
@@ -34,11 +34,19 @@ export function getLabwareOffsets(
   config: HostConfig,
   params: LabwareOffsetsSearchParams = {}
 ): ResponsePromise<LabwareOffsetsResponse> {
-  return request<LabwareOffsetsResponse>(
-    GET,
-    '/labwareOffsets',
-    null,
-    config,
-    params
-  )
+  // If we naively give an array to axios's `params`:
+  //   {params: {ourArray: [1, 2]}}
+  // Then axios will serialize it in the URL like:
+  //   ?ourArray[]=1&?ourArray[]=2
+  // We don't want that. We want:
+  //   ?ourArray=[1,2]
+  // So, serialize it to a string ourselves before giving it to axios.
+  params.filters satisfies unknown[] | undefined
+  const stringifiedFilters = params.filters === undefined ? undefined : JSON.stringify(params.filters)
+  const fixedParams = {
+    ...params,
+    filters: stringifiedFilters
+  }
+
+  return request<LabwareOffsetsResponse>(GET, '/labwareOffsets', null, config, fixedParams)
 }

--- a/api-client/src/labwareOffsets/getLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/getLabwareOffsets.ts
@@ -41,7 +41,7 @@ export function getLabwareOffsets(
   // We don't want that. We want:
   //   ?ourArray=[1,2]
   // So, serialize it to a string ourselves before giving it to axios.
-  params.filters satisfies unknown[] | undefined
+  params.filters satisfies unknown[] | undefined;
   const stringifiedFilters = params.filters === undefined ? undefined : JSON.stringify(params.filters)
   const fixedParams = {
     ...params,

--- a/api-client/src/labwareOffsets/getLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/getLabwareOffsets.ts
@@ -1,20 +1,10 @@
 import { GET, request } from '../request'
 
 import type { ResponsePromise } from '../request'
-import type {
-  HostConfig,
-  LabwareOffsetLocationSequenceComponent,
-} from '../types'
+import type { HostConfig } from '../types'
 import type { StoredLabwareOffset, MultiBodyMeta } from './types'
 
 export interface LabwareOffsetsSearchParams {
-  /** Filters are ORed together. Within a single filter, criteria are ANDed together. */
-  filters?: Array<{
-    id?: string
-    definitionUri?: string
-    locationSequence?: LabwareOffsetLocationSequenceComponent[]
-    mostRecentOnly?: boolean
-  }>
   cursor?: number
   pageLength?: number | 'unlimited'
 }
@@ -25,7 +15,7 @@ export interface LabwareOffsetsResponse {
 }
 
 /**
- * Get a filtered list of all the labware offsets currently stored on the robot.
+ * Get all the labware offsets currently stored on the robot.
  * Results are returned in order from oldest to newest.
  *
  * @param params - Optional filter parameters.
@@ -34,25 +24,11 @@ export function getLabwareOffsets(
   config: HostConfig,
   params: LabwareOffsetsSearchParams = {}
 ): ResponsePromise<LabwareOffsetsResponse> {
-  // If we naively give an array to axios's `params`:
-  //   {params: {ourArray: [1, 2]}}
-  // Then axios will serialize it in the URL like:
-  //   ?ourArray[]=1&?ourArray[]=2
-  // We don't want that. We want:
-  //   ?ourArray=[1,2]
-  // So, serialize it to a string ourselves before giving it to axios.
-  const stringifiedFilters =
-    params.filters === undefined ? undefined : JSON.stringify(params.filters)
-  const fixedParams = {
-    ...params,
-    filters: stringifiedFilters,
-  }
-
   return request<LabwareOffsetsResponse>(
     GET,
     '/labwareOffsets',
     null,
     config,
-    fixedParams
+    params
   )
 }

--- a/api-client/src/labwareOffsets/getLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/getLabwareOffsets.ts
@@ -41,12 +41,18 @@ export function getLabwareOffsets(
   // We don't want that. We want:
   //   ?ourArray=[1,2]
   // So, serialize it to a string ourselves before giving it to axios.
-  params.filters satisfies unknown[] | undefined;
-  const stringifiedFilters = params.filters === undefined ? undefined : JSON.stringify(params.filters)
+  const stringifiedFilters =
+    params.filters === undefined ? undefined : JSON.stringify(params.filters)
   const fixedParams = {
     ...params,
-    filters: stringifiedFilters
+    filters: stringifiedFilters,
   }
 
-  return request<LabwareOffsetsResponse>(GET, '/labwareOffsets', null, config, fixedParams)
+  return request<LabwareOffsetsResponse>(
+    GET,
+    '/labwareOffsets',
+    null,
+    config,
+    fixedParams
+  )
 }

--- a/api-client/src/labwareOffsets/getLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/getLabwareOffsets.ts
@@ -1,16 +1,20 @@
 import { GET, request } from '../request'
 
 import type { ResponsePromise } from '../request'
-import type { HostConfig } from '../types'
+import type {
+  HostConfig,
+  LabwareOffsetLocationSequenceComponent,
+} from '../types'
 import type { StoredLabwareOffset, MultiBodyMeta } from './types'
-import type { ModuleModel } from '@opentrons/shared-data'
 
 export interface LabwareOffsetsSearchParams {
-  id?: string
-  definitionUri?: string
-  locationSlotName?: string
-  locationModuleModel?: ModuleModel | null
-  locationDefinitionUri?: string | null
+  /** Filters are ORed together. Within a single filter, criteria are ANDed together. */
+  filters?: Array<{
+    id?: string
+    definitionUri?: string
+    locationSequence?: LabwareOffsetLocationSequenceComponent[]
+    mostRecentOnly?: boolean
+  }>
   cursor?: number
   pageLength?: number | 'unlimited'
 }
@@ -22,7 +26,7 @@ export interface LabwareOffsetsResponse {
 
 /**
  * Get a filtered list of all the labware offsets currently stored on the robot.
- * Filters are ANDed together. Results are returned in order from oldest to newest.
+ * Results are returned in order from oldest to newest.
  *
  * @param params - Optional filter parameters.
  */

--- a/api-client/src/labwareOffsets/searchLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/searchLabwareOffsets.ts
@@ -34,5 +34,5 @@ export function searchLabwareOffsets(
   return request<
     SearchLabwareOffsetsResponse,
     { data: SearchLabwareOffsetsData }
-  >(POST, '/labwareOffsets', { data }, config)
+  >(POST, '/labwareOffsets/searches', { data }, config)
 }

--- a/api-client/src/labwareOffsets/searchLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/searchLabwareOffsets.ts
@@ -1,0 +1,38 @@
+import { POST, request } from '../request'
+
+import type { ResponsePromise } from '../request'
+import type {
+  HostConfig,
+  LabwareOffsetLocationSequenceComponent,
+} from '../types'
+import type { StoredLabwareOffset } from './types'
+
+export interface SearchLabwareOffsetsData {
+  /** Filters are ORed together. Within a single filter, criteria are ANDed together. */
+  filters: Array<{
+    id?: string
+    definitionUri?: string
+    locationSequence?: LabwareOffsetLocationSequenceComponent[]
+    mostRecentOnly?: boolean
+  }>
+}
+
+export interface SearchLabwareOffsetsResponse {
+  data: StoredLabwareOffset[]
+}
+
+/**
+ * Search labware offsets by specific criteria.
+ *
+ * @param data - The criteria by which to search.
+ * @returns The matching labware offsets, oldest-to-newest.
+ */
+export function searchLabwareOffsets(
+  config: HostConfig,
+  data: SearchLabwareOffsetsData
+): ResponsePromise<SearchLabwareOffsetsResponse> {
+  return request<
+    SearchLabwareOffsetsResponse,
+    { data: SearchLabwareOffsetsData }
+  >(POST, '/labwareOffsets', { data }, config)
+}

--- a/robot-server/robot_server/labware_offsets/models.py
+++ b/robot-server/robot_server/labware_offsets/models.py
@@ -148,7 +148,7 @@ class SearchCreate(BaseModel):
 
                 A result is returned if it passes any of these filters
                 (in other words, these filters are OR'd together).
-                If no filters are provided, all results are returned.
+                If this list is empty, no results are returned.
                 """
             )
         ),

--- a/robot-server/robot_server/labware_offsets/models.py
+++ b/robot-server/robot_server/labware_offsets/models.py
@@ -136,6 +136,7 @@ class SearchFilter(BaseModel):
         Field(
             description=(
                 "If `true`, this filter returns only the most recent matching result."
+                " Otherwise, all matches are returned."
             )
         ),
     ] = False

--- a/robot-server/robot_server/labware_offsets/router.py
+++ b/robot-server/robot_server/labware_offsets/router.py
@@ -238,15 +238,12 @@ async def delete_all_labware_offsets(  # noqa: D103
 def _search(
     store: LabwareOffsetStore, filters: Sequence[SearchFilter]
 ) -> list[StoredLabwareOffset]:
-    if len(filters) == 0:
-        return store.search()
-    else:
-        # todo(mm, 2025-03-06): This would probably be more efficient in SQL.
-        result: list[StoredLabwareOffset] = []
-        for filter in filters:
-            result.extend(_search_single_filter(store, filter))
-        result.sort(key=lambda element: element.createdAt)
-        return result
+    # todo(mm, 2025-03-06): This would probably be more efficient in SQL.
+    result: list[StoredLabwareOffset] = []
+    for filter in filters:
+        result.extend(_search_single_filter(store, filter))
+    result.sort(key=lambda element: element.createdAt)
+    return result
 
 
 def _search_single_filter(

--- a/robot-server/robot_server/labware_offsets/router.py
+++ b/robot-server/robot_server/labware_offsets/router.py
@@ -235,6 +235,7 @@ def _search(
         result: list[StoredLabwareOffset] = []
         for filter in filters:
             result.extend(_search_single_filter(store, filter))
+        result.sort(key=lambda element: element.createdAt)
         return result
 
 

--- a/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
@@ -103,8 +103,14 @@ stages:
   # Just a basic test here. More complicated tests for the filters belong in the unit tests.
   - name: Test getting labware offsets with a filter
     request:
-      url: '{ot3_server_base_url}/labwareOffsets?locationSlotName="A2"'
+      url: '{ot3_server_base_url}/labwareOffsets'
       method: GET
+      params:
+        # JSON turducken:
+        # - The query parameter value is a string containing JSON
+        # - Putting single quotes around it keeps it as a string and keeps YAML from interpreting it as an object
+        # - Putting !raw before it prevents Tavern from trying to do {substitution}
+        filter: !raw '{"locationSequence":[{"kind":"onAddressableArea","addressableAreaName":"A2"}]}'
     response:
       json:
         data:
@@ -231,138 +237,3 @@ stages:
         meta:
           cursor: 0
           totalLength: 2
-
----
-# Some of the filter query parameters can have `null` values or be omitted,
-# with different semantics between the two. That distinction takes a bit of care to
-# preserve across our code, so here we test it specifically.
-test_name: Test null vs. omitted filter query parameters
-
-marks:
-  - usefixtures:
-      - ot3_server_base_url
-
-stages:
-  - name: POST test offset 1
-    request:
-      method: POST
-      url: '{ot3_server_base_url}/labwareOffsets'
-      json:
-        data:
-          definitionUri: testNamespace/loadName1/1
-          locationSequence:
-            - kind: onAddressableArea
-              addressableAreaName: A1
-              # No moduleModel
-              # No definitionUri
-          vector:
-            x: 1
-            y: 2
-            z: 3
-    response:
-      status_code: 201
-      save:
-        json:
-          offset_1_data: data
-
-  - name: POST test offset 2
-    request:
-      method: POST
-      url: '{ot3_server_base_url}/labwareOffsets'
-      json:
-        data:
-          definitionUri: testNamespace/loadName2/1
-          locationSequence:
-            - kind: onModule
-              moduleModel: temperatureModuleV2
-            - kind: onAddressableArea
-              addressableAreaName: A1
-              # No definitionUri
-          vector:
-            x: 1
-            y: 2
-            z: 3
-    response:
-      status_code: 201
-      save:
-        json:
-          offset_2_data: data
-
-  - name: POST test offset 3
-    request:
-      method: POST
-      url: '{ot3_server_base_url}/labwareOffsets'
-      json:
-        data:
-          definitionUri: testNamespace/loadName2/1
-          locationSequence:
-            - kind: onLabware
-              labwareUri: testNamespace/adapterLoadName/1
-            - kind: onAddressableArea
-              addressableAreaName: A1
-              # no moduleModel
-          vector:
-            x: 1
-            y: 2
-            z: 3
-    response:
-      status_code: 201
-      save:
-        json:
-          offset_3_data: data
-
-  - name: POST test offset 4
-    request:
-      method: POST
-      url: '{ot3_server_base_url}/labwareOffsets'
-      json:
-        data:
-          definitionUri: testNamespace/loadName3/1
-          locationSequence:
-            - kind: onLabware
-              labwareUri: testNamespace/adapterLoadName/1
-            - kind: onModule
-              moduleModel: temperatureModuleV2
-            - kind: onAddressableArea
-              addressableAreaName: A1
-          vector:
-            x: 1
-            y: 2
-            z: 3
-    response:
-      status_code: 201
-      save:
-        json:
-          offset_4_data: data
-
-  - name: Test no filters
-    request:
-      url: '{ot3_server_base_url}/labwareOffsets'
-    response:
-      json:
-        data:
-          - !force_format_include '{offset_1_data}'
-          - !force_format_include '{offset_2_data}'
-          - !force_format_include '{offset_3_data}'
-          - !force_format_include '{offset_4_data}'
-        meta: !anydict
-
-  - name: Test filtering on locationModuleModel=null
-    request:
-      url: '{ot3_server_base_url}/labwareOffsets?locationModuleModel=null'
-    response:
-      json:
-        data:
-          - !force_format_include '{offset_1_data}'
-          - !force_format_include '{offset_3_data}'
-        meta: !anydict
-
-  - name: Test filtering on locationDefinitionUri=null
-    request:
-      url: '{ot3_server_base_url}/labwareOffsets?locationDefinitionUri=null'
-    response:
-      json:
-        data:
-          - !force_format_include '{offset_1_data}'
-          - !force_format_include '{offset_2_data}'
-        meta: !anydict

--- a/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
@@ -107,10 +107,10 @@ stages:
       method: GET
       params:
         # JSON turducken:
-        # - The query parameter value is a string containing JSON
-        # - Putting single quotes around it keeps it as a string and keeps YAML from interpreting it as an object
-        # - Putting !raw before it prevents Tavern from trying to do {substitution}
-        filter: !raw '{"locationSequence":[{"kind":"onAddressableArea","addressableAreaName":"A2"}]}'
+        # - The query parameter value is a string containing JSON.
+        # - Putting single-quotes around that keeps the YAML parser from parsing the JSON.
+        # - Putting !raw before that prevents Tavern from trying to do {substitution}.
+        filters: !raw '[{"locationSequence":[{"kind":"onAddressableArea","addressableAreaName":"A2"}]}]'
     response:
       json:
         data:

--- a/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
@@ -101,16 +101,16 @@ stages:
           totalLength: 3
 
   # Just a basic test here. More complicated tests for the filters belong in the unit tests.
-  - name: Test getting labware offsets with a filter
+  - name: Test searching for labware offsets with a filter
     request:
-      url: '{ot3_server_base_url}/labwareOffsets'
-      method: GET
-      params:
-        # JSON turducken:
-        # - The query parameter value is a string containing JSON.
-        # - Putting single-quotes around that keeps the YAML parser from parsing the JSON.
-        # - Putting !raw before that prevents Tavern from trying to do {substitution}.
-        filters: !raw '[{"locationSequence":[{"kind":"onAddressableArea","addressableAreaName":"A2"}]}]'
+      url: '{ot3_server_base_url}/labwareOffsets/searches'
+      method: POST
+      json:
+        data:
+          filters:
+            - locationSequence:
+                - kind: onAddressableArea
+                  addressableAreaName: A2
     response:
       json:
         data:

--- a/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_labware_offsets.tavern.yaml
@@ -119,6 +119,23 @@ stages:
           cursor: 0
           totalLength: 1
 
+  # This behavior, as opposed to returning all results, is beneficial for edge cases
+  # like protocols without any labware. The client can naively search for all the
+  # labware in the protocol (an empty list) without accidentally blowing up the server.
+  - name: Test that an empty search query returns no results
+    request:
+      url: '{ot3_server_base_url}/labwareOffsets/searches'
+      method: POST
+      json:
+        data:
+          filters: []
+    response:
+      json:
+        data: []
+        meta:
+          cursor: 0
+          totalLength: 0
+
   - name: Delete a labware offset
     request:
       url: '{ot3_server_base_url}/labwareOffsets/{offset_1_id}'


### PR DESCRIPTION
## Overview

Closes EXEC-1293.

## Changelog

* ~~Replace the handful of filter parameters in `GET /labwareOffsets` with a single one. The new parameter receives a list of filter objects.~~

  [Edit] Replace the handful of filter parameters in `GET /labwareOffsets` with a new `POST /labwareOffsets/searches` endpoint.

  The new endpoint receives a list of filter objects. The filter objects are evaluated independently and their results are logically OR'd together. Given that a client knows, from protocol analysis, all the labware placements that are expected to happen in a run, this should let the client fetch all the labware offset data that it will need for that run in a single HTTP request.

* Change the location filter from a `locationDefinitionUri`+`locationSlotName`+`locationModuleModel` triad to an array. This does nothing for EXEC-1293, but it brings this API in line with [#17388](https://github.com/Opentrons/opentrons/pull/17388) and helps with EXEC-1284.

## Review requests

~~Is there a less bad API design than this gigantic JSON-encoded query parameter? I looked into a few things and they all seem gross in their own ways.~~

|  |  |
|---|---|
| `GET` with a body | Seems highly discouraged, if not outright disallowed |
| `POST` with a body instead of `GET` | Gross |
| `POST` to prepare a query, then `GET` to evaluate it | A bit much |
| Multiple filters as `?filter=a&filter=b` instead of `?filter=[a,b]` | Seems OK in the latest available axios version, but annoying in our current version |

[Edit: Switched to `POST`, see discussion below.]

## Test Plan and Hands on Testing

* [x] Frontend: played around with axios with the app dev tools and made sure it serializes the URLs as expected.
* [x] Backend: played around with the endpoint with Postman. We also have some automated tests, though they don't cover the array-parsing behavior yet, I'm afraid.

## Risk assessment

Medium. This API might introduce hazards with:

* Query parameter serialization (e.g. how axios serializes arrays as values)
* URL encoding
* URL lengths (tracking as EXEC-1294)