### PR TITLE
feat(step-generation): define a curryCommandCreator that discards Python

### DIFF
--- a/step-generation/src/utils/curryCommandCreator.ts
+++ b/step-generation/src/utils/curryCommandCreator.ts
@@ -9,3 +9,24 @@ export function curryCommandCreator<Args>(
   return (_invariantContext, _prevRobotState) =>
     commandCreator(args, _invariantContext, _prevRobotState)
 }
+
+/** Curry a CommandCreator but discard any Python code in it.
+ * Useful for compound commands when you need to suppress the Python for some of
+ * the constituent atomic commands. */
+export function curryWithoutPython<Args>(
+  commandCreator: CommandCreator<Args>,
+  args: Args
+): CurriedCommandCreator {
+  return (_invariantContext, _prevRobotState) => {
+    const commandCreatorResult = commandCreator(
+      args,
+      _invariantContext,
+      _prevRobotState
+    )
+    if ('python' in commandCreatorResult) {
+      const { python, ...resultWithoutPython } = commandCreatorResult
+      return resultWithoutPython
+    }
+    return commandCreatorResult
+  }
+}

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -1,7 +1,7 @@
 import uuidv4 from 'uuid/v4'
 import { absorbanceReaderCollision } from './absorbanceReaderCollision'
 import { commandCreatorsTimeline } from './commandCreatorsTimeline'
-import { curryCommandCreator } from './curryCommandCreator'
+import { curryCommandCreator, curryWithoutPython } from './curryCommandCreator'
 import { reduceCommandCreators } from './reduceCommandCreators'
 import { modulePipetteCollision } from './modulePipetteCollision'
 import { thermocyclerPipetteCollision } from './thermocyclerPipetteCollision'
@@ -12,6 +12,7 @@ export {
   absorbanceReaderCollision,
   commandCreatorsTimeline,
   curryCommandCreator,
+  curryWithoutPython,
   reduceCommandCreators,
   modulePipetteCollision,
   thermocyclerPipetteCollision,


### PR DESCRIPTION
# Overview

In step generation, compound commands are implemented by reducing over curried `CommandCreator`s. E.g., dropping a tip in trash is defined as something like:
```
[
  curryCommandCreator(moveToAddressableAreaForDropTip, ...),
  curryCommandCreator(dropTipInPlace, ...),
]
```
If we generated Python for each of the atomic commands individually, we would get something like
```
pipette.move_to(...)
pipette.drop_tip(...)
```
However, in the Python API, it is more idiomatic to emit a single Python command to drop the tip into the trash. We can do that by adding a `CommandCreator` that emits the standalone Python command for dropping a tip into the trash, but we need a way to **turn off** the Python for the `moveToAddressableAreaForDropTip`/`dropTipInPlace` atomic commands. (We can't just delete those atomic commands because we still need them for JSON generation, plus they do useful error checking for us.)

So this PR introduces a new variant of `curryCommandCreator` that suppresses Python from the `CommandCreator`.

So the implementation would become:
```
[
  curryWithoutPython(moveToAddressableAreaForDropTip, ...),
  curryWithoutPython(dropTipInPlace, ...),
  curryCommandCreator(pythonDropTipInTrashBin, ...),
]
```
This preserves the existing behavior when generating JSON, but emits only a single Python command when generating Python. AUTH-1385

## Test Plan and Hands on Testing

Added unit tests.

I have also been using this in my private experimental branch for hands-on testing.

## Risk assessment

Low. Python generation is behind a feature flag, and this is designed to not affect JSON generation at all.