### PR TITLE
fix(api): fix float conversion issue when truncating absorbance values. (#17670)

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import (
     Dict,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1237,22 +1237,20 @@ class ModuleView:
         else:
             return False
 
-    def convert_absorbance_reader_data_points(
-        self, data: List[float]
-    ) -> Dict[str, float]:
+    @staticmethod
+    def convert_absorbance_reader_data_points(data: List[float]) -> Dict[str, float]:
         """Return the data from the Absorbance Reader module in a map of wells for each read value."""
         if len(data) == 96:
             # We have to reverse the reader values because the Opentrons Absorbance Reader is rotated 180 degrees on the deck
-            data.reverse()
+            raw_data = data.copy()
+            raw_data.reverse()
             well_map: Dict[str, float] = {}
-            for i, value in enumerate(data):
+            for i, value in enumerate(raw_data):
                 row = chr(ord("A") + i // 12)  # Convert index to row (A-H)
                 col = (i % 12) + 1  # Convert index to column (1-12)
                 well_key = f"{row}{col}"
-                truncated_value = float(
-                    "{:.5}".format(str(value))
-                )  # Truncate the returned value to the third decimal place
-                well_map[well_key] = truncated_value
+                # Truncate the value to the third decimal place
+                well_map[well_key] = math.floor(value * 1000) / 1000
             return well_map
         else:
             raise ValueError(


### PR DESCRIPTION
Cherry picking 4f8e5896e2ed810a28e9b14097170438bbaa4446 from [Opentrons/opentrons#17670](https://github.com/Opentrons/opentrons/pull/17670)