### PR TITLE
fix(robot-server): Fix migrations failing when commands contain certain text

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v6_to_v7.py
+++ b/robot-server/robot_server/persistence/_migrations/v6_to_v7.py
@@ -83,7 +83,9 @@ def _migrate_command_table_with_new_command_intent_col(
         )
 
         dest_transaction.execute(
-            f"UPDATE run_command SET command_intent='{new_command_intent}' WHERE row_id={row.row_id}"
+            sqlalchemy.update(schema_7.run_command_table)
+            .where(schema_7.run_command_table.c.row_id == row.row_id)
+            .values(command_intent=new_command_intent),
         )
 
 

--- a/robot-server/robot_server/persistence/_migrations/v6_to_v7.py
+++ b/robot-server/robot_server/persistence/_migrations/v6_to_v7.py
@@ -75,9 +75,10 @@ def _migrate_command_table_with_new_command_intent_col(
     for row in dest_transaction.execute(select_commands).all():
         data = json.loads(row.command)
         new_command_intent = (
-            # Account for old_row.command["intent"] being NULL.
+            # Account for the `intent` prop of the old command JSON being omitted or `null`.
+            # We convert either case to the SQL string "protocol".
             "protocol"
-            if "intent" not in row.command or data["intent"] == None  # noqa: E711
+            if "intent" not in data or data["intent"] is None
             else data["intent"]
         )
 

--- a/robot-server/robot_server/persistence/_migrations/v7_to_v8.py
+++ b/robot-server/robot_server/persistence/_migrations/v7_to_v8.py
@@ -81,9 +81,10 @@ def _migrate_command_table_with_new_command_error_col_and_command_status(
     for row in dest_transaction.execute(select_commands).all():
         data = json.loads(row.command)
         new_command_error = (
-            # Account for old_row.command["error"] being null.
+            # Account for the `error` prop of the old command JSON being omitted or `null`.
+            # We convert either case to SQL `null`.
             None
-            if "error" not in row.command or data["error"] is None
+            if "error" not in data or data["error"] is None
             else json.dumps(data["error"])
         )
         # parse json as enum


### PR DESCRIPTION
## Overview

Fixes EXEC-1296 and RESC-406.

## Test Plan and Hands on Testing

Manual steps to reproduce are in EXEC-1296.

I've manually tested this with a dev server reading from the real-world data in RESC-406.

This strikes me as too specific of a bug for it to be worthwhile to add automated tests (robot-server/tests/integration/http_api/persistence/test_compatibility.py), given that each additional test there slows down robot-server's test suite by several seconds. But I'm happy to do it if anybody disagrees.

## Bug details

A couple of our migrations parse JSON from the old database, extract a field, and insert the field into a standalone column in the new database. They need to account for the field in the old JSON being omitted or `null`. They try to do that like this (paraphrasing):

```python
new_sql_value = (
    None if "fieldName" not in old_row.unparsed_json or parsed_json["fieldName"] is None
    else parsed_json["fieldName"]
)
```

The bug is that we are mistakenly looking at `unparsed_json`. If that raw JSON string happens to contain `fieldName` anywhere inside it, we mistakenly assume that the parsed JSON has a field called `fieldName`. When we try to access that field, and it doesn't actually exist, it raises a fatal `KeyError`.

In the specific case of RESC-406, the problematic JSON was like this:

```json
{
	"id": "2b8e15b5-689d-4310-aa46-e4781e39148b",
	"createdAt": "2024-07-22T12:15:23.450524+00:00",
	"commandType": "custom",
	"key": "1e129fb165210375eca0f21c6c6d723b",
	"status": "succeeded",
	"params": {
		"legacyCommandType": "command.COMMENT",
		"legacyCommandText": "Tip detection error with tip B1"
	},
	"result": {},
	"startedAt": "2024-07-22T12:15:23.453847+00:00",
	"completedAt": "2024-07-22T12:15:23.455063+00:00",
	"notes": []
}
```

Notice how it contains the string "error", in `params.legacyCommandText`, but does not have an `error` field.

## Review requests

The stack trace in RESC-406 pointed to one chunk of buggy code, and manual auditing (grepping `_migrations/` for "None" and "null") found another. If you have time, please be an extra pair of eyes to scrutinize our migration code and make sure I didn't miss any other instances.

## Risk assessment

Medium. It isn't easy for our automated tests to cover this code exhaustively, and bugs can prevent the robot from booting.