### PR TITLE
fix(api, shared-data): Pick up tc lid directly off deck slot fix

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -1365,6 +1365,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -1528,6 +1533,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -1695,6 +1705,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -1866,6 +1881,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -2041,6 +2061,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d16d5dbf0][Flex_X_v2_21_tc_lids_wrong_target].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d16d5dbf0][Flex_X_v2_21_tc_lids_wrong_target].json
@@ -2135,6 +2135,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -2297,6 +2302,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -2463,6 +2473,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -2633,6 +2648,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -2807,6 +2827,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[99c15c6c62][Flex_S_v2_21_tc_lids_happy_path].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[99c15c6c62][Flex_S_v2_21_tc_lids_happy_path].json
@@ -221,6 +221,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -383,6 +388,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {
@@ -549,6 +559,11 @@
               "x": 0,
               "y": 0,
               "z": 6.492
+            },
+            "protocol_engine_lid_stack_object": {
+              "x": 0,
+              "y": 0,
+              "z": 0
             }
           },
           "stackingOffsetWithModule": {

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -450,9 +450,9 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
             parent_updates: List[str] = []
             lid_updates: List[str | None] = []
             # when moving a lid between locations we need to:
-            assert isinstance(current_labware.location, OnLabwareLocation)
             if (
-                self._state_view.labware.get_lid_by_labware_id(
+                isinstance(current_labware.location, OnLabwareLocation)
+                and self._state_view.labware.get_lid_by_labware_id(
                     current_labware.location.labwareId
                 )
                 is not None

--- a/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
@@ -75,6 +75,11 @@
       "x": 0,
       "y": 0,
       "z": 34
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
     }
   },
   "stackLimit": 5,


### PR DESCRIPTION
# Overview
Changes in move labware during some of the lid architecture refactor accidentally removed the ability to load TC lids directly onto a base deck slot. Was missed because it usually is loaded onto a deck slot adapter. This fixes that issue, as well as fixing an issue where an older version of the TC lid labware definition did not support loading it onto the lid stack engine object, which results in the same problem occurring for 2.23 protocols using the v1 tc lid definition but when using the `move_lid()` command instead.

TODO:
Add test cases covering the following:
- [x] TC lid move from deck slot using old move labware methodology
- [x] TC lid moved from lid stack, entire lid stack emptied of lids

## Test Plan and Hands on Testing

- Added test cases should enforce desired labware movement for legacy protocols and new behavior for move_lid command set.

## Changelog

- Moved an over-eager assert statement in protocol engine move_labware to the qualifier for a lid location update instead for legacy behavior.
- Updated the V1 labware def for TC lids to contain the lid stack object, so that when executing move lid commands on a V1 lid labware definition-loaded object we do not encounter erroneous movement behavior.
- Addition of new test cases to enforce the following operating conditions:
   1.  Move lid from a base deck slot on V1 labware should move labware off a lid stack object
   2. Moving Lids as labware should NOT assert that the lowest labware under a lid is a labware (this is only true of move-lid commands)
 
## Risk assessment
Low - Fixing an issue introduced in 8.3 and with V1 labware in future builds