### PR TITLE
fix(protocol-designer): fix whitescreen if magnetic module deleted

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MagnetTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MagnetTools/index.tsx
@@ -28,7 +28,7 @@ export function MagnetTools(props: StepFormProps): JSX.Element {
   const moduleEntities = useSelector(getModuleEntities)
   const defaultEngageHeight = useSelector(getMagnetLabwareEngageHeight)
 
-  const moduleModel = moduleEntities[formData.moduleId].model
+  const moduleModel = moduleEntities[formData.moduleId]?.model
 
   const mmUnits = t('units.millimeter')
   const isGen1 = moduleModel === MAGNETIC_MODULE_V1

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MagnetTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MagnetTools/index.tsx
@@ -63,6 +63,7 @@ export function MagnetTools(props: StepFormProps): JSX.Element {
         {...propsForFields.moduleId}
         options={moduleLabwareOptions}
         title={t('protocol_steps:module')}
+        errorToShow={getFormLevelError('moduleId', mappedErrorsToField)}
       />
       <Divider marginY="0" />
       <Flex flexDirection={DIRECTION_COLUMN} paddingX={SPACING.spacing16}>

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -405,6 +405,13 @@ const ABSORBANCE_READER_MODULE_ID_REQUIRED: FormError = {
   showAtField: true,
   page: 0,
 }
+const MAGNETIC_MODULE_ID_REQUIRED: FormError = {
+  title: 'Module required',
+  dependentFields: ['moduleId'],
+  showAtForm: false,
+  showAtField: true,
+  page: 0,
+}
 
 export interface HydratedFormData {
   [key: string]: any
@@ -676,6 +683,12 @@ export const newLabwareLocationRequired = (
     ? NEW_LABWARE_LOCATION_REQUIRED
     : null
 }
+export const magneticModuleIdRequired = (
+  fields: HydratedFormData
+): FormError | null => {
+  const { moduleId } = fields
+  return moduleId == null ? MAGNETIC_MODULE_ID_REQUIRED : null
+}
 export const engageHeightRangeExceeded = (
   fields: HydratedFormData,
   moduleEntities?: ModuleEntities
@@ -684,7 +697,7 @@ export const engageHeightRangeExceeded = (
   if (moduleEntities == null) {
     return null
   }
-  const moduleModel = moduleEntities[moduleId].model
+  const moduleModel = moduleEntities[moduleId]?.model
   const engageHeightCast = Number(engageHeight)
   if (magnetAction === 'engage') {
     if (moduleModel === MAGNETIC_MODULE_V1) {

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -48,6 +48,7 @@ import {
   wavelengthOutOfRange,
   referenceWavelengthOutOfRange,
   absorbanceReaderModuleIdRequired,
+  magneticModuleIdRequired,
 } from './errors'
 
 import {
@@ -165,7 +166,8 @@ const stepFormHelperMap: Partial<Record<StepType, FormHelpers>> = {
       magnetActionRequired,
       engageHeightRequired,
       moduleIdRequired,
-      engageHeightRangeExceeded
+      engageHeightRangeExceeded,
+      magneticModuleIdRequired
     ),
   },
   temperature: {


### PR DESCRIPTION
# Overview

This fixes a case where a magnetic module is used in a magnet step (OT-2), and the magnet is then deleted, formerly resulting in a whitescreen. It also adds and wires up a form-level error for requiring a module ID.

Closes AUTH-1377

## Test Plan and Hands on Testing

- create or import a protocol on OT-2 with a magnetic module step
- delete the module
- navigate back to protocol steps, and verify no whitescreen occurs
- open magnet step, and verify that saving produces a module required error

## Changelog

- null check module ID for magnetic module step
- implement module required error for magnetic module

## Review requests

see test plan

## Risk assessment

low