### PR TITLE
refactor(api): opentrons driver error handling

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/__init__.py
+++ b/api/src/opentrons/drivers/asyncio/communication/__init__.py
@@ -5,6 +5,7 @@ from opentrons.drivers.asyncio.communication.errors import (
     AlarmResponse,
     ErrorResponse,
     UnhandledGcode,
+    DefaultErrorCodes,
 )
 from .async_serial import AsyncSerial
 
@@ -17,4 +18,5 @@ __all__ = [
     "AlarmResponse",
     "ErrorResponse",
     "UnhandledGcode",
+    "DefaultErrorCodes",
 ]

--- a/api/src/opentrons/drivers/asyncio/communication/errors.py
+++ b/api/src/opentrons/drivers/asyncio/communication/errors.py
@@ -61,14 +61,8 @@ class BaseErrorCode(Enum):
         return exc
 
     def raise_exception(self, port: str, response: str, command: str) -> None:
-        """
-        Raise the appropriate exception for this error code.
-
-        Since ErrorResponse now accepts an optional command parameter,
-        we can simply pass it to all exception classes.
-        """
-        exception_cls = self.exception
-        raise exception_cls(port=port, response=response, command=command)
+        """Raise the appropriate exception for this error code."""
+        raise self.exception(port=port, response=response, command=command)
 
     @classmethod
     def get_error_codes(cls) -> Dict[str, "BaseErrorCode"]:

--- a/api/src/opentrons/drivers/asyncio/communication/errors.py
+++ b/api/src/opentrons/drivers/asyncio/communication/errors.py
@@ -1,12 +1,7 @@
 """Errors raised by serial connection."""
 
-
 from enum import Enum
-
-
-class ErrorCodes(Enum):
-    UNHANDLED_GCODE = "ERR003"
-    MOTOR_STALL = "ERR403"
+from typing import Dict, Type, Optional
 
 
 class SerialException(Exception):
@@ -37,16 +32,53 @@ class AlarmResponse(FailedCommand):
 
 
 class ErrorResponse(FailedCommand):
-    pass
+    def __init__(self, port: str, response: str, command: Optional[str] = None) -> None:
+        super().__init__(port, response)
+        self.command = command
 
 
 class UnhandledGcode(ErrorResponse):
     def __init__(self, port: str, response: str, command: str) -> None:
-        self.command = command
-        super().__init__(port, response)
+        super().__init__(port, response, command)
 
 
-class MotorStall(ErrorResponse):
-    def __init__(self, port: str, response: str, command: str) -> None:
-        self.command = command
-        super().__init__(port, response)
+class BaseErrorCode(Enum):
+    """Base class for error code enums.
+
+    This class should be inherited to define specific sets of error codes.
+    """
+
+    @property
+    def code_string(self) -> str:
+        """Return the error code string."""
+        code: str = self.value[0]
+        return code
+
+    @property
+    def exception(self) -> Type[ErrorResponse]:
+        """Return the exception class associated with this error code."""
+        exc: Type[ErrorResponse] = self.value[1]
+        return exc
+
+    def raise_exception(self, port: str, response: str, command: str) -> None:
+        """
+        Raise the appropriate exception for this error code.
+
+        Since ErrorResponse now accepts an optional command parameter,
+        we can simply pass it to all exception classes.
+        """
+        exception_cls = self.exception
+        raise exception_cls(port=port, response=response, command=command)
+
+    @classmethod
+    def get_error_codes(cls) -> Dict[str, "BaseErrorCode"]:
+        """Get all error codes as a dictionary mapping code string to ErrorCode instance."""
+        return {code.code_string: code for code in cls}
+
+
+class DefaultErrorCodes(BaseErrorCode):
+    """
+    Default error codes that are previously handled by the SerialConnection class.
+    """
+
+    UNHANDLED_GCODE = ("ERR003", UnhandledGcode)

--- a/api/src/opentrons/drivers/flex_stacker/driver.py
+++ b/api/src/opentrons/drivers/flex_stacker/driver.py
@@ -3,7 +3,7 @@ import re
 import base64
 from typing import List, Optional
 
-from opentrons.drivers.asyncio.communication.errors import MotorStall, NoResponse
+from opentrons.drivers.asyncio.communication.errors import NoResponse
 from opentrons.drivers.command_builder import CommandBuilder
 from opentrons.drivers.asyncio.communication import AsyncResponseSerialConnection
 
@@ -109,6 +109,14 @@ STACKER_MOTION_CONFIG = {
         ),
     },
 }
+
+
+class MotorStall(Exception):
+    """Motor stall exception."""
+
+    def __init__(self, axis: StackerAxis) -> None:
+        """Constructor."""
+        super().__init__(f"Motor stall detected on axis {axis}")
 
 
 class FlexStackerDriver(AbstractFlexStackerDriver):

--- a/api/src/opentrons/drivers/flex_stacker/driver.py
+++ b/api/src/opentrons/drivers/flex_stacker/driver.py
@@ -112,14 +112,6 @@ STACKER_MOTION_CONFIG = {
 }
 
 
-class MotorStall(Exception):
-    """Motor stall exception."""
-
-    def __init__(self, axis: StackerAxis) -> None:
-        """Constructor."""
-        super().__init__(f"Motor stall detected on axis {axis}")
-
-
 class FlexStackerDriver(AbstractFlexStackerDriver):
     """FLEX Stacker driver."""
 

--- a/api/src/opentrons/drivers/flex_stacker/errors.py
+++ b/api/src/opentrons/drivers/flex_stacker/errors.py
@@ -5,7 +5,6 @@ from opentrons.drivers.asyncio.communication.errors import (
     ErrorResponse,
     UnhandledGcode,
 )
-from opentrons.drivers.flex_stacker.types import StackerAxis
 
 
 class MotorStallDetected(ErrorResponse):

--- a/api/src/opentrons/drivers/flex_stacker/errors.py
+++ b/api/src/opentrons/drivers/flex_stacker/errors.py
@@ -1,0 +1,57 @@
+"""Stacker-specific error codes and exceptions."""
+
+from opentrons.drivers.asyncio.communication.errors import (
+    BaseErrorCode,
+    ErrorResponse,
+    UnhandledGcode,
+)
+from opentrons.drivers.flex_stacker.types import StackerAxis
+
+
+class MotorStallDetected(ErrorResponse):
+    """Raised when a motor stall is detected."""
+
+    def __init__(self, port: str, response: str, command: str) -> None:
+        super().__init__(port, response, command)
+
+
+class MotorQueueFull(ErrorResponse):
+    """Raised when the motor command queue is full."""
+
+    def __init__(self, port: str, response: str, command: str) -> None:
+        super().__init__(port, response, command)
+
+
+class UnexpectedLimitSwitch(ErrorResponse):
+    """Raised when an unexpected limit switch is triggered."""
+
+    def __init__(self, port: str, response: str, command: str) -> None:
+        super().__init__(port, response, command)
+
+
+class MotorBusy(ErrorResponse):
+    """Raised when a motor is busy."""
+
+    # TODO: differentiate between motors
+    def __init__(self, port: str, response: str, command: str) -> None:
+        super().__init__(port, response, command)
+
+
+class StopRequested(ErrorResponse):
+    """Raised when a stop is requested during a movement."""
+
+    def __init__(self, port: str, response: str, command: str) -> None:
+        super().__init__(port, response, command)
+
+
+class StackerErrorCodes(BaseErrorCode):
+    """Stacker-specific error codes."""
+
+    UNHANDLED_GCODE = ("ERR003", UnhandledGcode)
+    MOTOR_STALL_DETECTED = ("ERR403", MotorStallDetected)
+    MOTOR_QUEUE_FULL = ("ERR404", MotorQueueFull)
+    UNEXPECTED_LIMIT_SWITCH = ("ERR405", UnexpectedLimitSwitch)
+    X_MOTOR_BUSY = ("ERR501", MotorBusy)
+    Z_MOTOR_BUSY = ("ERR502", MotorBusy)
+    L_MOTOR_BUSY = ("ERR503", MotorBusy)
+    STOP_REQUESTED = ("ERR504", StopRequested)


### PR DESCRIPTION
# Overview
This PR introduces some major improvements to how error handling works across Opentrons drivers to make error codes more modular and customizable. The goal is to make it easier to define error codes specific to different hardware modules (like the Flex Stacker), while keeping a shared structure for handling them.

These changes make error handling more consistent and maintainable across the Opentrons driver stack. It also sets the groundwork for easily adding hardware-specific error codes for future devices without needing to rewrite the core error handling logic.

## Changelog

- Introduced a `BaseErrorCode` class that acts as a foundation for defining error code enums.
- Created `DefaultErrorCodes`, which covers the existing error codes we were already using.
- Refactored the general error handling logic to work with this new system, making it easier to plug in hardware-specific error codes in the future.
- Added new tests for the `BaseErrorCode` system, including cases for raising exceptions from both default and custom error codes.
- Added a new `StackerErrorCodes` enum and a set of stacker-specific exception classes.

