### PR TITLE
refactor(protocol-designer): account for 96-channel load_instrument syntax & pythonName

### DIFF
--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -325,6 +325,37 @@ pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks
 pipette_left = protocol.load_instrument("p300_multi_gen2", "left")`.trimStart()
     )
   })
+
+  it('should generate loadPipette for 96-channel pipette with no tiprack', () => {
+    const pipette1 = 'pipette1'
+    const mockPipetteEntities: PipetteEntities = {
+      [pipette1]: {
+        id: pipette1,
+        pythonName: 'pipette',
+        name: 'p1000_96',
+        tiprackDefURI: [],
+        spec: { ...fixtureP1000SingleV2Specs, channels: 96 },
+        tiprackLabwareDef: [],
+      },
+    }
+
+    const mockTiprackEntities: LabwareEntities = {}
+    const pipetteRobotState: TimelineFrame['pipettes'] = {
+      [pipette1]: { mount: 'left' },
+    }
+
+    expect(
+      getLoadPipettes(
+        mockPipetteEntities,
+        mockTiprackEntities,
+        pipetteRobotState
+      )
+    ).toBe(
+      `
+# Load Pipettes:
+pipette = protocol.load_instrument("flex_96channel_1000")`.trimStart()
+    )
+  })
 })
 
 const liquid1 = 'liquid1'

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -206,7 +206,9 @@ export function getLoadPipettes(
     .map(pipette => {
       const { name, id, spec, pythonName, tiprackDefURI } = pipette
       const mount =
-        spec.channels === 96 ? '' : formatPyStr(pipetteRobotState[id].mount)
+        spec.channels === 96
+          ? ''
+          : `, ${formatPyStr(pipetteRobotState[id].mount)}`
       const pipetteName = isFlexPipette(name)
         ? getFlexNameConversion(spec)
         : name
@@ -223,7 +225,7 @@ export function getLoadPipettes(
 
       return `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_instrument(${formatPyStr(
         pipetteName
-      )}, ${mount}${pythonTipRacks})`
+      )}${mount}${pythonTipRacks})`
     })
     .join('\n')
 

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -145,11 +145,14 @@ export function denormalizePipetteEntities(
           `no pipette spec for pipette id "${pipetteId}", name "${pipette.name}"`
         )
       }
+      const is96Channel = spec.channels === 96
       const pipetteEntity: PipetteEntity = {
         ...pipette,
         spec,
         tiprackLabwareDef: pipette.tiprackDefURI.map(def => labwareDefs[def]),
-        pythonName: `pipette_${pipetteLocationUpdate[pipetteId]}`,
+        pythonName: is96Channel
+          ? 'pipette'
+          : `pipette_${pipetteLocationUpdate[pipetteId]}`,
       }
       return { ...acc, [pipetteId]: pipetteEntity }
     },


### PR DESCRIPTION
# Overview

Fixes a slight bug where the syntax was wrong when we don't have a mount for the 96-channel. Additionally, the python name for the 96-channel pipette is changed to just `pipette` instead of `pipette_left` since it is mounted onto both mounts

## Test Plan and Hands on Testing

Smoke test loading the 96-channel but i tested it and also there is a unit test

## Changelog

- fix syntax for load instrument
- fix python name for 96-channel

## Risk assessment

low, behind ff