### PR TITLE
fix(api): unit tests and fixes for liquid class setter validators

### DIFF
--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -636,7 +636,7 @@ def ensure_positive_int(value: int) -> int:
     return value
 
 
-def validate_coordinates(value: Any) -> Tuple[float, float, float]:
+def validate_coordinates(value: Sequence[float]) -> Tuple[float, float, float]:
     """Ensure value is a valid sequence of 3 floats and return a tuple of 3 floats."""
     if not hasattr(value, "__len__"):
         raise ValueError(f"Coordinates must be a sequence, got {type(value).__name__}")

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -612,7 +612,7 @@ def ensure_boolean(value: bool) -> bool:
 
 def ensure_float(value: Union[int, float]) -> float:
     """Ensure value is a float (or an integer) and return it as a float."""
-    if not isinstance(value, (int, float)):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError("Value must be a floating point number.")
     return float(value)
 
@@ -622,7 +622,7 @@ def ensure_positive_float(value: Union[int, float]) -> float:
     float_value = ensure_float(value)
     if isnan(float_value) or isinf(float_value):
         raise ValueError("Value must be a defined, non-infinite number.")
-    if float_value < 0:
+    if float_value <= 0:
         raise ValueError("Value must be a positive float.")
     return float_value
 
@@ -631,17 +631,19 @@ def ensure_positive_int(value: int) -> int:
     """Ensure value is a positive integer."""
     if not isinstance(value, int):
         raise ValueError("Value must be an integer.")
-    if value < 0:
+    if value <= 0:
         raise ValueError("Value must be a positive integer.")
     return value
 
 
-def validate_coordinates(value: Sequence[float]) -> Tuple[float, float, float]:
+def validate_coordinates(value: Any) -> Tuple[float, float, float]:
     """Ensure value is a valid sequence of 3 floats and return a tuple of 3 floats."""
+    if not hasattr(value, "__len__"):
+        raise ValueError(f"Coordinates must be a sequence, got {type(value).__name__}")
     if len(value) != 3:
         raise ValueError("Coordinates must be a sequence of exactly three numbers")
     if not all(isinstance(v, (float, int)) for v in value):
-        raise ValueError("All values in coordinates must be floats.")
+        raise ValueError("All values in coordinates must be floats or integers.")
     return float(value[0]), float(value[1]), float(value[2])
 
 

--- a/api/tests/opentrons/protocol_api/test_liquid_class_setters.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_setters.py
@@ -1,4 +1,7 @@
+"""Tests for liquid class property setter validations."""
 import pytest
+from typing import Any, cast
+
 from opentrons.protocol_api._liquid_properties import (
     DelayProperties,
     TouchTipProperties,
@@ -6,29 +9,36 @@ from opentrons.protocol_api._liquid_properties import (
     BlowoutProperties,
     Submerge,
     AspirateProperties,
+    RetractAspirate,
+    LiquidHandlingPropertyByVolume,
 )
-from opentrons_shared_data.liquid_classes.liquid_class_definition import BlowoutLocation
+
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     PositionReference,
+    BlowoutLocation,
+    Coordinate,
 )
 
 
 @pytest.mark.parametrize("bad_value", ["True", 123, 1.0, 1, 0])
-def test_delay_properties_enabled_raises_no_duration(bad_value):
+def test_delay_properties_enabled_raises_no_duration(bad_value: Any) -> None:
+    """Test that enabling delay without duration raises an error."""
     dp = DelayProperties(_enabled=False, _duration=None)
     with pytest.raises(ValueError):
         dp.enabled = bad_value
 
 
 @pytest.mark.parametrize("bad_duration", [-1.0, 0.0, 0, "1", True])
-def test_delay_properties_negative_zero_duration_raises(bad_duration):
+def test_delay_properties_negative_zero_duration_raises(bad_duration: Any) -> None:
+    """Test that negative or zero duration values raise an error."""
     dp = DelayProperties(_enabled=False, _duration=None)
     with pytest.raises(ValueError):
         dp.duration = bad_duration
 
 
 @pytest.mark.parametrize("bad_enable", ["True", 1, 0])
-def test_touch_tip_enable_raises_if_params_missing(bad_enable):
+def test_touch_tip_enable_raises_if_params_missing(bad_enable: Any) -> None:
+    """Test that enabling touch tip without required parameters raises an error."""
     tip = TouchTipProperties(
         _enabled=False, _z_offset=None, _mm_to_edge=None, _speed=None
     )
@@ -37,63 +47,72 @@ def test_touch_tip_enable_raises_if_params_missing(bad_enable):
 
 
 @pytest.mark.parametrize("bad_z_offset", [None, "nope", True])
-def test_touch_tip_z_offset_invalid_raises(bad_z_offset):
+def test_touch_tip_z_offset_invalid_raises(bad_z_offset: Any) -> None:
+    """Test that invalid z_offset values raise an error."""
     tip = TouchTipProperties(_enabled=False, _z_offset=1.0, _mm_to_edge=2.0, _speed=5.0)
     with pytest.raises(ValueError):
         tip.z_offset = bad_z_offset
 
 
 @pytest.mark.parametrize("bad_mm_to_edge", [True, "foo"])
-def test_touch_tip_mm_to_edge_invalid_raises(bad_mm_to_edge):
+def test_touch_tip_mm_to_edge_invalid_raises(bad_mm_to_edge: Any) -> None:
+    """Test that invalid mm_to_edge values raise an error."""
     tip = TouchTipProperties(_enabled=False, _z_offset=1.0, _mm_to_edge=2.0, _speed=5.0)
     with pytest.raises(ValueError):
         tip.mm_to_edge = bad_mm_to_edge
 
 
 @pytest.mark.parametrize("bad_speed", [0.0, -3.5, "fast", True])
-def test_touch_tip_speed_invalid_raises(bad_speed):
+def test_touch_tip_speed_invalid_raises(bad_speed: Any) -> None:
+    """Test that invalid speed values raise an error."""
     tip = TouchTipProperties(_enabled=False, _z_offset=1.0, _mm_to_edge=2.0, _speed=5.0)
     with pytest.raises(ValueError):
         tip.speed = bad_speed
 
 
 @pytest.mark.parametrize("bad_enable", ["True", 1, True])
-def test_mix_enable_raises_if_no_reps_or_volume(bad_enable):
+def test_mix_enable_raises_if_no_reps_or_volume(bad_enable: Any) -> None:
+    """Test that enabling mix without repetitions or volume raises an error."""
     mp = MixProperties(_enabled=False, _repetitions=None, _volume=None)
     with pytest.raises(ValueError):
         mp.enabled = bad_enable
 
 
 @pytest.mark.parametrize("bad_reps", [0, -2, "four", 3.5])
-def test_mix_repetitions_invalid_raises(bad_reps):
+def test_mix_repetitions_invalid_raises(bad_reps: Any) -> None:
+    """Test that invalid repetition values raise an error."""
     mp = MixProperties(_enabled=False, _repetitions=None, _volume=None)
     with pytest.raises(ValueError):
         mp.repetitions = bad_reps
 
 
 @pytest.mark.parametrize("bad_volume", [0, -5.5, -1, "ten", True])
-def test_mix_volume_invalid_raises(bad_volume):
+def test_mix_volume_invalid_raises(bad_volume: Any) -> None:
+    """Test that invalid volume values raise an error."""
     mp = MixProperties(_enabled=False, _repetitions=2, _volume=None)
     with pytest.raises(ValueError):
         mp.volume = bad_volume
 
 
 @pytest.mark.parametrize("bad_enable", [True, 1, "True", "yes"])
-def test_blowout_enable_raises_if_location_flow_rate_missing(bad_enable):
+def test_blowout_enable_raises_if_location_flow_rate_missing(bad_enable: Any) -> None:
+    """Test that enabling blowout without location or flow rate raises an error."""
     bp = BlowoutProperties(_enabled=False, _location=None, _flow_rate=None)
     with pytest.raises(ValueError):
         bp.enabled = bad_enable
 
 
 @pytest.mark.parametrize("invalid_loc", ["", "some_bad_loc"])
-def test_blowout_invalid_location_raises(invalid_loc):
+def test_blowout_invalid_location_raises(invalid_loc: str) -> None:
+    """Test that invalid blowout locations raise an error."""
     bp = BlowoutProperties(_enabled=False, _location=None, _flow_rate=10.0)
     with pytest.raises(ValueError):
-        bp.location = invalid_loc
+        bp.location = invalid_loc  # type: ignore
 
 
 @pytest.mark.parametrize("bad_flow", [0.0, -10.0, "fast", True])
-def test_blowout_flow_rate_invalid_raises(bad_flow):
+def test_blowout_flow_rate_invalid_raises(bad_flow: Any) -> None:
+    """Test that invalid flow rate values raise an error."""
     bp = BlowoutProperties(
         _enabled=False, _location=BlowoutLocation("destination"), _flow_rate=10
     )
@@ -102,10 +121,11 @@ def test_blowout_flow_rate_invalid_raises(bad_flow):
 
 
 @pytest.mark.parametrize("bad_position", ["invalid_position", 42])
-def test_submerge_position_reference_raises(bad_position):
+def test_submerge_position_reference_raises(bad_position: Any) -> None:
+    """Test that invalid position reference values raise an error."""
     s = Submerge(
         _position_reference=PositionReference.WELL_BOTTOM,
-        _offset=(0, 0, 0),
+        _offset=cast(Coordinate, (0, 0, 0)),
         _speed=10.0,
         _delay=DelayProperties(_enabled=False, _duration=None),
     )
@@ -114,10 +134,11 @@ def test_submerge_position_reference_raises(bad_position):
 
 
 @pytest.mark.parametrize("bad_offset", [(0, 0), "xyz", True, 1.0])
-def test_submerge_offset_raises(bad_offset):
+def test_submerge_offset_raises(bad_offset: Any) -> None:
+    """Test that invalid offset values raise an error."""
     s = Submerge(
         _position_reference=PositionReference.WELL_TOP,
-        _offset=(0, 0, 0),
+        _offset=cast(Coordinate, (0, 0, 0)),
         _speed=5.0,
         _delay=DelayProperties(_enabled=False, _duration=None),
     )
@@ -128,10 +149,11 @@ def test_submerge_offset_raises(bad_offset):
 
 
 @pytest.mark.parametrize("bad_speed", [0.0, -1.0, "fast", True])
-def test_submerge_speed_raises(bad_speed):
+def test_submerge_speed_raises(bad_speed: Any) -> None:
+    """Test that invalid speed values raise an error."""
     s = Submerge(
         _position_reference=PositionReference.WELL_CENTER,
-        _offset=(0, 0, 0),
+        _offset=cast(Coordinate, (0, 0, 0)),
         _speed=10.0,
         _delay=DelayProperties(_enabled=False, _duration=None),
     )
@@ -140,19 +162,20 @@ def test_submerge_speed_raises(bad_speed):
 
 
 @pytest.mark.parametrize("bad_position", ["X", 999])
-def test_base_liquid_handling_position_reference_raises(bad_position):
+def test_base_liquid_handling_position_reference_raises(bad_position: Any) -> None:
+    """Test that invalid position reference values raise an error."""
     ap = AspirateProperties(
         _submerge=Submerge(
             _position_reference=PositionReference.WELL_TOP,
-            _offset=(0, 0, 0),
+            _offset=cast(Coordinate, (0, 0, 0)),
             _speed=1.0,
             _delay=DelayProperties(_enabled=False, _duration=None),
         ),
-        _retract=None,
+        _retract=cast(RetractAspirate, None),
         _position_reference=PositionReference.WELL_TOP,
-        _offset=(1, 1, 1),
-        _flow_rate_by_volume=None,
-        _correction_by_volume=None,
+        _offset=cast(Coordinate, (1, 1, 1)),
+        _flow_rate_by_volume=cast(LiquidHandlingPropertyByVolume, None),
+        _correction_by_volume=cast(LiquidHandlingPropertyByVolume, None),
         _pre_wet=False,
         _mix=MixProperties(_enabled=False, _repetitions=None, _volume=None),
         _delay=DelayProperties(_enabled=False, _duration=None),
@@ -162,19 +185,20 @@ def test_base_liquid_handling_position_reference_raises(bad_position):
 
 
 @pytest.mark.parametrize("bad_offset", [[1, 2], 123, True, "offset"])
-def test_base_liquid_handling_offset_raises(bad_offset):
+def test_base_liquid_handling_offset_raises(bad_offset: Any) -> None:
+    """Test that invalid offset values raise an error."""
     ap = AspirateProperties(
         _submerge=Submerge(
             _position_reference=PositionReference.WELL_TOP,
-            _offset=(0, 0, 0),
+            _offset=cast(Coordinate, (0, 0, 0)),
             _speed=1.0,
             _delay=DelayProperties(_enabled=False, _duration=None),
         ),
-        _retract=None,
+        _retract=cast(RetractAspirate, None),
         _position_reference=PositionReference.WELL_BOTTOM,
-        _offset=(1, 1, 1),
-        _flow_rate_by_volume=None,
-        _correction_by_volume=None,
+        _offset=cast(Coordinate, (1, 1, 1)),
+        _flow_rate_by_volume=cast(LiquidHandlingPropertyByVolume, None),
+        _correction_by_volume=cast(LiquidHandlingPropertyByVolume, None),
         _pre_wet=False,
         _mix=MixProperties(_enabled=False, _repetitions=None, _volume=None),
         _delay=DelayProperties(_enabled=False, _duration=None),
@@ -184,19 +208,20 @@ def test_base_liquid_handling_offset_raises(bad_offset):
 
 
 @pytest.mark.parametrize("bad_pre_wet", [42, "not_bool"])
-def test_aspirate_properties_pre_wet_invalid(bad_pre_wet):
+def test_aspirate_properties_pre_wet_invalid(bad_pre_wet: Any) -> None:
+    """Test that invalid pre_wet values raise an error."""
     ap = AspirateProperties(
         _submerge=Submerge(
             _position_reference=PositionReference.WELL_BOTTOM,
-            _offset=(0, 0, 0),
+            _offset=cast(Coordinate, (0, 0, 0)),
             _speed=1.0,
             _delay=DelayProperties(_enabled=False, _duration=None),
         ),
-        _retract=None,
+        _retract=cast(RetractAspirate, None),
         _position_reference=PositionReference.WELL_BOTTOM,
-        _offset=(0, 0, 0),
-        _flow_rate_by_volume=None,
-        _correction_by_volume=None,
+        _offset=cast(Coordinate, (0, 0, 0)),
+        _flow_rate_by_volume=cast(LiquidHandlingPropertyByVolume, None),
+        _correction_by_volume=cast(LiquidHandlingPropertyByVolume, None),
         _pre_wet=False,
         _mix=MixProperties(_enabled=False, _repetitions=None, _volume=None),
         _delay=DelayProperties(_enabled=False, _duration=None),

--- a/api/tests/opentrons/protocol_api/test_liquid_class_setters.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_setters.py
@@ -1,0 +1,205 @@
+import pytest
+from opentrons.protocol_api._liquid_properties import (
+    DelayProperties,
+    TouchTipProperties,
+    MixProperties,
+    BlowoutProperties,
+    Submerge,
+    AspirateProperties,
+)
+from opentrons_shared_data.liquid_classes.liquid_class_definition import BlowoutLocation
+from opentrons_shared_data.liquid_classes.liquid_class_definition import (
+    PositionReference,
+)
+
+
+@pytest.mark.parametrize("bad_value", ["True", 123, 1.0, 1, 0])
+def test_delay_properties_enabled_raises_no_duration(bad_value):
+    dp = DelayProperties(_enabled=False, _duration=None)
+    with pytest.raises(ValueError):
+        dp.enabled = bad_value
+
+
+@pytest.mark.parametrize("bad_duration", [-1.0, 0.0, 0, "1", True])
+def test_delay_properties_negative_zero_duration_raises(bad_duration):
+    dp = DelayProperties(_enabled=False, _duration=None)
+    with pytest.raises(ValueError):
+        dp.duration = bad_duration
+
+
+@pytest.mark.parametrize("bad_enable", ["True", 1, 0])
+def test_touch_tip_enable_raises_if_params_missing(bad_enable):
+    tip = TouchTipProperties(
+        _enabled=False, _z_offset=None, _mm_to_edge=None, _speed=None
+    )
+    with pytest.raises(ValueError):
+        tip.enabled = bad_enable
+
+
+@pytest.mark.parametrize("bad_z_offset", [None, "nope", True])
+def test_touch_tip_z_offset_invalid_raises(bad_z_offset):
+    tip = TouchTipProperties(_enabled=False, _z_offset=1.0, _mm_to_edge=2.0, _speed=5.0)
+    with pytest.raises(ValueError):
+        tip.z_offset = bad_z_offset
+
+
+@pytest.mark.parametrize("bad_mm_to_edge", [True, "foo"])
+def test_touch_tip_mm_to_edge_invalid_raises(bad_mm_to_edge):
+    tip = TouchTipProperties(_enabled=False, _z_offset=1.0, _mm_to_edge=2.0, _speed=5.0)
+    with pytest.raises(ValueError):
+        tip.mm_to_edge = bad_mm_to_edge
+
+
+@pytest.mark.parametrize("bad_speed", [0.0, -3.5, "fast", True])
+def test_touch_tip_speed_invalid_raises(bad_speed):
+    tip = TouchTipProperties(_enabled=False, _z_offset=1.0, _mm_to_edge=2.0, _speed=5.0)
+    with pytest.raises(ValueError):
+        tip.speed = bad_speed
+
+
+@pytest.mark.parametrize("bad_enable", ["True", 1, True])
+def test_mix_enable_raises_if_no_reps_or_volume(bad_enable):
+    mp = MixProperties(_enabled=False, _repetitions=None, _volume=None)
+    with pytest.raises(ValueError):
+        mp.enabled = bad_enable
+
+
+@pytest.mark.parametrize("bad_reps", [0, -2, "four", 3.5])
+def test_mix_repetitions_invalid_raises(bad_reps):
+    mp = MixProperties(_enabled=False, _repetitions=None, _volume=None)
+    with pytest.raises(ValueError):
+        mp.repetitions = bad_reps
+
+
+@pytest.mark.parametrize("bad_volume", [0, -5.5, -1, "ten", True])
+def test_mix_volume_invalid_raises(bad_volume):
+    mp = MixProperties(_enabled=False, _repetitions=2, _volume=None)
+    with pytest.raises(ValueError):
+        mp.volume = bad_volume
+
+
+@pytest.mark.parametrize("bad_enable", [True, 1, "True", "yes"])
+def test_blowout_enable_raises_if_location_flow_rate_missing(bad_enable):
+    bp = BlowoutProperties(_enabled=False, _location=None, _flow_rate=None)
+    with pytest.raises(ValueError):
+        bp.enabled = bad_enable
+
+
+@pytest.mark.parametrize("invalid_loc", ["", "some_bad_loc"])
+def test_blowout_invalid_location_raises(invalid_loc):
+    bp = BlowoutProperties(_enabled=False, _location=None, _flow_rate=10.0)
+    with pytest.raises(ValueError):
+        bp.location = invalid_loc
+
+
+@pytest.mark.parametrize("bad_flow", [0.0, -10.0, "fast", True])
+def test_blowout_flow_rate_invalid_raises(bad_flow):
+    bp = BlowoutProperties(
+        _enabled=False, _location=BlowoutLocation("destination"), _flow_rate=10
+    )
+    with pytest.raises(ValueError):
+        bp.flow_rate = bad_flow
+
+
+@pytest.mark.parametrize("bad_position", ["invalid_position", 42])
+def test_submerge_position_reference_raises(bad_position):
+    s = Submerge(
+        _position_reference=PositionReference.WELL_BOTTOM,
+        _offset=(0, 0, 0),
+        _speed=10.0,
+        _delay=DelayProperties(_enabled=False, _duration=None),
+    )
+    with pytest.raises(ValueError):
+        s.position_reference = bad_position
+
+
+@pytest.mark.parametrize("bad_offset", [(0, 0), "xyz", True, 1.0])
+def test_submerge_offset_raises(bad_offset):
+    s = Submerge(
+        _position_reference=PositionReference.WELL_TOP,
+        _offset=(0, 0, 0),
+        _speed=5.0,
+        _delay=DelayProperties(_enabled=False, _duration=None),
+    )
+    with pytest.raises(
+        ValueError,
+    ):
+        s.offset = bad_offset
+
+
+@pytest.mark.parametrize("bad_speed", [0.0, -1.0, "fast", True])
+def test_submerge_speed_raises(bad_speed):
+    s = Submerge(
+        _position_reference=PositionReference.WELL_CENTER,
+        _offset=(0, 0, 0),
+        _speed=10.0,
+        _delay=DelayProperties(_enabled=False, _duration=None),
+    )
+    with pytest.raises(ValueError):
+        s.speed = bad_speed
+
+
+@pytest.mark.parametrize("bad_position", ["X", 999])
+def test_base_liquid_handling_position_reference_raises(bad_position):
+    ap = AspirateProperties(
+        _submerge=Submerge(
+            _position_reference=PositionReference.WELL_TOP,
+            _offset=(0, 0, 0),
+            _speed=1.0,
+            _delay=DelayProperties(_enabled=False, _duration=None),
+        ),
+        _retract=None,
+        _position_reference=PositionReference.WELL_TOP,
+        _offset=(1, 1, 1),
+        _flow_rate_by_volume=None,
+        _correction_by_volume=None,
+        _pre_wet=False,
+        _mix=MixProperties(_enabled=False, _repetitions=None, _volume=None),
+        _delay=DelayProperties(_enabled=False, _duration=None),
+    )
+    with pytest.raises(ValueError):
+        ap.position_reference = bad_position
+
+
+@pytest.mark.parametrize("bad_offset", [[1, 2], 123, True, "offset"])
+def test_base_liquid_handling_offset_raises(bad_offset):
+    ap = AspirateProperties(
+        _submerge=Submerge(
+            _position_reference=PositionReference.WELL_TOP,
+            _offset=(0, 0, 0),
+            _speed=1.0,
+            _delay=DelayProperties(_enabled=False, _duration=None),
+        ),
+        _retract=None,
+        _position_reference=PositionReference.WELL_BOTTOM,
+        _offset=(1, 1, 1),
+        _flow_rate_by_volume=None,
+        _correction_by_volume=None,
+        _pre_wet=False,
+        _mix=MixProperties(_enabled=False, _repetitions=None, _volume=None),
+        _delay=DelayProperties(_enabled=False, _duration=None),
+    )
+    with pytest.raises(ValueError):
+        ap.offset = bad_offset
+
+
+@pytest.mark.parametrize("bad_pre_wet", [42, "not_bool"])
+def test_aspirate_properties_pre_wet_invalid(bad_pre_wet):
+    ap = AspirateProperties(
+        _submerge=Submerge(
+            _position_reference=PositionReference.WELL_BOTTOM,
+            _offset=(0, 0, 0),
+            _speed=1.0,
+            _delay=DelayProperties(_enabled=False, _duration=None),
+        ),
+        _retract=None,
+        _position_reference=PositionReference.WELL_BOTTOM,
+        _offset=(0, 0, 0),
+        _flow_rate_by_volume=None,
+        _correction_by_volume=None,
+        _pre_wet=False,
+        _mix=MixProperties(_enabled=False, _repetitions=None, _volume=None),
+        _delay=DelayProperties(_enabled=False, _duration=None),
+    )
+    with pytest.raises(ValueError):
+        ap.pre_wet = bad_pre_wet


### PR DESCRIPTION
# Overview

Add unit tests for the builder and setters on `DelayProperties`

## Test Plan and Hands on Testing

Does the change to `StrictBool` make sense?

## Risk assessment

Low, mostly tests but a small change to some logic in the validators to reject additional improper values.
