### PR TITLE
feat(api): change volume splitting for liquid class to evenly split volumes larger than max volume

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1128,17 +1128,19 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         )
 
         # TODO: add multi-channel pipette handling here
-        source_dest_per_volume_step = tx_commons.expand_for_volume_constraints(
-            volumes=[volume for _ in range(len(source))],
-            targets=zip(source, dest),
-            max_volume=min(
-                self.get_max_volume(),
-                self._engine_client.state.geometry.get_nominal_tip_geometry(
-                    pipette_id=self.pipette_id,
-                    labware_id=tip_racks[0][1].labware_id,
-                    well_name=None,
-                ).volume,
-            ),
+        source_dest_per_volume_step = (
+            tx_commons.expand_for_volume_constraints_for_liquid_classes(
+                volumes=[volume for _ in range(len(source))],
+                targets=zip(source, dest),
+                max_volume=min(
+                    self.get_max_volume(),
+                    self._engine_client.state.geometry.get_nominal_tip_geometry(
+                        pipette_id=self.pipette_id,
+                        labware_id=tip_racks[0][1].labware_id,
+                        well_name=None,
+                    ).volume,
+                ),
+            )
         )
 
         last_tip_picked_up_from: Optional[WellCore] = None
@@ -1339,10 +1341,12 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         # This will return a generator that provides pairs of destination well and
         # the volume to dispense into it
-        dest_per_volume_step = tx_commons.expand_for_volume_constraints(
-            volumes=[volume for _ in range(len(dest))],
-            targets=dest,
-            max_volume=working_volume,
+        dest_per_volume_step = (
+            tx_commons.expand_for_volume_constraints_for_liquid_classes(
+                volumes=[volume for _ in range(len(dest))],
+                targets=dest,
+                max_volume=working_volume,
+            )
         )
 
         def _drop_tip() -> None:
@@ -1576,10 +1580,12 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         )
 
         # TODO: add multi-channel pipette handling here
-        source_per_volume_step = tx_commons.expand_for_volume_constraints(
-            volumes=[volume for _ in range(len(source))],
-            targets=source,
-            max_volume=max_volume,
+        source_per_volume_step = (
+            tx_commons.expand_for_volume_constraints_for_liquid_classes(
+                volumes=[volume for _ in range(len(source))],
+                targets=source,
+                max_volume=max_volume,
+            )
         )
 
         last_tip_picked_up_from: Optional[WellCore] = None

--- a/api/src/opentrons/protocols/advanced_control/transfers/common.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/common.py
@@ -74,9 +74,9 @@ def expand_for_volume_constraints(
         yield volume, target
 
 
-def _split_volume(volume: float, max_volume: float) -> List[float]:
+def _split_volume_equally(volume: float, max_volume: float) -> List[float]:
     """
-    Splits a given volume into a list of volumes that will are all less than or equal to max volume.
+    Splits a given volume into a list of volumes that are all less than or equal to max volume.
 
     If volume provided is more than the max volume, the volumes will be split evenly.
     """
@@ -95,5 +95,5 @@ def expand_for_volume_constraints_for_liquid_classes(
     """Split a sequence of proposed transfers to keep each under the max volume, splitting larger ones equally."""
     assert max_volume > 0
     for volume, target in zip(volumes, targets):
-        for split_volume in _split_volume(volume, max_volume):
+        for split_volume in _split_volume_equally(volume, max_volume):
             yield split_volume, target

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_common_functions.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_common_functions.py
@@ -7,6 +7,7 @@ from opentrons.protocols.advanced_control.transfers.common import (
     Target,
     check_valid_volume_parameters,
     expand_for_volume_constraints,
+    expand_for_volume_constraints_for_liquid_classes,
 )
 
 
@@ -81,8 +82,65 @@ def test_expand_for_volume_constraints(
     max_volume: float,
     expanded_list_result: List[Tuple[float, Target]],
 ) -> None:
-    """It should raise the expected error for invalid parameters."""
+    """It should create a list of volume and target transfers, fitting the volumes within the max."""
     result = expand_for_volume_constraints(
+        volumes=volumes,
+        targets=targets,
+        max_volume=max_volume,
+    )
+    assert list(result) == expanded_list_result
+
+
+@pytest.mark.parametrize(
+    argnames=["volumes", "targets", "max_volume", "expanded_list_result"],
+    argvalues=[
+        (
+            [25, 25],
+            ["dest1", "dest2"],
+            50,
+            [(25, "dest1"), (25, "dest2")],
+        ),
+        (
+            [50, 50],
+            ["dest1", "dest2"],
+            50,
+            [(50, "dest1"), (50, "dest2")],
+        ),
+        (
+            [75, 75],
+            ["dest1", "dest2"],
+            50,
+            [(37.5, "dest1"), (37.5, "dest1"), (37.5, "dest2"), (37.5, "dest2")],
+        ),
+        (
+            [100, 100],
+            ["dest1", "dest2"],
+            50,
+            [(50, "dest1"), (50, "dest1"), (50, "dest2"), (50, "dest2")],
+        ),
+        (
+            [103, 103],
+            ["dest1", "dest2"],
+            50,
+            [
+                (103 / 3, "dest1"),
+                (103 / 3, "dest1"),
+                (103 / 3, "dest1"),
+                (103 / 3, "dest2"),
+                (103 / 3, "dest2"),
+                (103 / 3, "dest2"),
+            ],
+        ),
+    ],
+)
+def test_expand_for_volume_constraints_for_liquid_classes(
+    volumes: Iterable[float],
+    targets: Iterable[Target],
+    max_volume: float,
+    expanded_list_result: List[Tuple[float, Target]],
+) -> None:
+    """It should create a list of volume and target transfers, splitting volumes equally if required."""
+    result = expand_for_volume_constraints_for_liquid_classes(
         volumes=volumes,
         targets=targets,
         max_volume=max_volume,


### PR DESCRIPTION
# Overview

Closes RQA-3936

This PR changes the volume splitting logic used in the liquid class transfers (`transfer_liquid`, `consolidate_liquid` and `distribute_liquid`) so that volumes that will not fit within the max volume of the pipette are split evenly by number of iterations needed to transfer the volume. Previously we would use the max volume of the pipette until the remaining volume was greater than the max but less than twice the max, at which point we would split that in half. For example, the old transfer would transfer 190 μl with a P50 single channel by doing two transfers of 50 μl followed by two transfers of 45 μl.

For the new liquid class transfers, for more reliability, we will instead divide the volume to be transferred by how many iterations are needed. So for 190 μl, which needs 4 transfers with a P50, we would do four transfers of 47.5 μl.

Certain volumes will end up being divided in ways that create long floating point representations. For simplicity and straightforwardness in implementation, we are not internally truncating this anywhere in the API code. This means that currently, the run log will display the long floating point. This is what the run log currently shows for one aspirate step if you transfer 103 μl using a P50.

<img width="870" alt="Screen Shot 2025-03-10 at 10 24 32 AM" src="https://github.com/user-attachments/assets/0702be22-f12b-4738-9003-970d14f4a54d" />

Before release the run log should truncate these values to an appropriate significant digit.

## Test Plan and Hands on Testing

Tested the following protocol, and unit tests and integration tests cover correctness in other areas.

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.23"
}

metadata = {
    "protocolName":'Liquid Class Volume Split Test',
    'author':'Jeremy'
}

def run(protocol_context):
	tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
	trash = protocol_context.load_trash_bin('A3')
	pipette = protocol_context.load_instrument("flex_1channel_50", "right", tip_racks=[tiprack])
	nest_plate = protocol_context.load_labware("nest_96_wellplate_2ml_deep", "D1")
	arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "D3")

	water_class = protocol_context.define_liquid_class("water")

	pipette.transfer_liquid(
		liquid_class=water_class,
		volume=103,
		source=nest_plate.columns()[0][:2],
		dest=arma_plate.columns()[0][:2],
		new_tip="once",
		trash_location=trash,
	)

	pipette.consolidate_liquid(
		liquid_class=water_class,
		volume=103,
		source=nest_plate.columns()[1][:2],
		dest=arma_plate.wells()[0],
		new_tip="once",
		trash_location=trash,
	)

	pipette.distribute_liquid(
		liquid_class=water_class,
		volume=103,
		source=nest_plate.wells()[0],
		dest=arma_plate.columns()[0][:2],
		new_tip="once",
		trash_location=trash,
	)

```

## Changelog

- Added new `expand_for_volume_constraints_for_liquid_classes` to split volumes equally for liquid class transfers

## Risk assessment

Low/medium, this only touches new functions yet to be released, but it is a non-trivial change to how we perform the transfers with how much volume we use for certain transfers.