### PR TITLE
fix(step-generation): movableTrashCommandsUtil should not have prevRobotState as an arg

### DIFF
--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -2485,6 +2485,27 @@ describe('consolidate single-channel', () => {
             seconds: 11,
           },
         },
+        {
+          commandType: 'moveToAddressableAreaForDropTip',
+          key: expect.any(String),
+          params: {
+            addressableAreaName: 'movableTrashA3',
+            alternateDropLocation: true,
+            offset: {
+              x: 0,
+              y: 0,
+              z: 0,
+            },
+            pipetteId: 'p300SingleId',
+          },
+        },
+        {
+          commandType: 'dropTipInPlace',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+          },
+        },
       ])
     })
 
@@ -3252,6 +3273,27 @@ describe('consolidate single-channel', () => {
           key: expect.any(String),
           params: {
             seconds: 11,
+          },
+        },
+        {
+          commandType: 'moveToAddressableAreaForDropTip',
+          key: expect.any(String),
+          params: {
+            addressableAreaName: 'movableTrashA3',
+            alternateDropLocation: true,
+            offset: {
+              x: 0,
+              y: 0,
+              z: 0,
+            },
+            pipetteId: 'p300SingleId',
+          },
+        },
+        {
+          commandType: 'dropTipInPlace',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
           },
         },
       ])

--- a/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
@@ -82,10 +82,6 @@ describe('movableTrashCommandsUtil', () => {
     movableTrashCommandsUtil({
       ...args,
       type: 'dropTip',
-      prevRobotState: {
-        ...args.prevRobotState,
-        tipState: { pipettes: { [mockId]: true } } as any,
-      },
     })
     expect(curryCommandCreator).toHaveBeenCalledWith(
       moveToAddressableAreaForDropTip,
@@ -102,10 +98,6 @@ describe('movableTrashCommandsUtil', () => {
     movableTrashCommandsUtil({
       ...args,
       type: 'airGap',
-      prevRobotState: {
-        ...args.prevRobotState,
-        tipState: { pipettes: { [mockId]: true } } as any,
-      },
     })
     expect(curryCommandCreator).toHaveBeenCalledWith(
       moveToAddressableArea,

--- a/step-generation/src/__tests__/moveToAddressableAreaForDropTip.test.ts
+++ b/step-generation/src/__tests__/moveToAddressableAreaForDropTip.test.ts
@@ -1,26 +1,26 @@
 import { describe, it, expect } from 'vitest'
-import { getSuccessResult } from '../fixtures'
+import {
+  DEFAULT_PIPETTE,
+  getRobotStateWithTipStandard,
+  getSuccessResult,
+  makeContext,
+} from '../fixtures'
 import { moveToAddressableAreaForDropTip } from '../commandCreators/atomic'
 
-const getRobotInitialState = (): any => {
-  return {}
-}
-const mockId = 'mockId'
-const invariantContext: any = {
-  pipetteEntities: {
-    [mockId]: {
-      name: 'p50_single_flex',
-      id: mockId,
-    },
-  },
-}
+const p300SingleId = DEFAULT_PIPETTE
 
 describe('moveToAddressableAreaForDropTip', () => {
+  let invariantContext = makeContext()
+
   it('should call moveToAddressableAreaForDropTip with correct params', () => {
-    const robotInitialState = getRobotInitialState()
+    let robotInitialState = getRobotStateWithTipStandard(invariantContext)
     const mockName = 'movableTrashA3'
+    robotInitialState.tipState.pipettes = {
+      [p300SingleId]: true,
+    }
+
     const result = moveToAddressableAreaForDropTip(
-      { pipetteId: mockId, addressableAreaName: mockName },
+      { pipetteId: p300SingleId, addressableAreaName: mockName },
       invariantContext,
       robotInitialState
     )
@@ -30,7 +30,7 @@ describe('moveToAddressableAreaForDropTip', () => {
         commandType: 'moveToAddressableAreaForDropTip',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: p300SingleId,
           addressableAreaName: mockName,
           offset: { x: 0, y: 0, z: 0 },
           alternateDropLocation: true,

--- a/step-generation/src/commandCreators/atomic/moveToAddressableArea.ts
+++ b/step-generation/src/commandCreators/atomic/moveToAddressableArea.ts
@@ -2,12 +2,23 @@ import { uuid } from '../../utils'
 import type { MoveToAddressableAreaParams } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
 
-export const moveToAddressableArea: CommandCreator<MoveToAddressableAreaParams> = (
+interface MoveToAddressableAreaAtomicParams extends MoveToAddressableAreaParams{
+  isForDropTip?: boolean
+}
+export const moveToAddressableArea: CommandCreator<MoveToAddressableAreaAtomicParams> = (
   args,
   invariantContext,
   prevRobotState
 ) => {
-  const { pipetteId, addressableAreaName, offset } = args
+  const { pipetteId, addressableAreaName, offset , isForDropTip} = args
+
+
+    // No-op if there is no tip
+    if (isForDropTip && !prevRobotState.tipState.pipettes[pipetteId]) {
+      return {
+        commands: [],
+      }
+    }
 
   const commands = [
     {

--- a/step-generation/src/commandCreators/atomic/moveToAddressableAreaForDropTip.ts
+++ b/step-generation/src/commandCreators/atomic/moveToAddressableAreaForDropTip.ts
@@ -9,6 +9,14 @@ export const moveToAddressableAreaForDropTip: CommandCreator<MoveToAddressableAr
 ) => {
   const { pipetteId, addressableAreaName } = args
 
+    // No-op if there is no tip
+    if (!prevRobotState.tipState.pipettes[pipetteId]) {
+      return {
+        commands: [],
+      }
+    }
+
+    
   const commands = [
     {
       commandType: 'moveToAddressableAreaForDropTip' as const,

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -497,7 +497,6 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         dropTipCommand = movableTrashCommandsUtil({
           type: 'dropTip',
           pipetteId: args.pipette,
-          prevRobotState,
           invariantContext,
         })
       }

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -408,7 +408,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
         dropTipCommand = movableTrashCommandsUtil({
           type: 'dropTip',
           pipetteId: args.pipette,
-          prevRobotState,
           invariantContext,
         })
       }

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -228,7 +228,6 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
       ...movableTrashCommandsUtil({
         type: 'dropTip',
         pipetteId: pipette,
-        prevRobotState,
         invariantContext,
       }),
       ...configureNozzleLayoutCommand,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -576,7 +576,6 @@ export const transfer: CommandCreator<TransferArgs> = (
               type: 'dropTip',
               pipetteId: args.pipette,
               invariantContext,
-              prevRobotState,
             })
           }
 

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -362,7 +362,6 @@ export const blowoutUtil = (args: {
     return movableTrashCommandsUtil({
       pipetteId: pipette,
       type: 'blowOut',
-      prevRobotState,
       invariantContext,
       flowRate,
     })
@@ -597,7 +596,6 @@ export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> 
       volume,
       flowRate,
       invariantContext,
-      prevRobotState,
     })
   }
 
@@ -654,7 +652,6 @@ export const moveHelper: CommandCreator<MoveHelperArgs> = (
       pipetteId,
       type: 'moveToWell',
       invariantContext,
-      prevRobotState,
     })
   }
 
@@ -772,7 +769,6 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
       volume,
       flowRate,
       invariantContext,
-      prevRobotState,
     })
   }
 

--- a/step-generation/src/utils/movableTrashCommandsUtil.ts
+++ b/step-generation/src/utils/movableTrashCommandsUtil.ts
@@ -31,7 +31,6 @@ interface MovableTrashCommandArgs {
   type: MovableTrashCommandsTypes
   pipetteId: string
   invariantContext: InvariantContext
-  prevRobotState?: RobotState
   volume?: number
   flowRate?: number
 }
@@ -43,7 +42,6 @@ export const movableTrashCommandsUtil = (
     pipetteId,
     type,
     invariantContext,
-    prevRobotState,
     volume,
     flowRate,
   } = args
@@ -104,18 +102,15 @@ export const movableTrashCommandsUtil = (
         break
       }
       case 'dropTip': {
-        inPlaceCommands =
-          prevRobotState != null && !prevRobotState.tipState.pipettes[pipetteId]
-            ? []
-            : [
-                curryCommandCreator(moveToAddressableAreaForDropTip, {
-                  pipetteId,
-                  addressableAreaName,
-                }),
-                curryCommandCreator(dropTipInPlace, {
-                  pipetteId,
-                }),
-              ]
+        inPlaceCommands = [
+          curryCommandCreator(moveToAddressableAreaForDropTip, {
+            pipetteId,
+            addressableAreaName,
+          }),
+          curryCommandCreator(dropTipInPlace, {
+            pipetteId,
+          }),
+        ]
 
         break
       }


### PR DESCRIPTION
# Overview

@ddcc4 noticed an error in `movableTrashCommandsUtil` which was `prevRobotState != null && !prevRobotState.tipState.pipettes[pipetteId] ? ...` where if prev robot state is null, it was incorrectly emitting the drop tip commands. Upon fixing that logic, we realized that `movableTrashCommandsUtil` should also **not** have `prevRobotState` as an arg. 

> The code inside a `CommandCreator` is allowed to examine the `prevRobotState`, but functions that return curried `CommandCreators` are not allowed to use `prevRobotState` at all. After all, the whole point of currying is that you don't have the arguments that the `CommandCreator` will be called with.
> So functions like `movableTrashCommandsUtil()` must return a list of `curryCommandCreator(...)` without using any of the values in `invariantContext`/`prevRobotState`/etc.

So, this PR refactors `movableTrashCommandsUtil` to not use `prevRobotState` as an arg. When fixing that, the only test that failed were a few in `consolidate.test` but upon examining, the added drop tip commands for the 2 cases are expected behavior.

Also, I smoke tested PD in Prod and PD on this branch and no matter the `changeTip` value (whether it is `never`, `once`, or `always`) should **ALWAYS** emit the drop tip commands at the very end. Which it does in prod and does in this branch.

## Test Plan and Hands on Testing

Review the code and smoke test yourself as well

## Changelog

- remove `prevRobotState` from args in `movableTrashCommandsUtil`
- add the no-op for no tip attached in `moveToAddressablreAreaForDropTip`
- fix tests

## Risk assessment

medium - this is not behind a ff but shouldn't be changing any protocol behaviors in a wild