### PR TITLE
feat(robot-server): Allow storing and retrieving location-nonspecific ("default") offsets

### DIFF
--- a/robot-server/robot_server/labware_offsets/_search_query_builder.py
+++ b/robot-server/robot_server/labware_offsets/_search_query_builder.py
@@ -1,177 +1,189 @@
 """Helper to build a search query."""
 
 from __future__ import annotations
-from typing import Final, TYPE_CHECKING
+from typing import Sequence
 
 import sqlalchemy
+import sqlalchemy.sql.functions
 
-from opentrons.protocol_engine import ModuleModel
+from opentrons.protocol_engine import (
+    OnAddressableAreaOffsetLocationSequenceComponent,
+    OnLabwareOffsetLocationSequenceComponent,
+    OnModuleOffsetLocationSequenceComponent,
+)
 
 from robot_server.persistence.tables import (
     labware_offset_table,
     labware_offset_location_sequence_components_table,
 )
-from .models import DoNotFilterType, DO_NOT_FILTER
+from .models import (
+    ANY_LOCATION,
+    AnyLocation,
+    DO_NOT_FILTER,
+    StoredLabwareOffsetLocationSequenceComponents,
+    SearchFilter,
+)
 
-if TYPE_CHECKING:
-    from typing_extensions import Self
 
+def build_query(filters: Sequence[SearchFilter]) -> sqlalchemy.sql.Selectable:
+    """Return a SQL query to select offsets matching the given filters.
 
-class SearchQueryBuilder:
-    """Helper class to build a search query.
+    The result set looks something like this:
 
-    This object is stateful, and should be kept around just long enough to have the parameters
-    of a single search injected.
+    ```
+    offset-1-id  offset-1-definition-uri  ...  offset-1-location-component-1  -- An offset with 2 location components.
+    offset-1-id  offset-1-definition-uri  ...  offset-1-location-component-2
+    offset-2-id  offset-2-definition-uri  ...  NULL                           -- An offset with ANY_LOCATION.
+    offset-3-id  offset-3-definition-uri  ...  offset-3-location-component-1  -- An offset with 3 location components.
+    offset-3-id  offset-3-definition-uri  ...  offset-3-location-component-2
+    offset-3-id  offset-3-definition-uri  ...  offset-3-location-component-3
+    ...
+    ```
     """
+    select_matching_offsets: sqlalchemy.sql.Selectable
+    if filters:
+        # Union the results from all of the filters together.
+        #
+        # Complication: Each filter's subquery possibly has an ORDER BY and LIMIT clause.
+        # SQLite's UNION only supports ORDER BY and LIMIT on the whole union, not on its
+        # constituent subqueries (SQLite will throw a syntax error). So we cannot
+        # directly use `_build_select_statement_for_single_filter(filter)`.
+        # We work around it by adding another layer of subquery (`.subquery().select()`),
+        # which would otherwise be a redundant pass-through.
+        subqueries_to_union = [
+            _build_select_statement_for_single_filter(filter).subquery().select()
+            for filter in filters
+        ]
+        select_matching_offsets = sqlalchemy.union(*subqueries_to_union)
+    else:
+        # The sqlalchemy.union() above doesn't support an empty list,
+        # so if we have no filters, we need to do this to get an empty result set
+        # of the same shape that the union would have returned.
+        select_matching_offsets = sqlalchemy.select(labware_offset_table).where(False)
 
-    def __init__(self) -> None:
-        """Build the object."""
-        super().__init__()
-        self._filter_original: Final = sqlalchemy.select(
-            labware_offset_table.c.row_id,
-            labware_offset_table.c.offset_id,
-            labware_offset_table.c.definition_uri,
-            labware_offset_table.c.vector_x,
-            labware_offset_table.c.vector_y,
-            labware_offset_table.c.vector_z,
-            labware_offset_table.c.created_at,
-            labware_offset_table.c.active,
-            labware_offset_location_sequence_components_table.c.sequence_ordinal,
-            labware_offset_location_sequence_components_table.c.component_kind,
-            labware_offset_location_sequence_components_table.c.primary_component_value,
-        ).select_from(
-            sqlalchemy.join(
-                labware_offset_table,
-                labware_offset_location_sequence_components_table,
-                labware_offset_table.c.row_id
-                == labware_offset_location_sequence_components_table.c.offset_id,
-            )
-        )
-        self._offset_location_alias: Final = (
-            labware_offset_location_sequence_components_table.alias()
-        )
-        self._current_base_filter_statement = self._filter_original
-        self._current_positive_location_filter: (
-            sqlalchemy.sql.selectable.Exists | None
-        ) = None
-        self._current_negative_filter_subqueries: list[
-            sqlalchemy.sql.selectable.Exists
-        ] = []
+    # Turn it into a common table expression so we can use it as one side of a join.
+    select_matching_offsets = select_matching_offsets.cte(
+        name="matching_offsets"  # An arbitrary dev-readable name for debugging.
+    )
 
-    def _positive_query(self) -> sqlalchemy.sql.selectable.Exists:
-        if self._current_positive_location_filter is not None:
-            return self._current_positive_location_filter
-        return sqlalchemy.exists().where(
-            self._offset_location_alias.c.offset_id
-            == labware_offset_location_sequence_components_table.c.offset_id
+    select_matching_offsets_and_their_locations = sqlalchemy.select(
+        select_matching_offsets.c.row_id,
+        select_matching_offsets.c.offset_id,
+        select_matching_offsets.c.definition_uri,
+        select_matching_offsets.c.vector_x,
+        select_matching_offsets.c.vector_y,
+        select_matching_offsets.c.vector_z,
+        select_matching_offsets.c.created_at,
+        select_matching_offsets.c.active,
+        labware_offset_location_sequence_components_table.c.sequence_ordinal,
+        labware_offset_location_sequence_components_table.c.component_kind,
+        labware_offset_location_sequence_components_table.c.primary_component_value,
+    ).select_from(
+        # This is a LEFT OUTER JOIN to account for offsets that have no entries
+        # in labware_offset_location_sequence_components_table. That is how we encode
+        # offsets that have locationSequence=ANY_LOCATION.
+        sqlalchemy.outerjoin(
+            select_matching_offsets,
+            labware_offset_location_sequence_components_table,
+            select_matching_offsets.c.row_id
+            == labware_offset_location_sequence_components_table.c.offset_id,
+        )
+    )
+
+    return select_matching_offsets_and_their_locations
+
+
+def _build_select_statement_for_single_filter(
+    filter: SearchFilter,
+) -> sqlalchemy.sql.Select:
+    statement = sqlalchemy.select(labware_offset_table)
+
+    statement = statement.where(labware_offset_table.c.active == sqlalchemy.true())
+
+    if filter.id != DO_NOT_FILTER:
+        statement = statement.where(labware_offset_table.c.offset_id == filter.id)
+    if filter.definitionUri != DO_NOT_FILTER:
+        statement = statement.where(
+            labware_offset_table.c.definition_uri == filter.definitionUri
+        )
+    if filter.locationSequence != DO_NOT_FILTER:
+        statement = statement.where(
+            _build_where_expression_for_location_match(filter.locationSequence)
         )
 
-    def build_query(self) -> sqlalchemy.sql.selectable.Selectable:
-        """Render the query into a sqlalchemy object suitable for passing to the database."""
-        statement = self._current_base_filter_statement
-        if self._current_positive_location_filter is not None:
-            statement = statement.where(self._current_positive_location_filter)
-        for subq in self._current_negative_filter_subqueries:
-            statement = statement.where(sqlalchemy.not_(subq))
-        statement = statement.order_by(labware_offset_table.c.row_id).order_by(
-            labware_offset_location_sequence_components_table.c.sequence_ordinal
-        )
-        return statement
+    if filter.mostRecentOnly:
+        statement = statement.order_by(labware_offset_table.c.row_id.desc()).limit(1)
 
-    def do_active_filter(self, active: bool) -> Self:
-        """Filter to only rows that are active (active=True) or inactive (active=False)."""
-        self._current_base_filter_statement = self._current_base_filter_statement.where(
-            labware_offset_table.c.active == active
-        )
-        return self
+    return statement
 
-    def do_id_filter(self, id_filter: str | DoNotFilterType) -> Self:
-        """Filter to rows with only the given offset ID."""
-        if id_filter is DO_NOT_FILTER:
-            return self
 
-        self._current_base_filter_statement = self._current_base_filter_statement.where(
-            labware_offset_table.c.offset_id == id_filter
-        )
-        return self
+def _build_where_expression_for_location_match(
+    location: Sequence[StoredLabwareOffsetLocationSequenceComponents] | AnyLocation,
+) -> object:
+    # Given a location like:
+    #
+    # [
+    #   {"kind": "onModule", "moduleModel": "magneticModuleV1"},
+    #   {"kind": "onAddressableArea", "addressableAreaName": "A1""}
+    # ]
+    #
+    # We want to return true if, and only if, in the SQL table:
+    #
+    # - There is a match to the first component.
+    #   - It's foreign-keyed to the labware offset in question.
+    #   - It has a sequence ordinal of 0.
+    #   - It has kind "onModule".
+    #   - It has value "magneticModuleV1".
+    # - There is a match to the second component.
+    #   - It's foreign-keyed to the labware offset in question.
+    #   - It has a sequence ordinal of 1.
+    #   - It has kind "onAddressableArea".
+    #   - It has value "A1".
+    # - There are exactly 2 components foreign-keyed to the labware offset in question
+    #   (no extras).
+    if location == ANY_LOCATION:
+        return sqlalchemy.sql.true()
 
-    def do_definition_uri_filter(
-        self, definition_uri_filter: str | DoNotFilterType
-    ) -> Self:
-        """Filter to rows of an offset that apply to a definition URI."""
-        if definition_uri_filter is DO_NOT_FILTER:
-            return self
-        self._current_base_filter_statement = self._current_base_filter_statement.where(
-            labware_offset_table.c.definition_uri == definition_uri_filter
-        )
-        return self
+    components_table = labware_offset_location_sequence_components_table
 
-    def do_on_addressable_area_filter(
-        self,
-        addressable_area_filter: str | DoNotFilterType,
-    ) -> Self:
-        """Filter to rows of an offset that applies to the given addressable area."""
-        if addressable_area_filter is DO_NOT_FILTER:
-            return self
-        self._current_positive_location_filter = (
-            self._positive_query()
-            .where(self._offset_location_alias.c.component_kind == "onAddressableArea")
-            .where(
-                self._offset_location_alias.c.primary_component_value
-                == addressable_area_filter
-            )
+    component_match_clauses = [
+        sqlalchemy.exists()
+        .where(
+            # Testing equality against `labware_offset_table.c.row_id` here looks confusing
+            # (which offset's row ID would it be?), but remember that this is evaluated
+            # in the context of some larger overall SELECT statement defined outside this
+            # function.
+            components_table.c.offset_id
+            == labware_offset_table.c.row_id
         )
-        return self
+        .where(components_table.c.sequence_ordinal == index)
+        .where(components_table.c.component_kind == component.kind)
+        .where(
+            components_table.c.primary_component_value
+            == _primary_component_value(component)
+        )
+        for index, component in enumerate(location)
+    ]
 
-    def do_on_labware_filter(
-        self, labware_uri_filter: str | DoNotFilterType | None
-    ) -> Self:
-        """Filter to the rows of an offset located on the given labware (or no labware)."""
-        if labware_uri_filter is DO_NOT_FILTER:
-            return self
-        if labware_uri_filter is None:
-            self._current_negative_filter_subqueries.append(
-                sqlalchemy.exists()
-                .where(
-                    self._offset_location_alias.c.offset_id
-                    == labware_offset_location_sequence_components_table.c.offset_id
-                )
-                .where(self._offset_location_alias.c.component_kind == "onLabware")
-            )
-            return self
-        self._current_positive_location_filter = (
-            self._positive_query()
-            .where(self._offset_location_alias.c.component_kind == "onLabware")
-            .where(
-                self._offset_location_alias.c.primary_component_value
-                == labware_uri_filter
-            )
-        )
-        return self
+    select_length = (
+        sqlalchemy.select(sqlalchemy.func.count(components_table.c.row_id))
+        .where(components_table.c.offset_id == labware_offset_table.c.row_id)
+        .scalar_subquery()
+    )
+    length_match_expression = select_length == len(location)
 
-    def do_on_module_filter(
-        self,
-        module_model_filter: ModuleModel | DoNotFilterType | None,
-    ) -> Self:
-        """Filter to the rows of an offset located on the given module (or no module)."""
-        if module_model_filter is DO_NOT_FILTER:
-            return self
-        if module_model_filter is None:
-            self._current_negative_filter_subqueries.append(
-                sqlalchemy.exists()
-                .where(
-                    self._offset_location_alias.c.offset_id
-                    == labware_offset_location_sequence_components_table.c.offset_id
-                )
-                .where(self._offset_location_alias.c.component_kind == "onModule")
-            )
-            return self
-        self._current_positive_location_filter = (
-            self._positive_query()
-            .where(self._offset_location_alias.c.component_kind == "onModule")
-            .where(
-                self._offset_location_alias.c.primary_component_value
-                == module_model_filter.value
-            )
-        )
-        return self
+    return sqlalchemy.and_(*component_match_clauses, length_match_expression)
+
+
+def _primary_component_value(
+    component: StoredLabwareOffsetLocationSequenceComponents,
+) -> str:
+    match component:
+        case OnLabwareOffsetLocationSequenceComponent(
+            labwareUri=value
+        ) | OnModuleOffsetLocationSequenceComponent(
+            moduleModel=value
+        ) | OnAddressableAreaOffsetLocationSequenceComponent(
+            addressableAreaName=value
+        ):
+            return value

--- a/robot-server/robot_server/labware_offsets/_search_query_builder.py
+++ b/robot-server/robot_server/labware_offsets/_search_query_builder.py
@@ -159,6 +159,7 @@ def _build_where_expression_for_location_match(
     length_match_expression = select_length == len(location)
 
     if location != ANY_LOCATION:
+        assert len(location) > 0  # This should be enforced by higher layers.
         component_match_clauses = [
             sqlalchemy.exists()
             .where(

--- a/robot-server/robot_server/labware_offsets/_search_query_builder.py
+++ b/robot-server/robot_server/labware_offsets/_search_query_builder.py
@@ -66,27 +66,34 @@ def build_query(filters: Sequence[SearchFilter]) -> sqlalchemy.sql.Selectable:
         name="matching_offsets"  # An arbitrary dev-readable name for debugging.
     )
 
-    select_matching_offsets_and_their_locations = sqlalchemy.select(
-        select_matching_offsets.c.row_id,
-        select_matching_offsets.c.offset_id,
-        select_matching_offsets.c.definition_uri,
-        select_matching_offsets.c.vector_x,
-        select_matching_offsets.c.vector_y,
-        select_matching_offsets.c.vector_z,
-        select_matching_offsets.c.created_at,
-        select_matching_offsets.c.active,
-        labware_offset_location_sequence_components_table.c.sequence_ordinal,
-        labware_offset_location_sequence_components_table.c.component_kind,
-        labware_offset_location_sequence_components_table.c.primary_component_value,
-    ).select_from(
-        # This is a LEFT OUTER JOIN to account for offsets that have no entries
-        # in labware_offset_location_sequence_components_table. That is how we encode
-        # offsets that have locationSequence=ANY_LOCATION.
-        sqlalchemy.outerjoin(
-            select_matching_offsets,
-            labware_offset_location_sequence_components_table,
-            select_matching_offsets.c.row_id
-            == labware_offset_location_sequence_components_table.c.offset_id,
+    select_matching_offsets_and_their_locations = (
+        sqlalchemy.select(
+            select_matching_offsets.c.row_id,
+            select_matching_offsets.c.offset_id,
+            select_matching_offsets.c.definition_uri,
+            select_matching_offsets.c.vector_x,
+            select_matching_offsets.c.vector_y,
+            select_matching_offsets.c.vector_z,
+            select_matching_offsets.c.created_at,
+            select_matching_offsets.c.active,
+            labware_offset_location_sequence_components_table.c.sequence_ordinal,
+            labware_offset_location_sequence_components_table.c.component_kind,
+            labware_offset_location_sequence_components_table.c.primary_component_value,
+        )
+        .select_from(
+            # This is a LEFT OUTER JOIN to account for offsets that have no entries
+            # in labware_offset_location_sequence_components_table. That is how we encode
+            # offsets that have locationSequence=ANY_LOCATION.
+            sqlalchemy.outerjoin(
+                select_matching_offsets,
+                labware_offset_location_sequence_components_table,
+                select_matching_offsets.c.row_id
+                == labware_offset_location_sequence_components_table.c.offset_id,
+            )
+        )
+        .order_by(
+            select_matching_offsets.c.row_id,
+            labware_offset_location_sequence_components_table.c.sequence_ordinal,
         )
     )
 

--- a/robot-server/robot_server/labware_offsets/models.py
+++ b/robot-server/robot_server/labware_offsets/models.py
@@ -25,8 +25,8 @@ class _DoNotFilter(enum.Enum):
 DO_NOT_FILTER: Final = _DoNotFilter.DO_NOT_FILTER
 """A sentinel value for when a filter should not be applied.
 
-This is different from filtering on `None`, which returns only entries where the
-value is equal to `None`.
+We use this instead of `None` to avoid confusion when it looks like `None` might have
+some other meaning, like "filter for entries that are equal to the value `None`".
 """
 
 
@@ -35,6 +35,12 @@ DoNotFilterType: TypeAlias = Literal[_DoNotFilter.DO_NOT_FILTER]
 
 Unfortunately, mypy doesn't let us write `Literal[DO_NOT_FILTER]`. Use this instead.
 """
+
+
+ANY_LOCATION: Final = "anyLocation"
+
+
+AnyLocation: TypeAlias = Literal["anyLocation"]
 
 
 class UnknownLabwareOffsetLocationSequenceComponent(BaseModel):
@@ -63,9 +69,15 @@ class StoredLabwareOffsetCreate(BaseModel):
 
     definitionUri: str = Field(..., description="The URI for the labware's definition.")
 
-    locationSequence: Sequence[StoredLabwareOffsetLocationSequenceComponents] = Field(
+    locationSequence: Sequence[
+        StoredLabwareOffsetLocationSequenceComponents
+    ] | AnyLocation = Field(
         ...,
-        description="Where the labware is located on the robot.",
+        description=(
+            "Where the labware is located on the robot."
+            " The special value `anyLocation` means this offset applies to any labware"
+            " with a matching `definitionUri`, regardless of its location."
+        ),
         min_length=1,
     )
     vector: LabwareOffsetVector = Field(
@@ -84,9 +96,15 @@ class StoredLabwareOffset(BaseModel):
     createdAt: datetime = Field(..., description="When this labware offset was added.")
 
     definitionUri: str = Field(..., description="The URI for the labware's definition.")
-    locationSequence: Sequence[ReturnedLabwareOffsetLocationSequenceComponents] = Field(
+    locationSequence: Sequence[
+        ReturnedLabwareOffsetLocationSequenceComponents
+    ] | AnyLocation = Field(
         ...,
-        description="Where the labware is located on the robot. Can represent all locations, but may not be present for older runs.",
+        description=(
+            "Where the labware is located on the robot."
+            " The special value `anyLocation` means this offset applies to any labware"
+            " with a matching `definitionUri`, regardless of its location."
+        ),
         min_length=1,
     )
 
@@ -116,6 +134,7 @@ class SearchFilter(BaseModel):  # noqa: D101 - more docs are in SearchCreate.
     ] = DO_NOT_FILTER
     locationSequence: Annotated[
         Sequence[StoredLabwareOffsetLocationSequenceComponents]
+        | AnyLocation
         | SkipJsonSchema[DoNotFilterType],
         Field(
             description=(

--- a/robot-server/robot_server/labware_offsets/models.py
+++ b/robot-server/robot_server/labware_offsets/models.py
@@ -133,7 +133,9 @@ class SearchFilter(BaseModel):  # noqa: D101 - more docs are in SearchCreate.
         ),
     ] = DO_NOT_FILTER
     locationSequence: Annotated[
-        Sequence[StoredLabwareOffsetLocationSequenceComponents]
+        Annotated[
+            Sequence[StoredLabwareOffsetLocationSequenceComponents], Field(min_length=1)
+        ]
         | AnyLocation
         | SkipJsonSchema[DoNotFilterType],
         Field(

--- a/robot-server/tests/labware_offsets/test_store.py
+++ b/robot-server/tests/labware_offsets/test_store.py
@@ -1,6 +1,7 @@
 # noqa: D100
 
 from datetime import datetime, timezone
+from typing import Sequence
 
 import pytest
 import sqlalchemy
@@ -11,7 +12,9 @@ from opentrons.protocol_engine import (
     OnModuleOffsetLocationSequenceComponent,
     OnAddressableAreaOffsetLocationSequenceComponent,
 )
-from opentrons.protocol_engine.types import ModuleModel
+from opentrons.protocol_engine.types import (
+    ModuleModel,
+)
 from robot_server.persistence.tables import (
     labware_offset_location_sequence_components_table,
 )
@@ -21,9 +24,12 @@ from robot_server.labware_offsets.store import (
     IncomingStoredLabwareOffset,
 )
 from robot_server.labware_offsets.models import (
+    ANY_LOCATION,
+    SearchFilter,
     StoredLabwareOffset,
     DoNotFilterType,
     DO_NOT_FILTER,
+    StoredLabwareOffsetLocationSequenceComponents,
     UnknownLabwareOffsetLocationSequenceComponent,
 )
 
@@ -34,17 +40,73 @@ def subject(sql_engine: sqlalchemy.engine.Engine) -> LabwareOffsetStore:
     return LabwareOffsetStore(sql_engine)
 
 
-def _get_all(store: LabwareOffsetStore) -> list[StoredLabwareOffset]:
-    return store.search()
+def test_empty_search(subject: LabwareOffsetStore) -> None:
+    """Searching with no filters should return no results."""
+    subject.add(
+        IncomingStoredLabwareOffset(
+            id="id",
+            createdAt=datetime.now(timezone.utc),
+            definitionUri="namespace/load_name/1",
+            locationSequence="anyLocation",
+            vector=LabwareOffsetVector(x=1, y=2, z=3),
+        )
+    )
+    assert subject.search([]) == []
+
+
+def test_search_most_recent_only(subject: LabwareOffsetStore) -> None:
+    """mostRecentOnly=True should restrict that specific filter to the most recent."""
+    uri_1 = "namespace/load_name_1/1"
+    uri_2 = "namespace/load_name_2/1"
+    ids_and_definition_uris = [
+        ("id-1", uri_1),
+        ("id-2", uri_1),
+        ("id-3", uri_2),
+        ("id-4", uri_2),
+    ]
+    for id, definition_uri in ids_and_definition_uris:
+        subject.add(
+            IncomingStoredLabwareOffset(
+                id=id,
+                definitionUri=definition_uri,
+                createdAt=datetime.now(timezone.utc),
+                locationSequence="anyLocation",
+                vector=LabwareOffsetVector(x=1, y=2, z=3),
+            )
+        )
+
+    results = subject.search([SearchFilter(mostRecentOnly=True)])
+    assert [result.id for result in results] == ["id-4"]
+
+    results = subject.search(
+        [
+            SearchFilter(definitionUri=uri_1, mostRecentOnly=True),
+        ]
+    )
+    assert [result.id for result in results] == ["id-2"]
+
+    results = subject.search(
+        [
+            SearchFilter(definitionUri=uri_1, mostRecentOnly=True),
+            SearchFilter(definitionUri=uri_2, mostRecentOnly=True),
+        ]
+    )
+    assert [result.id for result in results] == ["id-2", "id-4"]
+
+    results = subject.search(
+        [
+            SearchFilter(definitionUri=uri_1, mostRecentOnly=False),
+            SearchFilter(definitionUri=uri_1, mostRecentOnly=True),
+        ]
+    )
+    assert [result.id for result in results] == ["id-1", "id-2"]
 
 
 @pytest.mark.parametrize(
     argnames=[
         "id_filter",
         "definition_uri_filter",
-        "location_addressable_area_filter",
-        "location_module_model_filter",
-        "location_labware_uri_filter",
+        "location_sequence_filter",
         "returned_ids",
     ],
     argvalues=[
@@ -52,25 +114,30 @@ def _get_all(store: LabwareOffsetStore) -> list[StoredLabwareOffset]:
             "a",
             DO_NOT_FILTER,
             DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
             ["a"],
-            id="id-only",
+            id="id-filter-only",
         ),
         pytest.param(
             DO_NOT_FILTER,
             "definitionUri a",
             DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
             ["a", "c", "d", "e"],
-            id="labware-only",
+            id="labware-filter-only",
+        ),
+        pytest.param(
+            DO_NOT_FILTER,
+            DO_NOT_FILTER,
+            [
+                OnAddressableAreaOffsetLocationSequenceComponent(
+                    addressableAreaName="A1"
+                )
+            ],
+            ["c"],
+            id="location-filter-only",
         ),
         pytest.param(
             "a",
             "definitionUri a",
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
             DO_NOT_FILTER,
             ["a"],
             id="labware-and-id-matching",
@@ -79,82 +146,22 @@ def _get_all(store: LabwareOffsetStore) -> list[StoredLabwareOffset]:
             "a",
             "definitionUri b",
             DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
             [],
             id="labware-and-id-conflicting",
         ),
         pytest.param(
             DO_NOT_FILTER,
             DO_NOT_FILTER,
-            "A1",
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            ["a", "c", "d", "e"],
-            id="aa-only",
-        ),
-        pytest.param(
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            "A1",
-            None,
-            None,
-            ["c"],
+            [
+                OnAddressableAreaOffsetLocationSequenceComponent(
+                    kind="onAddressableArea",
+                    addressableAreaName="A1",
+                )
+            ],
+            [
+                "c",
+            ],
             id="aa-and-not-mod-or-lw",
-        ),
-        pytest.param(
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            "A1",
-            None,
-            DO_NOT_FILTER,
-            ["c", "d"],
-            id="aa-and-not-module",
-        ),
-        pytest.param(
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            "A1",
-            DO_NOT_FILTER,
-            None,
-            ["c", "e"],
-            id="aa-and-not-lw",
-        ),
-        pytest.param(
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            ModuleModel.MAGNETIC_BLOCK_V1,
-            DO_NOT_FILTER,
-            ["b", "e"],
-            id="module-only",
-        ),
-        pytest.param(
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            ModuleModel.MAGNETIC_BLOCK_V1,
-            None,
-            ["e"],
-            id="module-and-not-lw",
-        ),
-        pytest.param(
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            "location.definitionUri a",
-            ["a", "d"],
-            id="lw-only",
-        ),
-        pytest.param(
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            DO_NOT_FILTER,
-            None,
-            "location.definitionUri a",
-            ["d"],
-            id="lw-and-not-module",
         ),
     ],
 )
@@ -162,9 +169,8 @@ def test_filter_fields(
     subject: LabwareOffsetStore,
     id_filter: str | DoNotFilterType,
     definition_uri_filter: str | DoNotFilterType,
-    location_addressable_area_filter: str | DoNotFilterType,
-    location_module_model_filter: ModuleModel | None | DoNotFilterType,
-    location_labware_uri_filter: str | None | DoNotFilterType,
+    location_sequence_filter: Sequence[StoredLabwareOffsetLocationSequenceComponents]
+    | DoNotFilterType,
     returned_ids: list[str],
 ) -> None:
     """Test each filterable field to make sure it returns only matching entries."""
@@ -246,13 +252,18 @@ def test_filter_fields(
     for offset in offsets.values():
         subject.add(offset)
     results = subject.search(
-        id_filter=id_filter,
-        definition_uri_filter=definition_uri_filter,
-        location_addressable_area_filter=location_addressable_area_filter,
-        location_module_model_filter=location_module_model_filter,
-        location_definition_uri_filter=location_labware_uri_filter,
+        [
+            SearchFilter(
+                id=id_filter,
+                definitionUri=definition_uri_filter,
+                locationSequence=location_sequence_filter,
+            )
+        ]
     )
-    assert sorted(results, key=lambda o: o.id,) == sorted(
+    assert sorted(
+        results,
+        key=lambda o: o.id,
+    ) == sorted(
         [
             StoredLabwareOffset(
                 id=offsets[id_].id,
@@ -267,8 +278,8 @@ def test_filter_fields(
     )
 
 
-def test_filter_combinations(subject: LabwareOffsetStore) -> None:
-    """Test that multiple filters are combined correctly."""
+def test_filter_field_combinations(subject: LabwareOffsetStore) -> None:
+    """Test that multiple fields within a single filter are combined correctly."""
     ids_and_definition_uris = [
         ("id-1", "definition-uri-a"),
         ("id-2", "definition-uri-b"),
@@ -305,29 +316,74 @@ def test_filter_combinations(subject: LabwareOffsetStore) -> None:
     for labware_offset in labware_offsets:
         subject.add(labware_offset)
 
-    # No filters:
-    assert subject.search() == outgoing_offsets
+    # Filter accepting any value for each field (i.e. a return-everything filter):
+    result = subject.search([SearchFilter()])
+    assert result == outgoing_offsets
 
-    # Filter on one thing:
-    result = subject.search(definition_uri_filter="definition-uri-b")
+    # Filter on one field:
+    result = subject.search([SearchFilter(definitionUri="definition-uri-b")])
     assert len(result) == 3
     assert result == [
         entry for entry in outgoing_offsets if entry.definitionUri == "definition-uri-b"
     ]
 
-    # Filter on two things:
+    # Filter on two fields:
     result = subject.search(
-        id_filter="id-2",
-        definition_uri_filter="definition-uri-b",
+        [
+            SearchFilter(
+                id="id-2",
+                definitionUri="definition-uri-b",
+            )
+        ]
     )
     assert result == [outgoing_offsets[1]]
 
-    # Filters should be ANDed, not ORed, together:
+    # Filter fields should be ANDed, not ORed, together:
     result = subject.search(
-        id_filter="id-1",
-        definition_uri_filter="definition-uri-b",
+        [
+            SearchFilter(
+                id="id-1",
+                definitionUri="definition-uri-b",
+            )
+        ]
     )
     assert result == []
+
+
+def test_filter_combinations(subject: LabwareOffsetStore) -> None:
+    """Test that multiple filters are combined correctly."""
+    ids_and_definition_uris = [
+        ("id-1", "definition-uri-a"),
+        ("id-2", "definition-uri-b"),
+    ]
+    for id, definition_uri in ids_and_definition_uris:
+        subject.add(
+            IncomingStoredLabwareOffset(
+                id=id,
+                createdAt=datetime.now(timezone.utc),
+                definitionUri=definition_uri,
+                locationSequence=ANY_LOCATION,
+                vector=LabwareOffsetVector(x=1, y=2, z=3),
+            )
+        )
+
+    # Multiple filters should be OR'd together.
+    result = subject.search(
+        [
+            SearchFilter(definitionUri="definition-uri-a"),
+            SearchFilter(definitionUri="definition-uri-b"),
+        ]
+    )
+    assert [e.id for e in result] == ["id-1", "id-2"]
+
+    # It should be a true union, not just a concatenation--
+    # there should be no repeated offsets in the results.
+    result = subject.search(
+        [
+            SearchFilter(id="id-1"),
+            SearchFilter(definitionUri="definition-uri-a"),
+        ]
+    ) == ["id-1"]
 
 
 def test_delete(subject: LabwareOffsetStore) -> None:
@@ -367,12 +423,17 @@ def test_delete(subject: LabwareOffsetStore) -> None:
     subject.add(c)
 
     assert subject.delete(b.id) == out_b
-    assert _get_all(subject) == [out_a, out_c]
+    assert subject.get_all() == [out_a, out_c]
+    assert subject.search([SearchFilter()]) == [
+        out_a,
+        out_c,
+    ]  # A return-everything search filter.
     with pytest.raises(LabwareOffsetNotFoundError):
         subject.delete(out_b.id)
 
     subject.delete_all()
-    assert _get_all(subject) == []
+    assert subject.get_all() == []
+    assert subject.search([SearchFilter()]) == []  # A return-everything search filter.
 
 
 def test_handle_unknown(
@@ -413,4 +474,4 @@ def test_handle_unknown(
                 component_value_json='{"asdasda": "dddddd", "kind": "asdasdad"}',
             )
         )
-    assert subject.search(id_filter="id-a") == [outgoing_offset]
+    assert subject.search([SearchFilter(id="id-a")]) == [outgoing_offset]

--- a/robot-server/tests/labware_offsets/test_store.py
+++ b/robot-server/tests/labware_offsets/test_store.py
@@ -260,10 +260,7 @@ def test_filter_fields(
             )
         ]
     )
-    assert sorted(
-        results,
-        key=lambda o: o.id,
-    ) == sorted(
+    assert sorted(results, key=lambda o: o.id,) == sorted(
         [
             StoredLabwareOffset(
                 id=offsets[id_].id,
@@ -383,7 +380,8 @@ def test_filter_combinations(subject: LabwareOffsetStore) -> None:
             SearchFilter(id="id-1"),
             SearchFilter(definitionUri="definition-uri-a"),
         ]
-    ) == ["id-1"]
+    )
+    assert [e.id for e in result] == ["id-1"]
 
 
 def test_delete(subject: LabwareOffsetStore) -> None:


### PR DESCRIPTION
## Overview

Allows robot-server to store and retrieve "default" labware offsets—those that are meant to apply to any placement of a certain labware definition, regardless of the labware's location on the robot.

Closes EXEC-1284.

## Changelog

The `/labwareOffsets` HTTP endpoints for adding, retrieving, and searching for labware offsets now all support `locationSequence: "anyLocation"`. Previously, they only supported concrete values like `locationSequence: [{"kind": "onAddressableArea", "addressableAreaName": "A1"}]`.

The server's SQL-query–building logic is rewritten to:

* Accommodate `anyLocation`, as described above.
* Accommodate filters with `mostRecentOnly: true`. This replaces a router-level hack from [#17672][17672].
* Evaluate multiple filters at once and return the unioned result. This replaces a router-level hack from [#17672][17672].
* Be stateless instead of stateful, not for any real reason other than it's what I could wrap my head around and get to work for supporting the above.

[17672]: https://github.com/Opentrons/opentrons/pull/17672

## Test Plan and Hands on Testing

* [x] Automated tests
* [x] Play around with it a bit in Postman, paying special attention to `locationSequence: "anyLocation"`


## Review requests

* Any way to make the query building stuff clearer?
* Naming and HTTP API design. Is `{"locationSequence": "anyLocation"}` a good way to spell this?
  * @sfoster1 suggested putting the sentinel inside the `locationSequence` list, roughly like:

    ```json
    {"locationSequence": [{"kind": "anyLocation"}]}
    ```

    I haven't done that here because I found it conceptually confusing. Like, what would it mean if you mixed and matched the sentinel with "real" location components, like this:

    ```json
    {
        "locationSequence": [
            {"kind": "anyLocation"},
            {"kind": "onAddressableArea", "addressableAreaName": "A1"},
            {"kind": "anyLocation"}
        ]
    }
    ```

## Risk assessment

Medium.

There's definitely room for bugs here until I add Hypothesis tests to cover `LabwareStore` more exhaustively.

There's also risk of query inefficiency. I haven't done performance testing for this yet. (But I don't think we did performance testing for the old query builder, either).