### PR TITLE
feat(api): dynamic liquid tracking protocol engine changes

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -13,6 +13,7 @@ from ..errors.exceptions import (
     InvalidAspirateVolumeError,
     InvalidPushOutVolumeError,
     InvalidDispenseVolumeError,
+    InvalidLiquidHeightFound,
 )
 from opentrons.protocol_engine.types import WellLocation
 from opentrons.protocol_engine.types.liquid_level_detection import (
@@ -177,7 +178,30 @@ class HardwarePipettingHandler(PipettingHandler):
         Raises:
             PipetteOverpressureError, propagated as-is from the hardware controller.
         """
-        return 0.0
+        # get mount and config data from state and hardware controller
+        hw_pipette, adjusted_volume = self.get_hw_aspirate_params(
+            pipette_id, volume, command_note_adder
+        )
+        aspirate_z_distance = self._state_view.geometry.get_liquid_handling_z_change(
+            labware_id=labware_id,
+            well_name=well_name,
+            operation_volume=volume * -1,
+        )
+        # breakpoint()  # find what z distance is here
+        if isinstance(aspirate_z_distance, SimulatedProbeResult):
+            raise InvalidLiquidHeightFound(
+                "Aspirate distance must be a float in Hardware pipetting handler."
+            )
+
+        # raise ValueError(f"z_dist = {aspirate_z_distance}, volume={adjusted_volume}")
+        with self._set_flow_rate(pipette=hw_pipette, aspirate_flow_rate=flow_rate):
+            await self._hardware_api.aspirate_while_tracking(
+                mount=hw_pipette.mount,
+                z_distance=aspirate_z_distance,
+                flow_rate=flow_rate,
+                volume=adjusted_volume,
+            )
+        return adjusted_volume
 
     async def dispense_while_tracking(
         self,
@@ -193,7 +217,26 @@ class HardwarePipettingHandler(PipettingHandler):
         Raises:
             PipetteOverpressureError, propagated as-is from the hardware controller.
         """
-        return 0.0
+        # get mount and config data from state and hardware controller
+        hw_pipette, adjusted_volume = self.get_hw_dispense_params(pipette_id, volume)
+        dispense_z_distance = self._state_view.geometry.get_liquid_handling_z_change(
+            labware_id=labware_id,
+            well_name=well_name,
+            operation_volume=volume,
+        )
+        if isinstance(dispense_z_distance, SimulatedProbeResult):
+            raise InvalidLiquidHeightFound(
+                "Dispense distance must be a float in Hardware pipetting handler."
+            )
+        with self._set_flow_rate(pipette=hw_pipette, dispense_flow_rate=flow_rate):
+            await self._hardware_api.dispense_while_tracking(
+                mount=hw_pipette.mount,
+                z_distance=dispense_z_distance,
+                flow_rate=flow_rate,
+                volume=adjusted_volume,
+                push_out=push_out,
+            )
+        return adjusted_volume
 
     async def aspirate_in_place(
         self,

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -10,12 +10,16 @@ from opentrons.hardware_control.dev_types import PipetteDict
 
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state.pipettes import HardwarePipette
+from opentrons.protocol_engine.state.labware import LabwareView, LabwareStore
+from opentrons.protocol_engine.state.wells import WellView, WellStore
 from opentrons.protocol_engine.types import TipGeometry
 from opentrons.protocol_engine.execution.pipetting import (
     HardwarePipettingHandler,
     VirtualPipettingHandler,
     create_pipetting_handler,
 )
+
+# from opentrons.protocol_engine.state.geometry import GeometryView
 from opentrons.protocol_engine.errors.exceptions import (
     TipNotAttachedError,
     InvalidAspirateVolumeError,
@@ -24,6 +28,44 @@ from opentrons.protocol_engine.errors.exceptions import (
 )
 from opentrons.protocol_engine.notes import CommandNoteAdder, CommandNote
 from ..note_utils import CommandNoteMatcher
+
+
+from opentrons_shared_data.labware.labware_definition import (
+    CuboidalFrustum,
+    InnerWellGeometry,
+    SphericalSegment,
+    ConicalFrustum,
+    RectangularWellDefinition3,
+)
+
+_TEST_INNER_WELL_GEOMETRY = InnerWellGeometry(
+    sections=[
+        CuboidalFrustum(
+            shape="cuboidal",
+            topXDimension=7.6,
+            topYDimension=8.5,
+            bottomXDimension=5.6,
+            bottomYDimension=6.5,
+            topHeight=45,
+            bottomHeight=20,
+        ),
+        CuboidalFrustum(
+            shape="cuboidal",
+            topXDimension=5.6,
+            topYDimension=6.5,
+            bottomXDimension=4.5,
+            bottomYDimension=4.0,
+            topHeight=20,
+            bottomHeight=10,
+        ),
+        SphericalSegment(
+            shape="spherical",
+            radiusOfCurvature=6,
+            topHeight=10,
+            bottomHeight=0.0,
+        ),
+    ],
+)
 
 
 @pytest.fixture
@@ -47,6 +89,18 @@ def hardware_subject(
     return HardwarePipettingHandler(
         state_view=mock_state_view, hardware_api=mock_hardware_api
     )
+
+
+@pytest.fixture
+def mock_labware_view(decoy: Decoy) -> LabwareView:
+    """Get a mock in the shape of a LabwareView."""
+    return decoy.mock(cls=LabwareView)
+
+
+@pytest.fixture
+def mock_well_view(decoy: Decoy) -> WellView:
+    """Get a mock in the shape of a WellView."""
+    return decoy.mock(cls=WellView)
 
 
 async def test_create_pipette_handler(
@@ -215,6 +269,85 @@ async def test_hw_dispense_in_place_raises_invalid_push_out(
         await hardware_subject.dispense_in_place(
             pipette_id="pipette-id", volume=25, flow_rate=2.5, push_out=-7
         )
+
+
+async def test_hw_aspirate_while_tracking(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    mock_hardware_api: HardwareAPI,
+    mock_labware_view: LabwareView,
+    mock_well_view: WellView,
+    hardware_subject: HardwarePipettingHandler,
+    mock_command_note_adder: CommandNoteAdder,
+) -> None:
+    """Should set flow_rate and call hardware_api aspirate."""
+    decoy.when(mock_labware_view.get_well_definition("labware-id", "A1")).then_return(
+        RectangularWellDefinition3.model_construct(totalLiquidVolume=1100000)  # type: ignore[call-arg]
+    )
+    decoy.when(mock_labware_view.get_well_geometry("labware-id", "A1")).then_return(
+        _TEST_INNER_WELL_GEOMETRY
+    )
+
+    decoy.when(mock_state_view.pipettes.get_working_volume("pipette-id")).then_return(
+        25
+    )
+    decoy.when(mock_state_view.pipettes.get_aspirated_volume("pipette-id")).then_return(
+        0
+    )
+
+    decoy.when(mock_hardware_api.attached_instruments).then_return({})
+    decoy.when(
+        mock_state_view.pipettes.get_hardware_pipette(
+            pipette_id="pipette-id",
+            attached_pipettes={},
+        )
+    ).then_return(
+        HardwarePipette(
+            mount=Mount.LEFT,
+            config=cast(
+                PipetteDict,
+                {
+                    "aspirate_flow_rate": 1.23,
+                    "dispense_flow_rate": 4.56,
+                    "blow_out_flow_rate": 7.89,
+                },
+            ),
+        )
+    )
+    # tbh probably need 3 tests:
+    # - one to see the outcome of get_liquid_handling_z_change
+    # - one to see the aspirate_z_distance given the outcome of get_liquid_handling_z_change
+    # - get_meniscus_height
+
+    decoy.when(
+        mock_state_view.geometry.get_liquid_handling_z_change(
+            labware_id="labware-id", well_name="A1", operation_volume=25.0
+        )
+    ).then_return(4.544)
+
+    result = await hardware_subject.aspirate_while_tracking(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="A1",
+        volume=25,
+        flow_rate=2.5,
+        command_note_adder=mock_command_note_adder,
+    )
+    # breakpoint()
+
+    assert result == 25
+
+    decoy.verify(
+        mock_hardware_api.set_flow_rate(
+            mount=Mount.LEFT, aspirate=2.5, dispense=None, blow_out=None
+        ),
+        await mock_hardware_api.aspirate(
+            mount=Mount.LEFT, volume=25, correction_volume=0
+        ),
+        mock_hardware_api.set_flow_rate(
+            mount=Mount.LEFT, aspirate=1.23, dispense=4.56, blow_out=7.89
+        ),
+    )
 
 
 async def test_hw_aspirate_in_place(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
