### PR TITLE
feat(api-client): Support location-nonspecific ("default") offsets

### DIFF
--- a/api-client/src/labwareOffsets/createLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/createLabwareOffsets.ts
@@ -5,12 +5,14 @@ import type {
   HostConfig,
   LabwareOffsetLocationSequenceComponent,
 } from '../types'
-import type { StoredLabwareOffset } from './types'
+import type { ANY_LOCATION, StoredLabwareOffset } from './types'
 import type { VectorOffset } from '../runs'
 
 export interface StoredLabwareOffsetCreate {
   definitionUri: string
-  locationSequence: LabwareOffsetLocationSequenceComponent[]
+  locationSequence:
+    | LabwareOffsetLocationSequenceComponent[]
+    | typeof ANY_LOCATION
   vector: VectorOffset
 }
 

--- a/api-client/src/labwareOffsets/index.ts
+++ b/api-client/src/labwareOffsets/index.ts
@@ -2,5 +2,6 @@ export * from './getLabwareOffsets'
 export * from './createLabwareOffsets'
 export * from './deleteLabwareOffset'
 export * from './deleteAllLabwareOffsets'
+export * from './searchLabwareOffsets'
 
 export * from './types'

--- a/api-client/src/labwareOffsets/searchLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/searchLabwareOffsets.ts
@@ -5,14 +5,16 @@ import type {
   HostConfig,
   LabwareOffsetLocationSequenceComponent,
 } from '../types'
-import type { StoredLabwareOffset } from './types'
+import type { ANY_LOCATION, StoredLabwareOffset } from './types'
 
 export interface SearchLabwareOffsetsData {
   /** Filters are ORed together. Within a single filter, criteria are ANDed together. */
   filters: Array<{
     id?: string
     definitionUri?: string
-    locationSequence?: LabwareOffsetLocationSequenceComponent[]
+    locationSequence?:
+      | LabwareOffsetLocationSequenceComponent[]
+      | typeof ANY_LOCATION
     mostRecentOnly?: boolean
   }>
 }

--- a/api-client/src/labwareOffsets/types.ts
+++ b/api-client/src/labwareOffsets/types.ts
@@ -5,7 +5,9 @@ export interface StoredLabwareOffset {
   id: string
   createdAt: string
   definitionUri: string
-  locationSequence: LabwareOffsetLocationSequenceComponent[]
+  locationSequence:
+    | LabwareOffsetLocationSequenceComponent[]
+    | typeof ANY_LOCATION
   vector: VectorOffset
 }
 
@@ -13,3 +15,5 @@ export interface MultiBodyMeta {
   cursor: number
   totalLength: number
 }
+
+export const ANY_LOCATION = 'anyLocation' as const


### PR DESCRIPTION
## Changelog

* Update the `/labwareOffsets` endpoint bindings to support `locationSequence: "anyLocation"`, as implemented in #17704. Goes towards EXEC-1284.
* Fix a missing `./searchLabwareOffsets.ts` re-export.

## Test Plan and Hands on Testing

None.

## Review requests

* I think this is all that needs to change, right?
* Is a constant `ANY_LOCATION` + `typeof` the idiomatic way to do this?

## Risk assessment

Very low.