### PR TITLE
docs(api): hide API 2.23 documentation until release

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2089,7 +2089,7 @@ class InstrumentContext(publisher.CommandPublisher):
         From API version 2.15 to 2.22, this property returned an internal name for Flex
         pipettes. (e.g., ``"p1000_single_flex"``).
 
-        ..
+        .. TODO uncomment when 2.23 is ready
           In API version 2.23 and later, this property returns the Python Protocol API
           :ref:`load name <new-pipette-models>` of Flex pipettes (e.g.,
           ``"flex_1channel_1000"``).

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1535,6 +1535,8 @@ class InstrumentContext(publisher.CommandPublisher):
         """Transfer liquid from source to dest using the specified liquid class properties.
 
         TODO: Add args description.
+
+        :meta private:
         """
         transfer_args = verify_and_normalize_transfer_args(
             source=source,
@@ -1543,9 +1545,9 @@ class InstrumentContext(publisher.CommandPublisher):
             last_tip_picked_up_from=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             current_volume=self.current_volume,
-            trash_location=trash_location
-            if trash_location is not None
-            else self.trash_container,
+            trash_location=(
+                trash_location if trash_location is not None else self.trash_container
+            ),
         )
         if len(transfer_args.sources_list) != len(transfer_args.destinations_list):
             raise ValueError(
@@ -1595,6 +1597,8 @@ class InstrumentContext(publisher.CommandPublisher):
         using the specified liquid class properties.
 
         TODO: Add args description.
+
+        :meta private:
         """
         if not isinstance(source, labware.Well):
             raise ValueError(f"Source should be a single Well but received {source}.")
@@ -1606,9 +1610,9 @@ class InstrumentContext(publisher.CommandPublisher):
             last_tip_picked_up_from=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             current_volume=self.current_volume,
-            trash_location=trash_location
-            if trash_location is not None
-            else self.trash_container,
+            trash_location=(
+                trash_location if trash_location is not None else self.trash_container
+            ),
         )
         if transfer_args.tip_policy == TransferTipPolicyV2.PER_SOURCE:
             raise RuntimeError(
@@ -1653,6 +1657,8 @@ class InstrumentContext(publisher.CommandPublisher):
         using the specified liquid class properties.
 
         TODO: Add args description.
+
+        :meta private:
         """
         if not isinstance(dest, labware.Well):
             raise ValueError(
@@ -1665,9 +1671,9 @@ class InstrumentContext(publisher.CommandPublisher):
             last_tip_picked_up_from=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             current_volume=self.current_volume,
-            trash_location=trash_location
-            if trash_location is not None
-            else self.trash_container,
+            trash_location=(
+                trash_location if trash_location is not None else self.trash_container
+            ),
         )
         if transfer_args.tip_policy == TransferTipPolicyV2.PER_SOURCE:
             raise RuntimeError(
@@ -2078,11 +2084,15 @@ class InstrumentContext(publisher.CommandPublisher):
     @requires_version(2, 0)
     def name(self) -> str:
         """
-        The name string for the pipette (e.g., ``"p300_single"``).
+        The name string for the pipette.
 
-        From API v2.15 to v2.22, this property returned an internal name for Flex pipettes.
-        From API v2.23 onwards, this behavior is fixed so that this property returns
-        the Python Protocol API load names of Flex pipettes.
+        From API version 2.15 to 2.22, this property returned an internal name for Flex
+        pipettes. (e.g., ``"p1000_single_flex"``).
+
+        ..
+          In API version 2.23 and later, this property returns the Python Protocol API
+          :ref:`load name <new-pipette-models>` of Flex pipettes (e.g.,
+          ``"flex_1channel_1000"``).
         """
         return self._core.get_pipette_name()
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -695,6 +695,8 @@ class Labware:
             automatically.
 
         :return: The initialized and loaded labware object representing the Lid Stack.
+
+        :meta private:
         """
         if self._api_version < validation.LID_STACK_VERSION_GATE:
             raise APIVersionError(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -449,13 +449,16 @@ class ProtocolContext(CommandPublisher):
             values as the ``load_name`` parameter of :py:meth:`.load_adapter`. The
             adapter will use the same namespace as the labware, and the API will
             choose the adapter's version automatically.
-        :param lid: A lid to load the on top of the main labware. Accepts the same
-            values as the ``load_name`` parameter of :py:meth:`.load_lid_stack`. The
-            lid will use the same namespace as the labware, and the API will
-            choose the lid's version automatically.
 
                         .. versionadded:: 2.15
         """
+        # TODO: re-include in docstring when 2.23 is ready
+        #         :param lid: A lid to load the on top of the main labware. Accepts the same
+        #             values as the ``load_name`` parameter of :py:meth:`.load_lid_stack`. The
+        #             lid will use the same namespace as the labware, and the API will
+        #             choose the lid's version automatically.
+        #
+        #                         .. versionadded:: 2.23
         if isinstance(location, OffDeckType) and self._api_version < APIVersion(2, 15):
             raise APIVersionError(
                 api_element="Loading a labware off-deck",
@@ -865,7 +868,8 @@ class ProtocolContext(CommandPublisher):
                   .. versionchanged:: 2.15
                     Added ``MagneticBlockContext`` return value.
 
-                  .. versionchanged:: 2.23
+                  .. TODO uncomment when 2.23 is ready
+                    versionchanged:: 2.23
                     Added ``FlexStackerModuleContext`` return value.
         """
         if configuration:
@@ -1357,7 +1361,11 @@ class ProtocolContext(CommandPublisher):
         self,
         name: str,
     ) -> LiquidClass:
-        """Define a liquid class for use in the protocol."""
+        """
+        Define a liquid class for use in the protocol.
+
+        :meta private:
+        """
         return self._core.define_liquid_class(name=name)
 
     @property
@@ -1411,6 +1419,8 @@ class ProtocolContext(CommandPublisher):
             automatically.
 
         :return:  The initialized and loaded labware object representing the Lid Stack.
+
+        :meta private:
         """
         if self._api_version < validation.LID_STACK_VERSION_GATE:
             raise APIVersionError(
@@ -1504,6 +1514,8 @@ class ProtocolContext(CommandPublisher):
         Before moving a lid to or from a labware in a hardware module, make sure that the
         labware's current and new locations are accessible, i.e., open the Thermocycler lid
         or open the Heater-Shaker's labware latch.
+
+        :meta private:
         """
         source: Union[LabwareCore, DeckSlotName, StagingSlotName]
         if isinstance(source_location, Labware):


### PR DESCRIPTION

# Overview

Getting 2.23 features out of `edge` documentation build. These should be re-added when we have a feature branch for robot software that runs 2.23 (see RTC-706).

## Test Plan and Hands on Testing

[API ref sandbox](http://sandbox.docs.opentrons.com/docs-hide-future-2.23/v2/new_protocol_api.html) — no occurrences of the string `2.23` appearing on that page now

## Changelog

- Added `:meta private:` to liquid class and resin tip methods.
- Used RST and Python comments to hide additions to existing methods.
- `black` did some other formatting. Changes outside of docstrings are cosmetic only.

## Review requests

Check that we haven't hidden too much or too little. Also make sure that these features aren't described outside of the API Reference on this branch.

## Risk assessment

low