### PR TITLE
fix(shared-data): Zero out cornerOffsetFromSlot in opentrons_tough_pcr_auto_sealing_lid

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -1265,7 +1265,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -1433,7 +1433,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -1605,7 +1605,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -1781,7 +1781,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -1961,7 +1961,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d16d5dbf0][Flex_X_v2_21_tc_lids_wrong_target].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d16d5dbf0][Flex_X_v2_21_tc_lids_wrong_target].json
@@ -2035,7 +2035,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -2202,7 +2202,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -2373,7 +2373,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -2548,7 +2548,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -2727,7 +2727,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[99c15c6c62][Flex_S_v2_21_tc_lids_happy_path].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[99c15c6c62][Flex_S_v2_21_tc_lids_happy_path].json
@@ -121,7 +121,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -288,7 +288,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,
@@ -459,7 +459,7 @@
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
-            "z": -0.71
+            "z": 0
           },
           "dimensions": {
             "xDimension": 127.7,

--- a/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
@@ -26,7 +26,7 @@
   "cornerOffsetFromSlot": {
     "x": 0,
     "y": 0,
-    "z": -0.71
+    "z": 0
   },
   "parameters": {
     "format": "irregular",

--- a/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/2.json
+++ b/shared-data/labware/definitions/3/opentrons_tough_pcr_auto_sealing_lid/2.json
@@ -26,7 +26,7 @@
   "cornerOffsetFromSlot": {
     "x": 0,
     "y": 0,
-    "z": -0.71
+    "z": 0
   },
   "parameters": {
     "format": "irregular",


### PR DESCRIPTION
## Overview

Currently, `opentrons_tough_pcr_auto_sealing_lid` has a `cornerOffsetFromSlot` of (0, 0, -0.71). So, hypothetically, if you placed it in a deck slot, its bottom would be 0.71 mm "underground," below the deck. This seems wrong.

It seems like this was part of a snafu related to gripper offsets. Investigation is ongoing in EXEC-1268, which you should read for some background. But it seems clear at this point that `cornerOffsetFromSlot`, at least, ought to be zero.

## Test Plan and Hands on Testing

* [x] Robot behavior is unchanged.
  * As described in EXEC-1268, the robot always behaved as if this offset was (0, 0, 0) because of an unrelated bug, EXEC-1285.

## Changelog

* Zero out `cornerOffsetFromSlot` in the as-yet-unreleased v2 of this definition.
* Zero out `cornerOffsetFromSlot` in v1 of this definition, which *has* already been released.

  This is "bad"; we should usually not change definitions retroactively like this. I think it's justified in this case because someday we will fix EXEC-1285 (intentionally or not), so if we leave the offset in place, we're setting ourselves up for a change in behavior in the future. Better to nip it in the bud now, when this feature is still new.
  
  Also, @CaseyBatten changed the definition in #17683, and if he can do it then so can I. :P

  But this isn't a hill I'll die on. I'm happy to keep the offset in the v1 definition if we accept the risk of it making more of a mess in the future.

## Review requests

* OK with adjusting the already-released v1 of this definition?
* Any more insight to add to the investigation in EXEC-1268?

## Risk assessment

Low.