### PR TITLE
feat(app): display correct creation method for PD protocol exported i…

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -187,6 +187,23 @@ describe('ProtocolDetails', () => {
     screen.getByRole('heading', { name: 'creation method' })
     screen.getByText('Protocol Designer 6.0')
   })
+  it('renders the protocol creation method for py protocol made in PD', () => {
+    render({
+      mostRecentAnalysis: {
+        ...mockMostRecentAnalysis,
+        createdAt,
+        metadata: {
+          ...mockMostRecentAnalysis.metadata,
+          protocolDesigner: '8.0.0',
+        },
+        config: {
+          ...mockMostRecentAnalysis.config,
+        },
+      },
+    })
+    screen.getByRole('heading', { name: 'creation method' })
+    screen.getByText('Protocol Designer 8.0')
+  })
   it('renders the last analyzed date', () => {
     render({
       mostRecentAnalysis: {

--- a/app/src/organisms/Desktop/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -194,7 +194,7 @@ describe('ProtocolDetails', () => {
         createdAt,
         metadata: {
           ...mockMostRecentAnalysis.metadata,
-          protocolDesigner: '8.0.0',
+          protocolDesigner: '8.11.22',
         },
         config: {
           ...mockMostRecentAnalysis.config,

--- a/app/src/organisms/Desktop/ProtocolDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/index.tsx
@@ -311,11 +311,6 @@ export function ProtocolDetails(
       }
     }
   }
-  console.log(
-    'config',
-    mostRecentAnalysis?.config,
-    mostRecentAnalysis?.metadata
-  )
 
   const creationMethod =
     mostRecentAnalysis != null

--- a/app/src/organisms/Desktop/ProtocolDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/index.tsx
@@ -290,22 +290,39 @@ export function ProtocolDetails(
     mostRecentAnalysis
   )
 
-  const getCreationMethod = (config: JsonConfig | PythonConfig): string => {
+  const getCreationMethod = (
+    config: JsonConfig | PythonConfig,
+    metadata: { [key: string]: any }
+  ): string => {
     if (config.protocolType === 'json') {
       return t('protocol_designer_version', {
         version: config.schemaVersion.toFixed(1),
       })
     } else {
-      return t('python_api_version', {
-        version:
-          config.apiVersion != null ? config.apiVersion?.join('.') : null,
-      })
+      if ('protocolDesigner' in metadata) {
+        return t('protocol_designer_version', {
+          version: parseInt(metadata.protocolDesigner).toFixed(1),
+        })
+      } else {
+        return t('python_api_version', {
+          version:
+            config.apiVersion != null ? config.apiVersion?.join('.') : null,
+        })
+      }
     }
   }
+  console.log(
+    'config',
+    mostRecentAnalysis?.config,
+    mostRecentAnalysis?.metadata
+  )
 
   const creationMethod =
     mostRecentAnalysis != null
-      ? getCreationMethod(mostRecentAnalysis.config) ?? t('shared:no_data')
+      ? getCreationMethod(
+          mostRecentAnalysis.config,
+          mostRecentAnalysis.metadata
+        ) ?? t('shared:no_data')
       : t('shared:no_data')
   const author =
     mostRecentAnalysis != null

--- a/app/src/organisms/Desktop/ProtocolDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/index.tsx
@@ -301,7 +301,7 @@ export function ProtocolDetails(
     } else {
       if ('protocolDesigner' in metadata) {
         return t('protocol_designer_version', {
-          version: parseInt(metadata.protocolDesigner).toFixed(1),
+          version: parseInt(metadata.protocolDesigner as string).toFixed(1),
         })
       } else {
         return t('python_api_version', {


### PR DESCRIPTION
…n py

closes AUTH-1525

# Overview

If a protocol was made in PD and downloaded in py, we want the creation method to reflect the PD schema version

<img width="934" alt="Screenshot 2025-03-11 at 14 56 03" src="https://github.com/user-attachments/assets/ea328a88-c397-4664-b8b7-8158a9337ac4" />

## Test Plan and Hands on Testing

Review the code and test uploading to the app. look at the protocol details's creation method. here is a protocol you can test with:

[ot2AllModules.py.zip](https://github.com/user-attachments/files/19196545/ot2AllModules.py.zip)

## Changelog

- add logic for reading the `protocolDesigner` metadata
- add test case

## Risk assessment

low, shouldn't encounter this in prod
