### PR TITLE
refactor(step-generation): make dropTipInTrash a compound command instead of a util function

### DIFF
--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -2502,6 +2502,29 @@ describe('consolidate single-channel', () => {
             seconds: 11,
           },
         },
+
+        // Should drop tip at the end
+        {
+          commandType: 'moveToAddressableAreaForDropTip',
+          key: expect.any(String),
+          params: {
+            addressableAreaName: 'movableTrashA3',
+            alternateDropLocation: true,
+            offset: {
+              x: 0,
+              y: 0,
+              z: 0,
+            },
+            pipetteId: 'p300SingleId',
+          },
+        },
+        {
+          commandType: 'dropTipInPlace',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+          },
+        },
       ])
     })
 
@@ -3285,6 +3308,28 @@ describe('consolidate single-channel', () => {
           key: expect.any(String),
           params: {
             seconds: 11,
+          },
+        },
+        // Should drop tip at the end
+        {
+          commandType: 'moveToAddressableAreaForDropTip',
+          key: expect.any(String),
+          params: {
+            addressableAreaName: 'movableTrashA3',
+            alternateDropLocation: true,
+            offset: {
+              x: 0,
+              y: 0,
+              z: 0,
+            },
+            pipetteId: 'p300SingleId',
+          },
+        },
+        {
+          commandType: 'dropTipInPlace',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
           },
         },
       ])

--- a/step-generation/src/__tests__/dropTipInTrash.test.ts
+++ b/step-generation/src/__tests__/dropTipInTrash.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  getInitialRobotStateStandard,
+  getSuccessResult,
+  makeContext,
+} from '../fixtures'
+import { dropTipInTrash } from '../commandCreators/compound/dropTipInTrash'
+import type { InvariantContext, PipetteEntities, RobotState } from '../types'
+
+vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
+
+const mockTrashBinId = 'mockTrashBinId'
+const mockId = 'mockId'
+
+const mockPipEntities: PipetteEntities = {
+  [mockId]: {
+    name: 'p50_single_flex',
+    id: mockId,
+    spec: { channels: 1 },
+  },
+} as any
+const mockCutout = 'cutoutA3'
+const invariantContext: InvariantContext = {
+  ...makeContext(),
+  pipetteEntities: mockPipEntities,
+  additionalEquipmentEntities: {
+    [mockTrashBinId]: {
+      name: 'trashBin' as const,
+      location: mockCutout,
+      id: mockTrashBinId,
+    },
+  },
+}
+const prevRobotState: RobotState = {
+  ...getInitialRobotStateStandard(invariantContext),
+  tipState: { pipettes: { [mockId]: true } } as any,
+}
+
+describe('dropTipInTrash', () => {
+  it('returns correct commands for drop tip', () => {
+    const args = {
+      pipetteId: mockId,
+    }
+    const result = dropTipInTrash(args, invariantContext, prevRobotState)
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'moveToAddressableAreaForDropTip',
+        key: expect.any(String),
+        params: {
+          pipetteId: mockId,
+          addressableAreaName: 'movableTrashA3',
+          offset: { x: 0, y: 0, z: 0 },
+          alternateDropLocation: true,
+        },
+      },
+      {
+        commandType: 'dropTipInPlace',
+        key: expect.any(String),
+        params: {
+          pipetteId: mockId,
+        },
+      },
+    ])
+  })
+})

--- a/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
@@ -5,15 +5,12 @@ import {
   airGapInMovableTrash,
   blowOutInMovableTrash,
   dispenseInMovableTrash,
-  dropTipInMovableTrash,
 } from '../utils/movableTrashCommandsUtil'
 import {
   airGapInPlace,
   blowOutInPlace,
   dispenseInPlace,
-  dropTipInPlace,
   moveToAddressableArea,
-  moveToAddressableAreaForDropTip,
   prepareToAspirate,
 } from '../commandCreators/atomic'
 import type { PipetteEntities } from '../types'
@@ -79,25 +76,6 @@ describe('movableTrashCommandsUtil', () => {
       pipetteId: mockId,
 
       flowRate: 10,
-    })
-  })
-  it('returns correct commands for drop tip', () => {
-    dropTipInMovableTrash({
-      ...args,
-      prevRobotState: {
-        ...args.prevRobotState,
-        tipState: { pipettes: { [mockId]: true } } as any,
-      },
-    })
-    expect(curryCommandCreator).toHaveBeenCalledWith(
-      moveToAddressableAreaForDropTip,
-      {
-        pipetteId: mockId,
-        addressableAreaName: 'movableTrashA3',
-      }
-    )
-    expect(curryCommandCreator).toHaveBeenCalledWith(dropTipInPlace, {
-      pipetteId: mockId,
     })
   })
   it('returns correct commands for aspirate in place (air gap)', () => {

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -9,7 +9,7 @@ import {
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
-import { dropTipInMovableTrash } from '../../utils/movableTrashCommandsUtil'
+import { dropTipInTrash } from './dropTipInTrash'
 import {
   blowoutUtil,
   curryCommandCreator,
@@ -495,11 +495,9 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         })
       }
       if (isTrashBin) {
-        dropTipCommand = dropTipInMovableTrash({
-          pipetteId: args.pipette,
-          prevRobotState,
-          invariantContext,
-        })
+        dropTipCommand = [
+          curryCommandCreator(dropTipInTrash, { pipetteId: args.pipette }),
+        ]
       }
 
       // if using dispense > air gap, drop or change the tip at the end

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -10,7 +10,7 @@ import {
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
-import { dropTipInMovableTrash } from '../../utils/movableTrashCommandsUtil'
+import { dropTipInTrash } from './dropTipInTrash'
 import {
   curryCommandCreator,
   reduceCommandCreators,
@@ -410,11 +410,9 @@ export const distribute: CommandCreator<DistributeArgs> = (
         })
       }
       if (isTrashBin) {
-        dropTipCommand = dropTipInMovableTrash({
-          pipetteId: args.pipette,
-          prevRobotState,
-          invariantContext,
-        })
+        dropTipCommand = [
+          curryCommandCreator(dropTipInTrash, { pipetteId: args.pipette }),
+        ]
       }
 
       // if using dispense > air gap, drop or change the tip at the end

--- a/step-generation/src/commandCreators/compound/dropTipInTrash.ts
+++ b/step-generation/src/commandCreators/compound/dropTipInTrash.ts
@@ -1,0 +1,42 @@
+import {
+  getTrashBinAddressableAreaName,
+  curryCommandCreator,
+  reduceCommandCreators,
+} from '../../utils'
+import { moveToAddressableAreaForDropTip } from '../atomic/moveToAddressableAreaForDropTip'
+import { dropTipInPlace } from '../atomic/dropTipInPlace'
+import type { CurriedCommandCreator, CommandCreator } from '../../types'
+import type { DropTipInPlaceParams } from '@opentrons/shared-data'
+
+export const dropTipInTrash: CommandCreator<DropTipInPlaceParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { pipetteId } = args
+  let commandCreators: CurriedCommandCreator[] = []
+  const addressableAreaName = getTrashBinAddressableAreaName(
+    invariantContext.additionalEquipmentEntities
+  )
+  if (addressableAreaName == null) {
+    console.error('could not getTrashBinAddressableAreaName for dropTip')
+  } else if (prevRobotState.tipState.pipettes[pipetteId]) {
+    commandCreators = [
+      curryCommandCreator(moveToAddressableAreaForDropTip, {
+        pipetteId,
+        addressableAreaName,
+      }),
+      curryCommandCreator(dropTipInPlace, {
+        pipetteId,
+      }),
+      // TODO:
+      // CommandCreator to emit Python pipette.drop_tip() would go here
+    ]
+  }
+
+  return reduceCommandCreators(
+    commandCreators,
+    invariantContext,
+    prevRobotState
+  )
+}

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -226,7 +226,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
   if (isTrashBin) {
     commandCreators = [
       curryCommandCreator(dropTipInTrash, {
-        pipetteId: args.pipette,
+        pipetteId: pipette,
       }),
       ...configureNozzleLayoutCommand,
       curryCommandCreator(pickUpTip, {

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -6,7 +6,7 @@ import {
 } from '@opentrons/shared-data'
 import { getNextTiprack } from '../../robotStateSelectors'
 import * as errorCreators from '../../errorCreators'
-import { dropTipInMovableTrash } from '../../utils/movableTrashCommandsUtil'
+import { dropTipInTrash } from './dropTipInTrash'
 import {
   curryCommandCreator,
   getIsHeaterShakerEastWestMultiChannelPipette,
@@ -225,10 +225,8 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
   }
   if (isTrashBin) {
     commandCreators = [
-      ...dropTipInMovableTrash({
-        pipetteId: pipette,
-        prevRobotState,
-        invariantContext,
+      curryCommandCreator(dropTipInTrash, {
+        pipetteId: args.pipette,
       }),
       ...configureNozzleLayoutCommand,
       curryCommandCreator(pickUpTip, {

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -8,7 +8,7 @@ import {
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
-import { dropTipInMovableTrash } from '../../utils/movableTrashCommandsUtil'
+import { dropTipInTrash } from './dropTipInTrash'
 import {
   blowoutUtil,
   curryCommandCreator,
@@ -572,11 +572,9 @@ export const transfer: CommandCreator<TransferArgs> = (
             })
           }
           if (isTrashBin) {
-            dropTipCommand = dropTipInMovableTrash({
-              pipetteId: args.pipette,
-              invariantContext,
-              prevRobotState,
-            })
+            dropTipCommand = [
+              curryCommandCreator(dropTipInTrash, { pipetteId: args.pipette }),
+            ]
           }
 
           // if using dispense > air gap, drop or change the tip at the end

--- a/step-generation/src/utils/movableTrashCommandsUtil.ts
+++ b/step-generation/src/utils/movableTrashCommandsUtil.ts
@@ -2,9 +2,7 @@ import {
   airGapInPlace,
   blowOutInPlace,
   dispenseInPlace,
-  dropTipInPlace,
   moveToAddressableArea,
-  moveToAddressableAreaForDropTip,
   prepareToAspirate,
 } from '../commandCreators/atomic'
 import { ZERO_OFFSET } from '../constants'
@@ -47,33 +45,6 @@ export function airGapInMovableTrash(args: {
       pipetteId,
       volume,
       flowRate,
-    }),
-  ]
-}
-
-export function dropTipInMovableTrash(args: {
-  pipetteId: string
-  invariantContext: InvariantContext
-  prevRobotState: RobotState
-}): CurriedCommandCreator[] {
-  const { pipetteId, invariantContext, prevRobotState } = args
-  const addressableAreaName = getTrashBinAddressableAreaName(
-    invariantContext.additionalEquipmentEntities
-  )
-  if (addressableAreaName == null) {
-    console.error('could not getTrashBinAddressableAreaName for dropTip')
-    return []
-  }
-  if (!prevRobotState.tipState.pipettes[pipetteId]) {
-    return []
-  }
-  return [
-    curryCommandCreator(moveToAddressableAreaForDropTip, {
-      pipetteId,
-      addressableAreaName,
-    }),
-    curryCommandCreator(dropTipInPlace, {
-      pipetteId,
     }),
   ]
 }


### PR DESCRIPTION
# Overview

Previously, we had a util function in `movableTrashCommandsUtil.ts` to drop a tip into the trash bin. This PR changes it to a compound command to fit the pattern of our other `CommandCreators`, and to make it easier to implement Python generation for drop-tip later. AUTH-1541

While working on this refactoring, we discovered that the previous implementation was not dropping the tip at the end of `consolidate()` like it should have because the previous implementation was passing a stale copy of `prevRobotState` to the util function. After this refactoring, we do drop tip at the end of `consolidate` as intended, so this PR also updates `consolidate.test.ts`. 

## Test Plan and Hands on Testing

I'm relying on the existing unit tests to check that `dropTipInTrash` continues to work as expected.

I migrated the `dropTipInTrash` test from `movableTrashCommandsUtil.test.ts` to `dropTipInTrash.test.ts` and reformatted it to be a compound command test.

I updated `consolidate.test.ts` to expect drop-tip at the end of `consolidate()`, which is the behavior we expect.

## Risk assessment

Medium low. In isolated tests, this change will make us drop-tip where we were failing to do so before. But in practice, users will not see a difference, because we've also always had a separate "eager" drop-tip mechanism that added a drop-tip to protocols even when we were failing to generate one before.