### PR TITLE
refactor(step-generation): make dropTipInWasteChute a compound command

### DIFF
--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -148,6 +148,7 @@ describe('consolidate single-channel', () => {
     const res = getSuccessResult(result)
 
     expect(res.commands).toEqual([
+      //  drop tip from return tip
       {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),
@@ -174,6 +175,7 @@ describe('consolidate single-channel', () => {
       dispenseHelper('B1', 100),
       makeMoveToWellHelper('B1', DEST_LABWARE),
       ...makeAirGapHelper(5),
+      //   drop tip at end
       {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),

--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -144,16 +144,56 @@ describe('consolidate single-channel', () => {
       },
     }
 
-    const result = consolidate(data, invariantContext, initialRobotState)
+    const result = consolidate(data, invariantContext, robotStatePickedUpOneTip)
     const res = getSuccessResult(result)
 
     expect(res.commands).toEqual([
-      pickUpTipHelper('A1'),
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.any(String),
+        params: {
+          addressableAreaName: '1ChannelWasteChute',
+          offset: {
+            x: 0,
+            y: 0,
+            z: 0,
+          },
+          pipetteId: 'p300SingleId',
+        },
+      },
+      {
+        commandType: 'dropTipInPlace',
+        key: expect.any(String),
+        params: {
+          pipetteId: 'p300SingleId',
+        },
+      },
+      pickUpTipHelper('B1'),
       aspirateHelper('A1', 50),
       aspirateHelper('A2', 50),
       dispenseHelper('B1', 100),
       makeMoveToWellHelper('B1', DEST_LABWARE),
       ...makeAirGapHelper(5),
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.any(String),
+        params: {
+          addressableAreaName: '1ChannelWasteChute',
+          offset: {
+            x: 0,
+            y: 0,
+            z: 0,
+          },
+          pipetteId: 'p300SingleId',
+        },
+      },
+      {
+        commandType: 'dropTipInPlace',
+        key: expect.any(String),
+        params: {
+          pipetteId: 'p300SingleId',
+        },
+      },
     ])
   })
 

--- a/step-generation/src/__tests__/dropTipInWasteChute.test.ts
+++ b/step-generation/src/__tests__/dropTipInWasteChute.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
+import { getSuccessResult, makeContext } from '../fixtures'
+import { dropTipInWasteChute } from '../commandCreators'
+import type { AddressableAreaName } from '@opentrons/shared-data'
+
+import type { InvariantContext, PipetteEntities, RobotState } from '../types'
+
+vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
+
+const mockWasteChuteId = 'mockWasteChuteId'
+const mockId = 'mockId'
+
+const mockPipEntities: PipetteEntities = {
+  [mockId]: {
+    name: 'p50_single_flex',
+    id: mockId,
+    spec: { channels: 1 },
+  },
+} as any
+
+const invariantContext: InvariantContext = {
+  ...makeContext(),
+  pipetteEntities: mockPipEntities,
+  additionalEquipmentEntities: {
+    [mockWasteChuteId]: {
+      name: 'wasteChute' as const,
+      location: WASTE_CHUTE_CUTOUT,
+      id: mockWasteChuteId,
+    },
+  },
+}
+const prevRobotState: RobotState = {
+  tipState: { pipettes: { [mockId]: true } } as any,
+} as any
+
+describe('dropTipInWasteChute', () => {
+  it('returns correct commands for drop tip', () => {
+    const args = {
+      pipetteId: mockId,
+      addressableAreaName: '1ChannelWasteChute' as AddressableAreaName,
+    }
+    const result = dropTipInWasteChute(args, invariantContext, prevRobotState)
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.any(String),
+        params: {
+          pipetteId: mockId,
+          addressableAreaName: '1ChannelWasteChute',
+          offset: { x: 0, y: 0, z: 0 },
+        },
+      },
+      {
+        commandType: 'dropTipInPlace',
+        key: expect.any(String),
+        params: {
+          pipetteId: mockId,
+        },
+      },
+    ])
+  })
+})

--- a/step-generation/src/__tests__/dropTipInWasteChute.test.ts
+++ b/step-generation/src/__tests__/dropTipInWasteChute.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from 'vitest'
 import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import { getSuccessResult, makeContext } from '../fixtures'
 import { dropTipInWasteChute } from '../commandCreators'
-import type { AddressableAreaName } from '@opentrons/shared-data'
 
 import type { InvariantContext, PipetteEntities, RobotState } from '../types'
 
@@ -38,7 +37,6 @@ describe('dropTipInWasteChute', () => {
   it('returns correct commands for drop tip', () => {
     const args = {
       pipetteId: mockId,
-      addressableAreaName: '1ChannelWasteChute' as AddressableAreaName,
     }
     const result = dropTipInWasteChute(args, invariantContext, prevRobotState)
     expect(getSuccessResult(result).commands).toEqual([

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -129,6 +129,8 @@ describe('pick up tip if no tip on pipette', () => {
       },
     }
 
+    robotStateWithTip.tipState.pipettes.p300SingleId = true
+
     noTipArgs = {
       ...noTipArgs,
       changeTip: 'always',
@@ -140,11 +142,54 @@ describe('pick up tip if no tip on pipette', () => {
 
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.any(String),
+
+        params: {
+          addressableAreaName: '1ChannelWasteChute',
+          offset: {
+            x: 0,
+            y: 0,
+            z: 0,
+          },
+          pipetteId: 'p300SingleId',
+        },
+      },
+      {
+        commandType: 'dropTipInPlace',
+        key: expect.any(String),
+
+        params: {
+          pipetteId: 'p300SingleId',
+        },
+      },
       pickUpTipHelper('A1'),
       aspirateHelper('A1', 30),
       dispenseHelper('B2', 30),
       makeMoveToWellHelper('B2', 'destPlateId'),
       ...makeAirGapHelper(5),
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.any(String),
+        params: {
+          addressableAreaName: '1ChannelWasteChute',
+          offset: {
+            x: 0,
+            y: 0,
+            z: 0,
+          },
+          pipetteId: 'p300SingleId',
+        },
+      },
+      {
+        commandType: 'dropTipInPlace',
+        key: expect.any(String),
+
+        params: {
+          pipetteId: 'p300SingleId',
+        },
+      },
     ])
   })
 

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -142,6 +142,7 @@ describe('pick up tip if no tip on pipette', () => {
 
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
+      //   drop tip from return tip
       {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),
@@ -169,6 +170,7 @@ describe('pick up tip if no tip on pipette', () => {
       dispenseHelper('B2', 30),
       makeMoveToWellHelper('B2', 'destPlateId'),
       ...makeAirGapHelper(5),
+      //   drop tip at end
       {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),

--- a/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
@@ -3,15 +3,15 @@ import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 import { curryCommandCreator } from '../utils'
 import { wasteChuteCommandsUtil } from '../utils/wasteChuteCommandsUtil'
-import type { PipetteEntities } from '../types'
+import { dropTipInWasteChute } from '../commandCreators'
 import {
   airGapInPlace,
   blowOutInPlace,
   dispenseInPlace,
-  dropTipInPlace,
   moveToAddressableArea,
   prepareToAspirate,
 } from '../commandCreators/atomic'
+import type { PipetteEntities } from '../types'
 
 vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
 vi.mock('../utils/curryCommandCreator')
@@ -85,27 +85,16 @@ describe('wasteChuteCommandsUtil', () => {
     wasteChuteCommandsUtil({
       ...args,
       type: 'dropTip',
-      prevRobotState: {
-        ...args.prevRobotState,
-        tipState: { pipettes: { [mockId]: true } } as any,
-      },
     })
-    expect(curryCommandCreator).toHaveBeenCalledWith(
-      moveToAddressableArea,
-      mockMoveToAddressableAreaParams
-    )
-    expect(curryCommandCreator).toHaveBeenCalledWith(dropTipInPlace, {
+    expect(curryCommandCreator).toHaveBeenCalledWith(dropTipInWasteChute, {
       pipetteId: mockId,
+      addressableAreaName: mockAddressableAreaName,
     })
   })
   it('returns correct commands for air gap/aspirate in place', () => {
     wasteChuteCommandsUtil({
       ...args,
       type: 'airGap',
-      prevRobotState: {
-        ...args.prevRobotState,
-        tipState: { pipettes: { [mockId]: true } } as any,
-      },
     })
     expect(curryCommandCreator).toHaveBeenCalledWith(
       moveToAddressableArea,

--- a/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import { getInitialRobotStateStandard, makeContext } from '../fixtures'
-import { curryCommandCreator } from '../utils'
-import { wasteChuteCommandsUtil } from '../utils/wasteChuteCommandsUtil'
-import { dropTipInWasteChute } from '../commandCreators'
+import {
+  airGapInWasteChute,
+  blowoutInWasteChute,
+  curryCommandCreator,
+  dispenseInWasteChute,
+} from '../utils'
 import {
   airGapInPlace,
   blowOutInPlace,
@@ -56,7 +59,7 @@ describe('wasteChuteCommandsUtil', () => {
     }
   })
   it('returns correct commands for dispensing', () => {
-    wasteChuteCommandsUtil({ ...args, type: 'dispense' })
+    dispenseInWasteChute({ ...args })
     expect(curryCommandCreator).toHaveBeenCalledWith(
       moveToAddressableArea,
       mockMoveToAddressableAreaParams
@@ -68,9 +71,8 @@ describe('wasteChuteCommandsUtil', () => {
     })
   })
   it('returns correct commands for blow out', () => {
-    wasteChuteCommandsUtil({
+    blowoutInWasteChute({
       ...args,
-      type: 'blowOut',
     })
     expect(curryCommandCreator).toHaveBeenCalledWith(
       moveToAddressableArea,
@@ -81,20 +83,9 @@ describe('wasteChuteCommandsUtil', () => {
       flowRate: 10,
     })
   })
-  it('returns correct commands for drop tip', () => {
-    wasteChuteCommandsUtil({
-      ...args,
-      type: 'dropTip',
-    })
-    expect(curryCommandCreator).toHaveBeenCalledWith(dropTipInWasteChute, {
-      pipetteId: mockId,
-      addressableAreaName: mockAddressableAreaName,
-    })
-  })
   it('returns correct commands for air gap/aspirate in place', () => {
-    wasteChuteCommandsUtil({
+    airGapInWasteChute({
       ...args,
-      type: 'airGap',
     })
     expect(curryCommandCreator).toHaveBeenCalledWith(
       moveToAddressableArea,

--- a/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/wasteChuteCommandsUtil.test.ts
@@ -1,5 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
+import { describe, it, expect, vi } from 'vitest'
 import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 import {
   airGapInWasteChute,
@@ -19,45 +18,34 @@ import type { PipetteEntities } from '../types'
 vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
 vi.mock('../utils/curryCommandCreator')
 
-const mockWasteChuteId = 'mockWasteChuteId'
-const mockAddressableAreaName: 'A3' = 'A3'
 const mockId = 'mockId'
 
-let invariantContext = makeContext()
-const args = {
-  pipetteId: mockId,
-  addressableAreaName: mockAddressableAreaName,
-  volume: 10,
-  flowRate: 10,
-  prevRobotState: getInitialRobotStateStandard(invariantContext),
-}
-const mockMoveToAddressableAreaParams = {
-  pipetteId: mockId,
-  addressableAreaName: mockAddressableAreaName,
-  offset: { x: 0, y: 0, z: 0 },
-}
-
+const invariantContext = makeContext()
 const mockPipEntities: PipetteEntities = {
   [mockId]: {
     name: 'p50_single_flex',
     id: mockId,
+    spec: { channels: 1 },
   },
 } as any
 
+const args = {
+  pipetteId: mockId,
+  volume: 10,
+  flowRate: 10,
+  prevRobotState: getInitialRobotStateStandard(invariantContext),
+  invariantContext: {
+    ...invariantContext,
+    pipetteEntities: mockPipEntities,
+  },
+}
+const mockMoveToAddressableAreaParams = {
+  pipetteId: mockId,
+  addressableAreaName: '1ChannelWasteChute',
+  offset: { x: 0, y: 0, z: 0 },
+}
+
 describe('wasteChuteCommandsUtil', () => {
-  beforeEach(() => {
-    invariantContext = {
-      ...invariantContext,
-      pipetteEntities: mockPipEntities,
-      additionalEquipmentEntities: {
-        [mockWasteChuteId]: {
-          name: 'wasteChute',
-          location: WASTE_CHUTE_CUTOUT,
-          id: 'mockId',
-        },
-      },
-    }
-  })
   it('returns correct commands for dispensing', () => {
     dispenseInWasteChute({ ...args })
     expect(curryCommandCreator).toHaveBeenCalledWith(

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -490,7 +490,6 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         dropTipCommand = wasteChuteCommandsUtil({
           type: 'dropTip',
           pipetteId: args.pipette,
-          prevRobotState,
           addressableAreaName: addressableAreaNameWasteChute,
         })
       }

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -14,7 +14,6 @@ import {
   blowoutUtil,
   curryCommandCreator,
   reduceCommandCreators,
-  wasteChuteCommandsUtil,
   getTrashOrLabware,
   airGapHelper,
   dispenseLocationHelper,
@@ -34,6 +33,7 @@ import {
 } from '../atomic'
 import { mixUtil } from './mix'
 import { replaceTip } from './replaceTip'
+import { dropTipInWasteChute } from './dropTipInWasteChute'
 
 import type {
   ConsolidateArgs,
@@ -487,11 +487,12 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         }),
       ]
       if (isWasteChute) {
-        dropTipCommand = wasteChuteCommandsUtil({
-          type: 'dropTip',
-          pipetteId: args.pipette,
-          addressableAreaName: addressableAreaNameWasteChute,
-        })
+        dropTipCommand = [
+          curryCommandCreator(dropTipInWasteChute, {
+            pipetteId: args.pipette,
+            addressableAreaName: addressableAreaNameWasteChute,
+          }),
+        ]
       }
       if (isTrashBin) {
         dropTipCommand = dropTipInMovableTrash({

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -19,7 +19,6 @@ import {
   dispenseLocationHelper,
   moveHelper,
   getIsSafePipetteMovement,
-  getWasteChuteAddressableAreaNamePip,
   getHasWasteChute,
 } from '../../utils'
 import {
@@ -202,10 +201,6 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       null &&
     invariantContext.additionalEquipmentEntities[args.dropTipLocation].name ===
       'trashBin'
-  const channels = invariantContext.pipetteEntities[args.pipette].spec.channels
-  const addressableAreaNameWasteChute = getWasteChuteAddressableAreaNamePip(
-    channels
-  )
 
   const commandCreators = flatMap(
     sourceWellChunks,
@@ -490,7 +485,6 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         dropTipCommand = [
           curryCommandCreator(dropTipInWasteChute, {
             pipetteId: args.pipette,
-            addressableAreaName: addressableAreaNameWasteChute,
           }),
         ]
       }

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -15,7 +15,6 @@ import {
   curryCommandCreator,
   reduceCommandCreators,
   blowoutUtil,
-  wasteChuteCommandsUtil,
   getDispenseAirGapLocation,
   getIsSafePipetteMovement,
   getWasteChuteAddressableAreaNamePip,
@@ -34,6 +33,7 @@ import {
 } from '../atomic'
 import { mixUtil } from './mix'
 import { replaceTip } from './replaceTip'
+import { dropTipInWasteChute } from './dropTipInWasteChute'
 
 import type {
   DistributeArgs,
@@ -402,11 +402,12 @@ export const distribute: CommandCreator<DistributeArgs> = (
         }),
       ]
       if (isWasteChute) {
-        dropTipCommand = wasteChuteCommandsUtil({
-          type: 'dropTip',
-          pipetteId: args.pipette,
-          addressableAreaName: addressableAreaNameWasteChute,
-        })
+        dropTipCommand = [
+          curryCommandCreator(dropTipInWasteChute, {
+            pipetteId: args.pipette,
+            addressableAreaName: addressableAreaNameWasteChute,
+          }),
+        ]
       }
       if (isTrashBin) {
         dropTipCommand = dropTipInMovableTrash({

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -405,7 +405,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
         dropTipCommand = wasteChuteCommandsUtil({
           type: 'dropTip',
           pipetteId: args.pipette,
-          prevRobotState,
           addressableAreaName: addressableAreaNameWasteChute,
         })
       }

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -17,7 +17,6 @@ import {
   blowoutUtil,
   getDispenseAirGapLocation,
   getIsSafePipetteMovement,
-  getWasteChuteAddressableAreaNamePip,
   getHasWasteChute,
 } from '../../utils'
 import {
@@ -181,11 +180,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const isTrashBin =
     invariantContext.additionalEquipmentEntities[args.dropTipLocation]?.name ===
     'trashBin'
-
-  const channels = invariantContext.pipetteEntities[args.pipette].spec.channels
-  const addressableAreaNameWasteChute = getWasteChuteAddressableAreaNamePip(
-    channels
-  )
 
   if (maxWellsPerChunk === 0) {
     // distribute vol exceeds pipette vol
@@ -405,7 +399,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
         dropTipCommand = [
           curryCommandCreator(dropTipInWasteChute, {
             pipetteId: args.pipette,
-            addressableAreaName: addressableAreaNameWasteChute,
           }),
         ]
       }

--- a/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
@@ -1,0 +1,43 @@
+import { curryCommandCreator, reduceCommandCreators } from '../../utils'
+import { ZERO_OFFSET } from '../../constants'
+import { dropTipInPlace, moveToAddressableArea } from '../atomic'
+import type { AddressableAreaName } from '@opentrons/shared-data'
+import type { CommandCreator, CurriedCommandCreator } from '../../types'
+
+interface DropTipInWasteChuteArgs {
+  pipetteId: string
+  addressableAreaName: AddressableAreaName
+}
+
+export const dropTipInWasteChute: CommandCreator<DropTipInWasteChuteArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const offset = ZERO_OFFSET
+
+  const { pipetteId, addressableAreaName } = args
+
+  let commandCreators: CurriedCommandCreator[] = []
+
+  // No-op if there is no tip
+  if (!prevRobotState.tipState.pipettes[pipetteId]) {
+    commandCreators = []
+  }
+
+  commandCreators = [
+    curryCommandCreator(moveToAddressableArea, {
+      pipetteId,
+      addressableAreaName,
+      offset,
+    }),
+    curryCommandCreator(dropTipInPlace, {
+      pipetteId,
+    }),
+  ]
+  return reduceCommandCreators(
+    commandCreators,
+    invariantContext,
+    prevRobotState
+  )
+}

--- a/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
@@ -1,12 +1,14 @@
-import { curryCommandCreator, reduceCommandCreators } from '../../utils'
+import {
+  curryCommandCreator,
+  getWasteChuteAddressableAreaNamePip,
+  reduceCommandCreators,
+} from '../../utils'
 import { ZERO_OFFSET } from '../../constants'
 import { dropTipInPlace, moveToAddressableArea } from '../atomic'
-import type { AddressableAreaName } from '@opentrons/shared-data'
 import type { CommandCreator, CurriedCommandCreator } from '../../types'
 
 interface DropTipInWasteChuteArgs {
   pipetteId: string
-  addressableAreaName: AddressableAreaName
 }
 
 export const dropTipInWasteChute: CommandCreator<DropTipInWasteChuteArgs> = (
@@ -15,8 +17,12 @@ export const dropTipInWasteChute: CommandCreator<DropTipInWasteChuteArgs> = (
   prevRobotState
 ) => {
   const offset = ZERO_OFFSET
-
-  const { pipetteId, addressableAreaName } = args
+  const { pipetteId } = args
+  const pipetteChannels =
+    invariantContext.pipetteEntities[pipetteId].spec.channels
+  const addressableAreaName = getWasteChuteAddressableAreaNamePip(
+    pipetteChannels
+  )
 
   let commandCreators: CurriedCommandCreator[] = []
 

--- a/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
@@ -23,18 +23,18 @@ export const dropTipInWasteChute: CommandCreator<DropTipInWasteChuteArgs> = (
   // No-op if there is no tip
   if (!prevRobotState.tipState.pipettes[pipetteId]) {
     commandCreators = []
+  } else {
+    commandCreators = [
+      curryCommandCreator(moveToAddressableArea, {
+        pipetteId,
+        addressableAreaName,
+        offset,
+      }),
+      curryCommandCreator(dropTipInPlace, {
+        pipetteId,
+      }),
+    ]
   }
-
-  commandCreators = [
-    curryCommandCreator(moveToAddressableArea, {
-      pipetteId,
-      addressableAreaName,
-      offset,
-    }),
-    curryCommandCreator(dropTipInPlace, {
-      pipetteId,
-    }),
-  ]
   return reduceCommandCreators(
     commandCreators,
     invariantContext,

--- a/step-generation/src/commandCreators/compound/index.ts
+++ b/step-generation/src/commandCreators/compound/index.ts
@@ -2,6 +2,7 @@ export { absorbanceReaderCloseInitialize } from './absorbanceReaderCloseInitiali
 export { absorbanceReaderCloseRead } from './absorbanceReaderCloseRead'
 export { consolidate } from './consolidate'
 export { distribute } from './distribute'
+export { dropTipInWasteChute } from './dropTipInWasteChute'
 export { heaterShaker } from './heaterShaker'
 export { mix } from './mix'
 export { replaceTip } from './replaceTip'

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -212,7 +212,6 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
         type: 'dropTip',
         pipetteId: pipette,
         addressableAreaName: addressableAreaNameWasteChute,
-        prevRobotState,
       }),
       ...configureNozzleLayoutCommand,
       curryCommandCreator(pickUpTip, {

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -15,7 +15,6 @@ import {
   modulePipetteCollision,
   pipetteAdjacentHeaterShakerWhileShaking,
   reduceCommandCreators,
-  getWasteChuteAddressableAreaNamePip,
   PRIMARY_NOZZLE,
 } from '../../utils'
 import { dropTipInWasteChute } from './dropTipInWasteChute'
@@ -174,10 +173,6 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     }
   }
 
-  const addressableAreaNameWasteChute = getWasteChuteAddressableAreaNamePip(
-    channels
-  )
-
   const configureNozzleLayoutCommand: CurriedCommandCreator[] =
     //  only emit the command if previous nozzle state is different
     channels === 96 && args.nozzles != null && args.nozzles !== stateNozzles
@@ -210,7 +205,6 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     commandCreators = [
       curryCommandCreator(dropTipInWasteChute, {
         pipetteId: args.pipette,
-        addressableAreaName: addressableAreaNameWasteChute,
       }),
       ...configureNozzleLayoutCommand,
       curryCommandCreator(pickUpTip, {

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -15,10 +15,10 @@ import {
   modulePipetteCollision,
   pipetteAdjacentHeaterShakerWhileShaking,
   reduceCommandCreators,
-  wasteChuteCommandsUtil,
   getWasteChuteAddressableAreaNamePip,
   PRIMARY_NOZZLE,
 } from '../../utils'
+import { dropTipInWasteChute } from './dropTipInWasteChute'
 import { dropTip } from '../atomic/dropTip'
 import { pickUpTip } from '../atomic/pickUpTip'
 import { configureNozzleLayout } from '../atomic/configureNozzleLayout'
@@ -208,9 +208,8 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
   ]
   if (isWasteChute) {
     commandCreators = [
-      ...wasteChuteCommandsUtil({
-        type: 'dropTip',
-        pipetteId: pipette,
+      curryCommandCreator(dropTipInWasteChute, {
+        pipetteId: args.pipette,
         addressableAreaName: addressableAreaNameWasteChute,
       }),
       ...configureNozzleLayoutCommand,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -14,7 +14,6 @@ import {
   curryCommandCreator,
   airGapHelper,
   reduceCommandCreators,
-  wasteChuteCommandsUtil,
   getTrashOrLabware,
   dispenseLocationHelper,
   moveHelper,
@@ -40,6 +39,7 @@ import type {
   CommandCreator,
   CommandCreatorError,
 } from '../../types'
+import { dropTipInWasteChute } from './dropTipInWasteChute'
 
 export const transfer: CommandCreator<TransferArgs> = (
   args,
@@ -564,11 +564,12 @@ export const transfer: CommandCreator<TransferArgs> = (
             }),
           ]
           if (isWasteChute) {
-            dropTipCommand = wasteChuteCommandsUtil({
-              type: 'dropTip',
-              pipetteId: args.pipette,
-              addressableAreaName: addressableAreaNameWasteChute,
-            })
+            dropTipCommand = [
+              curryCommandCreator(dropTipInWasteChute, {
+                pipetteId: args.pipette,
+                addressableAreaName: addressableAreaNameWasteChute,
+              }),
+            ]
           }
           if (isTrashBin) {
             dropTipCommand = dropTipInMovableTrash({

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -567,7 +567,6 @@ export const transfer: CommandCreator<TransferArgs> = (
             dropTipCommand = wasteChuteCommandsUtil({
               type: 'dropTip',
               pipetteId: args.pipette,
-              prevRobotState,
               addressableAreaName: addressableAreaNameWasteChute,
             })
           }

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -17,7 +17,6 @@ import {
   getTrashOrLabware,
   dispenseLocationHelper,
   moveHelper,
-  getWasteChuteAddressableAreaNamePip,
   getHasWasteChute,
 } from '../../utils'
 import {
@@ -178,10 +177,6 @@ export const transfer: CommandCreator<TransferArgs> = (
       null &&
     invariantContext.additionalEquipmentEntities[args.dropTipLocation].name ===
       'trashBin'
-
-  const addressableAreaNameWasteChute = getWasteChuteAddressableAreaNamePip(
-    pipetteSpec.channels
-  )
 
   const aspirateAirGapVolume = args.aspirateAirGapVolume || 0
   const dispenseAirGapVolume = args.dispenseAirGapVolume || 0
@@ -567,7 +562,6 @@ export const transfer: CommandCreator<TransferArgs> = (
             dropTipCommand = [
               curryCommandCreator(dropTipInWasteChute, {
                 pipetteId: args.pipette,
-                addressableAreaName: addressableAreaNameWasteChute,
               }),
             ]
           }

--- a/step-generation/src/commandCreators/index.ts
+++ b/step-generation/src/commandCreators/index.ts
@@ -3,6 +3,7 @@ export {
   absorbanceReaderCloseRead,
   consolidate,
   distribute,
+  dropTipInWasteChute,
   heaterShaker,
   mix,
   replaceTip,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -14,7 +14,12 @@ import {
   OT2_ROBOT_TYPE,
   FLEX_ROBOT_TYPE,
 } from '@opentrons/shared-data'
-import { reduceCommandCreators, wasteChuteCommandsUtil } from './index'
+import {
+  airGapInWasteChute,
+  blowoutInWasteChute,
+  dispenseInWasteChute,
+  reduceCommandCreators,
+} from './index'
 import {
   airGapInPlace,
   dispense,
@@ -389,9 +394,8 @@ export const blowoutUtil = (args: {
       }),
     ]
   } else if (trashOrLabware === 'wasteChute') {
-    return wasteChuteCommandsUtil({
+    return blowoutInWasteChute({
       pipetteId: pipette,
-      type: 'blowOut',
       flowRate,
       addressableAreaName,
     })
@@ -618,8 +622,7 @@ export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> 
     const pipetteChannels =
       invariantContext.pipetteEntities[pipetteId].spec.channels
 
-    commands = wasteChuteCommandsUtil({
-      type: 'dispense',
+    commands = dispenseInWasteChute({
       pipetteId,
       volume,
       flowRate,
@@ -796,8 +799,7 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
   } else if (trashOrLabware === 'wasteChute') {
     const pipetteChannels =
       invariantContext.pipetteEntities[pipetteId].spec.channels
-    commands = wasteChuteCommandsUtil({
-      type: 'airGap',
+    commands = airGapInWasteChute({
       pipetteId,
       volume,
       flowRate,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -353,8 +353,6 @@ export const blowoutUtil = (args: {
     prevRobotState,
   } = args
   if (!blowoutLocation) return []
-  const channels = invariantContext.pipetteEntities[pipette].spec.channels
-  const addressableAreaName = getWasteChuteAddressableAreaNamePip(channels)
 
   const trashOrLabware = getTrashOrLabware(
     invariantContext.labwareEntities,
@@ -397,7 +395,7 @@ export const blowoutUtil = (args: {
     return blowoutInWasteChute({
       pipetteId: pipette,
       flowRate,
-      addressableAreaName,
+      invariantContext,
     })
   } else {
     return blowOutInMovableTrash({
@@ -619,14 +617,11 @@ export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> 
       }),
     ]
   } else if (trashOrLabware === 'wasteChute') {
-    const pipetteChannels =
-      invariantContext.pipetteEntities[pipetteId].spec.channels
-
     commands = dispenseInWasteChute({
       pipetteId,
       volume,
       flowRate,
-      addressableAreaName: getWasteChuteAddressableAreaNamePip(pipetteChannels),
+      invariantContext,
     })
   } else {
     commands = dispenseInMovableTrash({
@@ -797,13 +792,11 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
       ]
     }
   } else if (trashOrLabware === 'wasteChute') {
-    const pipetteChannels =
-      invariantContext.pipetteEntities[pipetteId].spec.channels
     commands = airGapInWasteChute({
       pipetteId,
       volume,
       flowRate,
-      addressableAreaName: getWasteChuteAddressableAreaNamePip(pipetteChannels),
+      invariantContext,
     })
   } else {
     commands = airGapInMovableTrash({

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -394,7 +394,6 @@ export const blowoutUtil = (args: {
       type: 'blowOut',
       flowRate,
       addressableAreaName,
-      prevRobotState,
     })
   } else {
     return blowOutInMovableTrash({
@@ -624,7 +623,6 @@ export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> 
       pipetteId,
       volume,
       flowRate,
-      prevRobotState,
       addressableAreaName: getWasteChuteAddressableAreaNamePip(pipetteChannels),
     })
   } else {
@@ -803,7 +801,6 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
       pipetteId,
       volume,
       flowRate,
-      prevRobotState,
       addressableAreaName: getWasteChuteAddressableAreaNamePip(pipetteChannels),
     })
   } else {

--- a/step-generation/src/utils/wasteChuteCommandsUtil.ts
+++ b/step-generation/src/utils/wasteChuteCommandsUtil.ts
@@ -7,12 +7,12 @@ import {
   prepareToAspirate,
 } from '../commandCreators/atomic'
 import { curryCommandCreator } from './curryCommandCreator'
-import type { AddressableAreaName } from '@opentrons/shared-data'
-import type { CurriedCommandCreator } from '../types'
+import { getWasteChuteAddressableAreaNamePip } from './misc'
+import type { CurriedCommandCreator, InvariantContext } from '../types'
 
 interface WasteChuteCommandArgs {
   pipetteId: string
-  addressableAreaName: AddressableAreaName
+  invariantContext: InvariantContext
   volume?: number
   flowRate?: number
 }
@@ -20,7 +20,12 @@ interface WasteChuteCommandArgs {
 export const dispenseInWasteChute = (
   args: WasteChuteCommandArgs
 ): CurriedCommandCreator[] => {
-  const { pipetteId, addressableAreaName, flowRate, volume } = args
+  const { pipetteId, invariantContext, flowRate, volume } = args
+  const pipetteChannels =
+    invariantContext.pipetteEntities[pipetteId].spec.channels
+  const addressableAreaName = getWasteChuteAddressableAreaNamePip(
+    pipetteChannels
+  )
 
   return flowRate != null && volume != null
     ? [
@@ -41,7 +46,12 @@ export const dispenseInWasteChute = (
 export const blowoutInWasteChute = (
   args: WasteChuteCommandArgs
 ): CurriedCommandCreator[] => {
-  const { pipetteId, addressableAreaName, flowRate } = args
+  const { pipetteId, invariantContext, flowRate } = args
+  const pipetteChannels =
+    invariantContext.pipetteEntities[pipetteId].spec.channels
+  const addressableAreaName = getWasteChuteAddressableAreaNamePip(
+    pipetteChannels
+  )
 
   return flowRate != null
     ? [
@@ -61,7 +71,12 @@ export const blowoutInWasteChute = (
 export const airGapInWasteChute = (
   args: WasteChuteCommandArgs
 ): CurriedCommandCreator[] => {
-  const { pipetteId, addressableAreaName, volume, flowRate } = args
+  const { pipetteId, invariantContext, volume, flowRate } = args
+  const pipetteChannels =
+    invariantContext.pipetteEntities[pipetteId].spec.channels
+  const addressableAreaName = getWasteChuteAddressableAreaNamePip(
+    pipetteChannels
+  )
 
   return flowRate != null && volume != null
     ? [

--- a/step-generation/src/utils/wasteChuteCommandsUtil.ts
+++ b/step-generation/src/utils/wasteChuteCommandsUtil.ts
@@ -1,15 +1,14 @@
+import { ZERO_OFFSET } from '../constants'
+import { dropTipInWasteChute, moveToAddressableArea } from '../commandCreators'
 import {
   airGapInPlace,
   blowOutInPlace,
   dispenseInPlace,
-  dropTipInPlace,
-  moveToAddressableArea,
   prepareToAspirate,
 } from '../commandCreators/atomic'
-import { ZERO_OFFSET } from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
 import type { AddressableAreaName } from '@opentrons/shared-data'
-import type { RobotState, CurriedCommandCreator } from '../types'
+import type { CurriedCommandCreator } from '../types'
 
 export type WasteChuteCommandsTypes =
   | 'dispense'
@@ -21,38 +20,24 @@ interface WasteChuteCommandArgs {
   type: WasteChuteCommandsTypes
   pipetteId: string
   addressableAreaName: AddressableAreaName
-  prevRobotState: RobotState
   volume?: number
   flowRate?: number
 }
-/** Helper fn for waste chute dispense, drop tip and blow_out commands */
+/** Helper fn for waste chute dispense, drop tip, air_gap, and blow_out commands */
 export const wasteChuteCommandsUtil = (
   args: WasteChuteCommandArgs
 ): CurriedCommandCreator[] => {
-  const {
-    pipetteId,
-    addressableAreaName,
-    type,
-    prevRobotState,
-    volume,
-    flowRate,
-  } = args
   const offset = ZERO_OFFSET
+  const { pipetteId, addressableAreaName, type, volume, flowRate } = args
   let commands: CurriedCommandCreator[] = []
   switch (type) {
     case 'dropTip': {
-      commands = !prevRobotState.tipState.pipettes[pipetteId]
-        ? []
-        : [
-            curryCommandCreator(moveToAddressableArea, {
-              pipetteId,
-              addressableAreaName,
-              offset,
-            }),
-            curryCommandCreator(dropTipInPlace, {
-              pipetteId,
-            }),
-          ]
+      commands = [
+        curryCommandCreator(dropTipInWasteChute, {
+          pipetteId,
+          addressableAreaName,
+        }),
+      ]
 
       break
     }


### PR DESCRIPTION
partially addresses AUTH-1541

# Overview

This is similar to @ddcc4's pr: https://github.com/Opentrons/opentrons/pull/17726. Basically, it turns the drop tip waste chute commands into a compound command so that it can correctly get the prev robot state. This PR also fixes a few affected unit tests by this bug. It is unclear if this affects any protocols in the wild (i guess theoretically, it should), when i smoke test dropping tip into the waste chute in Prod and edge, it correctly seems to drop tip.

## Test Plan and Hands on Testing

Review the code. Smoke test.

## Changelog

- turn waste chute drop tip commands into a compound command
- remove prevRobotState as a prop in `wasteChuteCommandUtils`
- fix affected unit tests

## Risk assessment

low-ish, might change functionality but its fixing the functionality.