### PR TITLE
feat(protocol-designer): add source to metadata for analytics trackin…

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -7,6 +7,7 @@
     "description": "Test all v3 commands",
     "created": 1585930833548,
     "lastModified": 1740602436658,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -7,6 +7,7 @@
     "description": "Test all v4 commands",
     "created": 1585930833548,
     "lastModified": 1740602484685,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -7,6 +7,7 @@
     "description": "",
     "created": 1689346890165,
     "lastModified": 1740602529129,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -7,6 +7,7 @@
     "description": "",
     "created": 1701659107408,
     "lastModified": 1738780362701,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -7,6 +7,7 @@
     "description": "Description here",
     "created": 1560957631666,
     "lastModified": 1740602363965,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
+++ b/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
@@ -7,6 +7,7 @@
     "description": "A test for 5.0.0 -> 5.1.0 migration",
     "created": 1600714068238,
     "lastModified": 1714570500165,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -7,6 +7,7 @@
     "description": "",
     "created": 1714565695341,
     "lastModified": 1740602770093,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -7,6 +7,7 @@
     "description": "",
     "created": 1701805621086,
     "lastModified": 1740602607511,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
@@ -7,6 +7,7 @@
     "description": "testing a thermocycler on OT-2",
     "created": 1731356664582,
     "lastModified": 1739996995712,
+    "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
     "tags": []

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -197,4 +197,4 @@ export const ABSORBANCE_READER_COLOR_BY_WAVELENGTH: Record<number, string> = {
 export const OFFDECK: 'offDeck' = 'offDeck'
 export const GRIPPER_LOCATION: 'mounted' = 'mounted'
 
-export const PROTOCOL_DESIGNER: 'Protocol Designer' = 'Protocol Designer' // protocolSource for tracking analytics in the app
+export const PROTOCOL_DESIGNER_SOURCE: 'Protocol Designer' = 'Protocol Designer' // protocolSource for tracking analytics in the app

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -196,3 +196,5 @@ export const ABSORBANCE_READER_COLOR_BY_WAVELENGTH: Record<number, string> = {
 
 export const OFFDECK: 'offDeck' = 'offDeck'
 export const GRIPPER_LOCATION: 'mounted' = 'mounted'
+
+export const PROTOCOL_DESIGNER: 'Protocol Designer' = 'Protocol Designer' // protocolSource for tracking analytics in the app

--- a/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
@@ -24,6 +24,7 @@ export const fileMetadata: FileMetadataFields = {
   author: 'The Author',
   description: 'Protocol description',
   created: 1582667312515,
+  source: 'Protocol Designer',
 }
 export const dismissedWarnings: DismissedWarningState = {
   form: [],

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -125,6 +125,7 @@ metadata = {
     "description": "Protocol description",
     "created": "2020-02-25T21:48:32.515Z",
     "protocolDesigner": "fake_PD_version",
+    "source": "Protocol Designer",
 }
 
 requirements = {

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -47,6 +47,7 @@ describe('pythonMetadata', () => {
         category: 'PCR',
         subcategory: 'PCR Prep',
         tags: ['wombat', 'kangaroo', 'wallaby'],
+        source: 'Protocol Designer',
       })
     ).toBe(
       `
@@ -60,6 +61,7 @@ metadata = {
     "subcategory": "PCR Prep",
     "tags": "wombat, kangaroo, wallaby",
     "protocolDesigner": "fake_PD_version",
+    "source": "Protocol Designer",
 }`.trimStart()
     )
   })

--- a/protocol-designer/src/file-data/reducers/index.ts
+++ b/protocol-designer/src/file-data/reducers/index.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import { PROTOCOL_DESIGNER_SOURCE } from '../../constants'
 import type { Reducer } from 'redux'
 import type { Timeline } from '@opentrons/step-generation'
 import type { RobotType } from '@opentrons/shared-data'
@@ -16,7 +17,6 @@ import type {
   SaveFileMetadataAction,
   SelectDesignerTabAction,
 } from '../types'
-import { PROTOCOL_DESIGNER } from '../../constants'
 
 export const timelineIsBeingComputed: Reducer<boolean, any> = handleActions(
   {
@@ -54,7 +54,7 @@ const defaultFields = {
   protocolName: '',
   author: '',
   description: '',
-  source: PROTOCOL_DESIGNER,
+  source: PROTOCOL_DESIGNER_SOURCE,
 }
 
 const updateMetadataFields = (

--- a/protocol-designer/src/file-data/reducers/index.ts
+++ b/protocol-designer/src/file-data/reducers/index.ts
@@ -101,7 +101,10 @@ const fileMetadata = handleActions(
     ): FileMetadataFields => ({ ...state, ...action.payload }),
     SAVE_PROTOCOL_FILE: (state: FileMetadataFields): FileMetadataFields => {
       // NOTE: 'last-modified' is updated "on-demand", in response to user clicking "save/export"
-      return { ...state, lastModified: Date.now() }
+      return {
+        ...state,
+        lastModified: Date.now(),
+      }
     },
   },
   defaultFields

--- a/protocol-designer/src/file-data/reducers/index.ts
+++ b/protocol-designer/src/file-data/reducers/index.ts
@@ -16,6 +16,7 @@ import type {
   SaveFileMetadataAction,
   SelectDesignerTabAction,
 } from '../types'
+import { PROTOCOL_DESIGNER } from '../../constants'
 
 export const timelineIsBeingComputed: Reducer<boolean, any> = handleActions(
   {
@@ -53,6 +54,7 @@ const defaultFields = {
   protocolName: '',
   author: '',
   description: '',
+  source: PROTOCOL_DESIGNER,
 }
 
 const updateMetadataFields = (

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -120,7 +120,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
     stepGroups,
     invariantContext
   ) => {
-    const { author, description, created } = fileMetadata
+    const { author, description, created, source } = fileMetadata
     const {
       pipetteEntities,
       labwareEntities,
@@ -286,6 +286,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
         description,
         created,
         lastModified,
+        source,
         // TODO LATER
         category: null,
         subcategory: null,

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -13,6 +13,7 @@ import {
   OFF_DECK,
   PROTOCOL_CONTEXT_NAME,
 } from '@opentrons/step-generation'
+import { PROTOCOL_DESIGNER } from '../../constants'
 import { getFlexNameConversion } from './utils'
 import type {
   AdditionalEquipmentEntities,
@@ -53,6 +54,7 @@ export function pythonMetadata(fileMetadata: FileMetadataFields): string {
       subcategory: fileMetadata.subcategory,
       tags: fileMetadata.tags?.length && fileMetadata.tags.join(', '),
       protocolDesigner: process.env.OT_PD_VERSION,
+      source: PROTOCOL_DESIGNER,
     }).filter(([key, value]) => value) // drop blank entries
   )
   return `metadata = ${formatPyDict(stringifiedMetadata)}`

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -13,7 +13,6 @@ import {
   OFF_DECK,
   PROTOCOL_CONTEXT_NAME,
 } from '@opentrons/step-generation'
-import { PROTOCOL_DESIGNER } from '../../constants'
 import { getFlexNameConversion } from './utils'
 import type {
   AdditionalEquipmentEntities,
@@ -54,7 +53,7 @@ export function pythonMetadata(fileMetadata: FileMetadataFields): string {
       subcategory: fileMetadata.subcategory,
       tags: fileMetadata.tags?.length && fileMetadata.tags.join(', '),
       protocolDesigner: process.env.OT_PD_VERSION,
-      source: PROTOCOL_DESIGNER,
+      source: fileMetadata.source,
     }).filter(([key, value]) => value) // drop blank entries
   )
   return `metadata = ${formatPyDict(stringifiedMetadata)}`

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -1,4 +1,5 @@
 import floor from 'lodash/floor'
+import { PROTOCOL_DESIGNER } from '../../constants'
 import { swatchColors } from '../../organisms/DefineLiquidsModal/swatchColors'
 import { getMigratedPositionFromTop } from './utils/getMigrationPositionFromTop'
 import { getAdditionalEquipmentLocationUpdate } from './utils/getAdditionalEquipmentLocationUpdate'
@@ -179,6 +180,10 @@ export const migrateFile = (
   )
   return {
     ...appData,
+    metadata: {
+      ...appData.metadata,
+      source: PROTOCOL_DESIGNER,
+    },
     designerApplication: {
       ...designerApplication,
       data: {

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -1,5 +1,5 @@
 import floor from 'lodash/floor'
-import { PROTOCOL_DESIGNER } from '../../constants'
+import { PROTOCOL_DESIGNER_SOURCE } from '../../constants'
 import { swatchColors } from '../../organisms/DefineLiquidsModal/swatchColors'
 import { getMigratedPositionFromTop } from './utils/getMigrationPositionFromTop'
 import { getAdditionalEquipmentLocationUpdate } from './utils/getAdditionalEquipmentLocationUpdate'
@@ -182,7 +182,7 @@ export const migrateFile = (
     ...appData,
     metadata: {
       ...appData.metadata,
-      source: PROTOCOL_DESIGNER,
+      source: PROTOCOL_DESIGNER_SOURCE,
     },
     designerApplication: {
       ...designerApplication,

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -105,6 +105,7 @@ export interface ProtocolBase<DesignerApplicationData> {
     category?: string | null | undefined
     subcategory?: string | null | undefined
     tags?: string[]
+    source?: string | null
   }
   designerApplication?: {
     name?: string


### PR DESCRIPTION
…g in app

closes AUTH-1529

# Overview

This adds a `source` key to the protocol metadata for PD protocols generated in both JSON and py. This key is for app analytics tracking.

For PD protocols, the `source` is added to the metadata by default when making a new protocol and it is added to the migration when uploading an old protocol

For py protocols, the `source` is added to the hardcoded metadata when the python file is created

## Test Plan and Hands on Testing

review code. you can also smoke test making a PD and py protocol and looking at the metadata

## Changelog

- add `source` as an optional key to the protocol metadata type for PD
- add it to both the metadata reducer and the py protocol fn
- add test cases
- fix cypress migration tests
- add source to the `8_5_0` migration file

## Risk assessment

low, only affects the protocol metadata which is minimal