### PR TITLE
fix(api): Correct g code error casing for serial errors

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/errors.py
+++ b/api/src/opentrons/drivers/asyncio/communication/errors.py
@@ -52,7 +52,7 @@ class BaseErrorCode(Enum):
     def code_string(self) -> str:
         """Return the error code string."""
         code: str = self.value[0]
-        return code
+        return code.lower()
 
     @property
     def exception(self) -> Type[ErrorResponse]:

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -180,6 +180,14 @@ def test_raise_on_error(
         subject.raise_on_error(response, "fake request")
 
 
+def test_get_error_codes_lowercase(
+    subject: SerialKind,
+) -> None:
+    """It should return an error code dictionary keyed by lowercase value."""
+    lowercase_result = subject._error_codes.get_error_codes()
+    assert lowercase_result == {"err003": DefaultErrorCodes.UNHANDLED_GCODE}
+
+
 async def test_on_retry(mock_serial_port: AsyncMock, subject: SerialKind) -> None:
     """It should try to re-open connection."""
     await subject.on_retry()


### PR DESCRIPTION
# Overview
Covers EXEC-1308
The PR [17689](https://github.com/Opentrons/opentrons/pull/17689) introduced some changes that were causing an `M114 Unhandled GCode` error while attempting to restart the robot server with a thermocycler attached. This was due to the loop in serial connect that is responsible for iterating over an error codes dictionary not properly matching keys with non-lowercase returned values. 

## Test Plan and Hands on Testing
- [x] Test that robot server properly reboots after a make push and also independent while a thermocycler is connected

## Changelog
- BaseErrorCode code string property now returns a value in expected casing
- Addition of unit test enforcing expected result on dependency funciton

## Review requests

## Risk assessment
Low - fixes some newly introduced behavior