### PR TITLE
refactor(step-generation): remove prevRobotState as an arg in blowout…

### DIFF
--- a/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { getInitialRobotStateStandard, makeContext } from '../fixtures'
+import { makeContext } from '../fixtures'
 import { curryCommandCreator } from '../utils'
 import {
   airGapInMovableTrash,
@@ -50,7 +50,6 @@ const args = {
       },
     },
   },
-  prevRobotState: getInitialRobotStateStandard(invariantContext),
 }
 
 describe('movableTrashCommandsUtil', () => {
@@ -81,10 +80,6 @@ describe('movableTrashCommandsUtil', () => {
   it('returns correct commands for aspirate in place (air gap)', () => {
     airGapInMovableTrash({
       ...args,
-      prevRobotState: {
-        ...args.prevRobotState,
-        tipState: { pipettes: { [mockId]: true } } as any,
-      },
     })
     expect(curryCommandCreator).toHaveBeenCalledWith(
       moveToAddressableArea,

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -450,7 +450,6 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         flowRate: blowoutFlowRateUlSec,
         offsetFromTopMm: blowoutOffsetFromTopMm,
         invariantContext,
-        prevRobotState,
       })
 
       const willReuseTip = args.changeTip !== 'always' && !isLastChunk

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -273,7 +273,6 @@ export const mix: CommandCreator<MixArgs> = (
         flowRate: blowoutFlowRateUlSec,
         offsetFromTopMm: blowoutOffsetFromTopMm,
         invariantContext,
-        prevRobotState,
       })
       const mixCommands = mixUtil({
         pipette,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -525,7 +525,6 @@ export const transfer: CommandCreator<TransferArgs> = (
             flowRate: blowoutFlowRateUlSec,
             offsetFromTopMm: blowoutOffsetFromTopMm,
             invariantContext,
-            prevRobotState,
           })
 
           const airGapAfterDispenseCommands =

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -338,7 +338,6 @@ export const blowoutUtil = (args: {
   offsetFromTopMm: number
   invariantContext: InvariantContext
   destWell: BlowoutParams['wellName'] | null
-  prevRobotState: RobotState
 }): CurriedCommandCreator[] => {
   const {
     pipette,
@@ -350,7 +349,6 @@ export const blowoutUtil = (args: {
     flowRate,
     offsetFromTopMm,
     invariantContext,
-    prevRobotState,
   } = args
   if (!blowoutLocation) return []
 
@@ -400,7 +398,6 @@ export const blowoutUtil = (args: {
   } else {
     return blowOutInMovableTrash({
       pipetteId: pipette,
-      prevRobotState,
       invariantContext,
       flowRate,
     })
@@ -629,7 +626,6 @@ export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> 
       volume,
       flowRate,
       invariantContext,
-      prevRobotState,
     })
   }
 
@@ -685,7 +681,6 @@ export const moveHelper: CommandCreator<MoveHelperArgs> = (
     commands = moveToMovableTrash({
       pipetteId,
       invariantContext,
-      prevRobotState,
     })
   }
 
@@ -804,7 +799,6 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
       volume,
       flowRate,
       invariantContext,
-      prevRobotState,
     })
   }
 

--- a/step-generation/src/utils/movableTrashCommandsUtil.ts
+++ b/step-generation/src/utils/movableTrashCommandsUtil.ts
@@ -8,11 +8,7 @@ import {
 import { ZERO_OFFSET } from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
 import { getTrashBinAddressableAreaName } from './misc'
-import type {
-  RobotState,
-  InvariantContext,
-  CurriedCommandCreator,
-} from '../types'
+import type { InvariantContext, CurriedCommandCreator } from '../types'
 
 /** Helper fn for movable trash commands for dispense, aspirate, air_gap, drop_tip and blow_out commands */
 
@@ -21,7 +17,6 @@ export function airGapInMovableTrash(args: {
   volume: number
   flowRate: number
   invariantContext: InvariantContext
-  prevRobotState: RobotState
 }): CurriedCommandCreator[] {
   const { pipetteId, invariantContext, volume, flowRate } = args
   const offset = ZERO_OFFSET
@@ -54,7 +49,6 @@ export function dispenseInMovableTrash(args: {
   volume: number
   flowRate: number
   invariantContext: InvariantContext
-  prevRobotState: RobotState
 }): CurriedCommandCreator[] {
   const { pipetteId, invariantContext, volume, flowRate } = args
   const offset = ZERO_OFFSET
@@ -83,7 +77,6 @@ export function blowOutInMovableTrash(args: {
   pipetteId: string
   flowRate: number
   invariantContext: InvariantContext
-  prevRobotState: RobotState
 }): CurriedCommandCreator[] {
   const { pipetteId, invariantContext, flowRate } = args
   const offset = ZERO_OFFSET
@@ -110,7 +103,6 @@ export function blowOutInMovableTrash(args: {
 export function moveToMovableTrash(args: {
   pipetteId: string
   invariantContext: InvariantContext
-  prevRobotState: RobotState
 }): CurriedCommandCreator[] {
   const { pipetteId, invariantContext } = args
   const offset = ZERO_OFFSET


### PR DESCRIPTION
…Util

closes AUTH-1541

# Overview

This PR is the final piece for addressing the usage of using the wrong `prevRobotState` outlined in AUTH-1541. After the waste chute and trash bin command utils were refactored and the appropriate ones turned into `CommandCreators`, the `blowoutUtil` was the last to be refactored to no longer have `prevRobotState` as an arg.

## Test Plan and Hands on Testing

Review the code, make sure there is no behavior change

## Changelog

- refactor blowoutUtil
- fix affected components
- remove `prevRobotState` as a prop for the trash bin command fns

## Risk assessment

medium - this affects all protocols made in edge but shouldn't change the functionality