### PR TITLE
test(api): Delete dead code: replace unused commands with placeholders

### DIFF
--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -86,9 +86,7 @@ from opentrons.protocol_engine.types import (
 )
 from opentrons.protocol_engine.commands import (
     CommandStatus,
-    LoadLabwareResult,
-    LoadLabware,
-    LoadLabwareParams,
+    Command,
     LoadModuleResult,
     LoadModule,
     LoadModuleParams,
@@ -128,6 +126,10 @@ from opentrons_shared_data.robot.types import (
     RobotDefinition,
     paddingOffset,
     mountOffset,
+)
+
+from .command_fixtures import (
+    create_comment_command,
 )
 from .inner_geometry_test_params import INNER_WELL_GEOMETRY_TEST_PARAMS
 from ..pipette_fixtures import get_default_nozzle_map
@@ -379,6 +381,11 @@ def subject(
             mock_addressable_area_view if use_mocks else addressable_area_view
         ),
     )
+
+
+def _dummy_command() -> Command:
+    """Return a placeholder command."""
+    return create_comment_command()
 
 
 def test_get_labware_parent_position(
@@ -3093,23 +3100,7 @@ def test_get_offset_location_deck_slot(
 ) -> None:
     """Test if you can get the offset location of a labware in a deck slot."""
     action = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -3155,23 +3146,7 @@ def test_get_offset_location_module(
         ),
     )
     load_labware = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=ModuleLocation(moduleId="module-id-1"),
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -3226,23 +3201,7 @@ def test_get_offset_location_module_with_adapter(
         ),
     )
     load_adapter = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-adapter-1",
-            createdAt=datetime.now(),
-            key="load-adapter-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="adapter-id-1",
-                definition=nice_adapter_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=ModuleLocation(moduleId="module-id-1"),
-                loadName=nice_adapter_definition.parameters.loadName,
-                namespace=nice_adapter_definition.namespace,
-                version=nice_adapter_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="adapter-id-1",
@@ -3254,23 +3213,7 @@ def test_get_offset_location_module_with_adapter(
         ),
     )
     load_labware = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=OnLabwareLocation(labwareId="adapter-id-1"),
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -3307,23 +3250,7 @@ def test_get_offset_fails_with_off_deck_labware(
 ) -> None:
     """You cannot get the offset location for a labware loaded OFF_DECK."""
     action = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=OFF_DECK_LOCATION,
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -3434,9 +3361,7 @@ def test_rectangular_frustum_math_helpers(
 
 @pytest.mark.parametrize("frustum", CIRCULAR_TEST_EXAMPLES)
 def test_circular_frustum_math_helpers(
-    decoy: Decoy,
     frustum: Dict[str, List[float]],
-    subject: GeometryView,
 ) -> None:
     """Test both height and volume calculation within a given circular frustum."""
     total_frustum_height = frustum["height"][0]
@@ -3794,23 +3719,7 @@ def test_get_location_sequence_deck_slot(
 ) -> None:
     """Test if you can get the location sequence of a labware in a deck slot."""
     action = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -3867,23 +3776,7 @@ def test_get_location_sequence_module(
         ),
     )
     load_labware = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=ModuleLocation(moduleId="module-id-1"),
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -3947,23 +3840,7 @@ def test_get_location_sequence_module_with_adapter(
         ),
     )
     load_adapter = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-adapter-1",
-            createdAt=datetime.now(),
-            key="load-adapter-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="adapter-id-1",
-                definition=nice_adapter_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=ModuleLocation(moduleId="module-id-1"),
-                loadName=nice_adapter_definition.parameters.loadName,
-                namespace=nice_adapter_definition.namespace,
-                version=nice_adapter_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="adapter-id-1",
@@ -3975,23 +3852,7 @@ def test_get_location_sequence_module_with_adapter(
         ),
     )
     load_labware = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=OnLabwareLocation(labwareId="adapter-id-1"),
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -4028,23 +3889,7 @@ def test_get_location_sequence_off_deck(
 ) -> None:
     """You cannot get the location sequence for a labware loaded OFF_DECK."""
     action = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=OFF_DECK_LOCATION,
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",
@@ -4096,23 +3941,7 @@ def test_get_location_sequence_stacker_hopper(
         ),
     )
     load_labware = SucceedCommandAction(
-        command=LoadLabware(
-            id="load-labware-1",
-            createdAt=datetime.now(),
-            key="load-labware-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadLabwareResult(
-                labwareId="labware-id-1",
-                definition=nice_labware_definition,
-                offsetId=None,
-            ),
-            params=LoadLabwareParams(
-                location=ModuleLocation(moduleId="module-id-1"),
-                loadName=nice_labware_definition.parameters.loadName,
-                namespace=nice_labware_definition.namespace,
-                version=nice_labware_definition.version,
-            ),
-        ),
+        command=_dummy_command(),
         state_update=StateUpdate(
             loaded_labware=LoadedLabwareUpdate(
                 labware_id="labware-id-1",

--- a/api/tests/opentrons/protocol_engine/state/test_liquid_class_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_liquid_class_store_old.py
@@ -10,10 +10,11 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
 )
 from opentrons.protocol_engine import actions
-from opentrons.protocol_engine.commands.load_liquid_class import LoadLiquidClass
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.liquid_classes import LiquidClassStore
 from opentrons.protocol_engine.types import LiquidClassRecord
+
+from .command_fixtures import create_comment_command
 
 
 @pytest.fixture
@@ -39,7 +40,7 @@ def test_handles_add_liquid_class(
 
     subject.handle_action(
         actions.SucceedCommandAction(
-            command=LoadLiquidClass.model_construct(),  # type: ignore[call-arg]
+            command=create_comment_command(),
             state_update=update_types.StateUpdate(
                 liquid_class_loaded=update_types.LiquidClassLoadedUpdate(
                     liquid_class_id="liquid-class-id",

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -11,7 +11,6 @@ from opentrons_shared_data.pipette import pipette_definition
 
 from opentrons.protocol_engine.state import update_types
 from opentrons.types import MountType, Point
-from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine.types import (
     CurrentAddressableArea,
     DeckPoint,
@@ -39,22 +38,7 @@ from opentrons.protocol_engine.resources.pipette_data_provider import (
 )
 from opentrons.protocol_engine.state.fluid_stack import FluidStack
 
-from .command_fixtures import (
-    create_load_pipette_command,
-    create_aspirate_command,
-    create_aspirate_in_place_command,
-    create_dispense_command,
-    create_dispense_in_place_command,
-    create_pick_up_tip_command,
-    create_drop_tip_command,
-    create_drop_tip_in_place_command,
-    create_succeeded_command,
-    create_unsafe_drop_tip_in_place_command,
-    create_blow_out_command,
-    create_blow_out_in_place_command,
-    create_prepare_to_aspirate_command,
-    create_unsafe_blow_out_in_place_command,
-)
+from .command_fixtures import create_comment_command
 from ..pipette_fixtures import get_default_nozzle_map
 
 
@@ -92,15 +76,8 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
 
 def test_location_state_update(subject: PipetteStore) -> None:
     """It should update pipette locations."""
-    load_command = create_load_pipette_command(
-        pipette_id="pipette-id",
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.RIGHT,
-    )
-    subject.handle_action(SucceedCommandAction(command=load_command))
-
     # Update the location to a well:
-    dummy_command = create_succeeded_command()
+    dummy_command = create_comment_command()
     subject.handle_action(
         SucceedCommandAction(
             command=dummy_command,
@@ -206,7 +183,7 @@ def test_handles_load_pipette(
     available_sensors: pipette_definition.AvailableSensorDefinition,
 ) -> None:
     """It should add the pipette data to the state."""
-    dummy_command = create_succeeded_command()
+    dummy_command = create_comment_command()
 
     load_pipette_update = update_types.LoadPipetteUpdate(
         pipette_id="pipette-id",
@@ -275,23 +252,11 @@ def test_handles_load_pipette(
 
 def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
     """It should set tip and volume details on pick up and drop tip."""
-    load_pipette_command = create_load_pipette_command(
-        pipette_id="abc",
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-
-    pick_up_tip_command = create_pick_up_tip_command(
-        pipette_id="abc", tip_volume=42, tip_length=101, tip_diameter=8.0
-    )
-
-    drop_tip_command = create_drop_tip_command(
-        pipette_id="abc",
-    )
+    dummy_command = create_comment_command()
 
     subject.handle_action(
         SucceedCommandAction(
-            command=load_pipette_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
                     pipette_id="abc",
@@ -308,7 +273,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            command=pick_up_tip_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="abc",
@@ -327,7 +292,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            command=drop_tip_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="abc", tip_geometry=None
@@ -344,23 +309,11 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
 
 def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
     """It should clear tip and volume details after a drop tip in place."""
-    load_pipette_command = create_load_pipette_command(
-        pipette_id="xyz",
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-
-    pick_up_tip_command = create_pick_up_tip_command(
-        pipette_id="xyz", tip_volume=42, tip_length=101, tip_diameter=8.0
-    )
-
-    drop_tip_in_place_command = create_drop_tip_in_place_command(
-        pipette_id="xyz",
-    )
+    dummy_command = create_comment_command()
 
     subject.handle_action(
         SucceedCommandAction(
-            command=load_pipette_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
                     pipette_id="xyz",
@@ -376,7 +329,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=pick_up_tip_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
@@ -395,7 +348,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            command=drop_tip_in_place_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz", tip_geometry=None
@@ -412,23 +365,10 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
 
 def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
     """It should clear tip and volume details after a drop tip in place."""
-    load_pipette_command = create_load_pipette_command(
-        pipette_id="xyz",
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-
-    pick_up_tip_command = create_pick_up_tip_command(
-        pipette_id="xyz", tip_volume=42, tip_length=101, tip_diameter=8.0
-    )
-
-    unsafe_drop_tip_in_place_command = create_unsafe_drop_tip_in_place_command(
-        pipette_id="xyz",
-    )
-
+    dummy_command = create_comment_command()
     subject.handle_action(
         SucceedCommandAction(
-            command=load_pipette_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
                     pipette_id="xyz",
@@ -444,7 +384,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=pick_up_tip_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
@@ -463,7 +403,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(
-            command=unsafe_drop_tip_in_place_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz", tip_geometry=None
@@ -478,49 +418,19 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
     assert subject.state.pipette_contents_by_id["xyz"] is None
 
 
-@pytest.mark.parametrize(
-    "aspirate_command,aspirate_update",
-    [
-        (
-            create_aspirate_command(pipette_id="pipette-id", volume=42, flow_rate=1.23),
-            update_types.StateUpdate(
-                pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
-                    pipette_id="pipette-id",
-                    fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=42),
-                )
-            ),
-        ),
-        (
-            create_aspirate_in_place_command(
-                pipette_id="pipette-id", volume=42, flow_rate=1.23
-            ),
-            update_types.StateUpdate(
-                pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
-                    pipette_id="pipette-id",
-                    fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=42),
-                )
-            ),
-        ),
-    ],
-)
-def test_aspirate_adds_volume(
-    subject: PipetteStore,
-    aspirate_command: cmd.Command,
-    aspirate_update: update_types.StateUpdate,
-) -> None:
+def test_aspirate_adds_volume(subject: PipetteStore) -> None:
     """It should add volume to pipette after an aspirate."""
-    load_command = create_load_pipette_command(
-        pipette_id="pipette-id",
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-    pick_up_tip_command = create_pick_up_tip_command(
-        pipette_id="pipette-id", tip_volume=42, tip_length=101, tip_diameter=8.0
+    dummy_command = create_comment_command()
+    aspirate_update = update_types.StateUpdate(
+        pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
+            pipette_id="pipette-id",
+            fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=42),
+        )
     )
 
     subject.handle_action(
         SucceedCommandAction(
-            command=load_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
                     pipette_id="pipette-id",
@@ -536,7 +446,7 @@ def test_aspirate_adds_volume(
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=pick_up_tip_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
@@ -548,11 +458,9 @@ def test_aspirate_adds_volume(
             ),
         )
     )
+
     subject.handle_action(
-        SucceedCommandAction(
-            command=aspirate_command,
-            state_update=aspirate_update,
-        )
+        SucceedCommandAction(command=dummy_command, state_update=aspirate_update)
     )
 
     assert subject.state.pipette_contents_by_id["pipette-id"] == FluidStack(
@@ -560,7 +468,7 @@ def test_aspirate_adds_volume(
     )
 
     subject.handle_action(
-        SucceedCommandAction(command=aspirate_command, state_update=aspirate_update)
+        SucceedCommandAction(command=dummy_command, state_update=aspirate_update)
     )
 
     assert subject.state.pipette_contents_by_id["pipette-id"] == FluidStack(
@@ -568,55 +476,18 @@ def test_aspirate_adds_volume(
     )
 
 
-@pytest.mark.parametrize(
-    "dispense_command,dispense_update",
-    [
-        (
-            create_dispense_command(pipette_id="pipette-id", volume=21, flow_rate=1.23),
-            update_types.StateUpdate(
-                pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
-                    pipette_id="pipette-id", volume=21
-                )
-            ),
-        ),
-        (
-            create_dispense_in_place_command(
-                pipette_id="pipette-id",
-                volume=21,
-                flow_rate=1.23,
-            ),
-            update_types.StateUpdate(
-                pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
-                    pipette_id="pipette-id", volume=21
-                )
-            ),
-        ),
-    ],
-)
-def test_dispense_subtracts_volume(
-    subject: PipetteStore,
-    dispense_command: cmd.Command,
-    dispense_update: update_types.StateUpdate,
-) -> None:
+def test_dispense_subtracts_volume(subject: PipetteStore) -> None:
     """It should subtract volume from pipette after a dispense."""
-    load_command = create_load_pipette_command(
-        pipette_id="pipette-id",
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-    pick_up_tip_command = create_pick_up_tip_command(
-        pipette_id="pipette-id", tip_volume=47, tip_length=101, tip_diameter=8.0
-    )
-
-    aspirate_command = create_aspirate_command(
-        pipette_id="pipette-id",
-        volume=42,
-        flow_rate=1.23,
+    dummy_command = create_comment_command()
+    dispense_update = update_types.StateUpdate(
+        pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
+            pipette_id="pipette-id", volume=21
+        )
     )
 
     subject.handle_action(
         SucceedCommandAction(
-            command=load_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
                     pipette_id="pipette-id",
@@ -632,7 +503,7 @@ def test_dispense_subtracts_volume(
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=pick_up_tip_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
@@ -646,7 +517,7 @@ def test_dispense_subtracts_volume(
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=aspirate_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
                     pipette_id="pipette-id",
@@ -656,7 +527,7 @@ def test_dispense_subtracts_volume(
         )
     )
     subject.handle_action(
-        SucceedCommandAction(command=dispense_command, state_update=dispense_update)
+        SucceedCommandAction(command=dummy_command, state_update=dispense_update)
     )
 
     assert subject.state.pipette_contents_by_id["pipette-id"] == FluidStack(
@@ -664,42 +535,19 @@ def test_dispense_subtracts_volume(
     )
 
     subject.handle_action(
-        SucceedCommandAction(command=dispense_command, state_update=dispense_update)
+        SucceedCommandAction(command=dummy_command, state_update=dispense_update)
     )
 
     assert subject.state.pipette_contents_by_id["pipette-id"] == FluidStack()
 
 
-@pytest.mark.parametrize(
-    "blow_out_command",
-    [
-        create_blow_out_command("pipette-id", 1.23),
-        create_blow_out_in_place_command("pipette-id", 1.23),
-        create_unsafe_blow_out_in_place_command("pipette-id", 1.23),
-    ],
-)
-def test_blow_out_clears_volume(
-    subject: PipetteStore, blow_out_command: cmd.Command
-) -> None:
+def test_blow_out_clears_volume(subject: PipetteStore) -> None:
     """It should wipe out the aspirated volume after a blowOut."""
-    load_command = create_load_pipette_command(
-        pipette_id="pipette-id",
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-    pick_up_tip_command = create_pick_up_tip_command(
-        pipette_id="pipette-id", tip_volume=47, tip_length=101, tip_diameter=8.0
-    )
-
-    aspirate_command = create_aspirate_command(
-        pipette_id="pipette-id",
-        volume=42,
-        flow_rate=1.23,
-    )
+    dummy_command = create_comment_command()
 
     subject.handle_action(
         SucceedCommandAction(
-            command=load_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
                     pipette_id="pipette-id",
@@ -712,7 +560,7 @@ def test_blow_out_clears_volume(
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=pick_up_tip_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
@@ -726,7 +574,7 @@ def test_blow_out_clears_volume(
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=aspirate_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
                     pipette_id="pipette-id",
@@ -737,7 +585,7 @@ def test_blow_out_clears_volume(
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=blow_out_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="pipette-id"
@@ -751,17 +599,10 @@ def test_blow_out_clears_volume(
 
 def test_set_movement_speed(subject: PipetteStore) -> None:
     """It should issue an action to set the movement speed."""
-    pipette_id = "pipette-id"
-    load_pipette_command = create_load_pipette_command(
-        pipette_id=pipette_id,
-        pipette_name=PipetteNameType.P300_SINGLE,
-        mount=MountType.LEFT,
-    )
-    subject.handle_action(SucceedCommandAction(command=load_pipette_command))
     subject.handle_action(
-        SetPipetteMovementSpeedAction(pipette_id=pipette_id, speed=123.456)
+        SetPipetteMovementSpeedAction(pipette_id="pipette-id", speed=123.456)
     )
-    assert subject.state.movement_speed_by_id[pipette_id] == 123.456
+    assert subject.state.movement_speed_by_id["pipette-id"] == 123.456
 
 
 def test_add_pipette_config(
@@ -770,12 +611,7 @@ def test_add_pipette_config(
     available_sensors: pipette_definition.AvailableSensorDefinition,
 ) -> None:
     """It should update state from any pipette config private result."""
-    command = cmd.LoadPipette.model_construct(
-        params=cmd.LoadPipetteParams.model_construct(  # type: ignore[call-arg]
-            mount=MountType.LEFT, pipetteName="p300_single"  # type: ignore[arg-type]
-        ),
-        result=cmd.LoadPipetteResult(pipetteId="pipette-id"),
-    )
+    dummy_command = create_comment_command()
     config = LoadedStaticPipetteData(
         model="pipette-model",
         display_name="pipette name",
@@ -807,7 +643,7 @@ def test_add_pipette_config(
 
     subject.handle_action(
         SucceedCommandAction(
-            command=command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_config=update_types.PipetteConfigUpdate(
                     pipette_id="pipette-id",
@@ -856,43 +692,29 @@ def test_add_pipette_config(
 
 
 @pytest.mark.parametrize(
-    "previous_cmd,previous_state",
+    "previous_state",
     [
-        (
-            create_blow_out_command(pipette_id="pipette-id", flow_rate=1.0),
-            update_types.StateUpdate(
-                pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
-                    pipette_id="pipette-id"
-                )
-            ),
+        update_types.StateUpdate(
+            pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
+                pipette_id="pipette-id"
+            )
         ),
-        (
-            create_dispense_command(pipette_id="pipette-id", volume=10, flow_rate=1.0),
-            update_types.StateUpdate(
-                pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
-                    pipette_id="pipette-id", volume=10
-                )
-            ),
+        update_types.StateUpdate(
+            pipette_aspirated_fluid=update_types.PipetteEjectedFluidUpdate(
+                pipette_id="pipette-id", volume=10
+            )
         ),
     ],
 )
 def test_prepare_to_aspirate_marks_pipette_ready(
     subject: PipetteStore,
-    previous_cmd: cmd.Command,
     previous_state: update_types.StateUpdate,
 ) -> None:
     """It should mark a pipette as ready to aspirate."""
-    load_pipette_command = create_load_pipette_command(
-        pipette_id="pipette-id",
-        pipette_name=PipetteNameType.P50_MULTI_FLEX,
-        mount=MountType.LEFT,
-    )
-    pick_up_tip_command = create_pick_up_tip_command(
-        pipette_id="pipette-id", tip_volume=42, tip_length=101, tip_diameter=8.0
-    )
+    dummy_command = create_comment_command()
     subject.handle_action(
         SucceedCommandAction(
-            command=load_pipette_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 loaded_pipette=update_types.LoadPipetteUpdate(
                     pipette_id="pipette-id",
@@ -908,7 +730,7 @@ def test_prepare_to_aspirate_marks_pipette_ready(
     )
     subject.handle_action(
         SucceedCommandAction(
-            command=pick_up_tip_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
@@ -922,15 +744,12 @@ def test_prepare_to_aspirate_marks_pipette_ready(
     )
 
     subject.handle_action(
-        SucceedCommandAction(command=previous_cmd, state_update=previous_state)
+        SucceedCommandAction(command=dummy_command, state_update=previous_state)
     )
 
-    prepare_to_aspirate_command = create_prepare_to_aspirate_command(
-        pipette_id="pipette-id"
-    )
     subject.handle_action(
         SucceedCommandAction(
-            command=prepare_to_aspirate_command,
+            command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id"


### PR DESCRIPTION
## Overview

This just deletes some dead code in the `opentrons/protocol_engine` tests to make the files marginally less gigantic.

## Test Plan and Hands on Testing

Just CI.

## Changelog

Historically, the interface to `PipetteStore` and friends had the caller give them a `SucceedCommandAction(command=...)`, with juicy details in the `command`. We have gradually been replacing that with `SucceedCommandAction(state_update=...)`, with juicy details in the `state_update`, and with `command` being ignored. (EXEC-639.)

Many tests were still constructing meaningful `command` values, even though the code under test was just throwing them away. This PR replaces those values with terser placeholders.

(`command=LoadModule(...)` is an exception—it is one of the last things that has not been ported to `state_update` yet.)

## Review requests

None in particular.

## Risk assessment

Very low.