### PR TITLE
feat(step-generation): generate Python for dropTipInTrash compound command

### DIFF
--- a/step-generation/src/__tests__/dropTipInTrash.test.ts
+++ b/step-generation/src/__tests__/dropTipInTrash.test.ts
@@ -17,6 +17,7 @@ const mockPipEntities: PipetteEntities = {
     name: 'p50_single_flex',
     id: mockId,
     spec: { channels: 1 },
+    pythonName: 'mock_pipette',
   },
 } as any
 const mockCutout = 'cutoutA3'
@@ -61,5 +62,6 @@ describe('dropTipInTrash', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe('mock_pipette.drop_tip()')
   })
 })

--- a/step-generation/src/commandCreators/compound/dropTipInTrash.ts
+++ b/step-generation/src/commandCreators/compound/dropTipInTrash.ts
@@ -1,7 +1,7 @@
 import {
   getTrashBinAddressableAreaName,
-  curryCommandCreator,
   reduceCommandCreators,
+  curryWithoutPython,
 } from '../../utils'
 import { moveToAddressableAreaForDropTip } from '../atomic/moveToAddressableAreaForDropTip'
 import { dropTipInPlace } from '../atomic/dropTipInPlace'
@@ -21,16 +21,33 @@ export const dropTipInTrash: CommandCreator<DropTipInPlaceParams> = (
   if (addressableAreaName == null) {
     console.error('could not getTrashBinAddressableAreaName for dropTip')
   } else if (prevRobotState.tipState.pipettes[pipetteId]) {
+    const pipettePythonName =
+      invariantContext.pipetteEntities[pipetteId].pythonName
+    const pythonCommandCreator: CurriedCommandCreator = () => ({
+      commands: [],
+      // This is tricky and subtle: When dropping tips into the trash bin, we always
+      // want to alternateDropLocation. However, the Python drop_tip() only alternates
+      // the drop location if you do NOT specify a location= argument, in which case
+      // drop_tip() drops into the default trash container for the pipette.
+      // PD only allows a single trash bin, so we don't need to worry about emitting
+      // location= to select among multiple trash bins.
+      // But we DO need to worry about the possibility that the waste chute might be
+      // the default trash container if we have both a waste chute and a trash bin. The
+      // API specifies that the default trash container is whichever was loaded first.
+      // Our code generator does load the trash bin before loading the waste chute,
+      // so this works for now, but it's very brittle.
+      python: `${pipettePythonName}.drop_tip()`,
+    })
+
     commandCreators = [
-      curryCommandCreator(moveToAddressableAreaForDropTip, {
+      curryWithoutPython(moveToAddressableAreaForDropTip, {
         pipetteId,
         addressableAreaName,
       }),
-      curryCommandCreator(dropTipInPlace, {
+      curryWithoutPython(dropTipInPlace, {
         pipetteId,
       }),
-      // TODO:
-      // CommandCreator to emit Python pipette.drop_tip() would go here
+      pythonCommandCreator,
     ]
   }
 


### PR DESCRIPTION
# Overview

This is the first compound command we're generating Python for (and it's the last piece we need to get a runnable Python protocol for simple transfers AUTH-1093).

As discussed earlier, our strategy for compound commands that map to a single Python command is that we'll add an extra `CommandCreator` that emits the single Python command. The extra `CommandCreator` does not emit any JSON commands, so the JSON behavior is unchanged.

## Test Plan and Hands on Testing

Added unit tests.

I also tried this in my private branch, and confirmed that the syntax is correct with `simulate`.

## Review requests

This implementation is brittle because the PAPI only allows you to vary the drop location within the trash bin (which we want) when you **DON'T** specify the trash bin location in the call to `pipette.drop_tip(location=...)`. So this would only work when there is only 1 trash bin, which is true for now. (See AUTH-1372 for more discussion.)

## Risk assessment

Low. Python export is behind a feature flag.