### PR TITLE
feat(step-generation): use dropTipInTrash compound command in generateRobotStateTimeline

### DIFF
--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -183,5 +183,43 @@ describe('generateRobotStateTimeline', () => {
         ],
       ]
     `)
+
+    // The regex elides all the indented arguments in the Python code
+    const pythonCommandsOverview = result.timeline.map(frame =>
+      frame.python?.replaceAll(/(\n\s+.*)+\n/g, '...')
+    )
+    expect(pythonCommandsOverview).toEqual([
+      // Step a:
+      `
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.aspirate(...)
+mockPythonName.dispense(...)
+mockPythonName.aspirate(...)
+mockPythonName.dispense(...)
+mockPythonName.drop_tip()
+`.trim(),
+      // Step b:
+      `
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.aspirate(...)
+mockPythonName.dispense(...)
+mockPythonName.drop_tip()
+`.trim(),
+      // Step c:
+      `
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.aspirate(...)
+mockPythonName.dispense(...)
+mockPythonName.aspirate(...)
+mockPythonName.dispense(...)
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.aspirate(...)
+mockPythonName.dispense(...)
+mockPythonName.aspirate(...)
+mockPythonName.dispense(...)
+mockPythonName.drop_tip()
+`.trim(),
+    ])
   })
 })

--- a/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
+++ b/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
@@ -3,7 +3,7 @@ import {
   moveToAddressableArea,
   getWasteChuteAddressableAreaNamePip,
   getTrashBinAddressableAreaName,
-  moveToAddressableAreaForDropTip,
+  dropTipInTrash,
   curryCommandCreator,
   dropTip,
   reduceCommandCreators,
@@ -109,15 +109,7 @@ export const generateRobotStateTimeline = (
           ]
         }
         if (isTrashBin && addressableAreaNameTrashBin != null) {
-          dropTipCommands = [
-            curryCommandCreator(moveToAddressableAreaForDropTip, {
-              pipetteId,
-              addressableAreaName: addressableAreaNameTrashBin,
-            }),
-            curryCommandCreator(dropTipInPlace, {
-              pipetteId,
-            }),
-          ]
+          dropTipCommands = [curryCommandCreator(dropTipInTrash, { pipetteId })]
         }
         if (!willReuseTip) {
           return [

--- a/step-generation/src/commandCreators/compound/index.ts
+++ b/step-generation/src/commandCreators/compound/index.ts
@@ -2,6 +2,7 @@ export { absorbanceReaderCloseInitialize } from './absorbanceReaderCloseInitiali
 export { absorbanceReaderCloseRead } from './absorbanceReaderCloseRead'
 export { consolidate } from './consolidate'
 export { distribute } from './distribute'
+export { dropTipInTrash } from './dropTipInTrash'
 export { dropTipInWasteChute } from './dropTipInWasteChute'
 export { heaterShaker } from './heaterShaker'
 export { mix } from './mix'

--- a/step-generation/src/commandCreators/index.ts
+++ b/step-generation/src/commandCreators/index.ts
@@ -3,6 +3,7 @@ export {
   absorbanceReaderCloseRead,
   consolidate,
   distribute,
+  dropTipInTrash,
   dropTipInWasteChute,
   heaterShaker,
   mix,

--- a/step-generation/src/index.ts
+++ b/step-generation/src/index.ts
@@ -16,6 +16,7 @@ export {
   distribute,
   dropTip,
   dropTipInPlace,
+  dropTipInTrash,
   engageMagnet,
   heaterShaker,
   mix,


### PR DESCRIPTION
# Overview

`generateRobotStateTimeline()` is responsible for emitting the final drop-tip at the end of step like Transfer or Mix. (We call this "eager tip dropping.")

Previously, `generateRobotStateTimeline()` manually generated the `moveToAddressableAreaForDropTip` + `dropTipInPlace` commands for dropping the tip into the trash bin at the end of the step.

This PR changes it to use the `dropTipInPlace` compound command instead. Since the compound command implements Python generation, after this change, eager tip dropping will emit the Python `drop_tip()` at the end of the step, which is what we want. AUTH-1093

## Test Plan and Hands on Testing

I'm relying on existing unit tests to confirm that the JSON commands haven't changed.

I added a new Python test for `generateRobotStateTimeline()` and confirmed that we now emit the eager-tip-dropping `drop_tip()` Python command at the end of each step.

I also examined the "Export Python" file from PD running in this branch.

## Risk assessment

Low. This should not affect any existing behavior for JSON protocols, and Python protocols are hidden behind a feature flag.