### PR TITLE
docs hotfix- push_out after dispense

### DIFF
--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -127,39 +127,46 @@ Push Out After Dispense
 
 The optional ``push_out`` parameter of ``dispense()`` helps ensure all liquid leaves the tip. Use ``push_out`` for applications that require moving the pipette plunger lower than the default, without performing a full :ref:`blow out <blow-out>`.
 
-Flex pipettes include a ``push_out`` by default for any dispense that completely empties the attached pipette tip. The default ``push_out`` volume depends on your pipette and tip combination. 
+Flex pipettes include a push out of air by default for any dispense that completely empties the attached pipette tip. The default and maximum push out volumes depend on your Flex pipette and tip combination. 
 
 .. list-table::
     :header-rows: 1
-    * - **Pipette**
-      - **Tip**
-      - **``push_out`` Volume (µL)**
+
+    * - Pipette
+      - Tip
+      - Default ``push_out`` Volume (µL)
+      - Maximum ``push_out`` Volume (µL)
     * - 1- and 8-channel (50 µL)
       - 
-          * 50
+          - 50
       - 
-          * Default: 2
-          * Low-volume mode: 7
+          - Default: 2
+          - Low-volume mode: 7
+      - 
+          - Default: 3.9
+          - Low-volume mode: 11.7
     * - 1-, 8-, and 96-channel (1000 µL)
       - 
-          * 50
-          * 200
-          * 1000
+          - 50
+          - 200
+          - 1000
       - 
-          * 7
-          * 5
-          * 20
+          - 7
+          - 5
+          - 20
+      - 
+          - All volumes: 79.5
 
-OT-2 pipettes do not include a ``push_out`` by default. 
+OT-2 pipettes do not include a push out by default. 
 
-You can change the ``push_out`` volume for any :py:meth:`~.InstrumentContext.dispense` command. For example, this dispense action moves the ``flex_1channel_1000`` pipette plunger the equivalent of an additional 5 µL beyond where it would stop when dispensing 100 µL of liquid. 
+You can change the push out volume for any :py:meth:`~.InstrumentContext.dispense` command. For example, this dispense action moves the Flex 1-Channel 1000 µL pipette plunger the equivalent of an additional 2 µL beyond where it would stop when dispensing all 100 µL of liquid in a 200 µL tip. 
 
     pipette.pick_up_tip()
     pipette.aspirate(100, plate["A1"])
-    pipette.dispense(100, plate["B1"], push_out=5)
+    pipette.dispense(100, plate["B1"], push_out=7)
     pipette.drop_tip()
 
-To disable ``push_out`` during a dispense action, set ``push_out=0``.
+To disable ``push_out`` during any dispense action, set ``push_out=0``. You can use this to avoid multiple ``push_out`` actions during a mix step. 
 
 .. versionadded:: 2.15
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -127,12 +127,39 @@ Push Out After Dispense
 
 The optional ``push_out`` parameter of ``dispense()`` helps ensure all liquid leaves the tip. Use ``push_out`` for applications that require moving the pipette plunger lower than the default, without performing a full :ref:`blow out <blow-out>`.
 
-For example, this dispense action moves the plunger the equivalent of an additional 5 µL beyond where it would stop if ``push_out`` was set to zero or omitted::
+Flex pipettes include a ``push_out`` by default for any dispense that completely empties the attached pipette tip. The default ``push_out`` volume depends on your pipette and tip combination. 
+
+.. list-table::
+    :header-rows: 1
+    * - **Pipette**
+      - **Tip**
+      - **``push_out`` Volume (µL)**
+    * - 1- and 8-channel (50 µL)
+      - 
+          * 50
+      - 
+          * Default: 2
+          * Low-volume mode: 7
+    * - 1-, 8-, and 96-channel (1000 µL)
+      - 
+          * 50
+          * 200
+          * 1000
+      - 
+          * 7
+          * 5
+          * 20
+
+OT-2 pipettes do not include a ``push_out`` by default. 
+
+You can change the ``push_out`` volume for any :py:meth:`~.InstrumentContext.dispense` command. For example, this dispense action moves the ``flex_1channel_1000`` pipette plunger the equivalent of an additional 5 µL beyond where it would stop when dispensing 100 µL of liquid. 
 
     pipette.pick_up_tip()
     pipette.aspirate(100, plate["A1"])
     pipette.dispense(100, plate["B1"], push_out=5)
     pipette.drop_tip()
+
+To disable ``push_out`` during a dispense action, set ``push_out=0``.
 
 .. versionadded:: 2.15
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -125,7 +125,7 @@ Flex and OT-2 pipettes dispense at :ref:`default flow rates <new-plunger-flow-ra
 Push Out After Dispense
 -----------------------
 
-Dispensing all liquid from the tip usually requires an additional volume of air to ensure no droplets remain. In a push out after dispense, the pipette dispenses all liquid by returning the plunger to its aspirate start position. Then, without without stopping, the plunger moves further down to dispense the additional push out volume. 
+Dispensing all liquid from the tip usually requires an additional volume of air to ensure no droplets remain. In a push out after dispense, the pipette dispenses all liquid by returning the plunger to its aspirate start position. Then, without stopping, the plunger moves further down to dispense the additional push out volume. 
 
 Use the optional ``push_out`` parameter of ``dispense()`` for applications that require moving the pipette plunger lower than the default, without performing a full :ref:`blow out <blow-out>`.
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -129,33 +129,22 @@ The optional ``push_out`` parameter of ``dispense()`` helps ensure all liquid le
 
 Flex pipettes include a push out of air by default for any dispense that completely empties the attached pipette tip. The default and maximum push out volumes depend on your Flex pipette and tip combination. 
 
-.. list-table::
-    :header-rows: 1
++----------------------------------+------+---------------------------+---------------------------+
+|              Pipette             |  Tip |          Default          |          Maximum          |
+|                                  |      |          push_out         |          push_out         |
+|                                  |      |         Volume (µL)       |         Volume (µL)       |
++==================================+======+=========+=================+=========+=================+ 
+|                                  |      | Default | Low-volume mode | Default | Low-volume mode | 
++----------------------------------+------+---------+-----------------+---------+-----------------+ 
+|     1- and 8-channel (50 µL)     |  50  |    2    |        7        |   3.9   |       11.7      | 
++----------------------------------+------+---------+-----------------+---------+-----------------+ 
+| 1-, 8-, and 96-channel (1000 µL) | 50   | 7       |        -        |   79.5  |        -        | 
+|                                  +------+---------+                 |         |                 |
+|                                  | 200  | 5       |                 |         |                 |
+|                                  +------+---------+                 |         |                 |
+|                                  | 1000 | 20      |                 |         |                 |
++----------------------------------+------+---------+-----------------+---------+-----------------+
 
-    * - Pipette
-      - Tip
-      - Default ``push_out`` Volume (µL)
-      - Maximum ``push_out`` Volume (µL)
-    * - 1- and 8-channel (50 µL)
-      - 
-          - 50
-      - 
-          - Default: 2
-          - Low-volume mode: 7
-      - 
-          - Default: 3.9
-          - Low-volume mode: 11.7
-    * - 1-, 8-, and 96-channel (1000 µL)
-      - 
-          - 50
-          - 200
-          - 1000
-      - 
-          - 7
-          - 5
-          - 20
-      - 
-          - All volumes: 79.5
 
 OT-2 pipettes do not include a push out by default. 
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -125,35 +125,38 @@ Flex and OT-2 pipettes dispense at :ref:`default flow rates <new-plunger-flow-ra
 Push Out After Dispense
 -----------------------
 
-The optional ``push_out`` parameter of ``dispense()`` helps ensure all liquid leaves the tip. Use ``push_out`` for applications that require moving the pipette plunger lower than the default, without performing a full :ref:`blow out <blow-out>`.
+Dispensing all liquid from the tip usually requires an additional volume of air to ensure no droplets remain. In a push out after dispense, the pipette dispenses all liquid by returning the plunger to its aspirate start position. Then, without without stopping, the plunger moves further down to dispense the additional push out volume. 
 
-Flex pipettes include a push out of air by default for any dispense that completely empties the attached pipette tip. The default and maximum push out volumes depend on your Flex pipette and tip combination. 
+Use the optional ``push_out`` parameter of ``dispense()`` for applications that require moving the pipette plunger lower than the default, without performing a full :ref:`blow out <blow-out>`.
 
-+----------------------------------+------+---------------------------+---------------------------+
-|              Pipette             |  Tip |          Default          |          Maximum          |
-|                                  |      |          push_out         |          push_out         |
-|                                  |      |         Volume (µL)       |         Volume (µL)       |
-+==================================+======+=========+=================+=========+=================+ 
-|                                  |      | Default | Low-volume mode | Default | Low-volume mode | 
-+----------------------------------+------+---------+-----------------+---------+-----------------+ 
-|     1- and 8-channel (50 µL)     |  50  |    2    |        7        |   3.9   |       11.7      | 
-+----------------------------------+------+---------+-----------------+---------+-----------------+ 
-| 1-, 8-, and 96-channel (1000 µL) | 50   | 7       |        -        |   79.5  |        -        | 
-|                                  +------+---------+                 |         |                 |
-|                                  | 200  | 5       |                 |         |                 |
-|                                  +------+---------+                 |         |                 |
-|                                  | 1000 | 20      |                 |         |                 |
-+----------------------------------+------+---------+-----------------+---------+-----------------+
+Flex pipettes include a push out of air by default for any dispense that completely empties the attached pipette tip. Both default and maximum push out volumes depend on your Flex pipette and tip combination. 
 
++----------------------------------+-----------+---------------------------+----------------------------+
+|              Pipette             |  Tip      |         Default           |          Maximum           |
+|                                  |           |         push out          |          push out          |
++==================================+===========+===========================+============================+ 
+| 50 µL (1- and 8-channel)         | 50 µL     | - Regular: 2 µL           | - Regular: 3.9 µL          | 
+|                                  |           | - Low-volume mode: 7 µL   | - Low-volume mode: 11.7 µL | 
++----------------------------------+-----------+---------------------------+---------+------------------+ 
+| 1000 µL (1-, 8-, and 96-channel) | 50 µL     |          7 µL             |         79.5 µL            | 
+|                                  +-----------+---------------------------+----------------------------+
+|                                  | 200 µL    |          5 µL             |         79.5 µL            | 
+|                                  +-----------+---------------------------+----------------------------+
+|                                  | 1000 µL   |          20 µL            |         79.5 µL            |
++----------------------------------+-----------+---------------------------+----------------------------+
 
 OT-2 pipettes do not include a push out by default. 
 
-You can change the push out volume for any :py:meth:`~.InstrumentContext.dispense` command. For example, this dispense action moves the Flex 1-Channel 1000 µL pipette plunger the equivalent of an additional 2 µL beyond where it would stop when dispensing all 100 µL of liquid in a 200 µL tip. 
+You can change the push out volume for any :py:meth:`~.InstrumentContext.dispense` command. For this example dispense of all 100 µL of liquid in a 200 µL tip, the Flex 1-Channel 1000 µL pipette plunger will move the equivalent of 7 µL (an additional 2 µL more than the default) beyond the aspirate start position to push out any remaining liquid in the tip. 
 
+.. code-block:: python
+    
     pipette.pick_up_tip()
     pipette.aspirate(100, plate["A1"])
     pipette.dispense(100, plate["B1"], push_out=7)
     pipette.drop_tip()
+
+Set ``push_out`` to override the default if you observe problems with dispensing. If liquid remains inside the tip after dispensing, set ``push_out`` higher. If no liquid remains, but contact dispenses create too many bubbles, set ``push_out`` lower. 
 
 To disable ``push_out`` during any dispense action, set ``push_out=0``. You can use this to avoid multiple ``push_out`` actions during a mix step. 
 

--- a/api/docs/v2/pipettes/volume_modes.rst
+++ b/api/docs/v2/pipettes/volume_modes.rst
@@ -29,6 +29,12 @@ Passing different values to ``configure_for_volume()`` changes the minimum and m
       - 5
       - 50
 
+When you use ``configure_for_volume()`` for a Flex 50 µL pipette, you also define the default push out volume:
+* For **low volume mode** (1-4.9 µL): 7 µL
+* For 5-50 µL: 2 µL
+
+For more, see :ref:`_push-out-dispense`.
+
 .. note::
     The pipette must not contain liquid when you call ``configure_for_volume()``, or the API will raise an error.
     

--- a/api/docs/v2/pipettes/volume_modes.rst
+++ b/api/docs/v2/pipettes/volume_modes.rst
@@ -30,10 +30,11 @@ Passing different values to ``configure_for_volume()`` changes the minimum and m
       - 50
 
 When you use ``configure_for_volume()`` for a Flex 50 µL pipette, you also define the default push out volume:
-* For **low volume mode** (1-4.9 µL): 7 µL
+
+* For low volume mode (1-4.9 µL): 7 µL
 * For 5-50 µL: 2 µL
 
-For more, see :ref:`_push-out-dispense`.
+For more, see :ref:`push-out-dispense`.
 
 .. note::
     The pipette must not contain liquid when you call ``configure_for_volume()``, or the API will raise an error.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -364,6 +364,8 @@ class InstrumentContext(publisher.CommandPublisher):
         :param push_out: Continue past the plunger bottom to help ensure all liquid
                          leaves the tip. Measured in µL. The default value is ``None``.
 
+                         When not specified or set to ``None``, the plunger moves by a non-zero default amount.
+
                          See :ref:`push-out-dispense` for details.
         :type push_out: float
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -366,7 +366,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
                          When not specified or set to ``None``, the plunger moves by a non-zero default amount.
 
-                         See :ref:`push-out-dispense` for details.
+
+                         For a table of default values, see :ref:`push-out-dispense`.
         :type push_out: float
 
         :returns: This instance.


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

This PR is for a docs hotfix, working from `@docs2.22_1`. 

We need to update the `push_out` after dispense text to include: 
- push_out defaults to a non-zero value for Flex pipettes during dispenses where the tip is completely emptied (and let's include those non-zero values)
- the only way to disable push out is to set it to ``push_out=0``

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

http://sandbox.docs.opentrons.com/docs-hotfix-pushout/v2/

Need to test and probably make changes to table. 

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

- added a table 
- updated text to clarify the differences between Flex and OT-2
- added default, non zero values from this slack conversation: https://opentrons.slack.com/archives/C01CA80CZT8/p1741282265613599 

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

Does this cover Andy's original docs request? 

Anything incorrect/missing? 

Do we need to clarify more the difference between ``push_out`` as an optional parameter and the default values? 

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->

Low, but check that my table doesn't break anything. 
