### PR TITLE
chore(api): load new evotips labware on api >= 2.23

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -759,7 +759,11 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore):
         )
 
         main_namespace, main_version = load_labware_params.resolve(
-            main_load_name, main_namespace, main_version, custom_labware_params
+            main_load_name,
+            main_namespace,
+            main_version,
+            custom_labware_params,
+            self._api_version,
         )
         main_labware = cmd.flex_stacker.StackerStoredLabwareDetails(
             loadName=main_load_name, namespace=main_namespace, version=main_version
@@ -769,7 +773,11 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore):
 
         if lid_load_name:
             lid_namespace, lid_version = load_labware_params.resolve(
-                lid_load_name, lid_namespace, lid_version, custom_labware_params
+                lid_load_name,
+                lid_namespace,
+                lid_version,
+                custom_labware_params,
+                self._api_version,
             )
             lid_labware = cmd.flex_stacker.StackerStoredLabwareDetails(
                 loadName=lid_load_name, namespace=lid_namespace, version=lid_version
@@ -783,6 +791,7 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore):
                 adapter_namespace,
                 adapter_version,
                 custom_labware_params,
+                self._api_version,
             )
             adapter_labware = cmd.flex_stacker.StackerStoredLabwareDetails(
                 loadName=adapter_load_name,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,4 +1,5 @@
 """ProtocolEngine-based Protocol API core implementation."""
+
 from __future__ import annotations
 from typing import Dict, Optional, Type, Union, List, Tuple, TYPE_CHECKING
 
@@ -224,7 +225,7 @@ class ProtocolCore(
             self._engine_client.state.labware.find_custom_labware_load_params()
         )
         namespace, version = load_labware_params.resolve(
-            load_name, namespace, version, custom_labware_params
+            load_name, namespace, version, custom_labware_params, self._api_version
         )
 
         load_result = self._engine_client.execute_command_without_recovery(
@@ -295,7 +296,7 @@ class ProtocolCore(
             self._engine_client.state.labware.find_custom_labware_load_params()
         )
         namespace, version = load_labware_params.resolve(
-            load_name, namespace, version, custom_labware_params
+            load_name, namespace, version, custom_labware_params, self._api_version
         )
         load_result = self._engine_client.execute_command_without_recovery(
             cmd.LoadLabwareParams(
@@ -343,7 +344,7 @@ class ProtocolCore(
             self._engine_client.state.labware.find_custom_labware_load_params()
         )
         namespace, version = load_labware_params.resolve(
-            load_name, namespace, version, custom_labware_params
+            load_name, namespace, version, custom_labware_params, self._api_version
         )
         load_result = self._engine_client.execute_command_without_recovery(
             cmd.LoadLidParams(
@@ -960,7 +961,7 @@ class ProtocolCore(
             self._engine_client.state.labware.find_custom_labware_load_params()
         )
         namespace, version = load_labware_params.resolve(
-            load_name, namespace, version, custom_labware_params
+            load_name, namespace, version, custom_labware_params, self._api_version
         )
 
         load_result = self._engine_client.execute_command_without_recovery(
@@ -1162,7 +1163,7 @@ class ProtocolCore(
             OffDeckType,
             WasteChute,
             TrashBin,
-        ]
+        ],
     ) -> NonStackedLocation:
         if isinstance(location, (ModuleCore, NonConnectedModuleCore)):
             return ModuleLocation(moduleId=location.module_id)

--- a/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
@@ -81,17 +81,29 @@ def test_set_stored_labware_all_elements(
     ).then_return(sentinel.custom_labware_load_params)
     decoy.when(
         load_labware_params.resolve(
-            "main-name", "main-namespace", 1, sentinel.custom_labware_load_params
+            "main-name",
+            "main-namespace",
+            1,
+            sentinel.custom_labware_load_params,
+            MAX_SUPPORTED_VERSION,
         )
     ).then_return(("main-namespace-verified", 10))
     decoy.when(
         load_labware_params.resolve(
-            "adapter-name", "adapter-namespace", 2, sentinel.custom_labware_load_params
+            "adapter-name",
+            "adapter-namespace",
+            2,
+            sentinel.custom_labware_load_params,
+            MAX_SUPPORTED_VERSION,
         )
     ).then_return(("adapter-namespace-verified", 20))
     decoy.when(
         load_labware_params.resolve(
-            "lid-name", "lid-namespace", 3, sentinel.custom_labware_load_params
+            "lid-name",
+            "lid-namespace",
+            3,
+            sentinel.custom_labware_load_params,
+            MAX_SUPPORTED_VERSION,
         )
     ).then_return(("lid-namespace-verified", 30))
 
@@ -139,7 +151,11 @@ def test_set_stored_labware_only_checks_load_name_for_lid_and_adapter_valid(
     ).then_return(sentinel.custom_labware_load_params)
     decoy.when(
         load_labware_params.resolve(
-            "main-name", "main-namespace", 1, sentinel.custom_labware_load_params
+            "main-name",
+            "main-namespace",
+            1,
+            sentinel.custom_labware_load_params,
+            MAX_SUPPORTED_VERSION,
         )
     ).then_return(("main-namespace-verified", 10))
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -347,6 +347,7 @@ def test_load_labware(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -421,6 +422,7 @@ def test_load_labware_on_staging_slot(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -498,6 +500,7 @@ def test_load_labware_on_labware(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -568,6 +571,7 @@ def test_load_labware_off_deck(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -632,6 +636,7 @@ def test_load_adapter(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -704,6 +709,7 @@ def test_load_adapter_on_staging_slot(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -778,6 +784,7 @@ def test_load_lid(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -849,6 +856,7 @@ def test_load_lid_stack(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -1193,6 +1201,7 @@ def test_load_labware_on_module(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 
@@ -1270,6 +1279,7 @@ def test_load_labware_on_non_connected_module(
             "a_namespace",
             456,
             [EngineLabwareLoadParams("hello", "world", 654)],
+            subject.api_version,
         )
     ).then_return(("some_namespace", 9001))
 

--- a/app/src/local-resources/labware/hooks/useAllLabware.ts
+++ b/app/src/local-resources/labware/hooks/useAllLabware.ts
@@ -8,6 +8,8 @@ import type { LabwareSort, LabwareFilter, LabwareDefAndDate } from '../types'
 const LABWARE_LOADNAME_BLOCKLIST = [
   'evotips_flex_96_tiprack_adapter',
   'evotips_opentrons_96_labware',
+  'evotips_tiprack_adapter',
+  'evotips_reservoir_adapter',
 ]
 
 export function useAllLabware(

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -47,6 +47,8 @@ export const LABWAREV2_DO_NOT_LIST = [
   // temporarily blocking evotips until it is out of beta
   'evotips_flex_96_tiprack_adapter',
   'evotips_opentrons_96_labware',
+  'evotips_tiprack_adapter',
+  'evotips_reservoir_adapter',
   // temporarily blocking tiprack lids until stacker launches
   'opentrons_flex_tiprack_lid',
   // temporarily blocking 20 uL Flex tip racks until they launch
@@ -71,6 +73,8 @@ export const PD_DO_NOT_LIST = [
   //  temporarily blocking evotips until it is supported in PD
   'evotips_flex_96_tiprack_adapter',
   'evotips_opentrons_96_labware',
+  'evotips_tiprack_adapter',
+  'evotips_reservoir_adapter',
   // temporarily blocking tiprack lids until stacker launches
   'opentrons_flex_tiprack_lid',
   // temporarily blocking 20 uL Flex tip racks until they launch


### PR DESCRIPTION
Loads the new adapter defs from #17675 by default on api versions about 2.23.

Tested by simulating the protocol from that PR and making sure the correct version gets loaded on 2.23 and the old one gets loaded (well, the protocol fails because the old version doesn't have stacking offsets for the new variants, which is proof enough) on 2.22.