### PR TITLE
refactor(api): raise more descriptive error when using liquid classes on OT-2

### DIFF
--- a/api/src/opentrons/protocol_api/_liquid.py
+++ b/api/src/opentrons/protocol_api/_liquid.py
@@ -7,6 +7,10 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
 )
 
+from opentrons.protocols.advanced_control.transfers.common import (
+    NoLiquidClassPropertyError,
+)
+
 from ._liquid_properties import (
     TransferProperties,
     build_transfer_properties,
@@ -96,13 +100,13 @@ class LiquidClass:
         try:
             settings_for_pipette = self._by_pipette_setting[pipette_name]
         except KeyError:
-            raise ValueError(
+            raise NoLiquidClassPropertyError(
                 f"No properties found for {pipette_name} in {self._name} liquid class"
             )
         try:
             transfer_properties = settings_for_pipette[tiprack_uri]
         except KeyError:
-            raise ValueError(
-                f"No properties found for {tiprack_uri} in {self._name} liquid class"
+            raise NoLiquidClassPropertyError(
+                f"No properties found for {tiprack_uri} for {pipette_name} in {self._name} liquid class"
             )
         return transfer_properties

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -21,7 +21,10 @@ from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.util import FlowRates, find_value_for_api_version
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.advanced_control.transfers.common import TransferTipPolicyV2
+from opentrons.protocols.advanced_control.transfers.common import (
+    TransferTipPolicyV2,
+    NoLiquidClassPropertyError,
+)
 from opentrons.protocols.advanced_control.transfers import common as tx_commons
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine import (
@@ -1117,9 +1120,17 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 "No tipracks found for pipette in order to perform transfer"
             )
         tiprack_uri_for_transfer_props = tip_racks[0][1].get_uri()
-        transfer_props = liquid_class.get_for(
-            pipette=self.get_pipette_name(), tip_rack=tiprack_uri_for_transfer_props
-        )
+        try:
+            transfer_props = liquid_class.get_for(
+                pipette=self.get_pipette_name(), tip_rack=tiprack_uri_for_transfer_props
+            )
+        except NoLiquidClassPropertyError:
+            if self._protocol_core.robot_type == "OT-2 Standard":
+                raise NoLiquidClassPropertyError(
+                    "Default liquid classes are not supported with OT-2 pipettes and tip racks."
+                )
+            raise
+
         # TODO: use the ID returned by load_liquid_class in command annotations
         self.load_liquid_class(
             name=liquid_class.name,
@@ -1302,10 +1313,17 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 well_name=None,
             ).volume,
         )
-        transfer_props = liquid_class.get_for(
-            pipette=self.get_pipette_name(),
-            tip_rack=tiprack_uri_for_transfer_props,
-        )
+
+        try:
+            transfer_props = liquid_class.get_for(
+                pipette=self.get_pipette_name(), tip_rack=tiprack_uri_for_transfer_props
+            )
+        except NoLiquidClassPropertyError:
+            if self._protocol_core.robot_type == "OT-2 Standard":
+                raise NoLiquidClassPropertyError(
+                    "Default liquid classes are not supported with OT-2 pipettes and tip racks."
+                )
+            raise
 
         # If there are no multi-dispense properties or if the volume to distribute
         # per destination well is so large that the tip cannot hold enough liquid
@@ -1549,10 +1567,19 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             raise RuntimeError(
                 "No tipracks found for pipette in order to perform transfer"
             )
+
         tiprack_uri_for_transfer_props = tip_racks[0][1].get_uri()
-        transfer_props = liquid_class.get_for(
-            pipette=self.get_pipette_name(), tip_rack=tiprack_uri_for_transfer_props
-        )
+        try:
+            transfer_props = liquid_class.get_for(
+                pipette=self.get_pipette_name(), tip_rack=tiprack_uri_for_transfer_props
+            )
+        except NoLiquidClassPropertyError:
+            if self._protocol_core.robot_type == "OT-2 Standard":
+                raise NoLiquidClassPropertyError(
+                    "Default liquid classes are not supported with OT-2 pipettes and tip racks."
+                )
+            raise
+
         blow_out_properties = transfer_props.dispense.retract.blowout
         if (
             blow_out_properties.enabled

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1128,7 +1128,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             if self._protocol_core.robot_type == "OT-2 Standard":
                 raise NoLiquidClassPropertyError(
                     "Default liquid classes are not supported with OT-2 pipettes and tip racks."
-                )
+                ) from None
             raise
 
         # TODO: use the ID returned by load_liquid_class in command annotations
@@ -1322,7 +1322,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             if self._protocol_core.robot_type == "OT-2 Standard":
                 raise NoLiquidClassPropertyError(
                     "Default liquid classes are not supported with OT-2 pipettes and tip racks."
-                )
+                ) from None
             raise
 
         # If there are no multi-dispense properties or if the volume to distribute
@@ -1577,7 +1577,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             if self._protocol_core.robot_type == "OT-2 Standard":
                 raise NoLiquidClassPropertyError(
                     "Default liquid classes are not supported with OT-2 pipettes and tip racks."
-                )
+                ) from None
             raise
 
         blow_out_properties = transfer_props.dispense.retract.blowout

--- a/api/src/opentrons/protocols/advanced_control/transfers/common.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/common.py
@@ -4,6 +4,10 @@ import math
 from typing import Iterable, Generator, Tuple, TypeVar, Literal, List
 
 
+class NoLiquidClassPropertyError(ValueError):
+    """An error raised when a liquid class property cannot be found for a pipette/tip combination"""
+
+
 class TransferTipPolicyV2(enum.Enum):
     ONCE = "once"
     NEVER = "never"

--- a/api/tests/opentrons/protocol_api/test_liquid_class.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class.py
@@ -7,6 +7,9 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
 )
 from opentrons.protocol_api import LiquidClass
 from opentrons.protocol_api import InstrumentContext, Labware
+from opentrons.protocols.advanced_control.transfers.common import (
+    NoLiquidClassPropertyError,
+)
 
 
 def test_create_liquid_class(
@@ -46,8 +49,8 @@ def test_get_for_raises_for_incorrect_pipette_or_tip(
     """It should raise an error when accessing non-existent properties."""
     liq_class = LiquidClass.create(minimal_liquid_class_def2)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NoLiquidClassPropertyError):
         liq_class.get_for("flex_1channel_50", "no_such_tiprack")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NoLiquidClassPropertyError):
         liq_class.get_for("no_such_pipette", "opentrons_flex_96_tiprack_50ul")


### PR DESCRIPTION
# Overview

Closes AUTH-1424.

This PR refactors some of the `liquid_class.get_for()` logic to raise a new error type that inherits from the previous `ValueError` being raised (along with being slightly more descriptive for the case where we do find a compatible pipette but not a compatible tip rack). We then, in the engine core implementation, check for this error when calling `get_for`, and if it is raised we then see if the robot type is OT-2. If it is, we raise a more specific error message that default liquid classes are not supported on OT-2.

This method of raising the error ensures that if somebody makes a custom liquid class, or edits an existing liquid class, to support an OT-2 pipette and tip rack, this function will pass and allow them to continue. It also will allow some flexibility if we choose to refactor the liquid transfers further to allow them to take `TransferProperties`, since this error is purely tied to find transfer properties in a liquid class.

## Test Plan and Hands on Testing

Tested this protocol to ensure the new error was properly raised.

```
requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.23"
}


def run(protocol_context):
    tiprack = protocol_context.load_labware('opentrons_96_tiprack_300ul', 1)
    pipette_300 = protocol_context.load_instrument('p300_single_gen2', 'left', tip_racks=[tiprack])
    nest_plate = protocol_context.load_labware("nest_96_wellplate_2ml_deep", 2)
    arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", 3)

    water_class = protocol_context.define_liquid_class("water")

    pipette_300.transfer_liquid(
        liquid_class=water_class,
        volume=100,
        source=nest_plate.columns()[0][:2],
        dest=arma_plate.columns()[0][:2],
        new_tip="once",
    )
```

## Changelog

- refactored `LiquidClass.get_for` to raise a `NoLiquidClassPropertyError` when a pipette and tip rack combination could not be found
- Added try/except clauses to `get_for` calls to catch new error and then raise a more specific error if the robot type is OT-2

## Review requests

Do we like the wording of the new OT-2 specific error?

## Risk assessment

Low