### PR TITLE
refactor(protocol-designer): show timeline errors when a step is opened

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -75,10 +75,9 @@ export function ProtocolSteps(): JSX.Element {
   const { errors: timelineErrors } = useSelector(getRobotStateTimeline)
   const hasTimelineErrors =
     timelineErrors != null ? timelineErrors.length > 0 : false
-  const showTimelineAlerts =
-    hasTimelineErrors && tab === 'protocolSteps' && formData == null
+  const showTimelineAlerts = hasTimelineErrors && tab === 'protocolSteps'
   const stepDetails = currentStep?.stepDetails ?? null
-
+  console.log(showTimelineAlerts, hasTimelineErrors, tab, formData)
   return (
     <Flex
       backgroundColor={COLORS.grey10}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -77,7 +77,7 @@ export function ProtocolSteps(): JSX.Element {
     timelineErrors != null ? timelineErrors.length > 0 : false
   const showTimelineAlerts = hasTimelineErrors && tab === 'protocolSteps'
   const stepDetails = currentStep?.stepDetails ?? null
-  console.log(showTimelineAlerts, hasTimelineErrors, tab, formData)
+
   return (
     <Flex
       backgroundColor={COLORS.grey10}


### PR DESCRIPTION
# Overview

Upon discussing flex stacker with Felix, we noticed that the timeline errors weren't showing when you open a step. This PR fixes that. Merging this into edge since i don't think its big enough to fix for the 8.4.3 release

## Test Plan and Hands on Testing

Produce a timeline error, such as deleting a module used in a step. See that the missing module timeline error shows, then open the step that has the error and see that the timeline error is still visible.

## Changelog

- always display timeline errors when they exist on the protocol steps page

## Risk assessment

low