### PR TITLE
feat(protocol-designer): release notes in doc for 8.4.1 and 8.4.2 release

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -16,6 +16,12 @@ This hotfix release addresses a bug during protocol analysis on the Opentrons Ap
 
 ---
 
+## Opentrons Protocol Designer Changes in 8.4.1
+
+Version 8.4.1 was not released due to internal branching issues.
+
+---
+
 ## Opentrons Protocol Designer Changes in 8.4.0
 
 **Welcome to Protocol Designer 8.4.0!**

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -8,6 +8,12 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ---
 
+## Opentrons Protocol Designer Changes in 8.4.2
+
+v8.4.2 of Opentrons Protocol Designer is a hot fix that addresses a bug when trying to air gap over a trash bin or waste chute and increases the command schema in JSON protocols for schema version 10.
+
+---
+
 ## Opentrons Protocol Designer Changes in 8.4.0
 
 **Welcome to Protocol Designer 8.4.0!**

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -10,7 +10,9 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ## Opentrons Protocol Designer Changes in 8.4.2
 
-v8.4.2 of Opentrons Protocol Designer is a hot fix that addresses a bug when trying to air gap over a trash bin or waste chute and increases the command schema in JSON protocols for schema version 10.
+**Welcome to Protocol Designer 8.4.2!**
+
+This hotfix release addresses a bug during protocol analysis on the Opentrons App caused by an air gap after dispense.
 
 ---
 


### PR DESCRIPTION
# Overview

This PR adds release notes to the release notes doc for the 8.4.2 hotfix that was released a few weeks ago as well as the unreleased version 8.4.1

## Test Plan and Hands on Testing

Review code. Emily already gave the approval

## Changelog

- add copy for the 8.4.2 release and unreleased 8.4.1

## Risk assessment

low, merging into edge