### PR TITLE
refactor(api): Introduce labware URI returns to remaining stacker commands

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/empty.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/empty.py
@@ -15,6 +15,7 @@ from ...errors import (
 from ...errors.exceptions import FlexStackerLabwarePoolNotYetDefinedError
 from ...state import update_types
 from ...types import StackerFillEmptyStrategy
+from opentrons.calibration_storage.helpers import uri_from_details
 
 if TYPE_CHECKING:
     from ...state.state import StateView
@@ -61,6 +62,18 @@ class EmptyResult(BaseModel):
     count: int = Field(
         ..., description="The new amount of labware stored in the stacker labware pool."
     )
+    primaryLabwareURI: str = Field(
+        ...,
+        description="The labware definition URI of the primary labware.",
+    )
+    adapterLabwareURI: str | None = Field(
+        None,
+        description="The labware definition URI of the adapter labware.",
+    )
+    lidLabwareURI: str | None = Field(
+        None,
+        description="The labware definition URI of the lid labware.",
+    )
 
 
 class EmptyImpl(AbstractCommandImpl[EmptyParams, SuccessData[EmptyResult]]):
@@ -97,8 +110,35 @@ class EmptyImpl(AbstractCommandImpl[EmptyParams, SuccessData[EmptyResult]]):
         if params.strategy == StackerFillEmptyStrategy.MANUAL_WITH_PAUSE:
             await self._run_control.wait_for_resume()
 
+        if stacker_state.pool_primary_definition is None:
+            raise FlexStackerLabwarePoolNotYetDefinedError(
+                "The Primary Labware must be defined in the stacker pool."
+            )
+
         return SuccessData(
-            public=EmptyResult(count=new_count), state_update=state_update
+            public=EmptyResult(
+                count=new_count,
+                primaryLabwareURI=uri_from_details(
+                    stacker_state.pool_primary_definition.namespace,
+                    stacker_state.pool_primary_definition.parameters.loadName,
+                    stacker_state.pool_primary_definition.version,
+                ),
+                adapterLabwareURI=uri_from_details(
+                    stacker_state.pool_adapter_definition.namespace,
+                    stacker_state.pool_adapter_definition.parameters.loadName,
+                    stacker_state.pool_adapter_definition.version,
+                )
+                if stacker_state.pool_adapter_definition is not None
+                else None,
+                lidLabwareURI=uri_from_details(
+                    stacker_state.pool_lid_definition.namespace,
+                    stacker_state.pool_lid_definition.parameters.loadName,
+                    stacker_state.pool_lid_definition.version,
+                )
+                if stacker_state.pool_lid_definition is not None
+                else None,
+            ),
+            state_update=state_update,
         )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_empty.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_empty.py
@@ -3,7 +3,6 @@
 import pytest
 from decoy import Decoy
 from typing import cast
-from unittest.mock import sentinel
 
 from opentrons.protocol_engine.state.update_types import (
     StateUpdate,
@@ -26,6 +25,7 @@ from opentrons.protocol_engine.errors import (
     ModuleNotLoadedError,
     FlexStackerLabwarePoolNotYetDefinedError,
 )
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons.types import DeckSlotName
 
 
@@ -54,12 +54,13 @@ async def test_empty_happypath(
     current_count: int,
     count_param: int | None,
     target_count: int,
+    flex_50uL_tiprack: LabwareDefinition,
 ) -> None:
     """It should empty a valid stacker's labware pool."""
     module_id = "some-module-id"
     stacker_state = FlexStackerSubState(
         module_id=cast(FlexStackerId, module_id),
-        pool_primary_definition=sentinel.pool_primary_definition,
+        pool_primary_definition=flex_50uL_tiprack,
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=current_count,
@@ -80,7 +81,10 @@ async def test_empty_happypath(
             module_id=module_id, pool_count=target_count
         )
     )
-    assert result.public == EmptyResult(count=target_count)
+    assert result.public == EmptyResult(
+        count=target_count,
+        primaryLabwareURI="opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+    )
 
 
 async def test_empty_requires_stacker(
@@ -139,6 +143,7 @@ async def test_pause_strategy_pauses(
     state_view: StateView,
     run_control: RunControlHandler,
     subject: EmptyImpl,
+    flex_50uL_tiprack: LabwareDefinition,
 ) -> None:
     """It should pause the system when the pause strategy is used."""
     module_id = "some-module-id"
@@ -147,7 +152,7 @@ async def test_pause_strategy_pauses(
     target_count = 1
     stacker_state = FlexStackerSubState(
         module_id=cast(FlexStackerId, module_id),
-        pool_primary_definition=sentinel.pool_primary_definition,
+        pool_primary_definition=flex_50uL_tiprack,
         pool_adapter_definition=None,
         pool_lid_definition=None,
         pool_count=current_count,
@@ -168,5 +173,8 @@ async def test_pause_strategy_pauses(
             module_id=module_id, pool_count=target_count
         )
     )
-    assert result.public == EmptyResult(count=target_count)
+    assert result.public == EmptyResult(
+        count=target_count,
+        primaryLabwareURI="opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+    )
     decoy.verify(await run_control.wait_for_resume())

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -459,6 +459,7 @@ async def test_store(
                     possibleCutoutFixtureIds=["flexStackerModuleV1"],
                 ),
             ],
+            primaryLabwareURI="opentrons/opentrons_flex_96_filtertiprack_50ul/1",
         ),
         state_update=StateUpdate(
             batch_labware_location=BatchLabwareLocationUpdate(


### PR DESCRIPTION
# Overview
Covers EXEC-1333

To further enable client application utilization of stacker data the Store, Fill and Empty commands should contain relevant URIs in their command results.

## Test Plan and Hands on Testing

## Changelog
Addition of Labware URI data to the results of the remaining stacker commands.

## Review requests
Anything else we'd want in these command results while we're at it?

## Risk assessment
Low - modifying new behavior.