### PR TITLE
refactor(protocol-designer, step-generation): make location required …

### DIFF
--- a/protocol-designer/src/components/organisms/MaterialsListModal/MaterialsListModal.stories.tsx
+++ b/protocol-designer/src/components/organisms/MaterialsListModal/MaterialsListModal.stories.tsx
@@ -5,10 +5,12 @@ import { i18n } from '../../../assets/localization'
 import { configureStore } from '../../../configureStore'
 import { MaterialsListModal as MaterialsListModalComponent } from '.'
 
-import type { LiquidEntities } from '@opentrons/step-generation'
+import type {
+  AdditionalEquipmentEntity,
+  LiquidEntities,
+} from '@opentrons/step-generation'
 import type { Meta, StoryObj } from '@storybook/react'
 import type { LabwareOnDeck, ModuleOnDeck } from '../../../step-forms'
-import type { FixtureInList } from '.'
 
 const mockStore = configureStore()
 const mockHardware = [
@@ -27,7 +29,7 @@ const mockHardware = [
 
 const mockFixture = [
   { location: 'cutoutB3', name: 'trashBin', id: 'mockId:trashBin' },
-] as FixtureInList[]
+] as AdditionalEquipmentEntity[]
 
 const mockLabware = [
   {

--- a/protocol-designer/src/components/organisms/MaterialsListModal/__tests__/MaterialsListModal.test.tsx
+++ b/protocol-designer/src/components/organisms/MaterialsListModal/__tests__/MaterialsListModal.test.tsx
@@ -11,9 +11,9 @@ import { getInitialDeckSetup } from '../../../../step-forms/selectors'
 import { MaterialsListModal } from '..'
 
 import type { ComponentProps } from 'react'
+import type { AdditionalEquipmentEntity } from '@opentrons/step-generation'
 import type { InfoScreen } from '@opentrons/components'
 import type { LabwareOnDeck, ModuleOnDeck } from '../../../../step-forms'
-import type { FixtureInList } from '..'
 
 vi.mock('../../../../step-forms/selectors')
 vi.mock('../../../../labware-ingred/selectors')
@@ -44,7 +44,7 @@ const mockHardWare = [
 
 const mockFixture = [
   { location: 'cutoutB3', name: 'trashBin', id: 'mockId:trashBin' },
-] as FixtureInList[]
+] as AdditionalEquipmentEntity[]
 
 const mockLabware = [
   {

--- a/protocol-designer/src/components/organisms/MaterialsListModal/index.tsx
+++ b/protocol-designer/src/components/organisms/MaterialsListModal/index.tsx
@@ -33,23 +33,17 @@ import { HandleEnter, LINE_CLAMP_TEXT_STYLE } from '../../atoms'
 import { getMainPagePortalEl } from '../Portal'
 
 import type {
-  AdditionalEquipmentName,
   LiquidEntities,
+  AdditionalEquipmentEntity,
 } from '@opentrons/step-generation'
 import type { LabwareOnDeck, ModuleOnDeck } from '../../../step-forms'
 
 // ToDo (kk:09/04/2024) this should be removed when break-point is set up
 const MODAL_MIN_WIDTH = '37.125rem'
 
-export interface FixtureInList {
-  name: AdditionalEquipmentName
-  id: string
-  location?: string
-}
-
 interface MaterialsListModalProps {
   hardware: ModuleOnDeck[]
-  fixtures: FixtureInList[]
+  fixtures: AdditionalEquipmentEntity[]
   labware: LabwareOnDeck[]
   liquids: LiquidEntities
   setShowMaterialsListModal: (showMaterialsListModal: boolean) => void
@@ -98,16 +92,9 @@ export function MaterialsListModal({
                         type="large"
                         description={
                           <Flex minWidth="13.75rem">
-                            {fixture.location != null ? (
-                              <DeckInfoLabel
-                                deckLabel={fixture.location.replace(
-                                  'cutout',
-                                  ''
-                                )}
-                              />
-                            ) : (
-                              ''
-                            )}
+                            <DeckInfoLabel
+                              deckLabel={fixture.location.replace('cutout', '')}
+                            />
                           </Flex>
                         }
                         content={

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -195,6 +195,5 @@ export const ABSORBANCE_READER_COLOR_BY_WAVELENGTH: Record<number, string> = {
 }
 
 export const OFFDECK: 'offDeck' = 'offDeck'
-export const GRIPPER_LOCATION: 'mounted' = 'mounted'
 
 export const PROTOCOL_DESIGNER_SOURCE: 'Protocol Designer' = 'Protocol Designer' // protocolSource for tracking analytics in the app

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -281,12 +281,11 @@ export function getLoadTrashBins(
   additionalEquipmentEntities: AdditionalEquipmentEntities
 ): string {
   const pythonLoadTrashBins = Object.values(additionalEquipmentEntities)
-    .filter(ae => ae.name === 'trashBin' && ae.location != null)
+    .filter(ae => ae.name === 'trashBin')
     ?.map(trashBin => {
-      const location =
-        trashBin.location != null
-          ? formatPyStr(getCutoutDisplayName(trashBin.location as CutoutId))
-          : 'unknown trash location' // note: should never hit unknown trash location since location is always defined for trashBin entity
+      const location = formatPyStr(
+        getCutoutDisplayName(trashBin.location as CutoutId)
+      )
       return `${trashBin.pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_trash_bin(${location})`
     })
     .join('\n')

--- a/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
@@ -9,9 +9,9 @@ import {
   COLUMN_4_SLOTS,
   uuid,
   getCutoutIdByAddressableArea,
+  GRIPPER_LOCATION,
 } from '@opentrons/step-generation'
 import { getUnoccupiedSlotForTrash } from '../../../step-forms'
-import { GRIPPER_LOCATION } from '../../../constants'
 import type {
   AddressableAreaName,
   CreateCommand,

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupTools.test.tsx
@@ -7,6 +7,7 @@ import {
   HEATERSHAKER_MODULE_V1,
   fixture96Plate,
 } from '@opentrons/shared-data'
+import { GRIPPER_LOCATION } from '@opentrons/step-generation'
 import { i18n } from '../../../../assets/localization'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { deleteContainer } from '../../../../labware-ingred/actions'
@@ -185,7 +186,11 @@ describe('DeckSetupTools', () => {
   })
   it('should save plate reader if gripper configured', () => {
     vi.mocked(getAdditionalEquipment).mockReturnValue({
-      gripperUri: { name: 'gripper', id: 'gripperId' },
+      gripperUri: {
+        name: 'gripper',
+        id: 'gripperId',
+        location: GRIPPER_LOCATION,
+      },
     })
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
       selectedLabwareDefUri: null,

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/InstrumentsInfo.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/InstrumentsInfo.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, vi, beforeEach, expect } from 'vitest'
 import { fireEvent, screen } from '@testing-library/react'
 
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+import { GRIPPER_LOCATION } from '@opentrons/step-generation'
 
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../assets/localization'
@@ -70,6 +71,7 @@ const mockAdditionalEquipment = {
   'mock:gripper': {
     name: 'gripper',
     id: 'mock:gripper',
+    location: GRIPPER_LOCATION,
   },
 } as AdditionalEquipmentEntities
 

--- a/protocol-designer/src/pages/ProtocolOverview/utils.ts
+++ b/protocol-designer/src/pages/ProtocolOverview/utils.ts
@@ -61,11 +61,6 @@ export const getUnusedStagingAreas = (
   const stagingAreaCutoutIds = Object.values(additionalEquipment)
     .filter(equipment => equipment?.name === 'stagingArea')
     .map(equipment => {
-      if (equipment.location == null) {
-        console.error(
-          `expected to find staging area slot location with id ${equipment.id} but could not.`
-        )
-      }
       return equipment.location ?? ''
     })
 

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -12,8 +12,9 @@ import {
   MAGNETIC_MODULE_V1,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
+import { GRIPPER_LOCATION } from '@opentrons/step-generation'
 import { rootReducer as labwareDefsRootReducer } from '../../labware-defs'
-import { GRIPPER_LOCATION, INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
+import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import { getPDMetadata } from '../../file-types'
 import {
   getDefaultsForStepType,
@@ -1320,6 +1321,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           [id]: {
             name: 'gripper' as const,
             id,
+            location: GRIPPER_LOCATION,
           },
         }
       }

--- a/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseInitialize.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  ABSORBANCE_READER_TYPE,
+  ABSORBANCE_READER_V1,
+} from '@opentrons/shared-data'
 import { absorbanceReaderCloseInitialize } from '../commandCreators'
 import {
   absorbanceReaderStateGetter,
@@ -6,6 +10,7 @@ import {
 } from '../robotStateSelectors'
 import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 import { getErrorResult, getSuccessResult } from '../fixtures/commandFixtures'
+import { GRIPPER_LOCATION } from '../constants'
 
 import type {
   AbsorbanceReaderInitializeArgs,
@@ -13,10 +18,6 @@ import type {
   InvariantContext,
   RobotState,
 } from '../types'
-import {
-  ABSORBANCE_READER_TYPE,
-  ABSORBANCE_READER_V1,
-} from '@opentrons/shared-data'
 
 vi.mock('../robotStateSelectors')
 
@@ -50,6 +51,7 @@ describe('absorbanceReaderCloseInitialize compound command creator', () => {
         [GRIPPER_ID]: {
           id: GRIPPER_ID,
           name: 'gripper',
+          location: GRIPPER_LOCATION,
         },
       },
     }

--- a/step-generation/src/__tests__/absorbanceReaderCloseLid.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseLid.test.ts
@@ -8,6 +8,7 @@ import {
   makeContext,
   getInitialRobotStateStandard,
 } from '../fixtures'
+import { GRIPPER_LOCATION } from '../constants'
 import { absorbanceReaderCloseLid } from '../commandCreators/atomic/absorbanceReaderCloseLid'
 import { absorbanceReaderStateGetter } from '../robotStateSelectors'
 import type {
@@ -34,6 +35,7 @@ describe('absorbanceReaderCloseLid', () => {
       gripperId: {
         name: 'gripper',
         id: 'gripperId',
+        location: GRIPPER_LOCATION,
       },
     }
     robotState = getInitialRobotStateStandard(invariantContext)

--- a/step-generation/src/__tests__/absorbanceReaderCloseRead.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderCloseRead.test.ts
@@ -4,6 +4,7 @@ import {
   absorbanceReaderStateGetter,
   getModuleState,
 } from '../robotStateSelectors'
+import { GRIPPER_LOCATION } from '../constants'
 import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 import { getErrorResult, getSuccessResult } from '../fixtures/commandFixtures'
 
@@ -50,6 +51,7 @@ describe('absorbanceReaderCloseRead compound command creator', () => {
         [GRIPPER_ID]: {
           id: GRIPPER_ID,
           name: 'gripper',
+          location: GRIPPER_LOCATION,
         },
       },
     }

--- a/step-generation/src/__tests__/absorbanceReaderOpenLid.test.ts
+++ b/step-generation/src/__tests__/absorbanceReaderOpenLid.test.ts
@@ -8,6 +8,7 @@ import {
   makeContext,
   getInitialRobotStateStandard,
 } from '../fixtures'
+import { GRIPPER_LOCATION } from '../constants'
 import { absorbanceReaderOpenLid } from '../commandCreators/atomic/absorbanceReaderOpenLid'
 import { absorbanceReaderStateGetter } from '../robotStateSelectors'
 import type {
@@ -34,6 +35,7 @@ describe('absorbanceReaderOpenLid', () => {
       gripperId: {
         name: 'gripper',
         id: 'gripperId',
+        location: GRIPPER_LOCATION,
       },
     }
 

--- a/step-generation/src/__tests__/moveLabware.test.ts
+++ b/step-generation/src/__tests__/moveLabware.test.ts
@@ -13,7 +13,7 @@ import {
   SOURCE_LABWARE,
   TIPRACK_1,
 } from '../fixtures'
-import { DEST_LABWARE, moveLabware } from '..'
+import { DEST_LABWARE, GRIPPER_LOCATION, moveLabware } from '..'
 
 import type {
   LabwareDefinition2,
@@ -38,6 +38,7 @@ describe('moveLabware', () => {
         mockGripperId: {
           name: 'gripper',
           id: mockGripperId,
+          location: GRIPPER_LOCATION,
         },
         mockTrashBinId: {
           name: 'trashBin',
@@ -373,6 +374,7 @@ describe('moveLabware', () => {
         mockGripperId: {
           name: 'gripper',
           id: mockGripperId,
+          location: GRIPPER_LOCATION,
         },
       },
       labwareEntities: {

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -84,3 +84,5 @@ export const OT_2_TRASH_DEF_URI = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
 export const FLEX_TRASH_DEF_URI = 'opentrons/opentrons_1_trash_3200ml_fixed/1'
 export const COLUMN_4_SLOTS = ['A4', 'B4', 'C4', 'D4']
 export const ZERO_OFFSET: AddressableOffsetVector = { x: 0, y: 0, z: 0 }
+
+export const GRIPPER_LOCATION: 'mounted' = 'mounted'

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -149,7 +149,7 @@ export interface NormalizedAdditionalEquipmentById {
   [additionalEquipmentId: string]: {
     name: AdditionalEquipmentName
     id: string
-    location?: string
+    location: string
     //  Note: leaving as optional since gripper and stagingArea
     //  will never need a pythonName
     pythonName?: string

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -17,6 +17,7 @@ import type {
   AdditionalEquipmentName,
 } from '../types'
 import { uuid } from '.'
+import { GRIPPER_LOCATION } from '../constants'
 
 export function constructInvariantContextFromRunCommands(
   commands: RunTimeCommand[]
@@ -108,7 +109,7 @@ export function constructInvariantContextFromRunCommands(
         const addressableAreaName = command.params.addressableAreaName
         const id = `${uuid()}:${addressableAreaName}`
         let name: AdditionalEquipmentName = 'trashBin'
-        let location
+        let location: string = GRIPPER_LOCATION
         if (addressableAreaName === 'fixedTrash') {
           location = '12'
         } else if (addressableAreaName.includes('WasteChute')) {


### PR DESCRIPTION
…for gripper entity

# Overview

the `location` key in `AdditionalEquipmentEntity` was causing a bunch of annoyance since it was optional. This is because the gripper entity previously didn't need a location. In this PR, I refactored it to make it required for the gripper. The reason why I opted for this instead of making a union type for gripper entity and the other additional equipment entities is because we have a `gripperLocationUpdate` that uses `mounted` as the location for the gripper. So I wanted to match that. 

the refactor was minimal, just had to hard code in `mounted` as the location in the reducer and then fix all affected components (mainly adding location to the mocks), plus I refactored a few logic areas that were checking if location was null.

once this merges in, I'll be able to refactor `getTrashBinAddressableAreaName` to be cleaner and less lines of code. See this [PR](https://github.com/Opentrons/opentrons/pull/17741) for more details.

## Test Plan and Hands on Testing

Review the code. LMK if it doesn't make sense or if you have questions.

## Changelog

- make location not null
- use the gripper location const: `GRIPPER_LOCATION` which = `mounted`
- refactor instances where it was checking if location was null
- fix mocks and tests

## Risk assessment

low, just refactoring behind the scenes. should not affect functionality