### PR TITLE
fix(api, shared-data): fix camel-casing for the flexStacker/setStored Labware command

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from opentrons.protocol_engine.state.state import StateView
     from opentrons.protocol_engine.execution import EquipmentHandler
 
-SetStoredLabwareCommandType = Literal["flexStacker/setStoredlabware"]
+SetStoredLabwareCommandType = Literal["flexStacker/setStoredLabware"]
 
 
 class StackerStoredLabwareDetails(BaseModel):
@@ -174,7 +174,7 @@ class SetStoredLabware(
 ):
     """A command to setstoredlabware the Flex Stacker."""
 
-    commandType: SetStoredLabwareCommandType = "flexStacker/setStoredlabware"
+    commandType: SetStoredLabwareCommandType = "flexStacker/setStoredLabware"
     params: SetStoredLabwareParams
     result: Optional[SetStoredLabwareResult] = None
 
@@ -184,7 +184,7 @@ class SetStoredLabware(
 class SetStoredLabwareCreate(BaseCommandCreate[SetStoredLabwareParams]):
     """A request to execute a Flex Stacker SetStoredLabware command."""
 
-    commandType: SetStoredLabwareCommandType = "flexStacker/setStoredlabware"
+    commandType: SetStoredLabwareCommandType = "flexStacker/setStoredLabware"
     params: SetStoredLabwareParams
 
     _CommandCls: Type[SetStoredLabware] = SetStoredLabware

--- a/shared-data/command/schemas/12.json
+++ b/shared-data/command/schemas/12.json
@@ -4933,9 +4933,9 @@
       "description": "A request to execute a Flex Stacker SetStoredLabware command.",
       "properties": {
         "commandType": {
-          "const": "flexStacker/setStoredlabware",
-          "default": "flexStacker/setStoredlabware",
-          "enum": ["flexStacker/setStoredlabware"],
+          "const": "flexStacker/setStoredLabware",
+          "default": "flexStacker/setStoredLabware",
+          "enum": ["flexStacker/setStoredLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6583,7 +6583,7 @@
       "flexStacker/empty": "#/$defs/EmptyCreate",
       "flexStacker/fill": "#/$defs/FillCreate",
       "flexStacker/retrieve": "#/$defs/RetrieveCreate",
-      "flexStacker/setStoredlabware": "#/$defs/SetStoredLabwareCreate",
+      "flexStacker/setStoredLabware": "#/$defs/SetStoredLabwareCreate",
       "flexStacker/store": "#/$defs/StoreCreate",
       "getNextTip": "#/$defs/GetNextTipCreate",
       "getTipPresence": "#/$defs/GetTipPresenceCreate",


### PR DESCRIPTION
The front-end was expecting camel-case `flexStacker/setStoredLabware` but provided `flexStacker/setStoredlabware` with lower-case labware. This pr corrects that.