### PR TITLE
fix(protocol engine): fix meniscus-relative static dispense

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -100,6 +100,7 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
             labware_id=labware_id,
             well_name=well_name,
             well_location=well_location,
+            operation_volume=volume,
         )
         if isinstance(move_result, DefinedErrorData):
             return move_result

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -79,7 +79,7 @@ async def test_dispense_implementation(
             force_direct=False,
             minimum_z_height=None,
             speed=None,
-            operation_volume=None,
+            operation_volume=50.0,
         )
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -201,7 +201,7 @@ async def test_overpressure_error(
             force_direct=False,
             minimum_z_height=None,
             speed=None,
-            operation_volume=None,
+            operation_volume=50.0,
         ),
     ).then_return(position)
 
@@ -302,7 +302,7 @@ async def test_stall_error(
             force_direct=False,
             minimum_z_height=None,
             speed=None,
-            operation_volume=None,
+            operation_volume=50.0,
         ),
     ).then_raise(StallOrCollisionDetectedError())
 


### PR DESCRIPTION
## Overview
There was a tiny bug that disabled meniscus-relative static dispensing. It's just that `move_to_well` needs to be called with an operation volume and it wasn't. Here's the fix- it's tested on the robot and dispense works now!