### PR TITLE
refactor(step-generation): extend trash bin command args to include trashLocation

### DIFF
--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -609,7 +609,18 @@ describe('consolidate single-channel', () => {
       changeTip: 'once',
       mixInDestination: { times: 3, volume: 54 },
       blowoutLocation: FIXED_TRASH_ID,
+      dropTipLocation: 'trashBinId',
     } as ConsolidateArgs
+    invariantContext = {
+      ...invariantContext,
+      additionalEquipmentEntities: {
+        trashBinId: {
+          name: 'trashBin',
+          id: 'trashBinId',
+          location: 'cutoutA3',
+        },
+      },
+    }
 
     const result = consolidate(data, invariantContext, initialRobotState)
     const res = getSuccessResult(result)
@@ -1136,7 +1147,18 @@ describe('consolidate single-channel', () => {
         blowoutFlowRateUlSec: 2.3,
         blowoutOffsetFromTopMm: 3.3,
         dispenseAirGapVolume: 35,
+        dropTipLocation: 'trashBinId',
       } as ConsolidateArgs
+      invariantContext = {
+        ...invariantContext,
+        additionalEquipmentEntities: {
+          trashBinId: {
+            name: 'trashBin',
+            id: 'trashBinId',
+            location: 'cutoutA3',
+          },
+        },
+      }
 
       const result = consolidate(
         args,

--- a/step-generation/src/__tests__/dropTipInTrash.test.ts
+++ b/step-generation/src/__tests__/dropTipInTrash.test.ts
@@ -5,6 +5,7 @@ import {
   makeContext,
 } from '../fixtures'
 import { dropTipInTrash } from '../commandCreators/compound/dropTipInTrash'
+import type { CutoutId } from '@opentrons/shared-data'
 import type { InvariantContext, PipetteEntities, RobotState } from '../types'
 
 vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
@@ -41,6 +42,7 @@ describe('dropTipInTrash', () => {
   it('returns correct commands for drop tip', () => {
     const args = {
       pipetteId: mockId,
+      trashLocation: 'cutoutA3' as CutoutId,
     }
     const result = dropTipInTrash(args, invariantContext, prevRobotState)
     expect(getSuccessResult(result).commands).toEqual([

--- a/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest'
-import { makeContext } from '../fixtures'
 import { curryCommandCreator } from '../utils'
 import {
   airGapInMovableTrash,
@@ -13,43 +12,25 @@ import {
   moveToAddressableArea,
   prepareToAspirate,
 } from '../commandCreators/atomic'
-import type { PipetteEntities } from '../types'
+import type { CutoutId } from '@opentrons/shared-data'
 
 vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
 vi.mock('../utils/curryCommandCreator')
 
-const mockTrashBinId = 'mockTrashBinId'
 const mockId = 'mockId'
 
-const mockPipEntities: PipetteEntities = {
-  [mockId]: {
-    name: 'p50_single_flex',
-    id: mockId,
-  },
-} as any
-const mockCutout = 'cutoutA3'
+const mockCutout: CutoutId = 'cutoutA3'
 const mockMoveToAddressableAreaParams = {
   pipetteId: mockId,
   addressableAreaName: 'movableTrashA3',
   offset: { x: 0, y: 0, z: 0 },
 }
-const invariantContext = makeContext()
 
 const args = {
   pipetteId: mockId,
   volume: 10,
   flowRate: 10,
-  invariantContext: {
-    ...invariantContext,
-    pipetteEntities: mockPipEntities,
-    additionalEquipmentEntities: {
-      [mockTrashBinId]: {
-        name: 'trashBin' as const,
-        location: mockCutout,
-        id: mockTrashBinId,
-      },
-    },
-  },
+  trashLocation: mockCutout,
 }
 
 describe('movableTrashCommandsUtil', () => {

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -5,7 +5,6 @@ import {
   getWellDepth,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
-  CutoutId,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -34,7 +33,7 @@ import {
 import { mixUtil } from './mix'
 import { replaceTip } from './replaceTip'
 import { dropTipInWasteChute } from './dropTipInWasteChute'
-
+import type { CutoutId } from '@opentrons/shared-data'
 import type {
   ConsolidateArgs,
   CommandCreator,

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -5,6 +5,7 @@ import {
   getWellDepth,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  CutoutId,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -191,16 +192,10 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
 
   const sourceWellChunks = chunk(args.sourceWells, maxWellsPerChunk)
 
-  const isWasteChute =
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation] !=
-      null &&
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation].name ===
-      'wasteChute'
-  const isTrashBin =
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation] !=
-      null &&
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation].name ===
-      'trashBin'
+  const dropTipEntity =
+    invariantContext.additionalEquipmentEntities[args.dropTipLocation]
+  const isWasteChute = dropTipEntity?.name === 'wasteChute'
+  const isTrashBin = dropTipEntity?.name === 'trashBin'
 
   const commandCreators = flatMap(
     sourceWellChunks,
@@ -489,7 +484,10 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       }
       if (isTrashBin) {
         dropTipCommand = [
-          curryCommandCreator(dropTipInTrash, { pipetteId: args.pipette }),
+          curryCommandCreator(dropTipInTrash, {
+            pipetteId: args.pipette,
+            trashLocation: dropTipEntity.location as CutoutId,
+          }),
         ]
       }
 

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -6,7 +6,6 @@ import {
   getWellDepth,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
-  CutoutId,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -34,7 +33,7 @@ import {
 import { mixUtil } from './mix'
 import { replaceTip } from './replaceTip'
 import { dropTipInWasteChute } from './dropTipInWasteChute'
-
+import type { CutoutId } from '@opentrons/shared-data'
 import type {
   DistributeArgs,
   CommandCreator,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -6,6 +6,7 @@ import {
   getWellDepth,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  CutoutId,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -174,12 +175,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
   )
   const { pipette } = args
 
-  const isWasteChute =
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation]?.name ===
-    'wasteChute'
-  const isTrashBin =
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation]?.name ===
-    'trashBin'
+  const dropTipEntity =
+    invariantContext.additionalEquipmentEntities[args.dropTipLocation]
+  const isWasteChute = dropTipEntity?.name === 'wasteChute'
+  const isTrashBin = dropTipEntity?.name === 'trashBin'
 
   if (maxWellsPerChunk === 0) {
     // distribute vol exceeds pipette vol
@@ -404,7 +403,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
       }
       if (isTrashBin) {
         dropTipCommand = [
-          curryCommandCreator(dropTipInTrash, { pipetteId: args.pipette }),
+          curryCommandCreator(dropTipInTrash, {
+            pipetteId: args.pipette,
+            trashLocation: dropTipEntity.location as CutoutId,
+          }),
         ]
       }
 

--- a/step-generation/src/commandCreators/compound/dropTipInTrash.ts
+++ b/step-generation/src/commandCreators/compound/dropTipInTrash.ts
@@ -6,21 +6,21 @@ import {
 import { moveToAddressableAreaForDropTip } from '../atomic/moveToAddressableAreaForDropTip'
 import { dropTipInPlace } from '../atomic/dropTipInPlace'
 import type { CurriedCommandCreator, CommandCreator } from '../../types'
-import type { DropTipInPlaceParams } from '@opentrons/shared-data'
+import type { CutoutId, DropTipInPlaceParams } from '@opentrons/shared-data'
 
-export const dropTipInTrash: CommandCreator<DropTipInPlaceParams> = (
+interface DropTipInTrashParams extends DropTipInPlaceParams {
+  trashLocation: CutoutId
+}
+export const dropTipInTrash: CommandCreator<DropTipInTrashParams> = (
   args,
   invariantContext,
   prevRobotState
 ) => {
-  const { pipetteId } = args
+  const { pipetteId, trashLocation } = args
   let commandCreators: CurriedCommandCreator[] = []
-  const addressableAreaName = getTrashBinAddressableAreaName(
-    invariantContext.additionalEquipmentEntities
-  )
-  if (addressableAreaName == null) {
-    console.error('could not getTrashBinAddressableAreaName for dropTip')
-  } else if (prevRobotState.tipState.pipettes[pipetteId]) {
+  const addressableAreaName = getTrashBinAddressableAreaName(trashLocation)
+
+  if (prevRobotState.tipState.pipettes[pipetteId]) {
     const pipettePythonName =
       invariantContext.pipetteEntities[pipetteId].pythonName
     const pythonCommandCreator: CurriedCommandCreator = () => ({

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -3,7 +3,6 @@ import {
   COLUMN,
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
-  SINGLE,
 } from '@opentrons/shared-data'
 import { getNextTiprack } from '../../robotStateSelectors'
 import * as errorCreators from '../../errorCreators'

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -169,24 +169,14 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     }
   }
 
-  let primaryNozzle
-  if (nozzles === COLUMN) {
-    primaryNozzle = PRIMARY_NOZZLE
-  } else if (nozzles === SINGLE && channels === 96) {
-    primaryNozzle = 'H12'
-  } else if (nozzles === SINGLE && channels === 8) {
-    primaryNozzle = 'H1'
-  }
-
   const configureNozzleLayoutCommand: CurriedCommandCreator[] =
     //  only emit the command if previous nozzle state is different
-    (channels === 96 || channels === 8) &&
-    args.nozzles != null &&
-    args.nozzles !== stateNozzles
+    channels === 96 && args.nozzles != null && args.nozzles !== stateNozzles
       ? [
           curryCommandCreator(configureNozzleLayout, {
             configurationParams: {
-              primaryNozzle,
+              primaryNozzle:
+                args.nozzles === COLUMN ? PRIMARY_NOZZLE : undefined,
               style: args.nozzles,
             },
             pipetteId: args.pipette,

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -3,6 +3,7 @@ import {
   COLUMN,
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
+  SINGLE,
 } from '@opentrons/shared-data'
 import { getNextTiprack } from '../../robotStateSelectors'
 import * as errorCreators from '../../errorCreators'
@@ -22,7 +23,7 @@ import { dropTip } from '../atomic/dropTip'
 import { pickUpTip } from '../atomic/pickUpTip'
 import { configureNozzleLayout } from '../atomic/configureNozzleLayout'
 
-import type { NozzleConfigurationStyle } from '@opentrons/shared-data'
+import type { CutoutId, NozzleConfigurationStyle } from '@opentrons/shared-data'
 import type { CommandCreator, CurriedCommandCreator } from '../../types'
 
 interface ReplaceTipArgs {
@@ -97,15 +98,10 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
   const labwareDef =
     invariantContext.labwareEntities[nextTiprack.tiprackId]?.def
 
-  const isWasteChute =
-    invariantContext.additionalEquipmentEntities[dropTipLocation] != null &&
-    invariantContext.additionalEquipmentEntities[dropTipLocation].name ===
-      'wasteChute'
-
-  const isTrashBin =
-    invariantContext.additionalEquipmentEntities[dropTipLocation] != null &&
-    invariantContext.additionalEquipmentEntities[dropTipLocation].name ===
-      'trashBin'
+  const dropTipEntity =
+    invariantContext.additionalEquipmentEntities[args.dropTipLocation]
+  const isWasteChute = dropTipEntity?.name === 'wasteChute'
+  const isTrashBin = dropTipEntity?.name === 'trashBin'
 
   if (!labwareDef) {
     return {
@@ -173,14 +169,24 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     }
   }
 
+  let primaryNozzle
+  if (nozzles === COLUMN) {
+    primaryNozzle = PRIMARY_NOZZLE
+  } else if (nozzles === SINGLE && channels === 96) {
+    primaryNozzle = 'H12'
+  } else if (nozzles === SINGLE && channels === 8) {
+    primaryNozzle = 'H1'
+  }
+
   const configureNozzleLayoutCommand: CurriedCommandCreator[] =
     //  only emit the command if previous nozzle state is different
-    channels === 96 && args.nozzles != null && args.nozzles !== stateNozzles
+    (channels === 96 || channels === 8) &&
+    args.nozzles != null &&
+    args.nozzles !== stateNozzles
       ? [
           curryCommandCreator(configureNozzleLayout, {
             configurationParams: {
-              primaryNozzle:
-                args.nozzles === COLUMN ? PRIMARY_NOZZLE : undefined,
+              primaryNozzle,
               style: args.nozzles,
             },
             pipetteId: args.pipette,
@@ -219,6 +225,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     commandCreators = [
       curryCommandCreator(dropTipInTrash, {
         pipetteId: pipette,
+        trashLocation: dropTipEntity.location as CutoutId,
       }),
       ...configureNozzleLayoutCommand,
       curryCommandCreator(pickUpTip, {

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -4,6 +4,7 @@ import {
   getWellDepth,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  CutoutId,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -167,16 +168,10 @@ export const transfer: CommandCreator<TransferArgs> = (
     }
   const pipetteSpec = invariantContext.pipetteEntities[args.pipette].spec
 
-  const isWasteChute =
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation] !=
-      null &&
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation].name ===
-      'wasteChute'
-  const isTrashBin =
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation] !=
-      null &&
-    invariantContext.additionalEquipmentEntities[args.dropTipLocation].name ===
-      'trashBin'
+  const dropTipEntity =
+    invariantContext.additionalEquipmentEntities[args.dropTipLocation]
+  const isWasteChute = dropTipEntity?.name === 'wasteChute'
+  const isTrashBin = dropTipEntity?.name === 'trashBin'
 
   const aspirateAirGapVolume = args.aspirateAirGapVolume || 0
   const dispenseAirGapVolume = args.dispenseAirGapVolume || 0
@@ -566,7 +561,10 @@ export const transfer: CommandCreator<TransferArgs> = (
           }
           if (isTrashBin) {
             dropTipCommand = [
-              curryCommandCreator(dropTipInTrash, { pipetteId: args.pipette }),
+              curryCommandCreator(dropTipInTrash, {
+                pipetteId: args.pipette,
+                trashLocation: dropTipEntity.location as CutoutId,
+              }),
             ]
           }
 

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -4,7 +4,6 @@ import {
   getWellDepth,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
-  CutoutId,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -32,7 +31,7 @@ import {
 } from '../atomic'
 import { mixUtil } from './mix'
 import { replaceTip } from './replaceTip'
-
+import type { CutoutId } from '@opentrons/shared-data'
 import type {
   TransferArgs,
   CurriedCommandCreator,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -388,10 +388,13 @@ export const blowoutUtil = (args: {
       invariantContext,
     })
   } else {
+    const trashBin = Object.values(additionalEquipmentEntities).find(
+      ae => ae.name === 'trashBin'
+    )
+    console.log('trashBin entity', trashBin)
     return blowOutInMovableTrash({
       pipetteId: pipette,
-      trashLocation: additionalEquipmentEntities[destLabwareId]
-        .location as CutoutId,
+      trashLocation: trashBin?.location as CutoutId,
       flowRate,
     })
   }

--- a/step-generation/src/utils/movableTrashCommandsUtil.ts
+++ b/step-generation/src/utils/movableTrashCommandsUtil.ts
@@ -8,7 +8,8 @@ import {
 import { ZERO_OFFSET } from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
 import { getTrashBinAddressableAreaName } from './misc'
-import type { InvariantContext, CurriedCommandCreator } from '../types'
+import type { CutoutId } from '@opentrons/shared-data'
+import type { CurriedCommandCreator } from '../types'
 
 /** Helper fn for movable trash commands for dispense, aspirate, air_gap, drop_tip and blow_out commands */
 
@@ -16,17 +17,12 @@ export function airGapInMovableTrash(args: {
   pipetteId: string
   volume: number
   flowRate: number
-  invariantContext: InvariantContext
+  trashLocation: CutoutId
 }): CurriedCommandCreator[] {
-  const { pipetteId, invariantContext, volume, flowRate } = args
+  const { pipetteId, trashLocation, volume, flowRate } = args
   const offset = ZERO_OFFSET
-  const addressableAreaName = getTrashBinAddressableAreaName(
-    invariantContext.additionalEquipmentEntities
-  )
-  if (addressableAreaName == null) {
-    console.error('could not getTrashBinAddressableAreaName for airGap')
-    return []
-  }
+  const addressableAreaName = getTrashBinAddressableAreaName(trashLocation)
+
   return [
     curryCommandCreator(moveToAddressableArea, {
       pipetteId,
@@ -48,17 +44,12 @@ export function dispenseInMovableTrash(args: {
   pipetteId: string
   volume: number
   flowRate: number
-  invariantContext: InvariantContext
+  trashLocation: CutoutId
 }): CurriedCommandCreator[] {
-  const { pipetteId, invariantContext, volume, flowRate } = args
+  const { pipetteId, trashLocation, volume, flowRate } = args
   const offset = ZERO_OFFSET
-  const addressableAreaName = getTrashBinAddressableAreaName(
-    invariantContext.additionalEquipmentEntities
-  )
-  if (addressableAreaName == null) {
-    console.error('could not getTrashBinAddressableAreaName for dispense')
-    return []
-  }
+  const addressableAreaName = getTrashBinAddressableAreaName(trashLocation)
+
   return [
     curryCommandCreator(moveToAddressableArea, {
       pipetteId,
@@ -76,17 +67,12 @@ export function dispenseInMovableTrash(args: {
 export function blowOutInMovableTrash(args: {
   pipetteId: string
   flowRate: number
-  invariantContext: InvariantContext
+  trashLocation: CutoutId
 }): CurriedCommandCreator[] {
-  const { pipetteId, invariantContext, flowRate } = args
+  const { pipetteId, trashLocation, flowRate } = args
   const offset = ZERO_OFFSET
-  const addressableAreaName = getTrashBinAddressableAreaName(
-    invariantContext.additionalEquipmentEntities
-  )
-  if (addressableAreaName == null) {
-    console.error('could not getTrashBinAddressableAreaName for blowOut')
-    return []
-  }
+  const addressableAreaName = getTrashBinAddressableAreaName(trashLocation)
+
   return [
     curryCommandCreator(moveToAddressableArea, {
       pipetteId,
@@ -102,17 +88,12 @@ export function blowOutInMovableTrash(args: {
 
 export function moveToMovableTrash(args: {
   pipetteId: string
-  invariantContext: InvariantContext
+  trashLocation: CutoutId
 }): CurriedCommandCreator[] {
-  const { pipetteId, invariantContext } = args
+  const { pipetteId, trashLocation } = args
   const offset = ZERO_OFFSET
-  const addressableAreaName = getTrashBinAddressableAreaName(
-    invariantContext.additionalEquipmentEntities
-  )
-  if (addressableAreaName == null) {
-    console.error('could not getTrashBinAddressableAreaName for moveTo')
-    return []
-  }
+  const addressableAreaName = getTrashBinAddressableAreaName(trashLocation)
+
   return [
     curryCommandCreator(moveToAddressableArea, {
       pipetteId,


### PR DESCRIPTION
# Overview

This PR refactors the step-generation trash commands to extend the args to include `trashLocation`. This cleans up the need to search for if a trash entity exists in the command creators because the parent (`transfer`, `consolidate`, `replaceTip`, etc) already checks if it exists.

## Test Plan and Hands on Testing

Review the code. I smoke tested and funcionality seems to be retained. Also there are unit tests and the migration e2e test that helps verify that functionality is retained 

## Changelog

- refactor to extend the trash location arg
- refactor and clean up affected components
- fix test
- refactor `getTrashBinAddressableAreaName` util to be cleaner and not need invariant context or return null

## Risk assessment

low, shouldn't affect functionality
