### PR TITLE
fix(shared-data): fix definition of PickUpTipParams, should not inherit from TouchTipParams

### DIFF
--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -286,7 +286,7 @@ export type TouchTipParams = PipetteAccessParams &
     speed?: number
   }
 export type DropTipParams = PipetteAccessParams & DropTipWellLocationParam
-export type PickUpTipParams = TouchTipParams
+export type PickUpTipParams = PipetteAccessParams & WellLocationParam
 export type PrepareToAspirateParams = PipetteIdentityParams
 
 interface AddressableOffsetVector {


### PR DESCRIPTION
# Overview

`PickUpTipParams` was defined to be the same as `TouchTipParams`, but that doesn't seem to make sense. `TouchTipParams` has fields like `speed`, which isn't applicable to the `pickUpTip` command.

@sfoster1 It looks like you originally authored this code in PR #13848. Was this a typo?

@ncdiehl11 Hm, or was it your change that added `speed` to `PickUpTipParams` in PR #17545?

In any case, I'm trying to untangle the definition of `PickUpTipParams` from `TouchTipParams` as part of the PD Python export implementation.

## Test Plan and Hands on Testing

I'm relying on our CI tests to see what breaks.

## Risk assessment

Just a type definition change, should not affect user-visible behavior.