### PR TITLE
refactor(shared-data): Backport labware schema 3 additions to schema 2

### DIFF
--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -77,15 +77,8 @@ describe(`test labware definitions with schema v3`, () => {
       const valid = validate(labwareDef)
       const validationErrors = validate.errors
 
-      // FIXME(mm, 2025-02-04): These new definitions have a displayCategory that
-      // the schema does not recognize. Either they need to change or the schema does.
-      const expectFailure = ['protocol_engine_lid_stack_object'].includes(
-        labwareDef.parameters.loadName
-      )
-
-      if (expectFailure) expect(validationErrors).not.toBe(null)
-      else expect(validationErrors).toBe(null)
-      expect(valid).toBe(!expectFailure)
+      expect(validationErrors).toBe(null)
+      expect(valid).toBe(true)
     })
 
     checkGeometryDefinitions(labwareDef)

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -126,6 +126,7 @@ export interface LabwareParameters {
   isTiprack: boolean
   tipLength?: number
   isMagneticModuleCompatible: boolean
+  isDeckSlotCompatible?: boolean
   magneticModuleEngageHeight?: number
   quirks?: string[]
 }
@@ -260,6 +261,8 @@ export interface LabwareDefinition2 {
   stackingOffsetWithLabware?: Record<string, LabwareOffset>
   stackingOffsetWithModule?: Record<string, LabwareOffset>
   stackLimit?: number
+  compatibleParentLabware?: string[]
+  innerLabwareGeometry?: Record<string, InnerWellGeometry> | null
 }
 
 export interface LabwareDefinition3 {
@@ -278,6 +281,8 @@ export interface LabwareDefinition3 {
   allowedRoles?: LabwareRoles[]
   stackingOffsetWithLabware?: Record<string, LabwareOffset>
   stackingOffsetWithModule?: Record<string, LabwareOffset>
+  stackLimit?: number
+  compatibleParentLabware?: string[]
   innerLabwareGeometry?: Record<string, InnerWellGeometry> | null
 }
 

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -80,6 +80,364 @@
           "description": "Offset added to calculate drop coordinates."
         }
       }
+    },
+    "well": {
+      "anyOf": [
+        { "$ref": "#/definitions/rectangularWell" },
+        { "$ref": "#/definitions/circularWell" }
+      ]
+    },
+    "rectangularWell": {
+      "type": "object",
+      "required": [
+        "shape",
+        "depth",
+        "totalLiquidVolume",
+        "x",
+        "y",
+        "z",
+        "xDimension",
+        "yDimension"
+      ],
+      "$comment": "The properties with a subschema of `true` ('always pass') are defined in wellCommon. They need to be mentioned here for additionalProperties to work right, until we have JSON Schema 2019-09 and we can switch to unevaluatedProperties.",
+      "properties": {
+        "shape": {
+          "const": "rectangular"
+        },
+        "depth": true,
+        "totalLiquidVolume": true,
+        "x": true,
+        "y": true,
+        "z": true,
+        "geometryDefinitionId": true,
+        "xDimension": {
+          "description": "x dimension of rectangular wells",
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "yDimension": {
+          "description": "y dimension of rectangular wells",
+          "$ref": "#/definitions/positiveNumber"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [{ "$ref": "#/definitions/wellCommon" }]
+    },
+    "circularWell": {
+      "type": "object",
+      "required": [
+        "shape",
+        "depth",
+        "totalLiquidVolume",
+        "x",
+        "y",
+        "z",
+        "diameter"
+      ],
+      "$comment": "The properties with a subschema of `true` ('always pass') are defined in wellCommon. They need to be mentioned here for additionalProperties to work right, until we have JSON Schema 2019-09 and we can switch to unevaluatedProperties.",
+      "properties": {
+        "shape": {
+          "const": "circular"
+        },
+        "depth": true,
+        "totalLiquidVolume": true,
+        "x": true,
+        "y": true,
+        "z": true,
+        "geometryDefinitionId": true,
+        "diameter": {
+          "description": "diameter of circular wells",
+          "$ref": "#/definitions/positiveNumber"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [{ "$ref": "#/definitions/wellCommon" }]
+    },
+    "wellCommon": {
+      "$comment": "These properties need to stay in sync with rectangularWell and circularWell. See comments there.",
+      "properties": {
+        "depth": {
+          "description": "The distance between the top and bottom of this well. If the labware is a tip rack, this will be ignored in favor of tipLength, but the values should match.",
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "totalLiquidVolume": {
+          "description": "Total well, tube, or tip volume in microliters",
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "x": {
+          "description": "x location of center-bottom of well in reference to left-front-bottom of labware",
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "y": {
+          "description": "y location of center-bottom of well in reference to left-front-bottom of labware",
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "z": {
+          "description": "z location of center-bottom of well in reference to left-front-bottom of labware",
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "geometryDefinitionId": {
+          "description": "string id of the well's corresponding innerWellGeometry",
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "SphericalSegment": {
+      "type": "object",
+      "description": "A partial sphere shaped section at the bottom of the well.",
+      "additionalProperties": false,
+      "required": ["shape", "radiusOfCurvature", "topHeight", "bottomHeight"],
+      "properties": {
+        "shape": {
+          "type": "string",
+          "enum": ["spherical"]
+        },
+        "radiusOfCurvature": {
+          "type": "number",
+          "description": "radius of curvature of bottom subsection of wells"
+        },
+        "topHeight": {
+          "type": "number",
+          "description": "The depth of a spherical bottom of a well"
+        },
+        "bottomHeight": {
+          "type": "number",
+          "description": "Height of the bottom of the segment, must be 0.0"
+        },
+        "xCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        },
+        "yCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        }
+      }
+    },
+    "ConicalFrustum": {
+      "type": "object",
+      "description": "A cone or conical segment, bounded by two circles on the top and bottom.",
+      "required": [
+        "shape",
+        "bottomDiameter",
+        "topDiameter",
+        "topHeight",
+        "bottomHeight"
+      ],
+      "properties": {
+        "shape": {
+          "type": "string",
+          "enum": ["conical"]
+        },
+        "bottomDiameter": {
+          "type": "number",
+          "description": "The diameter at the bottom cross-section of a circular frustum"
+        },
+        "topDiameter": {
+          "type": "number",
+          "description": "The diameter at the top cross-section of a circular frustum"
+        },
+        "topHeight": {
+          "type": "number",
+          "description": "The height at the top of a bounded subsection of a well, relative to the bottom of the well"
+        },
+        "bottomHeight": {
+          "type": "number",
+          "description": "The height at the bottom of a bounded subsection of a well, relative to the bottom of the well"
+        },
+        "xCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        },
+        "yCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        }
+      }
+    },
+    "CuboidalFrustum": {
+      "type": "object",
+      "description": "A cuboidal shape bounded by two rectangles on the top and bottom",
+      "required": [
+        "shape",
+        "bottomXDimension",
+        "bottomYDimension",
+        "topXDimension",
+        "topYDimension",
+        "topHeight",
+        "bottomHeight"
+      ],
+      "properties": {
+        "shape": {
+          "type": "string",
+          "enum": ["cuboidal"]
+        },
+        "bottomXDimension": {
+          "type": "number",
+          "description": "x dimension of the bottom cross-section of a rectangular frustum"
+        },
+        "bottomYDimension": {
+          "type": "number",
+          "description": "y dimension of the bottom cross-section of a rectangular frustum"
+        },
+        "topXDimension": {
+          "type": "number",
+          "description": "x dimension of the top cross-section of a rectangular frustum"
+        },
+        "topYDimension": {
+          "type": "number",
+          "description": "y dimension of the top cross-section of a rectangular frustum"
+        },
+        "topHeight": {
+          "type": "number",
+          "description": "The height at the top of a bounded subsection of a well, relative to the bottom of the well"
+        },
+        "bottomHeight": {
+          "type": "number",
+          "description": "The height at the bottom of a bounded subsection of a well, relative to the bottom of the well"
+        },
+        "xCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        },
+        "yCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        }
+      }
+    },
+    "SquaredConeSegment": {
+      "type": "object",
+      "description": "The intersection of a pyramid and a cone that both share a central axis where one face is a circle and one face is a rectangle",
+      "required": [
+        "shape",
+        "bottomCrossSection",
+        "circleDiameter",
+        "rectangleXDimension",
+        "rectangleYDimension",
+        "topHeight",
+        "bottomHeight"
+      ],
+      "properties": {
+        "shape": {
+          "type": "string",
+          "enum": ["squaredcone"]
+        },
+        "bottomCrossSection": {
+          "type": "string",
+          "enum": ["circular", "rectangular"],
+          "description": "Denote if the shape is going from circular to rectangular or vise versa"
+        },
+        "circleDiameter": {
+          "type": "number",
+          "description": "diameter of the circular face of a truncated circular segment"
+        },
+        "rectangleXDimension": {
+          "type": "number",
+          "description": "x dimension of the rectangular face of a truncated circular segment"
+        },
+        "rectangleYDimension": {
+          "type": "number",
+          "description": "y dimension of the rectangular face of a truncated circular segment"
+        },
+        "topHeight": {
+          "type": "number",
+          "description": "The height at the top of a bounded subsection of a well, relative to the bottom of the well"
+        },
+        "bottomHeight": {
+          "type": "number",
+          "description": "The height at the bottom of a bounded subsection of a well, relative to the bottom of the well"
+        },
+        "xCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        },
+        "yCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        }
+      }
+    },
+    "RoundedCuboidSegment": {
+      "type": "object",
+      "description": "A cuboidal frustum where each corner is filleted out by circles with centers on the diagonals between opposite corners",
+      "required": [
+        "shape",
+        "bottomCrossSection",
+        "circleDiameter",
+        "rectangleXDimension",
+        "rectangleYDimension",
+        "topHeight",
+        "bottomHeight"
+      ],
+      "properties": {
+        "shape": {
+          "type": "string",
+          "enum": ["roundedcuboid"]
+        },
+        "bottomCrossSection": {
+          "type": "string",
+          "enum": ["circular", "rectangular"],
+          "description": "Denote if the shape is going from circular to rectangular or vise versa"
+        },
+        "circleDiameter": {
+          "type": "number",
+          "description": "diameter of the circular face of a rounded rectangular segment"
+        },
+        "rectangleXDimension": {
+          "type": "number",
+          "description": "x dimension of the rectangular face of a rounded rectangular segment"
+        },
+        "rectangleYDimension": {
+          "type": "number",
+          "description": "y dimension of the rectangular face of a rounded rectangular segment"
+        },
+        "topHeight": {
+          "type": "number",
+          "description": "The height at the top of a bounded subsection of a well, relative to the bottom"
+        },
+        "bottomHeight": {
+          "type": "number",
+          "description": "The height at the bottom of a bounded subsection of a well, relative to the bottom of the well"
+        },
+        "xCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        },
+        "yCount": {
+          "type": "integer",
+          "description": "Number of instances of this shape in the stackup, used for wells that have multiple sub-wells"
+        }
+      }
+    },
+    "InnerWellGeometry": {
+      "type": "object",
+      "required": ["sections"],
+      "properties": {
+        "sections": {
+          "description": "A list of all of the sections of the well that have a contiguous shape. Must be ordered from top (highest z) to bottom (lowest z).",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/ConicalFrustum"
+              },
+              {
+                "$ref": "#/definitions/CuboidalFrustum"
+              },
+              {
+                "$ref": "#/definitions/SquaredConeSegment"
+              },
+              {
+                "$ref": "#/definitions/RoundedCuboidSegment"
+              },
+              {
+                "$ref": "#/definitions/SphericalSegment"
+              }
+            ]
+          }
+        }
+      }
     }
   },
   "type": "object",
@@ -186,6 +544,11 @@
           "description": "Flag marking whether a labware is compatible by default with the Magnetic Module",
           "type": "boolean"
         },
+        "isDeckSlotCompatible": {
+          "description": "Flag marking whether a labware is compatible by with being placed or loaded in a base deck slot, defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
         "magneticModuleEngageHeight": {
           "description": "Distance to move magnetic module magnets to engage",
           "$ref": "#/definitions/positiveNumber"
@@ -229,58 +592,7 @@
       "additionalProperties": false,
       "patternProperties": {
         "[A-Z]+[0-9]+": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["depth", "shape", "totalLiquidVolume", "x", "y", "z"],
-          "oneOf": [
-            { "required": ["xDimension", "yDimension"] },
-            { "required": ["diameter"] }
-          ],
-          "not": {
-            "anyOf": [
-              { "required": ["diameter", "xDimension"] },
-              { "required": ["diameter", "yDimension"] }
-            ]
-          },
-          "properties": {
-            "depth": {
-              "description": "The distance between the top and bottom of this well. If the labware is a tip rack, this will be ignored in favor of tipLength, but the values should match.",
-              "$ref": "#/definitions/positiveNumber"
-            },
-            "x": {
-              "description": "x location of center-bottom of well in reference to left-front-bottom of labware",
-              "$ref": "#/definitions/positiveNumber"
-            },
-            "y": {
-              "description": "y location of center-bottom of well in reference to left-front-bottom of labware",
-              "$ref": "#/definitions/positiveNumber"
-            },
-            "z": {
-              "description": "z location of center-bottom of well in reference to left-front-bottom of labware",
-              "$ref": "#/definitions/positiveNumber"
-            },
-            "totalLiquidVolume": {
-              "description": "Total well, tube, or tip volume in microliters",
-              "$ref": "#/definitions/positiveNumber"
-            },
-            "xDimension": {
-              "description": "x dimension of rectangular wells",
-              "$ref": "#/definitions/positiveNumber"
-            },
-            "yDimension": {
-              "description": "y dimension of rectangular wells",
-              "$ref": "#/definitions/positiveNumber"
-            },
-            "diameter": {
-              "description": "diameter of circular wells",
-              "$ref": "#/definitions/positiveNumber"
-            },
-            "shape": {
-              "description": "If 'rectangular', use xDimension and yDimension; if 'circular' use diameter",
-              "type": "string",
-              "enum": ["rectangular", "circular"]
-            }
-          }
+          "$ref": "#/definitions/well"
         }
       }
     },
@@ -389,6 +701,20 @@
     "stackLimit": {
       "type": "number",
       "description": "The limit representing the maximum stack size for a given labware. Defaults to 1 when unspecified indicating a single labware with no labware below it."
+    },
+    "compatibleParentLabware": {
+      "type": "array",
+      "description": "Array of parent Labware on which a labware may be loaded, primarily the labware which owns a lid.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "innerLabwareGeometry": {
+      "type": ["object", "null"],
+      "description": "A dictionary holding all unique inner well geometries in a labware.",
+      "additionalProperties": {
+        "$ref": "#/definitions/InnerWellGeometry"
+      }
     }
   }
 }

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -42,7 +42,8 @@
         "aluminumBlock",
         "adapter",
         "other",
-        "lid"
+        "lid",
+        "system"
       ]
     },
     "safeString": {

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -673,17 +673,6 @@
         "$ref": "#/definitions/vector"
       }
     },
-    "stackLimit": {
-      "type": "number",
-      "description": "The limit representing the maximum stack size for a given labware. Defaults to 1 when unspecified indicating a single labware with no labware below it."
-    },
-    "compatibleParentLabware": {
-      "type": "array",
-      "description": "Array of parent Labware on which a labware may be loaded, primarily the labware which owns a lid.",
-      "items": {
-        "type": "string"
-      }
-    },
     "gripperOffsets": {
       "type": "object",
       "description": "Offsets to add when picking up or dropping another labware stacked atop this one. Do not use this to adjust the position of the gripper paddles relative to this labware or the child labware; use `gripHeightFromLabwareBottom` on this definition or the child's definition for that.",
@@ -713,6 +702,17 @@
     "gripHeightFromLabwareBottom": {
       "type": "number",
       "description": "Recommended Z-height, from labware bottom to the center of gripper pads, when gripping the labware."
+    },
+    "stackLimit": {
+      "type": "number",
+      "description": "The limit representing the maximum stack size for a given labware. Defaults to 1 when unspecified indicating a single labware with no labware below it."
+    },
+    "compatibleParentLabware": {
+      "type": "array",
+      "description": "Array of parent Labware on which a labware may be loaded, primarily the labware which owns a lid.",
+      "items": {
+        "type": "string"
+      }
     },
     "innerLabwareGeometry": {
       "type": ["object", "null"],

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -42,7 +42,8 @@
         "aluminumBlock",
         "adapter",
         "other",
-        "lid"
+        "lid",
+        "system"
       ]
     },
     "safeString": {

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -106,11 +106,12 @@ class Parameters2(BaseModel):
     tipOverlap: _NonNegativeNumber | None = None
     loadName: Annotated[str, Field(pattern=SAFE_STRING_REGEX)]
     isMagneticModuleCompatible: bool
+    isDeckSlotCompatible: bool | None = None
     magneticModuleEngageHeight: _NonNegativeNumber | None = None
 
 
 class Parameters3(Parameters2, BaseModel):
-    isDeckSlotCompatible: bool | None = None
+    pass  # Currently equivalent to Parameters2.
 
 
 class Dimensions(BaseModel):
@@ -127,6 +128,7 @@ class _WellCommon2(BaseModel):
     x: _NonNegativeNumber
     y: _NonNegativeNumber
     z: _NonNegativeNumber
+    geometryDefinitionId: str | None = None
 
 
 class CircularWellDefinition2(_WellCommon2, BaseModel):
@@ -141,35 +143,22 @@ class RectangularWellDefinition2(_WellCommon2, BaseModel):
 
 
 WellDefinition2 = Annotated[
-    CircularWellDefinition2 | RectangularWellDefinition2, Field(discriminator="shape")
+    CircularWellDefinition2 | RectangularWellDefinition2, Discriminator("shape")
 ]
 
 
-class _WellCommon3(BaseModel):
-    model_config = ConfigDict(extra="allow")
-
-    depth: _NonNegativeNumber
-    totalLiquidVolume: _NonNegativeNumber
-    x: _NonNegativeNumber
-    y: _NonNegativeNumber
-    z: _NonNegativeNumber
-    geometryDefinitionId: str | None = None
+class CircularWellDefinition3(CircularWellDefinition2):
+    # Currently equivalent to CircularWellDefinition2.
+    pass
 
 
-class CircularWellDefinition3(_WellCommon3, BaseModel):
-    shape: Literal["circular"]
-    diameter: _NonNegativeNumber
-
-
-class RectangularWellDefinition3(_WellCommon3, BaseModel):
-    shape: Literal["rectangular"]
-    xDimension: _NonNegativeNumber
-    yDimension: _NonNegativeNumber
+class RectangularWellDefinition3(RectangularWellDefinition2):
+    # Currently equivalent to RectangularWellDefinition2.
+    pass
 
 
 WellDefinition3 = Annotated[
-    CircularWellDefinition3 | RectangularWellDefinition3,
-    Discriminator("shape"),
+    CircularWellDefinition3 | RectangularWellDefinition3, Discriminator("shape")
 ]
 
 
@@ -502,6 +491,8 @@ class LabwareDefinition2(BaseModel):
     gripForce: float | None = None
     gripHeightFromLabwareBottom: float | None = None
     stackLimit: int | None = None
+    compatibleParentLabware: list[str] | None = None
+    innerLabwareGeometry: dict[str, InnerWellGeometry] | None = None
 
 
 class LabwareDefinition3(BaseModel):
@@ -526,8 +517,8 @@ class LabwareDefinition3(BaseModel):
     gripForce: float | None = None
     gripHeightFromLabwareBottom: float | None = None
     stackLimit: int | None = None
-    innerLabwareGeometry: dict[str, InnerWellGeometry] | None = None
     compatibleParentLabware: list[str] | None = None
+    innerLabwareGeometry: dict[str, InnerWellGeometry] | None = None
 
 
 LabwareDefinition = Annotated[

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -59,6 +59,7 @@ class LabwareParameters2(TypedDict):
     isTiprack: bool
     loadName: str
     isMagneticModuleCompatible: bool
+    isDeckSlotCompatible: NotRequired[bool]
     quirks: NotRequired[list[str]]
     tipLength: NotRequired[float]
     tipOverlap: NotRequired[float]
@@ -66,7 +67,7 @@ class LabwareParameters2(TypedDict):
 
 
 class LabwareParameters3(LabwareParameters2, TypedDict):
-    isDeckSlotCompatible: NotRequired[bool]
+    pass  # Currently equivalent to LabwareParameters2.
 
 
 class LabwareBrandData(TypedDict):
@@ -164,6 +165,11 @@ class LabwareDefinition2(TypedDict):
     gripForce: NotRequired[float]
     gripHeightFromLabwareBottom: NotRequired[float]
     stackLimit: NotRequired[int]
+    compatibleParentLabware: NotRequired[list[str]]
+    # The innerLabwareGeometry dict values are not currently modeled in these
+    # TypedDict-based bindings. The only code that cares about them
+    # currentlyuses our Pydantic-based bindings instead.
+    innerLabwareGeometry: NotRequired[dict[str, object] | None]
 
 
 # Class to mix in the "$otSharedSchema" key. This cannot be defined with the normal
@@ -175,6 +181,7 @@ _OTSharedSchemaMixin = TypedDict(
 
 class LabwareDefinition3(_OTSharedSchemaMixin, TypedDict):
     schemaVersion: Literal[3]
+    # $otSharedSchema mixed in via subclassing
     version: int
     namespace: str
     metadata: LabwareMetadata
@@ -192,11 +199,11 @@ class LabwareDefinition3(_OTSharedSchemaMixin, TypedDict):
     gripForce: NotRequired[float]
     gripHeightFromLabwareBottom: NotRequired[float]
     stackLimit: NotRequired[int]
+    compatibleParentLabware: NotRequired[list[str]]
     # The innerLabwareGeometry dict values are not currently modeled in these
     # TypedDict-based bindings. The only code that cares about them
     # currentlyuses our Pydantic-based bindings instead.
     innerLabwareGeometry: NotRequired[dict[str, object] | None]
-    compatibleParentLabware: NotRequired[list[str]]
 
 
 LabwareDefinition = LabwareDefinition2 | LabwareDefinition3


### PR DESCRIPTION
## Overview

Goes towards EXEC-1322.

## Test Plan and Hands on Testing

None yet. This will be in subsequent PRs.

## Changelog

* Copy most of the changes in labware schema 3 to labware schema 2, as discussed in EXEC-1322.
    * Copy `isDeckSlotCompatible`.
    * Copy `compatibleParentLabware`.
    * Copy `innerLabwareGeometry`.
    * Copy a fix for how we represent the `rectangular`/`circular` well union. (See [#17501](https://github.com/Opentrons/opentrons/pull/17501) for background.)
    * The only remaining differences (and you can diff the files to make sure) are`$otSharedSchema` and `schemaVersion`.
* Update Python bindings.
* Update TypeScript bindings.
* Add a `system` `displayCategory` to both labware schemas so `protocol_engine_lid_stack_object` actually validates. Closes EXEC-1265.

Not done here, and will be in a separate PR: updating `api` to make sure it uses these new features even in schema 2.

## Review requests

Anyone want a different resolution to EXEC-1265, other than adding a `system` `displayCategory`?

## Risk assessment

Low.

There's a small risk that the `rectangular`/`circular` well union fix will "break" some buggy custom labware definition out in the wild, since it's making validation stricter. I weigh this less than the risks of *not* doing the fix: the buggy labware could break in more obscure ways when it hits internal code; new bugs could sneak in when we're adding standard labware definitions; and schemas 2 and 3 could accidentally fall out of sync with each other because they look very different and can't easily be diffed.
