### PR TITLE
refactor(api): Use new labware features even when the labware is schema 2

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -5,13 +5,9 @@ from typing import TYPE_CHECKING, Optional, Type, Any
 
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
-from typing_extensions import Literal, TypeGuard, assert_type
+from typing_extensions import Literal, TypeGuard
 
-from opentrons_shared_data.labware.labware_definition import (
-    LabwareDefinition,
-    LabwareDefinition2,
-    LabwareDefinition3,
-)
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from ..errors import LabwareIsNotAllowedInLocationError
 from ..resources import labware_validation, fixture_validation
@@ -107,7 +103,7 @@ class LoadLabwareImplementation(
         module: LoadedModule = self._state_view.modules.get(location.moduleId)
         return module.model == module_model
 
-    async def execute(  # noqa: C901
+    async def execute(
         self, params: LoadLabwareParams
     ) -> SuccessData[LoadLabwareResult]:
         """Load definition and calibration data necessary for a labware."""
@@ -175,18 +171,13 @@ class LoadLabwareImplementation(
             ):
                 # This parent is assumed to be compatible, unless the lid enumerates
                 # all its compatible parents and this parent is missing from the list.
-                if isinstance(loaded_labware.definition, LabwareDefinition2):
-                    # Labware schema 2 has no compatibleParentLabware list.
-                    parent_is_incompatible = False
-                else:
-                    assert_type(loaded_labware.definition, LabwareDefinition3)
-                    parent_is_incompatible = (
-                        loaded_labware.definition.compatibleParentLabware is not None
-                        and self._state_view.labware.get_load_name(
-                            verified_location.labwareId
-                        )
-                        not in loaded_labware.definition.compatibleParentLabware
+                parent_is_incompatible = (
+                    loaded_labware.definition.compatibleParentLabware is not None
+                    and self._state_view.labware.get_load_name(
+                        verified_location.labwareId
                     )
+                    not in loaded_labware.definition.compatibleParentLabware
+                )
 
                 if parent_is_incompatible:
                     raise ValueError(

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -2,13 +2,8 @@
 
 from dataclasses import dataclass
 from typing import Optional, overload, List
-from typing_extensions import assert_type
 
-from opentrons_shared_data.labware.labware_definition import (
-    LabwareDefinition,
-    LabwareDefinition2,
-    LabwareDefinition3,
-)
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.pipette.types import PipetteNameType
 
 from opentrons.calibration_storage.helpers import uri_from_details
@@ -441,7 +436,7 @@ class EquipmentHandler:
             definition=attached_module.definition,
         )
 
-    async def load_lids(  # noqa: C901
+    async def load_lids(
         self,
         load_name: str,
         namespace: str,
@@ -489,15 +484,11 @@ class EquipmentHandler:
                 f"Requested quantity {quantity} is greater than the stack limit of {stack_limit} provided by definition for {load_name}."
             )
 
-        if isinstance(definition, LabwareDefinition2):
-            is_deck_slot_compatible = True
-        else:
-            assert_type(definition, LabwareDefinition3)
-            is_deck_slot_compatible = (
-                True
-                if definition.parameters.isDeckSlotCompatible is None
-                else definition.parameters.isDeckSlotCompatible
-            )
+        is_deck_slot_compatible = (
+            True
+            if definition.parameters.isDeckSlotCompatible is None
+            else definition.parameters.isDeckSlotCompatible
+        )
 
         if isinstance(location, DeckSlotLocation) and not is_deck_slot_compatible:
             raise ValueError(

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -23,12 +23,9 @@ from opentrons_shared_data.gripper.constants import LABWARE_GRIP_FORCE
 from opentrons_shared_data.labware.labware_definition import (
     InnerWellGeometry,
     LabwareDefinition,
-    LabwareDefinition2,
     LabwareRole,
     WellDefinition2,
     WellDefinition3,
-    CircularWellDefinition2,
-    RectangularWellDefinition2,
 )
 from opentrons_shared_data.pipette.types import LabwareUri
 
@@ -684,19 +681,11 @@ class LabwareView:
     ) -> InnerWellGeometry:
         """Get a well's inner geometry by labware and well name."""
         labware_def = self.get_definition(labware_id)
-        if (
-            isinstance(labware_def, LabwareDefinition2)
-            or labware_def.innerLabwareGeometry is None
-        ):
+        if labware_def.innerLabwareGeometry is None:
             raise errors.IncompleteLabwareDefinitionError(
                 message=f"No innerLabwareGeometry found in labware definition for labware_id: {labware_id}."
             )
         well_def = self.get_well_definition(labware_id, well_name)
-        # Assert for type-checking. We expect the well definitions from schema *3*, specifically.
-        # This should always pass because we exclude LabwareDefinition2 above.
-        assert not isinstance(
-            well_def, (RectangularWellDefinition2, CircularWellDefinition2)
-        )
         geometry_id = well_def.geometryDefinitionId
         if geometry_id is None:
             raise errors.IncompleteWellDefinitionError(


### PR DESCRIPTION
## Overview

Goes towards EXEC-1322.

This depends on #17780 and will merge after it does.

## Test Plan and Hands on Testing

Test with PRs #17780 and #17787.

* [x] A protocol with liquid level detection and meniscus-relative pipetting continues to work, without modification.

## Changelog

PR #17780 changed labware schema 2 to add features that, until then, had only been in schema 3. This PR updates `api` so it knows to look for those features in schema 2.

We basically want to find all the places that were doing this:

```python
if isinstance(definition, LabwareDefinition3):
    use_new_thing(definition.new_thing)
else:
    use_fallback()
```

And change them to this:

```python
if definition.new_thing is not None:
    use_new_thing(definition.new_thing)
else:
    use_fallback()
```

Specifically, as described in PR #17780, the new things are:

* `innerLabwareGeometry`
* `isDeckSlotCompatible`
* `compatibleParentLabware`

I basically grepped for those to find the places that needed updating.

## Review requests

Does any other place need to be updated?

## Risk assessment

There's a medium risk that I've accidentally forgotten to update some place.
