### PR TITLE
fix(api): accidently left in a print statement.

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -391,7 +391,6 @@ async def dispense_in_place(
             ),
         )
     else:
-        print(f"Volume {volume}")
         return SuccessData(
             public=BaseLiquidHandlingResult(volume=volume),
             state_update=StateUpdate()


### PR DESCRIPTION
Removing a leftover print statement from https://github.com/Opentrons/opentrons/pull/17636
