### PR TITLE
fix(step-generation): double labwares on a module

### DIFF
--- a/step-generation/src/__tests__/moveLabware.test.ts
+++ b/step-generation/src/__tests__/moveLabware.test.ts
@@ -322,6 +322,43 @@ describe('moveLabware', () => {
       type: 'LABWARE_ON_ANOTHER_ENTITY',
     })
   })
+  it('should return an error for trying to move the labware to an occupied module', () => {
+    const state = getInitialRobotStateStandard(invariantContext)
+    const HEATER_SHAKER_ID = 'heaterShakerId'
+    const HEATER_SHAKER_SLOT = 'A1'
+
+    robotState = {
+      ...state,
+      modules: {
+        ...state.modules,
+        [HEATER_SHAKER_ID]: {
+          slot: HEATER_SHAKER_SLOT,
+          moduleState: {
+            type: HEATERSHAKER_MODULE_TYPE,
+            latchOpen: true,
+            targetSpeed: null,
+          },
+        } as any,
+      },
+      labware: {
+        ...state.labware,
+        mockLabwareId: {
+          slot: HEATER_SHAKER_ID,
+        },
+      },
+    }
+    const params = {
+      labwareId: SOURCE_LABWARE,
+      strategy: 'usingGripper',
+      newLocation: { moduleId: HEATER_SHAKER_ID },
+    } as MoveLabwareParams
+
+    const result = moveLabware(params, invariantContext, robotState)
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'LABWARE_ON_ANOTHER_ENTITY',
+    })
+  })
   it('should return an error for the labware already being discarded in previous step', () => {
     const wasteChuteInvariantContext = {
       ...invariantContext,

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -72,10 +72,8 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
   )
 
   const newLocationSlot =
-    newLocation !== 'offDeck' &&
-    newLocation !== 'systemLocation' &&
-    'slotName' in newLocation
-      ? newLocation.slotName
+    newLocation !== 'offDeck' && newLocation !== 'systemLocation'
+      ? Object.values(newLocation)[0]
       : null
 
   const multipleObjectsInSameSlotLabware =


### PR DESCRIPTION
fix RQA-4005

# Overview

This Pr fixes a bug where if you move a labware to a module but then go back and drag a labware to be on top of that module, there was no timeline error indicating that you have 2 labwares on that module. Now there is a timeline error

## Test Plan and Hands on Testing

Smoke test by moving a labware to a module then dragging a labware to that module and seeing the timeline error

## Changelog

- refine logic and add test case

## Risk assessment

low
