### PR TITLE
feat(step-generation): touch_tip python command generation and add speed to commands

### DIFF
--- a/step-generation/src/__tests__/touchTip.test.ts
+++ b/step-generation/src/__tests__/touchTip.test.ts
@@ -58,6 +58,24 @@ describe('touchTip', () => {
         },
       },
     ])
+    expect(res.python).toBe(
+      `mockPythonName.touch_tip(mockPythonName["A1"], v_offset=10)`
+    )
+  })
+
+  it('touchTip for python with tip, with no offset set', () => {
+    const result = touchTip(
+      {
+        pipetteId: DEFAULT_PIPETTE,
+        labwareId: SOURCE_LABWARE,
+        wellName: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    const res = getSuccessResult(result)
+
+    expect(res.python).toBe(`mockPythonName.touch_tip(mockPythonName["A1"])`)
   })
 
   it('touchTip with invalid pipette ID should throw error', () => {

--- a/step-generation/src/__tests__/touchTip.test.ts
+++ b/step-generation/src/__tests__/touchTip.test.ts
@@ -28,13 +28,14 @@ describe('touchTip', () => {
     robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
   })
 
-  it('touchTip with tip, specifying offsetFromBottomMm', () => {
+  it('touchTip with tip, specifying offsetFromBottomMm and speed', () => {
     const result = touchTip(
       {
         pipetteId: DEFAULT_PIPETTE,
         labwareId: SOURCE_LABWARE,
         wellName: 'A1',
         wellLocation,
+        speed: 10,
       },
       invariantContext,
       robotStateWithTip
@@ -55,15 +56,21 @@ describe('touchTip', () => {
               z: 10,
             },
           },
+          speed: 10,
         },
       },
     ])
     expect(res.python).toBe(
-      `mockPythonName.touch_tip(mockPythonName["A1"], v_offset=10)`
+      `
+mockPythonName.touch_tip(
+    mockPythonName["A1"],
+    v_offset=10,
+    speed=10,
+)`.trimStart()
     )
   })
 
-  it('touchTip for python with tip, with no offset set', () => {
+  it('touchTip for python with tip, with no offset or speed set', () => {
     const result = touchTip(
       {
         pipetteId: DEFAULT_PIPETTE,
@@ -75,7 +82,12 @@ describe('touchTip', () => {
     )
     const res = getSuccessResult(result)
 
-    expect(res.python).toBe(`mockPythonName.touch_tip(mockPythonName["A1"])`)
+    expect(res.python).toBe(
+      `
+mockPythonName.touch_tip(
+    mockPythonName["A1"],
+)`.trimStart()
+    )
   })
 
   it('touchTip with invalid pipette ID should throw error', () => {

--- a/step-generation/src/commandCreators/atomic/touchTip.ts
+++ b/step-generation/src/commandCreators/atomic/touchTip.ts
@@ -1,4 +1,4 @@
-import { uuid } from '../../utils'
+import { formatPyStr, uuid } from '../../utils'
 import { noTipOnPipette, pipetteDoesNotExist } from '../../errorCreators'
 import type { CreateCommand, TouchTipParams } from '@opentrons/shared-data'
 import type { CommandCreator, CommandCreatorError } from '../../types'
@@ -39,6 +39,18 @@ export const touchTip: CommandCreator<TouchTipParams> = (
     }
   }
 
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const labwarePythonName =
+    invariantContext.labwareEntities[labwareId].pythonName
+  const pythonOffset =
+    wellLocation?.offset?.z != null
+      ? `, v_offset=${wellLocation?.offset?.z}`
+      : ''
+  const python = `${pipettePythonName}.touch_tip(${labwarePythonName}[${formatPyStr(
+    wellName
+  )}]${pythonOffset})`
+
   const commands: CreateCommand[] = [
     {
       commandType: 'touchTip',
@@ -53,5 +65,6 @@ export const touchTip: CommandCreator<TouchTipParams> = (
   ]
   return {
     commands,
+    python,
   }
 }

--- a/step-generation/src/commandCreators/atomic/touchTip.ts
+++ b/step-generation/src/commandCreators/atomic/touchTip.ts
@@ -43,16 +43,14 @@ export const touchTip: CommandCreator<TouchTipParams> = (
     invariantContext.pipetteEntities[pipetteId].pythonName
   const labwarePythonName =
     invariantContext.labwareEntities[labwareId].pythonName
-  const pythonOffset =
-    wellLocation?.offset?.z != null
-      ? `v_offset=${wellLocation?.offset?.z},`
-      : null
-  const pythonSpeed = speed != null ? `speed=${speed},` : null
+
   const pythonArgs = [
     `${labwarePythonName}[${formatPyStr(wellName)}],`,
-    pythonOffset,
-    pythonSpeed,
-  ].filter(arg => arg != null)
+    ...(wellLocation?.offset?.z != null
+      ? [`v_offset=${wellLocation?.offset?.z},`]
+      : []),
+    ...(speed != null ? [`speed=${speed},`] : []),
+  ]
 
   //  TODO: add mmFromEdge to python and commandCreator
   const python = `${pipettePythonName}.touch_tip(\n${indentPyLines(


### PR DESCRIPTION
closes AUTH-1580

# Overview

This PR generates the touch_tip python command from step-generation and also wires in `speed` to the `touchTip` command creator.

## Test Plan and Hands on Testing

Review code and smoke test

example (it passes protocol analysis):

```
    # PROTOCOL STEPS

    # Step 1:
    pipette_left.pick_up_tip(location=tip_rack_1)
    pipette_left.configure_for_volume(10)
    pipette_left.aspirate(
        volume=10,
        location=well_plate_1["A1"].bottom(z=1),
        rate=35 / pipette_left.flow_rate.aspirate,
    )
    pipette_left.touch_tip(
        well_plate_1["A1"],
        v_offset=-1,
        speed=10,
    )
    pipette_left.drop_tip()
```

## Changelog

- add python generation for touchTip atomic command
- extend speed to command creator
- add test cases

## Review requests

Looking at the form fields for liquid classes work, it looks like touch tip has a speed (and according to @ncdiehl11's  liquid class [doc](https://opentrons.atlassian.net/wiki/spaces/PAR/pages/4895014920/Liquid+Classes+in+PD+Step+Generation+Field+Migration), also a `mmFromEdge`) now. Speed exists in the form already but `mmFromEdge` does not. I modified to add `speed` and left a TODO for `mmFromEdge` support - does that sound good? cc @ddcc4 

## Risk assessment

low, behind ff