### PR TITLE
docs(api): note on `set_offset()` for multiple of same labware in 2.12-13

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -770,7 +770,7 @@ class Labware:
               - Offsets only apply to the exact :py:class:`.Labware` instance.
 
                 If your protocol has multiple instances of the same type of labware,
-                you must either use ``set_offset`` on all of them or none of them.
+                you must either use ``set_offset()`` on all of them or none of them.
             * - 2.14–2.17
               - ``set_offset()`` is not available, and the API raises an error.
             * - 2.18 and newer

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -762,11 +762,15 @@ class Labware:
 
         .. list-table::
             :header-rows: 1
+            :widths: 1 5
 
             * - API level
               - Offset behavior
             * - 2.12–2.13
               - Offsets only apply to the exact :py:class:`.Labware` instance.
+
+                If your protocol has multiple instances of the same type of labware,
+                you must either use ``set_offset`` on all of them or none of them.
             * - 2.14–2.17
               - ``set_offset()`` is not available, and the API raises an error.
             * - 2.18 and newer


### PR DESCRIPTION
# Overview

Quick addition to the API reference to caution users away from an edge case with `set_offset()` and LPC. 

Addresses RTC-714.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-set_offset-note/v2/new_protocol_api.html#opentrons.protocol_api.Labware.set_offset)

## Changelog

Added a sentence to the existing table in the `set_offset()` API reference entry.

## Review requests

Good advice?

## Risk assessment

none