### PR TITLE
feat(step-generation): prepare_to_aspirate py generation

### DIFF
--- a/step-generation/src/__tests__/airGapInTrash.test.ts
+++ b/step-generation/src/__tests__/airGapInTrash.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  DEFAULT_PIPETTE,
   getInitialRobotStateStandard,
   getSuccessResult,
   makeContext,
@@ -8,7 +9,6 @@ import { airGapInTrash } from '../commandCreators/compound'
 import type { CutoutId } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
 
-const mockId = 'mockId'
 const mockCutout: CutoutId = 'cutoutA3'
 const invariantContext: InvariantContext = makeContext()
 const prevRobotState: RobotState = getInitialRobotStateStandard(
@@ -19,7 +19,7 @@ describe('airGapInTrash', () => {
   it('returns correct commands for airGapInPlace over a trash bin', () => {
     const result = airGapInTrash(
       {
-        pipetteId: mockId,
+        pipetteId: DEFAULT_PIPETTE,
         volume: 10,
         flowRate: 10,
         trashLocation: mockCutout,
@@ -32,7 +32,7 @@ describe('airGapInTrash', () => {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           addressableAreaName: 'movableTrashA3',
           offset: { x: 0, y: 0, z: 0 },
         },
@@ -41,14 +41,14 @@ describe('airGapInTrash', () => {
         commandType: 'prepareToAspirate',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
         },
       },
       {
         commandType: 'airGapInPlace',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           volume: 10,
           flowRate: 10,
         },

--- a/step-generation/src/__tests__/prepareToAspirate.test.ts
+++ b/step-generation/src/__tests__/prepareToAspirate.test.ts
@@ -3,6 +3,7 @@ import {
   makeContext,
   getRobotStateWithTipStandard,
   getSuccessResult,
+  DEFAULT_PIPETTE,
 } from '../fixtures'
 import { prepareToAspirate } from '../commandCreators/atomic'
 import type { PrepareToAspirateParams } from '@opentrons/shared-data'
@@ -12,14 +13,13 @@ describe('prepareToAspirate', () => {
   let invariantContext: InvariantContext
   let robotStateWithTip: RobotState
 
-  const mockId = 'mockId'
   beforeEach(() => {
     invariantContext = makeContext()
     robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
   })
   it('aspirate in place', () => {
     const params: PrepareToAspirateParams = {
-      pipetteId: mockId,
+      pipetteId: DEFAULT_PIPETTE,
     }
     const result = prepareToAspirate(
       params,
@@ -32,9 +32,10 @@ describe('prepareToAspirate', () => {
         commandType: 'prepareToAspirate',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
         },
       },
     ])
+    expect(res.python).toBe('mockPythonName.prepare_to_aspirate()')
   })
 })

--- a/step-generation/src/commandCreators/atomic/prepareToAspirate.ts
+++ b/step-generation/src/commandCreators/atomic/prepareToAspirate.ts
@@ -2,8 +2,14 @@ import { uuid } from '../../utils'
 import type { CommandCreator } from '../../types'
 import type { PrepareToAspirateParams } from '@opentrons/shared-data'
 
-export const prepareToAspirate: CommandCreator<PrepareToAspirateParams> = args => {
+export const prepareToAspirate: CommandCreator<PrepareToAspirateParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
   const { pipetteId } = args
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
 
   const commands = [
     {
@@ -16,5 +22,6 @@ export const prepareToAspirate: CommandCreator<PrepareToAspirateParams> = args =
   ]
   return {
     commands,
+    python: `${pipettePythonName}.prepare_to_aspirate()`,
   }
 }


### PR DESCRIPTION
closes AUTH-1583

# Overview

Generate the python command for `prepare_to_aspirate()`

## Test Plan and Hands on Testing

Review the code. a bit hard to test an example in the app because this command is paired with air gap

## Changelog

- add python generation for prepare to aspirate
- add test

## Risk assessment

low