### PR TITLE
fix(ai-client): filter EM pipette and 200ul 96

### DIFF
--- a/opentrons-ai-client/src/organisms/InstrumentsSection/index.tsx
+++ b/opentrons-ai-client/src/organisms/InstrumentsSection/index.tsx
@@ -92,9 +92,13 @@ export function InstrumentsSection(): JSX.Element | null {
         value: name,
         name: getPipetteSpecsV2(name)?.displayName ?? '',
       }))
-      .filter(o => o.value !== 'p1000_96')
-      .filter(o => o.value !== 'p1000_multi_em_flex')
-      .filter(o => o.value !== 'p200_96')
+      .filter(o => {
+        return (
+          o.value !== 'p1000_96' &&
+          o.value !== 'p1000_multi_em_flex' &&
+          o.value !== 'p200_96'
+        )
+      })
     return [{ name: t('none'), value: NO_PIPETTES }, ...allPipetteOptions]
   }, [robotType])
 

--- a/opentrons-ai-client/src/organisms/InstrumentsSection/index.tsx
+++ b/opentrons-ai-client/src/organisms/InstrumentsSection/index.tsx
@@ -93,6 +93,8 @@ export function InstrumentsSection(): JSX.Element | null {
         name: getPipetteSpecsV2(name)?.displayName ?? '',
       }))
       .filter(o => o.value !== 'p1000_96')
+      .filter(o => o.value !== 'p1000_multi_em_flex')
+      .filter(o => o.value !== 'p200_96')
     return [{ name: t('none'), value: NO_PIPETTES }, ...allPipetteOptions]
   }, [robotType])
 


### PR DESCRIPTION
# Overview

Filter Flex pipette dropdown to appropriate pipettes for Opentrons AI audience.

## Test Plan and Hands on Testing

Validated locally in the dropdown. 

## Risk assessment

Low, filtering additional keys from the list.