### PR TITLE
feat(app): save RTP list scroll position when selecting RTPs on ODD

### DIFF
--- a/app/src/App/ODDProviders/ScrollRefProvider.tsx
+++ b/app/src/App/ODDProviders/ScrollRefProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useState } from 'react'
+import type { FC, ReactNode } from 'react'
 
 export interface SharedScrollRefContextType {
   refCallback: (node: HTMLElement | null) => void
@@ -11,8 +12,8 @@ export const SharedScrollRefContext = createContext<SharedScrollRefContextType |
 
 // This provider exists to capture the ref of the main scrollable Box element in the ODD
 // This is so that we can do things like auto scroll (using the ref) across components
-export const SharedScrollRefProvider: React.FC<{
-  children: React.ReactNode
+export const SharedScrollRefProvider: FC<{
+  children: ReactNode
 }> = ({ children }) => {
   const [element, setCurrentElement] = useState<HTMLElement | null>(null)
 

--- a/app/src/App/ODDProviders/ScrollRefProvider.tsx
+++ b/app/src/App/ODDProviders/ScrollRefProvider.tsx
@@ -9,6 +9,8 @@ export const SharedScrollRefContext = createContext<SharedScrollRefContextType |
   null
 )
 
+// This provider exists to capture the ref of the main scrollable Box element in the ODD
+// This is so that we can do things like auto scroll (using the ref) across components
 export const SharedScrollRefProvider: React.FC<{
   children: React.ReactNode
 }> = ({ children }) => {
@@ -18,7 +20,6 @@ export const SharedScrollRefProvider: React.FC<{
   // This is necessary because we need a ref to be attached to the DOM
   // But also refs don't trigger rerenders, which we need in order to detect scrolling
   const refCallback = useCallback((node: HTMLElement | null) => {
-    console.log('calling refCallback')
     setCurrentElement(node)
   }, [])
 

--- a/app/src/App/ODDProviders/ScrollRefProvider.tsx
+++ b/app/src/App/ODDProviders/ScrollRefProvider.tsx
@@ -1,0 +1,30 @@
+import { createContext, useCallback, useState } from 'react'
+
+export interface SharedScrollRefContextType {
+  refCallback: (node: HTMLElement | null) => void
+  element: HTMLElement | null
+}
+
+export const SharedScrollRefContext = createContext<SharedScrollRefContextType | null>(
+  null
+)
+
+export const SharedScrollRefProvider: React.FC<{
+  children: React.ReactNode
+}> = ({ children }) => {
+  const [element, setCurrentElement] = useState<HTMLElement | null>(null)
+
+  // Callback ref that updates both the state and the ref
+  // This is necessary because we need a ref to be attached to the DOM
+  // But also refs don't trigger rerenders, which we need in order to detect scrolling
+  const refCallback = useCallback((node: HTMLElement | null) => {
+    console.log('calling refCallback')
+    setCurrentElement(node)
+  }, [])
+
+  return (
+    <SharedScrollRefContext.Provider value={{ refCallback, element }}>
+      {children}
+    </SharedScrollRefContext.Provider>
+  )
+}

--- a/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
@@ -27,7 +27,7 @@ import { getOnDeviceDisplaySettings } from '/app/redux/config'
 import { getIsShellReady } from '/app/redux/shell'
 import { getLocalRobot } from '/app/redux/discovery'
 import { mockConnectedRobot } from '/app/redux/discovery/__fixtures__'
-import { useProtocolReceiptToast } from '../hooks'
+import { useProtocolReceiptToast, useScrollRef } from '../hooks'
 import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
 import { ODDTopLevelRedirects } from '../ODDTopLevelRedirects'
 
@@ -93,6 +93,11 @@ describe('OnDeviceDisplayApp', () => {
     vi.mocked(getIsShellReady).mockReturnValue(true)
     vi.mocked(ODDTopLevelRedirects).mockReturnValue(null)
     vi.mocked(getLocalRobot).mockReturnValue(mockConnectedRobot)
+    vi.mocked(useScrollRef).mockReturnValue({
+      isScrolling: false,
+      refCallback: () => null,
+      element: null,
+    })
     vi.mocked(useNotifyCurrentMaintenanceRun).mockReturnValue({
       data: {
         data: {

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -124,16 +124,21 @@ export function useScrollRef(): {
   element: HTMLElement | null
 } {
   const refData = useContext(SharedScrollRefContext)
+  const isScrolling = useScrolling(refData?.element ?? null) // Assuming useScrolling is properly handling scroll state
 
-  if (!refData) {
-    throw new Error(
-      'useScrollRef must be used within a SharedScrollRefProvider'
+  if (refData == null) {
+    // log non critical error instead of throwing error to prevent white screens
+    console.error(
+      'useScrollRef must be used within a SharedScrollRefProvider. Falling back to dummy refs.'
     )
+    return {
+      refCallback: () => null,
+      isScrolling: false,
+      element: null,
+    }
   }
 
   const { refCallback, element } = refData
-
-  const isScrolling = useScrolling(element) // Assuming useScrolling is properly handling scroll state
 
   return {
     refCallback,

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -1,17 +1,21 @@
-import { useCallback, useRef, useEffect } from 'react'
+import { useCallback, useRef, useEffect, useContext } from 'react'
 import difference from 'lodash/difference'
 import { useTranslation } from 'react-i18next'
 import { useQueryClient } from 'react-query'
 import { useDispatch } from 'react-redux'
 
-import { useInterval, truncateString } from '@opentrons/components'
+import {
+  useInterval,
+  truncateString,
+  useScrolling,
+} from '@opentrons/components'
 import {
   useAllProtocolIdsQuery,
   useHost,
   useCreateLiveCommandMutation,
 } from '@opentrons/react-api-client'
 import { getProtocol } from '@opentrons/api-client'
-
+import { SharedScrollRefContext } from './ODDProviders/ScrollRefProvider'
 import { checkShellUpdate } from '/app/redux/shell'
 import { useToaster } from '/app/organisms/ToasterOven'
 
@@ -112,4 +116,28 @@ export function useProtocolReceiptToast(): void {
     // dont want this hook to rerun when other deps change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [protocolIds])
+}
+
+export function useScrollRef(): {
+  isScrolling: boolean
+  refCallback: (node: HTMLElement | null) => void
+  element: HTMLElement | null
+} {
+  const refData = useContext(SharedScrollRefContext)
+
+  if (!refData) {
+    throw new Error(
+      'useScrollRef must be used within a SharedScrollRefProvider'
+    )
+  }
+
+  const { refCallback, element } = refData
+
+  const isScrolling = useScrolling(element) // Assuming useScrolling is properly handling scroll state
+
+  return {
+    refCallback,
+    isScrolling,
+    element,
+  }
 }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
@@ -91,6 +91,8 @@ export function ProtocolSetupParameters({
           ({ ...parameter, value: parameter.default } as ValueRunTimeParameter)
     )
   )
+
+  // Scroll back to the place where the user was before they went into a specific RTP selection screen
   useEffect(() => {
     const isShowingParametersList =
       chooseValueScreen == null &&


### PR DESCRIPTION
# Overview

This PR saves the scroll position in the the ODD's RTP selection screen. This is so that scroll positions are saved as users scroll through their RTP selections, select an RTP to change, and then go back to the list.

closes AUTH-1586
closes https://opentrons.atlassian.net/browse/RQA-3523

## Test Plan and Hands on Testing

- Open a RTP protocol on the ODD with more than 5 RTP values (like the one attached to this PR). Scroll down, change a parameter (on a parameter selection screen), and then go back. Your scroll position should get saved


![screen-recording](https://github.com/user-attachments/assets/05ba51ec-72f9-4399-bfaf-95da302e0b28)

[rtp_demo.py.zip](https://github.com/user-attachments/files/19343341/rtp_demo.py.zip)



## Changelog

- save RTP list scroll position when selecting RTPs on ODD

## Review requests

See test plan

## Risk assessment

Low