### PR TITLE
feat(step-generation): set Python flow rate for blowOutInWell

### DIFF
--- a/step-generation/src/__tests__/blowOutInWell.test.ts
+++ b/step-generation/src/__tests__/blowOutInWell.test.ts
@@ -60,7 +60,10 @@ describe('blowOutInWell', () => {
       },
     ])
     expect(res.python).toBe(
-      'mockPythonName.blow_out(mockPythonName["A1"].top(z=-1.3))'
+      `
+mockPythonName.flow_rate.blow_out = 21.1
+mockPythonName.blow_out(mockPythonName["A1"].top(z=-1.3))
+`.trim()
     )
   })
   it('blowout with invalid pipette ID should throw error', () => {

--- a/step-generation/src/commandCreators/atomic/blowOutInWell.ts
+++ b/step-generation/src/commandCreators/atomic/blowOutInWell.ts
@@ -205,8 +205,12 @@ export const blowOutInWell: CommandCreator<BlowoutParams> = (
   ]
   return {
     commands,
-    python: `${pipettePythonName}.blow_out(${labwarePythonName}[${formatPyStr(
-      wellName
-    )}]${formatPyWellLocation(wellLocation)})`,
+    python:
+      // The Python blow_out() does not take a flow rate argument, so we have to
+      // reconfigure the pipette's default blow out rate instead:
+      `${pipettePythonName}.flow_rate.blow_out = ${flowRate}\n` +
+      `${pipettePythonName}.blow_out(${labwarePythonName}[${formatPyStr(
+        wellName
+      )}]${formatPyWellLocation(wellLocation)})`,
   }
 }


### PR DESCRIPTION
# Overview

The Python `blow_out()` command doesn't let you specify a flow rate. Instead, we have to override the default blowout flow rate for the pipette in `InstrumentContext.flow_rate.blow_out`, which is what this PR does. AUTH-1584

## Test Plan and Hands on Testing

Updated unit tests.

Here is what the generated code looks like when I select a blowout at -3 mm from the well top at a flow rate of 25 uL/s:
```
pipette_left.flow_rate.blow_out = 25
pipette_left.blow_out(well_plate_1["A1"].top(z=-3))
```

I confirmed that the generated Python protocol passes `simulate`.

## Risk assessment

Low, Python generation is behind feature flag.