### PR TITLE
feat(step-generation): blow_out py command for trash bin

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -5,7 +5,6 @@ import merge from 'lodash/merge'
 import omit from 'lodash/omit'
 import reduce from 'lodash/reduce'
 import {
-  FLEX_ROBOT_TYPE,
   getLabwareDefaultEngageHeight,
   getLabwareDefURI,
   getModuleType,
@@ -13,10 +12,7 @@ import {
   MAGNETIC_MODULE_V1,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import {
-  GRIPPER_LOCATION,
-  PROTOCOL_CONTEXT_FIXED_TRASH,
-} from '@opentrons/step-generation'
+import { GRIPPER_LOCATION } from '@opentrons/step-generation'
 import { rootReducer as labwareDefsRootReducer } from '../../labware-defs'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import { getPDMetadata } from '../../file-types'

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -5,6 +5,7 @@ import merge from 'lodash/merge'
 import omit from 'lodash/omit'
 import reduce from 'lodash/reduce'
 import {
+  FLEX_ROBOT_TYPE,
   getLabwareDefaultEngageHeight,
   getLabwareDefURI,
   getModuleType,
@@ -12,7 +13,10 @@ import {
   MAGNETIC_MODULE_V1,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { GRIPPER_LOCATION } from '@opentrons/step-generation'
+import {
+  GRIPPER_LOCATION,
+  PROTOCOL_CONTEXT_FIXED_TRASH,
+} from '@opentrons/step-generation'
 import { rootReducer as labwareDefsRootReducer } from '../../labware-defs'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import { getPDMetadata } from '../../file-types'
@@ -1260,7 +1264,8 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
               location,
               pythonName: getAdditionalEquipmentPythonName(
                 'trashBin',
-                index + 1
+                index + 1,
+                location
               ),
             },
           }),
@@ -1345,7 +1350,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           pythonName:
             name === 'stagingArea'
               ? undefined
-              : getAdditionalEquipmentPythonName(name, typeCount + 1),
+              : getAdditionalEquipmentPythonName(name, typeCount + 1, location),
         },
       }
     },

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -9,7 +9,7 @@ import {
   INTERACTIVE_WELL_DATA_ATTRIBUTE,
   LOW_VOLUME_PIPETTES,
 } from '@opentrons/shared-data'
-import { PROTOCOL_CONTEXT_FIXED_TRASH } from '@opentrons/step-generation'
+import { PROTOCOL_CONTEXT_NAME } from '@opentrons/step-generation'
 import type {
   AdditionalEquipmentEntity,
   LabwareEntities,
@@ -281,7 +281,7 @@ export const getAdditionalEquipmentPythonName = (
     }
     case 'trashBin': {
       if (location === 'cutout12') {
-        return PROTOCOL_CONTEXT_FIXED_TRASH
+        return `${PROTOCOL_CONTEXT_NAME}.fixed_trash`
       } else {
         return `${snakeCase(fixtureName)}_${typeCount}`
       }

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -9,6 +9,7 @@ import {
   INTERACTIVE_WELL_DATA_ATTRIBUTE,
   LOW_VOLUME_PIPETTES,
 } from '@opentrons/shared-data'
+import { PROTOCOL_CONTEXT_FIXED_TRASH } from '@opentrons/step-generation'
 import type {
   AdditionalEquipmentEntity,
   LabwareEntities,
@@ -271,9 +272,19 @@ export const getLabwarePythonName = (
 
 export const getAdditionalEquipmentPythonName = (
   fixtureName: 'wasteChute' | 'trashBin',
-  typeCount: number
+  typeCount: number,
+  location?: string
 ): string => {
-  return fixtureName === 'wasteChute'
-    ? snakeCase(fixtureName)
-    : `${snakeCase(fixtureName)}_${typeCount}`
+  switch (fixtureName) {
+    case 'wasteChute': {
+      return snakeCase(fixtureName)
+    }
+    case 'trashBin': {
+      if (location === 'cutout12') {
+        return PROTOCOL_CONTEXT_FIXED_TRASH
+      } else {
+        return `${snakeCase(fixtureName)}_${typeCount}`
+      }
+    }
+  }
 }

--- a/step-generation/src/__tests__/blowOutInTrash.test.ts
+++ b/step-generation/src/__tests__/blowOutInTrash.test.ts
@@ -5,10 +5,10 @@ import {
   getSuccessResult,
   makeContext,
 } from '../fixtures'
+import { PROTOCOL_CONTEXT_NAME } from '../utils'
 import { blowOutInTrash } from '../commandCreators/compound'
 import type { CutoutId } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
-import { PROTOCOL_CONTEXT_FIXED_TRASH } from '../constants'
 
 vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
 
@@ -73,7 +73,7 @@ mockPythonName.blow_out(mock_trash_bin_1)`.trim()
         [mockFixedTrashId]: {
           id: mockFixedTrashId,
           name: 'trashBin',
-          pythonName: PROTOCOL_CONTEXT_FIXED_TRASH,
+          pythonName: `${PROTOCOL_CONTEXT_NAME}.fixed_trash`,
           location: 'cutout12',
         },
       },
@@ -109,7 +109,7 @@ mockPythonName.blow_out(mock_trash_bin_1)`.trim()
     expect(getSuccessResult(result).python).toBe(
       `
 mockPythonName.flow_rate.blow_out = 10
-mockPythonName.blow_out(protocol_context.fixed_trash)`.trim()
+mockPythonName.blow_out(protocol.fixed_trash)`.trim()
     )
   })
 })

--- a/step-generation/src/__tests__/blowOutInTrash.test.ts
+++ b/step-generation/src/__tests__/blowOutInTrash.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
+  DEFAULT_PIPETTE,
   getInitialRobotStateStandard,
   getSuccessResult,
   makeContext,
@@ -10,20 +11,30 @@ import type { InvariantContext, RobotState } from '../types'
 
 vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
 
-const mockId = 'mockId'
 const mockCutout: CutoutId = 'cutoutA3'
-const invariantContext: InvariantContext = makeContext()
+const mockTrashId = 'mockTrashId'
+let invariantContext: InvariantContext = {
+  ...makeContext(),
+  additionalEquipmentEntities: {
+    [mockTrashId]: {
+      id: mockTrashId,
+      name: 'trashBin',
+      pythonName: 'mock_trash_bin_1',
+      location: mockCutout,
+    },
+  },
+}
 const prevRobotState: RobotState = getInitialRobotStateStandard(
   invariantContext
 )
 
 describe('blowOutInTrash', () => {
-  it('returns correct commands for blowout in a trash bin', () => {
+  it('returns correct commands for blowout in a trash bin for a flex', () => {
     const result = blowOutInTrash(
       {
-        pipetteId: mockId,
+        pipetteId: DEFAULT_PIPETTE,
         flowRate: 10,
-        trashLocation: mockCutout,
+        trashId: mockTrashId,
       },
       invariantContext,
       prevRobotState
@@ -33,7 +44,7 @@ describe('blowOutInTrash', () => {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           addressableAreaName: 'movableTrashA3',
           offset: { x: 0, y: 0, z: 0 },
         },
@@ -42,10 +53,13 @@ describe('blowOutInTrash', () => {
         commandType: 'blowOutInPlace',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           flowRate: 10,
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mockPythonName.blow_out(mock_trash_bin_1)'
+    )
   })
 })

--- a/step-generation/src/__tests__/blowOutInTrash.test.ts
+++ b/step-generation/src/__tests__/blowOutInTrash.test.ts
@@ -59,7 +59,9 @@ describe('blowOutInTrash', () => {
       },
     ])
     expect(getSuccessResult(result).python).toBe(
-      'mockPythonName.blow_out(mock_trash_bin_1)'
+      `
+mockPythonName.flow_rate.blow_out = 10
+mockPythonName.blow_out(mock_trash_bin_1)`.trim()
     )
   })
 })

--- a/step-generation/src/commandCreators/atomic/blowOutInPlace.ts
+++ b/step-generation/src/commandCreators/atomic/blowOutInPlace.ts
@@ -8,7 +8,6 @@ export const blowOutInPlace: CommandCreator<BlowoutInPlaceParams> = (
   prevRobotState
 ) => {
   const { pipetteId, flowRate } = args
-
   const commands = [
     {
       commandType: 'blowOutInPlace' as const,

--- a/step-generation/src/commandCreators/compound/blowOutInTrash.ts
+++ b/step-generation/src/commandCreators/compound/blowOutInTrash.ts
@@ -29,7 +29,9 @@ export const blowOutInTrash: CommandCreator<BlowOutInTrashParams> = (
 
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
-    python: `${pipettePythonName}.blow_out(${trashPythonName})`,
+    python:
+      `${pipettePythonName}.flow_rate.blow_out = ${flowRate}\n` +
+      `${pipettePythonName}.blow_out(${trashPythonName})`,
   })
   const commandCreators = [
     curryWithoutPython(moveToAddressableArea, {

--- a/step-generation/src/commandCreators/compound/blowOutInTrash.ts
+++ b/step-generation/src/commandCreators/compound/blowOutInTrash.ts
@@ -30,6 +30,8 @@ export const blowOutInTrash: CommandCreator<BlowOutInTrashParams> = (
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
     python:
+      // The Python blow_out() does not take a flow rate argument, so we have to
+      // reconfigure the pipette's default blow out rate instead:
       `${pipettePythonName}.flow_rate.blow_out = ${flowRate}\n` +
       `${pipettePythonName}.blow_out(${trashPythonName})`,
   })

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -86,3 +86,5 @@ export const COLUMN_4_SLOTS = ['A4', 'B4', 'C4', 'D4']
 export const ZERO_OFFSET: AddressableOffsetVector = { x: 0, y: 0, z: 0 }
 
 export const GRIPPER_LOCATION: 'mounted' = 'mounted'
+export const PROTOCOL_CONTEXT_FIXED_TRASH: 'protocol_context.fixed_trash' =
+  'protocol_context.fixed_trash'

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -86,5 +86,3 @@ export const COLUMN_4_SLOTS = ['A4', 'B4', 'C4', 'D4']
 export const ZERO_OFFSET: AddressableOffsetVector = { x: 0, y: 0, z: 0 }
 
 export const GRIPPER_LOCATION: 'mounted' = 'mounted'
-export const PROTOCOL_CONTEXT_FIXED_TRASH: 'protocol_context.fixed_trash' =
-  'protocol_context.fixed_trash'

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -392,7 +392,7 @@ export const blowoutUtil = (args: {
     return [
       curryCommandCreator(blowOutInTrash, {
         pipetteId: pipette,
-        trashLocation: trashBin?.location as CutoutId,
+        trashId: trashBin?.id as string,
         flowRate,
       }),
     ]


### PR DESCRIPTION
# Overview

This PR generates the python command for blowing out in a trash bin and should work for flex and ot-2.

## Test Plan and Hands on Testing

Review code. should also work if you smoke test the generated code and uploading to the app

## Changelog

- add python command for blowing out in trash bin
- add to the trash bin reducer to ensure the trash bin python name for an ot-2 is the fixedTrash string
- add test cases

## Risk assessment

low, doesn't affect functionality
