### PR TITLE
fix(protocol-designer): fix whitescreen when destination is trash

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -410,7 +410,7 @@ export const SecondStepsMoveLiquidTools = ({
           tooltipText={
             propsForFields[`${tab}_touchTip_checkbox`].tooltipContent
           }
-          disabled={tab === 'dispense' && isDestinationTrash}
+          disabled={propsForFields[`${tab}_touchTip_checkbox`].disabled}
         >
           {formData[`${tab}_touchTip_checkbox`] === true ? (
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing10}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -147,10 +147,9 @@ export const SecondStepsMoveLiquidTools = ({
     ]
   }
 
-  const minXYDimension = getMinXYDimension(
-    labwares[formData[`${tab}_labware`]].def,
-    ['A1']
-  )
+  const minXYDimension = isDestinationTrash
+    ? null
+    : getMinXYDimension(labwares[formData[`${tab}_labware`]]?.def, ['A1'])
   const minRadiusForTouchTip =
     minXYDimension != null ? round(minXYDimension / 2, 1) : null
 
@@ -411,6 +410,7 @@ export const SecondStepsMoveLiquidTools = ({
           tooltipText={
             propsForFields[`${tab}_touchTip_checkbox`].tooltipContent
           }
+          disabled={tab === 'dispense' && isDestinationTrash}
         >
           {formData[`${tab}_touchTip_checkbox`] === true ? (
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing10}>


### PR DESCRIPTION
# Overview

The recently added implementation of mm from edge field in transfer touch tip referenced the destination labware definition, which breaks if the destination is trash. This PR fixes this by checking if the destination is the trash before referencing its definition.

## Test Plan and Hands on Testing

- create or open a transfer step with trash as destination
- continue to advanced settings and select 'dispense' tab
- verify that no whitescreen occurs, and touch tip field is disabled

## Changelog

- check destination labware type before referencing its definition

## Review requests

see test plan

## Risk assessment

low