### PR TITLE
refactor(protocol-designer): clean up disabled and tooltip usage in mix & moveLiquid forms

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
@@ -261,9 +261,7 @@ export function MixTools(props: StepFormProps): JSX.Element {
           checkboxUpdateValue={
             propsForFields[`${tab}_delay_checkbox`].updateValue
           }
-          tooltipText={
-            propsForFields[`${tab}_delay_checkbox`].tooltipContent ?? null
-          }
+          tooltipText={propsForFields[`${tab}_delay_checkbox`].tooltipContent}
         >
           {formData[`${tab}_delay_checkbox`] === true ? (
             <InputStepFormField
@@ -290,9 +288,8 @@ export function MixTools(props: StepFormProps): JSX.Element {
               checkboxValue={propsForFields.blowout_checkbox.value}
               isChecked={propsForFields.blowout_checkbox.value === true}
               checkboxUpdateValue={propsForFields.blowout_checkbox.updateValue}
-              tooltipText={
-                propsForFields.blowout_checkbox.tooltipContent ?? null
-              }
+              tooltipText={propsForFields.blowout_checkbox.tooltipContent}
+              disabled={propsForFields.blowout_checkbox.disabled}
             >
               {formData.blowout_checkbox === true ? (
                 <Flex
@@ -338,9 +335,7 @@ export function MixTools(props: StepFormProps): JSX.Element {
               checkboxUpdateValue={
                 propsForFields.mix_touchTip_checkbox.updateValue
               }
-              tooltipText={
-                propsForFields.mix_touchTip_checkbox.tooltipContent ?? null
-              }
+              tooltipText={propsForFields.mix_touchTip_checkbox.tooltipContent}
             >
               {formData.mix_touchTip_checkbox === true ? (
                 <PositionField

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -404,7 +404,6 @@ export const SecondStepsMoveLiquidTools = ({
           tooltipText={
             propsForFields[`${tab}_touchTip_checkbox`].tooltipContent
           }
-          disabled={propsForFields[`${tab}_touchTip_checkbox`].disabled}
         >
           {formData[`${tab}_touchTip_checkbox`] === true ? (
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing10}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -281,11 +281,7 @@ export const SecondStepsMoveLiquidTools = ({
               ? dispenseMixDisabledTooltipText
               : propsForFields.aspirate_mix_checkbox.tooltipContent
           }
-          disabled={
-            tab === 'dispense'
-              ? isDestinationTrash || formData.path === 'multiDispense'
-              : formData.path === 'multiAspirate'
-          }
+          disabled={propsForFields[`${tab}_mix_checkbox`].disabled}
         >
           {formData[`${tab}_mix_checkbox`] === true ? (
             <Flex
@@ -360,10 +356,7 @@ export const SecondStepsMoveLiquidTools = ({
             isChecked={propsForFields.blowout_checkbox.value === true}
             checkboxUpdateValue={propsForFields.blowout_checkbox.updateValue}
             tooltipText={propsForFields.blowout_checkbox.tooltipContent}
-            disabled={
-              formData.path === 'multiDispense' &&
-              formData.disposalVolume_checkbox
-            }
+            disabled={propsForFields.blowout_checkbox.disabled}
           >
             {formData.blowout_checkbox === true ? (
               <Flex
@@ -411,6 +404,7 @@ export const SecondStepsMoveLiquidTools = ({
           tooltipText={
             propsForFields[`${tab}_touchTip_checkbox`].tooltipContent
           }
+          disabled={propsForFields[`${tab}_touchTip_checkbox`].disabled}
         >
           {formData[`${tab}_touchTip_checkbox`] === true ? (
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing10}>

--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsMoveLiquidForm.ts
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsMoveLiquidForm.ts
@@ -15,7 +15,6 @@ export function getDisabledFieldsMoveLiquidForm(
     'name' in hydratedForm.dispense_labware &&
     (hydratedForm.dispense_labware.name === 'wasteChute' ||
       hydratedForm.dispense_labware.name === 'trashBin')
-  console.log('isDispenseingintotrash', isDispensingIntoTrash)
   if (
     (hydratedForm.dispense_wells.length === 0 && !isDispensingIntoTrash) ||
     hydratedForm.aspirate_wells.length === 0 ||

--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsMoveLiquidForm.ts
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsMoveLiquidForm.ts
@@ -15,7 +15,7 @@ export function getDisabledFieldsMoveLiquidForm(
     'name' in hydratedForm.dispense_labware &&
     (hydratedForm.dispense_labware.name === 'wasteChute' ||
       hydratedForm.dispense_labware.name === 'trashBin')
-
+  console.log('isDispenseingintotrash', isDispensingIntoTrash)
   if (
     (hydratedForm.dispense_wells.length === 0 && !isDispensingIntoTrash) ||
     hydratedForm.aspirate_wells.length === 0 ||


### PR DESCRIPTION
# Overview

We have a nice architecture in place that we should continue to use that wires up tooltip content and disabled, among other props. This PR refactors a few things in `moveLiquid` and `mix` forms to follow those patterns.

## Test Plan and Hands on Testing

Smoke test the move liquid and mix forms to make sure they still work as expected

## Changelog

- fix a few tooltip and disabled reasons

## Risk assessment

low