### PR TITLE
feat(step-generation): py command for dispensing in trash

### DIFF
--- a/step-generation/src/__tests__/dispenseInTrash.test.ts
+++ b/step-generation/src/__tests__/dispenseInTrash.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
+  DEFAULT_PIPETTE,
   getInitialRobotStateStandard,
   getSuccessResult,
   makeContext,
@@ -7,24 +8,35 @@ import {
 import { dispenseInTrash } from '../commandCreators/compound'
 import type { CutoutId } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
+import { PROTOCOL_CONTEXT_NAME } from '../utils'
 
 vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
 
-const mockId = 'mockId'
 const mockCutout: CutoutId = 'cutoutA3'
-const invariantContext: InvariantContext = makeContext()
+const mockTrashId = 'mockTrashId'
+let invariantContext: InvariantContext = {
+  ...makeContext(),
+  additionalEquipmentEntities: {
+    [mockTrashId]: {
+      id: mockTrashId,
+      name: 'trashBin',
+      pythonName: 'mock_trash_bin_1',
+      location: mockCutout,
+    },
+  },
+}
 const prevRobotState: RobotState = getInitialRobotStateStandard(
   invariantContext
 )
 
 describe('dispenseInTrash', () => {
-  it('returns correct commands for dispenseInTrash in trash bin', () => {
+  it('returns correct commands for dispenseInTrash in trash bin for flex', () => {
     const result = dispenseInTrash(
       {
-        pipetteId: mockId,
+        pipetteId: DEFAULT_PIPETTE,
         flowRate: 10,
         volume: 10,
-        trashLocation: mockCutout,
+        trashId: mockTrashId,
       },
       invariantContext,
       prevRobotState
@@ -34,7 +46,7 @@ describe('dispenseInTrash', () => {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           addressableAreaName: 'movableTrashA3',
           offset: { x: 0, y: 0, z: 0 },
         },
@@ -43,11 +55,71 @@ describe('dispenseInTrash', () => {
         commandType: 'dispenseInPlace',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           volume: 10,
           flowRate: 10,
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      `
+mockPythonName.dispense(
+    volume=10,
+    location=mock_trash_bin_1,
+    rate=10 / mockPythonName.flow_rate.dispense,
+)`.trimStart()
+    )
+  })
+  it('returns correct commands for dispenseInTrash in trash bin for ot-2', () => {
+    const mockFixedTrashId = 'fixedTrashId'
+    invariantContext = {
+      ...invariantContext,
+      additionalEquipmentEntities: {
+        [mockFixedTrashId]: {
+          id: mockFixedTrashId,
+          name: 'trashBin',
+          pythonName: `${PROTOCOL_CONTEXT_NAME}.fixed_trash`,
+          location: 'cutout12',
+        },
+      },
+    }
+    const result = dispenseInTrash(
+      {
+        pipetteId: DEFAULT_PIPETTE,
+        flowRate: 10,
+        volume: 10,
+        trashId: mockFixedTrashId,
+      },
+      invariantContext,
+      prevRobotState
+    )
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.any(String),
+        params: {
+          pipetteId: DEFAULT_PIPETTE,
+          addressableAreaName: 'fixedTrash',
+          offset: { x: 0, y: 0, z: 0 },
+        },
+      },
+      {
+        commandType: 'dispenseInPlace',
+        key: expect.any(String),
+        params: {
+          pipetteId: DEFAULT_PIPETTE,
+          volume: 10,
+          flowRate: 10,
+        },
+      },
+    ])
+    expect(getSuccessResult(result).python).toBe(
+      `
+mockPythonName.dispense(
+    volume=10,
+    location=protocol.fixed_trash,
+    rate=10 / mockPythonName.flow_rate.dispense,
+)`.trimStart()
+    )
   })
 })

--- a/step-generation/src/commandCreators/compound/dispenseInTrash.ts
+++ b/step-generation/src/commandCreators/compound/dispenseInTrash.ts
@@ -2,6 +2,7 @@ import {
   getTrashBinAddressableAreaName,
   reduceCommandCreators,
   curryCommandCreator,
+  indentPyLines,
 } from '../../utils'
 import { ZERO_OFFSET } from '../../constants'
 import { dispenseInPlace, moveToAddressableArea } from '../atomic'
@@ -12,16 +13,37 @@ interface DispenseInTrashParams {
   pipetteId: string
   flowRate: number
   volume: number
-  trashLocation: CutoutId
+  trashId: string
 }
 export const dispenseInTrash: CommandCreator<DispenseInTrashParams> = (
   args,
   invariantContext,
   prevRobotState
 ) => {
-  const { pipetteId, trashLocation, flowRate, volume } = args
-  const addressableAreaName = getTrashBinAddressableAreaName(trashLocation)
-  const commandCreators: CurriedCommandCreator[] = [
+  const { pipetteId, trashId, flowRate, volume } = args
+  const { pipetteEntities, additionalEquipmentEntities } = invariantContext
+  const trashEntity = additionalEquipmentEntities[trashId]
+  const addressableAreaName = getTrashBinAddressableAreaName(
+    trashEntity.location as CutoutId
+  )
+  const pipettePythonName = pipetteEntities[pipetteId].pythonName
+  const trashPythonName = trashEntity.pythonName
+  const pythonArgs = [
+    `volume=${volume}`,
+    `location=${trashPythonName}`,
+    // rate= is a ratio in the PAPI, and we have no good way to figure out what
+    // flowrate the PAPI has set the pipette to, so we just have to emit a division:
+    `rate=${flowRate} / ${pipettePythonName}.flow_rate.dispense`,
+  ]
+
+  const pythonCommandCreator: CurriedCommandCreator = () => ({
+    commands: [],
+    python: `${pipettePythonName}.dispense(\n${indentPyLines(
+      pythonArgs.join(',\n')
+    )},\n)`,
+  })
+
+  const commandCreators = [
     curryCommandCreator(moveToAddressableArea, {
       pipetteId,
       addressableAreaName,
@@ -32,6 +54,7 @@ export const dispenseInTrash: CommandCreator<DispenseInTrashParams> = (
       volume,
       flowRate,
     }),
+    pythonCommandCreator,
   ]
 
   return reduceCommandCreators(

--- a/step-generation/src/commandCreators/compound/dispenseInTrash.ts
+++ b/step-generation/src/commandCreators/compound/dispenseInTrash.ts
@@ -1,8 +1,8 @@
 import {
   getTrashBinAddressableAreaName,
   reduceCommandCreators,
-  curryCommandCreator,
   indentPyLines,
+  curryWithoutPython,
 } from '../../utils'
 import { ZERO_OFFSET } from '../../constants'
 import { dispenseInPlace, moveToAddressableArea } from '../atomic'
@@ -44,12 +44,12 @@ export const dispenseInTrash: CommandCreator<DispenseInTrashParams> = (
   })
 
   const commandCreators = [
-    curryCommandCreator(moveToAddressableArea, {
+    curryWithoutPython(moveToAddressableArea, {
       pipetteId,
       addressableAreaName,
       offset: ZERO_OFFSET,
     }),
-    curryCommandCreator(dispenseInPlace, {
+    curryWithoutPython(dispenseInPlace, {
       pipetteId,
       volume,
       flowRate,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -628,8 +628,7 @@ export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> 
         pipetteId,
         volume,
         flowRate,
-        trashLocation: additionalEquipmentEntities[destinationId]
-          .location as CutoutId,
+        trashId: additionalEquipmentEntities[destinationId].id,
       }),
     ]
   }


### PR DESCRIPTION
# Overview

Generate the python command for dispensing in a trash bin or fixed trash

## Test Plan and Hands on Testing

Review the code and smoke test as well! i smoke tested and it passes analysis 😄 
```
    # Load Trash Bins:
    trash_bin_1 = protocol.load_trash_bin("A3")

    # PROTOCOL STEPS

    # Step 1:
    pipette_left.pick_up_tip(location=tip_rack_1)
    pipette_left.configure_for_volume(10)
    pipette_left.aspirate(
        volume=10,
        location=well_plate_1["D12"].bottom(z=1),
        rate=35 / pipette_left.flow_rate.aspirate,
    )
    pipette_left.dispense(
        volume=10,
        location=trash_bin_1,
        rate=57 / pipette_left.flow_rate.dispense,
    )
    pipette_left.drop_tip()
```

## Changelog

- add python generation to `dispenseInTrash` compound command and add test coverage

## Risk assessment

low, shouldn't affect functionality