### PR TITLE
feat(protocol-designer): create stacking labware ff and filter stacking labwar…

### DIFF
--- a/protocol-designer/src/assets/localization/en/feature_flags.json
+++ b/protocol-designer/src/assets/localization/en/feature_flags.json
@@ -46,5 +46,9 @@
   "OT_PD_ENABLE_PARTIAL_TIP_SUPPORT": {
     "title": "Enable partial tip support",
     "description": "Partial tip configurations that are not released yet"
+  },
+  "OT_PD_ENABLE_STACKING": {
+    "title": "Enable more labware capabilities",
+    "description": "Ability to stack labware, add lids, etc"
   }
 }

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -38,6 +38,7 @@ const initialFlags: Flags = {
     process.env.OT_PD_ENABLE_PYTHON_EXPORT === '1' || false,
   OT_PD_ENABLE_PARTIAL_TIP_SUPPORT:
     process.env.OT_PD_ENABLE_PARTIAL_TIP_SUPPORT === '1' || false,
+  OT_PD_ENABLE_STACKING: process.env.OT_PD_ENABLE_STACKING === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -61,3 +61,7 @@ export const getEnablePartialTipSupport: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_PARTIAL_TIP_SUPPORT ?? false
 )
+export const getEnableStacking: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_STACKING ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -41,6 +41,7 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_TIMELINE_SCRUBBER'
   | 'OT_PD_ENABLE_PYTHON_EXPORT'
   | 'OT_PD_ENABLE_PARTIAL_TIP_SUPPORT'
+  | 'OT_PD_ENABLE_STACKING'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',
@@ -58,5 +59,6 @@ export const allFlags: FlagTypes[] = [
   'OT_PD_ENABLE_TIMELINE_SCRUBBER',
   'OT_PD_ENABLE_PYTHON_EXPORT',
   'OT_PD_ENABLE_PARTIAL_TIP_SUPPORT',
+  'OT_PD_ENABLE_STACKING',
 ]
 export type Flags = Partial<Record<FlagTypes, boolean | null | undefined>>

--- a/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
@@ -45,6 +45,7 @@ import { getRobotType } from '../../../file-data/selectors'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { getPipetteEntities } from '../../../step-forms/selectors'
 import { selectors } from '../../../labware-ingred/selectors'
+import { getEnableStacking } from '../../../feature-flags/selectors'
 import {
   selectLabware,
   selectNestedLabware,
@@ -65,7 +66,6 @@ import type { ModuleOnDeck } from '../../../step-forms'
 import type { ThunkDispatch } from '../../../types'
 import type { LabwareDefByDefURI } from '../../../labware-defs'
 import type { CategoryExpand } from './DeckSetupTools'
-import { getEnableStacking } from '../../../feature-flags/selectors'
 
 const STANDARD_X_DIMENSION = 127.75
 const STANDARD_Y_DIMENSION = 85.48

--- a/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/LabwareTools.tsx
@@ -65,6 +65,7 @@ import type { ModuleOnDeck } from '../../../step-forms'
 import type { ThunkDispatch } from '../../../types'
 import type { LabwareDefByDefURI } from '../../../labware-defs'
 import type { CategoryExpand } from './DeckSetupTools'
+import { getEnableStacking } from '../../../feature-flags/selectors'
 
 const STANDARD_X_DIMENSION = 127.75
 const STANDARD_Y_DIMENSION = 85.48
@@ -103,6 +104,7 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
   const customLabwareDefs = useSelector(getCustomLabwareDefsByURI)
   const has96Channel = getHas96Channel(pipetteEntities)
   const defs = getOnlyLatestDefs()
+  const enableStacking = useSelector(getEnableStacking)
   const deckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const zoomedInSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
   const {
@@ -381,8 +383,11 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
                             />
 
                             {uri === selectedLabwareDefUri &&
-                              getLabwareCompatibleWithAdapter(defs, loadName)
-                                ?.length > 0 && (
+                              getLabwareCompatibleWithAdapter(
+                                defs,
+                                enableStacking,
+                                loadName
+                              )?.length > 0 && (
                                 <ListButtonAccordionContainer
                                   id={`nestedAccordionContainer_${loadName}`}
                                 >
@@ -433,6 +438,7 @@ export function LabwareTools(props: LabwareToolsProps): JSX.Element {
                                         )
                                       : getLabwareCompatibleWithAdapter(
                                           { ...defs, ...customLabwareDefs },
+                                          enableStacking,
                                           loadName
                                         ).map(nestedDefUri => {
                                           const nestedDef =

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -150,11 +150,21 @@ export const getLabwareIsRecommended = (
       )
 }
 
+const STACKING_LABWARE_LOADNAME_FILTER = [
+  'opentrons_96_wellplate_200ul_pcr_full_skirt',
+]
+
 export const getLabwareCompatibleWithAdapter = (
   defs: LabwareDefByDefURI,
+  enableStacking: boolean,
   adapterLoadName?: string
 ): string[] => {
-  if (adapterLoadName == null) {
+  if (
+    adapterLoadName == null ||
+    (adapterLoadName != null &&
+      !enableStacking &&
+      STACKING_LABWARE_LOADNAME_FILTER.includes(adapterLoadName))
+  ) {
     return []
   }
   return Object.entries(defs)


### PR DESCRIPTION
…e capabilities from deck setup

# Overview

Elyor noticed that we had the ability to add the tough 96 well plates as a labware on top of itself (for stacking). PD doesn't support stacking yet so I filtered it out and put it behind a ff.

## Test Plan and Hands on Testing

Turn on the stacking labware ff
Go to deck setup, add a 96 touch wellPlate and see that you have the ability to add another plate onto it
Turn off the stacking labware ff
Go to deck setup, add a 96 touch wellPlate and see that you DO NOT have the ability to add another plate onto it


## Changelog

- create labware stacking *& lids ff
- plug in the filtering of stacking 96 well plate

## Risk assessment

low, behind ff
