### PR TITLE
feat(step-generation): py command for dropping tip in waste chute

### DIFF
--- a/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
+++ b/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
@@ -1,14 +1,11 @@
 import {
-  dropTipInPlace,
-  moveToAddressableArea,
-  getWasteChuteAddressableAreaNamePip,
   dropTipInTrash,
+  dropTipInWasteChute,
   curryCommandCreator,
   dropTip,
   reduceCommandCreators,
   commandCreatorsTimeline,
   getPipetteIdFromCCArgs,
-  ZERO_OFFSET,
 } from '@opentrons/step-generation'
 import { commandCreatorFromStepArgs } from '../file-data/helpers'
 import type { StepArgsAndErrorsById } from '../steplist/types'
@@ -75,11 +72,6 @@ export const generateRobotStateTimeline = (
         const isWasteChute = dropTipEntity?.name === 'wasteChute'
         const isTrashBin = dropTipEntity?.name === 'trashBin'
 
-        const pipetteSpec = invariantContext.pipetteEntities[pipetteId]?.spec
-        const addressableAreaNameWasteChute = getWasteChuteAddressableAreaNamePip(
-          pipetteSpec.channels
-        )
-
         let dropTipCommands = [
           curryCommandCreator(dropTip, {
             pipette: pipetteId,
@@ -88,13 +80,9 @@ export const generateRobotStateTimeline = (
         ]
         if (isWasteChute) {
           dropTipCommands = [
-            curryCommandCreator(moveToAddressableArea, {
+            curryCommandCreator(dropTipInWasteChute, {
               pipetteId,
-              addressableAreaName: addressableAreaNameWasteChute,
-              offset: ZERO_OFFSET,
-            }),
-            curryCommandCreator(dropTipInPlace, {
-              pipetteId,
+              wasteChuteId: dropTipEntity.id,
             }),
           ]
         }

--- a/step-generation/src/__tests__/dropTipInWasteChute.test.ts
+++ b/step-generation/src/__tests__/dropTipInWasteChute.test.ts
@@ -49,44 +49,6 @@ describe('dropTipInWasteChute', () => {
         },
       },
     ])
-    expect(getSuccessResult(result).python).toBe('mockPythonName.drop_tip()')
-  })
-  it('returns correct commands for drop tip in waste chute when trash bin also exists', () => {
-    const mockTrashId = 'mockTrashId'
-    invariantContext = {
-      ...invariantContext,
-      additionalEquipmentEntities: {
-        ...invariantContext.additionalEquipmentEntities,
-        [mockTrashId]: {
-          name: 'trashBin',
-          location: 'cutoutA3',
-          id: mockTrashId,
-        },
-      },
-    }
-    const args = {
-      pipetteId: DEFAULT_PIPETTE,
-      wasteChuteId: mockWasteChuteId,
-    }
-    const result = dropTipInWasteChute(args, invariantContext, prevRobotState)
-    expect(getSuccessResult(result).commands).toEqual([
-      {
-        commandType: 'moveToAddressableArea',
-        key: expect.any(String),
-        params: {
-          pipetteId: DEFAULT_PIPETTE,
-          addressableAreaName: '1ChannelWasteChute',
-          offset: { x: 0, y: 0, z: 0 },
-        },
-      },
-      {
-        commandType: 'dropTipInPlace',
-        key: expect.any(String),
-        params: {
-          pipetteId: DEFAULT_PIPETTE,
-        },
-      },
-    ])
     expect(getSuccessResult(result).python).toBe(
       'mockPythonName.drop_tip(mock_waste_chute_1)'
     )

--- a/step-generation/src/__tests__/dropTipInWasteChute.test.ts
+++ b/step-generation/src/__tests__/dropTipInWasteChute.test.ts
@@ -9,7 +9,7 @@ vi.mock('../getNextRobotStateAndWarnings/dispenseUpdateLiquidState')
 
 const mockWasteChuteId = 'mockWasteChuteId'
 
-let invariantContext: InvariantContext = {
+const invariantContext: InvariantContext = {
   ...makeContext(),
   additionalEquipmentEntities: {
     [mockWasteChuteId]: {

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -460,6 +460,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         dropTipCommand = [
           curryCommandCreator(dropTipInWasteChute, {
             pipetteId: args.pipette,
+            wasteChuteId: dropTipEntity.id,
           }),
         ]
       }

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -386,6 +386,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         dropTipCommand = [
           curryCommandCreator(dropTipInWasteChute, {
             pipetteId: args.pipette,
+            wasteChuteId: dropTipEntity.id,
           }),
         ]
       }

--- a/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
@@ -24,10 +24,6 @@ export const dropTipInWasteChute: CommandCreator<DropTipInWasteChuteArgs> = (
   const addressableAreaName = getWasteChuteAddressableAreaNamePip(
     pipetteChannels
   )
-  const hasTrashBin =
-    Object.values(additionalEquipmentEntities).find(
-      ae => ae.name === 'trashBin'
-    ) != null
 
   let commandCreators: CurriedCommandCreator[] = []
 
@@ -38,15 +34,9 @@ export const dropTipInWasteChute: CommandCreator<DropTipInWasteChuteArgs> = (
     const pipettePythonName = pipetteEntities[pipetteId].pythonName
     const wasteChutePythonName =
       additionalEquipmentEntities[wasteChuteId].pythonName
-    //  if there is no trash bin selected, drop tip will occur at the default
-    //  trash container, which would be the waste_chute since we do not support
-    //  having no trash container in PD. Since our code generator always generates
-    //  the trash bins first, if a trash bin exists, we will have to provide the
-    //  waste chute location.
-    const pythonLocation = hasTrashBin ? [wasteChutePythonName] : []
     const pythonCommandCreator: CurriedCommandCreator = () => ({
       commands: [],
-      python: `${pipettePythonName}.drop_tip(${pythonLocation})`,
+      python: `${pipettePythonName}.drop_tip(${wasteChutePythonName})`,
     })
 
     commandCreators = [

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -211,6 +211,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     commandCreators = [
       curryCommandCreator(dropTipInWasteChute, {
         pipetteId: args.pipette,
+        wasteChuteId: dropTipEntity.id,
       }),
       ...configureNozzleLayoutCommand,
       curryCommandCreator(pickUpTip, {

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -545,6 +545,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             dropTipCommand = [
               curryCommandCreator(dropTipInWasteChute, {
                 pipetteId: args.pipette,
+                wasteChuteId: dropTipEntity.id,
               }),
             ]
           }

--- a/step-generation/src/index.ts
+++ b/step-generation/src/index.ts
@@ -17,6 +17,7 @@ export {
   dropTip,
   dropTipInPlace,
   dropTipInTrash,
+  dropTipInWasteChute,
   engageMagnet,
   heaterShaker,
   mix,


### PR DESCRIPTION
# Overview

Generate the python command for dropping tip in a waste chute

## Test Plan and Hands on Testing

Review the code and smoke test, should pass analysis  

```
    # Load Waste Chute:
    waste_chute = protocol.load_waste_chute()

    # PROTOCOL STEPS

    # Step 1:
    pipette_left.pick_up_tip(location=tip_rack_1)
    pipette_left.configure_for_volume(10)
    pipette_left.aspirate(
        volume=10,
        location=well_plate_1["D12"].bottom(z=1),
        rate=35 / pipette_left.flow_rate.aspirate,
    )
    pipette_left.dispense(
        volume=10,
         location=well_plate_1["D12"].bottom(z=1),
        rate=57 / pipette_left.flow_rate.dispense,
    )

   pipette_left.drop_tip(waste_chute)

```
## Changelog

- add python generation to `dropTipInWasteChute` compound command and add test coverage

## Risk assessment

low, shouldn't affect functionality
