### PR TITLE
feat(step-generation): py command generation for mix()

### DIFF
--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -208,16 +208,10 @@ mockPythonName.drop_tip()
       // Step c:
       `
 mockPythonName.pick_up_tip(location=mockPythonName)
-mockPythonName.aspirate(...)
-mockPythonName.dispense(...)
-mockPythonName.aspirate(...)
-mockPythonName.dispense(...)
+mockPythonName.mix(...)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
-mockPythonName.aspirate(...)
-mockPythonName.dispense(...)
-mockPythonName.aspirate(...)
-mockPythonName.dispense(...)
+mockPythonName.mix(...)
 mockPythonName.drop_tip()
 `.trim(),
     ])

--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -208,9 +208,13 @@ mockPythonName.drop_tip()
       // Step c:
       `
 mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.flow_rate.aspirate = 3.78
+mockPythonName.flow_rate.dispense = 3.78
 mockPythonName.mix(...)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.flow_rate.aspirate = 3.78
+mockPythonName.flow_rate.dispense = 3.78
 mockPythonName.mix(...)
 mockPythonName.drop_tip()
 `.trim(),

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -30,7 +30,7 @@ export * from './pipetting'
 export * from './setup'
 export * from './timing'
 export * from './unsafe'
-
+export * from './support'
 // NOTE: these key/value pairs will only be present on commands at analysis/run time
 // they pertain only to the actual execution status of a command on hardware, as opposed to
 // the command's identity and parameters which can be known prior to runtime

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -85,7 +85,7 @@ describe('mix: change tip', () => {
       wells: ['A1', 'B1', 'C1'],
       changeTip,
     } as MixArgs)
-  it('changeTip="always"', () => {
+  it('changeTip="always" with no advanced settings', () => {
     const args = makeArgs('always')
     const result = mix(args, invariantContext, robotStateWithTip)
     const res = getSuccessResult(result)
@@ -99,6 +99,18 @@ describe('mix: change tip', () => {
         aspirateHelper(well, volume, mockWellLocation),
         dispenseHelper(well, volume, mockWellLocation),
       ])
+    )
+    expect(res.python).toBe(
+      `
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.mix(2, 5, mockPythonName["A1"])
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.mix(2, 5, mockPythonName["B1"])
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.mix(2, 5, mockPythonName["C1"])`.trimStart()
     )
   })
 
@@ -303,7 +315,7 @@ describe('mix: advanced options', () => {
     )
   })
   describe('all advanced settings enabled', () => {
-    it('should create commands in the expected order with expected params', () => {
+    it('should create commands in the expected order with expected params with all args', () => {
       const args: MixArgs = {
         ...mixinArgs,
         touchTip: true,
@@ -341,7 +353,151 @@ describe('mix: advanced options', () => {
           touchTipHelper(well),
         ])
       )
+      expect(res.python).toBe(
+        `
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.aspirate(
+    volume=8,
+    location=mockPythonName["A1"].bottom(z=3.2),
+    rate=2.1 / mockPythonName.flow_rate.aspirate,
+)
+protocol.delay(seconds=10)
+mockPythonName.dispense(
+    volume=8,
+    location=mockPythonName["A1"].bottom(z=3.2),
+    rate=2.2 / mockPythonName.flow_rate.dispense,
+)
+protocol.delay(seconds=12)
+mockPythonName.aspirate(
+    volume=8,
+    location=mockPythonName["A1"].bottom(z=3.2),
+    rate=2.1 / mockPythonName.flow_rate.aspirate,
+)
+protocol.delay(seconds=10)
+mockPythonName.dispense(
+    volume=8,
+    location=mockPythonName["A1"].bottom(z=3.2),
+    rate=2.2 / mockPythonName.flow_rate.dispense,
+)
+protocol.delay(seconds=12)
+mockPythonName.flow_rate.blow_out = 2.3
+mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.touch_tip(
+    mockPythonName["A1"],
+    v_offset=-3.4,
+)
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.aspirate(
+    volume=8,
+    location=mockPythonName["B1"].bottom(z=3.2),
+    rate=2.1 / mockPythonName.flow_rate.aspirate,
+)
+protocol.delay(seconds=10)
+mockPythonName.dispense(
+    volume=8,
+    location=mockPythonName["B1"].bottom(z=3.2),
+    rate=2.2 / mockPythonName.flow_rate.dispense,
+)
+protocol.delay(seconds=12)
+mockPythonName.aspirate(
+    volume=8,
+    location=mockPythonName["B1"].bottom(z=3.2),
+    rate=2.1 / mockPythonName.flow_rate.aspirate,
+)
+protocol.delay(seconds=10)
+mockPythonName.dispense(
+    volume=8,
+    location=mockPythonName["B1"].bottom(z=3.2),
+    rate=2.2 / mockPythonName.flow_rate.dispense,
+)
+protocol.delay(seconds=12)
+mockPythonName.flow_rate.blow_out = 2.3
+mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.touch_tip(
+    mockPythonName["B1"],
+    v_offset=-3.4,
+)
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.aspirate(
+    volume=8,
+    location=mockPythonName["C1"].bottom(z=3.2),
+    rate=2.1 / mockPythonName.flow_rate.aspirate,
+)
+protocol.delay(seconds=10)
+mockPythonName.dispense(
+    volume=8,
+    location=mockPythonName["C1"].bottom(z=3.2),
+    rate=2.2 / mockPythonName.flow_rate.dispense,
+)
+protocol.delay(seconds=12)
+mockPythonName.aspirate(
+    volume=8,
+    location=mockPythonName["C1"].bottom(z=3.2),
+    rate=2.1 / mockPythonName.flow_rate.aspirate,
+)
+protocol.delay(seconds=10)
+mockPythonName.dispense(
+    volume=8,
+    location=mockPythonName["C1"].bottom(z=3.2),
+    rate=2.2 / mockPythonName.flow_rate.dispense,
+)
+protocol.delay(seconds=12)
+mockPythonName.flow_rate.blow_out = 2.3
+mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.touch_tip(
+    mockPythonName["C1"],
+    v_offset=-3.4,
+)`.trimStart()
+      )
     })
+  })
+  it('should create python commands with mix() with touchTip and blowOut and no delay set', () => {
+    const args: MixArgs = {
+      ...mixinArgs,
+      touchTip: true,
+      blowoutLocation: blowoutLabwareId,
+      volume,
+      times,
+      changeTip: 'always',
+      wells: ['A1', 'B1', 'C1'],
+    } as MixArgs
+
+    const result = mix(args, invariantContext, robotStateWithTip)
+    const res = getSuccessResult(result)
+
+    expect(res.python).toBe(
+      `
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.mix(2, 8, mockPythonName["A1"])
+mockPythonName.flow_rate.blow_out = 2.3
+mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.touch_tip(
+    mockPythonName["A1"],
+    v_offset=-3.4,
+)
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.mix(2, 8, mockPythonName["B1"])
+mockPythonName.flow_rate.blow_out = 2.3
+mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.touch_tip(
+    mockPythonName["B1"],
+    v_offset=-3.4,
+)
+mockPythonName.drop_tip()
+mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.mix(2, 8, mockPythonName["C1"])
+mockPythonName.flow_rate.blow_out = 2.3
+mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.touch_tip(
+    mockPythonName["C1"],
+    v_offset=-3.4,
+)`.trimStart()
+    )
   })
 })
 

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -104,27 +104,30 @@ describe('mix: change tip', () => {
       `
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.flow_rate.aspirate = 2.1
+mockPythonName.flow_rate.dispense = 2.2
 mockPythonName.mix(
     repetitions=2,
     volume=5,
     location=mockPythonName["A1"].bottom(z=3.2),
-    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
 )
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.flow_rate.aspirate = 2.1
+mockPythonName.flow_rate.dispense = 2.2
 mockPythonName.mix(
     repetitions=2,
     volume=5,
     location=mockPythonName["B1"].bottom(z=3.2),
-    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
 )
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.flow_rate.aspirate = 2.1
+mockPythonName.flow_rate.dispense = 2.2
 mockPythonName.mix(
     repetitions=2,
     volume=5,
     location=mockPythonName["C1"].bottom(z=3.2),
-    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
 )`.trimStart()
     )
   })
@@ -487,33 +490,36 @@ mockPythonName.touch_tip(mockPythonName["C1"], v_offset=-3.4)`.trimStart()
       `
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.flow_rate.aspirate = 2.1
+mockPythonName.flow_rate.dispense = 2.2
 mockPythonName.mix(
     repetitions=2,
     volume=8,
     location=mockPythonName["A1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
-    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
 )
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
 mockPythonName.touch_tip(mockPythonName["A1"], v_offset=-3.4)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.flow_rate.aspirate = 2.1
+mockPythonName.flow_rate.dispense = 2.2
 mockPythonName.mix(
     repetitions=2,
     volume=8,
     location=mockPythonName["B1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
-    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
 )
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
 mockPythonName.touch_tip(mockPythonName["B1"], v_offset=-3.4)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
+mockPythonName.flow_rate.aspirate = 2.1
+mockPythonName.flow_rate.dispense = 2.2
 mockPythonName.mix(
     repetitions=2,
     volume=8,
     location=mockPythonName["C1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
-    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
 )
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -104,13 +104,28 @@ describe('mix: change tip', () => {
       `
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
-mockPythonName.mix(2, 5, mockPythonName["A1"])
+mockPythonName.mix(
+    repetitions=2,
+    volume=5,
+    location=mockPythonName["A1"].bottom(z=3.2),
+    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
+)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
-mockPythonName.mix(2, 5, mockPythonName["B1"])
+mockPythonName.mix(
+    repetitions=2,
+    volume=5,
+    location=mockPythonName["B1"].bottom(z=3.2),
+    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
+)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
-mockPythonName.mix(2, 5, mockPythonName["C1"])`.trimStart()
+mockPythonName.mix(
+    repetitions=2,
+    volume=5,
+    location=mockPythonName["C1"].bottom(z=3.2),
+    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
+)`.trimStart()
     )
   })
 
@@ -326,7 +341,14 @@ describe('mix: advanced options', () => {
         times,
         changeTip: 'always',
         wells: ['A1', 'B1', 'C1'],
+        yOffset: 1,
       } as MixArgs
+      const mockWellLocationCustomXY: Partial<AspDispAirgapParams> = {
+        wellLocation: {
+          origin: 'bottom',
+          offset: { x: 0, y: 1, z: 3.2 },
+        },
+      }
 
       const result = mix(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
@@ -334,13 +356,13 @@ describe('mix: advanced options', () => {
       expect(res.commands).toEqual(
         flatMap(args.wells, (well, idx) => [
           ...replaceTipCommands(idx),
-          aspirateHelper(well, volume, mockWellLocation),
+          aspirateHelper(well, volume, mockWellLocationCustomXY),
           delayCommand(10),
-          dispenseHelper(well, volume, mockWellLocation),
+          dispenseHelper(well, volume, mockWellLocationCustomXY),
           delayCommand(12),
-          aspirateHelper(well, volume, mockWellLocation),
+          aspirateHelper(well, volume, mockWellLocationCustomXY),
           delayCommand(10),
-          dispenseHelper(well, volume, mockWellLocation),
+          dispenseHelper(well, volume, mockWellLocationCustomXY),
           delayCommand(12),
           blowoutHelper(blowoutLabwareId, {
             wellLocation: {
@@ -359,25 +381,25 @@ mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
 mockPythonName.aspirate(
     volume=8,
-    location=mockPythonName["A1"].bottom(z=3.2),
+    location=mockPythonName["A1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.1 / mockPythonName.flow_rate.aspirate,
 )
 protocol.delay(seconds=10)
 mockPythonName.dispense(
     volume=8,
-    location=mockPythonName["A1"].bottom(z=3.2),
+    location=mockPythonName["A1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.2 / mockPythonName.flow_rate.dispense,
 )
 protocol.delay(seconds=12)
 mockPythonName.aspirate(
     volume=8,
-    location=mockPythonName["A1"].bottom(z=3.2),
+    location=mockPythonName["A1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.1 / mockPythonName.flow_rate.aspirate,
 )
 protocol.delay(seconds=10)
 mockPythonName.dispense(
     volume=8,
-    location=mockPythonName["A1"].bottom(z=3.2),
+    location=mockPythonName["A1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.2 / mockPythonName.flow_rate.dispense,
 )
 protocol.delay(seconds=12)
@@ -391,25 +413,25 @@ mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
 mockPythonName.aspirate(
     volume=8,
-    location=mockPythonName["B1"].bottom(z=3.2),
+    location=mockPythonName["B1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.1 / mockPythonName.flow_rate.aspirate,
 )
 protocol.delay(seconds=10)
 mockPythonName.dispense(
     volume=8,
-    location=mockPythonName["B1"].bottom(z=3.2),
+    location=mockPythonName["B1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.2 / mockPythonName.flow_rate.dispense,
 )
 protocol.delay(seconds=12)
 mockPythonName.aspirate(
     volume=8,
-    location=mockPythonName["B1"].bottom(z=3.2),
+    location=mockPythonName["B1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.1 / mockPythonName.flow_rate.aspirate,
 )
 protocol.delay(seconds=10)
 mockPythonName.dispense(
     volume=8,
-    location=mockPythonName["B1"].bottom(z=3.2),
+    location=mockPythonName["B1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.2 / mockPythonName.flow_rate.dispense,
 )
 protocol.delay(seconds=12)
@@ -423,25 +445,25 @@ mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
 mockPythonName.aspirate(
     volume=8,
-    location=mockPythonName["C1"].bottom(z=3.2),
+    location=mockPythonName["C1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.1 / mockPythonName.flow_rate.aspirate,
 )
 protocol.delay(seconds=10)
 mockPythonName.dispense(
     volume=8,
-    location=mockPythonName["C1"].bottom(z=3.2),
+    location=mockPythonName["C1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.2 / mockPythonName.flow_rate.dispense,
 )
 protocol.delay(seconds=12)
 mockPythonName.aspirate(
     volume=8,
-    location=mockPythonName["C1"].bottom(z=3.2),
+    location=mockPythonName["C1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.1 / mockPythonName.flow_rate.aspirate,
 )
 protocol.delay(seconds=10)
 mockPythonName.dispense(
     volume=8,
-    location=mockPythonName["C1"].bottom(z=3.2),
+    location=mockPythonName["C1"].bottom(z=3.2).move(types.Point(y=1)),
     rate=2.2 / mockPythonName.flow_rate.dispense,
 )
 protocol.delay(seconds=12)
@@ -454,7 +476,7 @@ mockPythonName.touch_tip(
       )
     })
   })
-  it('should create python commands with mix() with touchTip and blowOut and no delay set', () => {
+  it('should create python commands with mix() with touchTip and blowOut and no delay or x/y offset set', () => {
     const args: MixArgs = {
       ...mixinArgs,
       touchTip: true,
@@ -463,6 +485,8 @@ mockPythonName.touch_tip(
       times,
       changeTip: 'always',
       wells: ['A1', 'B1', 'C1'],
+      xOffset: 1,
+      yOffset: 1,
     } as MixArgs
 
     const result = mix(args, invariantContext, robotStateWithTip)
@@ -472,7 +496,12 @@ mockPythonName.touch_tip(
       `
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
-mockPythonName.mix(2, 8, mockPythonName["A1"])
+mockPythonName.mix(
+    repetitions=2,
+    volume=8,
+    location=mockPythonName["A1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
+    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
+)
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
 mockPythonName.touch_tip(
@@ -481,7 +510,12 @@ mockPythonName.touch_tip(
 )
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
-mockPythonName.mix(2, 8, mockPythonName["B1"])
+mockPythonName.mix(
+    repetitions=2,
+    volume=8,
+    location=mockPythonName["B1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
+    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
+)
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
 mockPythonName.touch_tip(
@@ -490,7 +524,12 @@ mockPythonName.touch_tip(
 )
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
-mockPythonName.mix(2, 8, mockPythonName["C1"])
+mockPythonName.mix(
+    repetitions=2,
+    volume=8,
+    location=mockPythonName["C1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
+    rate=(2.1 / mockPythonName.flow_rate.aspirate) + (2.2 / mockPythonName.flow_rate.dispense),
+)
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
 mockPythonName.touch_tip(

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -405,10 +405,7 @@ mockPythonName.dispense(
 protocol.delay(seconds=12)
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
-mockPythonName.touch_tip(
-    mockPythonName["A1"],
-    v_offset=-3.4,
-)
+mockPythonName.touch_tip(mockPythonName["A1"], v_offset=-3.4)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
 mockPythonName.aspirate(
@@ -437,10 +434,7 @@ mockPythonName.dispense(
 protocol.delay(seconds=12)
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
-mockPythonName.touch_tip(
-    mockPythonName["B1"],
-    v_offset=-3.4,
-)
+mockPythonName.touch_tip(mockPythonName["B1"], v_offset=-3.4)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
 mockPythonName.aspirate(
@@ -469,10 +463,7 @@ mockPythonName.dispense(
 protocol.delay(seconds=12)
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
-mockPythonName.touch_tip(
-    mockPythonName["C1"],
-    v_offset=-3.4,
-)`.trimStart()
+mockPythonName.touch_tip(mockPythonName["C1"], v_offset=-3.4)`.trimStart()
       )
     })
   })
@@ -504,10 +495,7 @@ mockPythonName.mix(
 )
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
-mockPythonName.touch_tip(
-    mockPythonName["A1"],
-    v_offset=-3.4,
-)
+mockPythonName.touch_tip(mockPythonName["A1"], v_offset=-3.4)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
 mockPythonName.mix(
@@ -518,10 +506,7 @@ mockPythonName.mix(
 )
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
-mockPythonName.touch_tip(
-    mockPythonName["B1"],
-    v_offset=-3.4,
-)
+mockPythonName.touch_tip(mockPythonName["B1"], v_offset=-3.4)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
 mockPythonName.mix(
@@ -532,10 +517,7 @@ mockPythonName.mix(
 )
 mockPythonName.flow_rate.blow_out = 2.3
 mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
-mockPythonName.touch_tip(
-    mockPythonName["C1"],
-    v_offset=-3.4,
-)`.trimStart()
+mockPythonName.touch_tip(mockPythonName["C1"], v_offset=-3.4)`.trimStart()
     )
   })
 })

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -331,6 +331,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               xOffset: aspirateXOffset,
               yOffset: aspirateYOffset,
               nozzles,
+              invariantContext,
             })
           : []
       const preWetTipCommands = args.preWetTip // Pre-wet tip is equivalent to a single mix, with volume equal to the consolidate volume.
@@ -349,6 +350,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             xOffset: aspirateXOffset,
             yOffset: aspirateYOffset,
             nozzles,
+            invariantContext,
           })
         : []
       //  can not mix in a waste chute
@@ -369,6 +371,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               xOffset: dispenseXOffset,
               yOffset: dispenseYOffset,
               nozzles,
+              invariantContext,
             })
           : []
 

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -463,6 +463,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               xOffset: aspirateXOffset,
               yOffset: aspirateYOffset,
               nozzles,
+              invariantContext,
             })
           : []
 
@@ -501,6 +502,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               xOffset: aspirateXOffset,
               yOffset: aspirateYOffset,
               nozzles,
+              invariantContext,
             })
           : []
       return [

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -71,10 +71,14 @@ export function mixUtil(args: {
     nozzles,
     invariantContext,
   } = args
-  //  If delay is specified, emit individual py commands
-  //  otherwise, emit mix()
+  //  If delay is specified to something other than 0,
+  //  emit individual py commands. Otherwise, emit mix()
   const hasUnsupportedMixApiArg =
-    aspirateDelaySeconds != null || dispenseDelaySeconds != null
+    aspirateDelaySeconds != null ||
+    (aspirateDelaySeconds != null && aspirateDelaySeconds === 0) ||
+    dispenseDelaySeconds != null ||
+    (dispenseDelaySeconds != null && dispenseDelaySeconds === 0)
+
   const curryCreator = hasUnsupportedMixApiArg
     ? curryCommandCreator
     : curryWithoutPython

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -102,15 +102,17 @@ export function mixUtil(args: {
       `location=${labwarePythonName}[${formatPyStr(
         well
       )}]${formatPyWellLocation(pythonWellLocation)}`,
-      `rate=(${aspirateFlowRateUlSec} / ${pipettePythonName}.flow_rate.aspirate) + (${dispenseFlowRateUlSec} / ${pipettePythonName}.flow_rate.dispense)`,
     ]
     return {
       commands: [],
       //  Note: we do not support mix in trashBin or wasteChute so location
       //  will always be a well
-      python: `${pipettePythonName}.mix(\n${indentPyLines(
-        pythonArgs.join(',\n')
-      )},\n)`,
+      python:
+        `${pipettePythonName}.flow_rate.aspirate = ${aspirateFlowRateUlSec}\n` +
+        `${pipettePythonName}.flow_rate.dispense = ${dispenseFlowRateUlSec}\n` +
+        `${pipettePythonName}.mix(\n${indentPyLines(
+          pythonArgs.join(',\n')
+        )},\n)`,
     }
   }
   return [

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -102,7 +102,6 @@ export function mixUtil(args: {
       `location=${labwarePythonName}[${formatPyStr(
         well
       )}]${formatPyWellLocation(pythonWellLocation)}`,
-      //  Note: just wiring up the aspirate flow rate?
       `rate=(${aspirateFlowRateUlSec} / ${pipettePythonName}.flow_rate.aspirate) + (${dispenseFlowRateUlSec} / ${pipettePythonName}.flow_rate.dispense)`,
     ]
     return {

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -286,6 +286,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   xOffset: aspirateXOffset,
                   yOffset: aspirateYOffset,
                   nozzles: args.nozzles,
+                  invariantContext,
                 })
               : []
           const mixBeforeAspirateCommands =
@@ -305,6 +306,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   xOffset: aspirateXOffset,
                   yOffset: aspirateYOffset,
                   nozzles: args.nozzles,
+                  invariantContext,
                 })
               : []
           const delayAfterAspirateCommands =
@@ -374,6 +376,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   xOffset: dispenseXOffset,
                   yOffset: dispenseYOffset,
                   nozzles: args.nozzles,
+                  invariantContext,
                 })
               : []
 


### PR DESCRIPTION
closes AUTH-1097

# Overview

this PR introduces the py command generation for `mix()`!  It is emitted only if there are acceptable args. Meaning no aspirate delay, no dispense delay.

**TODO: figure out the flow rates! user can specify both aspirate and dispense flow rates but mix can only use one. how do we know which one to use?**

## Test Plan and Hands on Testing

Review the code and smoke test

here is an example i made that passes analysis for the different variations of commands

```
from contextlib import nullcontext as pd_step
from opentrons import protocol_api, types

metadata = {
    "protocolName": "test mixing",
    "created": "2025-03-20T17:54:17.554Z",
    "lastModified": "2025-03-20T17:55:04.093Z",
    "protocolDesigner": "8.4.3",
    "source": "Protocol Designer",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.23",
}

def run(protocol: protocol_api.ProtocolContext):
    # Load Labware:
    tip_rack_1 = protocol.load_labware(
        "opentrons_flex_96_tiprack_50ul",
        "C2",
        namespace="opentrons",
        version=1,
    )
    reservoir_1 = protocol.load_labware(
        "axygen_1_reservoir_90ml",
        "D1",
        namespace="opentrons",
        version=2,
    )

    # Load Pipettes:
    pipette_left = protocol.load_instrument("flex_1channel_50", "left", tip_racks=[tip_rack_1])

    # Load Trash Bins:
    trash_bin_1 = protocol.load_trash_bin("A3")

    # PROTOCOL STEPS

    # Step 1: NO MIX SINCE DELAY IS SET
    pipette_left.pick_up_tip(location=tip_rack_1)
    pipette_left.configure_for_volume(10)
    pipette_left.aspirate(
        volume=10,
        location=reservoir_1["A1"].bottom(z=1),
        rate=35 / pipette_left.flow_rate.aspirate,
    )
    protocol.delay(seconds=10)
    pipette_left.dispense(
        volume=10,
        location=reservoir_1["A1"].bottom(z=1),
        rate=57 / pipette_left.flow_rate.dispense,
    )
    protocol.delay(seconds=10)
    pipette_left.aspirate(
        volume=10,
        location=reservoir_1["A1"].bottom(z=1),
        rate=35 / pipette_left.flow_rate.aspirate,
    )
    protocol.delay(seconds=10)
    pipette_left.dispense(
        volume=10,
        location=reservoir_1["A1"].bottom(z=1),
        rate=57 / pipette_left.flow_rate.dispense,
    )
    protocol.delay(seconds=10)
    pipette_left.drop_tip()

    # Step 2: MIX SINCE DELAY IS NOT SET
    pipette_left.pick_up_tip(location=tip_rack_1)
    pipette_left.configure_for_volume(10)
    pipette_left.flow_rate.aspirate = 35
    pipette_left.flow_rate.dispense = 57
    pipette_left.mix(
        repetitions=2,
        volume=10,
        location=reservoir_1["A1"].bottom(z=1),
    )
    pipette_left.flow_rate.blow_out = 57
    pipette_left.blow_out(trash_bin_1)
    pipette_left.touch_tip(
        reservoir_1["A1"],
        v_offset=-1,
    )
    pipette_left.drop_tip()
```

## Changelog

- py command for `mix()` in the mixUtil
- add test cases for the different py command variations
- extend util to include invariant context and plug into all usages of the util

## Risk assessment

low, behind a ff
