### PR TITLE
feat(step-generation): cosmetic updates to load_labware and touch_tip

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -137,21 +137,21 @@ def run(protocol: protocol_api.ProtocolContext):
     # Load Labware:
     mock_python_name_1 = protocol.load_labware(
         "fixture_trash",
-        "12",
+        location="12",
         label="Trash",
         namespace="fixture",
         version=1,
     )
     mock_python_name_2 = protocol.load_labware(
         "fixture_tiprack_10_ul",
-        "1",
+        location="1",
         label="Opentrons 96 Tip Rack 10 µL",
         namespace="fixture",
         version=1,
     )
     mock_python_name_3 = protocol.load_labware(
         "fixture_96_plate",
-        "7",
+        location="7",
         label="NEST 96 Well Plate 100 µL PCR Full Skirt",
         namespace="fixture",
         version=1,

--- a/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/pythonFile.test.ts
@@ -238,7 +238,7 @@ well_plate_2 = magnetic_block_2.load_labware(
 )
 well_plate_3 = protocol.load_labware(
     "fixture_96_plate",
-    "C2",
+    location="C2",
     label="sample plate",
     namespace="fixture",
     version=1,

--- a/protocol-designer/src/file-data/selectors/pythonFile.ts
+++ b/protocol-designer/src/file-data/selectors/pythonFile.ts
@@ -163,7 +163,7 @@ export function getLoadLabware(
         `${formatPyStr(parameters.loadName)}`,
         ...(!onModule && !onAdapter
           ? [
-              `${formatPyStr(
+              `location=${formatPyStr(
                 labwareSlot === 'offDeck' ? OFF_DECK : labwareSlot
               )}`,
             ]

--- a/step-generation/src/__tests__/touchTip.test.ts
+++ b/step-generation/src/__tests__/touchTip.test.ts
@@ -58,13 +58,7 @@ describe('touchTip', () => {
       },
     ])
     expect(res.python).toBe(
-      `
-mockPythonName.touch_tip(
-    mockPythonName["A1"],
-    v_offset=10,
-    speed=10,
-    mm_from_edge=0.2,
-)`.trimStart()
+      `mockPythonName.touch_tip(mockPythonName["A1"], v_offset=10, speed=10, mm_from_edge=0.2)`
     )
   })
 
@@ -82,11 +76,7 @@ mockPythonName.touch_tip(
     const res = getSuccessResult(result)
 
     expect(res.python).toBe(
-      `
-mockPythonName.touch_tip(
-    mockPythonName["A1"],
-    v_offset=10,
-)`.trimStart()
+      `mockPythonName.touch_tip(mockPythonName["A1"], v_offset=10)`
     )
   })
 

--- a/step-generation/src/commandCreators/atomic/touchTip.ts
+++ b/step-generation/src/commandCreators/atomic/touchTip.ts
@@ -1,4 +1,4 @@
-import { formatPyStr, indentPyLines, uuid } from '../../utils'
+import { formatPyStr, uuid } from '../../utils'
 import { noTipOnPipette, pipetteDoesNotExist } from '../../errorCreators'
 import type { CreateCommand, TouchTipParams } from '@opentrons/shared-data'
 import type { CommandCreator, CommandCreatorError } from '../../types'
@@ -56,16 +56,14 @@ export const touchTip: CommandCreator<TouchTipAtomicParams> = (
     invariantContext.labwareEntities[labwareId].pythonName
 
   const pythonArgs = [
-    `${labwarePythonName}[${formatPyStr(wellName)}],`,
-    `v_offset=${zOffsetFromTop},`,
-    ...(speed != null ? [`speed=${speed},`] : []),
-    ...(mmFromEdge != null ? [`mm_from_edge=${mmFromEdge},`] : []),
+    `${labwarePythonName}[${formatPyStr(wellName)}]`,
+    `v_offset=${zOffsetFromTop}`,
+    ...(speed != null ? [`speed=${speed}`] : []),
+    ...(mmFromEdge != null ? [`mm_from_edge=${mmFromEdge}`] : []),
   ]
 
   //  TODO: add mmFromEdge to python and commandCreator
-  const python = `${pipettePythonName}.touch_tip(\n${indentPyLines(
-    pythonArgs.join('\n')
-  )}\n)`
+  const python = `${pipettePythonName}.touch_tip(${pythonArgs.join(', ')})`
 
   const commands: CreateCommand[] = [
     {


### PR DESCRIPTION
# Overview

1) For the OT-2, we were generating `load_labware` code like:
```
protocol.load_labware(
    "opentrons_96_tiprack_300ul",
    "2",
    namespace="opentrons",
    version=1,
)
```
The bare string `"2"` can be a bit perplexing to someone reading this code. So I'm changing it to `location="2"`.

2) The Python `touch_tip` command is short and can fit on one line. And having it on one line looks better next to the surrounding `aspirate()`/`dispense()` calls that have pretty long lines. So now `touch_tip` will look like this:
```
pipette_left.touch_tip(well_plate_2["A1"], v_offset=-1, speed=5)
```

## Test Plan and Hands on Testing

Updated unit tests.

Tried the generated output in `simulate`, which passes.

## Risk assessment

Low, Python export is behind feature flag.