### PR TITLE
fix(api): add more math function overrides to SimulatedLiquidProbe

### DIFF
--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -41,11 +41,41 @@ class SimulatedProbeResult(BaseModel):
         """Bypass subtraction and just return self."""
         return self
 
+    def __gt__(
+        self, other: float | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        """Bypass subtraction and just return self."""
+        return self
+
+    def __lt__(
+        self, other: float | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        """Bypass subtraction and just return self."""
+        return self
+
+    def __ge__(
+        self, other: float | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        """Bypass subtraction and just return self."""
+        return self
+
+    def __le__(
+        self, other: float | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        """Bypass subtraction and just return self."""
+        return self
+
     def __eq__(self, other: object) -> bool:
         """A SimulatedProbeResult should only be equal to the same instance of its class."""
         if not isinstance(other, SimulatedProbeResult):
             return False
         return self is other
+
+    def __neq__(self, other: object) -> bool:
+        """A SimulatedProbeResult should only be equal to the same instance of its class."""
+        if not isinstance(other, SimulatedProbeResult):
+            return False
+        return self is not other
 
     def simulate_probed_aspirate_dispense(self, volume: float) -> None:
         """Record the current state of aspirate/dispense calls."""

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -41,29 +41,21 @@ class SimulatedProbeResult(BaseModel):
         """Bypass subtraction and just return self."""
         return self
 
-    def __gt__(
-        self, other: float | SimulatedProbeResult
-    ) -> float | SimulatedProbeResult:
+    def __gt__(self, other: float | SimulatedProbeResult) -> bool:
         """Bypass 'greater than' and just return self."""
-        return self
+        return True
 
-    def __lt__(
-        self, other: float | SimulatedProbeResult
-    ) -> float | SimulatedProbeResult:
+    def __lt__(self, other: float | SimulatedProbeResult) -> bool:
         """Bypass 'less than' and just return self."""
-        return self
+        return False
 
-    def __ge__(
-        self, other: float | SimulatedProbeResult
-    ) -> float | SimulatedProbeResult:
+    def __ge__(self, other: float | SimulatedProbeResult) -> bool:
         """Bypass 'greater than or eaqual to' and just return self."""
-        return self
+        return True
 
-    def __le__(
-        self, other: float | SimulatedProbeResult
-    ) -> float | SimulatedProbeResult:
-        """Bypass 'less than or eaqual to' and just return self."""
-        return self
+    def __le__(self, other: float | SimulatedProbeResult) -> bool:
+        """Bypass 'less than or equal to' and just return self."""
+        return False
 
     def __eq__(self, other: object) -> bool:
         """A SimulatedProbeResult should only be equal to the same instance of its class."""

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -44,25 +44,25 @@ class SimulatedProbeResult(BaseModel):
     def __gt__(
         self, other: float | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
-        """Bypass subtraction and just return self."""
+        """Bypass 'greater than' and just return self."""
         return self
 
     def __lt__(
         self, other: float | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
-        """Bypass subtraction and just return self."""
+        """Bypass 'less than' and just return self."""
         return self
 
     def __ge__(
         self, other: float | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
-        """Bypass subtraction and just return self."""
+        """Bypass 'greater than or eaqual to' and just return self."""
         return self
 
     def __le__(
         self, other: float | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
-        """Bypass subtraction and just return self."""
+        """Bypass 'less than or eaqual to' and just return self."""
         return self
 
     def __eq__(self, other: object) -> bool:

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -66,7 +66,7 @@ class SimulatedProbeResult(BaseModel):
     def __neq__(self, other: object) -> bool:
         """A SimulatedProbeResult should only be equal to the same instance of its class."""
         if not isinstance(other, SimulatedProbeResult):
-            return False
+            return True
         return self is not other
 
     def simulate_probed_aspirate_dispense(self, volume: float) -> None:


### PR DESCRIPTION
## Overview
If you want to use functions like `well.estimate_liquid_height_after_pipetting` and compare that output with the minimum lld height or something to make sure you can aspirate, using a `gt` or `lt` comparison currently will cause protocol analysis to fail. Here is a fix for that.