### PR TITLE
feat(step-generation): py command for blowout in waste chute

### DIFF
--- a/step-generation/src/__tests__/blowoutUtil.test.ts
+++ b/step-generation/src/__tests__/blowoutUtil.test.ts
@@ -94,6 +94,7 @@ describe('blowoutUtil', () => {
     expect(curryCommandCreator).toHaveBeenCalledWith(blowOutInWasteChute, {
       pipetteId: blowoutArgs.pipette,
       flowRate: 2.3,
+      wasteChuteId,
     })
   })
   it('blowoutUtil curries blowout with dest plate params', () => {

--- a/step-generation/src/commandCreators/compound/blowOutInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/blowOutInWasteChute.ts
@@ -10,6 +10,7 @@ import type { CommandCreator, CurriedCommandCreator } from '../../types'
 interface BlowOutInWasteChuteArgs {
   pipetteId: string
   flowRate: number
+  wasteChuteId: string
 }
 
 export const blowOutInWasteChute: CommandCreator<BlowOutInWasteChuteArgs> = (
@@ -17,14 +18,25 @@ export const blowOutInWasteChute: CommandCreator<BlowOutInWasteChuteArgs> = (
   invariantContext,
   prevRobotState
 ) => {
-  const { pipetteId, flowRate } = args
-  const pipetteChannels =
-    invariantContext.pipetteEntities[pipetteId].spec.channels
+  const { pipetteId, flowRate, wasteChuteId } = args
+  const { pipetteEntities, additionalEquipmentEntities } = invariantContext
+  const pipetteChannels = pipetteEntities[pipetteId].spec.channels
   const addressableAreaName = getWasteChuteAddressableAreaNamePip(
     pipetteChannels
   )
+  const pipettePythonName = pipetteEntities[pipetteId].pythonName
+  const wasteChutePythonName =
+    additionalEquipmentEntities[wasteChuteId].pythonName
 
-  const commandCreators: CurriedCommandCreator[] = [
+  const pythonCommandCreator: CurriedCommandCreator = () => ({
+    commands: [],
+    python:
+      // The Python blow_out() does not take a flow rate argument, so we have to
+      // reconfigure the pipette's default blow out rate instead:
+      `${pipettePythonName}.flow_rate.blow_out = ${flowRate}\n` +
+      `${pipettePythonName}.blow_out(${wasteChutePythonName})`,
+  })
+  const commandCreators = [
     curryCommandCreator(moveToAddressableArea, {
       pipetteId,
       addressableAreaName,
@@ -34,6 +46,7 @@ export const blowOutInWasteChute: CommandCreator<BlowOutInWasteChuteArgs> = (
       pipetteId,
       flowRate,
     }),
+    pythonCommandCreator,
   ]
 
   return reduceCommandCreators(

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -379,10 +379,14 @@ export const blowoutUtil = (args: {
       }),
     ]
   } else if (trashOrLabware === 'wasteChute') {
+    const wasteChute = Object.values(additionalEquipmentEntities).find(
+      ae => ae.name === 'wasteChute'
+    )
     return [
       curryCommandCreator(blowOutInWasteChute, {
         pipetteId: pipette,
         flowRate,
+        wasteChuteId: wasteChute?.id as string,
       }),
     ]
   } else {


### PR DESCRIPTION
# Overview

This PR generates the py command for `blow_out()` in a waste chute

## Test Plan and Hands on Testing

Review code and smoke test. should pass analysis if blowing out in the waste chute.

## Changelog

- generate py command for blow out in a waste chute
- add to unit test

## Risk assessment

low, behind ff