### PR TITLE
fix(api): add field validator for SimulatedLiquidProbe to WellSummary

### DIFF
--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -107,19 +107,16 @@ class WellInfoSummary(BaseModel):
     @field_validator("probed_height", "probed_volume", mode="before")
     @classmethod
     def validate_simulated_probe_result(
-        cls, input_val: str | LiquidTrackingType | None
+        cls, input_val: object
     ) -> LiquidTrackingType | None:
         """Return the appropriate input to WellInfoSummary from json data."""
-        if not input_val:
+        if input_val is None:
             return None
         if isinstance(input_val, LiquidTrackingType):
             return input_val
-        if isinstance(input_val, str):
-            if input_val.isdigit():
-                return float(input_val)
-            elif input_val == "SimulatedProbeResult":
-                return SimulatedProbeResult()
-        return None
+        if isinstance(input_val, str) and input_val == "SimulatedProbeResult":
+            return SimulatedProbeResult()
+        raise ValueError(f"Invalid input value {input_val} to WellInfoSummary")
 
     labware_id: str
     well_name: str

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, List
-from pydantic import BaseModel, model_serializer
+from pydantic import BaseModel, model_serializer, field_validator
 
 
 class SimulatedProbeResult(BaseModel):
@@ -103,6 +103,19 @@ class ProbedVolumeInfo(BaseModel):
 
 class WellInfoSummary(BaseModel):
     """Payload for a well's liquid info in StateSummary."""
+
+    @field_validator("probed_height", "probed_volume", mode="before")
+    @classmethod
+    def validate_simulated_probe_result(
+        cls, input_val: str | None
+    ) -> LiquidTrackingType | None:
+        """Return the appropriate input to WellInfoSummary from json data."""
+        if not input_val:
+            return None
+        if input_val.isdigit():
+            return float(input_val)
+        else:
+            return SimulatedProbeResult()
 
     labware_id: str
     well_name: str

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -104,6 +104,9 @@ class ProbedVolumeInfo(BaseModel):
 class WellInfoSummary(BaseModel):
     """Payload for a well's liquid info in StateSummary."""
 
+    # TODO(cm): 3/21/25: refactor SimulatedLiquidProbe in a way that
+    # doesn't require models like this one that are just using it to
+    # need a custom validator
     @field_validator("probed_height", "probed_volume", mode="before")
     @classmethod
     def validate_simulated_probe_result(

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -107,15 +107,19 @@ class WellInfoSummary(BaseModel):
     @field_validator("probed_height", "probed_volume", mode="before")
     @classmethod
     def validate_simulated_probe_result(
-        cls, input_val: str | None
+        cls, input_val: str | LiquidTrackingType | None
     ) -> LiquidTrackingType | None:
         """Return the appropriate input to WellInfoSummary from json data."""
         if not input_val:
             return None
-        if input_val.isdigit():
-            return float(input_val)
-        else:
-            return SimulatedProbeResult()
+        if isinstance(input_val, LiquidTrackingType):
+            return input_val
+        if isinstance(input_val, str):
+            if input_val.isdigit():
+                return float(input_val)
+            elif input_val == "SimulatedProbeResult":
+                return SimulatedProbeResult()
+        return None
 
     labware_id: str
     well_name: str


### PR DESCRIPTION
## Overview
When a `SimulatedLiquidProbe` object is serialized into json data, it becomes the string `"SimulatedLiquidProbe"`. Trying to create a `StateSummary` from json data causes a str to try to get validated into a `SimulatedProbeResult` Base Model, which is no good. Try and intervene and give `StateSummary` a new `SimulatedLiquidProbe` class object instead.