### PR TITLE
fix(api): Disposal location slot occupation collision checking

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1042,6 +1042,14 @@ class GeometryView:
             maybe_fixture = self._addressable_areas.get_fixture_by_deck_slot_name(
                 slot_name
             )
+            if maybe_fixture is None:
+                for area in self._addressable_areas.get_all():
+                    if "WasteChute" in area or "moveableTrash" in area:
+                        if slot_name == self._addressable_areas.get_addressable_area_base_slot(area):
+                            # Given we only have one Waste Chute fixture and one type of Trash bin fixture, it's fine to use the first of the set
+                            potential_fixture = deck_configuration_provider.get_potential_cutout_fixtures(area, self._addressable_areas.deck_definition)[1].pop()
+                            maybe_fixture = deck_configuration_provider.get_cutout_fixture(potential_fixture.cutout_fixture_id, self._addressable_areas.deck_definition)
+
             # Ignore generic single slot fixtures
             if maybe_fixture and maybe_fixture["id"] in {
                 "singleLeftSlot",

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1070,13 +1070,6 @@ class GeometryView:
                 slot_name
             )
 
-            # For protocol analysis identify collisions with trash fixtures
-            if maybe_fixture is None:
-                # todo(chb 2025-03-19): This can go away once we solve the problem of no deck config in analysis
-                maybe_fixture = self._get_potential_disposal_location_cutout_fixtures(
-                    slot_name
-                )
-
             # Ignore generic single slot fixtures
             if maybe_fixture and maybe_fixture["id"] in {
                 "singleLeftSlot",
@@ -1088,6 +1081,13 @@ class GeometryView:
             maybe_module = self._modules.get_by_slot(
                 slot_name=slot_name,
             ) or self._modules.get_overflowed_module_in_slot(slot_name=slot_name)
+
+            # For situations in which the deck config is none
+            if maybe_fixture is None and maybe_labware is None and maybe_module is None:
+                # todo(chb 2025-03-19): This can go away once we solve the problem of no deck config in analysis
+                maybe_fixture = self._get_potential_disposal_location_cutout_fixtures(
+                    slot_name
+                )
         else:
             # Modules and fixtures can't be loaded on staging slots
             maybe_fixture = None


### PR DESCRIPTION
# Overview
This addresses **part of** the cause of EXEC-1353

We depend upon get_slot_item(...) in geometry to return to us an object occupying a given deck slot, including labware modules and fixtures. However, during analysis we couldn't return fixtures because a deck configuration is not present in analysis. This wasn't a problem for module fixtures at they were already accounted for, and staging slots were ignored. The blind spot here was disposal locations such as the waste chute. This lead to situations where one could write protocols that would result in a collision with the waste chute passing analysis. 

**Future Note:**
However, a secondary cause of the issues in the related ticket will not be solved by this PR. Our base overlap calculations assume the bounding box of the deck slot under the fixture when checking for collisions. This means that fixtures wider than their deck slot, like the waste chute, have some area of overlap (30mm~) which are not being accounted for. A follow up PR will need to cover an extension to our geometry and shared-data logic to the greater bounds of fixtures not currently accounted for.

## Test Plan and Hands on Testing
- [x] The following protocol should fail analysis:
```
def run(protocol: ProtocolContext) -> None:
    """Protocol."""
    chute = protocol.load_waste_chute()
    tiprack = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "C2")
    pipette = protocol.load_instrument("flex_96channel_1000", "left", [tiprack])
    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D2")
    pipette.configure_nozzle_layout(COLUMN, "A1", tip_racks=[tiprack])
    pipette.pick_up_tip()
    pipette.drop_tip(chute)
    pipette.pick_up_tip()
    pipette.aspirate(20, plate.wells_by_name()["A12"])
```
## Changelog
Addition of checks within the geometry `get_slot_item(...)` logic to ensure that loaded disposal locations are identified during analysis without a deck configuration.

Of note, due to an approach to returning the first relevant potential cutout fixture, if in the future we add new types of waste chute or new types of trash bin with different whole-body geometry this fix could return the wrong fixture. However, this fix will also no longer be needed if we fix the larger issue of deck configuration in analysis.

## Review requests
Thoughts on the approach to our potential fixtures return?

## Risk assessment
Low - this effects analysis only since in a live run a deck configuration will be present. Covers cases where we should've been raising in the first place.