### PR TITLE
fix(hardware): bump minimum move timeout to 10s

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -677,7 +677,7 @@ class MoveScheduler:
             log.error(f"received error trying to execute move group: {str(error)}")
 
         expected_time = max(3.0, self._durations[group_id - self._start_at_index] * 1.1)
-        full_timeout = max(5.0, self._durations[group_id - self._start_at_index] * 2)
+        full_timeout = max(10.0, self._durations[group_id - self._start_at_index] * 2)
         start_time = time.time()
 
         try:


### PR DESCRIPTION
There's some delays in the canbus message reading that cause occasional timeouts. Increase the error timeout to 10s.

Closes RESC-381
