### PR TITLE
refactor(shared-data): Update comment about older labware definition bugs

### DIFF
--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -95,17 +95,7 @@ const expectedWellsNotMatchingZDimension: Record<string, Set<string>> = {
     'B4',
   ]),
 
-  // These height mismatches are legitimate. The zDimension should match the taller side.
-  'opentrons_calibrationblock_short_side_left/1.json': new Set(['A1']),
-  'opentrons_calibrationblock_short_side_right/1.json': new Set(['A2']),
-
-  // this labware has a lip
-  'evotips_opentrons_96_labware/2.json': standard96WellNames,
-
-  // These height mismatches need to be investigated. See Jira RSS-202.
-  // Each one should either be explained here or marked as a known bug.
-  'nest_1_reservoir_195ml/1.json': new Set(['A1']),
-  'nest_1_reservoir_195ml/2.json': new Set(['A1']),
+  // This is probably legitimate. Heterogeneous tubes.
   'opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip/1.json': new Set(
     [
       'A3',
@@ -134,9 +124,24 @@ const expectedWellsNotMatchingZDimension: Record<string, Set<string>> = {
       'D8',
     ]
   ),
+
+  // These height mismatches are legitimate. The zDimension should match the taller side.
+  'opentrons_calibrationblock_short_side_left/1.json': new Set(['A1']),
+  'opentrons_calibrationblock_short_side_right/1.json': new Set(['A2']),
+
+  // this labware has a lip
+  'evotips_opentrons_96_labware/2.json': standard96WellNames,
+
+  // Presumably a bug. Fixed in v3 of this labware.
+  'nest_1_reservoir_195ml/1.json': new Set(['A1']),
+  'nest_1_reservoir_195ml/2.json': new Set(['A1']),
+
+  // These were probably bugs, but it's moot now, since these adapter+wellplate
+  // combo-definitions have been superseded by proper labware stacking.
   'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1.json': standard96WellNames,
   'opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/1.json': standard96WellNames,
   'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json': standard384WellNames,
+
   // This batch may have incompletely-updated geometry from recent work related to
   // liquid level detection and meniscus-relative pipetting. Probably, the wells were
   // updated but not the overall labware dimensions. This needs to be investigated and fixed.


### PR DESCRIPTION
## Overview

There were several labware definitions whose numbers were internally inconsistent. They were marked with a comment explaining that we didn't know why, and that they needed to be investigated. Those errors have all been resolved by now, so this PR updates the comment.

Goes towards EXEC-1238, fka RSS-202.

## Test Plan and Hands on Testing

None needed.

## Review requests

None.

## Risk assessment

No risk.