### PR TITLE
refactor(step-generation): consistent names for misc.ts location helper functions

### DIFF
--- a/step-generation/src/__tests__/blowoutUtil.test.ts
+++ b/step-generation/src/__tests__/blowoutUtil.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 import {
-  blowoutUtil,
+  blowoutLocationHelper,
   SOURCE_WELL_BLOWOUT_DESTINATION,
   DEST_WELL_BLOWOUT_DESTINATION,
 } from '../utils'
@@ -34,7 +34,7 @@ let blowoutArgs: {
   invariantContext: InvariantContext
   prevRobotState: RobotState
 }
-describe('blowoutUtil', () => {
+describe('blowoutLocationHelper', () => {
   let invariantContext: InvariantContext
 
   beforeEach(() => {
@@ -54,8 +54,8 @@ describe('blowoutUtil', () => {
     }
     vi.mocked(curryCommandCreator).mockClear()
   })
-  it('blowoutUtil curries blowout with source well params', () => {
-    blowoutUtil({
+  it('blowoutLocationHelper curries blowout with source well params', () => {
+    blowoutLocationHelper({
       ...blowoutArgs,
       blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
     })
@@ -72,7 +72,7 @@ describe('blowoutUtil', () => {
       },
     })
   })
-  it('blowoutUtil curries waste chute commands when there is no well', () => {
+  it('blowoutLocationHelper curries waste chute commands when there is no well', () => {
     const wasteChuteId = 'wasteChuteId'
     invariantContext = {
       ...invariantContext,
@@ -84,7 +84,7 @@ describe('blowoutUtil', () => {
         },
       },
     }
-    blowoutUtil({
+    blowoutLocationHelper({
       ...blowoutArgs,
       destLabwareId: wasteChuteId,
       invariantContext: invariantContext,
@@ -97,8 +97,8 @@ describe('blowoutUtil', () => {
       wasteChuteId,
     })
   })
-  it('blowoutUtil curries blowout with dest plate params', () => {
-    blowoutUtil({
+  it('blowoutLocationHelper curries blowout with dest plate params', () => {
+    blowoutLocationHelper({
       ...blowoutArgs,
       blowoutLocation: DEST_WELL_BLOWOUT_DESTINATION,
     })
@@ -115,8 +115,8 @@ describe('blowoutUtil', () => {
       },
     })
   })
-  it('blowoutUtil curries blowout with an arbitrary labware Id', () => {
-    blowoutUtil({
+  it('blowoutLocationHelper curries blowout with an arbitrary labware Id', () => {
+    blowoutLocationHelper({
       ...blowoutArgs,
       blowoutLocation: TROUGH_LABWARE,
     })
@@ -133,8 +133,8 @@ describe('blowoutUtil', () => {
       },
     })
   })
-  it('blowoutUtil returns an empty array if not given a blowoutLocation', () => {
-    const result = blowoutUtil({
+  it('blowoutLocationHelper returns an empty array if not given a blowoutLocation', () => {
+    const result = blowoutLocationHelper({
       ...blowoutArgs,
       blowoutLocation: null,
     })

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -9,10 +9,10 @@ import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import { dropTipInTrash } from './dropTipInTrash'
 import {
-  blowoutUtil,
+  blowoutLocationHelper,
   curryCommandCreator,
   reduceCommandCreators,
-  airGapHelper,
+  airGapLocationHelper,
   dispenseLocationHelper,
   moveHelper,
   getIsSafePipetteMovement,
@@ -383,7 +383,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             ]
           : []
 
-      const blowoutCommand = blowoutUtil({
+      const blowoutCommand = blowoutLocationHelper({
         pipette: args.pipette,
         sourceLabwareId: args.sourceLabware,
         sourceWell: sourceWellChunk[0],
@@ -399,7 +399,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       const airGapAfterDispenseCommands =
         dispenseAirGapVolume && !willReuseTip
           ? [
-              curryCommandCreator(airGapHelper, {
+              curryCommandCreator(airGapLocationHelper, {
                 pipetteId: args.pipette,
                 volume: dispenseAirGapVolume,
                 destinationId: args.destLabware,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -13,11 +13,11 @@ import { dropTipInTrash } from './dropTipInTrash'
 import {
   curryCommandCreator,
   reduceCommandCreators,
-  blowoutUtil,
+  blowoutLocationHelper,
   getDispenseAirGapLocation,
   getIsSafePipetteMovement,
   getHasWasteChute,
-  airGapHelper,
+  airGapLocationHelper,
 } from '../../utils'
 import {
   aspirate,
@@ -325,7 +325,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
       const airGapAfterDispenseCommands =
         dispenseAirGapVolume && !willReuseTip
           ? [
-              curryCommandCreator(airGapHelper, {
+              curryCommandCreator(airGapLocationHelper, {
                 pipetteId: args.pipette,
                 destinationId: dispenseAirGapLabware,
                 destWell: dispenseAirGapWell,
@@ -369,7 +369,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
       const dropTipAfterDispenseAirGap =
         airGapAfterDispenseCommands.length > 0 ? dropTipCommand : []
       const blowoutCommands = disposalVolume
-        ? blowoutUtil({
+        ? blowoutLocationHelper({
             pipette: pipette,
             sourceLabwareId: args.sourceLabware,
             sourceWell: args.sourceWell,

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -6,7 +6,7 @@ import {
 } from '@opentrons/shared-data'
 import {
   repeatArray,
-  blowoutUtil,
+  blowoutLocationHelper,
   curryCommandCreator,
   reduceCommandCreators,
   getIsSafePipetteMovement,
@@ -260,7 +260,7 @@ export const mix: CommandCreator<MixArgs> = (
             }),
           ]
         : []
-      const blowoutCommand = blowoutUtil({
+      const blowoutCommand = blowoutLocationHelper({
         pipette: data.pipette,
         sourceLabwareId: data.labware,
         sourceWell: well,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -8,9 +8,9 @@ import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import { dropTipInTrash } from './dropTipInTrash'
 import {
-  blowoutUtil,
+  blowoutLocationHelper,
   curryCommandCreator,
-  airGapHelper,
+  airGapLocationHelper,
   reduceCommandCreators,
   getTrashOrLabware,
   dispenseLocationHelper,
@@ -475,7 +475,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                 ]
               : []
 
-          const blowoutCommand = blowoutUtil({
+          const blowoutCommand = blowoutLocationHelper({
             pipette: args.pipette,
             sourceLabwareId: args.sourceLabware,
             sourceWell: sourceWell,
@@ -490,7 +490,7 @@ export const transfer: CommandCreator<TransferArgs> = (
           const airGapAfterDispenseCommands =
             dispenseAirGapVolume && !willReuseTip
               ? [
-                  curryCommandCreator(airGapHelper, {
+                  curryCommandCreator(airGapLocationHelper, {
                     sourceWell,
                     blowOutLocation: args.blowoutLocation,
                     sourceId: args.sourceLabware,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -317,7 +317,7 @@ export function getWellsForTips(
 // Set blowout location depending on the 'blowoutLocation' arg: set it to
 // the SOURCE_WELL_BLOWOUT_DESTINATION / DEST_WELL_BLOWOUT_DESTINATION
 // special strings, or to a labware ID.
-export const blowoutUtil = (args: {
+export const blowoutLocationHelper = (args: {
   pipette: BlowoutParams['pipetteId']
   sourceLabwareId: string
   sourceWell: BlowoutParams['wellName']
@@ -702,7 +702,7 @@ export const moveHelper: CommandCreator<MoveHelperArgs> = (
   return reduceCommandCreators(commands, invariantContext, prevRobotState)
 }
 
-interface AirGapArgs {
+interface AirGapLocationArgs {
   //  destinationId is either labware or addressableAreaName for waste chute
   destinationId: string
   destWell: string | null
@@ -713,7 +713,7 @@ interface AirGapArgs {
   sourceId?: string
   sourceWell?: string
 }
-export const airGapHelper: CommandCreator<AirGapArgs> = (
+export const airGapLocationHelper: CommandCreator<AirGapLocationArgs> = (
   args,
   invariantContext,
   prevRobotState


### PR DESCRIPTION
# Overview

There are 4 helper functions in `misc.ts` that have the same structure of performing an action at some well or trash bin or waste chute:

- `blowoutUtil()`
- `dispenseLocationHelper()`
- `airGapHelper()`
- and coming soon: a `delay()`-at-location helper

These are also the only functions that emit `CommandCreators` in `misc.ts`.

I'd like to give them all consistent names to make them easier to recognize. So I'd like to rename them to:

- `blowoutLocationHelper()`
- `dispenseLocationHelper()`
- `airGapLocationHelper()`
- `delayLocationHelper()` (coming soon, will replace `moveHelper()`)

## Test Plan and Hands on Testing

I'm relying on existing CI tests to make sure I don't break anything.

## Risk assessment

Pure refactoring, there should be no functional change at all.