### PR TITLE
feat(step-generation): generate py command for moveToAddressableArea

### DIFF
--- a/step-generation/src/__tests__/airGapInTrash.test.ts
+++ b/step-generation/src/__tests__/airGapInTrash.test.ts
@@ -10,7 +10,18 @@ import type { CutoutId } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
 
 const mockCutout: CutoutId = 'cutoutA3'
-const invariantContext: InvariantContext = makeContext()
+const mockTrashId = 'mockTrashId'
+const invariantContext: InvariantContext = {
+  ...makeContext(),
+  additionalEquipmentEntities: {
+    [mockTrashId]: {
+      id: mockTrashId,
+      name: 'trashBin',
+      pythonName: 'mock_trash_bin_1',
+      location: mockCutout,
+    },
+  },
+}
 const prevRobotState: RobotState = getInitialRobotStateStandard(
   invariantContext
 )
@@ -22,7 +33,7 @@ describe('airGapInTrash', () => {
         pipetteId: DEFAULT_PIPETTE,
         volume: 10,
         flowRate: 10,
-        trashLocation: mockCutout,
+        trashId: mockTrashId,
       },
       invariantContext,
       prevRobotState

--- a/step-generation/src/__tests__/airGapInWasteChute.test.ts
+++ b/step-generation/src/__tests__/airGapInWasteChute.test.ts
@@ -1,24 +1,25 @@
 import { describe, it, expect } from 'vitest'
+import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import {
+  DEFAULT_PIPETTE,
   getInitialRobotStateStandard,
   getSuccessResult,
   makeContext,
 } from '../fixtures'
 import { airGapInWasteChute } from '../commandCreators/compound'
-import type { InvariantContext, PipetteEntities, RobotState } from '../types'
+import type { InvariantContext, RobotState } from '../types'
 
-const mockId = 'mockId'
-const mockPipEntities: PipetteEntities = {
-  [mockId]: {
-    name: 'p50_single_flex',
-    id: mockId,
-    spec: { channels: 1 },
-  },
-} as any
-
+const wasteChuteId = 'wasteChuteId'
 const invariantContext: InvariantContext = {
   ...makeContext(),
-  pipetteEntities: mockPipEntities,
+  additionalEquipmentEntities: {
+    [wasteChuteId]: {
+      id: wasteChuteId,
+      name: 'wasteChute',
+      pythonName: 'mock_waste_chute_1',
+      location: WASTE_CHUTE_CUTOUT,
+    },
+  },
 }
 const prevRobotState: RobotState = getInitialRobotStateStandard(
   invariantContext
@@ -28,9 +29,10 @@ describe('airGapInWasteChute', () => {
   it('returns correct commands for air gap in waste chute', () => {
     const result = airGapInWasteChute(
       {
-        pipetteId: mockId,
+        pipetteId: DEFAULT_PIPETTE,
         volume: 10,
         flowRate: 10,
+        wasteChuteId,
       },
       invariantContext,
       prevRobotState
@@ -40,7 +42,7 @@ describe('airGapInWasteChute', () => {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           addressableAreaName: '1ChannelWasteChute',
           offset: { x: 0, y: 0, z: 0 },
         },
@@ -49,14 +51,14 @@ describe('airGapInWasteChute', () => {
         commandType: 'prepareToAspirate',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
         },
       },
       {
         commandType: 'airGapInPlace',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           flowRate: 10,
           volume: 10,
         },

--- a/step-generation/src/__tests__/moveToAddressableArea.test.ts
+++ b/step-generation/src/__tests__/moveToAddressableArea.test.ts
@@ -1,32 +1,42 @@
 import { describe, it, expect } from 'vitest'
-import { getSuccessResult } from '../fixtures'
+import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
+import {
+  getSuccessResult,
+  makeContext,
+  getInitialRobotStateStandard,
+  DEFAULT_PIPETTE,
+} from '../fixtures'
 import { moveToAddressableArea } from '../commandCreators/atomic'
+import type { InvariantContext, RobotState } from '../types'
+import type { CutoutId } from '@opentrons/shared-data'
 
-const getRobotInitialState = (): any => {
-  return {}
-}
-const mockId = 'mockId'
-const invariantContext: any = {
-  pipetteEntities: {
-    [mockId]: {
-      name: 'p50_single_flex',
-      id: mockId,
+const mockCutout = 'cutoutA3' as CutoutId
+const mockTrashId = 'mockTrashId'
+let invariantContext: InvariantContext = {
+  ...makeContext(),
+  additionalEquipmentEntities: {
+    [mockTrashId]: {
+      id: mockTrashId,
+      name: 'trashBin',
+      pythonName: 'mock_trash_bin_1',
+      location: mockCutout,
     },
   },
 }
+const prevRobotState: RobotState = getInitialRobotStateStandard(
+  invariantContext
+)
 
 describe('moveToAddressableArea', () => {
-  it('should call moveToAddressableArea with correct params', () => {
-    const robotInitialState = getRobotInitialState()
-    const mockName = '1ChannelWasteChute'
+  it('should call moveToAddressableArea with correct params for trash bin', () => {
     const result = moveToAddressableArea(
       {
-        pipetteId: mockId,
-        addressableAreaName: mockName,
-        offset: { x: 0, y: 0, z: 0 },
+        pipetteId: DEFAULT_PIPETTE,
+        fixtureId: mockTrashId,
+        offset: { x: 0, y: 0, z: 1 },
       },
       invariantContext,
-      robotInitialState
+      prevRobotState
     )
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
@@ -34,11 +44,52 @@ describe('moveToAddressableArea', () => {
         commandType: 'moveToAddressableArea',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
-          addressableAreaName: mockName,
-          offset: { x: 0, y: 0, z: 0 },
+          pipetteId: DEFAULT_PIPETTE,
+          addressableAreaName: 'movableTrashA3',
+          offset: { x: 0, y: 0, z: 1 },
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mockPythonName.move_to(mock_trash_bin_1)'
+    )
+  })
+  it('should call moveToAddressableArea with correct params for waste chute', () => {
+    const wasteChuteId = 'wasteChuteId'
+    invariantContext = {
+      ...invariantContext,
+      additionalEquipmentEntities: {
+        [wasteChuteId]: {
+          id: wasteChuteId,
+          name: 'wasteChute',
+          pythonName: 'mock_waste_chute_1',
+          location: WASTE_CHUTE_CUTOUT,
+        },
+      },
+    }
+    const result = moveToAddressableArea(
+      {
+        pipetteId: DEFAULT_PIPETTE,
+        fixtureId: wasteChuteId,
+        offset: { x: 0, y: 0, z: 1 },
+      },
+      invariantContext,
+      prevRobotState
+    )
+    const res = getSuccessResult(result)
+    expect(res.commands).toEqual([
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.any(String),
+        params: {
+          pipetteId: DEFAULT_PIPETTE,
+          addressableAreaName: '1ChannelWasteChute',
+          offset: { x: 0, y: 0, z: 1 },
+        },
+      },
+    ])
+    expect(getSuccessResult(result).python).toBe(
+      'mockPythonName.move_to(mock_waste_chute_1)'
+    )
   })
 })

--- a/step-generation/src/commandCreators/compound/airGapInTrash.ts
+++ b/step-generation/src/commandCreators/compound/airGapInTrash.ts
@@ -1,8 +1,4 @@
-import {
-  getTrashBinAddressableAreaName,
-  reduceCommandCreators,
-  curryCommandCreator,
-} from '../../utils'
+import { reduceCommandCreators, curryCommandCreator } from '../../utils'
 import { ZERO_OFFSET } from '../../constants'
 import {
   airGapInPlace,
@@ -10,25 +6,23 @@ import {
   prepareToAspirate,
 } from '../atomic'
 import type { CurriedCommandCreator, CommandCreator } from '../../types'
-import type { CutoutId } from '@opentrons/shared-data'
 
 interface AirGapInTrashParams {
   pipetteId: string
   flowRate: number
   volume: number
-  trashLocation: CutoutId
+  trashId: string
 }
 export const airGapInTrash: CommandCreator<AirGapInTrashParams> = (
   args,
   invariantContext,
   prevRobotState
 ) => {
-  const { pipetteId, trashLocation, flowRate, volume } = args
-  const addressableAreaName = getTrashBinAddressableAreaName(trashLocation)
+  const { pipetteId, trashId, flowRate, volume } = args
   const commandCreators: CurriedCommandCreator[] = [
     curryCommandCreator(moveToAddressableArea, {
       pipetteId,
-      addressableAreaName,
+      fixtureId: trashId,
       offset: ZERO_OFFSET,
     }),
     curryCommandCreator(prepareToAspirate, {

--- a/step-generation/src/commandCreators/compound/airGapInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/airGapInWasteChute.ts
@@ -1,8 +1,4 @@
-import {
-  curryCommandCreator,
-  getWasteChuteAddressableAreaNamePip,
-  reduceCommandCreators,
-} from '../../utils'
+import { curryCommandCreator, reduceCommandCreators } from '../../utils'
 import { ZERO_OFFSET } from '../../constants'
 import {
   airGapInPlace,
@@ -15,6 +11,7 @@ interface AirGapInWasteChuteArgs {
   pipetteId: string
   volume: number
   flowRate: number
+  wasteChuteId: string
 }
 
 export const airGapInWasteChute: CommandCreator<AirGapInWasteChuteArgs> = (
@@ -22,17 +19,12 @@ export const airGapInWasteChute: CommandCreator<AirGapInWasteChuteArgs> = (
   invariantContext,
   prevRobotState
 ) => {
-  const { pipetteId, volume, flowRate } = args
-  const pipetteChannels =
-    invariantContext.pipetteEntities[pipetteId].spec.channels
-  const addressableAreaName = getWasteChuteAddressableAreaNamePip(
-    pipetteChannels
-  )
+  const { pipetteId, volume, flowRate, wasteChuteId } = args
 
   const commandCreators: CurriedCommandCreator[] = [
     curryCommandCreator(moveToAddressableArea, {
       pipetteId,
-      addressableAreaName,
+      fixtureId: wasteChuteId,
       offset: ZERO_OFFSET,
     }),
     curryCommandCreator(prepareToAspirate, {

--- a/step-generation/src/commandCreators/compound/blowOutInTrash.ts
+++ b/step-generation/src/commandCreators/compound/blowOutInTrash.ts
@@ -1,12 +1,7 @@
-import {
-  getTrashBinAddressableAreaName,
-  reduceCommandCreators,
-  curryWithoutPython,
-} from '../../utils'
+import { reduceCommandCreators, curryWithoutPython } from '../../utils'
 import { ZERO_OFFSET } from '../../constants'
 import { blowOutInPlace, moveToAddressableArea } from '../atomic'
 import type { CurriedCommandCreator, CommandCreator } from '../../types'
-import type { CutoutId } from '@opentrons/shared-data'
 
 interface BlowOutInTrashParams {
   pipetteId: string
@@ -21,9 +16,6 @@ export const blowOutInTrash: CommandCreator<BlowOutInTrashParams> = (
   const { pipetteId, trashId, flowRate } = args
   const { pipetteEntities, additionalEquipmentEntities } = invariantContext
   const trashEntity = additionalEquipmentEntities[trashId]
-  const addressableAreaName = getTrashBinAddressableAreaName(
-    trashEntity.location as CutoutId
-  )
   const pipettePythonName = pipetteEntities[pipetteId].pythonName
   const trashPythonName = trashEntity.pythonName
 
@@ -38,7 +30,7 @@ export const blowOutInTrash: CommandCreator<BlowOutInTrashParams> = (
   const commandCreators = [
     curryWithoutPython(moveToAddressableArea, {
       pipetteId,
-      addressableAreaName,
+      fixtureId: trashId,
       offset: ZERO_OFFSET,
     }),
     curryWithoutPython(blowOutInPlace, {

--- a/step-generation/src/commandCreators/compound/blowOutInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/blowOutInWasteChute.ts
@@ -1,8 +1,4 @@
-import {
-  curryCommandCreator,
-  getWasteChuteAddressableAreaNamePip,
-  reduceCommandCreators,
-} from '../../utils'
+import { curryWithoutPython, reduceCommandCreators } from '../../utils'
 import { ZERO_OFFSET } from '../../constants'
 import { blowOutInPlace, moveToAddressableArea } from '../atomic'
 import type { CommandCreator, CurriedCommandCreator } from '../../types'
@@ -20,10 +16,6 @@ export const blowOutInWasteChute: CommandCreator<BlowOutInWasteChuteArgs> = (
 ) => {
   const { pipetteId, flowRate, wasteChuteId } = args
   const { pipetteEntities, additionalEquipmentEntities } = invariantContext
-  const pipetteChannels = pipetteEntities[pipetteId].spec.channels
-  const addressableAreaName = getWasteChuteAddressableAreaNamePip(
-    pipetteChannels
-  )
   const pipettePythonName = pipetteEntities[pipetteId].pythonName
   const wasteChutePythonName =
     additionalEquipmentEntities[wasteChuteId].pythonName
@@ -37,12 +29,12 @@ export const blowOutInWasteChute: CommandCreator<BlowOutInWasteChuteArgs> = (
       `${pipettePythonName}.blow_out(${wasteChutePythonName})`,
   })
   const commandCreators = [
-    curryCommandCreator(moveToAddressableArea, {
+    curryWithoutPython(moveToAddressableArea, {
       pipetteId,
-      addressableAreaName,
+      fixtureId: wasteChuteId,
       offset: ZERO_OFFSET,
     }),
-    curryCommandCreator(blowOutInPlace, {
+    curryWithoutPython(blowOutInPlace, {
       pipetteId,
       flowRate,
     }),

--- a/step-generation/src/commandCreators/compound/dispenseInTrash.ts
+++ b/step-generation/src/commandCreators/compound/dispenseInTrash.ts
@@ -1,5 +1,4 @@
 import {
-  getTrashBinAddressableAreaName,
   reduceCommandCreators,
   indentPyLines,
   curryWithoutPython,
@@ -7,7 +6,6 @@ import {
 import { ZERO_OFFSET } from '../../constants'
 import { dispenseInPlace, moveToAddressableArea } from '../atomic'
 import type { CurriedCommandCreator, CommandCreator } from '../../types'
-import type { CutoutId } from '@opentrons/shared-data'
 
 interface DispenseInTrashParams {
   pipetteId: string
@@ -23,9 +21,6 @@ export const dispenseInTrash: CommandCreator<DispenseInTrashParams> = (
   const { pipetteId, trashId, flowRate, volume } = args
   const { pipetteEntities, additionalEquipmentEntities } = invariantContext
   const trashEntity = additionalEquipmentEntities[trashId]
-  const addressableAreaName = getTrashBinAddressableAreaName(
-    trashEntity.location as CutoutId
-  )
   const pipettePythonName = pipetteEntities[pipetteId].pythonName
   const trashPythonName = trashEntity.pythonName
   const pythonArgs = [
@@ -46,7 +41,7 @@ export const dispenseInTrash: CommandCreator<DispenseInTrashParams> = (
   const commandCreators = [
     curryWithoutPython(moveToAddressableArea, {
       pipetteId,
-      addressableAreaName,
+      fixtureId: trashId,
       offset: ZERO_OFFSET,
     }),
     curryWithoutPython(dispenseInPlace, {

--- a/step-generation/src/commandCreators/compound/dispenseInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/dispenseInWasteChute.ts
@@ -1,6 +1,5 @@
 import {
   curryWithoutPython,
-  getWasteChuteAddressableAreaNamePip,
   indentPyLines,
   reduceCommandCreators,
 } from '../../utils'
@@ -22,10 +21,6 @@ export const dispenseInWasteChute: CommandCreator<DispenseInWasteChuteArgs> = (
 ) => {
   const { pipetteId, flowRate, volume, wasteChuteId } = args
   const { pipetteEntities, additionalEquipmentEntities } = invariantContext
-  const pipetteChannels = pipetteEntities[pipetteId].spec.channels
-  const addressableAreaName = getWasteChuteAddressableAreaNamePip(
-    pipetteChannels
-  )
   const wasteChutePythonName =
     additionalEquipmentEntities[wasteChuteId].pythonName
   const pipettePythonName = pipetteEntities[pipetteId].pythonName
@@ -47,7 +42,7 @@ export const dispenseInWasteChute: CommandCreator<DispenseInWasteChuteArgs> = (
   const commandCreators = [
     curryWithoutPython(moveToAddressableArea, {
       pipetteId,
-      addressableAreaName,
+      fixtureId: wasteChuteId,
       offset: ZERO_OFFSET,
     }),
     curryWithoutPython(dispenseInPlace, {

--- a/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/dropTipInWasteChute.ts
@@ -1,8 +1,4 @@
-import {
-  curryWithoutPython,
-  getWasteChuteAddressableAreaNamePip,
-  reduceCommandCreators,
-} from '../../utils'
+import { curryWithoutPython, reduceCommandCreators } from '../../utils'
 import { ZERO_OFFSET } from '../../constants'
 import { dropTipInPlace, moveToAddressableArea } from '../atomic'
 import type { CommandCreator, CurriedCommandCreator } from '../../types'
@@ -20,10 +16,6 @@ export const dropTipInWasteChute: CommandCreator<DropTipInWasteChuteArgs> = (
   const offset = ZERO_OFFSET
   const { pipetteId, wasteChuteId } = args
   const { pipetteEntities, additionalEquipmentEntities } = invariantContext
-  const pipetteChannels = pipetteEntities[pipetteId].spec.channels
-  const addressableAreaName = getWasteChuteAddressableAreaNamePip(
-    pipetteChannels
-  )
 
   let commandCreators: CurriedCommandCreator[] = []
 
@@ -42,7 +34,7 @@ export const dropTipInWasteChute: CommandCreator<DropTipInWasteChuteArgs> = (
     commandCreators = [
       curryWithoutPython(moveToAddressableArea, {
         pipetteId,
-        addressableAreaName,
+        fixtureId: wasteChuteId,
         offset,
       }),
       curryWithoutPython(dropTipInPlace, {

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -675,25 +675,18 @@ export const moveHelper: CommandCreator<MoveHelperArgs> = (
       }),
     ]
   } else if (trashOrLabware === 'wasteChute') {
-    const pipetteChannels =
-      invariantContext.pipetteEntities[pipetteId].spec.channels
     commands = [
       curryCommandCreator(moveToAddressableArea, {
         pipetteId,
-        addressableAreaName: getWasteChuteAddressableAreaNamePip(
-          pipetteChannels
-        ),
+        fixtureId: additionalEquipmentEntities[destinationId].id,
         offset: { x: 0, y: 0, z: 0 },
       }),
     ]
   } else {
-    const addressableAreaName = getTrashBinAddressableAreaName(
-      additionalEquipmentEntities[destinationId].location as CutoutId
-    )
     commands = [
       curryCommandCreator(moveToAddressableArea, {
         pipetteId,
-        addressableAreaName,
+        fixtureId: additionalEquipmentEntities[destinationId].id,
         offset: ZERO_OFFSET,
       }),
     ]
@@ -763,7 +756,7 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
         pipetteId,
         volume,
         flowRate,
-        invariantContext,
+        wasteChuteId: additionalEquipmentEntities[destinationId].id,
       }),
     ]
   } else {
@@ -772,8 +765,7 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
         pipetteId,
         volume,
         flowRate,
-        trashLocation: additionalEquipmentEntities[destinationId]
-          .location as CutoutId,
+        trashId: additionalEquipmentEntities[destinationId].id,
       }),
     ]
   }


### PR DESCRIPTION
# Overview

This PR generates python command for `moveToAddressableArea` as `move_to()` for waste chute and trash bin. As a result, I had to refactor all the affected utils and compound commands because i needed to add a `fixtureId` arg in order to return the trash bin or waste chute python name.

## Test Plan and Hands on Testing

Review the code. Had to do a bit of a refactor in order to get the correct args. 

## Changelog

- generate the `move_to()` api command for moving to a waste chute or trash bin
- refactor affects utils and compound commands to pass the fixture id as an arg
- fix affected tests
- add unit test for testing the py command

## Risk assessment

low, shouldn't affect functionality