### PR TITLE
feat(app): add remaining pythonNames to Quick Transfer for py export

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -63,7 +63,7 @@ function getInvariantContextAndRobotState(
   const pipetteEntities: PipetteEntities = {
     [pipetteId]: {
       name: pipetteName as PipetteName,
-    id: pipetteId,
+      id: pipetteId,
       tiprackDefURI: [tipRackDefURI],
       tiprackLabwareDef: [quickTransferState.tipRack],
       spec: quickTransferState.pipette,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -67,8 +67,7 @@ function getInvariantContextAndRobotState(
       tiprackDefURI: [tipRackDefURI],
       tiprackLabwareDef: [quickTransferState.tipRack],
       spec: quickTransferState.pipette,
-      pythonName:
-        quickTransferState.pipette.channels === 96 ? 'pipette' : 'pipette_left',
+      pythonName: 'pipette',
     },
   }
   const pipetteLocations: RobotState['pipettes'] = {

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -77,6 +77,8 @@ function getInvariantContextAndRobotState(
   }
   const sourceLabwareURI = getLabwareDefURI(quickTransferState.source)
   const sourceLabwareId = `${uuid()}_${sourceLabwareURI}`
+  const pythonTrashBinName = 'trash_bin_1'
+  const pythonWasteChuteName = 'waste_chute'
 
   let labwareEntities: LabwareEntities = {}
   let labwareLocations: RobotState['labware'] = {}
@@ -166,6 +168,7 @@ function getInvariantContextAndRobotState(
         name: 'trashBin',
         id: trashId,
         location: trashLocation,
+        pythonName: pythonTrashBinName,
       },
     }
   }
@@ -187,6 +190,7 @@ function getInvariantContextAndRobotState(
           name: 'trashBin',
           id: trashId,
           location: trashLocation,
+          pythonName: pythonTrashBinName,
         },
       }
     }
@@ -205,6 +209,7 @@ function getInvariantContextAndRobotState(
         name: 'wasteChute',
         id: wasteChuteId,
         location: wasteChuteLocation,
+        pythonName: pythonWasteChuteName,
       },
     }
   }
@@ -226,6 +231,7 @@ function getInvariantContextAndRobotState(
           name: 'wasteChute',
           id: wasteChuteId,
           location: wasteChuteLocation,
+          pythonName: pythonWasteChuteName,
         },
       }
     }

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -63,11 +63,12 @@ function getInvariantContextAndRobotState(
   const pipetteEntities: PipetteEntities = {
     [pipetteId]: {
       name: pipetteName as PipetteName,
-      id: pipetteId,
+    id: pipetteId,
       tiprackDefURI: [tipRackDefURI],
       tiprackLabwareDef: [quickTransferState.tipRack],
       spec: quickTransferState.pipette,
-      pythonName: 'pipette_left',
+      pythonName:
+        quickTransferState.pipette.channels === 96 ? 'pipette' : 'pipette_left',
     },
   }
   const pipetteLocations: RobotState['pipettes'] = {


### PR DESCRIPTION
# Overview

Quick Transfer needs to export python since we will eventually have step-generation only emitting python. The labware entities and most of the pipette entities already have the `pythonName` generated in the key but there were 2 things missing:

1. generating the pythonName for additional equipment entities for `wasteChute` and `trashBin`
2. generating the pythonName correctly for a 96-channel

## Test Plan and Hands on Testing

Doesn't affect functionality at all, just review the code!

## Changelog

- add python name for trashBin, wasteChute, and fix for a 96-channel pipette

## Review requests

@smb2268 - does this change require adding something to the `README`? Probably not, right? I think when we officially emit python, that should be added to the `README`.

## Risk assessment

low, code not in use yet and doesn't affect functionality
