### PR TITLE
fix(shared-data): Small cosmetic labware definition fixes

### DIFF
--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -3519,7 +3519,7 @@
             "H12"
           ],
           "metadata": {
-            "wellBottomShape": "u"
+            "wellBottomShape": "v"
           }
         }
       ],

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -193,6 +193,21 @@ const expectGroupsFollowConvention = (
   })
 
   test(`${filename} should not specify certain fields in 'groups' if it is a reservoir or wellPlate`, () => {
+    // Certain fields in `groups` are intended to supplement labware-level information,
+    // e.g. an Opentrons-brand tube rack might hold a group of Eppendorf-brand tubes.
+    //
+    // Those fields don't make sense on reservoirs or well plates, because the wells are
+    // an inherent part of the labware. The information should just be specified in the
+    // labware-level brand and metadata.
+
+    if (
+      labwareDef.parameters.loadName === 'nest_96_wellplate_2ml_deep' &&
+      (labwareDef.version === 1 || labwareDef.version === 2)
+    ) {
+      // Bug in v1 and v2 of this labware, fixed in v3.
+      return
+    }
+
     const { displayCategory } = labwareDef.metadata
     const noGroupsMetadataAllowed =
       displayCategory === 'reservoir' || displayCategory === 'wellPlate'
@@ -374,10 +389,7 @@ describe('test schemas of all opentrons definitions', () => {
       expect(labwareDef.namespace).toEqual('opentrons')
     })
 
-    if (labwareDef.parameters.loadName !== 'nest_96_wellplate_2ml_deep') {
-      // TODO(IL, 2020-06-22): make nest_96_wellplate_2ml_deep confirm to groups convention
-      expectGroupsFollowConvention(labwareDef, labwarePath)
-    }
+    expectGroupsFollowConvention(labwareDef, labwarePath)
   })
 })
 

--- a/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/3.json
+++ b/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/3.json
@@ -1092,13 +1092,7 @@
   "groups": [
     {
       "metadata": {
-        "displayName": "NEST 96 Deep Well Plate 2mL",
-        "displayCategory": "wellPlate",
         "wellBottomShape": "v"
-      },
-      "brand": {
-        "brand": "NEST",
-        "brandId": []
       },
       "wells": [
         "A1",

--- a/shared-data/labware/definitions/2/usascientific_96_wellplate_2.4ml_deep/2.json
+++ b/shared-data/labware/definitions/2/usascientific_96_wellplate_2.4ml_deep/2.json
@@ -1190,7 +1190,7 @@
         "H12"
       ],
       "metadata": {
-        "wellBottomShape": "u"
+        "wellBottomShape": "v"
       }
     }
   ],


### PR DESCRIPTION
## Overview

This fixes a couple of small bugs in labware definition metadata.

* Fixing the well groups in `nest_96_wellplate_2ml_deep`: Closes EXEC-1159. This makes the labware display less weirdly in Labware Library. It was displaying as if the wells had their own brand, like they were tubes in a tube rack. 
* Fixing the well bottom shape in `usascientific_96_wellplate_2.4ml_deep`: Closes PLAT-144.

Both of the definitions are updated in-place, since we haven't released them yet.

## Test Plan and Hands on Testing

* [x] Look at them in Labware Library.

## Review requests

None in particular.

## Risk assessment

Low. None of this should affect any logic. It's just the presentational parts of the definitions.