### PR TITLE
refactor(app): add test for `shouldUseNotifications` false to true

### DIFF
--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -74,6 +74,7 @@ const callbackStore: CallbackStore = {}
 interface AppShellListener {
   hostname: string
   notifyTopic: NotifyTopic
+  /* The callback MUST be memoized so it's identity is stable between calls from the same location. */
   callback: (data: NotifyResponseData) => void
   isDismounting?: boolean
 }
@@ -104,6 +105,7 @@ export function appShellListener({
       callbackStore[hostname] = callbackStore[hostname] ?? {}
       callbackStore[hostname][topic] ??= []
 
+      // Assumes callback is memoized.
       if (!callbackStore[hostname][topic].includes(callback)) {
         callbackStore[hostname][topic].push(callback)
       }

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -103,7 +103,10 @@ export function appShellListener({
     } else {
       callbackStore[hostname] = callbackStore[hostname] ?? {}
       callbackStore[hostname][topic] ??= []
-      callbackStore[hostname][topic].push(callback)
+
+      if (!callbackStore[hostname][topic].includes(callback)) {
+        callbackStore[hostname][topic].push(callback)
+      }
     }
   })
 

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -74,7 +74,6 @@ const callbackStore: CallbackStore = {}
 interface AppShellListener {
   hostname: string
   notifyTopic: NotifyTopic
-  /* The callback MUST be memoized so it's identity is stable between calls from the same location. */
   callback: (data: NotifyResponseData) => void
   isDismounting?: boolean
 }
@@ -104,11 +103,7 @@ export function appShellListener({
     } else {
       callbackStore[hostname] = callbackStore[hostname] ?? {}
       callbackStore[hostname][topic] ??= []
-
-      // Assumes callback is memoized.
-      if (!callbackStore[hostname][topic].includes(callback)) {
-        callbackStore[hostname][topic].push(callback)
-      }
+      callbackStore[hostname][topic].push(callback)
     }
   })
 

--- a/app/src/resources/__tests__/useNotifyDataReady.test.ts
+++ b/app/src/resources/__tests__/useNotifyDataReady.test.ts
@@ -241,4 +241,20 @@ describe('useNotifyDataReady', () => {
     result.current.queryOptionsNotify.onSettled?.(undefined, null)
     expect(mockOnSettled).toHaveBeenCalled()
   })
+
+  it('should enable notifications if `enabled` is initially false and then becomes true', () => {
+    const { rerender, result } = renderHook(
+      props =>
+        useNotifyDataReady({
+          topic: MOCK_TOPIC,
+          options: props,
+        }),
+      { initialProps: { enabled: false, refetchInterval: 5000 } }
+    )
+    expect(result.current.shouldRefetch).toEqual(false)
+
+    rerender({ enabled: true, refetchInterval: 5000 })
+
+    expect(result.current.shouldRefetch).toEqual(true)
+  })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

EDIT: See discussion below. Woops, we were already covered. Will just merge in the testing.

https://github.com/Opentrons/opentrons/pull/17853 fixes an issue when the `shouldUseNotifications` flag is initially `false` and then flips to `true`. We must also account for scenarios in which the caller repeatedly sets the `shouldUseNotifications` flag between `false` and `true`: we do not want to add a new callback to the store every time `shouldUseNotifications` is `true`, only if it is not in the store already. Note that the callback added to the store is memoized, so `includes` is a sufficient filter check here. Also, we don't need to remove the callback every time `shouldUseNotifications` becomes `false`: we remove the callback on dismount.

This fix currently doesn't impact our codebase, fortunately. The one spot `shouldUseNotifications` flips is a one-time `false` to `true`. 

This PR also adds testing for the earlier fix in the linked PR.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Can't test in office, but easy to reason through.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
