### PR TITLE
fix(api): Remove is_full_dispense argument from dispense

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1077,7 +1077,6 @@ class API(
         rate: float = 1.0,
         push_out: Optional[float] = None,
         correction_volume: float = 0.0,
-        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid in microliters(uL) using this pipette.

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -607,7 +607,6 @@ class OT3PipetteHandler:
         volume: Optional[float],
         rate: float,
         push_out: Optional[float],
-        is_full_dispense: bool,
         correction_volume: float = 0.0,
     ) -> Optional[LiquidActionSpec]:
         """Check preconditions for dispense, parse args, and calculate positions.
@@ -646,20 +645,7 @@ class OT3PipetteHandler:
         # so we don't expect this to trigger in practice.
         disp_vol = min(instrument.current_volume, disp_vol)
 
-        # TODO (Ryan): Remove this check in the future.
-        # we moved this logic up to protocol_engine but replacing with this check to make sure
-        # we don't accidentally call this incorrectly from somewhere else.
-        if not is_full_dispense and numpy.isclose(
-            instrument.current_volume - disp_vol, 0
-        ):
-            raise CommandPreconditionViolated(
-                message="Command created a full-dispense without the full dispense argument",
-                detail={
-                    "command": "dispense",
-                    "current-volume": str(instrument.current_volume),
-                    "dispense-volume": str(disp_vol),
-                },
-            )
+        is_full_dispense = numpy.isclose(instrument.current_volume - disp_vol, 0)
 
         if disp_vol == 0:
             return None

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2100,7 +2100,6 @@ class OT3API(
         rate: float = 1.0,
         push_out: Optional[float] = None,
         correction_volume: float = 0.0,
-        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid in microliters(uL) using this pipette."""
@@ -2110,7 +2109,6 @@ class OT3API(
             volume=volume,
             rate=rate,
             push_out=push_out,
-            is_full_dispense=is_full_dispense,
             correction_volume=correction_volume,
         )
         if not dispense_spec:
@@ -3051,7 +3049,6 @@ class OT3API(
         volume: float,
         push_out: Optional[float],
         flow_rate: float = 1.0,
-        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid (in microliters/uL) while moving the z axis synchronously.
@@ -3063,7 +3060,7 @@ class OT3API(
         """
         realmount = OT3Mount.from_mount(mount)
         dispense_spec = self._pipette_handler.plan_check_dispense(
-            realmount, volume, flow_rate, push_out, is_full_dispense
+            realmount, volume, flow_rate, push_out
         )
         if not dispense_spec:
             return

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -146,7 +146,6 @@ class LiquidHandler(
         rate: float = 1.0,
         push_out: Optional[float] = None,
         correction_volume: float = 0.0,
-        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid in microliters(uL) using this pipette
@@ -168,7 +167,6 @@ class LiquidHandler(
         volume: float,
         push_out: Optional[float],
         flow_rate: float = 1.0,
-        is_full_dispense: bool = False,
     ) -> None:
         """
         Dispense a volume of liquid (in microliters/uL) while moving the z axis synchronously.

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -297,7 +297,7 @@ async def dispense_while_tracking(
         pipetting.get_state_view().pipettes.get_aspirated_volume(pipette_id) or 0.0
     )
     is_full_dispense = bool(numpy.isclose(current_volume - volume, 0))
-    ready = push_out == 0 if push_out is not None else not is_full_dispense
+    ready = push_out == 0 or not is_full_dispense
     try:
         volume_dispensed = await pipetting.dispense_while_tracking(
             pipette_id=pipette_id,
@@ -306,7 +306,6 @@ async def dispense_while_tracking(
             volume=volume,
             flow_rate=flow_rate,
             push_out=push_out,
-            is_full_dispense=is_full_dispense,
         )
     except PipetteOverpressureError as e:
         return DefinedErrorData(
@@ -360,14 +359,13 @@ async def dispense_in_place(
         pipetting.get_state_view().pipettes.get_aspirated_volume(pipette_id) or 0.0
     )
     is_full_dispense = bool(numpy.isclose(current_volume - volume, 0))
-    ready: bool = push_out == 0 if push_out is not None else not is_full_dispense
+    ready: bool = push_out == 0 or not is_full_dispense
     try:
         volume = await pipetting.dispense_in_place(
             pipette_id=pipette_id,
             volume=volume,
             flow_rate=flow_rate,
             push_out=push_out,
-            is_full_dispense=is_full_dispense,
             correction_volume=correction_volume,
         )
     except PipetteOverpressureError as e:

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -73,7 +73,6 @@ class PipettingHandler(TypingProtocol):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
-        is_full_dispense: bool = False,
     ) -> float:
         """Set flow-rate and dispense while tracking."""
 
@@ -83,7 +82,6 @@ class PipettingHandler(TypingProtocol):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
-        is_full_dispense: bool,
         correction_volume: float = 0.0,
     ) -> float:
         """Set flow-rate and dispense."""
@@ -218,7 +216,6 @@ class HardwarePipettingHandler(PipettingHandler):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
-        is_full_dispense: bool = False,
     ) -> float:
         """Set flow-rate and dispense.
 
@@ -278,7 +275,6 @@ class HardwarePipettingHandler(PipettingHandler):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
-        is_full_dispense: bool,
         correction_volume: float = 0.0,
     ) -> float:
         """Dispense liquid without moving the pipette."""
@@ -294,7 +290,6 @@ class HardwarePipettingHandler(PipettingHandler):
                 volume=adjusted_volume,
                 push_out=push_out,
                 correction_volume=correction_volume,
-                is_full_dispense=is_full_dispense,
             )
 
         return adjusted_volume
@@ -416,7 +411,6 @@ class VirtualPipettingHandler(PipettingHandler):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
-        is_full_dispense: bool,
         correction_volume: float = 0.0,
     ) -> float:
         """Virtually dispense (no-op)."""
@@ -482,7 +476,6 @@ class VirtualPipettingHandler(PipettingHandler):
         volume: float,
         flow_rate: float,
         push_out: Optional[float],
-        is_full_dispense: bool = False,
     ) -> float:
         """Virtually dispense (no-op)."""
         # TODO (tz, 8-23-23): add a check for push_out not larger that the max volume allowed when working on this https://opentrons.atlassian.net/browse/RSS-329

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -585,7 +585,7 @@ async def test_dispense_ot3(
     with pytest.raises(CommandPreconditionViolated):
         await hw_api.dispense(mount, 5, push_out=10)
 
-    await hw_api.dispense(mount, rate=2, push_out=10, is_full_dispense=True)
+    await hw_api.dispense(mount, rate=2, push_out=10)
     plunger_pos_2 = 72.2715
     assert (await hw_api.current_position(mount))[Axis.B] == pytest.approx(
         plunger_pos_2, 0.1
@@ -832,7 +832,7 @@ async def test_dispense_flow_rate(
         assert_move_called(mock_move, 10)
 
     with mock.patch.object(hw_api, "_move") as mock_move:
-        await hw_api.dispense(types.Mount.LEFT, 1, rate=0.5, is_full_dispense=True)
+        await hw_api.dispense(types.Mount.LEFT, 1, rate=0.5)
         assert_move_called(mock_move, 5)
 
 

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1783,9 +1783,7 @@ async def test_plunger_ready_to_aspirate_after_dispense(
     assert ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate
 
     await ot3_hardware.aspirate(OT3Mount.LEFT, asp_vol)
-    await ot3_hardware.dispense(
-        OT3Mount.LEFT, disp_vol, push_out=push_out, is_full_dispense=disp_vol == asp_vol
-    )
+    await ot3_hardware.dispense(OT3Mount.LEFT, disp_vol, push_out=push_out)
     assert (
         ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate == is_ready
     )
@@ -1871,13 +1869,9 @@ async def test_dispense_while_tracking(
 
     if not tip_present:
         with pytest.raises(UnexpectedTipRemovalError):
-            await ot3_hardware.dispense_while_tracking(
-                mount, 8.0, 80.0, push_out=None, is_full_dispense=is_ready
-            )
+            await ot3_hardware.dispense_while_tracking(mount, 8.0, 80.0, push_out=None)
     else:
-        await ot3_hardware.dispense_while_tracking(
-            mount, 8.0, 80.0, push_out=None, is_full_dispense=True
-        )
+        await ot3_hardware.dispense_while_tracking(mount, 8.0, 80.0, push_out=None)
         if is_ready:
             # make sure the move planning math stays the same
             expected_target_pos = {

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -109,7 +109,6 @@ async def test_dispense_implementation(
             volume=50,
             flow_rate=1.23,
             push_out=None,
-            is_full_dispense=False,
             correction_volume=0,
         )
     ).then_return(42)
@@ -213,7 +212,6 @@ async def test_overpressure_error(
             volume=50,
             flow_rate=1.23,
             push_out=None,
-            is_full_dispense=False,
             correction_volume=0,
         ),
     ).then_raise(PipetteOverpressureError())

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
@@ -84,7 +84,6 @@ async def test_dispense_in_place_implementation(
             volume=123,
             flow_rate=456,
             push_out=None,
-            is_full_dispense=False,
             correction_volume=0,
         )
     ).then_return(42)
@@ -183,7 +182,6 @@ async def test_dispense_in_place_is_ready_response(
             volume=dispense_volume,
             flow_rate=456,
             push_out=push_out,
-            is_full_dispense=dispense_volume == asp_volume,
             correction_volume=0,
         )
     ).then_return(dispense_volume)
@@ -280,7 +278,6 @@ async def test_overpressure_error(
             volume=50,
             flow_rate=1.23,
             push_out=10,
-            is_full_dispense=False,
             correction_volume=0,
         ),
     ).then_raise(PipetteOverpressureError())

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
@@ -110,7 +110,6 @@ async def test_dispense_while_tracking_implementation(
             push_out=None,
             well_name=stateupdateWell,
             labware_id=stateupdateLabware,
-            is_full_dispense=True,
         )
     ).then_return(42)
     decoy.when(state_view.pipettes.get_aspirated_volume("pipette-id-abc")).then_return(
@@ -274,7 +273,6 @@ async def test_overpressure_error(
             push_out=10,
             well_name=stateupdateWell,
             labware_id=stateupdateLabware,
-            is_full_dispense=True,
         ),
     ).then_raise(PipetteOverpressureError())
 

--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_dispense.py
@@ -112,7 +112,6 @@ async def test_evotip_dispense_implementation(
             volume=100.0,
             flow_rate=456.0,
             push_out=None,
-            is_full_dispense=True,
             correction_volume=0,
         )
     ).then_return(100)

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -221,7 +221,6 @@ async def test_hw_dispense_in_place(
         volume=25,
         flow_rate=2.5,
         push_out=None,
-        is_full_dispense=True,
     )
 
     assert result == 25
@@ -235,7 +234,6 @@ async def test_hw_dispense_in_place(
             volume=25,
             push_out=None,
             correction_volume=0,
-            is_full_dispense=True,
         ),
         mock_hardware_api.set_flow_rate(
             mount=Mount.RIGHT, aspirate=1.23, dispense=4.56, blow_out=7.89
@@ -280,7 +278,6 @@ async def test_hw_dispense_in_place_raises_invalid_push_out(
             volume=25,
             flow_rate=2.5,
             push_out=-7,
-            is_full_dispense=True,
         )
 
 
@@ -523,7 +520,6 @@ async def test_virtual_dispense_in_place(
         volume=3,
         flow_rate=5,
         push_out=None,
-        is_full_dispense=True,
     )
     assert result == 3
 
@@ -544,7 +540,6 @@ async def test_virtual_dispense_in_place_raises_invalid_push_out(
             volume=3,
             flow_rate=5,
             push_out=-7,
-            is_full_dispense=False,
         )
 
 
@@ -568,7 +563,6 @@ async def test_virtual_dispense_in_place_raises_invalid_volume(
             volume=3,
             flow_rate=5,
             push_out=7,
-            is_full_dispense=False,
         )
 
 
@@ -607,7 +601,7 @@ async def test_virtual_dispense_validate_tip_attached(
         TipNotAttachedError, match="Cannot perform dispense without a tip attached"
     ):
         await subject.dispense_in_place(
-            "pipette-id", volume=20, flow_rate=1, push_out=None, is_full_dispense=False
+            "pipette-id", volume=20, flow_rate=1, push_out=None
         )
 
 
@@ -740,7 +734,6 @@ async def test_dispense_volume_validation(
                 volume=ok_volume,
                 flow_rate=5,
                 push_out=7,
-                is_full_dispense=True,
             )
             == expected_adjusted_volume
         )
@@ -750,5 +743,4 @@ async def test_dispense_volume_validation(
                 volume=not_ok_volume,
                 flow_rate=5,
                 push_out=7,
-                is_full_dispense=True,
             )

--- a/hardware-testing/hardware_testing/examples/plunger_ot3.py
+++ b/hardware-testing/hardware_testing/examples/plunger_ot3.py
@@ -24,7 +24,7 @@ async def _main(is_simulating: bool) -> None:
     max_vol = pipette.working_volume
     for vol in [max_vol, max_vol / 2, max_vol / 10]:
         await api.aspirate(mount, volume=vol)
-        await api.dispense(mount, volume=vol, is_full_dispense=True)
+        await api.dispense(mount, volume=vol)
         await api.prepare_for_aspirate(mount)
     api.remove_tip(mount)
 

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
@@ -129,7 +129,7 @@ async def aspirate_and_wait(
     await api.move_to(
         OT3Mount.LEFT, reservoir + Point(z=DEPTH_INTO_RESERVOIR_FOR_DISPENSE)
     )
-    await api.dispense(OT3Mount.LEFT, is_full_dispense=True)
+    await api.dispense(OT3Mount.LEFT)
     return result, duration_seconds
 
 

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_pressure.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_pressure.py
@@ -156,7 +156,7 @@ async def run(
 
         # DISPENSE-Pa
         dispense_pa = 0.0
-        await api.dispense(OT3Mount.LEFT, ASPIRATE_VOLUME, is_full_dispense=True)
+        await api.dispense(OT3Mount.LEFT, ASPIRATE_VOLUME)
         if not api.is_simulator:
             try:
                 dispense_pa = await _read_from_sensor(

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -462,7 +462,7 @@ async def _aspirate_and_look_for_droplets(
         leak_test_passed = _get_operator_answer_to_question("did it pass? no leaking?")
     print("dispensing back into reservoir")
     await api.move_rel(mount, Point(z=-LEAK_HOVER_ABOVE_LIQUID_MM))
-    await api.dispense(mount, pipette_volume, is_full_dispense=True)
+    await api.dispense(mount, pipette_volume)
     await api.blow_out(mount)
     await api.move_rel(mount, Point(z=ASPIRATE_SUBMERGE_MM))
     return leak_test_passed
@@ -648,9 +648,7 @@ async def _fixture_check_pressure(
     )
     results.append(r)
     # dispense
-    await api.dispense(
-        mount, PRESSURE_FIXTURE_ASPIRATE_VOLUME[pip_vol], is_full_dispense=True
-    )
+    await api.dispense(mount, PRESSURE_FIXTURE_ASPIRATE_VOLUME[pip_vol])
     r, _ = await _read_pressure_and_check_results(
         api,
         pip_channels,
@@ -1127,7 +1125,7 @@ async def _test_diagnostics_pressure(
     if not api.is_simulator:
         _get_operator_answer_to_question('REMOVE your finger, enter "y" when ready')
     print("moving plunger back down to BOTTOM position")
-    await api.dispense(mount, is_full_dispense=True)
+    await api.dispense(mount)
     await api.prepare_for_aspirate(mount)
 
     await _drop_tip_in_trash(api, mount)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
