### PR TITLE
feat(protocol-designer): add release notes link to announcement modal

### DIFF
--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -79,7 +79,7 @@
       "body7": "Removing ability to dispense to off-deck labware or move off-deck labware with a gripper",
       "body8": "Removing quantity dropdown from all modules during the Flex setup flow to reduce deck setup conflicts",
       "body9": "All protocols now require Opentrons App version 8.3.0+ to run.",
-      "body10": "For more information, see the <link1>Protocol Designer Instruction Manual</link1> or the <link2>Release Notes.</link2>."
+      "body10": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
     }
   },
   "labware_selection": {
@@ -197,6 +197,7 @@
   "review_file_details": "Review file details",
   "robot_type": "Robot Type",
   "staging_areas": "Staging area slots",
+  "view_full_release_notes": "View full release notes",
   "upload_tiprack": "Upload a custom tiprack to select its definition",
   "upload": "Upload",
   "well_order": {

--- a/protocol-designer/src/components/organisms/AnnouncementModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AnnouncementModal/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
+  ALIGN_CENTER,
   DIRECTION_COLUMN,
   Flex,
   Icon,
@@ -18,8 +19,8 @@ import {
   getLocalStorageItem,
   localStorageAnnouncementKey,
 } from '../../../persist'
-import { useAnnouncements } from './announcements'
 import { RELEASE_NOTES_URL } from '../KnowledgeLink'
+import { useAnnouncements } from './announcements'
 
 interface AnnouncementModalProps {
   isViewReleaseNotes?: boolean
@@ -65,7 +66,7 @@ export const AnnouncementModal = (
               justifyContent={JUSTIFY_END}
               paddingX={SPACING.spacing24}
               paddingBottom={SPACING.spacing24}
-              alignItems="center"
+              alignItems={ALIGN_CENTER}
               gridGap={SPACING.spacing8}
             >
               <Link
@@ -73,7 +74,7 @@ export const AnnouncementModal = (
                 href={RELEASE_NOTES_URL}
                 css={TYPOGRAPHY.linkPSemiBold}
               >
-                <Flex alignItems="center" gridGap={SPACING.spacing8}>
+                <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
                   <StyledText>{t('view_full_release_notes')}</StyledText>
                   <Icon
                     size={SPACING.spacing8}

--- a/protocol-designer/src/components/organisms/AnnouncementModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AnnouncementModal/index.tsx
@@ -3,11 +3,15 @@ import { useTranslation } from 'react-i18next'
 import {
   DIRECTION_COLUMN,
   Flex,
+  Icon,
   JUSTIFY_CENTER,
   JUSTIFY_END,
+  Link,
   Modal,
   PrimaryButton,
   SPACING,
+  StyledText,
+  TYPOGRAPHY,
 } from '@opentrons/components'
 import {
   setLocalStorageItem,
@@ -15,6 +19,7 @@ import {
   localStorageAnnouncementKey,
 } from '../../../persist'
 import { useAnnouncements } from './announcements'
+import { RELEASE_NOTES_URL } from '../KnowledgeLink'
 
 interface AnnouncementModalProps {
   isViewReleaseNotes?: boolean
@@ -60,7 +65,24 @@ export const AnnouncementModal = (
               justifyContent={JUSTIFY_END}
               paddingX={SPACING.spacing24}
               paddingBottom={SPACING.spacing24}
+              alignItems="center"
+              gridGap={SPACING.spacing8}
             >
+              <Link
+                external
+                href={RELEASE_NOTES_URL}
+                css={TYPOGRAPHY.linkPSemiBold}
+              >
+                <Flex alignItems="center" gridGap={SPACING.spacing8}>
+                  <StyledText>{t('view_full_release_notes')}</StyledText>
+                  <Icon
+                    size={SPACING.spacing8}
+                    name="open-in-new"
+                    aria-label="open_in_new_icon"
+                  />
+                </Flex>
+              </Link>
+
               <PrimaryButton onClick={handleClick}>
                 {i18n.format(t('close'), 'capitalize')}
               </PrimaryButton>


### PR DESCRIPTION
closes AUTH-1423

# Overview

Add release notes link button to the announcement modal

<img width="527" alt="Screenshot 2025-03-25 at 13 28 37" src="https://github.com/user-attachments/assets/b4b36638-a4ff-4bcc-aebc-a7e0e528f4c5" />

## Test Plan and Hands on Testing

Check out the release notes modal in the setting page and make sure that it works when you click on it.

## Changelog

- add link for release notes link
- fix up i18n

## Risk assessment

low