### PR TITLE
feat(api): return FlexStackerShuttleMissing from stacker engine commands

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -14,7 +14,10 @@ from .pipetting_common import (
     TipPhysicallyAttachedError,
 )
 from .movement_common import StallOrCollisionError
-from .flex_stacker.common import FlexStackerStallOrCollisionError
+from .flex_stacker.common import (
+    FlexStackerStallOrCollisionError,
+    FlexStackerShuttleError,
+)
 
 from . import absorbance_reader
 from . import flex_stacker
@@ -920,6 +923,7 @@ CommandDefinedErrorData = Union[
     DefinedErrorData[GripperMovementError],
     DefinedErrorData[StallOrCollisionError],
     DefinedErrorData[FlexStackerStallOrCollisionError],
+    DefinedErrorData[FlexStackerShuttleError],
 ]
 
 

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -13,3 +13,13 @@ class FlexStackerStallOrCollisionError(ErrorOccurrence):
 
     errorCode: str = ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED.value.code
     detail: str = ErrorCodes.FLEX_STACKER_STALL_OR_COLLISION_DETECTED.value.detail
+
+
+class FlexStackerShuttleError(ErrorOccurrence):
+    """Returned when the Flex Stacker Shuttle is not in the correct location."""
+
+    isDefined: bool = True
+    errorType: Literal["flexStackerShuttleMissing"] = "flexStackerShuttleMissing"
+
+    errorCode: str = ErrorCodes.FLEX_STACKER_SHUTTLE_MISSING.value.code
+    detail: str = ErrorCodes.FLEX_STACKER_SHUTTLE_MISSING.value.detail

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -4,11 +4,13 @@ from datetime import datetime
 
 import pytest
 from decoy import Decoy, matchers
+from typing import Type, Union
 
 from opentrons.drivers.flex_stacker.types import StackerAxis
-from opentrons.hardware_control.modules import FlexStacker
+from opentrons.hardware_control.modules import FlexStacker, PlatformState
 from opentrons.protocol_engine.commands.flex_stacker.common import (
     FlexStackerStallOrCollisionError,
+    FlexStackerShuttleError,
 )
 from opentrons.protocol_engine.resources import ModelUtils
 
@@ -48,7 +50,10 @@ from opentrons.protocol_engine.execution import LoadedLabwareData
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
 )
-from opentrons_shared_data.errors.exceptions import FlexStackerStallError
+from opentrons_shared_data.errors.exceptions import (
+    FlexStackerStallError,
+    FlexStackerShuttleMissingError,
+)
 
 
 def _prep_stacker_own_location(
@@ -793,6 +798,23 @@ async def test_retrieve_primary_adapter_and_lid(
     )
 
 
+@pytest.mark.parametrize(
+    "shared_data_error,protocol_engine_error",
+    [
+        (
+            FlexStackerStallError(serial="123", axis=StackerAxis.Z),
+            FlexStackerStallOrCollisionError,
+        ),
+        (
+            FlexStackerShuttleMissingError(
+                serial="123",
+                expected_state=PlatformState.EXTENDED,
+                shuttle_state=PlatformState.UNKNOWN,
+            ),
+            FlexStackerShuttleError,
+        ),
+    ],
+)
 async def test_retrieve_raises_if_stall(
     decoy: Decoy,
     equipment: EquipmentHandler,
@@ -802,6 +824,10 @@ async def test_retrieve_raises_if_stall(
     stacker_id: FlexStackerId,
     flex_50uL_tiprack: LabwareDefinition,
     stacker_hardware: FlexStacker,
+    shared_data_error: Exception,
+    protocol_engine_error: Type[
+        Union[FlexStackerStallOrCollisionError, FlexStackerShuttleError]
+    ],
 ) -> None:
     """It should raise a stall error."""
     error_id = "error-id"
@@ -856,13 +882,13 @@ async def test_retrieve_raises_if_stall(
     decoy.when(model_utils.get_timestamp()).then_return(error_timestamp)
 
     decoy.when(await stacker_hardware.dispense_labware(labware_height=16)).then_raise(
-        FlexStackerStallError(serial="123", axis=StackerAxis.Z)
+        shared_data_error
     )
 
     result = await subject.execute(data)
 
     assert result == DefinedErrorData(
-        public=FlexStackerStallOrCollisionError.model_construct(
+        public=protocol_engine_error.model_construct(
             id=error_id,
             createdAt=error_timestamp,
             wrappedErrors=[matchers.Anything()],

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -210,6 +210,10 @@
       "detail": "HEPA UV Failed",
       "category": "roboticsInteractionError"
     },
+    "3020": {
+      "detail": "Flex Stacker Shuttle Missing",
+      "category": "roboticsInteractionError"
+    },
     "4000": {
       "detail": "Unknown or Uncategorized Error",
       "category": "generalError"

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -82,6 +82,7 @@ class ErrorCodes(Enum):
     INVALID_LIQUID_CLASS_NAME = _code_from_dict_entry("3017")
     TIP_DETECTOR_NOT_FOUND = _code_from_dict_entry("3018")
     HEPA_UV_FAILED = _code_from_dict_entry("3019")
+    FLEX_STACKER_SHUTTLE_MISSING = _code_from_dict_entry("3020")
     GENERAL_ERROR = _code_from_dict_entry("4000")
     ROBOT_IN_USE = _code_from_dict_entry("4001")
     API_REMOVED = _code_from_dict_entry("4002")

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -769,16 +769,28 @@ class FlexStackerShuttleMissingError(RoboticsInteractionError):
     def __init__(
         self,
         serial: str,
+        expected_state: str,
+        shuttle_state: str,
         message: Optional[str] = None,
         detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a FlexStackerStallError."""
-        self.serial = serial
+        checked_detail: Dict[str, Any] = detail or {}
+        checked_detail["serial"] = serial
+        checked_detail["expected_state"] = expected_state
+        checked_detail["shuttle_state"] = shuttle_state
+        if message is not None:
+            checked_message = message
+        else:
+            checked_message = (
+                "Flex Stacker shuttle not detected in state "
+                f"{expected_state}, found {shuttle_state}."
+            )
         super().__init__(
             ErrorCodes.FLEX_STACKER_SHUTTLE_MISSING,
-            message,
-            detail,
+            checked_message,
+            checked_detail,
             wrapping,
         )
 

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -763,6 +763,26 @@ class HepaUVFailedError(RoboticsInteractionError):
         super().__init__(ErrorCodes.HEPA_UV_FAILED, message, detail, wrapping)
 
 
+class FlexStackerShuttleMissingError(RoboticsInteractionError):
+    """An error indicating the Flex Stacker shuttle cannot be detected."""
+
+    def __init__(
+        self,
+        serial: str,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, str]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a FlexStackerStallError."""
+        self.serial = serial
+        super().__init__(
+            ErrorCodes.FLEX_STACKER_SHUTTLE_MISSING,
+            message,
+            detail,
+            wrapping,
+        )
+
+
 class FirmwareUpdateRequiredError(RoboticsInteractionError):
     """An error indicating that a firmware update is required."""
 


### PR DESCRIPTION
# Overview
We want to enable error recovery during a protocol if the Flex Stacker shuttle is not detected. This PR does the first step, which is to catch this error. The hardware controller layer now checks for the platform status before executing dispense and store labware, and raises the appropriate error. 

closes EXEC-1287, EXEC-1200

