### PR TITLE
fix(protocol-designer): remove PD version number from navigation bar

### DIFF
--- a/protocol-designer/src/components/organisms/Navigation/__tests__/Navigation.test.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/__tests__/Navigation.test.tsx
@@ -31,7 +31,6 @@ describe('Navigation', () => {
     render()
     screen.getByText('Opentrons')
     screen.getByText('Protocol Designer')
-    screen.getByText('Version fake_PD_version')
     screen.getByText('Create new')
     screen.getByText('Import')
     screen.getByText('mock SettingsIcon')

--- a/protocol-designer/src/components/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/index.tsx
@@ -57,9 +57,6 @@ export function Navigation(): JSX.Element | null {
         <StyledText desktopStyle="bodyLargeSemiBold" color={COLORS.purple50}>
           {t('protocol_designer')}
         </StyledText>
-        <StyledText desktopStyle="captionRegular" color={COLORS.grey50}>
-          {t('version', { version: process.env.OT_PD_VERSION })}
-        </StyledText>
       </Flex>
       <Flex gridGap={SPACING.spacing40} alignItems={ALIGN_CENTER}>
         {location.pathname === '/createNew' ? null : (


### PR DESCRIPTION
closes AUTH-1544

# Overview

Remove the version number from the navigation bar. it is still accessible in the settings

## Test Plan and Hands on Testing

Check that the version number is no longer listed in the navigation bar when you first open PD

## Changelog

- remove PD version number from the navigation, fix test

## Risk assessment

low