### PR TITLE
docs(api): API reference entries for liquid class methods

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -445,6 +445,7 @@ nitpick_ignore_regex = [
     ("py:class", r".*protocol_api\.config.*"),
     ("py:class", r".*opentrons_shared_data.*"),
     ("py:class", r".*protocol_api._parameters.Parameters.*"),
+    ("py:class", r".*protocol_api._liquid_properties.TransferProperties*"),
     ("py:class", r".*RobotContext"),  # shh it's a secret (for now)
     ("py:class", r".*FlexStackerContext"),  # ssh it's a secret (for now)
     (

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -48,6 +48,8 @@ Wells and Liquids
 
 .. autoclass:: opentrons.protocol_api.Liquid
 
+.. autoclass:: opentrons.protocol_api.LiquidClass
+
 .. _protocol-api-modules:
 
 Modules

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -49,6 +49,7 @@ Wells and Liquids
 .. autoclass:: opentrons.protocol_api.Liquid
 
 .. autoclass:: opentrons.protocol_api.LiquidClass
+   :members:
 
 .. _protocol-api-modules:
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1542,6 +1542,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
               - ``"once"``: Use one tip for the entire command.
               - ``"always"``: Use a new tip for each set of aspirate and dispense steps.
+              - ``"per source"``: Use one tip for each source well, even if
+                :ref:`tip refilling <complex-tip-refilling>` is required.
               - ``"never"``: Do not pick up or drop tips at all.
 
             See :ref:`param-tip-handling` for details.
@@ -1623,7 +1625,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param new_tip: When to pick up and drop tips during the command.
             Defaults to ``"once"``.
 
-              - ``"once"``: Use one tip for the entire command.
+              - ``"once"`` or ``"per source"``: Use one tip for the entire command.
               - ``"always"``: Use a new tip for each set of aspirate and dispense steps.
               - ``"never"``: Do not pick up or drop tips at all.
 
@@ -1712,6 +1714,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
               - ``"once"``: Use one tip for the entire command.
               - ``"always"``: Use a new tip for each set of aspirate and dispense steps.
+              - ``"per source"``: Not available when consolidating.
               - ``"never"``: Do not pick up or drop tips at all.
 
             See :ref:`param-tip-handling` for details.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1526,11 +1526,30 @@ class InstrumentContext(publisher.CommandPublisher):
         return_tip: bool = False,
         visit_every_well: bool = False,
     ) -> InstrumentContext:
-        """Transfer liquid from source to dest using the specified liquid class properties.
+        """Move a particular type of liquid from one well or group of wells to another.
 
-        TODO: Add args description.
+        :param liquid_class: The type of liquid to move. You must specify the liquid class,
+            even if you have used :py:meth:`.load_liquid` to indicate what liquid the
+            source contains.
+        :type liquid_class: :py:class:`.LiquidClass`
 
-        :meta private:
+        :param volume: The amount, in µL, to aspirate from each source and dispense to
+                       each destination.
+        :param source: A single well or a list of wells to aspirate liquid from.
+        :param dest: A single well or a list of wells to dispense liquid into.
+        :param new_tip: When to pick up and drop tips during the command.
+            Defaults to ``"once"``.
+
+              - ``"once"``: Use one tip for the entire command.
+              - ``"always"``: Use a new tip for each set of aspirate and dispense steps.
+              - ``"never"``: Do not pick up or drop tips at all.
+
+            See :ref:`param-tip-handling` for details.
+
+        :param trash_location: A trash container, well, or other location to dispose of
+            tips. Depending on the liquid class, the pipette may also blow out liquid here.
+        :param return_tip: Whether to drop used tips in their original locations
+            in the tip rack, instead of the trash.
         """
         transfer_args = verify_and_normalize_transfer_args(
             source=source,
@@ -1590,12 +1609,30 @@ class InstrumentContext(publisher.CommandPublisher):
         visit_every_well: bool = False,
     ) -> InstrumentContext:
         """
-        Distribute liquid from a single source to multiple destinations
-        using the specified liquid class properties.
+        Distribute a particular type of liquid from one well to a group of wells.
 
-        TODO: Add args description.
+        :param liquid_class: The type of liquid to move. You must specify the liquid class,
+            even if you have used :py:meth:`.load_liquid` to indicate what liquid the
+            source contains.
+        :type liquid_class: :py:class:`.LiquidClass`
 
-        :meta private:
+        :param volume: The amount, in µL, to aspirate from the source and dispense to
+                       each destination.
+        :param source: A single well to aspirate liquid from.
+        :param dest: A list of wells to dispense liquid into.
+        :param new_tip: When to pick up and drop tips during the command.
+            Defaults to ``"once"``.
+
+              - ``"once"``: Use one tip for the entire command.
+              - ``"always"``: Use a new tip for each set of aspirate and dispense steps.
+              - ``"never"``: Do not pick up or drop tips at all.
+
+            See :ref:`param-tip-handling` for details.
+
+        :param trash_location: A trash container, well, or other location to dispose of
+            tips. Depending on the liquid class, the pipette may also blow out liquid here.
+        :param return_tip: Whether to drop used tips in their original locations
+            in the tip rack, instead of the trash.
         """
         transfer_args = verify_and_normalize_transfer_args(
             source=source,
@@ -1659,12 +1696,30 @@ class InstrumentContext(publisher.CommandPublisher):
         visit_every_well: bool = False,
     ) -> InstrumentContext:
         """
-        Consolidate liquid from multiple sources to a single destination
-        using the specified liquid class properties.
+        Consolidate a particular type of liquid from a group of wells to one well.
 
-        TODO: Add args description.
+        :param liquid_class: The type of liquid to move. You must specify the liquid class,
+            even if you have used :py:meth:`.load_liquid` to indicate what liquid the
+            source contains.
+        :type liquid_class: :py:class:`.LiquidClass`
 
-        :meta private:
+        :param volume: The amount, in µL, to aspirate from the source and dispense to
+                       each destination.
+        :param source: A list of wells to aspirate liquid from.
+        :param dest: A single well to dispense liquid into.
+        :param new_tip: When to pick up and drop tips during the command.
+            Defaults to ``"once"``.
+
+              - ``"once"``: Use one tip for the entire command.
+              - ``"always"``: Use a new tip for each set of aspirate and dispense steps.
+              - ``"never"``: Do not pick up or drop tips at all.
+
+            See :ref:`param-tip-handling` for details.
+
+        :param trash_location: A trash container, well, or other location to dispose of
+            tips. Depending on the liquid class, the pipette may also blow out liquid here.
+        :param return_tip: Whether to drop used tips in their original locations
+            in the tip rack, instead of the trash.
         """
         transfer_args = verify_and_normalize_transfer_args(
             source=source,


### PR DESCRIPTION

# Overview

Adding methods like `transfer_with_liquid_class()` to the API reference.

Addresses RTC-610.

Any follow-up edits to these docstrings can be handled in #17992.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/api-ref-liquid-classes/v2/new_protocol_api.html)

## Changelog

- Param descriptions for the three main liquid class methods.
- Unhide the methods
- Add `LiquidClass` to the ref.
- Nitpicks to allow docs to build.

## Review requests

Are these "good enough"? Want to get these merged to keep other liquid class docs work moving.

## Risk assessment

low, docs