### PR TITLE
chore(shared-data): command schema bump version to 13

### DIFF
--- a/scripts/command_schema_diff.py
+++ b/scripts/command_schema_diff.py
@@ -1,0 +1,101 @@
+# /// script
+# requires-python = "==3.10.*"
+# dependencies = [
+#     "rich",
+#     "requests",
+# ]
+# ///
+
+import requests
+import sys
+import json
+import difflib
+from rich.prompt import IntPrompt, Prompt
+from rich.console import Console
+from rich.progress import Progress
+from rich.syntax import Syntax
+from rich.panel import Panel
+
+console = Console()
+
+BASE_URL_TEMPLATE = "https://raw.githubusercontent.com/Opentrons/opentrons/{branch}/shared-data/command/schemas/{schema}.json"
+
+
+def fetch_schema(branch, schema_number):
+    """Fetches the schema file from GitHub for a given branch and schema number."""
+    url = BASE_URL_TEMPLATE.format(branch=branch, schema=schema_number)
+    console.print(f"[bold blue]Fetching schema from:[/bold blue] {url}")
+
+    try:
+        with Progress() as progress:
+            task = progress.add_task("[green]Downloading...", total=100)
+            response = requests.get(url, timeout=10)
+            progress.update(task, advance=100)
+
+        if response.status_code == 200:
+            console.print(
+                f"[bold green]Download successful from {branch}![/bold green]"
+            )
+            return response.json()
+        else:
+            console.print(
+                f"[bold red]Failed to retrieve schema from {branch}: {response.status_code}[/bold red]"
+            )
+            return None
+    except requests.RequestException as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        return None
+
+
+def compare_schemas(schema1, schema2):
+    """Compares two JSON schemas and prints the differences."""
+    schema1_str = json.dumps(schema1, indent=2, sort_keys=True)
+    schema2_str = json.dumps(schema2, indent=2, sort_keys=True)
+
+    if schema1_str == schema2_str:
+        console.print("[bold green]No differences found! ✅[/bold green]")
+        return
+
+    console.print("[bold yellow]Differences found:[/bold yellow] ❗")
+    diff = difflib.unified_diff(
+        schema1_str.splitlines(),
+        schema2_str.splitlines(),
+        fromfile="edge.json",
+        tofile="branch.json",
+        lineterm="",
+    )
+
+    diff_output = "\n".join(diff)
+    console.print(
+        Panel(Syntax(diff_output, "diff", theme="monokai", line_numbers=True))
+    )
+
+
+def main():
+    """Main function to handle interactive and non-interactive modes."""
+    if len(sys.argv) > 2:
+        try:
+            schema_number = int(sys.argv[1])
+            branch = sys.argv[2]
+        except ValueError:
+            console.print(
+                "[bold red]Invalid input. Schema number must be an integer.[/bold red]"
+            )
+            sys.exit(1)
+    else:
+        schema_number = IntPrompt.ask(
+            "[bold yellow]Enter the schema number[/bold yellow]"
+        )
+        branch = Prompt.ask(
+            "[bold yellow]Enter the branch to compare against edge[/bold yellow]"
+        )
+
+    schema_edge = fetch_schema("edge", schema_number)
+    schema_branch = fetch_schema(branch, schema_number)
+
+    if schema_edge and schema_branch:
+        compare_schemas(schema_edge, schema_branch)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared-data/command/index.ts
+++ b/shared-data/command/index.ts
@@ -2,7 +2,18 @@ import commandSchemaV7 from './schemas/7.json'
 import commandSchemaV8 from './schemas/8.json'
 import commandSchemaV9 from './schemas/9.json'
 import commandSchemaV10 from './schemas/10.json'
+import commandSchemaV11 from './schemas/11.json'
+import commandSchemaV12 from './schemas/12.json'
+import commandSchemaV13 from './schemas/13.json'
 export * from './types/index'
-export const commandSchemaLatest = commandSchemaV10
+export const commandSchemaLatest = commandSchemaV13
 
-export { commandSchemaV7, commandSchemaV8, commandSchemaV9, commandSchemaV10 }
+export {
+  commandSchemaV7,
+  commandSchemaV8,
+  commandSchemaV9,
+  commandSchemaV10,
+  commandSchemaV11,
+  commandSchemaV12,
+  commandSchemaV13,
+}

--- a/shared-data/command/schemas/13.json
+++ b/shared-data/command/schemas/13.json
@@ -1,0 +1,7078 @@
+{
+  "$defs": {
+    "AddressableAreaLocation": {
+      "description": "The location of something place in an addressable area. This is a superset of deck slots.",
+      "properties": {
+        "addressableAreaName": {
+          "description": "The name of the addressable area that you want to use. Valid values are the `id`s of `addressableArea`s in the [deck definition](https://github.com/Opentrons/opentrons/tree/edge/shared-data/deck).",
+          "title": "Addressableareaname",
+          "type": "string"
+        }
+      },
+      "required": ["addressableAreaName"],
+      "title": "AddressableAreaLocation",
+      "type": "object"
+    },
+    "AddressableOffsetVector": {
+      "description": "Offset, in deck coordinates, from nominal to actual position of an addressable area.",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": ["x", "y", "z"],
+      "title": "AddressableOffsetVector",
+      "type": "object"
+    },
+    "AirGapInPlaceCreate": {
+      "description": "AirGapInPlace command request model.",
+      "properties": {
+        "commandType": {
+          "const": "airGapInPlace",
+          "default": "airGapInPlace",
+          "enum": ["airGapInPlace"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/AirGapInPlaceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "AirGapInPlaceCreate",
+      "type": "object"
+    },
+    "AirGapInPlaceParams": {
+      "description": "Payload required to air gap in place.",
+      "properties": {
+        "correctionVolume": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The correction volume in uL.",
+          "title": "Correctionvolume"
+        },
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "volume": {
+          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        }
+      },
+      "required": ["flowRate", "volume", "pipetteId"],
+      "title": "AirGapInPlaceParams",
+      "type": "object"
+    },
+    "AllNozzleLayoutConfiguration": {
+      "description": "All basemodel to represent a reset to the nozzle configuration. Sending no parameters resets to default.",
+      "properties": {
+        "style": {
+          "const": "ALL",
+          "default": "ALL",
+          "enum": ["ALL"],
+          "title": "Style",
+          "type": "string"
+        }
+      },
+      "title": "AllNozzleLayoutConfiguration",
+      "type": "object"
+    },
+    "AspirateCreate": {
+      "description": "Create aspirate command request model.",
+      "properties": {
+        "commandType": {
+          "const": "aspirate",
+          "default": "aspirate",
+          "enum": ["aspirate"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/AspirateParams"
+        }
+      },
+      "required": ["params"],
+      "title": "AspirateCreate",
+      "type": "object"
+    },
+    "AspirateInPlaceCreate": {
+      "description": "AspirateInPlace command request model.",
+      "properties": {
+        "commandType": {
+          "const": "aspirateInPlace",
+          "default": "aspirateInPlace",
+          "enum": ["aspirateInPlace"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/AspirateInPlaceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "AspirateInPlaceCreate",
+      "type": "object"
+    },
+    "AspirateInPlaceParams": {
+      "description": "Payload required to aspirate in place.",
+      "properties": {
+        "correctionVolume": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The correction volume in uL.",
+          "title": "Correctionvolume"
+        },
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "volume": {
+          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        }
+      },
+      "required": ["flowRate", "volume", "pipetteId"],
+      "title": "AspirateInPlaceParams",
+      "type": "object"
+    },
+    "AspirateParams": {
+      "description": "Parameters required to aspirate from a specific well.",
+      "properties": {
+        "correctionVolume": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The correction volume in uL.",
+          "title": "Correctionvolume"
+        },
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "volume": {
+          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/LiquidHandlingWellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "title": "AspirateParams",
+      "type": "object"
+    },
+    "AspirateProperties": {
+      "description": "Properties specific to the aspirate function.",
+      "properties": {
+        "correctionByVolume": {
+          "description": "Settings for volume correction keyed by by target aspiration volume, representing additional volume the plunger should move to accurately hit target volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Correctionbyvolume",
+          "type": "array"
+        },
+        "delay": {
+          "$ref": "#/$defs/DelayProperties",
+          "description": "Delay settings after an aspirate"
+        },
+        "flowRateByVolume": {
+          "description": "Settings for flow rate keyed by target aspiration volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Flowratebyvolume",
+          "type": "array"
+        },
+        "mix": {
+          "$ref": "#/$defs/MixProperties",
+          "description": "Mixing settings for before an aspirate"
+        },
+        "offset": {
+          "$ref": "#/$defs/Coordinate",
+          "description": "Relative offset for aspiration."
+        },
+        "positionReference": {
+          "$ref": "#/$defs/PositionReference",
+          "description": "Position reference for aspiration."
+        },
+        "preWet": {
+          "description": "Whether to perform a pre-wet action.",
+          "title": "Prewet",
+          "type": "boolean"
+        },
+        "retract": {
+          "$ref": "#/$defs/RetractAspirate",
+          "description": "Pipette retract settings after an aspirate."
+        },
+        "submerge": {
+          "$ref": "#/$defs/Submerge",
+          "description": "Submerge settings for aspirate."
+        }
+      },
+      "required": [
+        "submerge",
+        "retract",
+        "positionReference",
+        "offset",
+        "flowRateByVolume",
+        "correctionByVolume",
+        "preWet",
+        "mix",
+        "delay"
+      ],
+      "title": "AspirateProperties",
+      "type": "object"
+    },
+    "AspirateWhileTrackingCreate": {
+      "description": "Create aspirateWhileTracking command request model.",
+      "properties": {
+        "commandType": {
+          "const": "aspirateWhileTracking",
+          "default": "aspirateWhileTracking",
+          "enum": ["aspirateWhileTracking"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/AspirateWhileTrackingParams"
+        }
+      },
+      "required": ["params"],
+      "title": "AspirateWhileTrackingCreate",
+      "type": "object"
+    },
+    "AspirateWhileTrackingParams": {
+      "description": "Parameters required to aspirate from a specific well.",
+      "properties": {
+        "correctionVolume": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The correction volume in uL.",
+          "title": "Correctionvolume"
+        },
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "volume": {
+          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/LiquidHandlingWellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "title": "AspirateWhileTrackingParams",
+      "type": "object"
+    },
+    "BlowOutCreate": {
+      "description": "Create blow-out command request model.",
+      "properties": {
+        "commandType": {
+          "const": "blowout",
+          "default": "blowout",
+          "enum": ["blowout"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/BlowOutParams"
+        }
+      },
+      "required": ["params"],
+      "title": "BlowOutCreate",
+      "type": "object"
+    },
+    "BlowOutInPlaceCreate": {
+      "description": "BlowOutInPlace command request model.",
+      "properties": {
+        "commandType": {
+          "const": "blowOutInPlace",
+          "default": "blowOutInPlace",
+          "enum": ["blowOutInPlace"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/BlowOutInPlaceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "BlowOutInPlaceCreate",
+      "type": "object"
+    },
+    "BlowOutInPlaceParams": {
+      "description": "Payload required to blow-out in place.",
+      "properties": {
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["flowRate", "pipetteId"],
+      "title": "BlowOutInPlaceParams",
+      "type": "object"
+    },
+    "BlowOutParams": {
+      "description": "Payload required to blow-out a specific well.",
+      "properties": {
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/WellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"],
+      "title": "BlowOutParams",
+      "type": "object"
+    },
+    "BlowoutLocation": {
+      "description": "Location for blowout during a transfer function.",
+      "enum": ["source", "destination", "trash"],
+      "title": "BlowoutLocation",
+      "type": "string"
+    },
+    "BlowoutParams": {
+      "description": "Parameters for blowout.",
+      "properties": {
+        "flowRate": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0.0,
+              "type": "number"
+            }
+          ],
+          "description": "Flow rate for blow out, in microliters per second.",
+          "title": "Flowrate"
+        },
+        "location": {
+          "$ref": "#/$defs/BlowoutLocation",
+          "description": "Location well or trash entity for blow out."
+        }
+      },
+      "required": ["location", "flowRate"],
+      "title": "BlowoutParams",
+      "type": "object"
+    },
+    "BlowoutProperties": {
+      "description": "Blowout properties.",
+      "properties": {
+        "enable": {
+          "description": "Whether blow-out is enabled.",
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "params": {
+          "$ref": "#/$defs/BlowoutParams",
+          "description": "Parameters for the blowout function.",
+          "title": "Params"
+        }
+      },
+      "required": ["enable"],
+      "title": "BlowoutProperties",
+      "type": "object"
+    },
+    "CalibrateGripperCreate": {
+      "description": "A request to create a `calibrateGripper` command.",
+      "properties": {
+        "commandType": {
+          "const": "calibration/calibrateGripper",
+          "default": "calibration/calibrateGripper",
+          "enum": ["calibration/calibrateGripper"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CalibrateGripperParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CalibrateGripperCreate",
+      "type": "object"
+    },
+    "CalibrateGripperParams": {
+      "description": "Parameters for a `calibrateGripper` command.",
+      "properties": {
+        "jaw": {
+          "$ref": "#/$defs/CalibrateGripperParamsJaw",
+          "description": "Which of the gripper's jaws to use to measure its offset. The robot will assume that a human operator has already attached the capacitive probe to the jaw and none is attached to the other jaw."
+        },
+        "otherJawOffset": {
+          "$ref": "#/$defs/Vec3f",
+          "description": "If an offset for the other probe is already found, then specifying it here will enable the CalibrateGripper command to complete the calibration process by calculating the total offset and saving it to disk. If this param is not specified then the command will only find and return the offset for the specified probe.",
+          "title": "Otherjawoffset"
+        }
+      },
+      "required": ["jaw"],
+      "title": "CalibrateGripperParams",
+      "type": "object"
+    },
+    "CalibrateGripperParamsJaw": {
+      "enum": ["front", "rear"],
+      "title": "CalibrateGripperParamsJaw",
+      "type": "string"
+    },
+    "CalibrateModuleCreate": {
+      "description": "Create calibrate-module command request model.",
+      "properties": {
+        "commandType": {
+          "const": "calibration/calibrateModule",
+          "default": "calibration/calibrateModule",
+          "enum": ["calibration/calibrateModule"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CalibrateModuleParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CalibrateModuleCreate",
+      "type": "object"
+    },
+    "CalibrateModuleParams": {
+      "description": "Payload required to calibrate-module.",
+      "properties": {
+        "labwareId": {
+          "description": "The unique id of module calibration adapter labware.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "moduleId": {
+          "description": "The unique id of module to calibrate.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "mount": {
+          "$ref": "#/$defs/MountType",
+          "description": "The instrument mount used to calibrate the module."
+        }
+      },
+      "required": ["moduleId", "labwareId", "mount"],
+      "title": "CalibrateModuleParams",
+      "type": "object"
+    },
+    "CalibratePipetteCreate": {
+      "description": "Create calibrate-pipette command request model.",
+      "properties": {
+        "commandType": {
+          "const": "calibration/calibratePipette",
+          "default": "calibration/calibratePipette",
+          "enum": ["calibration/calibratePipette"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CalibratePipetteParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CalibratePipetteCreate",
+      "type": "object"
+    },
+    "CalibratePipetteParams": {
+      "description": "Payload required to calibrate-pipette.",
+      "properties": {
+        "mount": {
+          "$ref": "#/$defs/MountType",
+          "description": "Instrument mount to calibrate."
+        }
+      },
+      "required": ["mount"],
+      "title": "CalibratePipetteParams",
+      "type": "object"
+    },
+    "CloseLabwareLatchCreate": {
+      "description": "A request to create a Heater-Shaker's close latch command.",
+      "properties": {
+        "commandType": {
+          "const": "heaterShaker/closeLabwareLatch",
+          "default": "heaterShaker/closeLabwareLatch",
+          "enum": ["heaterShaker/closeLabwareLatch"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CloseLabwareLatchParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CloseLabwareLatchCreate",
+      "type": "object"
+    },
+    "CloseLabwareLatchParams": {
+      "description": "Input parameters to close a Heater-Shaker Module's labware latch.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "CloseLabwareLatchParams",
+      "type": "object"
+    },
+    "CloseLatchCreate": {
+      "description": "A request to execute a Flex Stacker CloseLatch command.",
+      "properties": {
+        "commandType": {
+          "const": "flexStacker/closeLatch",
+          "default": "flexStacker/closeLatch",
+          "enum": ["flexStacker/closeLatch"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CloseLatchParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CloseLatchCreate",
+      "type": "object"
+    },
+    "CloseLatchParams": {
+      "description": "The parameters defining how a stacker should close its latch.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Flex Stacker",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "CloseLatchParams",
+      "type": "object"
+    },
+    "ColumnNozzleLayoutConfiguration": {
+      "description": "Information required for nozzle configurations of type ROW and COLUMN.",
+      "properties": {
+        "primaryNozzle": {
+          "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
+          "enum": ["A1", "H1", "A12", "H12"],
+          "title": "Primarynozzle",
+          "type": "string"
+        },
+        "style": {
+          "const": "COLUMN",
+          "default": "COLUMN",
+          "enum": ["COLUMN"],
+          "title": "Style",
+          "type": "string"
+        }
+      },
+      "required": ["primaryNozzle"],
+      "title": "ColumnNozzleLayoutConfiguration",
+      "type": "object"
+    },
+    "CommandIntent": {
+      "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
+      "enum": ["protocol", "setup", "fixit"],
+      "title": "CommandIntent",
+      "type": "string"
+    },
+    "CommentCreate": {
+      "description": "Comment command request model.",
+      "properties": {
+        "commandType": {
+          "const": "comment",
+          "default": "comment",
+          "enum": ["comment"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CommentParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CommentCreate",
+      "type": "object"
+    },
+    "CommentParams": {
+      "description": "Payload required to annotate execution with a comment.",
+      "properties": {
+        "message": {
+          "description": "A user-facing message",
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": ["message"],
+      "title": "CommentParams",
+      "type": "object"
+    },
+    "ConfigureForVolumeCreate": {
+      "description": "Configure for volume command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "configureForVolume",
+          "default": "configureForVolume",
+          "enum": ["configureForVolume"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ConfigureForVolumeParams"
+        }
+      },
+      "required": ["params"],
+      "title": "ConfigureForVolumeCreate",
+      "type": "object"
+    },
+    "ConfigureForVolumeParams": {
+      "description": "Parameters required to configure volume for a specific pipette.",
+      "properties": {
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "tipOverlapNotAfterVersion": {
+          "description": "A version of tip overlap data to not exceed. The highest-versioned tip overlap data that does not exceed this version will be used. Versions are expressed as vN where N is an integer, counting up from v0. If None, the current highest version will be used.",
+          "title": "Tipoverlapnotafterversion",
+          "type": "string"
+        },
+        "volume": {
+          "description": "Amount of liquid in uL. Must be at least 0 and no greater than a pipette-specific maximum volume.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        }
+      },
+      "required": ["pipetteId", "volume"],
+      "title": "ConfigureForVolumeParams",
+      "type": "object"
+    },
+    "ConfigureNozzleLayoutCreate": {
+      "description": "Configure nozzle layout creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "configureNozzleLayout",
+          "default": "configureNozzleLayout",
+          "enum": ["configureNozzleLayout"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ConfigureNozzleLayoutParams"
+        }
+      },
+      "required": ["params"],
+      "title": "ConfigureNozzleLayoutCreate",
+      "type": "object"
+    },
+    "ConfigureNozzleLayoutParams": {
+      "description": "Parameters required to configure the nozzle layout for a specific pipette.",
+      "properties": {
+        "configurationParams": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AllNozzleLayoutConfiguration"
+            },
+            {
+              "$ref": "#/$defs/SingleNozzleLayoutConfiguration"
+            },
+            {
+              "$ref": "#/$defs/RowNozzleLayoutConfiguration"
+            },
+            {
+              "$ref": "#/$defs/ColumnNozzleLayoutConfiguration"
+            },
+            {
+              "$ref": "#/$defs/QuadrantNozzleLayoutConfiguration"
+            }
+          ],
+          "title": "Configurationparams"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId", "configurationParams"],
+      "title": "ConfigureNozzleLayoutParams",
+      "type": "object"
+    },
+    "Coordinate": {
+      "description": "Three-dimensional coordinates.",
+      "properties": {
+        "x": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "title": "X"
+        },
+        "y": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "title": "Y"
+        },
+        "z": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "title": "Z"
+        }
+      },
+      "required": ["x", "y", "z"],
+      "title": "Coordinate",
+      "type": "object"
+    },
+    "CustomCreate": {
+      "description": "A request to create a custom command.",
+      "properties": {
+        "commandType": {
+          "const": "custom",
+          "default": "custom",
+          "enum": ["custom"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CustomParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CustomCreate",
+      "type": "object"
+    },
+    "CustomParams": {
+      "additionalProperties": true,
+      "description": "Payload used by a custom command.",
+      "properties": {},
+      "title": "CustomParams",
+      "type": "object"
+    },
+    "DeactivateBlockCreate": {
+      "description": "A request to create a Thermocycler's deactivate block command.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/deactivateBlock",
+          "default": "thermocycler/deactivateBlock",
+          "enum": ["thermocycler/deactivateBlock"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DeactivateBlockParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DeactivateBlockCreate",
+      "type": "object"
+    },
+    "DeactivateBlockParams": {
+      "description": "Input parameters to unset a Thermocycler's target block temperature.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "DeactivateBlockParams",
+      "type": "object"
+    },
+    "DeactivateHeaterCreate": {
+      "description": "A request to create a Heater-Shaker's deactivate heater command.",
+      "properties": {
+        "commandType": {
+          "const": "heaterShaker/deactivateHeater",
+          "default": "heaterShaker/deactivateHeater",
+          "enum": ["heaterShaker/deactivateHeater"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DeactivateHeaterParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DeactivateHeaterCreate",
+      "type": "object"
+    },
+    "DeactivateHeaterParams": {
+      "description": "Input parameters to unset a Heater-Shaker's target temperature.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "DeactivateHeaterParams",
+      "type": "object"
+    },
+    "DeactivateLidCreate": {
+      "description": "A request to create a Thermocycler's deactivate lid command.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/deactivateLid",
+          "default": "thermocycler/deactivateLid",
+          "enum": ["thermocycler/deactivateLid"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DeactivateLidParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DeactivateLidCreate",
+      "type": "object"
+    },
+    "DeactivateLidParams": {
+      "description": "Input parameters to unset a Thermocycler's target lid temperature.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "DeactivateLidParams",
+      "type": "object"
+    },
+    "DeactivateShakerCreate": {
+      "description": "A request to create a Heater-Shaker's deactivate shaker command.",
+      "properties": {
+        "commandType": {
+          "const": "heaterShaker/deactivateShaker",
+          "default": "heaterShaker/deactivateShaker",
+          "enum": ["heaterShaker/deactivateShaker"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DeactivateShakerParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DeactivateShakerCreate",
+      "type": "object"
+    },
+    "DeactivateShakerParams": {
+      "description": "Input parameters to deactivate shaker for a Heater-Shaker Module.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "DeactivateShakerParams",
+      "type": "object"
+    },
+    "DeactivateTemperatureCreate": {
+      "description": "A request to deactivate a Temperature Module.",
+      "properties": {
+        "commandType": {
+          "const": "temperatureModule/deactivate",
+          "default": "temperatureModule/deactivate",
+          "enum": ["temperatureModule/deactivate"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DeactivateTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DeactivateTemperatureCreate",
+      "type": "object"
+    },
+    "DeactivateTemperatureParams": {
+      "description": "Input parameters to deactivate a Temperature Module.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Temperature Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "DeactivateTemperatureParams",
+      "type": "object"
+    },
+    "DeckPoint": {
+      "description": "Coordinates of a point in deck space.",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": ["x", "y", "z"],
+      "title": "DeckPoint",
+      "type": "object"
+    },
+    "DeckSlotLocation": {
+      "description": "The location of something placed in a single deck slot.",
+      "properties": {
+        "slotName": {
+          "$ref": "#/$defs/DeckSlotName",
+          "description": "A slot on the robot's deck.\n\nThe plain numbers like `\"5\"` are for the OT-2, and the coordinates like `\"C2\"` are for the Flex.\n\nWhen you provide one of these values, you can use either style. It will automatically be converted to match the robot.\n\nWhen one of these values is returned, it will always match the robot."
+        }
+      },
+      "required": ["slotName"],
+      "title": "DeckSlotLocation",
+      "type": "object"
+    },
+    "DeckSlotName": {
+      "description": "Deck slot identifiers.",
+      "enum": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "A1",
+        "A2",
+        "A3",
+        "B1",
+        "B2",
+        "B3",
+        "C1",
+        "C2",
+        "C3",
+        "D1",
+        "D2",
+        "D3"
+      ],
+      "title": "DeckSlotName",
+      "type": "string"
+    },
+    "DelayParams": {
+      "description": "Parameters for delay.",
+      "properties": {
+        "duration": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0.0,
+              "type": "number"
+            }
+          ],
+          "description": "Duration of delay, in seconds.",
+          "title": "Duration"
+        }
+      },
+      "required": ["duration"],
+      "title": "DelayParams",
+      "type": "object"
+    },
+    "DelayProperties": {
+      "description": "Shared properties for delay..",
+      "properties": {
+        "enable": {
+          "description": "Whether delay is enabled.",
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "params": {
+          "$ref": "#/$defs/DelayParams",
+          "description": "Parameters for the delay function.",
+          "title": "Params"
+        }
+      },
+      "required": ["enable"],
+      "title": "DelayProperties",
+      "type": "object"
+    },
+    "DisengageCreate": {
+      "description": "A request to create a Magnetic Module disengage command.",
+      "properties": {
+        "commandType": {
+          "const": "magneticModule/disengage",
+          "default": "magneticModule/disengage",
+          "enum": ["magneticModule/disengage"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DisengageParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DisengageCreate",
+      "type": "object"
+    },
+    "DisengageParams": {
+      "description": "Input data to disengage a Magnetic Module's magnets.",
+      "properties": {
+        "moduleId": {
+          "description": "The ID of the Magnetic Module whose magnets you want to disengage, from a prior `loadModule` command.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "DisengageParams",
+      "type": "object"
+    },
+    "DispenseCreate": {
+      "description": "Create dispense command request model.",
+      "properties": {
+        "commandType": {
+          "const": "dispense",
+          "default": "dispense",
+          "enum": ["dispense"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DispenseParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DispenseCreate",
+      "type": "object"
+    },
+    "DispenseInPlaceCreate": {
+      "description": "DispenseInPlace command request model.",
+      "properties": {
+        "commandType": {
+          "const": "dispenseInPlace",
+          "default": "dispenseInPlace",
+          "enum": ["dispenseInPlace"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DispenseInPlaceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DispenseInPlaceCreate",
+      "type": "object"
+    },
+    "DispenseInPlaceParams": {
+      "description": "Payload required to dispense in place.",
+      "properties": {
+        "correctionVolume": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The correction volume in uL.",
+          "title": "Correctionvolume"
+        },
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "pushOut": {
+          "description": "push the plunger a small amount farther than necessary for accurate low-volume dispensing",
+          "title": "Pushout",
+          "type": "number"
+        },
+        "volume": {
+          "description": "The amount of liquid to dispense, in \u00b5L. Must not be greater than the currently aspirated volume. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        }
+      },
+      "required": ["flowRate", "volume", "pipetteId"],
+      "title": "DispenseInPlaceParams",
+      "type": "object"
+    },
+    "DispenseParams": {
+      "description": "Payload required to dispense to a specific well.",
+      "properties": {
+        "correctionVolume": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The correction volume in uL.",
+          "title": "Correctionvolume"
+        },
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "pushOut": {
+          "description": "push the plunger a small amount farther than necessary for accurate low-volume dispensing",
+          "title": "Pushout",
+          "type": "number"
+        },
+        "volume": {
+          "description": "The amount of liquid to dispense, in \u00b5L. Must not be greater than the currently aspirated volume. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/LiquidHandlingWellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "title": "DispenseParams",
+      "type": "object"
+    },
+    "DispenseWhileTrackingCreate": {
+      "description": "Create dispenseWhileTracking command request model.",
+      "properties": {
+        "commandType": {
+          "const": "dispenseWhileTracking",
+          "default": "dispenseWhileTracking",
+          "enum": ["dispenseWhileTracking"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DispenseWhileTrackingParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DispenseWhileTrackingCreate",
+      "type": "object"
+    },
+    "DispenseWhileTrackingParams": {
+      "description": "Payload required to dispense to a specific well.",
+      "properties": {
+        "correctionVolume": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The correction volume in uL.",
+          "title": "Correctionvolume"
+        },
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "pushOut": {
+          "description": "push the plunger a small amount farther than necessary for accurate low-volume dispensing",
+          "title": "Pushout",
+          "type": "number"
+        },
+        "volume": {
+          "description": "The amount of liquid to dispense, in \u00b5L. Must not be greater than the currently aspirated volume. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/LiquidHandlingWellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "title": "DispenseWhileTrackingParams",
+      "type": "object"
+    },
+    "DropTipCreate": {
+      "description": "Drop tip command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "dropTip",
+          "default": "dropTip",
+          "enum": ["dropTip"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DropTipParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DropTipCreate",
+      "type": "object"
+    },
+    "DropTipInPlaceCreate": {
+      "description": "Drop tip in place command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "dropTipInPlace",
+          "default": "dropTipInPlace",
+          "enum": ["dropTipInPlace"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/DropTipInPlaceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "DropTipInPlaceCreate",
+      "type": "object"
+    },
+    "DropTipInPlaceParams": {
+      "description": "Payload required to drop a tip in place.",
+      "properties": {
+        "homeAfter": {
+          "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
+          "title": "Homeafter",
+          "type": "boolean"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId"],
+      "title": "DropTipInPlaceParams",
+      "type": "object"
+    },
+    "DropTipParams": {
+      "description": "Payload required to drop a tip in a specific well.",
+      "properties": {
+        "alternateDropLocation": {
+          "description": "Whether to alternate location where tip is dropped within the labware. If True, this command will ignore the wellLocation provided and alternate between dropping tips at two predetermined locations inside the specified labware well. If False, the tip will be dropped at the top center of the well.",
+          "title": "Alternatedroplocation",
+          "type": "boolean"
+        },
+        "homeAfter": {
+          "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
+          "title": "Homeafter",
+          "type": "boolean"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "scrape_tips": {
+          "description": "Whether or not to scrape off the tips with the ejector all the way down. If True, and the target location is a tip rack well, it will move the pipette. Towards the center of the tip rack with the ejector in the 'drop_tip' position. If False, no horizontal movement will occur.",
+          "title": "Scrape Tips",
+          "type": "boolean"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/DropTipWellLocation",
+          "description": "Relative well location at which to drop the tip."
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId", "labwareId", "wellName"],
+      "title": "DropTipParams",
+      "type": "object"
+    },
+    "DropTipWellLocation": {
+      "description": "Like WellLocation, but for dropping tips.\n\nUnlike a typical WellLocation, the location for a drop tip\ndefaults to location based on the tip length rather than the well's top.",
+      "properties": {
+        "offset": {
+          "$ref": "#/$defs/WellOffset"
+        },
+        "origin": {
+          "$ref": "#/$defs/DropTipWellOrigin",
+          "default": "default"
+        }
+      },
+      "title": "DropTipWellLocation",
+      "type": "object"
+    },
+    "DropTipWellOrigin": {
+      "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
+      "enum": ["top", "bottom", "center", "default"],
+      "title": "DropTipWellOrigin",
+      "type": "string"
+    },
+    "EmptyCreate": {
+      "description": "A request to execute a Flex Stacker empty command.",
+      "properties": {
+        "commandType": {
+          "const": "flexStacker/empty",
+          "default": "flexStacker/empty",
+          "enum": ["flexStacker/empty"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/EmptyParams"
+        }
+      },
+      "required": ["params"],
+      "title": "EmptyCreate",
+      "type": "object"
+    },
+    "EmptyParams": {
+      "description": "The parameters defining how a stacker should be emptied.",
+      "properties": {
+        "count": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The new count of labware in the pool. If None, default to an empty pool. If this number is larger than the amount of labware currently in the pool, default to the smaller amount. Do not use the value in the parameters as an outside observer; instead, use the count value from the results.",
+          "title": "Count"
+        },
+        "message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The message to display on connected clients during a manualWithPause strategy empty.",
+          "title": "Message"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Flex Stacker",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "strategy": {
+          "$ref": "#/$defs/StackerFillEmptyStrategy",
+          "description": "How to empty the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and mark the labware pool as empty thereafter. If logical, do not pause but immediately apply the specified count."
+        }
+      },
+      "required": ["moduleId", "strategy"],
+      "title": "EmptyParams",
+      "type": "object"
+    },
+    "EngageCreate": {
+      "description": "A request to create a Magnetic Module engage command.",
+      "properties": {
+        "commandType": {
+          "const": "magneticModule/engage",
+          "default": "magneticModule/engage",
+          "enum": ["magneticModule/engage"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/EngageParams"
+        }
+      },
+      "required": ["params"],
+      "title": "EngageCreate",
+      "type": "object"
+    },
+    "EngageParams": {
+      "description": "Input data to engage a Magnetic Module.",
+      "properties": {
+        "height": {
+          "description": "How high, in millimeters, to raise the magnets.\n\nZero means the tops of the magnets are level with the ledge that the labware rests on. This will be slightly above the magnets' minimum height, the hardware home position. Negative values are allowed, to put the magnets below the ledge.\n\nUnits are always true millimeters. This is unlike certain labware definitions, engage commands in the Python Protocol API, and engage commands in older versions of the JSON protocol schema. Take care to convert properly.",
+          "title": "Height",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "The ID of the Magnetic Module whose magnets you want to raise, from a prior `loadModule` command.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId", "height"],
+      "title": "EngageParams",
+      "type": "object"
+    },
+    "EvotipDispenseCreate": {
+      "description": "DispenseInPlace command request model.",
+      "properties": {
+        "commandType": {
+          "const": "evotipDispense",
+          "default": "evotipDispense",
+          "enum": ["evotipDispense"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/EvotipDispenseParams"
+        }
+      },
+      "required": ["params"],
+      "title": "EvotipDispenseCreate",
+      "type": "object"
+    },
+    "EvotipDispenseParams": {
+      "description": "Payload required to dispense in place.",
+      "properties": {
+        "correctionVolume": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The correction volume in uL.",
+          "title": "Correctionvolume"
+        },
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "volume": {
+          "description": "The amount of liquid to dispense, in \u00b5L. Must not be greater than the currently aspirated volume. There is some tolerance for floating point rounding errors.",
+          "minimum": 0.0,
+          "title": "Volume",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/LiquidHandlingWellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "title": "EvotipDispenseParams",
+      "type": "object"
+    },
+    "EvotipSealPipetteCreate": {
+      "description": "Seal evotip resin tip command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "evotipSealPipette",
+          "default": "evotipSealPipette",
+          "enum": ["evotipSealPipette"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/EvotipSealPipetteParams"
+        }
+      },
+      "required": ["params"],
+      "title": "EvotipSealPipetteCreate",
+      "type": "object"
+    },
+    "EvotipSealPipetteParams": {
+      "description": "Payload needed to seal resin tips to a pipette.",
+      "properties": {
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "tipPickUpParams": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TipPickUpParams"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Specific parameters for "
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/PickUpTipWellLocation",
+          "description": "Relative well location at which to pick up the tip."
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId", "labwareId", "wellName"],
+      "title": "EvotipSealPipetteParams",
+      "type": "object"
+    },
+    "EvotipUnsealPipetteCreate": {
+      "description": "Evotip unseal command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "evotipUnsealPipette",
+          "default": "evotipUnsealPipette",
+          "enum": ["evotipUnsealPipette"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/EvotipUnsealPipetteParams"
+        }
+      },
+      "required": ["params"],
+      "title": "EvotipUnsealPipetteCreate",
+      "type": "object"
+    },
+    "EvotipUnsealPipetteParams": {
+      "description": "Payload required to drop a tip in a specific well.",
+      "properties": {
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/DropTipWellLocation",
+          "description": "Relative well location at which to drop the tip."
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId", "labwareId", "wellName"],
+      "title": "EvotipUnsealPipetteParams",
+      "type": "object"
+    },
+    "FillCreate": {
+      "description": "A request to execute a Flex Stacker fill command.",
+      "properties": {
+        "commandType": {
+          "const": "flexStacker/fill",
+          "default": "flexStacker/fill",
+          "enum": ["flexStacker/fill"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/FillParams"
+        }
+      },
+      "required": ["params"],
+      "title": "FillCreate",
+      "type": "object"
+    },
+    "FillParams": {
+      "description": "The parameters defining how a stacker should be filled.",
+      "properties": {
+        "count": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "How full the labware pool should now be. If None, default to the maximum amount of the currently-configured labware the pool can hold. If this number is larger than the maximum the pool can hold, it will be clamped to the maximum. If this number is smaller than the current amount of labware the pool holds, it will be clamped to that minimum. Do not use the value in the parameters as an outside observer; instead, use the count value from the results.",
+          "title": "Count"
+        },
+        "message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The message to display on connected clients during a manualWithPause strategy fill.",
+          "title": "Message"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Flex Stacker",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "strategy": {
+          "$ref": "#/$defs/StackerFillEmptyStrategy",
+          "description": "How to fill the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and apply the new specified count thereafter. If logical, do not pause but immediately apply the specified count."
+        }
+      },
+      "required": ["moduleId", "strategy"],
+      "title": "FillParams",
+      "type": "object"
+    },
+    "GetNextTipCreate": {
+      "description": "Get next tip command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "getNextTip",
+          "default": "getNextTip",
+          "enum": ["getNextTip"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/GetNextTipParams"
+        }
+      },
+      "required": ["params"],
+      "title": "GetNextTipCreate",
+      "type": "object"
+    },
+    "GetNextTipParams": {
+      "description": "Payload needed to resolve the next available tip.",
+      "properties": {
+        "labwareIds": {
+          "description": "Labware ID(s) of tip racks to resolve next available tip(s) from Labware IDs will be resolved sequentially",
+          "items": {
+            "type": "string"
+          },
+          "title": "Labwareids",
+          "type": "array"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "startingTipWell": {
+          "description": "Name of starting tip rack 'well'. This only applies to the first tip rack in the list provided in labwareIDs",
+          "title": "Startingtipwell",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId", "labwareIds"],
+      "title": "GetNextTipParams",
+      "type": "object"
+    },
+    "GetTipPresenceCreate": {
+      "description": "GetTipPresence command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "getTipPresence",
+          "default": "getTipPresence",
+          "enum": ["getTipPresence"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/GetTipPresenceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "GetTipPresenceCreate",
+      "type": "object"
+    },
+    "GetTipPresenceParams": {
+      "description": "Payload required for a GetTipPresence command.",
+      "properties": {
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId"],
+      "title": "GetTipPresenceParams",
+      "type": "object"
+    },
+    "HomeCreate": {
+      "description": "Data to create a Home command.",
+      "properties": {
+        "commandType": {
+          "const": "home",
+          "default": "home",
+          "enum": ["home"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/HomeParams"
+        }
+      },
+      "required": ["params"],
+      "title": "HomeCreate",
+      "type": "object"
+    },
+    "HomeParams": {
+      "description": "Payload required for a Home command.",
+      "properties": {
+        "axes": {
+          "description": "Axes to return to their home positions. If omitted, will home all motors. Extra axes may be implicitly homed to ensure accurate homing of the explicitly specified axes.",
+          "items": {
+            "$ref": "#/$defs/MotorAxis"
+          },
+          "title": "Axes",
+          "type": "array"
+        },
+        "skipIfMountPositionOk": {
+          "$ref": "#/$defs/MountType",
+          "description": "If this parameter is provided, the gantry will only be homed if the specified mount has an invalid position. If omitted, the homing action will be executed unconditionally.",
+          "title": "Skipifmountpositionok"
+        }
+      },
+      "title": "HomeParams",
+      "type": "object"
+    },
+    "InitializeCreate": {
+      "description": "A request to execute an Absorbance Reader measurement.",
+      "properties": {
+        "commandType": {
+          "const": "absorbanceReader/initialize",
+          "default": "absorbanceReader/initialize",
+          "enum": ["absorbanceReader/initialize"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/InitializeParams"
+        }
+      },
+      "required": ["params"],
+      "title": "InitializeCreate",
+      "type": "object"
+    },
+    "InitializeParams": {
+      "description": "Input parameters to initialize an absorbance reading.",
+      "properties": {
+        "measureMode": {
+          "description": "Initialize single or multi measurement mode.",
+          "enum": ["single", "multi"],
+          "title": "Measuremode",
+          "type": "string"
+        },
+        "moduleId": {
+          "description": "Unique ID of the absorbance reader.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "referenceWavelength": {
+          "description": "Optional reference wavelength in nm.",
+          "title": "Referencewavelength",
+          "type": "integer"
+        },
+        "sampleWavelengths": {
+          "description": "Sample wavelengths in nm.",
+          "items": {
+            "type": "integer"
+          },
+          "title": "Samplewavelengths",
+          "type": "array"
+        }
+      },
+      "required": ["moduleId", "measureMode", "sampleWavelengths"],
+      "title": "InitializeParams",
+      "type": "object"
+    },
+    "InstrumentSensorId": {
+      "description": "Primary and secondary sensor ids.",
+      "enum": ["primary", "secondary", "both"],
+      "title": "InstrumentSensorId",
+      "type": "string"
+    },
+    "LabwareMovementStrategy": {
+      "description": "Strategy to use for labware movement.",
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
+      "title": "LabwareMovementStrategy",
+      "type": "string"
+    },
+    "LabwareOffsetVector": {
+      "description": "Offset, in deck coordinates from nominal to actual position.",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": ["x", "y", "z"],
+      "title": "LabwareOffsetVector",
+      "type": "object"
+    },
+    "LiquidClassRecord": {
+      "description": "LiquidClassRecord is our internal representation of an (immutable) liquid class.\n\nConceptually, a liquid class record is the tuple (name, pipette, tip, transfer properties).\nWe consider two liquid classes to be the same if every entry in that tuple is the same; and liquid\nclasses are different if any entry in the tuple is different.\n\nThis class defines the tuple via inheritance so that we can reuse the definitions from shared_data.",
+      "properties": {
+        "aspirate": {
+          "$ref": "#/$defs/AspirateProperties",
+          "description": "Aspirate parameters for this tip type."
+        },
+        "liquidClassName": {
+          "description": "Identifier for the liquid of this liquid class, e.g. glycerol50.",
+          "title": "Liquidclassname",
+          "type": "string"
+        },
+        "multiDispense": {
+          "$ref": "#/$defs/MultiDispenseProperties",
+          "description": "Optional multi-dispense parameters for this tip type.",
+          "title": "Multidispense"
+        },
+        "pipetteModel": {
+          "description": "Identifier for the pipette of this liquid class.",
+          "title": "Pipettemodel",
+          "type": "string"
+        },
+        "singleDispense": {
+          "$ref": "#/$defs/SingleDispenseProperties",
+          "description": "Single dispense parameters for this tip type."
+        },
+        "tiprack": {
+          "description": "The name of tiprack whose tip will be used when handling this specific liquid class with this pipette",
+          "title": "Tiprack",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tiprack",
+        "aspirate",
+        "singleDispense",
+        "liquidClassName",
+        "pipetteModel"
+      ],
+      "title": "LiquidClassRecord",
+      "type": "object"
+    },
+    "LiquidClassTouchTipParams": {
+      "description": "Parameters for touch-tip.",
+      "properties": {
+        "mmToEdge": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "description": "Offset away from the the well edge, in millimeters.",
+          "title": "Mmtoedge"
+        },
+        "speed": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "exclusiveMinimum": 0.0,
+              "type": "number"
+            }
+          ],
+          "description": "Touch-tip speed, in millimeters per second.",
+          "title": "Speed"
+        },
+        "zOffset": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "description": "Offset from the top of the well for touch-tip, in millimeters.",
+          "title": "Zoffset"
+        }
+      },
+      "required": ["zOffset", "mmToEdge", "speed"],
+      "title": "LiquidClassTouchTipParams",
+      "type": "object"
+    },
+    "LiquidHandlingWellLocation": {
+      "description": "A relative location in reference to a well's location.\n\nTo be used with commands that handle liquids.",
+      "properties": {
+        "offset": {
+          "$ref": "#/$defs/WellOffset"
+        },
+        "origin": {
+          "$ref": "#/$defs/WellOrigin",
+          "default": "top"
+        },
+        "volumeOffset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "const": "operationVolume",
+              "enum": ["operationVolume"],
+              "type": "string"
+            }
+          ],
+          "default": 0.0,
+          "description": "A volume of liquid, in \u00b5L, to offset the z-axis offset. When \"operationVolume\" is specified, this volume is pulled from the command volume parameter.",
+          "title": "Volumeoffset"
+        }
+      },
+      "title": "LiquidHandlingWellLocation",
+      "type": "object"
+    },
+    "LiquidProbeCreate": {
+      "description": "The request model for a `liquidProbe` command.",
+      "properties": {
+        "commandType": {
+          "const": "liquidProbe",
+          "default": "liquidProbe",
+          "enum": ["liquidProbe"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LiquidProbeParams"
+        }
+      },
+      "required": ["params"],
+      "title": "LiquidProbeCreate",
+      "type": "object"
+    },
+    "LiquidProbeParams": {
+      "description": "Parameters required for a `liquidProbe` command.",
+      "properties": {
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/WellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "pipetteId"],
+      "title": "LiquidProbeParams",
+      "type": "object"
+    },
+    "LoadLabwareCreate": {
+      "description": "Load labware command creation request.",
+      "properties": {
+        "commandType": {
+          "const": "loadLabware",
+          "default": "loadLabware",
+          "enum": ["loadLabware"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoadLabwareParams"
+        }
+      },
+      "required": ["params"],
+      "title": "LoadLabwareCreate",
+      "type": "object"
+    },
+    "LoadLabwareParams": {
+      "description": "Payload required to load a labware into a slot.",
+      "properties": {
+        "displayName": {
+          "description": "An optional user-specified display name or label for this labware.",
+          "title": "Displayname",
+          "type": "string"
+        },
+        "labwareId": {
+          "description": "An optional ID to assign to this labware. If None, an ID will be generated.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "loadName": {
+          "description": "Name used to reference a labware definition.",
+          "title": "Loadname",
+          "type": "string"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DeckSlotLocation"
+            },
+            {
+              "$ref": "#/$defs/ModuleLocation"
+            },
+            {
+              "$ref": "#/$defs/OnLabwareLocation"
+            },
+            {
+              "const": "offDeck",
+              "enum": ["offDeck"],
+              "type": "string"
+            },
+            {
+              "const": "systemLocation",
+              "enum": ["systemLocation"],
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/AddressableAreaLocation"
+            }
+          ],
+          "description": "Location the labware should be loaded into.",
+          "title": "Location"
+        },
+        "namespace": {
+          "description": "The namespace the labware definition belongs to.",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "version": {
+          "description": "The labware definition version.",
+          "title": "Version",
+          "type": "integer"
+        }
+      },
+      "required": ["location", "loadName", "namespace", "version"],
+      "title": "LoadLabwareParams",
+      "type": "object"
+    },
+    "LoadLidCreate": {
+      "description": "Load lid command creation request.",
+      "properties": {
+        "commandType": {
+          "const": "loadLid",
+          "default": "loadLid",
+          "enum": ["loadLid"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoadLidParams"
+        }
+      },
+      "required": ["params"],
+      "title": "LoadLidCreate",
+      "type": "object"
+    },
+    "LoadLidParams": {
+      "description": "Payload required to load a lid onto a labware.",
+      "properties": {
+        "loadName": {
+          "description": "Name used to reference a lid labware definition.",
+          "title": "Loadname",
+          "type": "string"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DeckSlotLocation"
+            },
+            {
+              "$ref": "#/$defs/ModuleLocation"
+            },
+            {
+              "$ref": "#/$defs/OnLabwareLocation"
+            },
+            {
+              "const": "offDeck",
+              "enum": ["offDeck"],
+              "type": "string"
+            },
+            {
+              "const": "systemLocation",
+              "enum": ["systemLocation"],
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/AddressableAreaLocation"
+            }
+          ],
+          "description": "Labware the lid should be loaded onto.",
+          "title": "Location"
+        },
+        "namespace": {
+          "description": "The namespace the lid labware definition belongs to.",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "version": {
+          "description": "The lid labware definition version.",
+          "title": "Version",
+          "type": "integer"
+        }
+      },
+      "required": ["location", "loadName", "namespace", "version"],
+      "title": "LoadLidParams",
+      "type": "object"
+    },
+    "LoadLidStackCreate": {
+      "description": "Load lid stack command creation request.",
+      "properties": {
+        "commandType": {
+          "const": "loadLidStack",
+          "default": "loadLidStack",
+          "enum": ["loadLidStack"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoadLidStackParams"
+        }
+      },
+      "required": ["params"],
+      "title": "LoadLidStackCreate",
+      "type": "object"
+    },
+    "LoadLidStackParams": {
+      "description": "Payload required to load a lid stack onto a location.",
+      "properties": {
+        "labwareIds": {
+          "description": "An optional list of IDs to assign to the lids in the stack.If None, an ID will be generated.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Labwareids",
+          "type": "array"
+        },
+        "loadName": {
+          "description": "Name used to reference a lid labware definition.",
+          "title": "Loadname",
+          "type": "string"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DeckSlotLocation"
+            },
+            {
+              "$ref": "#/$defs/ModuleLocation"
+            },
+            {
+              "$ref": "#/$defs/OnLabwareLocation"
+            },
+            {
+              "const": "offDeck",
+              "enum": ["offDeck"],
+              "type": "string"
+            },
+            {
+              "const": "systemLocation",
+              "enum": ["systemLocation"],
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/AddressableAreaLocation"
+            }
+          ],
+          "description": "Location the lid stack should be loaded into.",
+          "title": "Location"
+        },
+        "namespace": {
+          "description": "The namespace the lid labware definition belongs to.",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "quantity": {
+          "description": "The quantity of lids to load.",
+          "title": "Quantity",
+          "type": "integer"
+        },
+        "stackLabwareId": {
+          "description": "An optional ID to assign to the lid stack labware object created.If None, an ID will be generated.",
+          "title": "Stacklabwareid",
+          "type": "string"
+        },
+        "version": {
+          "description": "The lid labware definition version.",
+          "title": "Version",
+          "type": "integer"
+        }
+      },
+      "required": ["location", "loadName", "namespace", "version", "quantity"],
+      "title": "LoadLidStackParams",
+      "type": "object"
+    },
+    "LoadLiquidClassCreate": {
+      "description": "Load Liquid Class command creation request.",
+      "properties": {
+        "commandType": {
+          "const": "loadLiquidClass",
+          "default": "loadLiquidClass",
+          "enum": ["loadLiquidClass"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoadLiquidClassParams"
+        }
+      },
+      "required": ["params"],
+      "title": "LoadLiquidClassCreate",
+      "type": "object"
+    },
+    "LoadLiquidClassParams": {
+      "description": "The liquid class transfer properties to store.",
+      "properties": {
+        "liquidClassId": {
+          "description": "Unique identifier for the liquid class to store. If you do not supply a liquidClassId, we will generate one.",
+          "title": "Liquidclassid",
+          "type": "string"
+        },
+        "liquidClassRecord": {
+          "$ref": "#/$defs/LiquidClassRecord",
+          "description": "The liquid class to store."
+        }
+      },
+      "required": ["liquidClassRecord"],
+      "title": "LoadLiquidClassParams",
+      "type": "object"
+    },
+    "LoadLiquidCreate": {
+      "description": "Load liquid command creation request.",
+      "properties": {
+        "commandType": {
+          "const": "loadLiquid",
+          "default": "loadLiquid",
+          "enum": ["loadLiquid"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoadLiquidParams"
+        }
+      },
+      "required": ["params"],
+      "title": "LoadLiquidCreate",
+      "type": "object"
+    },
+    "LoadLiquidParams": {
+      "description": "Payload required to load a liquid into a well.",
+      "properties": {
+        "labwareId": {
+          "description": "Unique identifier of labware to load liquid into.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "liquidId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "const": "EMPTY",
+              "enum": ["EMPTY"],
+              "type": "string"
+            }
+          ],
+          "description": "Unique identifier of the liquid to load. If this is the sentinel value EMPTY, all values of volumeByWell must be 0.",
+          "title": "Liquidid"
+        },
+        "volumeByWell": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Volume of liquid, in \u00b5L, loaded into each well by name, in this labware. If the liquid id is the sentinel value EMPTY, all volumes must be 0.",
+          "title": "Volumebywell",
+          "type": "object"
+        }
+      },
+      "required": ["liquidId", "labwareId", "volumeByWell"],
+      "title": "LoadLiquidParams",
+      "type": "object"
+    },
+    "LoadModuleCreate": {
+      "description": "The model for a creation request for a load module command.",
+      "properties": {
+        "commandType": {
+          "const": "loadModule",
+          "default": "loadModule",
+          "enum": ["loadModule"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoadModuleParams"
+        }
+      },
+      "required": ["params"],
+      "title": "LoadModuleCreate",
+      "type": "object"
+    },
+    "LoadModuleParams": {
+      "description": "Payload required to load a module.",
+      "properties": {
+        "location": {
+          "$ref": "#/$defs/DeckSlotLocation",
+          "description": "The location into which this module should be loaded.\n\nFor the Thermocycler Module, which occupies multiple deck slots, this should be the front-most occupied slot (normally slot 7)."
+        },
+        "model": {
+          "$ref": "#/$defs/ModuleModel",
+          "description": "The model name of the module to load.\n\nProtocol Engine will look for a connected module that either exactly matches this one, or is compatible.\n\n For example, if you request a `temperatureModuleV1` here, Protocol Engine might load a `temperatureModuleV1` or a `temperatureModuleV2`.\n\n The model that it finds connected will be available through `result.model`."
+        },
+        "moduleId": {
+          "description": "An optional ID to assign to this module. If None, an ID will be generated.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["model", "location"],
+      "title": "LoadModuleParams",
+      "type": "object"
+    },
+    "LoadPipetteCreate": {
+      "description": "Load pipette command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "loadPipette",
+          "default": "loadPipette",
+          "enum": ["loadPipette"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoadPipetteParams"
+        }
+      },
+      "required": ["params"],
+      "title": "LoadPipetteCreate",
+      "type": "object"
+    },
+    "LoadPipetteParams": {
+      "description": "Payload needed to load a pipette on to a mount.",
+      "properties": {
+        "liquidPresenceDetection": {
+          "description": "Enable liquid presence detection for this pipette. Defaults to False.",
+          "title": "Liquidpresencedetection",
+          "type": "boolean"
+        },
+        "mount": {
+          "$ref": "#/$defs/MountType",
+          "description": "The mount the pipette should be present on."
+        },
+        "pipetteId": {
+          "description": "An optional ID to assign to this pipette. If None, an ID will be generated.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "pipetteName": {
+          "$ref": "#/$defs/PipetteNameType",
+          "description": "The load name of the pipette to be required."
+        },
+        "tipOverlapNotAfterVersion": {
+          "description": "A version of tip overlap data to not exceed. The highest-versioned tip overlap data that does not exceed this version will be used. Versions are expressed as vN where N is an integer, counting up from v0. If None, the current highest version will be used.",
+          "title": "Tipoverlapnotafterversion",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteName", "mount"],
+      "title": "LoadPipetteParams",
+      "type": "object"
+    },
+    "MaintenancePosition": {
+      "description": "Maintenance position options.",
+      "enum": ["attachPlate", "attachInstrument"],
+      "title": "MaintenancePosition",
+      "type": "string"
+    },
+    "MixParams": {
+      "description": "Parameters for mix.",
+      "properties": {
+        "repetitions": {
+          "description": "Number of mixing repetitions. 0 is valid, but no mixing will occur.",
+          "minimum": 0,
+          "title": "Repetitions",
+          "type": "integer"
+        },
+        "volume": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "exclusiveMinimum": 0.0,
+              "type": "number"
+            }
+          ],
+          "description": "Volume used for mixing, in microliters.",
+          "title": "Volume"
+        }
+      },
+      "required": ["repetitions", "volume"],
+      "title": "MixParams",
+      "type": "object"
+    },
+    "MixProperties": {
+      "description": "Mixing properties.",
+      "properties": {
+        "enable": {
+          "description": "Whether mix is enabled.",
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "params": {
+          "$ref": "#/$defs/MixParams",
+          "description": "Parameters for the mix function.",
+          "title": "Params"
+        }
+      },
+      "required": ["enable"],
+      "title": "MixProperties",
+      "type": "object"
+    },
+    "ModuleLocation": {
+      "description": "The location of something placed atop a hardware module.",
+      "properties": {
+        "moduleId": {
+          "description": "The ID of a loaded module from a prior `loadModule` command.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "ModuleLocation",
+      "type": "object"
+    },
+    "ModuleModel": {
+      "description": "All available modules' models.",
+      "enum": [
+        "temperatureModuleV1",
+        "temperatureModuleV2",
+        "magneticModuleV1",
+        "magneticModuleV2",
+        "thermocyclerModuleV1",
+        "thermocyclerModuleV2",
+        "heaterShakerModuleV1",
+        "magneticBlockV1",
+        "absorbanceReaderV1",
+        "flexStackerModuleV1"
+      ],
+      "title": "ModuleModel",
+      "type": "string"
+    },
+    "MotorAxis": {
+      "description": "Motor axis on which to issue a home command.",
+      "enum": [
+        "x",
+        "y",
+        "leftZ",
+        "rightZ",
+        "leftPlunger",
+        "rightPlunger",
+        "extensionZ",
+        "extensionJaw",
+        "axis96ChannelCam"
+      ],
+      "title": "MotorAxis",
+      "type": "string"
+    },
+    "MountType": {
+      "enum": ["left", "right", "extension"],
+      "title": "MountType",
+      "type": "string"
+    },
+    "MoveAxesRelativeCreate": {
+      "description": "MoveAxesRelative command request model.",
+      "properties": {
+        "commandType": {
+          "const": "robot/moveAxesRelative",
+          "default": "robot/moveAxesRelative",
+          "enum": ["robot/moveAxesRelative"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveAxesRelativeParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveAxesRelativeCreate",
+      "type": "object"
+    },
+    "MoveAxesRelativeParams": {
+      "description": "Payload required to move axes relative to position.",
+      "properties": {
+        "axis_map": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "A dictionary mapping axes to relative movements in mm.",
+          "title": "Axis Map",
+          "type": "object"
+        },
+        "speed": {
+          "description": "The max velocity to move the axes at. Will fall to hardware defaults if none provided.",
+          "title": "Speed",
+          "type": "number"
+        }
+      },
+      "required": ["axis_map"],
+      "title": "MoveAxesRelativeParams",
+      "type": "object"
+    },
+    "MoveAxesToCreate": {
+      "description": "MoveAxesTo command request model.",
+      "properties": {
+        "commandType": {
+          "const": "robot/moveAxesTo",
+          "default": "robot/moveAxesTo",
+          "enum": ["robot/moveAxesTo"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveAxesToParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveAxesToCreate",
+      "type": "object"
+    },
+    "MoveAxesToParams": {
+      "description": "Payload required to move axes to absolute position.",
+      "properties": {
+        "axis_map": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "The specified axes to move to an absolute deck position with.",
+          "title": "Axis Map",
+          "type": "object"
+        },
+        "critical_point": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "The critical point to move the mount with.",
+          "title": "Critical Point",
+          "type": "object"
+        },
+        "speed": {
+          "description": "The max velocity to move the axes at. Will fall to hardware defaults if none provided.",
+          "title": "Speed",
+          "type": "number"
+        }
+      },
+      "required": ["axis_map"],
+      "title": "MoveAxesToParams",
+      "type": "object"
+    },
+    "MoveLabwareCreate": {
+      "description": "A request to create a ``moveLabware`` command.",
+      "properties": {
+        "commandType": {
+          "const": "moveLabware",
+          "default": "moveLabware",
+          "enum": ["moveLabware"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveLabwareParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveLabwareCreate",
+      "type": "object"
+    },
+    "MoveLabwareParams": {
+      "description": "Input parameters for a ``moveLabware`` command.",
+      "properties": {
+        "dropOffset": {
+          "$ref": "#/$defs/LabwareOffsetVector",
+          "description": "Offset to use when dropping off labware. Experimental param, subject to change",
+          "title": "Dropoffset"
+        },
+        "labwareId": {
+          "description": "The ID of the labware to move.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "newLocation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DeckSlotLocation"
+            },
+            {
+              "$ref": "#/$defs/ModuleLocation"
+            },
+            {
+              "$ref": "#/$defs/OnLabwareLocation"
+            },
+            {
+              "const": "offDeck",
+              "enum": ["offDeck"],
+              "type": "string"
+            },
+            {
+              "const": "systemLocation",
+              "enum": ["systemLocation"],
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/AddressableAreaLocation"
+            }
+          ],
+          "description": "Where to move the labware.",
+          "title": "Newlocation"
+        },
+        "pickUpOffset": {
+          "$ref": "#/$defs/LabwareOffsetVector",
+          "description": "Offset to use when picking up labware. Experimental param, subject to change",
+          "title": "Pickupoffset"
+        },
+        "strategy": {
+          "$ref": "#/$defs/LabwareMovementStrategy",
+          "description": "Whether to use the gripper to perform the labware movement or to perform a manual movement with an option to pause."
+        }
+      },
+      "required": ["labwareId", "newLocation", "strategy"],
+      "title": "MoveLabwareParams",
+      "type": "object"
+    },
+    "MoveRelativeCreate": {
+      "description": "Data to create a MoveRelative command.",
+      "properties": {
+        "commandType": {
+          "const": "moveRelative",
+          "default": "moveRelative",
+          "enum": ["moveRelative"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveRelativeParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveRelativeCreate",
+      "type": "object"
+    },
+    "MoveRelativeParams": {
+      "description": "Payload required for a MoveRelative command.",
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/MovementAxis",
+          "description": "Axis along which to move."
+        },
+        "distance": {
+          "description": "Distance to move in millimeters. A positive number will move towards the right (x), back (y), top (z) of the deck.",
+          "title": "Distance",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Pipette to move.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId", "axis", "distance"],
+      "title": "MoveRelativeParams",
+      "type": "object"
+    },
+    "MoveToAddressableAreaCreate": {
+      "description": "Move to addressable area command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "moveToAddressableArea",
+          "default": "moveToAddressableArea",
+          "enum": ["moveToAddressableArea"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveToAddressableAreaParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveToAddressableAreaCreate",
+      "type": "object"
+    },
+    "MoveToAddressableAreaForDropTipCreate": {
+      "description": "Move to addressable area for drop tip command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "moveToAddressableAreaForDropTip",
+          "default": "moveToAddressableAreaForDropTip",
+          "enum": ["moveToAddressableAreaForDropTip"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveToAddressableAreaForDropTipParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveToAddressableAreaForDropTipCreate",
+      "type": "object"
+    },
+    "MoveToAddressableAreaForDropTipParams": {
+      "description": "Payload required to move a pipette to a specific addressable area.\n\nAn *addressable area* is a space in the robot that may or may not be usable depending on how\nthe robot's deck is configured. For example, if a Flex is configured with a waste chute, it will\nhave additional addressable areas representing the opening of the waste chute, where tips and\nlabware can be dropped.\n\nThis moves the pipette so all of its nozzles are centered over the addressable area.\nIf the pipette is currently configured with a partial tip layout, this centering is over all\nthe pipette's physical nozzles, not just the nozzles that are active.\n\nThe z-position will be chosen to put the bottom of the tips---or the bottom of the nozzles,\nif there are no tips---level with the top of the addressable area.\n\nWhen this command is executed, Protocol Engine will make sure the robot's deck is configured\nsuch that the requested addressable area actually exists. For example, if you request\nthe addressable area B4, it will make sure the robot is set up with a B3/B4 staging area slot.\nIf that's not the case, the command will fail.",
+      "properties": {
+        "addressableAreaName": {
+          "description": "The name of the addressable area that you want to use. Valid values are the `id`s of `addressableArea`s in the [deck definition](https://github.com/Opentrons/opentrons/tree/edge/shared-data/deck).",
+          "title": "Addressableareaname",
+          "type": "string"
+        },
+        "alternateDropLocation": {
+          "description": "Whether to alternate location where tip is dropped within the addressable area. If True, this command will ignore the offset provided and alternate between dropping tips at two predetermined locations inside the specified labware well. If False, the tip will be dropped at the top center of the area.",
+          "title": "Alternatedroplocation",
+          "type": "boolean"
+        },
+        "forceDirect": {
+          "default": false,
+          "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+          "title": "Forcedirect",
+          "type": "boolean"
+        },
+        "ignoreTipConfiguration": {
+          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "title": "Ignoretipconfiguration",
+          "type": "boolean"
+        },
+        "minimumZHeight": {
+          "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect.",
+          "title": "Minimumzheight",
+          "type": "number"
+        },
+        "offset": {
+          "$ref": "#/$defs/AddressableOffsetVector",
+          "default": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "description": "Relative offset of addressable area to move pipette's critical point."
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "speed": {
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "title": "Speed",
+          "type": "number"
+        }
+      },
+      "required": ["pipetteId", "addressableAreaName"],
+      "title": "MoveToAddressableAreaForDropTipParams",
+      "type": "object"
+    },
+    "MoveToAddressableAreaParams": {
+      "description": "Payload required to move a pipette to a specific addressable area.\n\nAn *addressable area* is a space in the robot that may or may not be usable depending on how\nthe robot's deck is configured. For example, if a Flex is configured with a waste chute, it will\nhave additional addressable areas representing the opening of the waste chute, where tips and\nlabware can be dropped.\n\nThis moves the pipette so all of its nozzles are centered over the addressable area.\nIf the pipette is currently configured with a partial tip layout, this centering is over all\nthe pipette's physical nozzles, not just the nozzles that are active.\n\nThe z-position will be chosen to put the bottom of the tips---or the bottom of the nozzles,\nif there are no tips---level with the top of the addressable area.\n\nWhen this command is executed, Protocol Engine will make sure the robot's deck is configured\nsuch that the requested addressable area actually exists. For example, if you request\nthe addressable area B4, it will make sure the robot is set up with a B3/B4 staging area slot.\nIf that's not the case, the command will fail.",
+      "properties": {
+        "addressableAreaName": {
+          "description": "The name of the addressable area that you want to use. Valid values are the `id`s of `addressableArea`s in the [deck definition](https://github.com/Opentrons/opentrons/tree/edge/shared-data/deck).",
+          "title": "Addressableareaname",
+          "type": "string"
+        },
+        "forceDirect": {
+          "default": false,
+          "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+          "title": "Forcedirect",
+          "type": "boolean"
+        },
+        "minimumZHeight": {
+          "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect.",
+          "title": "Minimumzheight",
+          "type": "number"
+        },
+        "offset": {
+          "$ref": "#/$defs/AddressableOffsetVector",
+          "default": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "description": "Relative offset of addressable area to move pipette's critical point."
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "speed": {
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "title": "Speed",
+          "type": "number"
+        },
+        "stayAtHighestPossibleZ": {
+          "default": false,
+          "description": "If `true`, the pipette will retract to its highest possible height and stay there instead of descending to the destination. `minimumZHeight` will be ignored.",
+          "title": "Stayathighestpossiblez",
+          "type": "boolean"
+        }
+      },
+      "required": ["pipetteId", "addressableAreaName"],
+      "title": "MoveToAddressableAreaParams",
+      "type": "object"
+    },
+    "MoveToCoordinatesCreate": {
+      "description": "Move to coordinates command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "moveToCoordinates",
+          "default": "moveToCoordinates",
+          "enum": ["moveToCoordinates"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveToCoordinatesParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveToCoordinatesCreate",
+      "type": "object"
+    },
+    "MoveToCoordinatesParams": {
+      "description": "Payload required to move a pipette to coordinates.",
+      "properties": {
+        "coordinates": {
+          "$ref": "#/$defs/DeckPoint",
+          "description": "X, Y and Z coordinates in mm from deck's origin location (left-front-bottom corner of work space)"
+        },
+        "forceDirect": {
+          "default": false,
+          "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+          "title": "Forcedirect",
+          "type": "boolean"
+        },
+        "minimumZHeight": {
+          "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect.",
+          "title": "Minimumzheight",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "speed": {
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "title": "Speed",
+          "type": "number"
+        }
+      },
+      "required": ["pipetteId", "coordinates"],
+      "title": "MoveToCoordinatesParams",
+      "type": "object"
+    },
+    "MoveToCreate": {
+      "description": "MoveTo command request model.",
+      "properties": {
+        "commandType": {
+          "const": "robot/moveTo",
+          "default": "robot/moveTo",
+          "enum": ["robot/moveTo"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveToParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveToCreate",
+      "type": "object"
+    },
+    "MoveToMaintenancePositionCreate": {
+      "description": "Calibration set up position command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "calibration/moveToMaintenancePosition",
+          "default": "calibration/moveToMaintenancePosition",
+          "enum": ["calibration/moveToMaintenancePosition"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveToMaintenancePositionParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveToMaintenancePositionCreate",
+      "type": "object"
+    },
+    "MoveToMaintenancePositionParams": {
+      "description": "Calibration set up position command parameters.",
+      "properties": {
+        "maintenancePosition": {
+          "$ref": "#/$defs/MaintenancePosition",
+          "default": "attachInstrument",
+          "description": "The position the gantry mount needs to move to."
+        },
+        "mount": {
+          "$ref": "#/$defs/MountType",
+          "description": "Gantry mount to move maintenance position."
+        }
+      },
+      "required": ["mount"],
+      "title": "MoveToMaintenancePositionParams",
+      "type": "object"
+    },
+    "MoveToParams": {
+      "description": "Payload required to move to a destination position.",
+      "properties": {
+        "destination": {
+          "$ref": "#/$defs/DeckPoint",
+          "description": "X, Y and Z coordinates in mm from deck's origin location (left-front-bottom corner of work space)"
+        },
+        "mount": {
+          "$ref": "#/$defs/MountType",
+          "description": "The mount to move to the destination point."
+        },
+        "speed": {
+          "description": "The max velocity to move the axes at. Will fall to hardware defaults if none provided.",
+          "title": "Speed",
+          "type": "number"
+        }
+      },
+      "required": ["mount", "destination"],
+      "title": "MoveToParams",
+      "type": "object"
+    },
+    "MoveToWellCreate": {
+      "description": "Move to well command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "moveToWell",
+          "default": "moveToWell",
+          "enum": ["moveToWell"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/MoveToWellParams"
+        }
+      },
+      "required": ["params"],
+      "title": "MoveToWellCreate",
+      "type": "object"
+    },
+    "MoveToWellParams": {
+      "description": "Payload required to move a pipette to a specific well.",
+      "properties": {
+        "forceDirect": {
+          "default": false,
+          "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+          "title": "Forcedirect",
+          "type": "boolean"
+        },
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "minimumZHeight": {
+          "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect.",
+          "title": "Minimumzheight",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "speed": {
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "title": "Speed",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/WellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "pipetteId"],
+      "title": "MoveToWellParams",
+      "type": "object"
+    },
+    "MovementAxis": {
+      "description": "Axis on which to issue a relative movement.",
+      "enum": ["x", "y", "z"],
+      "title": "MovementAxis",
+      "type": "string"
+    },
+    "MultiDispenseProperties": {
+      "description": "Properties specific to the multi-dispense function.",
+      "properties": {
+        "conditioningByVolume": {
+          "description": "Settings for conditioning volume keyed by target dispense volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Conditioningbyvolume",
+          "type": "array"
+        },
+        "correctionByVolume": {
+          "description": "Settings for volume correction keyed by by target dispense volume, representing additional volume the plunger should move to accurately hit target volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Correctionbyvolume",
+          "type": "array"
+        },
+        "delay": {
+          "$ref": "#/$defs/DelayProperties",
+          "description": "Delay settings after each dispense"
+        },
+        "disposalByVolume": {
+          "description": "Settings for disposal volume keyed by target dispense volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Disposalbyvolume",
+          "type": "array"
+        },
+        "flowRateByVolume": {
+          "description": "Settings for flow rate keyed by target dispense volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Flowratebyvolume",
+          "type": "array"
+        },
+        "offset": {
+          "$ref": "#/$defs/Coordinate",
+          "description": "Relative offset for single multi-dispense."
+        },
+        "positionReference": {
+          "$ref": "#/$defs/PositionReference",
+          "description": "Position reference for multi-dispense."
+        },
+        "retract": {
+          "$ref": "#/$defs/RetractDispense",
+          "description": "Pipette retract settings after a multi-dispense."
+        },
+        "submerge": {
+          "$ref": "#/$defs/Submerge",
+          "description": "Submerge settings for multi-dispense."
+        }
+      },
+      "required": [
+        "submerge",
+        "retract",
+        "positionReference",
+        "offset",
+        "flowRateByVolume",
+        "correctionByVolume",
+        "conditioningByVolume",
+        "disposalByVolume",
+        "delay"
+      ],
+      "title": "MultiDispenseProperties",
+      "type": "object"
+    },
+    "OnLabwareLocation": {
+      "description": "The location of something placed atop another labware.",
+      "properties": {
+        "labwareId": {
+          "description": "The ID of a loaded Labware from a prior `loadLabware` command.",
+          "title": "Labwareid",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId"],
+      "title": "OnLabwareLocation",
+      "type": "object"
+    },
+    "OpenLabwareLatchCreate": {
+      "description": "A request to create a Heater-Shaker's open labware latch command.",
+      "properties": {
+        "commandType": {
+          "const": "heaterShaker/openLabwareLatch",
+          "default": "heaterShaker/openLabwareLatch",
+          "enum": ["heaterShaker/openLabwareLatch"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/OpenLabwareLatchParams"
+        }
+      },
+      "required": ["params"],
+      "title": "OpenLabwareLatchCreate",
+      "type": "object"
+    },
+    "OpenLabwareLatchParams": {
+      "description": "Input parameters to open a Heater-Shaker Module's labware latch.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "OpenLabwareLatchParams",
+      "type": "object"
+    },
+    "OpenLatchCreate": {
+      "description": "A request to execute a Flex Stacker OpenLatch command.",
+      "properties": {
+        "commandType": {
+          "const": "flexStacker/openLatch",
+          "default": "flexStacker/openLatch",
+          "enum": ["flexStacker/openLatch"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/OpenLatchParams"
+        }
+      },
+      "required": ["params"],
+      "title": "OpenLatchCreate",
+      "type": "object"
+    },
+    "OpenLatchParams": {
+      "description": "The parameters defining how a stacker should open its latch.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Flex Stacker",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "OpenLatchParams",
+      "type": "object"
+    },
+    "PickUpTipCreate": {
+      "description": "Pick up tip command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "pickUpTip",
+          "default": "pickUpTip",
+          "enum": ["pickUpTip"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PickUpTipParams"
+        }
+      },
+      "required": ["params"],
+      "title": "PickUpTipCreate",
+      "type": "object"
+    },
+    "PickUpTipParams": {
+      "description": "Payload needed to move a pipette to a specific well.",
+      "properties": {
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/PickUpTipWellLocation",
+          "description": "Relative well location at which to pick up the tip."
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId", "labwareId", "wellName"],
+      "title": "PickUpTipParams",
+      "type": "object"
+    },
+    "PickUpTipWellLocation": {
+      "description": "A relative location in reference to a well's location.\n\nTo be used for picking up tips.",
+      "properties": {
+        "offset": {
+          "$ref": "#/$defs/WellOffset"
+        },
+        "origin": {
+          "$ref": "#/$defs/PickUpTipWellOrigin",
+          "default": "top"
+        }
+      },
+      "title": "PickUpTipWellLocation",
+      "type": "object"
+    },
+    "PickUpTipWellOrigin": {
+      "description": "The origin of a PickUpTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
+      "enum": ["top", "bottom", "center"],
+      "title": "PickUpTipWellOrigin",
+      "type": "string"
+    },
+    "PipetteNameType": {
+      "description": "Pipette load name values.",
+      "enum": [
+        "p10_single",
+        "p10_multi",
+        "p20_single_gen2",
+        "p20_multi_gen2",
+        "p50_single",
+        "p50_multi",
+        "p50_single_flex",
+        "p50_multi_flex",
+        "p300_single",
+        "p300_multi",
+        "p300_single_gen2",
+        "p300_multi_gen2",
+        "p1000_single",
+        "p1000_single_gen2",
+        "p1000_single_flex",
+        "p1000_multi_flex",
+        "p1000_multi_em_flex",
+        "p1000_96",
+        "p200_96"
+      ],
+      "title": "PipetteNameType",
+      "type": "string"
+    },
+    "PositionReference": {
+      "description": "Positional reference for liquid handling operations.",
+      "enum": ["well-bottom", "well-top", "well-center", "liquid-meniscus"],
+      "title": "PositionReference",
+      "type": "string"
+    },
+    "PrepareShuttleCreate": {
+      "description": "A request to execute a Flex Stacker PrepareShuttle command.",
+      "properties": {
+        "commandType": {
+          "const": "flexStacker/prepareShuttle",
+          "default": "flexStacker/prepareShuttle",
+          "enum": ["flexStacker/prepareShuttle"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PrepareShuttleParams"
+        }
+      },
+      "required": ["params"],
+      "title": "PrepareShuttleCreate",
+      "type": "object"
+    },
+    "PrepareShuttleParams": {
+      "description": "The parameters for a PrepareShuttle command.",
+      "properties": {
+        "ignoreLatch": {
+          "default": false,
+          "description": "Ignore the latch state of the shuttle",
+          "title": "Ignorelatch",
+          "type": "boolean"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Flex Stacker",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "PrepareShuttleParams",
+      "type": "object"
+    },
+    "PrepareToAspirateCreate": {
+      "description": "Prepare for aspirate command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "prepareToAspirate",
+          "default": "prepareToAspirate",
+          "enum": ["prepareToAspirate"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PrepareToAspirateParams"
+        }
+      },
+      "required": ["params"],
+      "title": "PrepareToAspirateCreate",
+      "type": "object"
+    },
+    "PrepareToAspirateParams": {
+      "description": "Parameters required to prepare a specific pipette for aspiration.",
+      "properties": {
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId"],
+      "title": "PrepareToAspirateParams",
+      "type": "object"
+    },
+    "ProfileCycle": {
+      "description": "An individual cycle in a Thermocycler extended profile.",
+      "properties": {
+        "repetitions": {
+          "description": "Number of times to repeat the steps.",
+          "title": "Repetitions",
+          "type": "integer"
+        },
+        "steps": {
+          "description": "Steps to repeat.",
+          "items": {
+            "$ref": "#/$defs/ProfileStep"
+          },
+          "title": "Steps",
+          "type": "array"
+        }
+      },
+      "required": ["steps", "repetitions"],
+      "title": "ProfileCycle",
+      "type": "object"
+    },
+    "ProfileStep": {
+      "description": "An individual step in a Thermocycler extended profile.",
+      "properties": {
+        "celsius": {
+          "description": "Target temperature in \u00b0C.",
+          "title": "Celsius",
+          "type": "number"
+        },
+        "holdSeconds": {
+          "description": "Time to hold target temperature in seconds.",
+          "title": "Holdseconds",
+          "type": "number"
+        }
+      },
+      "required": ["celsius", "holdSeconds"],
+      "title": "ProfileStep",
+      "type": "object"
+    },
+    "QuadrantNozzleLayoutConfiguration": {
+      "description": "Information required for nozzle configurations of type QUADRANT.",
+      "properties": {
+        "backLeftNozzle": {
+          "description": "The back left nozzle in your configuration.",
+          "pattern": "[A-Z]\\d{1,2}",
+          "title": "Backleftnozzle",
+          "type": "string"
+        },
+        "frontRightNozzle": {
+          "description": "The front right nozzle in your configuration.",
+          "pattern": "[A-Z]\\d{1,2}",
+          "title": "Frontrightnozzle",
+          "type": "string"
+        },
+        "primaryNozzle": {
+          "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
+          "enum": ["A1", "H1", "A12", "H12"],
+          "title": "Primarynozzle",
+          "type": "string"
+        },
+        "style": {
+          "const": "QUADRANT",
+          "default": "QUADRANT",
+          "enum": ["QUADRANT"],
+          "title": "Style",
+          "type": "string"
+        }
+      },
+      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"],
+      "title": "QuadrantNozzleLayoutConfiguration",
+      "type": "object"
+    },
+    "ReadAbsorbanceCreate": {
+      "description": "A request to execute an Absorbance Reader measurement.",
+      "properties": {
+        "commandType": {
+          "const": "absorbanceReader/read",
+          "default": "absorbanceReader/read",
+          "enum": ["absorbanceReader/read"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ReadAbsorbanceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "ReadAbsorbanceCreate",
+      "type": "object"
+    },
+    "ReadAbsorbanceParams": {
+      "description": "Input parameters for an absorbance reading.",
+      "properties": {
+        "fileName": {
+          "description": "Optional file name to use when storing the results of a measurement.",
+          "title": "Filename",
+          "type": "string"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Absorbance Reader.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "ReadAbsorbanceParams",
+      "type": "object"
+    },
+    "ReloadLabwareCreate": {
+      "description": "Reload labware command creation request.",
+      "properties": {
+        "commandType": {
+          "const": "reloadLabware",
+          "default": "reloadLabware",
+          "enum": ["reloadLabware"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ReloadLabwareParams"
+        }
+      },
+      "required": ["params"],
+      "title": "ReloadLabwareCreate",
+      "type": "object"
+    },
+    "ReloadLabwareParams": {
+      "description": "Payload required to load a labware into a slot.",
+      "properties": {
+        "labwareId": {
+          "description": "The already-loaded labware instance to update.",
+          "title": "Labwareid",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId"],
+      "title": "ReloadLabwareParams",
+      "type": "object"
+    },
+    "RetractAspirate": {
+      "description": "Shared properties for the retract function after aspiration.",
+      "properties": {
+        "airGapByVolume": {
+          "description": "Settings for air gap keyed by target aspiration volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Airgapbyvolume",
+          "type": "array"
+        },
+        "delay": {
+          "$ref": "#/$defs/DelayProperties",
+          "description": "Delay settings for retract after aspirate."
+        },
+        "offset": {
+          "$ref": "#/$defs/Coordinate",
+          "description": "Relative offset for retract after aspirate."
+        },
+        "positionReference": {
+          "$ref": "#/$defs/PositionReference",
+          "description": "Position reference for retract after aspirate."
+        },
+        "speed": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0.0,
+              "type": "number"
+            }
+          ],
+          "description": "Speed of retraction, in millimeters per second.",
+          "title": "Speed"
+        },
+        "touchTip": {
+          "$ref": "#/$defs/TouchTipProperties",
+          "description": "Touch tip settings for retract after aspirate."
+        }
+      },
+      "required": [
+        "positionReference",
+        "offset",
+        "speed",
+        "airGapByVolume",
+        "touchTip",
+        "delay"
+      ],
+      "title": "RetractAspirate",
+      "type": "object"
+    },
+    "RetractAxisCreate": {
+      "description": "Data to create a Retract Axis command.",
+      "properties": {
+        "commandType": {
+          "const": "retractAxis",
+          "default": "retractAxis",
+          "enum": ["retractAxis"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RetractAxisParams"
+        }
+      },
+      "required": ["params"],
+      "title": "RetractAxisCreate",
+      "type": "object"
+    },
+    "RetractAxisParams": {
+      "description": "Payload required for a Retract Axis command.",
+      "properties": {
+        "axis": {
+          "$ref": "#/$defs/MotorAxis",
+          "description": "Axis to retract to its home position as quickly as safely possible. The difference between retracting an axis and homing an axis using the home command is that a home will always probe the limit switch and will work as the first motion command a robot will need to execute; On the other hand, retraction will rely on this previously determined  home position to move to it as fast as safely possible. So on the Flex, it will move (fast) the axis to the previously recorded home position and on the OT2, it will move (fast) the axis a safe distance from the previously recorded home position, and then slowly approach the limit switch."
+        }
+      },
+      "required": ["axis"],
+      "title": "RetractAxisParams",
+      "type": "object"
+    },
+    "RetractDispense": {
+      "description": "Shared properties for the retract function after dispense.",
+      "properties": {
+        "airGapByVolume": {
+          "description": "Settings for air gap keyed by target aspiration volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Airgapbyvolume",
+          "type": "array"
+        },
+        "blowout": {
+          "$ref": "#/$defs/BlowoutProperties",
+          "description": "Blowout properties for retract after dispense."
+        },
+        "delay": {
+          "$ref": "#/$defs/DelayProperties",
+          "description": "Delay settings for retract after dispense."
+        },
+        "offset": {
+          "$ref": "#/$defs/Coordinate",
+          "description": "Relative offset for retract after dispense."
+        },
+        "positionReference": {
+          "$ref": "#/$defs/PositionReference",
+          "description": "Position reference for retract after dispense."
+        },
+        "speed": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0.0,
+              "type": "number"
+            }
+          ],
+          "description": "Speed of retraction, in millimeters per second.",
+          "title": "Speed"
+        },
+        "touchTip": {
+          "$ref": "#/$defs/TouchTipProperties",
+          "description": "Touch tip settings for retract after dispense."
+        }
+      },
+      "required": [
+        "positionReference",
+        "offset",
+        "speed",
+        "airGapByVolume",
+        "blowout",
+        "touchTip",
+        "delay"
+      ],
+      "title": "RetractDispense",
+      "type": "object"
+    },
+    "RetrieveCreate": {
+      "description": "A request to execute a Flex Stacker retrieve command.",
+      "properties": {
+        "commandType": {
+          "const": "flexStacker/retrieve",
+          "default": "flexStacker/retrieve",
+          "enum": ["flexStacker/retrieve"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RetrieveParams"
+        }
+      },
+      "required": ["params"],
+      "title": "RetrieveCreate",
+      "type": "object"
+    },
+    "RetrieveParams": {
+      "description": "Input parameters for a labware retrieval command.",
+      "properties": {
+        "adapterId": {
+          "description": "An optional ID to assign to an adapter. If None, an ID will be generated.",
+          "title": "Adapterid",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "An optional user-specified display name or label for this labware.",
+          "title": "Displayname",
+          "type": "string"
+        },
+        "labwareId": {
+          "description": "An optional ID to assign to this labware. If None, an ID will be generated.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "lidId": {
+          "description": "An optional ID to assign to a lid. If None, an ID will be generated.",
+          "title": "Lidid",
+          "type": "string"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Flex Stacker.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "RetrieveParams",
+      "type": "object"
+    },
+    "RowNozzleLayoutConfiguration": {
+      "description": "Minimum information required for a new nozzle configuration.",
+      "properties": {
+        "primaryNozzle": {
+          "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
+          "enum": ["A1", "H1", "A12", "H12"],
+          "title": "Primarynozzle",
+          "type": "string"
+        },
+        "style": {
+          "const": "ROW",
+          "default": "ROW",
+          "enum": ["ROW"],
+          "title": "Style",
+          "type": "string"
+        }
+      },
+      "required": ["primaryNozzle"],
+      "title": "RowNozzleLayoutConfiguration",
+      "type": "object"
+    },
+    "RunExtendedProfileCreate": {
+      "description": "A request to execute a Thermocycler profile run.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/runExtendedProfile",
+          "default": "thermocycler/runExtendedProfile",
+          "enum": ["thermocycler/runExtendedProfile"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RunExtendedProfileParams"
+        }
+      },
+      "required": ["params"],
+      "title": "RunExtendedProfileCreate",
+      "type": "object"
+    },
+    "RunExtendedProfileParams": {
+      "description": "Input parameters for an individual Thermocycler profile step.",
+      "properties": {
+        "blockMaxVolumeUl": {
+          "description": "Amount of liquid in uL of the most-full well in labware loaded onto the thermocycler.",
+          "title": "Blockmaxvolumeul",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "profileElements": {
+          "description": "Elements of the profile. Each can be either a step or a cycle.",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ProfileStep"
+              },
+              {
+                "$ref": "#/$defs/ProfileCycle"
+              }
+            ]
+          },
+          "title": "Profileelements",
+          "type": "array"
+        }
+      },
+      "required": ["moduleId", "profileElements"],
+      "title": "RunExtendedProfileParams",
+      "type": "object"
+    },
+    "RunProfileCreate": {
+      "description": "A request to execute a Thermocycler profile run.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/runProfile",
+          "default": "thermocycler/runProfile",
+          "enum": ["thermocycler/runProfile"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RunProfileParams"
+        }
+      },
+      "required": ["params"],
+      "title": "RunProfileCreate",
+      "type": "object"
+    },
+    "RunProfileParams": {
+      "description": "Input parameters to run a Thermocycler profile.",
+      "properties": {
+        "blockMaxVolumeUl": {
+          "description": "Amount of liquid in uL of the most-full well in labware loaded onto the thermocycler.",
+          "title": "Blockmaxvolumeul",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "profile": {
+          "description": "Array of profile steps with target temperature and temperature hold time.",
+          "items": {
+            "$ref": "#/$defs/RunProfileStepParams"
+          },
+          "title": "Profile",
+          "type": "array"
+        }
+      },
+      "required": ["moduleId", "profile"],
+      "title": "RunProfileParams",
+      "type": "object"
+    },
+    "RunProfileStepParams": {
+      "description": "Input parameters for an individual Thermocycler profile step.",
+      "properties": {
+        "celsius": {
+          "description": "Target temperature in \u00b0C.",
+          "title": "Celsius",
+          "type": "number"
+        },
+        "holdSeconds": {
+          "description": "Time to hold target temperature at in seconds.",
+          "title": "Holdseconds",
+          "type": "number"
+        }
+      },
+      "required": ["celsius", "holdSeconds"],
+      "title": "RunProfileStepParams",
+      "type": "object"
+    },
+    "SavePositionCreate": {
+      "description": "Save position command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "savePosition",
+          "default": "savePosition",
+          "enum": ["savePosition"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SavePositionParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SavePositionCreate",
+      "type": "object"
+    },
+    "SavePositionParams": {
+      "description": "Payload needed to save a pipette's current position.",
+      "properties": {
+        "failOnNotHomed": {
+          "description": "Require all axes to be homed before saving position.",
+          "title": "Failonnothomed",
+          "type": "boolean"
+        },
+        "pipetteId": {
+          "description": "Unique identifier of the pipette in question.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "positionId": {
+          "description": "An optional ID to assign to this command instance. Auto-assigned if not defined.",
+          "title": "Positionid",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId"],
+      "title": "SavePositionParams",
+      "type": "object"
+    },
+    "SetAndWaitForShakeSpeedCreate": {
+      "description": "A request to create a Heater-Shaker's set and wait for shake speed command.",
+      "properties": {
+        "commandType": {
+          "const": "heaterShaker/setAndWaitForShakeSpeed",
+          "default": "heaterShaker/setAndWaitForShakeSpeed",
+          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SetAndWaitForShakeSpeedParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SetAndWaitForShakeSpeedCreate",
+      "type": "object"
+    },
+    "SetAndWaitForShakeSpeedParams": {
+      "description": "Input parameters to set and wait for a shake speed for a Heater-Shaker Module.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "rpm": {
+          "description": "Target speed in rotations per minute.",
+          "title": "Rpm",
+          "type": "number"
+        }
+      },
+      "required": ["moduleId", "rpm"],
+      "title": "SetAndWaitForShakeSpeedParams",
+      "type": "object"
+    },
+    "SetRailLightsCreate": {
+      "description": "setRailLights command request model.",
+      "properties": {
+        "commandType": {
+          "const": "setRailLights",
+          "default": "setRailLights",
+          "enum": ["setRailLights"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SetRailLightsParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SetRailLightsCreate",
+      "type": "object"
+    },
+    "SetRailLightsParams": {
+      "description": "Payload required to set the rail lights on or off.",
+      "properties": {
+        "on": {
+          "description": "The field that determines if the light is turned off or on.",
+          "title": "On",
+          "type": "boolean"
+        }
+      },
+      "required": ["on"],
+      "title": "SetRailLightsParams",
+      "type": "object"
+    },
+    "SetStatusBarCreate": {
+      "description": "setStatusBar command request model.",
+      "properties": {
+        "commandType": {
+          "const": "setStatusBar",
+          "default": "setStatusBar",
+          "enum": ["setStatusBar"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SetStatusBarParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SetStatusBarCreate",
+      "type": "object"
+    },
+    "SetStatusBarParams": {
+      "description": "Payload required to set the status bar to run an animation.",
+      "properties": {
+        "animation": {
+          "$ref": "#/$defs/StatusBarAnimation",
+          "description": "The animation that should be executed on the status bar."
+        }
+      },
+      "required": ["animation"],
+      "title": "SetStatusBarParams",
+      "type": "object"
+    },
+    "SetStoredLabwareCreate": {
+      "description": "A request to execute a Flex Stacker SetStoredLabware command.",
+      "properties": {
+        "commandType": {
+          "const": "flexStacker/setStoredLabware",
+          "default": "flexStacker/setStoredLabware",
+          "enum": ["flexStacker/setStoredLabware"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SetStoredLabwareParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SetStoredLabwareCreate",
+      "type": "object"
+    },
+    "SetStoredLabwareParams": {
+      "description": "Input parameters for a setStoredLabware command.",
+      "properties": {
+        "adapterLabware": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StackerStoredLabwareDetails"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The details of the adapter under the primary labware, if any."
+        },
+        "initialCount": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The number of labware that should be initially stored in the stacker. This number will be silently clamped to the maximum number of labware that will fit; do not rely on the parameter to know how many labware are in the stacker.",
+          "title": "Initialcount"
+        },
+        "lidLabware": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StackerStoredLabwareDetails"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The details of the lid on the primary labware, if any."
+        },
+        "moduleId": {
+          "description": "Unique ID of the Flex Stacker.",
+          "title": "Moduleid",
+          "type": "string"
+        },
+        "primaryLabware": {
+          "$ref": "#/$defs/StackerStoredLabwareDetails",
+          "description": "The details of the primary labware (i.e. not the lid or adapter, if any) stored in the stacker."
+        }
+      },
+      "required": ["moduleId", "primaryLabware"],
+      "title": "SetStoredLabwareParams",
+      "type": "object"
+    },
+    "SetTargetBlockTemperatureCreate": {
+      "description": "A request to create a Thermocycler's set block temperature command.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/setTargetBlockTemperature",
+          "default": "thermocycler/setTargetBlockTemperature",
+          "enum": ["thermocycler/setTargetBlockTemperature"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SetTargetBlockTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SetTargetBlockTemperatureCreate",
+      "type": "object"
+    },
+    "SetTargetBlockTemperatureParams": {
+      "description": "Input parameters to set a Thermocycler's target block temperature.",
+      "properties": {
+        "blockMaxVolumeUl": {
+          "description": "Amount of liquid in uL of the most-full well in labware loaded onto the thermocycler.",
+          "title": "Blockmaxvolumeul",
+          "type": "number"
+        },
+        "celsius": {
+          "description": "Target temperature in \u00b0C.",
+          "title": "Celsius",
+          "type": "number"
+        },
+        "holdTimeSeconds": {
+          "description": "Amount of time, in seconds, to hold the temperature for. If specified, a waitForBlockTemperature command will block until the given hold time has elapsed.",
+          "title": "Holdtimeseconds",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId", "celsius"],
+      "title": "SetTargetBlockTemperatureParams",
+      "type": "object"
+    },
+    "SetTargetLidTemperatureCreate": {
+      "description": "A request to create a Thermocycler's set lid temperature command.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/setTargetLidTemperature",
+          "default": "thermocycler/setTargetLidTemperature",
+          "enum": ["thermocycler/setTargetLidTemperature"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SetTargetLidTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SetTargetLidTemperatureCreate",
+      "type": "object"
+    },
+    "SetTargetLidTemperatureParams": {
+      "description": "Input parameters to set a Thermocycler's target lid temperature.",
+      "properties": {
+        "celsius": {
+          "description": "Target temperature in \u00b0C.",
+          "title": "Celsius",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId", "celsius"],
+      "title": "SetTargetLidTemperatureParams",
+      "type": "object"
+    },
+    "SingleDispenseProperties": {
+      "description": "Properties specific to the single-dispense function.",
+      "properties": {
+        "correctionByVolume": {
+          "description": "Settings for volume correction keyed by by target dispense volume, representing additional volume the plunger should move to accurately hit target volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Correctionbyvolume",
+          "type": "array"
+        },
+        "delay": {
+          "$ref": "#/$defs/DelayProperties",
+          "description": "Delay after dispense, in seconds."
+        },
+        "flowRateByVolume": {
+          "description": "Settings for flow rate keyed by target dispense volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Flowratebyvolume",
+          "type": "array"
+        },
+        "mix": {
+          "$ref": "#/$defs/MixProperties",
+          "description": "Mixing settings for after a dispense"
+        },
+        "offset": {
+          "$ref": "#/$defs/Coordinate",
+          "description": "Relative offset for single dispense."
+        },
+        "positionReference": {
+          "$ref": "#/$defs/PositionReference",
+          "description": "Position reference for single dispense."
+        },
+        "pushOutByVolume": {
+          "description": "Settings for pushout keyed by target dispense volume.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "minimum": 0.0,
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Pushoutbyvolume",
+          "type": "array"
+        },
+        "retract": {
+          "$ref": "#/$defs/RetractDispense",
+          "description": "Pipette retract settings after a single dispense."
+        },
+        "submerge": {
+          "$ref": "#/$defs/Submerge",
+          "description": "Submerge settings for single dispense."
+        }
+      },
+      "required": [
+        "submerge",
+        "retract",
+        "positionReference",
+        "offset",
+        "flowRateByVolume",
+        "correctionByVolume",
+        "mix",
+        "pushOutByVolume",
+        "delay"
+      ],
+      "title": "SingleDispenseProperties",
+      "type": "object"
+    },
+    "SingleNozzleLayoutConfiguration": {
+      "description": "Minimum information required for a new nozzle configuration.",
+      "properties": {
+        "primaryNozzle": {
+          "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
+          "enum": ["A1", "H1", "A12", "H12"],
+          "title": "Primarynozzle",
+          "type": "string"
+        },
+        "style": {
+          "const": "SINGLE",
+          "default": "SINGLE",
+          "enum": ["SINGLE"],
+          "title": "Style",
+          "type": "string"
+        }
+      },
+      "required": ["primaryNozzle"],
+      "title": "SingleNozzleLayoutConfiguration",
+      "type": "object"
+    },
+    "StackerFillEmptyStrategy": {
+      "description": "Strategy to use for filling or emptying a stacker.",
+      "enum": ["manualWithPause", "logical"],
+      "title": "StackerFillEmptyStrategy",
+      "type": "string"
+    },
+    "StackerStoredLabwareDetails": {
+      "description": "The parameters defining a labware to be stored in the stacker.",
+      "properties": {
+        "loadName": {
+          "description": "Name used to reference the definition of this labware.",
+          "title": "Loadname",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the definition of this labware.",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the definition of this labware.",
+          "title": "Version",
+          "type": "integer"
+        }
+      },
+      "required": ["loadName", "namespace", "version"],
+      "title": "StackerStoredLabwareDetails",
+      "type": "object"
+    },
+    "StatusBarAnimation": {
+      "description": "Status Bar animation options.",
+      "enum": ["idle", "confirm", "updating", "disco", "off"],
+      "title": "StatusBarAnimation",
+      "type": "string"
+    },
+    "StoreCreate": {
+      "description": "A request to execute a Flex Stacker store command.",
+      "properties": {
+        "commandType": {
+          "const": "flexStacker/store",
+          "default": "flexStacker/store",
+          "enum": ["flexStacker/store"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/StoreParams"
+        }
+      },
+      "required": ["params"],
+      "title": "StoreCreate",
+      "type": "object"
+    },
+    "StoreParams": {
+      "description": "Input parameters for a labware storage command.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the flex stacker.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "StoreParams",
+      "type": "object"
+    },
+    "Submerge": {
+      "description": "Shared properties for the submerge function before aspiration or dispense.",
+      "properties": {
+        "delay": {
+          "$ref": "#/$defs/DelayProperties",
+          "description": "Delay settings for submerge."
+        },
+        "offset": {
+          "$ref": "#/$defs/Coordinate",
+          "description": "Relative offset for submerge."
+        },
+        "positionReference": {
+          "$ref": "#/$defs/PositionReference",
+          "description": "Position reference for submerge."
+        },
+        "speed": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0.0,
+              "type": "number"
+            }
+          ],
+          "description": "Speed of submerging, in millimeters per second.",
+          "title": "Speed"
+        }
+      },
+      "required": ["positionReference", "offset", "speed", "delay"],
+      "title": "Submerge",
+      "type": "object"
+    },
+    "TipPickUpParams": {
+      "description": "Payload used to specify press-tip parameters for a seal command.",
+      "properties": {
+        "ejectorPushMm": {
+          "default": 0,
+          "description": "The distance to back off to ensure that the tip presence sensors are not triggered.",
+          "title": "Ejectorpushmm",
+          "type": "number"
+        },
+        "prepDistance": {
+          "default": 0,
+          "description": "The distance to move down to fit the tips on.",
+          "title": "Prepdistance",
+          "type": "number"
+        },
+        "pressDistance": {
+          "default": 0,
+          "description": "The distance to press on tips.",
+          "title": "Pressdistance",
+          "type": "number"
+        }
+      },
+      "title": "TipPickUpParams",
+      "type": "object"
+    },
+    "TipPresenceStatus": {
+      "description": "Tip presence status reported by a pipette.",
+      "enum": ["present", "absent", "unknown"],
+      "title": "TipPresenceStatus",
+      "type": "string"
+    },
+    "TouchTipCreate": {
+      "description": "Touch tip command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "touchTip",
+          "default": "touchTip",
+          "enum": ["touchTip"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/TouchTipParams"
+        }
+      },
+      "required": ["params"],
+      "title": "TouchTipCreate",
+      "type": "object"
+    },
+    "TouchTipParams": {
+      "description": "Payload needed to touch a pipette tip the sides of a specific well.",
+      "properties": {
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "mmFromEdge": {
+          "description": "Offset away from the the well edge, in millimeters.Incompatible when a radius is included as a non 1.0 value.",
+          "title": "Mmfromedge",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "radius": {
+          "default": 1.0,
+          "description": "The proportion of the target well's radius the pipette tip will move towards.",
+          "title": "Radius",
+          "type": "number"
+        },
+        "speed": {
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "title": "Speed",
+          "type": "number"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/WellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "pipetteId"],
+      "title": "TouchTipParams",
+      "type": "object"
+    },
+    "TouchTipProperties": {
+      "description": "Shared properties for the touch-tip function.",
+      "properties": {
+        "enable": {
+          "description": "Whether touch-tip is enabled.",
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "params": {
+          "$ref": "#/$defs/LiquidClassTouchTipParams",
+          "description": "Parameters for the touch-tip function.",
+          "title": "Params"
+        }
+      },
+      "required": ["enable"],
+      "title": "TouchTipProperties",
+      "type": "object"
+    },
+    "TryLiquidProbeCreate": {
+      "description": "The request model for a `tryLiquidProbe` command.",
+      "properties": {
+        "commandType": {
+          "const": "tryLiquidProbe",
+          "default": "tryLiquidProbe",
+          "enum": ["tryLiquidProbe"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/TryLiquidProbeParams"
+        }
+      },
+      "required": ["params"],
+      "title": "TryLiquidProbeCreate",
+      "type": "object"
+    },
+    "TryLiquidProbeParams": {
+      "description": "Parameters required for a `tryLiquidProbe` command.",
+      "properties": {
+        "labwareId": {
+          "description": "Identifier of labware to use.",
+          "title": "Labwareid",
+          "type": "string"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        },
+        "wellLocation": {
+          "$ref": "#/$defs/WellLocation",
+          "description": "Relative well location at which to perform the operation"
+        },
+        "wellName": {
+          "description": "Name of well to use in labware.",
+          "title": "Wellname",
+          "type": "string"
+        }
+      },
+      "required": ["labwareId", "wellName", "pipetteId"],
+      "title": "TryLiquidProbeParams",
+      "type": "object"
+    },
+    "UnsafeBlowOutInPlaceCreate": {
+      "description": "UnsafeBlowOutInPlace command request model.",
+      "properties": {
+        "commandType": {
+          "const": "unsafe/blowOutInPlace",
+          "default": "unsafe/blowOutInPlace",
+          "enum": ["unsafe/blowOutInPlace"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/UnsafeBlowOutInPlaceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "UnsafeBlowOutInPlaceCreate",
+      "type": "object"
+    },
+    "UnsafeBlowOutInPlaceParams": {
+      "description": "Payload required to blow-out in place while position is unknown.",
+      "properties": {
+        "flowRate": {
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0.0,
+          "title": "Flowrate",
+          "type": "number"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["flowRate", "pipetteId"],
+      "title": "UnsafeBlowOutInPlaceParams",
+      "type": "object"
+    },
+    "UnsafeDropTipInPlaceCreate": {
+      "description": "Drop tip in place command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "unsafe/dropTipInPlace",
+          "default": "unsafe/dropTipInPlace",
+          "enum": ["unsafe/dropTipInPlace"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/UnsafeDropTipInPlaceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "UnsafeDropTipInPlaceCreate",
+      "type": "object"
+    },
+    "UnsafeDropTipInPlaceParams": {
+      "description": "Payload required to drop a tip in place even if the plunger position is not known.",
+      "properties": {
+        "homeAfter": {
+          "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
+          "title": "Homeafter",
+          "type": "boolean"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId"],
+      "title": "UnsafeDropTipInPlaceParams",
+      "type": "object"
+    },
+    "UnsafeEngageAxesCreate": {
+      "description": "UnsafeEngageAxes command request model.",
+      "properties": {
+        "commandType": {
+          "const": "unsafe/engageAxes",
+          "default": "unsafe/engageAxes",
+          "enum": ["unsafe/engageAxes"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/UnsafeEngageAxesParams"
+        }
+      },
+      "required": ["params"],
+      "title": "UnsafeEngageAxesCreate",
+      "type": "object"
+    },
+    "UnsafeEngageAxesParams": {
+      "description": "Payload required for an UnsafeEngageAxes command.",
+      "properties": {
+        "axes": {
+          "description": "The axes for which to enable.",
+          "items": {
+            "$ref": "#/$defs/MotorAxis"
+          },
+          "title": "Axes",
+          "type": "array"
+        }
+      },
+      "required": ["axes"],
+      "title": "UnsafeEngageAxesParams",
+      "type": "object"
+    },
+    "UnsafePlaceLabwareCreate": {
+      "description": "UnsafePlaceLabware command request model.",
+      "properties": {
+        "commandType": {
+          "const": "unsafe/placeLabware",
+          "default": "unsafe/placeLabware",
+          "enum": ["unsafe/placeLabware"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/UnsafePlaceLabwareParams"
+        }
+      },
+      "required": ["params"],
+      "title": "UnsafePlaceLabwareCreate",
+      "type": "object"
+    },
+    "UnsafePlaceLabwareParams": {
+      "description": "Payload required for an UnsafePlaceLabware command.",
+      "properties": {
+        "labwareURI": {
+          "description": "Labware URI for labware.",
+          "title": "Labwareuri",
+          "type": "string"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DeckSlotLocation"
+            },
+            {
+              "$ref": "#/$defs/ModuleLocation"
+            },
+            {
+              "$ref": "#/$defs/OnLabwareLocation"
+            },
+            {
+              "$ref": "#/$defs/AddressableAreaLocation"
+            }
+          ],
+          "description": "Where to place the labware.",
+          "title": "Location"
+        }
+      },
+      "required": ["labwareURI", "location"],
+      "title": "UnsafePlaceLabwareParams",
+      "type": "object"
+    },
+    "UnsafeUngripLabwareCreate": {
+      "description": "UnsafeEngageAxes command request model.",
+      "properties": {
+        "commandType": {
+          "const": "unsafe/ungripLabware",
+          "default": "unsafe/ungripLabware",
+          "enum": ["unsafe/ungripLabware"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/UnsafeUngripLabwareParams"
+        }
+      },
+      "required": ["params"],
+      "title": "UnsafeUngripLabwareCreate",
+      "type": "object"
+    },
+    "UnsafeUngripLabwareParams": {
+      "description": "Payload required for an UngripLabware command.",
+      "properties": {},
+      "title": "UnsafeUngripLabwareParams",
+      "type": "object"
+    },
+    "UpdatePositionEstimatorsCreate": {
+      "description": "UpdatePositionEstimators command request model.",
+      "properties": {
+        "commandType": {
+          "const": "unsafe/updatePositionEstimators",
+          "default": "unsafe/updatePositionEstimators",
+          "enum": ["unsafe/updatePositionEstimators"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/UpdatePositionEstimatorsParams"
+        }
+      },
+      "required": ["params"],
+      "title": "UpdatePositionEstimatorsCreate",
+      "type": "object"
+    },
+    "UpdatePositionEstimatorsParams": {
+      "description": "Payload required for an UpdatePositionEstimators command.",
+      "properties": {
+        "axes": {
+          "description": "The axes for which to update the position estimators. Any axes that are not physically present will be ignored.",
+          "items": {
+            "$ref": "#/$defs/MotorAxis"
+          },
+          "title": "Axes",
+          "type": "array"
+        }
+      },
+      "required": ["axes"],
+      "title": "UpdatePositionEstimatorsParams",
+      "type": "object"
+    },
+    "Vec3f": {
+      "description": "A 3D vector of floats.",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": ["x", "y", "z"],
+      "title": "Vec3f",
+      "type": "object"
+    },
+    "VerifyTipPresenceCreate": {
+      "description": "VerifyTipPresence command creation request model.",
+      "properties": {
+        "commandType": {
+          "const": "verifyTipPresence",
+          "default": "verifyTipPresence",
+          "enum": ["verifyTipPresence"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/VerifyTipPresenceParams"
+        }
+      },
+      "required": ["params"],
+      "title": "VerifyTipPresenceCreate",
+      "type": "object"
+    },
+    "VerifyTipPresenceParams": {
+      "description": "Payload required for a VerifyTipPresence command.",
+      "properties": {
+        "expectedState": {
+          "$ref": "#/$defs/TipPresenceStatus",
+          "description": "The expected tip presence status on the pipette."
+        },
+        "followSingularSensor": {
+          "$ref": "#/$defs/InstrumentSensorId",
+          "description": "The sensor id to follow if the other can be ignored.",
+          "title": "Followsingularsensor"
+        },
+        "pipetteId": {
+          "description": "Identifier of pipette to use for liquid handling.",
+          "title": "Pipetteid",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId", "expectedState"],
+      "title": "VerifyTipPresenceParams",
+      "type": "object"
+    },
+    "WaitForBlockTemperatureCreate": {
+      "description": "A request to create Thermocycler's wait for block temperature command.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/waitForBlockTemperature",
+          "default": "thermocycler/waitForBlockTemperature",
+          "enum": ["thermocycler/waitForBlockTemperature"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/WaitForBlockTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "WaitForBlockTemperatureCreate",
+      "type": "object"
+    },
+    "WaitForBlockTemperatureParams": {
+      "description": "Input parameters to wait for Thermocycler's target block temperature.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "WaitForBlockTemperatureParams",
+      "type": "object"
+    },
+    "WaitForDurationCreate": {
+      "description": "Wait for duration command request model.",
+      "properties": {
+        "commandType": {
+          "const": "waitForDuration",
+          "default": "waitForDuration",
+          "enum": ["waitForDuration"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/WaitForDurationParams"
+        }
+      },
+      "required": ["params"],
+      "title": "WaitForDurationCreate",
+      "type": "object"
+    },
+    "WaitForDurationParams": {
+      "description": "Payload required to pause the protocol.",
+      "properties": {
+        "message": {
+          "description": "A user-facing message associated with the pause",
+          "title": "Message",
+          "type": "string"
+        },
+        "seconds": {
+          "description": "Duration, in seconds, to wait for.",
+          "title": "Seconds",
+          "type": "number"
+        }
+      },
+      "required": ["seconds"],
+      "title": "WaitForDurationParams",
+      "type": "object"
+    },
+    "WaitForLidTemperatureCreate": {
+      "description": "A request to create Thermocycler's wait for lid temperature command.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/waitForLidTemperature",
+          "default": "thermocycler/waitForLidTemperature",
+          "enum": ["thermocycler/waitForLidTemperature"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/WaitForLidTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "WaitForLidTemperatureCreate",
+      "type": "object"
+    },
+    "WaitForLidTemperatureParams": {
+      "description": "Input parameters to wait for Thermocycler's lid temperature.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "WaitForLidTemperatureParams",
+      "type": "object"
+    },
+    "WaitForResumeCreate": {
+      "description": "Wait for resume command request model.",
+      "properties": {
+        "commandType": {
+          "default": "waitForResume",
+          "enum": ["waitForResume", "pause"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/WaitForResumeParams"
+        }
+      },
+      "required": ["params"],
+      "title": "WaitForResumeCreate",
+      "type": "object"
+    },
+    "WaitForResumeParams": {
+      "description": "Payload required to pause the protocol.",
+      "properties": {
+        "message": {
+          "description": "A user-facing message associated with the pause",
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "title": "WaitForResumeParams",
+      "type": "object"
+    },
+    "WellLocation": {
+      "description": "A relative location in reference to a well's location.",
+      "properties": {
+        "offset": {
+          "$ref": "#/$defs/WellOffset"
+        },
+        "origin": {
+          "$ref": "#/$defs/WellOrigin",
+          "default": "top"
+        },
+        "volumeOffset": {
+          "default": 0.0,
+          "description": "A volume of liquid, in \u00b5L, to offset the z-axis offset.",
+          "title": "Volumeoffset",
+          "type": "number"
+        }
+      },
+      "title": "WellLocation",
+      "type": "object"
+    },
+    "WellOffset": {
+      "description": "An offset vector in (x, y, z).",
+      "properties": {
+        "x": {
+          "default": 0,
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "default": 0,
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "default": 0,
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "title": "WellOffset",
+      "type": "object"
+    },
+    "WellOrigin": {
+      "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    MENISCUS: the meniscus-center of the well",
+      "enum": ["top", "bottom", "center", "meniscus"],
+      "title": "WellOrigin",
+      "type": "string"
+    },
+    "closeGripperJawCreate": {
+      "description": "closeGripperJaw command request model.",
+      "properties": {
+        "commandType": {
+          "const": "robot/closeGripperJaw",
+          "default": "robot/closeGripperJaw",
+          "enum": ["robot/closeGripperJaw"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/closeGripperJawParams"
+        }
+      },
+      "required": ["params"],
+      "title": "closeGripperJawCreate",
+      "type": "object"
+    },
+    "closeGripperJawParams": {
+      "description": "Payload required to close a gripper.",
+      "properties": {
+        "force": {
+          "description": "The force the gripper should use to hold the jaws, falls to default if none is provided.",
+          "title": "Force",
+          "type": "number"
+        }
+      },
+      "title": "closeGripperJawParams",
+      "type": "object"
+    },
+    "openGripperJawCreate": {
+      "description": "openGripperJaw command request model.",
+      "properties": {
+        "commandType": {
+          "const": "robot/openGripperJaw",
+          "default": "robot/openGripperJaw",
+          "enum": ["robot/openGripperJaw"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/openGripperJawParams"
+        }
+      },
+      "required": ["params"],
+      "title": "openGripperJawCreate",
+      "type": "object"
+    },
+    "openGripperJawParams": {
+      "description": "Payload required to release a gripper.",
+      "properties": {},
+      "title": "openGripperJawParams",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidCreate": {
+      "description": "A request to execute an Absorbance Reader close lid command.",
+      "properties": {
+        "commandType": {
+          "const": "absorbanceReader/closeLid",
+          "default": "absorbanceReader/closeLid",
+          "enum": ["absorbanceReader/closeLid"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CloseLidCreate",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams": {
+      "description": "Input parameters to close the lid on an absorbance reading.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the absorbance reader.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "CloseLidParams",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidCreate": {
+      "description": "A request to execute an Absorbance Reader open lid command.",
+      "properties": {
+        "commandType": {
+          "const": "absorbanceReader/openLid",
+          "default": "absorbanceReader/openLid",
+          "enum": ["absorbanceReader/openLid"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams"
+        }
+      },
+      "required": ["params"],
+      "title": "OpenLidCreate",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams": {
+      "description": "Input parameters to open the lid on an absorbance reading.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the absorbance reader.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "OpenLidParams",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
+      "description": "A request to create a Heater-Shaker's set temperature command.",
+      "properties": {
+        "commandType": {
+          "const": "heaterShaker/setTargetTemperature",
+          "default": "heaterShaker/setTargetTemperature",
+          "enum": ["heaterShaker/setTargetTemperature"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SetTargetTemperatureCreate",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
+      "description": "Input parameters to set a Heater-Shaker's target temperature.",
+      "properties": {
+        "celsius": {
+          "description": "Target temperature in \u00b0C.",
+          "title": "Celsius",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId", "celsius"],
+      "title": "SetTargetTemperatureParams",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
+      "description": "A request to create a Heater-Shaker's wait for temperature command.",
+      "properties": {
+        "commandType": {
+          "const": "heaterShaker/waitForTemperature",
+          "default": "heaterShaker/waitForTemperature",
+          "enum": ["heaterShaker/waitForTemperature"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "WaitForTemperatureCreate",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
+      "description": "Input parameters to wait for a Heater-Shaker's target temperature.",
+      "properties": {
+        "celsius": {
+          "description": "Target temperature in \u00b0C. If not specified, will default to the module's target temperature. Specifying a celsius parameter other than the target temperature could lead to unpredictable behavior and hence is not recommended for use. This parameter can be removed in a future version without prior notice.",
+          "title": "Celsius",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "WaitForTemperatureParams",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
+      "description": "A request to create a Temperature Module's set temperature command.",
+      "properties": {
+        "commandType": {
+          "const": "temperatureModule/setTargetTemperature",
+          "default": "temperatureModule/setTargetTemperature",
+          "enum": ["temperatureModule/setTargetTemperature"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "SetTargetTemperatureCreate",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
+      "description": "Input parameters to set a Temperature Module's target temperature.",
+      "properties": {
+        "celsius": {
+          "description": "Target temperature in \u00b0C.",
+          "title": "Celsius",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Temperature Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId", "celsius"],
+      "title": "SetTargetTemperatureParams",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
+      "description": "A request to create a Temperature Module's wait for temperature command.",
+      "properties": {
+        "commandType": {
+          "const": "temperatureModule/waitForTemperature",
+          "default": "temperatureModule/waitForTemperature",
+          "enum": ["temperatureModule/waitForTemperature"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams"
+        }
+      },
+      "required": ["params"],
+      "title": "WaitForTemperatureCreate",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
+      "description": "Input parameters to wait for a Temperature Module's target temperature.",
+      "properties": {
+        "celsius": {
+          "description": "Target temperature in \u00b0C. If not specified, will default to the module's target temperature. Specifying a celsius parameter other than the target temperature could lead to unpredictable behavior and hence is not recommended for use. This parameter can be removed in a future version without prior notice.",
+          "title": "Celsius",
+          "type": "number"
+        },
+        "moduleId": {
+          "description": "Unique ID of the Temperature Module.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "WaitForTemperatureParams",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidCreate": {
+      "description": "A request to close a Thermocycler's lid.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/closeLid",
+          "default": "thermocycler/closeLid",
+          "enum": ["thermocycler/closeLid"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams"
+        }
+      },
+      "required": ["params"],
+      "title": "CloseLidCreate",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams": {
+      "description": "Input parameters to close a Thermocycler's lid.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "CloseLidParams",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidCreate": {
+      "description": "A request to open a Thermocycler's lid.",
+      "properties": {
+        "commandType": {
+          "const": "thermocycler/openLid",
+          "default": "thermocycler/openLid",
+          "enum": ["thermocycler/openLid"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams"
+        }
+      },
+      "required": ["params"],
+      "title": "OpenLidCreate",
+      "type": "object"
+    },
+    "opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams": {
+      "description": "Input parameters to open a Thermocycler's lid.",
+      "properties": {
+        "moduleId": {
+          "description": "Unique ID of the Thermocycler.",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["moduleId"],
+      "title": "OpenLidParams",
+      "type": "object"
+    }
+  },
+  "$id": "opentronsCommandSchemaV13",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "discriminator": {
+    "mapping": {
+      "absorbanceReader/closeLid": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidCreate",
+      "absorbanceReader/initialize": "#/$defs/InitializeCreate",
+      "absorbanceReader/openLid": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidCreate",
+      "absorbanceReader/read": "#/$defs/ReadAbsorbanceCreate",
+      "airGapInPlace": "#/$defs/AirGapInPlaceCreate",
+      "aspirate": "#/$defs/AspirateCreate",
+      "aspirateInPlace": "#/$defs/AspirateInPlaceCreate",
+      "aspirateWhileTracking": "#/$defs/AspirateWhileTrackingCreate",
+      "blowOutInPlace": "#/$defs/BlowOutInPlaceCreate",
+      "blowout": "#/$defs/BlowOutCreate",
+      "calibration/calibrateGripper": "#/$defs/CalibrateGripperCreate",
+      "calibration/calibrateModule": "#/$defs/CalibrateModuleCreate",
+      "calibration/calibratePipette": "#/$defs/CalibratePipetteCreate",
+      "calibration/moveToMaintenancePosition": "#/$defs/MoveToMaintenancePositionCreate",
+      "comment": "#/$defs/CommentCreate",
+      "configureForVolume": "#/$defs/ConfigureForVolumeCreate",
+      "configureNozzleLayout": "#/$defs/ConfigureNozzleLayoutCreate",
+      "custom": "#/$defs/CustomCreate",
+      "dispense": "#/$defs/DispenseCreate",
+      "dispenseInPlace": "#/$defs/DispenseInPlaceCreate",
+      "dispenseWhileTracking": "#/$defs/DispenseWhileTrackingCreate",
+      "dropTip": "#/$defs/DropTipCreate",
+      "dropTipInPlace": "#/$defs/DropTipInPlaceCreate",
+      "evotipDispense": "#/$defs/EvotipDispenseCreate",
+      "evotipSealPipette": "#/$defs/EvotipSealPipetteCreate",
+      "evotipUnsealPipette": "#/$defs/EvotipUnsealPipetteCreate",
+      "flexStacker/closeLatch": "#/$defs/CloseLatchCreate",
+      "flexStacker/empty": "#/$defs/EmptyCreate",
+      "flexStacker/fill": "#/$defs/FillCreate",
+      "flexStacker/openLatch": "#/$defs/OpenLatchCreate",
+      "flexStacker/prepareShuttle": "#/$defs/PrepareShuttleCreate",
+      "flexStacker/retrieve": "#/$defs/RetrieveCreate",
+      "flexStacker/setStoredLabware": "#/$defs/SetStoredLabwareCreate",
+      "flexStacker/store": "#/$defs/StoreCreate",
+      "getNextTip": "#/$defs/GetNextTipCreate",
+      "getTipPresence": "#/$defs/GetTipPresenceCreate",
+      "heaterShaker/closeLabwareLatch": "#/$defs/CloseLabwareLatchCreate",
+      "heaterShaker/deactivateHeater": "#/$defs/DeactivateHeaterCreate",
+      "heaterShaker/deactivateShaker": "#/$defs/DeactivateShakerCreate",
+      "heaterShaker/openLabwareLatch": "#/$defs/OpenLabwareLatchCreate",
+      "heaterShaker/setAndWaitForShakeSpeed": "#/$defs/SetAndWaitForShakeSpeedCreate",
+      "heaterShaker/setTargetTemperature": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate",
+      "heaterShaker/waitForTemperature": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate",
+      "home": "#/$defs/HomeCreate",
+      "liquidProbe": "#/$defs/LiquidProbeCreate",
+      "loadLabware": "#/$defs/LoadLabwareCreate",
+      "loadLid": "#/$defs/LoadLidCreate",
+      "loadLidStack": "#/$defs/LoadLidStackCreate",
+      "loadLiquid": "#/$defs/LoadLiquidCreate",
+      "loadLiquidClass": "#/$defs/LoadLiquidClassCreate",
+      "loadModule": "#/$defs/LoadModuleCreate",
+      "loadPipette": "#/$defs/LoadPipetteCreate",
+      "magneticModule/disengage": "#/$defs/DisengageCreate",
+      "magneticModule/engage": "#/$defs/EngageCreate",
+      "moveLabware": "#/$defs/MoveLabwareCreate",
+      "moveRelative": "#/$defs/MoveRelativeCreate",
+      "moveToAddressableArea": "#/$defs/MoveToAddressableAreaCreate",
+      "moveToAddressableAreaForDropTip": "#/$defs/MoveToAddressableAreaForDropTipCreate",
+      "moveToCoordinates": "#/$defs/MoveToCoordinatesCreate",
+      "moveToWell": "#/$defs/MoveToWellCreate",
+      "pause": "#/$defs/WaitForResumeCreate",
+      "pickUpTip": "#/$defs/PickUpTipCreate",
+      "prepareToAspirate": "#/$defs/PrepareToAspirateCreate",
+      "reloadLabware": "#/$defs/ReloadLabwareCreate",
+      "retractAxis": "#/$defs/RetractAxisCreate",
+      "robot/closeGripperJaw": "#/$defs/closeGripperJawCreate",
+      "robot/moveAxesRelative": "#/$defs/MoveAxesRelativeCreate",
+      "robot/moveAxesTo": "#/$defs/MoveAxesToCreate",
+      "robot/moveTo": "#/$defs/MoveToCreate",
+      "robot/openGripperJaw": "#/$defs/openGripperJawCreate",
+      "savePosition": "#/$defs/SavePositionCreate",
+      "setRailLights": "#/$defs/SetRailLightsCreate",
+      "setStatusBar": "#/$defs/SetStatusBarCreate",
+      "temperatureModule/deactivate": "#/$defs/DeactivateTemperatureCreate",
+      "temperatureModule/setTargetTemperature": "#/$defs/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate",
+      "temperatureModule/waitForTemperature": "#/$defs/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate",
+      "thermocycler/closeLid": "#/$defs/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidCreate",
+      "thermocycler/deactivateBlock": "#/$defs/DeactivateBlockCreate",
+      "thermocycler/deactivateLid": "#/$defs/DeactivateLidCreate",
+      "thermocycler/openLid": "#/$defs/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidCreate",
+      "thermocycler/runExtendedProfile": "#/$defs/RunExtendedProfileCreate",
+      "thermocycler/runProfile": "#/$defs/RunProfileCreate",
+      "thermocycler/setTargetBlockTemperature": "#/$defs/SetTargetBlockTemperatureCreate",
+      "thermocycler/setTargetLidTemperature": "#/$defs/SetTargetLidTemperatureCreate",
+      "thermocycler/waitForBlockTemperature": "#/$defs/WaitForBlockTemperatureCreate",
+      "thermocycler/waitForLidTemperature": "#/$defs/WaitForLidTemperatureCreate",
+      "touchTip": "#/$defs/TouchTipCreate",
+      "tryLiquidProbe": "#/$defs/TryLiquidProbeCreate",
+      "unsafe/blowOutInPlace": "#/$defs/UnsafeBlowOutInPlaceCreate",
+      "unsafe/dropTipInPlace": "#/$defs/UnsafeDropTipInPlaceCreate",
+      "unsafe/engageAxes": "#/$defs/UnsafeEngageAxesCreate",
+      "unsafe/placeLabware": "#/$defs/UnsafePlaceLabwareCreate",
+      "unsafe/ungripLabware": "#/$defs/UnsafeUngripLabwareCreate",
+      "unsafe/updatePositionEstimators": "#/$defs/UpdatePositionEstimatorsCreate",
+      "verifyTipPresence": "#/$defs/VerifyTipPresenceCreate",
+      "waitForDuration": "#/$defs/WaitForDurationCreate",
+      "waitForResume": "#/$defs/WaitForResumeCreate"
+    },
+    "propertyName": "commandType"
+  },
+  "oneOf": [
+    {
+      "$ref": "#/$defs/AirGapInPlaceCreate"
+    },
+    {
+      "$ref": "#/$defs/AspirateCreate"
+    },
+    {
+      "$ref": "#/$defs/AspirateWhileTrackingCreate"
+    },
+    {
+      "$ref": "#/$defs/AspirateInPlaceCreate"
+    },
+    {
+      "$ref": "#/$defs/CommentCreate"
+    },
+    {
+      "$ref": "#/$defs/ConfigureForVolumeCreate"
+    },
+    {
+      "$ref": "#/$defs/ConfigureNozzleLayoutCreate"
+    },
+    {
+      "$ref": "#/$defs/CustomCreate"
+    },
+    {
+      "$ref": "#/$defs/DispenseCreate"
+    },
+    {
+      "$ref": "#/$defs/DispenseInPlaceCreate"
+    },
+    {
+      "$ref": "#/$defs/DispenseWhileTrackingCreate"
+    },
+    {
+      "$ref": "#/$defs/BlowOutCreate"
+    },
+    {
+      "$ref": "#/$defs/BlowOutInPlaceCreate"
+    },
+    {
+      "$ref": "#/$defs/DropTipCreate"
+    },
+    {
+      "$ref": "#/$defs/DropTipInPlaceCreate"
+    },
+    {
+      "$ref": "#/$defs/HomeCreate"
+    },
+    {
+      "$ref": "#/$defs/RetractAxisCreate"
+    },
+    {
+      "$ref": "#/$defs/LoadLabwareCreate"
+    },
+    {
+      "$ref": "#/$defs/ReloadLabwareCreate"
+    },
+    {
+      "$ref": "#/$defs/LoadLiquidCreate"
+    },
+    {
+      "$ref": "#/$defs/LoadLiquidClassCreate"
+    },
+    {
+      "$ref": "#/$defs/LoadModuleCreate"
+    },
+    {
+      "$ref": "#/$defs/LoadPipetteCreate"
+    },
+    {
+      "$ref": "#/$defs/LoadLidStackCreate"
+    },
+    {
+      "$ref": "#/$defs/LoadLidCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveLabwareCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveRelativeCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveToCoordinatesCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveToWellCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveToAddressableAreaCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveToAddressableAreaForDropTipCreate"
+    },
+    {
+      "$ref": "#/$defs/PrepareToAspirateCreate"
+    },
+    {
+      "$ref": "#/$defs/WaitForResumeCreate"
+    },
+    {
+      "$ref": "#/$defs/WaitForDurationCreate"
+    },
+    {
+      "$ref": "#/$defs/PickUpTipCreate"
+    },
+    {
+      "$ref": "#/$defs/SavePositionCreate"
+    },
+    {
+      "$ref": "#/$defs/SetRailLightsCreate"
+    },
+    {
+      "$ref": "#/$defs/TouchTipCreate"
+    },
+    {
+      "$ref": "#/$defs/SetStatusBarCreate"
+    },
+    {
+      "$ref": "#/$defs/VerifyTipPresenceCreate"
+    },
+    {
+      "$ref": "#/$defs/GetTipPresenceCreate"
+    },
+    {
+      "$ref": "#/$defs/GetNextTipCreate"
+    },
+    {
+      "$ref": "#/$defs/LiquidProbeCreate"
+    },
+    {
+      "$ref": "#/$defs/TryLiquidProbeCreate"
+    },
+    {
+      "$ref": "#/$defs/EvotipSealPipetteCreate"
+    },
+    {
+      "$ref": "#/$defs/EvotipDispenseCreate"
+    },
+    {
+      "$ref": "#/$defs/EvotipUnsealPipetteCreate"
+    },
+    {
+      "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/DeactivateHeaterCreate"
+    },
+    {
+      "$ref": "#/$defs/SetAndWaitForShakeSpeedCreate"
+    },
+    {
+      "$ref": "#/$defs/DeactivateShakerCreate"
+    },
+    {
+      "$ref": "#/$defs/OpenLabwareLatchCreate"
+    },
+    {
+      "$ref": "#/$defs/CloseLabwareLatchCreate"
+    },
+    {
+      "$ref": "#/$defs/DisengageCreate"
+    },
+    {
+      "$ref": "#/$defs/EngageCreate"
+    },
+    {
+      "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/DeactivateTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/SetTargetBlockTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/WaitForBlockTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/SetTargetLidTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/WaitForLidTemperatureCreate"
+    },
+    {
+      "$ref": "#/$defs/DeactivateBlockCreate"
+    },
+    {
+      "$ref": "#/$defs/DeactivateLidCreate"
+    },
+    {
+      "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidCreate"
+    },
+    {
+      "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidCreate"
+    },
+    {
+      "$ref": "#/$defs/RunProfileCreate"
+    },
+    {
+      "$ref": "#/$defs/RunExtendedProfileCreate"
+    },
+    {
+      "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidCreate"
+    },
+    {
+      "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidCreate"
+    },
+    {
+      "$ref": "#/$defs/InitializeCreate"
+    },
+    {
+      "$ref": "#/$defs/ReadAbsorbanceCreate"
+    },
+    {
+      "$ref": "#/$defs/RetrieveCreate"
+    },
+    {
+      "$ref": "#/$defs/StoreCreate"
+    },
+    {
+      "$ref": "#/$defs/SetStoredLabwareCreate"
+    },
+    {
+      "$ref": "#/$defs/FillCreate"
+    },
+    {
+      "$ref": "#/$defs/EmptyCreate"
+    },
+    {
+      "$ref": "#/$defs/CloseLatchCreate"
+    },
+    {
+      "$ref": "#/$defs/OpenLatchCreate"
+    },
+    {
+      "$ref": "#/$defs/PrepareShuttleCreate"
+    },
+    {
+      "$ref": "#/$defs/CalibrateGripperCreate"
+    },
+    {
+      "$ref": "#/$defs/CalibratePipetteCreate"
+    },
+    {
+      "$ref": "#/$defs/CalibrateModuleCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveToMaintenancePositionCreate"
+    },
+    {
+      "$ref": "#/$defs/UnsafeBlowOutInPlaceCreate"
+    },
+    {
+      "$ref": "#/$defs/UnsafeDropTipInPlaceCreate"
+    },
+    {
+      "$ref": "#/$defs/UpdatePositionEstimatorsCreate"
+    },
+    {
+      "$ref": "#/$defs/UnsafeEngageAxesCreate"
+    },
+    {
+      "$ref": "#/$defs/UnsafeUngripLabwareCreate"
+    },
+    {
+      "$ref": "#/$defs/UnsafePlaceLabwareCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveAxesRelativeCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveAxesToCreate"
+    },
+    {
+      "$ref": "#/$defs/MoveToCreate"
+    },
+    {
+      "$ref": "#/$defs/openGripperJawCreate"
+    },
+    {
+      "$ref": "#/$defs/closeGripperJawCreate"
+    }
+  ]
+}


### PR DESCRIPTION
# Overview

Since we have isolated Robot Stack release 8.4 into `chore_release-8.4.0` we must lock down command schema 12 for that Robot Stack Release.  If changes are needed to command schema 12 they must first be done in  `chore_release-8.4.0` then incorporated in `edge` via a merge back. 

I produced the new schema version by running 
```shell
cd api
python -m pipenv run python src/opentrons/protocol_engine/commands/generate_command_schema.py 13 --overwrite-shared-data
```

- edited the out of date index, but maybe not used anywhere?
- added a script that quickly diffs the edge schema vs a branch schema
![image](https://github.com/user-attachments/assets/26c9ad25-9e58-4bf2-b29d-b3457c678146)

## Review requests

- [ ] Is this all the steps?

## Risk assessment

Medium rare 🍖  - need validation this is all the steps and that all tests pass.