### PR TITLE
fix(app): Fix blocking Flex LPC for OT-2 reasons

### DIFF
--- a/app/src/molecules/WizardHeader/index.tsx
+++ b/app/src/molecules/WizardHeader/index.tsx
@@ -85,7 +85,11 @@ export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
   return (
     <Box css={BOX_STYLE}>
       <Flex css={HEADER_CONTAINER_STYLE}>
-        <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          alignItems={ALIGN_CENTER}
+          gap={SPACING.spacing8}
+        >
           <StyledText
             desktopStyle="bodyLargeSemiBold"
             oddStyle="bodyTextSemiBold"

--- a/app/src/resources/runs/useLPCDisabledReason.tsx
+++ b/app/src/resources/runs/useLPCDisabledReason.tsx
@@ -7,6 +7,7 @@ import { useMostRecentCompletedAnalysis } from './useMostRecentCompletedAnalysis
 import { useRunCalibrationStatus } from './useRunCalibrationStatus'
 import { useRunHasStarted } from './useRunHasStarted'
 import { useUnmatchedModulesForProtocol } from './useUnmatchedModulesForProtocol'
+import { useIsFlex } from '/app/redux-resources/robots'
 
 interface LPCDisabledReasonProps {
   runId: string
@@ -34,6 +35,7 @@ export function useLPCDisabledReason(
   const isCalibrationComplete =
     robotName != null ? complete : !hasMissingCalForOdd
   const { missingModuleIds } = unmatchedModuleResults
+  const isFlex = useIsFlex(robotName ?? '')
   const robotProtocolAnalysis = useMostRecentCompletedAnalysis(runId)
   const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)
   const protocolData = robotProtocolAnalysis ?? storedProtocolAnalysis
@@ -97,13 +99,13 @@ export function useLPCDisabledReason(
         ? 'labware_position_check_not_available_empty_protocol'
         : 'must_have_labware_and_pip'
     )
-  } else if (!tipRackLoadedInProtocol) {
+  } else if (!tipRackLoadedInProtocol && !isFlex) {
     lpcDisabledReason = t(
       robotName != null
         ? 'lpc_disabled_no_tipracks_loaded'
         : 'no_tiprack_loaded'
     )
-  } else if (!tipsArePickedUp) {
+  } else if (!tipsArePickedUp && !isFlex) {
     lpcDisabledReason = t(
       robotName != null ? 'lpc_disabled_no_tipracks_used' : 'no_tiprack_used'
     )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Woops, it's possible for users to perform LPC on the Flex without a tiprack in the protocol, and we should, you know, let users LPC, since that's really just an OT-2 restriction. A minor CSS fix is included here too for the OT-2 wizard header. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Unit testing is sufficient.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
