### PR TITLE
refactor(protocol-designer): use HydratedFormData union type for form errors & warnings

### DIFF
--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -260,6 +260,8 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   pipette: PipetteEntity
   tipRack: string
   volume: number
+  pushOut_volume: number | null
+  pushOut_checkbox: boolean
   aspirate_airGap_volume?: number | null
   aspirate_delay_mmFromBottom?: number | null
   aspirate_delay_seconds?: number | null
@@ -318,8 +320,6 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   pickUpTip_wellNames?: string[] | null
   preWetTip?: boolean | null
   liquidClass?: string | null
-  pushOut_volume: number | null
-  pushOut_checkbox: boolean
 }
 
 export interface HydratedMoveLabwareFormData extends AnnotationFields {

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -190,7 +190,7 @@ export interface ChangeTipFields {
   changeTip?: ChangeTipOptions
 }
 export type HydratedPauseFormData = AnnotationFields & {
-  stepType: 'pause'
+  stepType: Extract<StepType, 'pause'>
   id: StepIdType
   pauseAction?:
     | typeof PAUSE_UNTIL_RESUME
@@ -233,7 +233,7 @@ export type BlankForm = AnnotationFields & {
 
 export interface HydratedMoveLiquidFormData extends AnnotationFields {
   id: string
-  stepType: 'moveLiquid'
+  stepType: Extract<StepType, 'moveLiquid'>
   aspirate_airGap_checkbox: boolean
   aspirate_delay_checkbox: boolean
   aspirate_labware: LabwareEntity
@@ -318,11 +318,13 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   pickUpTip_wellNames?: string[] | null
   preWetTip?: boolean | null
   liquidClass?: string | null
+  pushOut_volume: number | null
+  pushOut_checkbox: boolean
 }
 
 export interface HydratedMoveLabwareFormData extends AnnotationFields {
   id: string
-  stepType: 'moveLabware'
+  stepType: Extract<StepType, 'moveLabware'>
   labware: LabwareEntity
   newLocation: LabwareLocation
   useGripper: boolean
@@ -330,7 +332,7 @@ export interface HydratedMoveLabwareFormData extends AnnotationFields {
 
 export interface HydratedCommentFormData extends AnnotationFields {
   id: string
-  stepType: 'comment'
+  stepType: Extract<StepType, 'comment'>
   message: string
 }
 
@@ -348,7 +350,7 @@ export interface HydratedMixFormData extends AnnotationFields {
   mix_wellOrder_second: WellOrderOption
   nozzles: NozzleConfigurationStyle | null
   pipette: PipetteEntity
-  stepType: 'mix'
+  stepType: Extract<StepType, 'mix'>
   tipRack: string
   volume: number
   wells: string[]
@@ -375,13 +377,13 @@ export type HydratedMagnetFormData = AnnotationFields & {
   magnetAction: MagnetAction
   moduleId: string
   stepDetails: string | null
-  stepType: 'magnet'
+  stepType: Extract<StepType, 'magnet'>
 }
 export interface HydratedTemperatureFormData extends AnnotationFields {
   id: string
   moduleId: string | null
   setTemperature: 'true' | 'false'
-  stepType: 'temperature'
+  stepType: Extract<StepType, 'temperature'>
   targetTemperature: string | null
 }
 export interface HydratedHeaterShakerFormData extends AnnotationFields {
@@ -392,14 +394,14 @@ export interface HydratedHeaterShakerFormData extends AnnotationFields {
   moduleId: string
   setHeaterShakerTemperature: boolean
   setShake: boolean
-  stepType: 'heaterShaker'
+  stepType: Extract<StepType, 'heaterShaker'>
   targetHeaterShakerTemperature: string | null
   targetSpeed: string | null
 }
 
 export interface HydratedThermocyclerFormData extends AnnotationFields {
   id: string
-  stepType: 'thermocycler'
+  stepType: Extract<StepType, 'thermocycler'>
   blockIsActive: boolean
   blockIsActiveHold: boolean
   blockTargetTemp: string | null
@@ -424,7 +426,7 @@ export type AbsorbanceReaderFormType =
   | typeof ABSORBANCE_READER_LID
 
 export interface HydratedAbsorbanceReaderFormData extends AnnotationFields {
-  stepType: 'absorbanceReader'
+  stepType: Extract<StepType, 'absorbanceReader'>
   id: string
   absorbanceReaderFormType: AbsorbanceReaderFormType | null
   fileName: string | null

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -190,7 +190,7 @@ export interface ChangeTipFields {
   changeTip?: ChangeTipOptions
 }
 export type HydratedPauseFormData = AnnotationFields & {
-  stepType: Extract<StepType, 'pause'>
+  stepType: 'pause'
   id: StepIdType
   pauseAction?:
     | typeof PAUSE_UNTIL_RESUME
@@ -233,7 +233,7 @@ export type BlankForm = AnnotationFields & {
 
 export interface HydratedMoveLiquidFormData extends AnnotationFields {
   id: string
-  stepType: Extract<StepType, 'moveLiquid'>
+  stepType: 'moveLiquid'
   aspirate_airGap_checkbox: boolean
   aspirate_delay_checkbox: boolean
   aspirate_labware: LabwareEntity
@@ -324,7 +324,7 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
 
 export interface HydratedMoveLabwareFormData extends AnnotationFields {
   id: string
-  stepType: Extract<StepType, 'moveLabware'>
+  stepType: 'moveLabware'
   labware: LabwareEntity
   newLocation: LabwareLocation
   useGripper: boolean
@@ -332,7 +332,7 @@ export interface HydratedMoveLabwareFormData extends AnnotationFields {
 
 export interface HydratedCommentFormData extends AnnotationFields {
   id: string
-  stepType: Extract<StepType, 'comment'>
+  stepType: 'comment'
   message: string
 }
 
@@ -350,7 +350,7 @@ export interface HydratedMixFormData extends AnnotationFields {
   mix_wellOrder_second: WellOrderOption
   nozzles: NozzleConfigurationStyle | null
   pipette: PipetteEntity
-  stepType: Extract<StepType, 'mix'>
+  stepType: 'mix'
   tipRack: string
   volume: number
   wells: string[]
@@ -377,13 +377,13 @@ export type HydratedMagnetFormData = AnnotationFields & {
   magnetAction: MagnetAction
   moduleId: string
   stepDetails: string | null
-  stepType: Extract<StepType, 'magnet'>
+  stepType: 'magnet'
 }
 export interface HydratedTemperatureFormData extends AnnotationFields {
   id: string
   moduleId: string | null
   setTemperature: 'true' | 'false'
-  stepType: Extract<StepType, 'temperature'>
+  stepType: 'temperature'
   targetTemperature: string | null
 }
 export interface HydratedHeaterShakerFormData extends AnnotationFields {
@@ -394,14 +394,14 @@ export interface HydratedHeaterShakerFormData extends AnnotationFields {
   moduleId: string
   setHeaterShakerTemperature: boolean
   setShake: boolean
-  stepType: Extract<StepType, 'heaterShaker'>
+  stepType: 'heaterShaker'
   targetHeaterShakerTemperature: string | null
   targetSpeed: string | null
 }
 
 export interface HydratedThermocyclerFormData extends AnnotationFields {
   id: string
-  stepType: Extract<StepType, 'thermocycler'>
+  stepType: 'thermocycler'
   blockIsActive: boolean
   blockIsActiveHold: boolean
   blockTargetTemp: string | null
@@ -426,7 +426,7 @@ export type AbsorbanceReaderFormType =
   | typeof ABSORBANCE_READER_LID
 
 export interface HydratedAbsorbanceReaderFormData extends AnnotationFields {
-  stepType: Extract<StepType, 'absorbanceReader'>
+  stepType: 'absorbanceReader'
   id: string
   absorbanceReaderFormType: AbsorbanceReaderFormType | null
   fileName: string | null

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -582,14 +582,13 @@ export const pauseForTimeOrUntilTold = (
   }
 }
 export const wellRatioMoveLiquid = (
-  fields: HydratedFormData
+  fields: HydratedMoveLiquidFormData
 ): FormError | null => {
-  if (!('aspirate_wells' in fields) || !('dispense_wells' in fields)) {
-    return null
-  }
   const { aspirate_wells, dispense_wells, dispense_labware } = fields
   const dispenseLabware =
-    'name' in dispense_labware ? dispense_labware.name ?? null : null
+    dispense_labware != null && 'name' in dispense_labware
+      ? dispense_labware.name ?? null
+      : null
   const isDispensingIntoTrash =
     dispenseLabware != null
       ? dispenseLabware === 'wasteChute' || dispenseLabware === 'trashBin'
@@ -1085,7 +1084,10 @@ export const dispenseTouchTipMmFromEdgeOutOfRange = (
   if (dispense_touchTip_checkbox == null) {
     return null
   }
-  const labwareDef = 'def' in dispense_labware ? dispense_labware.def : null
+  const labwareDef =
+    dispense_labware != null && 'def' in dispense_labware
+      ? dispense_labware.def
+      : null
   if (labwareDef == null) {
     return null
   }

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -950,8 +950,8 @@ export const wavelengthRequired = (
     0,
     mode === 'single' ? 1 : wavelengths.length
   )
-  //  @ts-expect-error
-  return wavelengthsToCheck?.some((wavelength: string[]) => !wavelength) &&
+
+  return wavelengthsToCheck?.some(wavelength => !wavelength) &&
     absorbanceReaderFormType === ABSORBANCE_READER_INITIALIZE
     ? WAVELENGTH_REQUIRED
     : null
@@ -1155,17 +1155,15 @@ export const getIsOutOfRange = (
  **     Helpers    **
  ********************/
 type ComposeErrors = <T extends HydratedFormData>(
-  ...errorCheckers: ((
-    fields: T,
-    moduleEntities?: ModuleEntities
-  ) => FormError | null)[]
+  ...errorCheckers: Array<
+    (fields: T, moduleEntities?: ModuleEntities) => FormError | null
+  >
 ) => (arg: T, moduleEntities?: ModuleEntities) => FormError[]
 
 export const composeErrors: ComposeErrors = <T extends HydratedFormData>(
-  ...errorCheckers: ((
-    fields: T,
-    moduleEntities?: ModuleEntities
-  ) => FormError | null)[]
+  ...errorCheckers: Array<
+    (fields: T, moduleEntities?: ModuleEntities) => FormError | null
+  >
 ) => (formData: T, moduleEntities?: ModuleEntities) =>
   errorCheckers
     .map(checker => checker(formData, moduleEntities))

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -242,6 +242,8 @@ export const getFormErrors = (
     return []
   }
 
+  //  TODO: try to find a cleaner way to write this via mapping
+  //  while also making TS happy
   switch (stepType) {
     case 'absorbanceReader':
       return stepFormHelperMap[stepType].getErrors(
@@ -313,6 +315,8 @@ export const getFormWarnings = (
     return []
   }
 
+  //  TODO: try to find a cleaner way to write this via mapping
+  //  while also making TS happy
   switch (stepType) {
     case 'mix':
       return stepFormHelperMap.mix.getWarnings != null

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -315,14 +315,12 @@ export const getFormWarnings = (
 
   switch (stepType) {
     case 'mix':
-      return stepFormHelperMap[stepType].getWarnings != null
-        ? stepFormHelperMap[stepType].getWarnings(
-            formData as HydratedMixFormData
-          )
+      return stepFormHelperMap.mix.getWarnings != null
+        ? stepFormHelperMap.mix.getWarnings(formData as HydratedMixFormData)
         : []
     case 'moveLiquid':
-      return stepFormHelperMap[stepType].getWarnings != null
-        ? stepFormHelperMap[stepType].getWarnings(
+      return stepFormHelperMap.moveLiquid.getWarnings != null
+        ? stepFormHelperMap.moveLiquid.getWarnings(
             formData as HydratedMoveLiquidFormData
           )
         : []

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -114,7 +114,7 @@ interface StepFormDataMap {
   comment: HydratedCommentFormData
 }
 interface FormHelpers<K extends keyof StepFormDataMap> {
-  getErrors?: (
+  getErrors: (
     arg: StepFormDataMap[K],
     moduleEntities: ModuleEntities
   ) => FormError[]
@@ -237,26 +237,97 @@ export const getFormErrors = (
   formData: HydratedFormData,
   moduleEntities: ModuleEntities
 ): FormError[] => {
-  //  manualIntervention is the starting deck state step
+  //  manualIntervention is the initial starting deck state step
   if (stepType === 'manualIntervention') {
     return []
   }
 
-  const formErrorGetter =
-    stepFormHelperMap[stepType] != null
-      ? stepFormHelperMap[stepType].getErrors
-      : null
+  switch (stepType) {
+    case 'absorbanceReader':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedAbsorbanceReaderFormData,
+        moduleEntities
+      )
+    case 'heaterShaker':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedHeaterShakerFormData,
+        moduleEntities
+      )
 
-  const errors =
-    formErrorGetter != null ? formErrorGetter(formData, moduleEntities) : []
-  return errors
+    case 'magnet':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedMagnetFormData,
+        moduleEntities
+      )
+
+    case 'mix':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedMixFormData,
+        moduleEntities
+      )
+
+    case 'moveLabware':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedMoveLabwareFormData,
+        moduleEntities
+      )
+
+    case 'moveLiquid':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedMoveLiquidFormData,
+        moduleEntities
+      )
+
+    case 'pause':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedPauseFormData,
+        moduleEntities
+      )
+
+    case 'temperature':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedTemperatureFormData,
+        moduleEntities
+      )
+
+    case 'thermocycler':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedThermocyclerFormData,
+        moduleEntities
+      )
+
+    case 'comment':
+      return stepFormHelperMap[stepType].getErrors(
+        formData as HydratedCommentFormData,
+        moduleEntities
+      )
+  }
 }
 
 export const getFormWarnings = (
   stepType: StepType,
   formData: HydratedFormData
 ): FormWarning[] => {
-  const formWarningGetter = stepFormHelperMap[stepType]?.getWarnings
-  const warnings = formWarningGetter != null ? formWarningGetter(formData) : []
-  return warnings
+  //  manualIntervention is the initial starting deck state step
+  if (stepType === 'manualIntervention') {
+    return []
+  }
+
+  switch (stepType) {
+    case 'mix':
+      return stepFormHelperMap[stepType].getWarnings != null
+        ? stepFormHelperMap[stepType].getWarnings(
+            formData as HydratedMixFormData
+          )
+        : []
+    case 'moveLiquid':
+      return stepFormHelperMap[stepType].getWarnings != null
+        ? stepFormHelperMap[stepType].getWarnings(
+            formData as HydratedMoveLiquidFormData
+          )
+        : []
+    default:
+      //  NOTE: if a new form has warnings, we need to wire it up!
+      return []
+  }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/heaterShakerFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/heaterShakerFormToArgs.ts
@@ -25,7 +25,7 @@ export const heaterShakerFormToArgs = (
     setShake ? !Number.isNaN(targetSpeed) : true,
     'heaterShakerFormToArgs expected targeShake to be a number when setShake is true'
   )
-  const { minutes, seconds } = getTimeFromForm(formData, 'heaterShakerTimer')
+  const { minutes, seconds } = getTimeFromForm(formData.heaterShakerTimer)
 
   const isNullTime = minutes === 0 && seconds === 0
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
@@ -13,7 +13,9 @@ import type {
 export const pauseFormToArgs = (
   formData: HydratedPauseFormData
 ): PauseArgs | WaitForTemperatureArgs | null => {
-  const { hours, minutes, seconds } = getTimeFromForm(formData, 'pauseTime')
+  const { hours, minutes, seconds } = getTimeFromForm(
+    'pauseTime' in formData ? formData.pauseTime ?? null : null
+  )
   const totalSeconds = (hours ?? 0) * 3600 + minutes * 60 + seconds
   const temperature = parseFloat(formData.pauseTemperature as string)
   const message = formData.pauseMessage ?? ''

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/stepFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/stepFormToArgs.test.ts
@@ -70,6 +70,8 @@ describe('form casting', () => {
       dispense_submerge_x_position: 1,
       dispense_submerge_y_position: -1,
       dispense_position_reference: 'well-bottom',
+      pushOut_volume: null,
+      pushOut_checkbox: false,
     }
     expect(_castForm(input)).toEqual({
       ...input,

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
@@ -40,7 +40,7 @@ describe('Min air gap volume', () => {
           [checkboxField]: false,
           [volumeField]: null,
           ...{ pipette },
-        }
+        } as any
         expect(minAirGapVolume({ ...fields })).toBe(null)
       })
       it('should NOT return a warning when there is no air gap volume specified', () => {
@@ -48,7 +48,7 @@ describe('Min air gap volume', () => {
           [checkboxField]: true,
           [volumeField]: null,
           ...{ pipette },
-        }
+        } as any
         expect(minAirGapVolume({ ...fields })).toBe(null)
       })
       it('should NOT return a warning when the air gap volume is greater than the pipette min volume', () => {
@@ -56,7 +56,7 @@ describe('Min air gap volume', () => {
           [checkboxField]: true,
           [volumeField]: '150',
           ...{ pipette },
-        }
+        } as any
         expect(minAirGapVolume(fields)).toBe(null)
       })
 
@@ -65,7 +65,7 @@ describe('Min air gap volume', () => {
           [checkboxField]: true,
           [volumeField]: '100',
           ...{ pipette },
-        }
+        } as any
         expect(minAirGapVolume(fields)).toBe(null)
       })
       it('should return a warning when the air gap volume is less than the pipette min volume', () => {
@@ -110,14 +110,14 @@ describe('Below pipette minimum volume', () => {
     const fields = {
       ...fieldsWithPipette,
       volume: 100,
-    }
+    } as any
     expect(belowPipetteMinimumVolume(fields)).toBe(null)
   })
   it('should NOT return a warning when the volume is greater than the min pipette volume', () => {
     const fields = {
       ...fieldsWithPipette,
       volume: 101,
-    }
+    } as any
     expect(belowPipetteMinimumVolume(fields)).toBe(null)
   })
   it('should return a warning when the volume is less than the min pipette volume', () => {
@@ -158,35 +158,35 @@ describe('Below min disposal volume', () => {
     const fields = {
       ...fieldsWithPipette,
       pipette: undefined,
-    }
+    } as any
     expect(minDisposalVolume(fields)).toBe(null)
   })
   it('should NOT return a warning when there is no pipette spec', () => {
     const fields = {
       ...fieldsWithPipette,
       pipette: { spec: undefined },
-    }
+    } as any
     expect(minDisposalVolume(fields)).toBe(null)
   })
   it('should NOT return a warning when the path is NOT multi dispense', () => {
     const fields = {
       ...fieldsWithPipette,
       path: 'another_path',
-    }
+    } as any
     expect(minDisposalVolume(fields)).toBe(null)
   })
   it('should NOT return a warning when the volume is equal to the min pipette volume', () => {
     const fields = {
       ...fieldsWithPipette,
       disposalVolume_volume: 100,
-    }
+    } as any
     expect(minDisposalVolume(fields)).toBe(null)
   })
   it('should NOT return a warning when the volume is greater than the min pipette volume', () => {
     const fields = {
       ...fieldsWithPipette,
       disposalVolume_volume: 100,
-    }
+    } as any
     expect(minDisposalVolume(fields)).toBe(null)
   })
 
@@ -297,8 +297,10 @@ describe('Max dispense well volume', () => {
       }
     })
     it('renders the errors for all 2', () => {
-      expect(tipPositionInTube(fields)?.type).toBe('TIP_POSITIONED_LOW_IN_TUBE')
-      expect(mixTipPositionInTube(fields)?.type).toBe(
+      expect(tipPositionInTube(fields as any)?.type).toBe(
+        'TIP_POSITIONED_LOW_IN_TUBE'
+      )
+      expect(mixTipPositionInTube(fields as any)?.type).toBe(
         'MIX_TIP_POSITIONED_LOW_IN_TUBE'
       )
     })
@@ -306,8 +308,8 @@ describe('Max dispense well volume', () => {
       fields.aspirate_mmFromBottom = 3
       fields.dispense_mmFromBottom = 3
       fields.mix_mmFromBottom = 3
-      expect(tipPositionInTube(fields)).toBe(null)
-      expect(mixTipPositionInTube(fields)).toBe(null)
+      expect(tipPositionInTube(fields as any)).toBe(null)
+      expect(mixTipPositionInTube(fields as any)).toBe(null)
     })
     it('renders null for both when the labware is not a tube rack', () => {
       fields.aspirate_labware = {
@@ -328,8 +330,8 @@ describe('Max dispense well volume', () => {
         labwareDefURI: 'mockURI',
         pythonName: 'mockPythonName',
       }
-      expect(tipPositionInTube(fields)).toBe(null)
-      expect(mixTipPositionInTube(fields)).toBe(null)
+      expect(tipPositionInTube(fields as any)).toBe(null)
+      expect(mixTipPositionInTube(fields as any)).toBe(null)
     })
   })
 })

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -1,11 +1,11 @@
 import { getWellTotalVolume } from '@opentrons/shared-data'
-import type { FormError } from './errors'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import {
+import type {
   HydratedFormData,
   HydratedMixFormData,
   HydratedMoveLiquidFormData,
 } from '../../form-types'
+import type { FormError } from './errors'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 /*******************
  ** Warning Messages **
@@ -207,11 +207,11 @@ export const minDispenseAirGapVolume: (
  ********************/
 
 type ComposeWarnings = <T extends HydratedFormData>(
-  ...warningCheckers: ((fields: T) => FormWarning | null)[]
+  ...warningCheckers: Array<(fields: T) => FormWarning | null>
 ) => (arg: T) => FormWarning[]
 
 export const composeWarnings: ComposeWarnings = <T extends HydratedFormData>(
-  ...warningCheckers: ((fields: T) => FormWarning | null)[]
+  ...warningCheckers: Array<(fields: T) => FormWarning | null>
 ) => (formData: T) =>
   warningCheckers.reduce<FormWarning[]>((acc, checker) => {
     const possibleWarning = checker(formData)

--- a/protocol-designer/src/steplist/utils/getTimeFromForm.ts
+++ b/protocol-designer/src/steplist/utils/getTimeFromForm.ts
@@ -1,6 +1,3 @@
-import type { FormData } from '../../form-types'
-import type { HydratedFormData } from '../formLevel/errors'
-
 const TIME_DELIMITER = ':'
 
 interface TimeData {
@@ -9,14 +6,12 @@ interface TimeData {
   hours: number
 }
 
-export const getTimeFromForm = (
-  formData: FormData | HydratedFormData,
-  timeField: string
-): TimeData => {
-  if (formData[timeField] == null) {
+export const getTimeFromForm = (timeFieldValue: string | null): TimeData => {
+  if (timeFieldValue == null) {
     return { hours: 0, minutes: 0, seconds: 0 }
   }
-  const timeSplit = formData[timeField].split(TIME_DELIMITER)
+
+  const timeSplit = timeFieldValue.split(TIME_DELIMITER)
   const [hoursFromForm, minutesFromForm, secondsFromForm] =
     timeSplit.length === 3 ? timeSplit : [0, ...timeSplit]
 


### PR DESCRIPTION
# Overview

Kept running into some bugs that were uncaught because the PD form errors/warnings were using the `HydratedFormData` typed as `any` instead of the union type. This PR refactors all form errors & warnigns to using the hydrate form data type that is a union of all PD forms types.

## Test Plan and Hands on Testing

Definitely need to smoke test a bit to make sure the form errors/warnings are working as expected! i smoke tested a few but probably worth it to go through each form and try to produce them.

## Changelog

- use the union type for HydratedFormData 
- plug into the formErrors and formWarnings
- update each formErrors and warnings arg type
- fix tests

## Risk assessment

medium-ish, touches all form errors and warnings
