### PR TITLE
fix(app): Fix LPC not POSTing labware defs to the maintenance run

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -4,7 +4,6 @@ import { getLabwareDefinitionsFromCommands } from '@opentrons/components'
 import {
   useCreateMaintenanceRunLabwareDefinitionMutation,
   useDeleteMaintenanceRunMutation,
-  useRunLoadedLabwareDefinitions,
 } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
@@ -121,26 +120,26 @@ export function useLPCFlows({
     createLabwareDefinition,
   } = useCreateMaintenanceRunLabwareDefinitionMutation()
   const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation()
-  useRunLoadedLabwareDefinitions(runId ?? null, {
-    onSuccess: res => {
+
+  // After the maintenance run is created, add labware defs to the maintenance run.
+  useEffect(() => {
+    if (maintenanceRunId != null) {
       void Promise.all(
-        res.data.map(def => {
-          if ('schemaVersion' in def) {
-            return createLabwareDefinition({
-              maintenanceRunId: maintenanceRunId as string,
-              labwareDef: def,
-            })
-          }
+        labwareDefs.map(def => {
+          return createLabwareDefinition({
+            maintenanceRunId,
+            labwareDef: def,
+          })
         })
-      ).then(() => {
-        setHasCreatedLPCRun(true)
-      })
-    },
-    onSettled: () => {
-      setIsLaunching(false)
-    },
-    enabled: maintenanceRunId != null,
-  })
+      )
+        .then(() => {
+          setHasCreatedLPCRun(true)
+        })
+        .finally(() => {
+          setIsLaunching(false)
+        })
+    }
+  }, [maintenanceRunId])
 
   const launchLPC = (): Promise<void> => {
     // Avoid accidentally creating several maintenance runs if a request is ongoing.


### PR DESCRIPTION
Closes [RQA-4010](https://opentrons.atlassian.net/browse/RQA-4010)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Currently, LPC utilizes the existing labware definitions from `runs/:runId/loaded_labware_defintions` and POSTs those definitions to the LPC maintenance run. However, it turns out that those definitions do not necessarily exist on the run resource at the time of LPC maintenance run creation.

We actually have access to the labware definitions from analysis directly and don't need to query the server for them. A much simpler (and functional) approach is to just POST the definitions we already have.

**Current Behavior**

https://github.com/user-attachments/assets/8172cc4a-7cef-435b-a5a3-05658eb58a6a

**With Fix**

https://github.com/user-attachments/assets/e5755dc6-8457-41e8-85cf-273ccffb52da



<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
- See ticket for protocol and custom labware if you'd like to test yourself.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed custom labware definitions used in a protocol crashing LPC.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4010]: https://opentrons.atlassian.net/browse/RQA-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ