### PR TITLE
feat(shared-data): enable multi dispense blowout

### DIFF
--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -1658,6 +1658,8 @@ def test_water_distribution_raises_error_for_disposal_vol_without_blowout(
         "nest_96_wellplate_200ul_flat", "C3"
     )
     water = simulated_protocol_context.define_liquid_class("water")
+    water_props = water.get_for(pipette_1k, tiprack)
+    water_props.multi_dispense.retract.blowout.enabled = False  # type: ignore[union-attr]
     with pytest.raises(
         RuntimeError,
         match="Specify a blowout location and enable blowout when using a disposal volume",

--- a/shared-data/liquid-class/definitions/1/ethanol_80.json
+++ b/shared-data/liquid-class/definitions/1/ethanol_80.json
@@ -189,7 +189,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 30.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -419,7 +423,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 30.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -654,7 +662,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 30.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -884,7 +896,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 30.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1124,7 +1140,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1359,7 +1379,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1593,7 +1617,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1827,7 +1855,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2061,7 +2093,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2295,7 +2331,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2535,7 +2575,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2770,7 +2814,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3004,7 +3052,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3238,7 +3290,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3472,7 +3528,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3706,7 +3766,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3946,7 +4010,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4181,7 +4249,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4415,7 +4487,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4649,7 +4725,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 125.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4883,7 +4963,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -5117,7 +5201,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
               },
               "touchTip": {
                 "enable": false,

--- a/shared-data/liquid-class/definitions/1/glycerol_50.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50.json
@@ -182,7 +182,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 25.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -405,7 +409,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 25.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -633,7 +641,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 25.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -856,7 +868,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 25.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1083,7 +1099,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1305,7 +1325,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1523,7 +1547,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1741,7 +1769,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1959,7 +1991,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2177,7 +2213,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2404,7 +2444,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2626,7 +2670,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2844,7 +2892,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3062,7 +3114,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3280,7 +3336,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3498,7 +3558,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3729,7 +3793,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 7.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3959,7 +4027,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 7.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4181,7 +4253,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4399,7 +4475,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4618,7 +4698,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4837,7 +4921,11 @@
               "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 250.0
+                }
               },
               "touchTip": {
                 "enable": false,

--- a/shared-data/liquid-class/definitions/1/water.json
+++ b/shared-data/liquid-class/definitions/1/water.json
@@ -187,7 +187,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -409,7 +413,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -636,7 +644,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -858,7 +870,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1083,7 +1099,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 318.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1307,7 +1327,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 318.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1523,7 +1547,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1735,7 +1763,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -1947,7 +1979,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2159,7 +2195,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2384,7 +2424,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 318.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2608,7 +2652,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 318.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -2824,7 +2872,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3036,7 +3088,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3248,7 +3304,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3460,7 +3520,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3677,7 +3741,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -3889,7 +3957,11 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4101,7 +4173,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4313,7 +4389,11 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4525,7 +4605,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
               },
               "touchTip": {
                 "enable": false,
@@ -4737,7 +4821,11 @@
                 [1000.0, 0.0]
               ],
               "blowout": {
-                "enable": false
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
               },
               "touchTip": {
                 "enable": false,


### PR DESCRIPTION
Closes RQA-3980
Potentially closes AUTH-1602, AUTH-1619

# Overview

Updates all liquid classes' multi-dispense blowout entries to:
- specify blowout location of `trash`
- specify blowout flow rate to be the same as the single dispense flow rate specified for that pipette+tip combo
- enable blowout

## Test Plan and Hands on Testing

The protocols in RQA-3908 should pass

## Review requests

- Verify that we want to keep blowout location of `trash`
- check that blowout flow rates are correct

## Risk assessment

Low. Just enables a setting that was disabled by default. We already have tests that check that transfers happen correctly when these properties are enabled
