### PR TITLE
fix(app): fix not applying offsets for locations containing modules

### DIFF
--- a/app/src/local-resources/offsets/utils/getLwOffsetLocSeqFromLocSeq.ts
+++ b/app/src/local-resources/offsets/utils/getLwOffsetLocSeqFromLocSeq.ts
@@ -3,7 +3,10 @@ import type {
   LoadedLabware,
   LoadedModule,
 } from '@opentrons/shared-data'
-import type { LabwareOffsetLocationSequence } from '@opentrons/api-client'
+import type {
+  LabwareOffsetLocationSequence,
+  OnAddressableAreaOffsetLocationSequenceComponent,
+} from '@opentrons/api-client'
 
 // Returns the offset location sequence, which is used to get/store offsets from the server,
 // and drive LPC UI.
@@ -12,7 +15,14 @@ export function getLwOffsetLocSeqFromLocSeq(
   lw: LoadedLabware[],
   modules: LoadedModule[]
 ): LabwareOffsetLocationSequence {
-  return locSequence.reduce<LabwareOffsetLocationSequence>(
+  // The addressable area name is always the last item of an offset loc seq, but
+  // can appear above a module in a loc seq, so we always append the addressable
+  // area component last.
+  // This assumes there is always only one addressable area component!
+  const { mainItems, addressableAreaComponent } = locSequence.reduce<{
+    mainItems: LabwareOffsetLocationSequence
+    addressableAreaComponent: OnAddressableAreaOffsetLocationSequenceComponent | null
+  }>(
     (acc, locSeqComponent) => {
       const { kind } = locSeqComponent
 
@@ -22,30 +32,46 @@ export function getLwOffsetLocSeqFromLocSeq(
           const matchingMod = modules.find(mod => mod.id === moduleId)
 
           return matchingMod != null
-            ? [...acc, { kind, moduleModel: matchingMod.model }]
+            ? {
+                ...acc,
+                mainItems: [
+                  ...acc.mainItems,
+                  { kind, moduleModel: matchingMod.model },
+                ],
+              }
             : acc
         }
         case 'onAddressableArea': {
-          return [
+          return {
             ...acc,
-            {
+            addressableAreaComponent: {
               kind,
               addressableAreaName: locSeqComponent.addressableAreaName,
             },
-          ]
+          }
         }
         case 'onLabware': {
           const { labwareId } = locSeqComponent
           const matchingLw = lw.find(aLw => aLw.id === labwareId)
 
           return matchingLw != null
-            ? [...acc, { kind, labwareUri: matchingLw.definitionUri }]
+            ? {
+                ...acc,
+                mainItems: [
+                  ...acc.mainItems,
+                  { kind, labwareUri: matchingLw.definitionUri },
+                ],
+              }
             : acc
         }
         default:
           return acc
       }
     },
-    []
+    { mainItems: [], addressableAreaComponent: null }
   )
+
+  return addressableAreaComponent != null
+    ? [...mainItems, addressableAreaComponent]
+    : mainItems
 }


### PR DESCRIPTION
Closes [RQA-4012](https://opentrons.atlassian.net/browse/RQA-4012)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes an issue applying offsets when the `offsetLocationSequence` involves a module. The util that converts the `locationSequence` to an `offsetLocationSequence` assumed that the ordering of the sequence should translate 1:1, but for `offsetLocationSequence`, the `addressableArea` kind component must be last in order to successfully POST updates for the offset.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that "applying offsets" now works when a labware offset location sequence contains a module.
- Verified no regression in LPC flows (nothing directly depends on the ordering of the labware offset location sequence).

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed unable to apply offsets when an offset contains a module.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4012]: https://opentrons.atlassian.net/browse/RQA-4012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ