### PR TITLE
refactor(step-generation): show location string for location arg in g…

### DIFF
--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -207,7 +207,7 @@ adapter_1 = magnetic_block_1.load_adapter(
 )
 adapter_2 = protocol.load_adapter(
     "fixture_flex_96_tiprack_adapter",
-    "B2",
+    location="B2",
     namespace="fixture",
     version=1,
 )`.trimStart()

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -127,7 +127,7 @@ export function getLoadAdapters(
         `${formatPyStr(parameters.loadName)}`,
         ...(!onModule
           ? [
-              `${formatPyStr(
+              `location=${formatPyStr(
                 adapterSlot === 'offDeck' ? OFF_DECK : adapterSlot
               )}`,
             ]


### PR DESCRIPTION
…etLoadAdapters

# Overview

match the pattern in `getLoadLabwares` where she show the `location` string with the `location` arg in `getLoadAdapters`. 

## Test Plan and Hands on Testing

Review the code. there is a unit test so if checks pass then we are good to go.

## Changelog

- add location string to arg, update test
- fix test file name

## Risk assessment

low
