### PR TITLE
fix(shared-data): fix multi dispense blowout flow rate values

### DIFF
--- a/shared-data/liquid-class/definitions/1/glycerol_50.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50.json
@@ -3796,7 +3796,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 7.0
+                  "flowRate": 40.0
                 }
               },
               "touchTip": {
@@ -4030,7 +4030,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 7.0
+                  "flowRate": 40.0
                 }
               },
               "touchTip": {

--- a/shared-data/liquid-class/definitions/1/water.json
+++ b/shared-data/liquid-class/definitions/1/water.json
@@ -1102,7 +1102,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 318.0
+                  "flowRate": 478.0
                 }
               },
               "touchTip": {
@@ -1330,7 +1330,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 318.0
+                  "flowRate": 478.0
                 }
               },
               "touchTip": {
@@ -2427,7 +2427,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 318.0
+                  "flowRate": 478.0
                 }
               },
               "touchTip": {
@@ -2655,7 +2655,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 318.0
+                  "flowRate": 478.0
                 }
               },
               "touchTip": {


### PR DESCRIPTION
# Overview

Realized a few wrong values in my previous PR #17895. 
The multi-disp blowout flow rates are supposed to be the max of the single dispense flow rates for that pipette+tiprack. A couple of entries got min values instead. Fixed those

## Risk assessment

Low. Small fixes in definitions
