### PR TITLE
fix(api): Estimating volume when liquid height is zero should return zero not error (now in 8.4.0) 

### DIFF
--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -344,7 +344,7 @@ def _find_volume_in_partial_frustum(
 ) -> float:
     """Look through a sorted list of frusta for a target height, and find the volume at that height."""
     for segment in sorted_well:
-        if segment.bottomHeight < target_height < segment.topHeight:
+        if segment.bottomHeight <= target_height <= segment.topHeight:
             relative_target_height = target_height - segment.bottomHeight
             section_height = segment.topHeight - segment.bottomHeight
             return volume_at_height_within_section(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

(identical to [this PR](https://github.com/Opentrons/opentrons/pull/17877) which was accidentally merged to `edge`)

As written before, the _find_volume_in_partial_frustum function would raise an error if the target_height equaled the top or bottom of any frustum. For example, 0.0 in my case, because I was getting this error during my protocol run:

```
opentrons.protocol_engine.errors.exceptions.InvalidLiquidHeightFound: Error 4000 GENERAL_ERROR
(InvalidLiquidHeightFound): Unable to find volume at given well-height 0.0.
```

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
