### PR TITLE
feat(step-generation): python command generation for air_gap in well

### DIFF
--- a/step-generation/src/__tests__/airGapInWell.test.ts
+++ b/step-generation/src/__tests__/airGapInWell.test.ts
@@ -66,6 +66,7 @@ describe('airGapInWell', () => {
         },
       },
     ])
+    expect(res.python).toBe('mockPythonName.air_gap(volume=10, height=1)')
   })
   it('air gap for multi wells for consolidate dispense', () => {
     const args = {
@@ -114,6 +115,7 @@ describe('airGapInWell', () => {
         },
       },
     ])
+    expect(res.python).toBe('mockPythonName.air_gap(volume=10, height=1)')
   })
   it('air gap after aspirate', () => {
     const args = {
@@ -155,5 +157,6 @@ describe('airGapInWell', () => {
         },
       },
     ])
+    expect(res.python).toBe('mockPythonName.air_gap(volume=10, height=1)')
   })
 })

--- a/step-generation/src/commandCreators/compound/airGapInWell.ts
+++ b/step-generation/src/commandCreators/compound/airGapInWell.ts
@@ -1,8 +1,4 @@
-import {
-  curryCommandCreator,
-  curryWithoutPython,
-  reduceCommandCreators,
-} from '../../utils'
+import { curryWithoutPython, reduceCommandCreators } from '../../utils'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import { airGapInPlace, moveToWell, prepareToAspirate } from '../atomic'
 import type { CommandCreator, CurriedCommandCreator } from '../../types'


### PR DESCRIPTION
# Overview

Generate python for `air_gap` in a well. It is the same for air gap after an aspirate vs dispense

## Test Plan and Hands on Testing

Review the code and smoke test

## Changelog

- add python generation for air gapping in a well

## Risk assessment

low, behind ff