### PR TITLE
feat(protocol-designer): add conditioning volume field

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -228,7 +228,9 @@
           "id": "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
           "dispense_touchTip_mmfromTop": -2,
           "pushOut_checkbox": false,
-          "pushOut_volume": 0
+          "pushOut_volume": 0,
+          "conditioning_checkbox": false,
+          "conditioning_volume": null
         },
         "54dc3200-75c7-11ea-b42f-4b64e50f43e5": {
           "moduleId": null,

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -260,7 +260,9 @@
           "id": "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
           "dispense_touchTip_mmfromTop": null,
           "pushOut_checkbox": false,
-          "pushOut_volume": 0
+          "pushOut_volume": 0,
+          "conditioning_checkbox": false,
+          "conditioning_volume": null
         },
         "4f4057e0-75c7-11ea-b42f-4b64e50f43e5": {
           "engageHeight": "6",

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -278,7 +278,9 @@
           "id": "f9a294f1-f42b-4cae-893a-592405349d56",
           "dispense_touchTip_mmfromTop": null,
           "pushOut_checkbox": true,
-          "pushOut_volume": 7
+          "pushOut_volume": 7,
+          "conditioning_checkbox": false,
+          "conditioning_volume": null
         },
         "5fdb9a12-fab4-42fd-886f-40af107b15d6": {
           "aspirate_delay_checkbox": false,

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -241,7 +241,9 @@
           "id": "d2f74144-a7bf-4ba2-aaab-30d70b2b62c7",
           "dispense_touchTip_mmfromTop": null,
           "pushOut_checkbox": true,
-          "pushOut_volume": 7
+          "pushOut_volume": 7,
+          "conditioning_checkbox": false,
+          "conditioning_volume": null
         },
         "240a2c96-3db8-4679-bdac-049306b7b9c4": {
           "blockIsActive": true,

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -208,7 +208,9 @@
           "id": "e7d36200-92a5-11e9-ac62-1b173f839d9e",
           "dispense_touchTip_mmfromTop": null,
           "pushOut_checkbox": false,
-          "pushOut_volume": 0
+          "pushOut_volume": 0,
+          "conditioning_checkbox": false,
+          "conditioning_volume": null
         },
         "18113c80-92a6-11e9-ac62-1b173f839d9e": {
           "aspirate_delay_checkbox": false,

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -142,7 +142,9 @@
           "dispense_touchTip_mmfromTop": null,
           "id": "292e8b18-f59e-4c63-b0f3-e242bf50094b",
           "pushOut_checkbox": true,
-          "pushOut_volume": 2
+          "pushOut_volume": 2,
+          "conditioning_checkbox": false,
+          "conditioning_volume": null
         },
         "960c2d3b-9cf9-49b0-ab4c-af4113f6671a": {
           "moduleId": "d6966555-6c0e-45e0-8056-428d7c486401:temperatureModuleType",

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -141,7 +141,9 @@
           "dispense_touchTip_mmfromTop": null,
           "id": "83a095fa-b649-4105-99d4-177f1a3f363a",
           "pushOut_checkbox": true,
-          "pushOut_volume": 7
+          "pushOut_volume": 7,
+          "conditioning_checkbox": false,
+          "conditioning_volume": null
         },
         "f5ea3139-1585-4848-9d5f-832eb88c99ca": {
           "aspirate_airGap_checkbox": false,
@@ -233,7 +235,9 @@
           "dispense_touchTip_mmfromTop": null,
           "id": "f5ea3139-1585-4848-9d5f-832eb88c99ca",
           "pushOut_checkbox": true,
-          "pushOut_volume": 7
+          "pushOut_volume": 7,
+          "conditioning_checkbox": false,
+          "conditioning_volume": null
         }
       },
       "orderedStepIds": [

--- a/protocol-designer/src/assets/localization/en/form.json
+++ b/protocol-designer/src/assets/localization/en/form.json
@@ -128,6 +128,13 @@
       "comment": {
         "label": "comment"
       },
+      "conditioning": {
+        "conditioning_volume": {
+          "caption": "Valid range between {{min}}-{{max}}µL",
+          "label": "Conditioning volume"
+        },
+        "title": "Condition"
+      },
       "delay": {
         "label": "delay"
       },

--- a/protocol-designer/src/assets/localization/en/tooltip.json
+++ b/protocol-designer/src/assets/localization/en/tooltip.json
@@ -47,6 +47,7 @@
       "blowout_location": "Where to dispose of remaining volume in tip",
       "blowout_z_offset": "The height at which blowout occurs from the top of the well",
       "changeTip": "Choose when the robot picks up fresh tips",
+      "conditioning_checkbox": "First aspirate and dispense liquid into the source well to ensure a more accurate first multi-dispense",
       "dispense_airGap_checkbox": "Draw in air before moving to trash to dispose of tip.",
       "dispense_delay_checkbox": "Delay after each dispense",
       "dispense_delay_mmFromBottom": "Distance from the bottom of the well",

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -310,6 +310,8 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   blowout_flowRate?: number | null
   blowout_location?: string | null
   blowout_z_offset?: number | null
+  conditioning_checkbox: boolean | null
+  conditioning_volume: number | null
   dispense_airGap_volume?: number | null
   dispense_delay_mmFromBottom?: number | null
   dispense_delay_seconds?: number | null

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -142,6 +142,8 @@ export const migrateFile = (
           pushOut_checkbox:
             defaultPushOutVolume != null && defaultPushOutVolume > 0,
           pushOut_volume: defaultPushOutVolume,
+          conditioning_checkbox: false,
+          conditioning_volume: null,
         },
       }
     }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -31,7 +31,10 @@ import {
   getLabwareEntities,
   getPipetteEntities,
 } from '../../../../../../step-forms/selectors'
-import { getMaxPushOutVolume } from '../../../../../../utils'
+import {
+  getMaxConditioningVolume,
+  getMaxPushOutVolume,
+} from '../../../../../../utils'
 import {
   getBlowoutLocationOptionsForForm,
   getFormErrorsMappedToField,
@@ -149,6 +152,11 @@ export const SecondStepsMoveLiquidTools = ({
 
   const maxPushoutVolume = getMaxPushOutVolume(
     Number(formData.volume),
+    pipetteSpec
+  )
+  const maxConditioningVolume = getMaxConditioningVolume(
+    Number(formData.volume),
+    Number(formData.disposalVolume_volume),
     pipetteSpec
   )
 
@@ -367,6 +375,31 @@ export const SecondStepsMoveLiquidTools = ({
             </Flex>
           ) : null}
         </CheckboxExpandStepFormField>
+        {tab === 'dispense' && formData.path === 'multiDispense' ? (
+          <CheckboxExpandStepFormField
+            title={t('form:step_edit_form.field.conditioning.title')}
+            fieldProps={propsForFields.conditioning_checkbox}
+          >
+            {formData.conditioning_checkbox === true ? (
+              <InputStepFormField
+                title={t(
+                  'form:step_edit_form.field.conditioning.conditioning_volume.label'
+                )}
+                caption={t(
+                  'form:step_edit_form.field.conditioning.conditioning_volume.caption',
+                  { min: 0, max: maxConditioningVolume }
+                )}
+                padding="0"
+                {...propsForFields.conditioning_volume}
+                showTooltip={false}
+                errorToShow={getFormLevelError(
+                  'conditioning_volume',
+                  mappedErrorsToField
+                )}
+              />
+            ) : null}
+          </CheckboxExpandStepFormField>
+        ) : null}
         {tab === 'dispense' ? (
           <CheckboxExpandStepFormField
             title={i18n.format(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -154,12 +154,16 @@ export const SecondStepsMoveLiquidTools = ({
     Number(formData.volume),
     pipetteSpec
   )
-  const maxConditioningVolume = getMaxConditioningVolume(
-    Number(formData.volume),
-    Number(formData.disposalVolume_volume),
-    pipetteSpec
-  )
-
+  const maxConditioningVolume = getMaxConditioningVolume({
+    transferVolume: Number(formData.volume),
+    disposalVolume:
+      formData.disposalVolume_checkbox === true
+        ? Number(formData.disposalVolume_volume)
+        : 0,
+    pipetteSpecs: pipetteSpec,
+    labwareEntities: labwares,
+    tiprackDefUri: formData.tipRack,
+  })
   const minXYDimension = isDestinationTrash
     ? null
     : getMinXYDimension(labwares[formData[`${tab}_labware`]]?.def, ['A1'])

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { round } from 'lodash'
@@ -154,16 +155,25 @@ export const SecondStepsMoveLiquidTools = ({
     Number(formData.volume),
     pipetteSpec
   )
-  const maxConditioningVolume = getMaxConditioningVolume({
-    transferVolume: Number(formData.volume),
-    disposalVolume:
-      formData.disposalVolume_checkbox === true
-        ? Number(formData.disposalVolume_volume)
-        : 0,
-    pipetteSpecs: pipetteSpec,
-    labwareEntities: labwares,
-    tiprackDefUri: formData.tipRack,
-  })
+  const maxConditioningVolume = useMemo(
+    () =>
+      getMaxConditioningVolume({
+        transferVolume: Number(formData.volume),
+        disposalVolume:
+          formData.disposalVolume_checkbox === true
+            ? Number(formData.disposalVolume_volume)
+            : 0,
+        pipetteSpecs: pipetteSpec,
+        labwareEntities: labwares,
+        tiprackDefUri: formData.tipRack,
+      }),
+    [
+      formData.transferVolume,
+      formData.disposalVolume_volume,
+      formData.pipette,
+      formData.tipRack,
+    ]
+  )
   const minXYDimension = isDestinationTrash
     ? null
     : getMinXYDimension(labwares[formData[`${tab}_labware`]]?.def, ['A1'])

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -588,9 +588,15 @@ export const getBatchEditFormHasUnsavedChanges: Selector<
 
 const _formLevelErrors = (
   hydratedForm: HydratedFormData,
-  moduleEntities: ModuleEntities
+  moduleEntities: ModuleEntities,
+  labwareEntities: LabwareEntities
 ): StepFormErrors => {
-  return getFormErrors(hydratedForm.stepType, hydratedForm, moduleEntities)
+  return getFormErrors(
+    hydratedForm.stepType,
+    hydratedForm,
+    moduleEntities,
+    labwareEntities
+  )
 }
 
 const _dynamicFieldFormErrors = (
@@ -673,7 +679,11 @@ export const _hasFormLevelErrors = (
   invariantContext: InvariantContext
 ): boolean => {
   if (
-    _formLevelErrors(hydratedForm, invariantContext.moduleEntities).length > 0
+    _formLevelErrors(
+      hydratedForm,
+      invariantContext.moduleEntities,
+      invariantContext.labwareEntities
+    ).length > 0
   )
     return true
 
@@ -833,7 +843,8 @@ export const getFormLevelErrorsForUnsavedForm: Selector<
 
     const errors = _formLevelErrors(
       hydratedForm,
-      invariantContext.moduleEntities
+      invariantContext.moduleEntities,
+      invariantContext.labwareEntities
     )
 
     return errors

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
@@ -219,6 +219,8 @@ describe('createPresavedStepForm', () => {
       preWetTip: false,
       pushOut_checkbox: null,
       pushOut_volume: null,
+      conditioning_checkbox: false,
+      conditioning_volume: null,
       stepDetails: '',
       stepName: 'transfer',
       volume: null,

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -440,6 +440,10 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: numberOrNull,
   },
+  conditioning_volume: {
+    maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
+    castValue: numberOrNull,
+  },
 }
 const profileFieldHelperMap: Record<string, StepFieldHelpers> = {
   // profile step fields

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -19,7 +19,11 @@ import {
   THERMOCYCLER_PROFILE,
 } from '../../constants'
 import { getPipetteCapacity } from '../../pipettes/pipetteData'
-import { canPipetteUseLabware, getMaxPushOutVolume } from '../../utils'
+import {
+  canPipetteUseLabware,
+  getMaxConditioningVolume,
+  getMaxPushOutVolume,
+} from '../../utils'
 import { getWellRatio } from '../utils'
 import { getTimeFromForm } from '../utils/getTimeFromForm'
 
@@ -480,6 +484,30 @@ const DISPENSE_TOUCH_TIP_MM_FROM_EDGE_REQUIRED: FormError = {
 const PUSH_OUT_VOLUME_REQUIRED: FormError = {
   title: 'Push out volume required',
   dependentFields: ['pushOut_volume'],
+  showAtForm: false,
+  showAtField: true,
+  page: 2,
+  tab: 'dispense',
+}
+const PUSH_OUT_VOLUME_OUT_OF_RANGE: FormError = {
+  title: 'Push out volume out of range',
+  dependentFields: ['pushOut_volume'],
+  showAtForm: false,
+  showAtField: true,
+  page: 2,
+  tab: 'dispense',
+}
+const CONDITIONING_VOLUME_REQUIRED: FormError = {
+  title: 'Conditioning volume required',
+  dependentFields: ['conditioning_volume'],
+  showAtForm: false,
+  showAtField: true,
+  page: 2,
+  tab: 'dispense',
+}
+const CONDITIONING_VOLUME_OUT_OF_RANGE: FormError = {
+  title: 'Conditioning volume out of range',
+  dependentFields: ['conditioning_volume'],
   showAtForm: false,
   showAtField: true,
   page: 2,
@@ -1140,7 +1168,38 @@ export const pushOutVolumeOutOfRange = (
     (pipette as PipetteEntity).spec
   )
   return pushOut_checkbox && pushOut_volume > maxPushOutVolume
-    ? PUSH_OUT_VOLUME_REQUIRED
+    ? PUSH_OUT_VOLUME_OUT_OF_RANGE
+    : null
+}
+export const conditioningVolumeRequired = (
+  fields: HydratedMoveLiquidFormData
+): FormError | null => {
+  const { conditioning_checkbox, conditioning_volume } = fields
+  return conditioning_checkbox && !conditioning_volume
+    ? CONDITIONING_VOLUME_REQUIRED
+    : null
+}
+export const conditioningVolumeOutOfRange = (
+  fields: HydratedMoveLiquidFormData
+): FormError | null => {
+  const {
+    conditioning_checkbox,
+    conditioning_volume,
+    pipette,
+    volume,
+    disposalVolume_checkbox,
+    disposalVolume_volume,
+  } = fields
+  if (pipette == null || conditioning_volume == null) {
+    return null
+  }
+  const maxConditioningVolume = getMaxConditioningVolume(
+    Number(volume),
+    disposalVolume_checkbox === true ? Number(disposalVolume_volume) : 0,
+    pipette.spec
+  )
+  return conditioning_checkbox && conditioning_volume > maxConditioningVolume
+    ? CONDITIONING_VOLUME_OUT_OF_RANGE
     : null
 }
 

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -29,7 +29,7 @@ import { getTimeFromForm } from '../utils/getTimeFromForm'
 
 import type { ReactNode } from 'react'
 import type { LabwareDefinition2, PipetteV2Specs } from '@opentrons/shared-data'
-import type { PipetteEntity } from '@opentrons/step-generation'
+import type { LabwareEntities, PipetteEntity } from '@opentrons/step-generation'
 import type {
   HydratedAbsorbanceReaderFormData,
   HydratedFormData,
@@ -1180,7 +1180,9 @@ export const conditioningVolumeRequired = (
     : null
 }
 export const conditioningVolumeOutOfRange = (
-  fields: HydratedMoveLiquidFormData
+  fields: HydratedMoveLiquidFormData,
+  moduleEntities?: ModuleEntities,
+  labwareEntities?: LabwareEntities
 ): FormError | null => {
   const {
     conditioning_checkbox,
@@ -1189,15 +1191,19 @@ export const conditioningVolumeOutOfRange = (
     volume,
     disposalVolume_checkbox,
     disposalVolume_volume,
+    tipRack,
   } = fields
   if (pipette == null || conditioning_volume == null) {
     return null
   }
-  const maxConditioningVolume = getMaxConditioningVolume(
-    Number(volume),
-    disposalVolume_checkbox === true ? Number(disposalVolume_volume) : 0,
-    pipette.spec
-  )
+  const maxConditioningVolume = getMaxConditioningVolume({
+    transferVolume: Number(volume),
+    disposalVolume:
+      disposalVolume_checkbox === true ? Number(disposalVolume_volume) : 0,
+    pipetteSpecs: pipette.spec,
+    labwareEntities: labwareEntities ?? {},
+    tiprackDefUri: tipRack,
+  })
   return conditioning_checkbox && conditioning_volume > maxConditioningVolume
     ? CONDITIONING_VOLUME_OUT_OF_RANGE
     : null
@@ -1217,15 +1223,31 @@ export const getIsOutOfRange = (
  ********************/
 type ComposeErrors = <T extends HydratedFormData>(
   ...errorCheckers: Array<
-    (fields: T, moduleEntities?: ModuleEntities) => FormError | null
+    (
+      fields: T,
+      moduleEntities?: ModuleEntities,
+      labwareEntities?: LabwareEntities
+    ) => FormError | null
   >
-) => (arg: T, moduleEntities?: ModuleEntities) => FormError[]
+) => (
+  arg: T,
+  moduleEntities?: ModuleEntities,
+  labwareEntities?: LabwareEntities
+) => FormError[]
 
 export const composeErrors: ComposeErrors = <T extends HydratedFormData>(
   ...errorCheckers: Array<
-    (fields: T, moduleEntities?: ModuleEntities) => FormError | null
+    (
+      fields: T,
+      moduleEntities?: ModuleEntities,
+      labwareEntities?: LabwareEntities
+    ) => FormError | null
   >
-) => (formData: T, moduleEntities?: ModuleEntities) =>
+) => (
+  formData: T,
+  moduleEntities?: ModuleEntities,
+  labwareEntities?: LabwareEntities
+) =>
   errorCheckers
-    .map(checker => checker(formData, moduleEntities))
+    .map(checker => checker(formData, moduleEntities, labwareEntities))
     .filter((error): error is FormError => error !== null)

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -90,6 +90,8 @@ export function getDefaultsForStepType(
         blowout_location: null,
         blowout_z_offset: DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP,
         changeTip: DEFAULT_CHANGE_TIP_OPTION,
+        conditioning_checkbox: false,
+        conditioning_volume: null,
         dispense_airGap_checkbox: false,
         dispense_airGap_volume: null,
         dispense_delay_checkbox: false,

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -88,7 +88,10 @@ import type {
   StepType,
 } from '../../form-types'
 import type { FormError } from './errors'
-import type { ModuleEntities } from '@opentrons/step-generation'
+import type {
+  LabwareEntities,
+  ModuleEntities,
+} from '@opentrons/step-generation'
 export { handleFormChange } from './handleFormChange'
 export { createBlankForm } from './createBlankForm'
 export { getDefaultsForStepType } from './getDefaultsForStepType'
@@ -118,7 +121,8 @@ interface StepFormDataMap {
 interface FormHelpers<K extends keyof StepFormDataMap> {
   getErrors: (
     arg: StepFormDataMap[K],
-    moduleEntities: ModuleEntities
+    moduleEntities: ModuleEntities,
+    labwareEntities: LabwareEntities
   ) => FormError[]
   getWarnings?: (arg: StepFormDataMap[K]) => FormWarning[] // Changed to match step type
 }
@@ -239,7 +243,8 @@ const stepFormHelperMap: {
 export const getFormErrors = (
   stepType: StepType,
   formData: HydratedFormData,
-  moduleEntities: ModuleEntities
+  moduleEntities: ModuleEntities,
+  labwareEntities: LabwareEntities
 ): FormError[] => {
   //  manualIntervention is the initial starting deck state step
   if (stepType === 'manualIntervention') {
@@ -252,60 +257,70 @@ export const getFormErrors = (
     case 'absorbanceReader':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedAbsorbanceReaderFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
     case 'heaterShaker':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedHeaterShakerFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
 
     case 'magnet':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedMagnetFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
 
     case 'mix':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedMixFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
 
     case 'moveLabware':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedMoveLabwareFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
 
     case 'moveLiquid':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedMoveLiquidFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
 
     case 'pause':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedPauseFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
 
     case 'temperature':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedTemperatureFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
 
     case 'thermocycler':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedThermocyclerFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
 
     case 'comment':
       return stepFormHelperMap[stepType].getErrors(
         formData as HydratedCommentFormData,
-        moduleEntities
+        moduleEntities,
+        labwareEntities
       )
   }
 }

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -57,6 +57,8 @@ import {
   dispenseTouchTipMmFromEdgeRequired,
   pushOutVolumeRequired,
   pushOutVolumeOutOfRange,
+  conditioningVolumeOutOfRange,
+  conditioningVolumeRequired,
 } from './errors'
 
 import {
@@ -194,7 +196,9 @@ const stepFormHelperMap: {
       aspirateTouchTipMmFromEdgeOutOfRange,
       dispenseTouchTipMmFromEdgeOutOfRange,
       aspirateTouchTipMmFromEdgeRequired,
-      dispenseTouchTipMmFromEdgeRequired
+      dispenseTouchTipMmFromEdgeRequired,
+      conditioningVolumeRequired,
+      conditioningVolumeOutOfRange
     ),
     getWarnings: composeWarnings(
       belowPipetteMinimumVolume,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/stepFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/stepFormToArgs.test.ts
@@ -73,6 +73,8 @@ describe('form casting', () => {
       dispense_position_reference: 'well-bottom',
       pushOut_volume: null,
       pushOut_checkbox: false,
+      conditioning_checkbox: false,
+      conditioning_volume: null,
     }
     expect(_castForm(input)).toEqual({
       ...input,

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
@@ -86,6 +86,8 @@ describe('getDefaultsForStepType', () => {
         preWetTip: false,
         pushOut_checkbox: null,
         pushOut_volume: null,
+        conditioning_checkbox: false,
+        conditioning_volume: null,
 
         aspirate_airGap_checkbox: false,
         aspirate_airGap_volume: null,

--- a/protocol-designer/src/ui/steps/test/selectors.test.ts
+++ b/protocol-designer/src/ui/steps/test/selectors.test.ts
@@ -485,6 +485,14 @@ describe('_getSavedMultiSelectFieldValues', () => {
           isIndeterminate: false,
           value: undefined,
         },
+        conditioning_checkbox: {
+          isIndeterminate: false,
+          value: undefined,
+        },
+        conditioning_volume: {
+          isIndeterminate: false,
+          value: undefined,
+        },
         aspirate_mix_checkbox: {
           value: true,
           isIndeterminate: false,
@@ -878,6 +886,14 @@ describe('_getSavedMultiSelectFieldValues', () => {
           value: undefined,
         },
         pushOut_volume: {
+          isIndeterminate: false,
+          value: undefined,
+        },
+        conditioning_checkbox: {
+          isIndeterminate: false,
+          value: undefined,
+        },
+        conditioning_volume: {
           isIndeterminate: false,
           value: undefined,
         },

--- a/protocol-designer/src/utils/__tests__/utils.test.ts
+++ b/protocol-designer/src/utils/__tests__/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { getMaxPushOutVolume, removeOpentronsPhrases } from '..'
+import {
+  getMaxConditioningVolume,
+  getMaxPushOutVolume,
+  removeOpentronsPhrases,
+} from '..'
 
 describe('removeOpentronsPhrases', () => {
   it('should remove "Opentrons Flex 96"', () => {
@@ -108,5 +112,136 @@ describe('getMaxPushOutVolume', () => {
     const result = getMaxPushOutVolume(50, pipetteSpecNoLowVolume)
 
     expect(result).toBe(4)
+  })
+})
+
+describe('getMaxConditioningVolume', () => {
+  it('should calculate the max conditioning volume with default liquid specs and tiprack volume', () => {
+    const args = {
+      transferVolume: 10,
+      disposalVolume: 5,
+      tiprackDefUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      labwareEntities: {
+        tiprack: {
+          id: 'tiprack',
+          labwareDefURI: 'opentrons/opentrons_96_tiprack_300ul/1',
+          def: {
+            parameters: {
+              loadName: 'opentrons_96_tiprack_300ul',
+            },
+            wells: {
+              A1: {
+                totalLiquidVolume: 300,
+              },
+            },
+          },
+        },
+      },
+      pipetteSpecs: {
+        liquids: {
+          default: {
+            maxVolume: 200,
+            minVolume: 1,
+          },
+        },
+      },
+    } as any
+
+    const result = getMaxConditioningVolume(args)
+    expect(result).toBe(200 - 5 - 10)
+  })
+
+  it('should calculate the max conditioning volume with low volume liquid specs and tiprack volume', () => {
+    const args = {
+      transferVolume: 4,
+      disposalVolume: 1,
+      tiprackDefUri: 'opentrons/opentrons_96_tiprack_10ul/1',
+      labwareEntities: {
+        tiprack: {
+          id: 'tiprack',
+          labwareDefURI: 'opentrons/opentrons_96_tiprack_10ul/1',
+          def: {
+            parameters: {
+              loadName: 'opentrons_96_tiprack_10ul',
+            },
+            wells: {
+              A1: {
+                totalLiquidVolume: 10,
+              },
+            },
+          },
+        },
+      },
+      pipetteSpecs: {
+        liquids: {
+          default: {
+            maxVolume: 10,
+            minVolume: 5,
+          },
+          lowVolumeDefault: {
+            maxVolume: 5,
+            minVolume: 0.1,
+          },
+        },
+      },
+    } as any
+
+    const result = getMaxConditioningVolume(args)
+    expect(result).toBe(5 - 4 - 1)
+  })
+
+  it('should calculate the max conditioning volume without tiprack volume', () => {
+    const args = {
+      transferVolume: 10,
+      disposalVolume: 5,
+      tiprackDefUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      labwareEntities: {},
+      pipetteSpecs: {
+        liquids: {
+          default: {
+            maxVolume: 200,
+            minVolume: 1,
+          },
+        },
+      },
+    } as any
+
+    const result = getMaxConditioningVolume(args)
+    expect(result).toBe(200 - 5 - 10)
+  })
+
+  it('should handle zero disposal volume', () => {
+    const args = {
+      transferVolume: 10,
+      disposalVolume: 0,
+      tiprackDefUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+      labwareEntities: {
+        tiprack: {
+          id: 'tiprack',
+          labwareDefURI: 'opentrons/opentrons_96_tiprack_300ul/1',
+          def: {
+            parameters: {
+              loadName: 'opentrons_96_tiprack_300ul',
+            },
+            wells: {
+              A1: {
+                totalLiquidVolume: 300,
+              },
+            },
+          },
+        },
+      },
+      pipetteSpecs: {
+        liquids: {
+          default: {
+            maxVolume: 200,
+            minVolume: 1,
+          },
+        },
+      },
+    } as any
+
+    const result = getMaxConditioningVolume(args)
+    expect(result).toBe(200 - 10)
   })
 })

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -335,3 +335,17 @@ export const getDefaultPushOutVolume = (
     liquids[lookupKey].supportedTips[tipVolumeKey]?.defaultPushOutVolume ?? 0
   )
 }
+
+export const getMaxConditioningVolume = (
+  transferVolume: number,
+  disposalVolume: number,
+  pipetteSpecs: PipetteV2Specs
+): number => {
+  const { liquids } = pipetteSpecs
+  const isInLowVolumeMode =
+    transferVolume < liquids.default.minVolume && 'lowVolumeDefault' in liquids
+  const maxWorkingVolume = isInLowVolumeMode
+    ? liquids.lowVolumeDefault.maxVolume
+    : liquids.default.maxVolume
+  return maxWorkingVolume - disposalVolume - transferVolume
+}


### PR DESCRIPTION
# Overview

This PR wires up the conditioning volume field for multiDispense move liquid steps. It also enforces the maximum allowed conditioning volume based on pipette specs, transfer volume, and disposal volume configured. The logic for determining the max conditioning volume is as follows:

- determine max working volume for that pipette based on whether low volume mode is active
- determine max tip volume based on tiprack assigned for that step
- take the minimum of the above two calculations to determine the max effective working volume
- from this number, subtract the transfer volume (need to accommodate at least one destination-worth) and the disposal volume

Closes AUTH-912

## Test Plan and Hands on Testing

- create or open a multi-dispense transfer
- navigate to dispense advanced settings
- verify that "conditioning volume" is present and unchecked
- check the field and verify that the new field matches design
- verify error handling on save if volume not present or out of range

## Changelog

- create new conditioning volume form fields
- wire up in move liquid step form toolbox
- update migrations
- feed labwareEntities to formlevel errors
- create utility to determine max conditioning volume available

## Review requests

see test plan

## Risk assessment

low