### PR TITLE
fix(app): Fix ODD LPC labware selection

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
@@ -41,8 +41,8 @@ export function LPCLabwareList(props: LPCWizardContentProps): JSX.Element {
   const dispatch = useDispatch()
   const [selectedUri, setSelectedUri] = useState('')
 
-  const handlePrimaryOnClick = (): void => {
-    dispatch(setSelectedLabwareUri(props.runId, selectedUri))
+  const handlePrimaryOnClick = (uri: string): void => {
+    dispatch(setSelectedLabwareUri(props.runId, uri))
     dispatch(proceedEditOffsetSubstep(props.runId))
   }
 
@@ -56,7 +56,12 @@ export function LPCLabwareList(props: LPCWizardContentProps): JSX.Element {
         onClickButton: props.commandUtils.headerCommands.handleNavToDetachProbe,
       }
     } else {
-      return { buttonText: t('continue'), onClickButton: handlePrimaryOnClick }
+      return {
+        buttonText: t('continue'),
+        onClickButton: () => {
+          handlePrimaryOnClick(selectedUri)
+        },
+      }
     }
   }
 
@@ -80,7 +85,7 @@ export function LPCLabwareList(props: LPCWizardContentProps): JSX.Element {
 interface LPCLabwareListContentProps extends LPCWizardContentProps {
   selectedUri: string
   setSelectedUri: (uri: string) => void
-  handlePrimaryOnClickOdd: () => void
+  handlePrimaryOnClickOdd: (uri: string) => void
 }
 
 function LPCLabwareListContent(props: LPCLabwareListContentProps): JSX.Element {
@@ -89,10 +94,13 @@ function LPCLabwareListContent(props: LPCLabwareListContentProps): JSX.Element {
   const labwareInfo = useSelector(
     selectAllLabwareInfoAndDefaultStatusSorted(runId)
   )
+  const isOnDevice = useSelector(getIsOnDevice)
 
   // On the initial render, select the first uri from the list of labware (for desktop app purposes).
   useLayoutEffect(() => {
-    props.setSelectedUri(labwareInfo[0].uri)
+    if (!isOnDevice) {
+      props.setSelectedUri(labwareInfo[0].uri)
+    }
   }, [])
 
   return (
@@ -114,7 +122,12 @@ function LPCLabwareListContent(props: LPCLabwareListContentProps): JSX.Element {
         </thead>
       </Flex>
       {labwareInfo.map(({ uri, info }) => (
-        <LabwareItem key={`labware_${uri}`} uri={uri} info={info} {...props} />
+        <LabwareItem
+          key={`labware_${uri}${Math.random()}`}
+          uri={uri}
+          info={info}
+          {...props}
+        />
       ))}
       {/* Accommodate scrolling on the ODD. */}
       <Flex css={ODD_SCROLL_BUFFER} />
@@ -147,7 +160,9 @@ function LabwareItem({
   return isOnDevice ? (
     <ListButton
       type={isNecessaryDefaultOffsetMissing ? 'notConnected' : 'noActive'}
-      onClick={handlePrimaryOnClickOdd}
+      onClick={() => {
+        handlePrimaryOnClickOdd(uri)
+      }}
       width="100%"
     >
       <Flex css={CONTENT_CONTAINER_STYLE}>


### PR DESCRIPTION
Closes [RQA-4014](https://opentrons.atlassian.net/browse/RQA-4014)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

On the ODD during LPC, on the Labware List view, if you click anything but the first labware, you will still select the first labware in the list. This PR makes it so when you click on not the first labware, you get the labware you actually selected.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that clicking other labware on the ODD actually selects those other labware.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a bug in which clicking any labware from the labware list view on the ODD during LPC would always select the first labware in the list.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4014]: https://opentrons.atlassian.net/browse/RQA-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ