### PR TITLE
fix(app): allow LPCing default offsets for 'stackingOnly' labware  in an adapter

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
@@ -1,15 +1,25 @@
 import { ANY_LOCATION } from '@opentrons/api-client'
+import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import { OFFSET_KIND_DEFAULT } from '/app/redux/protocol-runs'
 
-import type { DefaultOffsetDetails } from '/app/redux/protocol-runs'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  DefaultOffsetDetails,
+  LocationSpecificOffsetDetails,
+  LabwareModuleStackupDetails,
+} from '/app/redux/protocol-runs'
 import type { GetLPCLabwareInfoForURI } from '.'
 
-export function getDefaultOffsetDetailsForLabware({
-  currentOffsets,
-  lwLocInfo,
-  uri,
-}: GetLPCLabwareInfoForURI): DefaultOffsetDetails {
+interface GetDefaultOffsetDetailsForLabwareParams
+  extends GetLPCLabwareInfoForURI {
+  locationSpecificOffsetDetails: LocationSpecificOffsetDetails[]
+}
+
+export function getDefaultOffsetDetailsForLabware(
+  params: GetDefaultOffsetDetailsForLabwareParams
+): DefaultOffsetDetails {
+  const { lwLocInfo, uri, currentOffsets } = params
   const aLabwareId =
     lwLocInfo?.find(combo => combo.definitionUri === uri)?.labwareId ?? ''
 
@@ -18,6 +28,11 @@ export function getDefaultOffsetDetailsForLabware({
       offset =>
         offset.locationSequence === ANY_LOCATION && offset.definitionUri === uri
     ) ?? null
+
+  const { lwModOnlyStackupDetails, closestBeneathAdapterId } = getStackupInfo({
+    ...params,
+    aLabwareId,
+  })
 
   return {
     workingOffset: null,
@@ -29,10 +44,87 @@ export function getDefaultOffsetDetailsForLabware({
       // We always do default offset LPCing in this slot.
       addressableAreaName: 'C2',
       lwOffsetLocSeq: ANY_LOCATION,
+      closestBeneathAdapterId,
       // The only labware present on deck when configuring the default offset is the top-most labware itself.
-      lwModOnlyStackupDetails: [
-        { kind: 'labware', labwareUri: uri, id: aLabwareId },
-      ],
+      lwModOnlyStackupDetails,
     },
   }
+}
+
+interface GetStackingInfoParams
+  extends GetDefaultOffsetDetailsForLabwareParams {
+  aLabwareId: string
+}
+
+// Certain labware must be part of a stackup unconditionally (as noted by the 'stackingOnly' quirk),
+// and cannot be placed directly on the deck as the sole labware when setting a default offset (ex, evotips).
+// It must be accompanied by an adapter.
+//
+// In these circumstances, the default offset info should include adapter details, which the view
+// layer utilizes for appropriate deck and copy rendering.
+// We arbitrarily select the first adapter utilized in the run, which is also the adapter
+// associated with the first location-specific offset.
+function getStackupInfo({
+  uri,
+  labwareDefs,
+  locationSpecificOffsetDetails,
+  protocolData,
+  aLabwareId,
+}: GetStackingInfoParams): {
+  lwModOnlyStackupDetails: LabwareModuleStackupDetails
+  closestBeneathAdapterId: string | undefined
+} {
+  const requiresAdapterId = getRequiresAdapterId(uri, labwareDefs)
+
+  const closestBeneathAdapterId = requiresAdapterId
+    ? getFirstAdapterIdFrom(locationSpecificOffsetDetails)
+    : undefined
+
+  const adapterUri =
+    protocolData?.labware.find(lw => lw.id === closestBeneathAdapterId)
+      ?.definitionUri ?? ''
+
+  const lwModOnlyStackupDetails: LabwareModuleStackupDetails = requiresAdapterId
+    ? [
+        {
+          kind: 'labware',
+          labwareUri: adapterUri,
+          id: closestBeneathAdapterId ?? '',
+        },
+        { kind: 'labware', labwareUri: uri, id: aLabwareId },
+      ]
+    : [{ kind: 'labware', labwareUri: uri, id: aLabwareId }]
+
+  if (
+    requiresAdapterId &&
+    (closestBeneathAdapterId == null || adapterUri == null)
+  ) {
+    console.error(
+      `Expected to find required adapter for mandatory stackup for labware: ${uri}`
+    )
+  }
+
+  return { lwModOnlyStackupDetails, closestBeneathAdapterId }
+}
+
+function getRequiresAdapterId(
+  uri: string,
+  labwareDefs: GetLPCLabwareInfoForURI['labwareDefs']
+): boolean {
+  const matchingDef =
+    labwareDefs?.find(def => getLabwareDefURI(def) === uri) ?? null
+
+  return requiresAdapter(matchingDef)
+}
+
+function requiresAdapter(def: LabwareDefinition2 | null): boolean {
+  return def?.parameters.quirks?.includes('stackingOnly') ?? false
+}
+
+function getFirstAdapterIdFrom(
+  lsOffsets: LocationSpecificOffsetDetails[]
+): string | undefined {
+  return lsOffsets.find(
+    lsOffset => lsOffset.locationDetails.closestBeneathAdapterId != null
+  )?.locationDetails.closestBeneathAdapterId
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/index.ts
@@ -51,6 +51,12 @@ function getLabwareInfoRecords(
 
   params.lwLocInfo.forEach(combo => {
     const uri = combo.definitionUri
+    const locationSpecificOffsetDetails = getLocationSpecificOffsetDetailsForLabware(
+      {
+        ...params,
+        uri,
+      }
+    )
 
     if (!(uri in labwareDetails)) {
       labwareDetails[uri] = {
@@ -59,13 +65,9 @@ function getLabwareInfoRecords(
         defaultOffsetDetails: getDefaultOffsetDetailsForLabware({
           ...params,
           uri,
+          locationSpecificOffsetDetails,
         }),
-        locationSpecificOffsetDetails: getLocationSpecificOffsetDetailsForLabware(
-          {
-            ...params,
-            uri,
-          }
-        ),
+        locationSpecificOffsetDetails,
       }
     }
   })


### PR DESCRIPTION
Closes [EXEC-1390](https://opentrons.atlassian.net/browse/EXEC-1390)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Certain labware should always be LPC'd in an adapter, even when setting a default offset (eg, evotips). To determine whether or not we require an adapter for all offset calculations, we examine the `stackingOnly` quirk present on the labware definition.

Fortunately, the change for this is pretty minimal - the view layer (including the deck, copy, and load/remove commands), all utilize a couple pieces of state, specifically the `closestBeneathAdapterId` and `lwModOnlyStackupDetails` for driving appropriate behavior. Therefore, all we have to do is modify the default offset that is built and injected into LPC, now accounting for the `stackingOnly` quirk. If the quirk is present, utilize the first adapter the labware is loaded with.


https://github.com/user-attachments/assets/6314c2a4-d6eb-433c-9fe6-dcf6dcb7a5d0

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
- Verified that load/unload commands work as expected.
- Verified the pipette doesn't plough through evotips with the adapter attached.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added default offset support for labware with a `stackingOnly` property.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1390]: https://opentrons.atlassian.net/browse/EXEC-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ