### PR TITLE
feat(api): prepare for aspirate in air gap

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -778,6 +778,7 @@ class InstrumentContext(publisher.CommandPublisher):
         target = loc.labware.as_well().top(height)
         self.move_to(target, publish=False)
         if self.api_version >= _AIR_GAP_TRACKING_ADDED_IN:
+            self._core.prepare_to_aspirate()
             c_vol = self._core.get_available_volume() if volume is None else volume
             flow_rate = self._core.get_aspirate_flow_rate()
             self._core.air_gap_in_place(c_vol, flow_rate)

--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -9,7 +9,6 @@ from .pipetting_common import (
     OverpressureError,
     PipetteIdMixin,
     prepare_for_aspirate,
-    EmptyResult,
 )
 from .command import (
     AbstractCommandImpl,
@@ -113,9 +112,9 @@ class PrepareToAspirate(
     params: PrepareToAspirateParams
     result: Optional[PrepareToAspirateResult] = None
 
-    _ImplementationCls: Type[PrepareToAspirateImplementation] = (
+    _ImplementationCls: Type[
         PrepareToAspirateImplementation
-    )
+    ] = PrepareToAspirateImplementation
 
 
 class PrepareToAspirateCreate(BaseCommandCreate[PrepareToAspirateParams]):

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1786,6 +1786,7 @@ def test_air_gap_uses_air_gap(
     subject.air_gap(volume=10, height=5)
 
     decoy.verify(mock_move_to(top_location, publish=False))
+    decoy.verify(mock_instrument_core.prepare_to_aspirate())
     decoy.verify(mock_instrument_core.air_gap_in_place(10, 11))
 
 


### PR DESCRIPTION
We should add a prepare-to-aspirate to the python protocol api `air_gap` command, where it can issue the command after we've moved to a known-dry position and before we actually dispense the airgap command. We know the position is dry and therefore it's safe to do a prepare.

However, to be able to _unconditionally_ do a prepare, we also need to add a fix to the engine prepare command to no-op if the pipette is already prepared to aspirate. This is pretty important because if we've already aspirated some liquid, we really don't want to move back to the bottom position and dispense it all. 


Useful testing protocol:
```
from opentrons.protocol_api import ProtocolContext

metadata = {"protocolName": "Test air gap prepare"}
requirements = {"apiLevel": "2.22", "robotType": "Flex"}


def run(protocol: ProtocolContext) -> None:
    plate = protocol.load_labware("biorad_384_wellplate_50ul", "A1")
    rack = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "A2")
    pipette = protocol.load_instrument("flex_1channel_50", "left", tip_racks=[rack])

    pipette.pick_up_tip()
    pipette.aspirate(location=plate["A1"].bottom(z=2), volume=10)
    pipette.dispense(location=plate["A1"].top(), volume=10)
    pipette.blow_out(location=plate["A1"].top())
    pipette.air_gap(height=5, volume=10)

    pipette.dispense(location=plate["A2"].top(), volume=10)
    pipette.return_tip()
```


Closes EXEC-1391

