### PR TITLE
feat(protocol-designer): resolve conditioning volume + air gap incompatibility

### DIFF
--- a/protocol-designer/src/assets/localization/en/tooltip.json
+++ b/protocol-designer/src/assets/localization/en/tooltip.json
@@ -101,6 +101,7 @@
     "moveLiquid": {
       "disabled": {
         "$generic": "Incompatible with current path",
+        "aspirate_airGap_checkbox": "Air gap after aspirate not available with conditioning volume configured",
         "aspirate_wells": "Select a source labware in order to select wells",
         "aspirate_mix_checkbox": "Advanced setting not compatible with pipette path",
         "aspirate_touchTip_checkbox": "Touch tip is not supported",

--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsMoveLiquidForm.ts
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsMoveLiquidForm.ts
@@ -61,6 +61,10 @@ export function getDisabledFieldsMoveLiquidForm(
     }
   })
 
+  if (hydratedForm.conditioning_checkbox === true) {
+    disabled.add('aspirate_airGap_checkbox')
+  }
+
   if (
     !hydratedForm.blowout_location ||
     hydratedForm.blowout_location.includes('wasteChute') ||

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -166,7 +166,17 @@ export function updatePatchPathField(
     return { ...patch, path: 'single' }
   }
 
-  return patch
+  const conditioningPatch =
+    path === 'multiDispense'
+      ? {}
+      : {
+          ...getDefaultFields('conditioning_checkbox', 'conditioning_volume'),
+        }
+
+  return {
+    ...patch,
+    ...conditioningPatch,
+  }
 }
 
 const updatePatchOnLabwareChange = (

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -691,6 +691,22 @@ const updatePatchOnNozzleChange = (
   return patch
 }
 
+const updatePatchOnConditioningVolumeChange = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (
+    fieldHasChanged(rawForm, patch, 'conditioning_checkbox') &&
+    patch.conditioning_checkbox === true
+  ) {
+    return {
+      ...patch,
+      ...getDefaultFields('aspirate_airGap_checkbox', 'aspirate_airGap_volume'),
+    }
+  }
+  return patch
+}
+
 export function dependentFieldsUpdateMoveLiquid(
   originalPatch: FormPatch,
   rawForm: FormData, // raw = NOT hydrated
@@ -730,5 +746,6 @@ export function dependentFieldsUpdateMoveLiquid(
       updatePatchOnTiprackChange(chainPatch, rawForm, pipetteEntities),
     chainPatch =>
       updatePatchOnNozzleChange(chainPatch, rawForm, pipetteEntities),
+    chainPatch => updatePatchOnConditioningVolumeChange(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -166,17 +166,7 @@ export function updatePatchPathField(
     return { ...patch, path: 'single' }
   }
 
-  const conditioningPatch =
-    path === 'multiDispense'
-      ? {}
-      : {
-          ...getDefaultFields('conditioning_checkbox', 'conditioning_volume'),
-        }
-
-  return {
-    ...patch,
-    ...conditioningPatch,
-  }
+  return patch
 }
 
 const updatePatchOnLabwareChange = (


### PR DESCRIPTION
# Overview


When using a conditioning volume, we do not allow an air gap after aspiration. This is becuase conditioning volume conditions the tip such that the pressure in the tip is optimal for multi-dispensing. Adding air gaps disrupts that pressure. If conditioning volume is turned on, we should disable aspirate air gap.

Closes AUTH-1639

## Test Plan and Hands on Testing

- create a distribute step
- in aspirate advanced settings, turn air gap on
- then in dispense settings, turn conditioning volume on
- navigate back to aspirate > air gap and verify it is off and disabled with tooltip

## Changelog

- add patch to dependentFieldsUpdateMoveLiquid to turn off aspirate air gap if conditioning volume enabled
- update getDisabledFieldsMoveLiquidForm to disable aspirate air gap if conditioning volume enabled

## Review requests

see test plan

## Risk assessment

lowish