### PR TITLE
feat(protocol-designer): update required app version to 8.4.0

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -18,7 +18,7 @@ import {
   LINE_CLAMP_TEXT_STYLE,
 } from '../../components/atoms'
 
-const REQUIRED_APP_VERSION = '8.3.0'
+const REQUIRED_APP_VERSION = '8.4.0'
 
 type MetadataInfo = Array<{
   author?: string

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
@@ -45,7 +45,7 @@ describe('ProtocolMetadata', () => {
     screen.getByText('Protocol Metadata')
     screen.getByText('Edit')
     screen.getByText('Required app version')
-    screen.getByText('8.3.0 or higher')
+    screen.getByText('8.4.0 or higher')
   })
 
   it('should render protocol metadata', () => {


### PR DESCRIPTION
closes AUTH-1631

# Overview

Update the required app version for PD to 8.4.0 for liquid classes

## Test Plan and Hands on Testing

Review protocol metadata in the overview page. see that the app version required is 8.4.0

## Changelog

- update app version

## Risk assessment

low
