### PR TITLE
fix(app): do not infinitely jog during LPC

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useHandleJog.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useHandleJog.test.ts
@@ -1,0 +1,276 @@
+import { vi, it, describe, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useCreateMaintenanceCommandMutation } from '@opentrons/react-api-client'
+import { selectActivePipette } from '/app/redux/protocol-runs'
+import { useHandleJog } from '../useHandleJog'
+import { useSelector } from 'react-redux'
+import { moveRelativeCommand, moveToWellCommands } from '../commands'
+
+vi.mock('react-redux')
+vi.mock('/app/redux/protocol-runs')
+vi.mock('@opentrons/react-api-client')
+vi.mock('../commands')
+
+describe('useHandleJog', () => {
+  vi.useFakeTimers()
+
+  const mockPipetteId = 'mock_pipette'
+  const mockRunId = 'mock_run'
+  const mockMaintenanceRunId = 'mock_maintenance_run'
+  const mockSetErrorMessage = vi.fn()
+  const mockChainLPCCommands = vi.fn(() => Promise.resolve())
+  const mockCreateSilentCommand = vi.fn()
+
+  const mockCommandResult = {
+    data: {
+      result: {
+        position: { x: 10, y: 20, z: 30 },
+      },
+    },
+  }
+  const mockProps = {
+    runId: mockRunId,
+    maintenanceRunId: mockMaintenanceRunId,
+    setErrorMessage: mockSetErrorMessage,
+    chainLPCCommands: mockChainLPCCommands,
+  } as any
+  const mockPipette = {
+    id: mockPipetteId,
+    pipetteName: 'p1000_single',
+  } as any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(moveRelativeCommand).mockImplementation(
+      ({ pipetteId, axis, dir, step }) =>
+        ({
+          commandType: 'moveRelative',
+          params: { pipetteId, axis, dir, step },
+        } as any)
+    )
+    vi.mocked(moveToWellCommands).mockImplementation(
+      (offsetLocationDetails, pipetteId, offset) => [
+        {
+          commandType: 'moveToWell',
+          params: { pipetteId, offsetLocationDetails, offset } as any,
+        },
+      ]
+    )
+    vi.mocked(selectActivePipette).mockReturnValue(() => mockPipette)
+    vi.mocked(useSelector).mockImplementation(fn => fn(fn))
+    vi.mocked(useCreateMaintenanceCommandMutation).mockReturnValue({
+      createMaintenanceCommand: mockCreateSilentCommand,
+    } as any)
+    mockCreateSilentCommand.mockResolvedValue(mockCommandResult)
+  })
+
+  it('should initialize with empty queue', () => {
+    const { result } = renderHook(() => useHandleJog(mockProps))
+
+    expect(result.current).toHaveProperty('handleJog')
+    expect(result.current).toHaveProperty('resetJog')
+  })
+
+  it('should issue a jog command when handleJog is called', async () => {
+    const { result } = renderHook(() => useHandleJog(mockProps))
+    const mockOnSuccess = vi.fn()
+
+    act(() => {
+      result.current.handleJog('x', 1, 1, mockOnSuccess)
+    })
+
+    vi.runAllTimers()
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledWith({
+      maintenanceRunId: mockMaintenanceRunId,
+      command: {
+        commandType: 'moveRelative',
+        params: { pipetteId: mockPipetteId, axis: 'x', dir: 1, step: 1 },
+      },
+      waitUntilComplete: true,
+      timeout: 10000,
+    })
+
+    await vi.runAllTimersAsync()
+
+    expect(mockOnSuccess).toHaveBeenCalledWith({ x: 10, y: 20, z: 30 })
+  })
+
+  it('should queue multiple jog commands and process them sequentially', async () => {
+    const { result } = renderHook(() => useHandleJog(mockProps))
+
+    mockCreateSilentCommand.mockClear()
+
+    act(() => {
+      result.current.handleJog('x', 1, 1)
+    })
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(1)
+    expect(mockCreateSilentCommand.mock.calls[0][0].command.params).toEqual({
+      pipetteId: mockPipetteId,
+      axis: 'x',
+      dir: 1,
+      step: 1,
+    })
+
+    mockCreateSilentCommand.mockClear()
+
+    act(() => {
+      result.current.handleJog('y', -1, 1)
+    })
+
+    await vi.runAllTimersAsync()
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(1)
+    expect(mockCreateSilentCommand.mock.calls[0][0].command.params).toEqual({
+      pipetteId: mockPipetteId,
+      axis: 'y',
+      dir: -1,
+      step: 1,
+    })
+
+    mockCreateSilentCommand.mockClear()
+
+    act(() => {
+      result.current.handleJog('z', 1, 0.1)
+    })
+
+    await vi.runAllTimersAsync()
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(1)
+    expect(mockCreateSilentCommand.mock.calls[0][0].command.params).toEqual({
+      pipetteId: mockPipetteId,
+      axis: 'z',
+      dir: 1,
+      step: 0.1,
+    })
+  })
+
+  it('should limit the queue to MAX_QUEUED_JOGS (3) commands plus the command that runs immediately', async () => {
+    const { result } = renderHook(() => useHandleJog(mockProps))
+
+    mockCreateSilentCommand.mockClear()
+
+    await act(async () => {
+      result.current.handleJog('x', 1, 1)
+      result.current.handleJog('y', -1, 1)
+      result.current.handleJog('z', 1, 1)
+      result.current.handleJog('x', -1, 1)
+      result.current.handleJog('x', -1, 1)
+      result.current.handleJog('x', 1, 1)
+      result.current.handleJog('x', -1, 1)
+    })
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(1)
+
+    await vi.runAllTimersAsync()
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(4)
+  })
+
+  it('should set error message when command fails', async () => {
+    const mockError = new Error('Command failed')
+    mockCreateSilentCommand.mockRejectedValueOnce(mockError)
+
+    const { result } = renderHook(() => useHandleJog(mockProps))
+
+    act(() => {
+      result.current.handleJog('x', 1, 1)
+    })
+
+    await vi.runAllTimersAsync()
+
+    expect(mockSetErrorMessage).toHaveBeenCalledWith(
+      'Error issuing jog command: Command failed'
+    )
+  })
+
+  it('should set error message when pipette is not found', async () => {
+    vi.mocked(selectActivePipette).mockReturnValueOnce(() => null)
+
+    const { result } = renderHook(() => useHandleJog(mockProps))
+
+    act(() => {
+      result.current.handleJog('x', 1, 1)
+    })
+
+    await vi.runAllTimersAsync()
+
+    expect(mockSetErrorMessage).toHaveBeenCalledWith(
+      'Could not find pipette to jog with id: '
+    )
+  })
+
+  it('should clear the queue when resetJog is called', async () => {
+    const { result } = renderHook(() => useHandleJog(mockProps))
+    const mockOffsetLocationDetails = { labwareId: 'lw-123', well: 'A1' } as any
+    const mockOffset = { x: 1, y: 2, z: 3 }
+
+    act(() => {
+      result.current.handleJog('x', 1, 1)
+      result.current.handleJog('y', -1, 1)
+    })
+
+    await act(async () => {
+      await result.current.resetJog(
+        mockOffsetLocationDetails,
+        mockPipetteId,
+        mockOffset
+      )
+    })
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(1)
+
+    expect(mockChainLPCCommands).toHaveBeenCalledWith(
+      [
+        {
+          commandType: 'moveToWell',
+          params: {
+            pipetteId: mockPipetteId,
+            offsetLocationDetails: mockOffsetLocationDetails,
+            offset: mockOffset,
+          },
+        },
+      ],
+      false
+    )
+
+    act(() => {
+      result.current.handleJog('z', 1, 0.1)
+    })
+
+    await vi.runAllTimersAsync()
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(2)
+  })
+
+  it('should debounce rapid jog requests', async () => {
+    const { result } = renderHook(() => useHandleJog(mockProps))
+
+    act(() => {
+      result.current.handleJog('x', 1, 1)
+      result.current.handleJog('x', 1, 1)
+      result.current.handleJog('x', 1, 1)
+    })
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(1)
+
+    await vi.runAllTimersAsync()
+
+    expect(mockCreateSilentCommand).toHaveBeenCalledTimes(3)
+  })
+
+  it('should clean up debounce on unmount', () => {
+    const { unmount } = renderHook(() => useHandleJog(mockProps))
+
+    unmount()
+
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(mockCreateSilentCommand).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleJog.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleJog.ts
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
+import debounce from 'lodash/debounce'
 
 import { useCreateMaintenanceCommandMutation } from '@opentrons/react-api-client'
 
 import { moveRelativeCommand, moveToWellCommands } from './commands'
 import { selectActivePipette } from '/app/redux/protocol-runs'
 
-import type { Coordinates, CreateCommand } from '@opentrons/shared-data'
+import type { Coordinates } from '@opentrons/shared-data'
 import type {
   Axis,
   Jog,
@@ -19,6 +20,7 @@ import type { OffsetLocationDetails } from '/app/redux/protocol-runs'
 
 const JOG_COMMAND_TIMEOUT_MS = 10000
 const MAX_QUEUED_JOGS = 3
+const DEBOUNCE_TIME_MS = 50
 
 interface UseHandleJogProps extends UseLPCCommandWithChainRunChildProps {
   setErrorMessage: (msg: string | null) => void
@@ -41,65 +43,89 @@ export function useHandleJog({
   setErrorMessage,
   chainLPCCommands,
 }: UseHandleJogProps): UseHandleJogResult {
-  const [isJogging, setIsJogging] = useState(false)
-  const [jogQueue, setJogQueue] = useState<Array<() => Promise<void>>>([])
   const pipette = useSelector(selectActivePipette(runId))
   const pipetteId = pipette?.id
   const {
     createMaintenanceCommand: createSilentCommand,
   } = useCreateMaintenanceCommandMutation()
 
-  const executeJog = useCallback(
-    (
-      axis: Axis,
-      dir: Sign,
-      step: StepSize,
+  const queueRef = useRef<
+    Array<{
+      axis: Axis
+      dir: Sign
+      step: StepSize
       onSuccess?: (position: Coordinates | null) => void
-    ): Promise<void> => {
-      return new Promise<void>((resolve, reject) => {
-        if (pipetteId != null) {
-          createSilentCommand({
-            maintenanceRunId,
-            command: moveRelativeCommand({ pipetteId, axis, dir, step }),
-            waitUntilComplete: true,
-            timeout: JOG_COMMAND_TIMEOUT_MS,
-          })
-            .then(data => {
-              onSuccess?.(
-                (data?.data?.result?.position ?? null) as Coordinates | null
-              )
-              resolve()
-            })
-            .catch((e: Error) => {
-              setErrorMessage(`Error issuing jog command: ${e.message}`)
-              reject(e)
-            })
-        } else {
-          const error = new Error(
-            `Could not find pipette to jog with id: ${pipetteId ?? ''}`
-          )
-          setErrorMessage(error.message)
-          reject(error)
-        }
+    }>
+  >([])
+  const processingRef = useRef(false)
+
+  const processNextInQueue = useCallback(() => {
+    if (processingRef.current || queueRef.current.length === 0) {
+      return
+    }
+
+    processingRef.current = true
+    const nextJog = queueRef.current.shift()
+
+    if (nextJog == null) {
+      processingRef.current = false
+      return
+    }
+
+    const { axis, dir, step, onSuccess } = nextJog
+
+    if (pipetteId != null) {
+      createSilentCommand({
+        maintenanceRunId,
+        command: moveRelativeCommand({ pipetteId, axis, dir, step }),
+        waitUntilComplete: true,
+        timeout: JOG_COMMAND_TIMEOUT_MS,
       })
-    },
-    [pipetteId, maintenanceRunId, createSilentCommand, setErrorMessage]
+        .then(data => {
+          onSuccess?.(
+            (data?.data?.result?.position ?? null) as Coordinates | null
+          )
+        })
+        .catch((e: Error) => {
+          setErrorMessage(`Error issuing jog command: ${e.message}`)
+        })
+        .finally(() => {
+          processingRef.current = false
+          // Use setTimeout to ensure we're outside the current call stack.
+          // This helps prevent stack overflow with rapid queue processing.
+          setTimeout(() => {
+            processNextInQueue()
+          }, DEBOUNCE_TIME_MS)
+        })
+    } else {
+      const error = new Error(
+        `Could not find pipette to jog with id: ${pipetteId ?? ''}`
+      )
+      setErrorMessage(error.message)
+      processingRef.current = false
+      setTimeout(() => {
+        processNextInQueue()
+      }, DEBOUNCE_TIME_MS)
+    }
+  }, [pipetteId, maintenanceRunId, createSilentCommand, setErrorMessage])
+
+  const debouncedProcessQueue = useCallback(
+    debounce(
+      () => {
+        processNextInQueue()
+      },
+      DEBOUNCE_TIME_MS,
+      { leading: true, trailing: true }
+    ),
+    [processNextInQueue]
   )
 
-  const processJogQueue = useCallback((): void => {
-    if (jogQueue.length > 0 && !isJogging) {
-      setIsJogging(true)
-      const nextJog = jogQueue[0]
-      setJogQueue(prevQueue => prevQueue.slice(1))
-      void nextJog().finally(() => {
-        setIsJogging(false)
-      })
-    }
-  }, [jogQueue, isJogging])
-
+  // Clear the queue on dismount so the pipette doesn't continue to jog.
   useEffect(() => {
-    processJogQueue()
-  }, [processJogQueue, jogQueue.length, isJogging])
+    return () => {
+      debouncedProcessQueue.cancel()
+    }
+  }, [debouncedProcessQueue])
 
   const handleJog = useCallback(
     (
@@ -108,29 +134,32 @@ export function useHandleJog({
       step: StepSize,
       onSuccess?: (position: Coordinates | null) => void
     ): void => {
-      setJogQueue(prevQueue => {
-        if (prevQueue.length < MAX_QUEUED_JOGS) {
-          return [...prevQueue, () => executeJog(axis, dir, step, onSuccess)]
-        }
-        return prevQueue
-      })
+      if (queueRef.current.length < MAX_QUEUED_JOGS) {
+        queueRef.current.push({ axis, dir, step, onSuccess })
+        debouncedProcessQueue()
+      }
     },
-    [executeJog]
+    [debouncedProcessQueue]
   )
 
-  const resetJog = (
-    offsetLocationDetails: OffsetLocationDetails,
-    pipetteId: string,
-    offset?: VectorOffset | null
-  ): Promise<void> => {
-    const resetJogCommands: CreateCommand[] = [
-      ...moveToWellCommands(offsetLocationDetails, pipetteId, offset),
-    ]
+  const resetJog = useCallback(
+    (
+      offsetLocationDetails: OffsetLocationDetails,
+      pipetteId: string,
+      offset?: VectorOffset | null
+    ): Promise<void> => {
+      queueRef.current = []
 
-    return chainLPCCommands(resetJogCommands, false).then(() =>
-      Promise.resolve()
-    )
-  }
+      const resetJogCommands = [
+        ...moveToWellCommands(offsetLocationDetails, pipetteId, offset),
+      ]
+
+      return chainLPCCommands(resetJogCommands, false).then(() =>
+        Promise.resolve()
+      )
+    },
+    [chainLPCCommands]
+  )
 
   return { handleJog, resetJog }
 }


### PR DESCRIPTION
Closes [RQA-4017](https://opentrons.atlassian.net/browse/RQA-4017) and [RQA-4011](https://opentrons.atlassian.net/browse/RQA-4011)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

On the physical ODD, it's possible queue jog commands in such a way that jog commands execute indefinitely. This issue was caused by using React async state updates to trigger queue processing. This PR rewrites the code to use refs for avoiding React asynchronous state updates, and also use Lodash's lovely `debounce` util, helping to improve the control flow.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Repro'd the issue readily on the physical ODD by pressing exactly three times in rapid succession.
- With PR, verified that jog controls do not jog indefinitely on the desktop and ODD.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed jogging during LPC on the ODD causing infinite jogs.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4017]: https://opentrons.atlassian.net/browse/RQA-4017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-4011]: https://opentrons.atlassian.net/browse/RQA-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ