### PR TITLE
chore(shared-data): update command schema 13

### DIFF
--- a/shared-data/command/schemas/13.json
+++ b/shared-data/command/schemas/13.json
@@ -576,11 +576,11 @@
         "flowRate": {
           "anyOf": [
             {
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
-              "minimum": 0.0,
+              "exclusiveMinimum": 0.0,
               "type": "number"
             }
           ],


### PR DESCRIPTION
This change that was made to command schema 12 - the command schema releasing with Robot Stack v8.4.0 - needs to be added to the edge current version schema of 13.

```shell
cd api
make command-schema
```

see #17889
