### PR TITLE
fix(robot-server): Require clientData keys to have at least one character

### DIFF
--- a/robot-server/robot_server/client_data/router.py
+++ b/robot-server/robot_server/client_data/router.py
@@ -25,7 +25,7 @@ router = LightRouter()
 Key = Annotated[
     str,
     fastapi.Path(
-        pattern="^[a-zA-Z0-9-_]*$",
+        pattern="^[a-zA-Z0-9-_]+$",
         description=(
             "A key for storing and retrieving the piece of data."
             " This should be chosen to avoid colliding with other clients,"


### PR DESCRIPTION
## Overview

This fixes a small problem I noticed with the `/clientData` endpoints.

These endpoints have a path parameter that's an arbitrary client-defined ID, like `PUT /clientData/<id>`, `GET /clientData/<id>`. The string ought to be at least one character long, otherwise there's no way to distinguish `DELETE /clientData/<id>`, which deletes the specific entry represented by `<id>`, from `DELETE /clientData/`, which deletes all entries. This PR adds validation for that.

## Test Plan and Hands on Testing

* [x] Tested manually with Postman. I tried adding a Tavern test but there's some weird internal Tavern bug (?) that prevents me from parametrizing the existing invalid-key test with an empty string.

## Review requests

None.

## Risk assessment

Low.