### PR TITLE
feat(protocol-designer): add designerApplication comment to py file a…

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -104,17 +104,20 @@ describe('createFile selector', () => {
     // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     const result = createPythonFile.resultFunc(
       fileMetadata,
-      OT2_ROBOT_TYPE,
-      entities,
       v7Fixture.initialRobotState,
       v7Fixture.robotStateTimeline,
+      OT2_ROBOT_TYPE,
+      dismissedWarnings,
       ingredLocations,
-      labwareNicknamesById
+      v7Fixture.savedStepForms,
+      v7Fixture.orderedStepIds,
+      labwareNicknamesById,
+      entities
     )
     // This is just a quick smoke test to make sure createPythonFile() produces
     // something that looks like a Python file. The individual sections of the
     // generated Python will be tested in separate unit tests.
-    expect(result).toBe(
+    expect(result.python).toBe(
       `
 from contextlib import nullcontext as pd_step
 from opentrons import protocol_api, types
@@ -166,6 +169,104 @@ def run(protocol: protocol_api.ProtocolContext):
     pass
 `.trimStart()
     )
+
+    expect(result.designerApplication).toEqual({
+      designerApplication: {
+        data: {
+          dismissedWarnings: {
+            form: [],
+            timeline: [],
+          },
+          ingredLocations: {},
+          ingredients: {},
+          labware: {
+            fixedTrash: {
+              displayName: 'Trash',
+              labwareDefURI: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
+            },
+            plateId: {
+              displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+              labwareDefURI:
+                'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+            },
+            tiprackId: {
+              displayName: 'Opentrons 96 Tip Rack 10 µL',
+              labwareDefURI: 'opentrons/opentrons_96_tiprack_10ul/1',
+            },
+          },
+          modules: {},
+          orderedStepIds: ['moveLiquidStepId'],
+          pipetteTiprackAssignments: {
+            pipetteId: ['opentrons/opentrons_96_tiprack_10ul/1'],
+          },
+          pipettes: {
+            pipetteId: {
+              pipetteName: 'p10_single',
+            },
+          },
+          savedStepForms: {
+            __INITIAL_DECK_SETUP_STEP__: {
+              id: '__INITIAL_DECK_SETUP_STEP__',
+              labwareLocationUpdate: {
+                fixedTrash: '12',
+                plateId: '1',
+                tiprackId: '2',
+              },
+              moduleLocationUpdate: {},
+              pipetteLocationUpdate: {
+                pipetteId: 'left',
+              },
+              stepType: 'manualIntervention',
+            },
+            moveLiquidStepId: {
+              aspirate_airGap_checkbox: true,
+              aspirate_airGap_volume: '1',
+              aspirate_delay_checkbox: true,
+              aspirate_delay_mmFromBottom: '1',
+              aspirate_delay_seconds: '1',
+              aspirate_flowRate: null,
+              aspirate_labwareId: 'plateId',
+              aspirate_mix_checkbox: false,
+              aspirate_mix_times: null,
+              aspirate_mix_volume: null,
+              aspirate_mmFromBottom: '1',
+              aspirate_touchTip_checkbox: false,
+              aspirate_wellOrder_first: 't2b',
+              aspirate_wellOrder_second: 'l2r',
+              aspirate_wells: ['A1', 'B1'],
+              aspirate_wells_grouped: false,
+              blowout_checkbox: false,
+              blowout_location: 'fixedTrash',
+              changeTip: 'always',
+              dispense_delay_checkbox: false,
+              dispense_delay_mmFromBottom: '0.5',
+              dispense_delay_seconds: '1',
+              dispense_flowRate: null,
+              dispense_labwareId: 'plateId',
+              dispense_mix_checkbox: false,
+              dispense_mix_times: null,
+              dispense_mix_volume: null,
+              dispense_mmFromBottom: '0.5',
+              dispense_touchTip_checkbox: false,
+              dispense_wellOrder_first: 't2b',
+              dispense_wellOrder_second: 'l2r',
+              dispense_wells: ['A12', 'B12'],
+              disposalVolume_checkbox: true,
+              disposalVolume_volume: '1',
+              id: 'moveLiquidStepId',
+              path: 'single',
+              pipetteId: 'pipetteId',
+              preWetTip: false,
+              stepDetails: '',
+              stepName: 'transfer',
+              stepType: 'moveLiquid',
+              volume: '5',
+            },
+          },
+        },
+        version: '8.5.0',
+      },
+    })
   })
 })
 

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -265,6 +265,7 @@ def run(protocol: protocol_api.ProtocolContext):
           },
         },
         version: '8.5.0',
+        name: 'opentrons/protocol-designer',
       },
     })
   })

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -117,7 +117,7 @@ describe('createFile selector', () => {
     // This is just a quick smoke test to make sure createPythonFile() produces
     // something that looks like a Python file. The individual sections of the
     // generated Python will be tested in separate unit tests.
-    expect(result.python).toBe(
+    expect(result.pythonProtocol).toBe(
       `
 from contextlib import nullcontext as pd_step
 from opentrons import protocol_api, types
@@ -170,7 +170,7 @@ def run(protocol: protocol_api.ProtocolContext):
 `.trimStart()
     )
 
-    expect(result.pythonDesignerApplication).toEqual({
+    expect(result.designerApplication).toEqual({
       designerApplication: {
         data: {
           dismissedWarnings: {
@@ -267,7 +267,7 @@ def run(protocol: protocol_api.ProtocolContext):
         version: '8.5.0',
         name: 'opentrons/protocol-designer',
       },
-      robotType: OT2_ROBOT_TYPE,
+      robot: { model: OT2_ROBOT_TYPE },
     })
   })
 })

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -170,7 +170,7 @@ def run(protocol: protocol_api.ProtocolContext):
 `.trimStart()
     )
 
-    expect(result.designerApplication).toEqual({
+    expect(result.pythonDesignerApplication).toEqual({
       designerApplication: {
         data: {
           dismissedWarnings: {
@@ -267,6 +267,7 @@ def run(protocol: protocol_api.ProtocolContext):
         version: '8.5.0',
         name: 'opentrons/protocol-designer',
       },
+      robotType: OT2_ROBOT_TYPE,
     })
   })
 })

--- a/protocol-designer/src/file-data/reducers/index.ts
+++ b/protocol-designer/src/file-data/reducers/index.ts
@@ -118,7 +118,7 @@ const robotTypeReducer = (
   if (action.type === 'CREATE_NEW_PROTOCOL') {
     return action.payload.robotType
   } else if (action.type === 'LOAD_FILE') {
-    return action.payload.file.robot?.model ?? action.payload.file.robotType
+    return action.payload.file.robot.model
   }
   return state
 }

--- a/protocol-designer/src/file-data/reducers/index.ts
+++ b/protocol-designer/src/file-data/reducers/index.ts
@@ -118,7 +118,7 @@ const robotTypeReducer = (
   if (action.type === 'CREATE_NEW_PROTOCOL') {
     return action.payload.robotType
   } else if (action.type === 'LOAD_FILE') {
-    return action.payload.file.robot.model
+    return action.payload.file.robot?.model ?? action.payload.file.robotType
   }
   return state
 }

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -52,7 +52,7 @@ import type {
 } from '@opentrons/shared-data'
 import type { LabwareDefByDefURI } from '../../labware-defs'
 import type { Selector } from '../../types'
-import type { PDMetadata } from '../../file-types'
+import type { PDMetadata, PDPythonFile, PythonMetadata } from '../../file-types'
 
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
 // console.assert(!isEmpty(process.env.OT_PD_VERSION), 'Could not find application version!')
@@ -305,24 +305,70 @@ export const createFile: Selector<ProtocolFile> = createSelector(
   }
 )
 
-export const createPythonFile: Selector<string> = createSelector(
+export const createPythonFile: Selector<PDPythonFile> = createSelector(
   getFileMetadata,
-  getRobotType,
-  stepFormSelectors.getInvariantContext,
   getInitialRobotState,
   getRobotStateTimeline,
+  getRobotType,
+  dismissSelectors.getAllDismissedWarnings,
   ingredSelectors.getLiquidsByLabwareId,
+  stepFormSelectors.getSavedStepForms,
+  stepFormSelectors.getOrderedStepIds,
   uiLabwareSelectors.getLabwareNicknamesById,
+  stepFormSelectors.getInvariantContext,
   (
     fileMetadata,
-    robotType,
-    invariantContext,
     robotState,
     robotStateTimeline,
-    liquidsByLabwareId,
-    labwareNicknamesById
+    robotType,
+    dismissedWarnings,
+    ingredLocations,
+    savedStepForms,
+    orderedStepIds,
+    labwareNicknamesById,
+    invariantContext
   ) => {
-    return (
+    const {
+      pipetteEntities,
+      moduleEntities,
+      labwareEntities,
+      liquidEntities,
+    } = invariantContext
+
+    const savedOrderedStepIds = orderedStepIds.filter(
+      stepId => savedStepForms[stepId]
+    )
+
+    const ingredients: Ingredients = Object.fromEntries(
+      Object.entries(
+        liquidEntities
+      ).map(([liquidId, { pythonName, ...rest }]) => [liquidId, rest])
+    )
+
+    const designerApplication: PythonMetadata = {
+      designerApplication: {
+        //  hardcoding this version in to avoid unnecessary migrating
+        //  TODO: remember to update to the applicationVersion const
+        version: '8.5.0',
+        data: {
+          pipetteTiprackAssignments: mapValues(
+            pipetteEntities,
+            (
+              p: typeof pipetteEntities[keyof typeof pipetteEntities]
+            ): string[] => p.tiprackDefURI
+          ),
+          dismissedWarnings,
+          ingredients,
+          ingredLocations,
+          savedStepForms,
+          orderedStepIds: savedOrderedStepIds,
+          pipettes: getPipettesLoadInfo(pipetteEntities),
+          modules: getModulesLoadInfo(moduleEntities),
+          labware: getLabwareLoadInfo(labwareEntities, labwareNicknamesById),
+        },
+      },
+    }
+    const python =
       [
         // Here are the sections of the Python file:
         pythonImports(),
@@ -332,13 +378,14 @@ export const createPythonFile: Selector<string> = createSelector(
           invariantContext,
           robotState,
           robotStateTimeline,
-          liquidsByLabwareId,
+          ingredLocations,
           labwareNicknamesById,
           robotType
         ),
       ]
         .filter(section => section) // skip any blank sections
         .join('\n\n') + '\n'
-    )
+
+    return { python, designerApplication }
   }
 )

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -350,7 +350,10 @@ export const createPythonFile: Selector<PDPythonFile> = createSelector(
       ).map(([liquidId, { pythonName, ...rest }]) => [liquidId, rest])
     )
 
-    const designerApplication: DesignerApplication = {
+    const designerApplication: PythonDesignerApplication = {
+      robot: {
+        model: robotType,
+      },
       designerApplication: {
         name: 'opentrons/protocol-designer',
         //  hardcoding this version in to avoid unnecessary migrating
@@ -374,11 +377,8 @@ export const createPythonFile: Selector<PDPythonFile> = createSelector(
         },
       },
     }
-    const pythonDesignerApplication: PythonDesignerApplication = {
-      ...designerApplication,
-      robotType,
-    }
-    const python =
+
+    const pythonProtocol =
       [
         // Here are the sections of the Python file:
         pythonImports(),
@@ -396,6 +396,6 @@ export const createPythonFile: Selector<PDPythonFile> = createSelector(
         .filter(section => section) // skip any blank sections
         .join('\n\n') + '\n'
 
-    return { python, pythonDesignerApplication }
+    return { pythonProtocol, designerApplication }
   }
 )

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -52,7 +52,11 @@ import type {
 } from '@opentrons/shared-data'
 import type { LabwareDefByDefURI } from '../../labware-defs'
 import type { Selector } from '../../types'
-import type { PDMetadata, PDPythonFile, PythonMetadata } from '../../file-types'
+import type {
+  PDMetadata,
+  PDPythonFile,
+  DesignerApplication,
+} from '../../file-types'
 
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
 // console.assert(!isEmpty(process.env.OT_PD_VERSION), 'Could not find application version!')
@@ -345,8 +349,9 @@ export const createPythonFile: Selector<PDPythonFile> = createSelector(
       ).map(([liquidId, { pythonName, ...rest }]) => [liquidId, rest])
     )
 
-    const designerApplication: PythonMetadata = {
+    const designerApplication: DesignerApplication = {
       designerApplication: {
+        name: 'opentrons/protocol-designer',
         //  hardcoding this version in to avoid unnecessary migrating
         //  TODO: remember to update to the applicationVersion const
         version: '8.5.0',

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -53,9 +53,10 @@ import type {
 import type { LabwareDefByDefURI } from '../../labware-defs'
 import type { Selector } from '../../types'
 import type {
+  DesignerApplication,
   PDMetadata,
   PDPythonFile,
-  DesignerApplication,
+  PythonDesignerApplication,
 } from '../../file-types'
 
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures
@@ -373,6 +374,10 @@ export const createPythonFile: Selector<PDPythonFile> = createSelector(
         },
       },
     }
+    const pythonDesignerApplication: PythonDesignerApplication = {
+      ...designerApplication,
+      robotType,
+    }
     const python =
       [
         // Here are the sections of the Python file:
@@ -391,6 +396,6 @@ export const createPythonFile: Selector<PDPythonFile> = createSelector(
         .filter(section => section) // skip any blank sections
         .join('\n\n') + '\n'
 
-    return { python, designerApplication }
+    return { python, pythonDesignerApplication }
   }
 )

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -53,7 +53,6 @@ import type {
 import type { LabwareDefByDefURI } from '../../labware-defs'
 import type { Selector } from '../../types'
 import type {
-  DesignerApplication,
   PDMetadata,
   PDPythonFile,
   PythonDesignerApplication,

--- a/protocol-designer/src/file-types.ts
+++ b/protocol-designer/src/file-types.ts
@@ -34,6 +34,14 @@ export interface PDMetadata {
   labware: Labware
 }
 
+export interface PythonMetadata {
+  designerApplication: { version: string; data: PDMetadata }
+}
+export interface PDPythonFile {
+  python: string
+  designerApplication: PythonMetadata
+}
+
 export type PDProtocolFile = ProtocolFile<PDMetadata>
 
 export function getPDMetadata(file: PDProtocolFile): PDMetadata {

--- a/protocol-designer/src/file-types.ts
+++ b/protocol-designer/src/file-types.ts
@@ -40,12 +40,14 @@ export interface DesignerApplication {
 }
 
 export interface PythonDesignerApplication extends DesignerApplication {
-  robotType: RobotType
+  robot: {
+    model: RobotType
+  }
 }
 
 export interface PDPythonFile {
-  python: string
-  pythonDesignerApplication: PythonDesignerApplication
+  pythonProtocol: string
+  designerApplication: PythonDesignerApplication
 }
 
 export type PDProtocolFile = ProtocolFile<PDMetadata>

--- a/protocol-designer/src/file-types.ts
+++ b/protocol-designer/src/file-types.ts
@@ -2,6 +2,7 @@ import type {
   ModuleModel,
   PipetteName,
   ProtocolFile,
+  RobotType,
 } from '@opentrons/shared-data'
 import type { Ingredients } from '@opentrons/step-generation'
 import type { RootState as IngredRoot } from './labware-ingred/reducers'
@@ -37,9 +38,14 @@ export interface PDMetadata {
 export interface DesignerApplication {
   designerApplication: { version: string; name: string; data: PDMetadata }
 }
+
+export interface PythonDesignerApplication extends DesignerApplication {
+  robotType: RobotType
+}
+
 export interface PDPythonFile {
   python: string
-  designerApplication: DesignerApplication
+  pythonDesignerApplication: PythonDesignerApplication
 }
 
 export type PDProtocolFile = ProtocolFile<PDMetadata>

--- a/protocol-designer/src/file-types.ts
+++ b/protocol-designer/src/file-types.ts
@@ -34,12 +34,12 @@ export interface PDMetadata {
   labware: Labware
 }
 
-export interface PythonMetadata {
-  designerApplication: { version: string; data: PDMetadata }
+export interface DesignerApplication {
+  designerApplication: { version: string; name: string; data: PDMetadata }
 }
 export interface PDPythonFile {
   python: string
-  designerApplication: PythonMetadata
+  designerApplication: DesignerApplication
 }
 
 export type PDProtocolFile = ProtocolFile<PDMetadata>

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -83,12 +83,11 @@ export const loadProtocolFile = (
       try {
         // Extract designer application blob
         const designerApplication = result.match(
-          /^DESIGNER_APPLICATION\s?=\s?"""(.*)"""/
+          /DESIGNER_APPLICATION\s?=\s?"""(.*)"""/
         )
         if (designerApplication != null && designerApplication[1]) {
           const designerApplicationString = designerApplication[1]
           const designerApplicationJson = JSON.parse(designerApplicationString) // Convert to JSON
-
           dispatch(loadFileAction(designerApplicationJson as PDPythonFile))
         } else {
           console.warn('No blob found in file.')

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -81,16 +81,20 @@ export const loadProtocolFile = (
       const result = (readEvent.currentTarget as FileReader).result as string
 
       try {
-        // Extract secret blob from a comment line
-        const secretMatch = result.match(/# DESIGNER_APPLICATION: (.+)/)
-        if (secretMatch && secretMatch[1]) {
-          const base64EncodedBlob = secretMatch[1].trim()
+        // Extract designer application blob
+        const designerApplicationComment = result.match(
+          /# DESIGNER_APPLICATION: (.+)/
+        )
+        if (designerApplicationComment && designerApplicationComment[1]) {
+          const base64EncodedBlob = designerApplicationComment[1].trim()
           const decodedBlob = atob(base64EncodedBlob) // Decode Base64
-          const secretJson = JSON.parse(decodedBlob) // Convert back to JSON
+          const designerApplicationJson = JSON.parse(decodedBlob) // Convert to JSON
 
-          console.log('Extracted JSON:', secretJson)
+          // TODO: remove this when uploading python is fully working for phase 1
+          // still need to add in labware definitions and robotType
+          console.log('Designer application JSON:', designerApplicationJson)
 
-          dispatch(loadFileAction(secretJson as PDPythonFile))
+          dispatch(loadFileAction(designerApplicationJson as PDPythonFile))
         } else {
           console.warn('No secret blob found in file.')
         }

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -85,10 +85,12 @@ export const loadProtocolFile = (
         const designerApplicationComment = result.match(
           /# DESIGNER_APPLICATION: (.+)/
         )
-        if (designerApplicationComment && designerApplicationComment[1]) {
-          const base64EncodedBlob = designerApplicationComment[1].trim()
-          const decodedBlob = atob(base64EncodedBlob) // Decode Base64
-          const designerApplicationJson = JSON.parse(decodedBlob) // Convert to JSON
+        if (
+          designerApplicationComment != null &&
+          designerApplicationComment[1]
+        ) {
+          const designerApplicationString = designerApplicationComment[1].trim()
+          const designerApplicationJson = JSON.parse(designerApplicationString) // Convert to JSON
 
           // TODO: remove this when uploading python is fully working for phase 1
           // still need to add in labware definitions and robotType

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -83,7 +83,7 @@ export const loadProtocolFile = (
       try {
         // Extract designer application blob
         const designerApplication = result.match(
-          /DESIGNER_APPLICATION\s?=\s?"""(.*)"""/
+          /^DESIGNER_APPLICATION\s?=\s?"""(.*)"""/
         )
         if (designerApplication != null && designerApplication[1]) {
           const designerApplicationString = designerApplication[1]

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -83,7 +83,7 @@ export const loadProtocolFile = (
       try {
         // Extract designer application blob
         const designerApplicationComment = result.match(
-          /# DESIGNER_APPLICATION: """([\s\S]+?)"""/
+          /DESIGNER_APPLICATION: """([\s\S]+?)"""/
         )
         if (
           designerApplicationComment != null &&

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -82,22 +82,12 @@ export const loadProtocolFile = (
 
       try {
         // Extract designer application blob
-        const designerApplicationComment = result.match(
-          /DESIGNER_APPLICATION: """([\s\S]+?)"""/
+        const designerApplication = result.match(
+          /^DESIGNER_APPLICATION\s?=\s?"""(.*)"""/
         )
-        if (
-          designerApplicationComment != null &&
-          designerApplicationComment[1]
-        ) {
-          const designerApplicationString = designerApplicationComment[1]
+        if (designerApplication != null && designerApplication[1]) {
+          const designerApplicationString = designerApplication[1]
           const designerApplicationJson = JSON.parse(designerApplicationString) // Convert to JSON
-
-          // TODO: remove this when uploading python is fully working for phase 1
-          // still need to add in labware definitions and robotType
-          console.log(
-            'Python designer application JSON:',
-            designerApplicationJson
-          )
 
           dispatch(loadFileAction(designerApplicationJson as PDPythonFile))
         } else {

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -94,7 +94,10 @@ export const loadProtocolFile = (
 
           // TODO: remove this when uploading python is fully working for phase 1
           // still need to add in labware definitions and robotType
-          console.log('Designer application JSON:', designerApplicationJson)
+          console.log(
+            'Python designer application JSON:',
+            designerApplicationJson
+          )
 
           dispatch(loadFileAction(designerApplicationJson as PDPythonFile))
         } else {

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -83,13 +83,13 @@ export const loadProtocolFile = (
       try {
         // Extract designer application blob
         const designerApplicationComment = result.match(
-          /# DESIGNER_APPLICATION: (.+)/
+          /# DESIGNER_APPLICATION: """([\s\S]+?)"""/
         )
         if (
           designerApplicationComment != null &&
           designerApplicationComment[1]
         ) {
-          const designerApplicationString = designerApplicationComment[1].trim()
+          const designerApplicationString = designerApplicationComment[1]
           const designerApplicationJson = JSON.parse(designerApplicationString) // Convert to JSON
 
           // TODO: remove this when uploading python is fully working for phase 1
@@ -98,10 +98,10 @@ export const loadProtocolFile = (
 
           dispatch(loadFileAction(designerApplicationJson as PDPythonFile))
         } else {
-          console.warn('No secret blob found in file.')
+          console.warn('No blob found in file.')
         }
       } catch (error) {
-        console.error('Error extracting secret blob:', error)
+        console.error('Error extracting blob:', error)
         if (error instanceof Error) {
           fileError('INVALID_FILE_TYPE', error.message)
         }

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -3,7 +3,7 @@ import { selectors as fileDataSelectors } from '../file-data'
 import { saveFile, savePythonFile } from './utils'
 
 import type { SyntheticEvent } from 'react'
-import type { PDProtocolFile } from '../file-types'
+import type { PDProtocolFile, PDPythonFile } from '../file-types'
 import type { GetState, ThunkAction, ThunkDispatch } from '../types'
 import type {
   FileUploadErrorType,
@@ -28,7 +28,9 @@ export const dismissFileUploadMessage = (): DismissFileUploadMessageAction => ({
   type: 'DISMISS_FILE_UPLOAD_MESSAGE',
 })
 // expects valid, parsed JSON protocol.
-export const loadFileAction = (payload: PDProtocolFile): LoadFileAction => ({
+export const loadFileAction = (
+  payload: PDProtocolFile | PDPythonFile
+): LoadFileAction => ({
   type: 'LOAD_FILE',
   payload: migration(payload),
 })
@@ -54,9 +56,9 @@ export const loadProtocolFile = (
   // reset the state of the input to allow file re-uploads
   event.currentTarget.value = ''
 
-  if (!file.name.endsWith('.json')) {
+  if (!file.name.endsWith('.json') && !file.name.endsWith('.py')) {
     fileError('INVALID_FILE_TYPE')
-  } else {
+  } else if (file.name.endsWith('.json')) {
     reader.onload = readEvent => {
       const result = ((readEvent.currentTarget as any) as FileReader).result
       let parsedProtocol: PDProtocolFile | null | undefined
@@ -69,6 +71,33 @@ export const loadProtocolFile = (
         console.error(error)
         if (error instanceof Error) {
           fileError('INVALID_JSON_FILE', error.message)
+        }
+      }
+    }
+
+    reader.readAsText(file)
+  } else {
+    reader.onload = readEvent => {
+      const result = (readEvent.currentTarget as FileReader).result as string
+
+      try {
+        // Extract secret blob from a comment line
+        const secretMatch = result.match(/# DESIGNER_APPLICATION: (.+)/)
+        if (secretMatch && secretMatch[1]) {
+          const base64EncodedBlob = secretMatch[1].trim()
+          const decodedBlob = atob(base64EncodedBlob) // Decode Base64
+          const secretJson = JSON.parse(decodedBlob) // Convert back to JSON
+
+          console.log('Extracted JSON:', secretJson)
+
+          dispatch(loadFileAction(secretJson as PDPythonFile))
+        } else {
+          console.warn('No secret blob found in file.')
+        }
+      } catch (error) {
+        console.error('Error extracting secret blob:', error)
+        if (error instanceof Error) {
+          fileError('INVALID_FILE_TYPE', error.message)
         }
       }
     }

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -83,7 +83,7 @@ export const loadProtocolFile = (
       try {
         // Extract designer application blob
         const designerApplication = result.match(
-          /^DESIGNER_APPLICATION\s?=\s?"""(.*)"""/
+          /^DESIGNER_APPLICATION\s?=\s?"""(.*)"""/m
         )
         if (designerApplication != null && designerApplication[1]) {
           const designerApplicationString = designerApplication[1]

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -10,7 +10,7 @@ export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
 }
 export const savePythonFile = (file: PDPythonFile, fileName: string): void => {
   const fileData = file.python
-  const stringifiedBlob = JSON.stringify(file.designerApplication)
+  const stringifiedBlob = JSON.stringify(file.pythonDesignerApplication)
   const designerApplicationBlob = `\n# DESIGNER_APPLICATION: """${stringifiedBlob}"""\n`
   const blob = new Blob([fileData, designerApplicationBlob], {
     type: 'text/x-python;charset=UTF-8',

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -10,8 +10,8 @@ export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
 }
 export const savePythonFile = (file: PDPythonFile, fileName: string): void => {
   const fileData = file.python
-  const secretBlob = btoa(JSON.stringify(file.designerApplication))
-  const hiddenBlob = `\n# DESIGNER_APPLICATION: ${secretBlob}\n`
+  const stringifiedBlob = JSON.stringify(file.designerApplication)
+  const hiddenBlob = `\n# DESIGNER_APPLICATION: ${stringifiedBlob}\n`
   const blob = new Blob([fileData, hiddenBlob], {
     type: 'text/x-python;charset=UTF-8',
   })

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -11,8 +11,8 @@ export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
 export const savePythonFile = (file: PDPythonFile, fileName: string): void => {
   const fileData = file.python
   const stringifiedBlob = JSON.stringify(file.designerApplication)
-  const hiddenBlob = `\n# DESIGNER_APPLICATION: ${stringifiedBlob}\n`
-  const blob = new Blob([fileData, hiddenBlob], {
+  const designerApplicationBlob = `\n# DESIGNER_APPLICATION: """${stringifiedBlob}"""\n`
+  const blob = new Blob([fileData, designerApplicationBlob], {
     type: 'text/x-python;charset=UTF-8',
   })
   // For now, show the generated Python in a new window instead of saving it to a file.

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -11,7 +11,7 @@ export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
 export const savePythonFile = (file: PDPythonFile, fileName: string): void => {
   const fileData = file.pythonProtocol
   const stringifiedBlob = JSON.stringify(file.designerApplication)
-  const designerApplicationBlob = `DESIGNER_APPLICATION: """${stringifiedBlob}"""\n`
+  const designerApplicationBlob = `\nDESIGNER_APPLICATION= """${stringifiedBlob}"""\n`
   const blob = new Blob([fileData, designerApplicationBlob], {
     type: 'text/x-python;charset=UTF-8',
   })

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -1,13 +1,20 @@
 import { saveAs } from 'file-saver'
 import type { ProtocolFile } from '@opentrons/shared-data'
+import type { PDPythonFile } from '../file-types'
+
 export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
   const blob = new Blob([JSON.stringify(fileData, null, 2)], {
     type: 'application/json',
   })
   saveAs(blob, fileName)
 }
-export const savePythonFile = (fileData: string, fileName: string): void => {
-  const blob = new Blob([fileData], { type: 'text/x-python;charset=UTF-8' })
+export const savePythonFile = (file: PDPythonFile, fileName: string): void => {
+  const fileData = file.python
+  const secretBlob = btoa(JSON.stringify(file.designerApplication))
+  const hiddenBlob = `\n# DESIGNER_APPLICATION: ${secretBlob}\n`
+  const blob = new Blob([fileData, hiddenBlob], {
+    type: 'text/x-python;charset=UTF-8',
+  })
   // For now, show the generated Python in a new window instead of saving it to a file.
   // (A saved Python file wouldn't be runnable anyway until we finish this project.)
   window.open(URL.createObjectURL(blob), '_blank')

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -11,7 +11,7 @@ export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
 export const savePythonFile = (file: PDPythonFile, fileName: string): void => {
   const fileData = file.python
   const stringifiedBlob = JSON.stringify(file.pythonDesignerApplication)
-  const designerApplicationBlob = `\n# DESIGNER_APPLICATION: """${stringifiedBlob}"""\n`
+  const designerApplicationBlob = `\nDESIGNER_APPLICATION: """${stringifiedBlob}"""\n`
   const blob = new Blob([fileData, designerApplicationBlob], {
     type: 'text/x-python;charset=UTF-8',
   })

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -11,7 +11,7 @@ export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
 export const savePythonFile = (file: PDPythonFile, fileName: string): void => {
   const fileData = file.pythonProtocol
   const stringifiedBlob = JSON.stringify(file.designerApplication)
-  const designerApplicationBlob = `\nDESIGNER_APPLICATION= """${stringifiedBlob}"""\n`
+  const designerApplicationBlob = `\nDESIGNER_APPLICATION = """${stringifiedBlob}"""\n`
   const blob = new Blob([fileData, designerApplicationBlob], {
     type: 'text/x-python;charset=UTF-8',
   })

--- a/protocol-designer/src/load-file/utils.ts
+++ b/protocol-designer/src/load-file/utils.ts
@@ -9,9 +9,9 @@ export const saveFile = (fileData: ProtocolFile, fileName: string): void => {
   saveAs(blob, fileName)
 }
 export const savePythonFile = (file: PDPythonFile, fileName: string): void => {
-  const fileData = file.python
-  const stringifiedBlob = JSON.stringify(file.pythonDesignerApplication)
-  const designerApplicationBlob = `\nDESIGNER_APPLICATION: """${stringifiedBlob}"""\n`
+  const fileData = file.pythonProtocol
+  const stringifiedBlob = JSON.stringify(file.designerApplication)
+  const designerApplicationBlob = `DESIGNER_APPLICATION: """${stringifiedBlob}"""\n`
   const blob = new Blob([fileData, designerApplicationBlob], {
     type: 'text/x-python;charset=UTF-8',
   })


### PR DESCRIPTION
…nd allow reupload

# Overview

This PR adds the `DESIGNER_APPLICATION` variable which stringifies the designer application key at the end of a python file. When you export, the python file now has a long variable at the end with the string.

When you import back into PD, it now accepts the python file and extracts the stringified blob back into a json. BUT there are still followups to be done for importing to fully work:
1. need to fix up logic for getting the labware definitions in use (this will require refactoring the `load-file` reducer to get the definition based off of the `labwareDefUri` in the `labware` key of `designerApplication`) (https://github.com/Opentrons/opentrons/pull/17945)
2. add some error handling if the python file doesn't have the designerApplication comment
3. refactor logic for how the `containers` key gets populated (https://github.com/Opentrons/opentrons/pull/17944)

## Test Plan and Hands on Testing

Review the code. designer application variable is a bit long though

```
from contextlib import nullcontext as pd_step
from opentrons import protocol_api, types

metadata = {
    "protocolName": "untitled",
    "created": "2025-04-01T15:32:34.358Z",
    "lastModified": "2025-04-01T17:43:56.398Z",
    "protocolDesigner": "8.4.3",
    "source": "Protocol Designer",
}

requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.23",
}

def run(protocol: protocol_api.ProtocolContext):
    # Load Labware:
    tip_rack_1 = protocol.load_labware(
        "opentrons_96_tiprack_300ul",
        location="2",
        namespace="opentrons",
        version=1,
    )
    reservoir_1 = protocol.load_labware(
        "nest_1_reservoir_195ml",
        location="1",
        namespace="opentrons",
        version=3,
    )

    # Load Pipettes:
    pipette_left = protocol.load_instrument("p300_single", "left", tip_racks=[tip_rack_1])

    # PROTOCOL STEPS



DESIGNER_APPLICATION: """{"designerApplication":{"name":"opentrons/protocol-designer","version":"8.5.0","data":{"pipetteTiprackAssignments":{"6e6b747d-a836-4fa8-a906-42819faac94f":["opentrons/opentrons_96_tiprack_300ul/1"]},"dismissedWarnings":{"form":[],"timeline":[]},"ingredients":{},"ingredLocations":{},"savedStepForms":{"__INITIAL_DECK_SETUP_STEP__":{"labwareLocationUpdate":{"54ee16f0-1d33-4996-bd35-132caa97782f:opentrons/opentrons_96_tiprack_300ul/1":"2","321649da-f6fe-4e07-9826-1cb2927aa3ca:opentrons/nest_1_reservoir_195ml/3":"1"},"moduleLocationUpdate":{},"pipetteLocationUpdate":{"6e6b747d-a836-4fa8-a906-42819faac94f":"left"},"trashBinLocationUpdate":{"efbf49ea-7f40-4eb5-9fb4-cadc0a8af97d:trashBin":"cutout12"},"wasteChuteLocationUpdate":{},"stagingAreaLocationUpdate":{},"gripperLocationUpdate":{},"stepType":"manualIntervention","id":"__INITIAL_DECK_SETUP_STEP__"},"8c6e0dab-5e31-43eb-bdd3-d53af6561513":{"aspirate_airGap_checkbox":false,"aspirate_airGap_volume":null,"aspirate_delay_checkbox":false,"aspirate_delay_mmFromBottom":null,"aspirate_delay_seconds":"1","aspirate_flowRate":"150","aspirate_labware":"321649da-f6fe-4e07-9826-1cb2927aa3ca:opentrons/nest_1_reservoir_195ml/3","aspirate_mix_checkbox":false,"aspirate_mix_times":null,"aspirate_mix_volume":null,"aspirate_mmFromBottom":null,"aspirate_position_reference":null,"aspirate_retract_delay_seconds":null,"aspirate_retract_mmFromBottom":null,"aspirate_retract_speed":null,"aspirate_retract_x_position":0,"aspirate_retract_y_position":0,"aspirate_retract_position_reference":null,"aspirate_submerge_delay_seconds":null,"aspirate_submerge_speed":null,"aspirate_submerge_mmFromBottom":null,"aspirate_submerge_x_position":null,"aspirate_submerge_y_position":null,"aspirate_submerge_position_reference":null,"aspirate_touchTip_checkbox":false,"aspirate_touchTip_mmFromTop":null,"aspirate_touchTip_speed":null,"aspirate_touchTip_mmFromEdge":0,"aspirate_wellOrder_first":"t2b","aspirate_wellOrder_second":"l2r","aspirate_wells_grouped":false,"aspirate_wells":["A1"],"aspirate_x_position":0,"aspirate_y_position":0,"blowout_checkbox":false,"blowout_flowRate":null,"blowout_location":null,"blowout_z_offset":0,"changeTip":"always","conditioning_checkbox":false,"conditioning_volume":null,"dispense_airGap_checkbox":false,"dispense_airGap_volume":null,"dispense_delay_checkbox":false,"dispense_delay_mmFromBottom":null,"dispense_delay_seconds":"1","dispense_flowRate":null,"dispense_labware":"321649da-f6fe-4e07-9826-1cb2927aa3ca:opentrons/nest_1_reservoir_195ml/3","dispense_mix_checkbox":false,"dispense_mix_times":null,"dispense_mix_volume":null,"dispense_mmFromBottom":null,"dispense_position_reference":null,"dispense_retract_delay_seconds":null,"dispense_retract_mmFromBottom":null,"dispense_retract_speed":null,"dispense_retract_x_position":0,"dispense_retract_y_position":0,"dispense_retract_position_reference":null,"dispense_submerge_delay_seconds":null,"dispense_submerge_speed":null,"dispense_submerge_mmFromBottom":null,"dispense_submerge_x_position":null,"dispense_submerge_y_position":null,"dispense_submerge_position_reference":null,"dispense_touchTip_checkbox":false,"dispense_touchTip_mmFromTop":null,"dispense_touchTip_speed":null,"dispense_touchTip_mmFromEdge":0,"dispense_wellOrder_first":"t2b","dispense_wellOrder_second":"l2r","dispense_wells":["A1"],"dispense_x_position":0,"dispense_y_position":0,"disposalVolume_checkbox":true,"disposalVolume_volume":null,"dropTip_location":"77b23d5f-da8f-49bb-84f0-5729f2c851c7:trashBin","liquidClassesSupported":true,"liquidClass":null,"nozzles":null,"path":"single","pipette":"6e6b747d-a836-4fa8-a906-42819faac94f","preWetTip":false,"pushOut_checkbox":false,"pushOut_volume":0,"tipRack":"opentrons/opentrons_96_tiprack_300ul/1","volume":"10","stepType":"moveLiquid","stepName":"transfer","stepDetails":"","id":"8c6e0dab-5e31-43eb-bdd3-d53af6561513","dispense_touchTip_mmfromTop":null}},"orderedStepIds":["8c6e0dab-5e31-43eb-bdd3-d53af6561513"],"pipettes":{"6e6b747d-a836-4fa8-a906-42819faac94f":{"pipetteName":"p300_single"}},"modules":{},"labware":{"54ee16f0-1d33-4996-bd35-132caa97782f:opentrons/opentrons_96_tiprack_300ul/1":{"displayName":"Opentrons OT-2 96 Tip Rack 300 µL","labwareDefURI":"opentrons/opentrons_96_tiprack_300ul/1"},"321649da-f6fe-4e07-9826-1cb2927aa3ca:opentrons/nest_1_reservoir_195ml/3":{"displayName":"NEST 1 Well Reservoir 195 mL","labwareDefURI":"opentrons/nest_1_reservoir_195ml/3"}}}},"robotType":"OT-2 Standard"}"""

```

## Changelog

- add a blob to the python file as stringified json designerApplication object
- add logic for importing a python file and extracting the stringified json back into a regular json
- add unit test

## Risk assessment

low, behind ff
