### PR TITLE
fix(app): Fix Desktop LPC "apply offsets" state

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -133,6 +133,13 @@ export function ProtocolRunSetup({
   const noLwOffsetsInRun =
     useSelector(selectTotalCountLocationSpecificOffsets(runId)) === 0 && isFlex
 
+  // A separate app can apply offsets. We need to update the missing steps as a side effect.
+  useEffect(() => {
+    if (flexOffsetsApplied) {
+      dispatch(updateRunSetupStepsComplete(runId, { [LPC_STEP_KEY]: true }))
+    }
+  }, [flexOffsetsApplied])
+
   const offsetsConfirmed = isFlex
     ? flexOffsetsApplied && !missingSteps.includes(LPC_STEP_KEY)
     : !missingSteps.includes(LPC_STEP_KEY)
@@ -266,9 +273,6 @@ export function ProtocolRunSetup({
         <SetupLabwarePositionCheck
           {...{ runId, robotName, robotType }}
           setOffsetsConfirmed={confirmed => {
-            dispatch(
-              updateRunSetupStepsComplete(runId, { [LPC_STEP_KEY]: confirmed })
-            )
             if (confirmed) {
               dispatch(appliedOffsetsToRun(runId))
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
@@ -17,7 +17,6 @@ import {
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useLPCDisabledReason } from '/app/resources/runs'
 import {
-  selectAreOffsetsApplied,
   selectIsAnyNecessaryDefaultOffsetMissing,
   selectLabwareOffsetsToAddToRun,
   selectTotalCountNonHardCodedLSOffsets,
@@ -31,6 +30,7 @@ export interface LPCSetupFlexBtnsProps extends SetupLabwarePositionCheckProps {
 
 export function LPCSetupFlexBtns({
   setOffsetsConfirmed,
+  offsetsConfirmed,
   launchLPC,
   runId,
   robotName,
@@ -41,7 +41,6 @@ export function LPCSetupFlexBtns({
   const isNecessaryDefaultOffsetMissing = useSelector(
     selectIsAnyNecessaryDefaultOffsetMissing(runId)
   )
-  const offsetsConfirmed = useSelector(selectAreOffsetsApplied(runId))
   const [runLPCTargetProps, runLPCTooltipProps] = useHoverTooltip({
     placement: TOOLTIP_BOTTOM,
   })
@@ -79,6 +78,16 @@ export function LPCSetupFlexBtns({
     }
   }
 
+  const runLPCDisabledTooltipText = (): string | null => {
+    if (lpcDisabledReason != null) {
+      return lpcDisabledReason
+    } else if (offsetsConfirmed) {
+      return t('offsets_already_applied')
+    } else {
+      return null
+    }
+  }
+
   const onApplyOffsets = (): void => {
     if (!isApplyOffsets && lwOffsetsForRun != null) {
       setIsApplyingOffsets(true)
@@ -103,12 +112,14 @@ export function LPCSetupFlexBtns({
         onClick={launchLPC}
         id="LabwareSetup_checkLabwarePositionsButton"
         {...runLPCTargetProps}
-        disabled={lpcDisabledReason !== null}
+        disabled={lpcDisabledReason !== null || offsetsConfirmed}
       >
         {t('run_labware_position_check')}
       </SecondaryButton>
-      {lpcDisabledReason !== null ? (
-        <Tooltip tooltipProps={runLPCTooltipProps}>{lpcDisabledReason}</Tooltip>
+      {lpcDisabledReason !== null || offsetsConfirmed ? (
+        <Tooltip tooltipProps={runLPCTooltipProps}>
+          {runLPCDisabledTooltipText()}
+        </Tooltip>
       ) : null}
       <PrimaryButton
         onClick={onApplyOffsets}


### PR DESCRIPTION
Closes [RQA-4022](https://opentrons.atlassian.net/browse/RQA-4022)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Woops, the "apply offsets" button disabled status utilized different state than the copy that would render the "offsets applied/not applied". These should be the same. More importantly, on the desktop, if a different user applied offsets, the `missingSteps` would not filter out LPC, since it was directly tied to a CTA.

Additionally, after talking to Design/QA, we've decided that when applying offsets, the "launch LPC" button should be disabled, too. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified the state sync issue mentioned in the ticket is fixed.
- Verified that after applying offsets, the "launch LPC" button is disabled, too.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the desktop app sometimes not allowing users to apply offsets.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4022]: https://opentrons.atlassian.net/browse/RQA-4022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ