### PR TITLE
fix(api): do not move plunger in 96chan DTW

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -78,7 +78,9 @@ class UnsafeDropTipInPlaceImplementation(
             [Axis.of_main_tool_actuator(pipette_location.mount.to_hw_mount())]
         )
         await self._tip_handler.drop_tip(
-            pipette_id=params.pipetteId, home_after=params.homeAfter
+            pipette_id=params.pipetteId,
+            home_after=params.homeAfter,
+            ignore_plunger=True,
         )
 
         state_update = StateUpdate()

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -80,7 +80,10 @@ class UnsafeDropTipInPlaceImplementation(
         await self._tip_handler.drop_tip(
             pipette_id=params.pipetteId,
             home_after=params.homeAfter,
-            ignore_plunger=True,
+            ignore_plunger=(
+                self._state_view.tips.get_pipette_active_channels(params.pipetteId)
+                == 96
+            ),
         )
 
         state_update = StateUpdate()

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -30,11 +30,13 @@ def mock_tip_handler(decoy: Decoy) -> TipHandler:
     return decoy.mock(cls=TipHandler)
 
 
+@pytest.mark.parametrize("channels", [1, 8, 96])
 async def test_drop_tip_implementation(
     decoy: Decoy,
     mock_tip_handler: TipHandler,
     state_view: StateView,
     ot3_hardware_api: OT3HardwareControlAPI,
+    channels: int,
 ) -> None:
     """A DropTip command should have an execution implementation."""
     subject = UnsafeDropTipInPlaceImplementation(
@@ -47,6 +49,9 @@ async def test_drop_tip_implementation(
     decoy.when(state_view.motion.get_pipette_location(pipette_id="abc")).then_return(
         PipetteLocationData(mount=MountType.LEFT, critical_point=None)
     )
+    decoy.when(
+        state_view.tips.get_pipette_active_channels(params.pipetteId)
+    ).then_return(channels)
 
     result = await subject.execute(params)
 
@@ -63,7 +68,7 @@ async def test_drop_tip_implementation(
     decoy.verify(
         await ot3_hardware_api.update_axis_position_estimations([Axis.P_L]),
         await mock_tip_handler.drop_tip(
-            pipette_id="abc", home_after=False, ignore_plunger=True
+            pipette_id="abc", home_after=False, ignore_plunger=(channels == 96)
         ),
         times=1,
     )

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -1,4 +1,5 @@
 """Test unsafe drop tip in place commands."""
+
 from opentrons.protocol_engine.state.update_types import (
     PipetteTipStateUpdate,
     PipetteUnknownFluidUpdate,
@@ -61,6 +62,8 @@ async def test_drop_tip_implementation(
 
     decoy.verify(
         await ot3_hardware_api.update_axis_position_estimations([Axis.P_L]),
-        await mock_tip_handler.drop_tip(pipette_id="abc", home_after=False),
+        await mock_tip_handler.drop_tip(
+            pipette_id="abc", home_after=False, ignore_plunger=True
+        ),
         times=1,
     )


### PR DESCRIPTION
In the drop tip wizard, when you do an `unsafe/dropTipInPlace`, we were telling the plunger to move to the bottom even if this was a cam action setup. This isn't technically necessary, and if we do it then we will cause an overpressure or stall to immediately reoccur which you really don't want.

## testing
- you should be able to drop tips in the drop tip wizard using a full-rack 96 config, even if you have an overpressure error that persists into the drop tip wizard (like a clogged or physically deformed tip)
   - also support has some method for making the plunger stall which should now be fixed as well

Closes RESC-418