### PR TITLE
refactor(protocol-designer): labware-ingred reducers to not use load commands

### DIFF
--- a/protocol-designer/src/labware-ingred/reducers/index.ts
+++ b/protocol-designer/src/labware-ingred/reducers/index.ts
@@ -12,7 +12,6 @@ import type {
   LiquidEntities,
   LiquidEntity,
 } from '@opentrons/step-generation'
-import type { LoadLabwareCreateCommand } from '@opentrons/shared-data'
 import type { Action, DeckSlot } from '../../types'
 import type {
   DisplayLabware,
@@ -43,6 +42,7 @@ import type {
   GenerateNewProtocolAction,
   EditMultipleLiquidGroupsAction,
 } from '../actions'
+
 // REDUCERS
 // modeLabwareSelection: boolean. If true, we're selecting labware to add to a slot
 // (this state just toggles a modal)
@@ -174,105 +174,24 @@ export const containers: Reducer<ContainersState, any> = handleActions(
       action: LoadFileAction
     ): ContainersState => {
       const { file } = action.payload
+      const metadata = getPDMetadata(file)
+      const containers: ContainersState = Object.entries(
+        metadata.labware
+      ).reduce((acc: ContainersState, [id, labwareLoadInfo], key) => {
+        acc[id] = {
+          nickname: labwareLoadInfo.displayName,
+          disambiguationNumber: key,
+        }
 
-      const loadLabwareCommands = Object.values(file.commands).filter(
-        command => command.commandType === 'loadLabware'
-      ) as LoadLabwareCreateCommand[]
+        return acc
+      }, {})
 
-      return loadLabwareCommands.reduce(
-        (acc: ContainersState, command, key): ContainersState => {
-          const { labwareId, displayName } = command.params
-
-          if (labwareId == null) {
-            console.error('expected to find a labwareId but could not')
-          }
-
-          return {
-            ...acc,
-            [labwareId ?? '']: {
-              nickname: displayName,
-              disambiguationNumber: key,
-            },
-          }
-        },
-        {}
-      )
+      return containers
     },
   },
   initialLabwareState
 )
-type SavedLabwareState = Record<string, boolean>
 
-/** Keeps track of which labware have saved nicknames */
-// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
-// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
-export const savedLabware: Reducer<SavedLabwareState, any> = handleActions(
-  {
-    DELETE_CONTAINER: (
-      state: SavedLabwareState,
-      action: DeleteContainerAction
-    ) => ({ ...state, [action.payload.labwareId]: false }),
-    RENAME_LABWARE: (
-      state: SavedLabwareState,
-      action: RenameLabwareAction
-    ) => ({ ...state, [action.payload.labwareId]: true }),
-    DUPLICATE_LABWARE: (
-      state: SavedLabwareState,
-      action: DuplicateLabwareAction
-    ) => ({ ...state, [action.payload.duplicateLabwareId]: true }),
-    LOAD_FILE: (
-      state: SavedLabwareState,
-      action: LoadFileAction
-    ): SavedLabwareState => {
-      const file = action.payload.file
-      const loadLabwareAndAdapterCommands = Object.values(file.commands).filter(
-        (command): command is LoadLabwareCreateCommand =>
-          command.commandType === 'loadLabware'
-      )
-
-      const labware = loadLabwareAndAdapterCommands.reduce(
-        (
-          acc: Record<
-            string,
-            {
-              slot: string
-              definitionId?: string
-              displayName?: string
-            }
-          >,
-          command
-        ) => {
-          const { displayName, loadName, labwareId } = command.params
-          const location = command.params.location
-          let slot
-          if (location === 'offDeck' || location === 'systemLocation') {
-            slot = 'offDeck'
-          } else if ('moduleId' in location) {
-            slot = location.moduleId
-          } else if ('labwareId' in location) {
-            slot = location.labwareId
-          } else if ('addressableAreaName' in location) {
-            slot = location.addressableAreaName
-          } else {
-            slot = location.slotName
-          }
-
-          return {
-            ...acc,
-            [loadName]: {
-              slot,
-              definitionId: labwareId,
-              displayName: displayName,
-            },
-          }
-        },
-        {}
-      )
-      return mapValues(labware, () => true)
-    },
-  },
-  {}
-)
 export type IngredientsState = LiquidEntities
 // @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
@@ -452,7 +371,6 @@ export interface RootState {
   selectedContainerId: SelectedContainerId
   drillDownLabwareId: DrillDownLabwareId
   containers: ContainersState
-  savedLabware: SavedLabwareState
   selectedLiquidGroup: SelectedLiquidGroupState
   ingredients: IngredientsState
   ingredLocations: LocationsState
@@ -466,7 +384,6 @@ export const rootReducer: Reducer<RootState, Action> = combineReducers({
   selectedLiquidGroup,
   drillDownLabwareId,
   containers,
-  savedLabware,
   ingredients,
   ingredLocations,
   generateNewProtocol,

--- a/protocol-designer/src/labware-ingred/selectors.ts
+++ b/protocol-designer/src/labware-ingred/selectors.ts
@@ -74,10 +74,6 @@ const getLiquidSelectionOptions: Selector<
 const selectedAddLabwareSlot = (state: BaseState): DeckSlot | false =>
   rootSelector(state).modeLabwareSelection
 
-// TODO(mc, 2020-06-04): move SavedLabwareState to common location and import here
-const getSavedLabware = (state: BaseState): Record<string, boolean> =>
-  rootSelector(state).savedLabware
-
 const getSelectedLabwareId: Selector<
   RootSlice,
   SelectedContainerId
@@ -177,7 +173,6 @@ export const selectors = {
   getLiquidSelectionOptions,
   getLiquidGroupsOnDeck,
   getNextLiquidGroupId,
-  getSavedLabware,
   getSelectedLabwareId,
   getSelectedLiquidGroupState,
   getDrillDownLabwareId,


### PR DESCRIPTION
# Overview

For importing python back into PD, i noticed that we forgot to refactor the `containers` load-file logic in the redux key to not look at the load commands. This PR refactors it by looking at the `labware` object in the `designerApplication` key to populate the information. 

Additionally, `saveLabware` in the redux tree wasn't in use anywhere so rather than refactoring it to also not use the load commands, I deleted it. I know its not in use anywhere because the selector wasn't in use anywhere. Plus unit tests still pass and smoke tests work. And from what i can tell, i don't see what it actually adds to the redux tree since the comment indicating that it is to keep track of nicknames doesn't make sense anymore. We keep track of nicknames in the `containers` key.

## Test Plan and Hands on Testing

Upload a protocol to PD and make sure it uploads correctly. see that the labware are all populated on the deck as expected. Also review the logic for anything that doesn't make sense.

## Changelog

- deprecate the `savedLabware` top level key
- refactor `containers` key to grab info from the labware object

## Risk assessment

low, shouldn't affect functionality
