### PR TITLE
fix(protocol-designer): show dropdown menu if value is null 

### DIFF
--- a/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
@@ -90,7 +90,9 @@ export function DropdownStepFormField(
     <Flex padding={padding ?? SPACING.spacing16}>
       {/* NOTE: we should not run into value == null when length === 1, but this
       just some extra error protection so users can't stuck where they can't select a value */}
-      {options.length > 1 || options.length === 0 || value == null ? (
+      {options.length > 1 ||
+      options.length === 0 ||
+      (value == null && options.length === 1) ? (
         <DropdownMenu
           tooltipText={tooltipContent != null ? t(`${tooltipContent}`) : null}
           width={width}

--- a/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
@@ -88,7 +88,9 @@ export function DropdownStepFormField(
 
   return (
     <Flex padding={padding ?? SPACING.spacing16}>
-      {options.length > 1 || options.length === 0 ? (
+      {/* NOTE: we should not run into value == null when length === 1, but this
+      just some extra error protection so users can't stuck where they can't select a value */}
+      {options.length > 1 || options.length === 0 || value == null ? (
         <DropdownMenu
           tooltipText={tooltipContent != null ? t(`${tooltipContent}`) : null}
           width={width}


### PR DESCRIPTION
closes AUTH-1646

# Overview

There were a few escalation tickets where the user somehow exported their protocol with no trash bin command and so upon reimporting back into pd, the trash bin was autogenerated with a new trash bin id from before. This resulted in the dropdown not actually selecting the new trash bin id. So this PR allows for the dropdown still if the `value == null` in this scenario

## Test Plan and Hands on Testing

upload the attached protocol into PD. to to timeline and open the errored step. select "trash bin" in the drop tip location dropdown. Save the form and see that it saved correctly

[untitled (75).json](https://github.com/user-attachments/files/19554036/untitled.75.json)

## Changelog

- protection for if value == null

## Risk assessment

low -ish