### PR TITLE
feat(api): protocol engine command for identifying module (w/ stacker implementation)

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -561,6 +561,10 @@ class FlexStacker(mod_abc.AbstractModule):
                 case _:
                     await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
 
+    async def identify(self) -> None:
+        """Identify the module."""
+        await self.set_led_state(1.0, LEDColor.WHITE, LEDPattern.PULSE, reps=10)
+
 
 class FlexStackerReader(Reader):
     error: Optional[str]

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -563,7 +563,7 @@ class FlexStacker(mod_abc.AbstractModule):
 
     async def identify(self) -> None:
         """Identify the module."""
-        await self.set_led_state(1.0, LEDColor.WHITE, LEDPattern.PULSE, reps=10)
+        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.PULSE, reps=10)
 
 
 class FlexStackerReader(Reader):

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -168,6 +168,7 @@ class FlexStacker(mod_abc.AbstractModule):
         self._poller = poller
         self._stacker_status = FlexStackerStatus.IDLE
         self._stall_detected = False
+        self._last_status_bar_event: Optional[StatusBarUpdateEvent] = None
 
     async def cleanup(self) -> None:
         """Stop the poller task"""
@@ -564,6 +565,8 @@ class FlexStacker(mod_abc.AbstractModule):
     async def identify(self) -> None:
         """Identify the module."""
         await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.PULSE, reps=10)
+        if self._last_status_bar_event:
+            await self._handle_status_bar_event(self._last_status_bar_event)
 
 
 class FlexStackerReader(Reader):

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -234,3 +234,7 @@ class AbstractModule(abc.ABC):
     def event_listener(self, event: Any) -> None:
         """Listen for events and update the module state."""
         pass
+
+    async def identify(self) -> None:
+        """Identify the module."""
+        pass

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -419,6 +419,14 @@ from .evotip_dispense import (
     EvotipDispenseCommandType,
 )
 
+from .identify_module import (
+    IdentifyModule,
+    IdentifyModuleParams,
+    IdentifyModuleCreate,
+    IdentifyModuleResult,
+    IdentifyModuleCommandType,
+)
+
 __all__ = [
     # command type unions
     "Command",
@@ -740,4 +748,10 @@ __all__ = [
     "EvotipDispenseCreate",
     "EvotipDispenseResult",
     "EvotipDispenseCommandType",
+    # identify module command bundle
+    "IdentifyModule",
+    "IdentifyModuleParams",
+    "IdentifyModuleCreate",
+    "IdentifyModuleResult",
+    "IdentifyModuleCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -406,6 +406,14 @@ from .evotip_unseal_pipette import (
     EvotipUnsealPipetteCommandType,
 )
 
+from .identify_module import (
+    IdentifyModule,
+    IdentifyModuleParams,
+    IdentifyModuleCreate,
+    IdentifyModuleResult,
+    IdentifyModuleCommandType,
+)
+
 Command = Annotated[
     Union[
         AirGapInPlace,
@@ -455,6 +463,7 @@ Command = Annotated[
         EvotipSealPipette,
         EvotipDispense,
         EvotipUnsealPipette,
+        IdentifyModule,
         heater_shaker.WaitForTemperature,
         heater_shaker.SetTargetTemperature,
         heater_shaker.DeactivateHeater,
@@ -557,6 +566,7 @@ CommandParams = Union[
     EvotipSealPipetteParams,
     EvotipDispenseParams,
     EvotipUnsealPipetteParams,
+    IdentifyModuleParams,
     heater_shaker.WaitForTemperatureParams,
     heater_shaker.SetTargetTemperatureParams,
     heater_shaker.DeactivateHeaterParams,
@@ -657,6 +667,7 @@ CommandType = Union[
     EvotipSealPipetteCommandType,
     EvotipDispenseCommandType,
     EvotipUnsealPipetteCommandType,
+    IdentifyModuleCommandType,
     heater_shaker.WaitForTemperatureCommandType,
     heater_shaker.SetTargetTemperatureCommandType,
     heater_shaker.DeactivateHeaterCommandType,
@@ -758,6 +769,7 @@ CommandCreate = Annotated[
         EvotipSealPipetteCreate,
         EvotipDispenseCreate,
         EvotipUnsealPipetteCreate,
+        IdentifyModuleCreate,
         heater_shaker.WaitForTemperatureCreate,
         heater_shaker.SetTargetTemperatureCreate,
         heater_shaker.DeactivateHeaterCreate,
@@ -867,6 +879,7 @@ CommandResult = Union[
     EvotipSealPipetteResult,
     EvotipDispenseResult,
     EvotipUnsealPipetteResult,
+    IdentifyModuleResult,
     heater_shaker.WaitForTemperatureResult,
     heater_shaker.SetTargetTemperatureResult,
     heater_shaker.DeactivateHeaterResult,

--- a/api/src/opentrons/protocol_engine/commands/identify_module.py
+++ b/api/src/opentrons/protocol_engine/commands/identify_module.py
@@ -1,0 +1,83 @@
+"""Command models to pulse the light on a module for identification."""
+
+from __future__ import annotations
+
+from __future__ import annotations
+from typing import Optional, Literal, TYPE_CHECKING
+from typing_extensions import Type
+
+from pydantic import BaseModel, Field
+
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
+from ..types import ModuleModel
+
+if TYPE_CHECKING:
+    from ..state.state import StateView
+    from opentrons.protocol_engine.execution import EquipmentHandler
+
+IdentifyModuleCommandType = Literal["identifyModule"]
+
+
+class IdentifyModuleParams(BaseModel):
+    """The parameters defining the module to be identified."""
+
+    model: ModuleModel = Field(..., description="The model of the module")
+    moduleId: str = Field(..., description="Unique ID of the module")
+
+
+class IdentifyModuleResult(BaseModel):
+    """Result data from an IdentifyModule command."""
+
+
+class IdentifyModuleImpl(
+    AbstractCommandImpl[IdentifyModuleParams, SuccessData[IdentifyModuleResult]]
+):
+    """Implementation of an IdentifyModule command."""
+
+    def __init__(
+        self, state_view: StateView, equipment: EquipmentHandler, **kwargs: object
+    ) -> None:
+        self._state_view = state_view
+        self._equipment = equipment
+
+    async def execute(
+        self, params: IdentifyModuleParams
+    ) -> SuccessData[IdentifyModuleResult]:
+        """Execute the IdentifyModule command."""
+        # ONLY flex stacker has support for identify module command
+        if params.model == ModuleModel.FLEX_STACKER_MODULE_V1:
+            module_substate = self._state_view.modules.get_flex_stacker_substate(
+                module_id=params.moduleId
+            )
+            module_hw = self._equipment.get_module_hardware_api(
+                module_substate.module_id
+            )
+            await module_hw.identify()
+        else:
+            raise NotImplementedError(
+                f"IdentifyModule is not supported for {params.model}"
+            )
+
+        return SuccessData(public=IdentifyModuleResult())
+
+
+class IdentifyModule(
+    BaseCommand[IdentifyModuleParams, IdentifyModuleResult, ErrorOccurrence]
+):
+    """A command to identify a module."""
+
+    commandType: IdentifyModuleCommandType = "identifyModule"
+    params: IdentifyModuleParams
+    result: Optional[IdentifyModuleResult] = None
+
+    _ImplementationCls: Type[IdentifyModuleImpl] = IdentifyModuleImpl
+
+
+class IdentifyModuleCreate(BaseCommandCreate[IdentifyModuleParams]):
+    """A request to execute an IdentifyModule command."""
+
+    commandType: IdentifyModuleCommandType = "identifyModule"
+    params: IdentifyModuleParams
+
+    _CommandCls: Type[IdentifyModule] = IdentifyModule

--- a/api/src/opentrons/protocol_engine/commands/identify_module.py
+++ b/api/src/opentrons/protocol_engine/commands/identify_module.py
@@ -53,7 +53,8 @@ class IdentifyModuleImpl(
             module_hw = self._equipment.get_module_hardware_api(
                 module_substate.module_id
             )
-            await module_hw.identify()
+            if module_hw is not None:
+                await module_hw.identify()
         else:
             raise NotImplementedError(
                 f"IdentifyModule is not supported for {params.model}"

--- a/shared-data/command/schemas/13.json
+++ b/shared-data/command/schemas/13.json
@@ -2340,6 +2340,51 @@
       "title": "HomeParams",
       "type": "object"
     },
+    "IdentifyModuleCreate": {
+      "description": "A request to execute an IdentifyModule command.",
+      "properties": {
+        "commandType": {
+          "const": "identifyModule",
+          "default": "identifyModule",
+          "enum": ["identifyModule"],
+          "title": "Commandtype",
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/$defs/CommandIntent",
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "title": "Intent"
+        },
+        "key": {
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "title": "Key",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/IdentifyModuleParams"
+        }
+      },
+      "required": ["params"],
+      "title": "IdentifyModuleCreate",
+      "type": "object"
+    },
+    "IdentifyModuleParams": {
+      "description": "The parameters defining the module to be identified.",
+      "properties": {
+        "model": {
+          "$ref": "#/$defs/ModuleModel",
+          "description": "The model of the module"
+        },
+        "moduleId": {
+          "description": "Unique ID of the module",
+          "title": "Moduleid",
+          "type": "string"
+        }
+      },
+      "required": ["model", "moduleId"],
+      "title": "IdentifyModuleParams",
+      "type": "object"
+    },
     "InitializeCreate": {
       "description": "A request to execute an Absorbance Reader measurement.",
       "properties": {
@@ -6764,6 +6809,7 @@
       "heaterShaker/setTargetTemperature": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate",
       "heaterShaker/waitForTemperature": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate",
       "home": "#/$defs/HomeCreate",
+      "identifyModule": "#/$defs/IdentifyModuleCreate",
       "liquidProbe": "#/$defs/LiquidProbeCreate",
       "loadLabware": "#/$defs/LoadLabwareCreate",
       "loadLid": "#/$defs/LoadLidCreate",
@@ -6962,6 +7008,9 @@
     },
     {
       "$ref": "#/$defs/EvotipUnsealPipetteCreate"
+    },
+    {
+      "$ref": "#/$defs/IdentifyModuleCreate"
     },
     {
       "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate"


### PR DESCRIPTION
# Overview
This PR introduces the `identifyModule` command to the protocol engine, allowing hardware modules to be identified by module model and module ID. Currently, the identify function is only implemented for the stacker. 