### PR TITLE
fix(api): dont crash subsystem manager with usage

### DIFF
--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -58,7 +58,7 @@ class SubsystemManager:
     _expected_core_targets: Set[FirmwareTarget]
     _present_tools: tools.types.ToolSummary
     _tool_task_condition: asyncio.Condition
-    _tool_task_state: Union[bool, Exception]
+    _tool_task_state: Union[bool, BaseException]
     _updates_required: Dict[FirmwareTarget, FirmwareUpdateRequirements]
     _updates_ongoing: Dict[SubSystem, UpdateStatus]
     _update_bag: FirmwareUpdate
@@ -370,7 +370,8 @@ class SubsystemManager:
     async def _tool_detection_task_main(self) -> None:
         try:
             await self._tool_detection_task_protected()
-        except Exception as e:
+        except BaseException as e:
+            log.exception("Tool reader task failed")
             async with self._tool_task_condition:
                 self._tool_task_state = e
                 self._tool_task_condition.notify_all()
@@ -414,9 +415,7 @@ class SubsystemManager:
             )
             self._present_tools = await self._tool_detector.resolve(to_resolve, 10.0)
             log.info(f"Present tools are now {self._present_tools}")
-            await network.log_motor_usage_data(
-                self._can_messenger, list(set(base_can_nodes + [t for t in tool_nodes]))
-            )
+            await network.log_motor_usage_data(self._can_messenger)
             async with self._tool_task_condition:
                 self._tool_task_state = True
                 self._tool_task_condition.notify_all()

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -348,7 +348,11 @@ class CanMessenger:
         listener: MessageListenerCallback,
         filter: Optional[MessageListenerCallbackFilter] = None,
     ) -> None:
-        """Add a message listener."""
+        """Add a message listener.
+
+        Will not leak listener objects if called multiple times with the same-by-identity
+        function; it will overwrite the old entry each time in that case.
+        """
         self._listeners[listener] = listener, filter
 
     def remove_listener(self, listener: MessageListenerCallback) -> None:

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from itertools import chain
 import logging
-from typing import Any, Dict, Set, Optional, Union, cast, Iterable, Tuple, List
+from typing import Any, Dict, Set, Optional, Union, cast, Iterable, Tuple
 from .types import PCBARevision
 from opentrons_hardware.firmware_bindings import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import (
@@ -509,40 +509,31 @@ def _parse_can_device_info_response(
     return None
 
 
-async def log_motor_usage_data(  # noqa: C901
-    can_messenger: CanMessenger, nodes: List[NodeId]
-) -> None:
-    """Broadcasts a message to get motor usage request and waits for a list of expected nodes."""
-    event = asyncio.Event()
-    log.info(f"Getting usage data from {nodes}")
+def _listener(message: MessageDefinition, arb_id: ArbitrationId) -> None:
+    if isinstance(message, GetMotorUsageResponse):
+        usage_elements = message.payload.usage_elements
+        node = arb_id.parts.originating_node_id
+        logline = f"Usage from {node}: "
+        for m in usage_elements:
+            data_name = MotorUsageValueType(m.key).name
+            data_value = m.usage_value
+            logline += f"\n    {data_name}: {data_value}"
+        log.info(logline)
+
+
+async def log_motor_usage_data(can_messenger: CanMessenger) -> None:
+    """Broadcasts a message to get motor usage request and installs a listener to log responses.
+
+    This is really only intended to make sure that usage data gets logged; it will return before
+    responses get sent and shouldn't be relied upon beyond logging.
+    """
+    log.info(f"Getting usage data using listener {_listener}")
 
     def _filter(arb_id: ArbitrationId) -> bool:
         return MessageId(arb_id.parts.message_id) == MessageId.get_motor_usage_response
 
-    def _listener(message: MessageDefinition, arb_id: ArbitrationId) -> None:
-        if isinstance(message, GetMotorUsageResponse):
-            usage_elements = message.payload.usage_elements
-            node = arb_id.parts.originating_node_id
-            logline = f"Usage from {node}: "
-            for m in usage_elements:
-                data_name = MotorUsageValueType(m.key).name
-                data_value = m.usage_value
-                logline += f"\n    {data_name}: {data_value}"
-            log.info(logline)
-            try:
-                nodes.remove(node)
-            except ValueError:
-                log.warning(
-                    f"Usage response from {node} which was not passed in as expected originally"
-                )
-            if len(nodes) == 0:
-                event.set()
-
+    # Note: this adds but does not remove a listener. this is safe asl ong as add_listener
+    # is implemented with a dictionary keyed on function object identity, because this
+    # function should be stable. It will not be okay if we ever change that.
     can_messenger.add_listener(_listener, _filter)
     await can_messenger.send(node_id=NodeId.broadcast, message=GetMotorUsageRequest())
-    try:
-        await asyncio.wait_for(event.wait(), 1.0)
-    except TimeoutError:
-        log.error(f"Receiving usage data failed with {nodes} remaining")
-    finally:
-        can_messenger.remove_listener(_listener)


### PR DESCRIPTION
The usage system just doesn't calculate its expected respondants correctly. It would be sort of annoying to fix because a bunch of logic would have to move around, and we don't really use the data for anything, so let's just make it stop waiting for all the responses (they'll show up in the logs anyway). That fixes an occasional timeout that would crash the tool reader task.

Closes RQA-4020
