### PR TITLE
fix(api): Liquid height at 0ul is 0mm not error

### DIFF
--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -402,7 +402,7 @@ def _find_height_in_partial_frustum(
         section_top_height, section_volume = capacity
         if (
             bottom_section_volume
-            < target_volume
+            <= target_volume
             <= (bottom_section_volume + section_volume)
         ):
             relative_target_volume = target_volume - bottom_section_volume

--- a/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
+++ b/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
@@ -317,10 +317,12 @@ def test_volume_and_height_spherical(well: List[Any]) -> None:
 
 
 @pytest.mark.parametrize("well", fake_frusta())
-def test_height_at_volume_within_section(well: List[Any]) -> None:
-    """Test that finding the height when volume ~= capacity  works."""
+def test_height_at_volume_at_section_boundaries(well: List[Any]) -> None:
+    """Test that finding the height when volume 0 or ~= capacity  works."""
     for segment in well:
         segment_height = segment.topHeight - segment.bottomHeight
+        height = height_at_volume_within_section(segment, 0.0, segment_height)
+        assert isclose(height, 0.0)
         height = height_at_volume_within_section(
             segment, _get_segment_capacity(segment), segment_height
         )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This change was required in order to do dynamic tracking during a dispense into an empty well.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
