### PR TITLE
fix(protocol-designer): more robust custom labware upload validation

### DIFF
--- a/protocol-designer/src/labware-defs/actions.ts
+++ b/protocol-designer/src/labware-defs/actions.ts
@@ -133,9 +133,7 @@ const _createCustomLabwareDef: (
 
     const valid: boolean | PromiseLike<any> =
       parsedLabwareDef === null ? false : validate(parsedLabwareDef)
-    const hasWellMatching = validateCustomLabwareHelper(
-      parsedLabwareDef ?? null
-    )
+    const hasWellMatching = validateCustomLabwareHelper(parsedLabwareDef)
     const loadName = parsedLabwareDef?.parameters?.loadName || ''
     const displayName = parsedLabwareDef?.metadata?.displayName || ''
 

--- a/protocol-designer/src/labware-defs/actions.ts
+++ b/protocol-designer/src/labware-defs/actions.ts
@@ -133,15 +133,22 @@ const _createCustomLabwareDef: (
 
     const valid: boolean | PromiseLike<any> =
       parsedLabwareDef === null ? false : validate(parsedLabwareDef)
-    const hasWellA1 = flatten(parsedLabwareDef?.ordering || []).includes('A1')
+    const hasWellMatching =
+      parsedLabwareDef != null
+        ? Object.keys(parsedLabwareDef.wells).every(well =>
+            flatten(parsedLabwareDef?.ordering || []).includes(well)
+          )
+        : true
     const loadName = parsedLabwareDef?.parameters?.loadName || ''
     const displayName = parsedLabwareDef?.metadata?.displayName || ''
 
-    if (!hasWellA1) {
-      console.warn('uploaded labware conforms to schema, but has no well A1!')
+    if (!hasWellMatching) {
+      console.warn(
+        'uploaded labware conforms to schema, but wells do not match!'
+      )
     }
 
-    if (!valid || !hasWellA1) {
+    if (!valid || !hasWellMatching) {
       return dispatch(
         labwareUploadMessage({
           messageType: 'INVALID_JSON_FILE',

--- a/protocol-designer/src/labware-defs/actions.ts
+++ b/protocol-designer/src/labware-defs/actions.ts
@@ -1,6 +1,5 @@
 import Ajv from 'ajv'
 import isEqual from 'lodash/isEqual'
-import flatten from 'lodash/flatten'
 import values from 'lodash/values'
 import uniqBy from 'lodash/uniqBy'
 import {
@@ -8,6 +7,7 @@ import {
   getIsTiprack,
   OPENTRONS_LABWARE_NAMESPACE,
   labwareSchemaV2,
+  validateCustomLabwareHelper,
 } from '@opentrons/shared-data'
 import { getAllWellSetsForLabware } from '../utils'
 import * as labwareDefSelectors from './selectors'
@@ -133,12 +133,9 @@ const _createCustomLabwareDef: (
 
     const valid: boolean | PromiseLike<any> =
       parsedLabwareDef === null ? false : validate(parsedLabwareDef)
-    const hasWellMatching =
-      parsedLabwareDef != null
-        ? Object.keys(parsedLabwareDef.wells).every(well =>
-            flatten(parsedLabwareDef?.ordering || []).includes(well)
-          )
-        : true
+    const hasWellMatching = validateCustomLabwareHelper(
+      parsedLabwareDef ?? null
+    )
     const loadName = parsedLabwareDef?.parameters?.loadName || ''
     const displayName = parsedLabwareDef?.metadata?.displayName || ''
 

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -45,6 +45,7 @@ export * from './formatRunTimeParameterMinMax'
 export * from './orderRuntimeParameterRangeOptions'
 export * from './sortRunTimeParameters'
 export * from './parseAddressableArea'
+export * from './validateCustomLabwareHelper'
 
 export const getLabwareDefIsStandard = (def: LabwareDefinition2): boolean =>
   def?.namespace === OPENTRONS_LABWARE_NAMESPACE

--- a/shared-data/js/helpers/validateCustomLabwareHelper.ts
+++ b/shared-data/js/helpers/validateCustomLabwareHelper.ts
@@ -8,7 +8,7 @@ import type { LabwareDefinition2 } from '..'
  * @returns A boolean for if they exist
  */
 export const validateCustomLabwareHelper = (
-  definition: LabwareDefinition2 | null
+  definition?: LabwareDefinition2 | null
 ): boolean => {
   if (definition == null) {
     return false

--- a/shared-data/js/helpers/validateCustomLabwareHelper.ts
+++ b/shared-data/js/helpers/validateCustomLabwareHelper.ts
@@ -1,0 +1,23 @@
+import type { LabwareDefinition2 } from '..'
+
+/**
+ * This function is used to help validate that the wells and ordering matches in
+ * a custom labware definition in terms of the wellName and the wells length
+ *
+ * @param definition - a labware definition
+ * @returns A boolean for if they exist
+ */
+export const validateCustomLabwareHelper = (
+  definition: LabwareDefinition2 | null
+): boolean => {
+  if (definition == null) {
+    return false
+  }
+  const wellSet = new Set(definition.ordering.flat())
+  const wellKeys = Object.keys(definition.wells)
+
+  return (
+    wellKeys.length === wellSet.size &&
+    wellKeys.every(well => wellSet.has(well))
+  )
+}


### PR DESCRIPTION
partially addresses AUTH-1463

# Overview

The custom labware that the user tried to upload was made from AI and it was wrong even though the schema matches. this pr adds more robust validation to check if the custom labware is correct or not

## Test Plan and Hands on Testing

try uploading the bugged and fixed version into pd and make sure the fixed works and the bugged doesn't

[FIXED_full_skirted_96_wellplate_100ul_fixed (1).json](https://github.com/user-attachments/files/19557045/FIXED_full_skirted_96_wellplate_100ul_fixed.1.json)
[BUGGED_full_skirted_96_wellplate_100ul_fixed (1).json](https://github.com/user-attachments/files/19557046/BUGGED_full_skirted_96_wellplate_100ul_fixed.1.json)



## Changelog

-validate that all the wells match between wells key and ordering key by making a shared-data util. note that this util is a replica of [here](https://github.com/Opentrons/opentrons/pull/17960/files), used in the app and merged into the 8.4.0 release branch

## Risk assessment

low
