### PR TITLE
fix(protocol-designer): fix getMaxPushout util logic

### DIFF
--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -310,7 +310,8 @@ export const getMaxPushOutVolume = (
     ? plungerPositionsConfigurations.lowVolumeDefault ??
       plungerPositionsConfigurations.default
     : plungerPositionsConfigurations.default
-  return round((blowout - bottom) * shaftULperMM, 1)
+  // absolute value to account for flipped z-axis on OT-2 vs. Flex pipettes
+  return round(Math.abs(blowout - bottom) * shaftULperMM, 1)
 }
 
 export const getDefaultPushOutVolume = (


### PR DESCRIPTION
# Overview

This PR ensures that the distance from bottom to blowout is an absolute value when converting mm to uL. This is due to the z-axis for Flex pipettes being flipped relative to OT-2 pipettes.

## Test Plan and Hands on Testing

- in an OT-2 protocol, create a transfer step and navigate to dispense advanced settings
- expand pushout field and verify that specified range is from 0 to a positive number
- repeat with Flex

## Changelog

- take absolute value of distance between bottom and blowout positions when calculating max pushout volume

## Review requests

see test plan

## Risk assessment

low