### PR TITLE
fix(app): more robust custom labware validation

### DIFF
--- a/app-shell/src/labware/validation.ts
+++ b/app-shell/src/labware/validation.ts
@@ -1,6 +1,9 @@
 import Ajv from 'ajv'
 import sortBy from 'lodash/sortBy'
-import { labwareSchemaV2 as labwareSchema } from '@opentrons/shared-data'
+import {
+  labwareSchemaV2 as labwareSchema,
+  validateCustomLabwareHelper,
+} from '@opentrons/shared-data'
 import { sameIdentity } from './compare'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -14,6 +17,7 @@ import {
   OPENTRONS_LABWARE_FILE,
   VALID_LABWARE_FILE,
 } from '../constants'
+import { flatten } from 'lodash'
 
 const ajv = new Ajv()
 const validateDefinition = ajv.compile(labwareSchema)
@@ -34,7 +38,10 @@ export function validateLabwareFiles(
     // check file against the schema
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const definition = data && validateLabwareDefinition(data)
-    if (definition === null) {
+
+    const hasValidWellInfo = validateCustomLabwareHelper(definition)
+
+    if (definition === null || !hasValidWellInfo) {
       return { filename, modified, type: INVALID_LABWARE_FILE }
     }
 

--- a/app-shell/src/labware/validation.ts
+++ b/app-shell/src/labware/validation.ts
@@ -17,7 +17,6 @@ import {
   OPENTRONS_LABWARE_FILE,
   VALID_LABWARE_FILE,
 } from '../constants'
-import { flatten } from 'lodash'
 
 const ajv = new Ajv()
 const validateDefinition = ajv.compile(labwareSchema)

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -45,6 +45,7 @@ export * from './formatRunTimeParameterMinMax'
 export * from './orderRuntimeParameterRangeOptions'
 export * from './sortRunTimeParameters'
 export * from './parseAddressableArea'
+export * from './validateCustomLabwareHelper'
 
 export const getLabwareDefIsStandard = (def: LabwareDefinition2): boolean =>
   def?.namespace === OPENTRONS_LABWARE_NAMESPACE

--- a/shared-data/js/helpers/validateCustomLabwareHelper.ts
+++ b/shared-data/js/helpers/validateCustomLabwareHelper.ts
@@ -1,4 +1,3 @@
-import flatten from 'lodash/flatten'
 import type { LabwareDefinition2 } from '..'
 
 /**
@@ -11,12 +10,15 @@ import type { LabwareDefinition2 } from '..'
 export const validateCustomLabwareHelper = (
   definition: LabwareDefinition2 | null
 ): boolean => {
+  if (definition == null) {
+    return false
+  }
+  const wellSet = new Set(definition.ordering.flat())
+  const wellKeys = Object.keys(definition.wells)
+
   return (
     definition != null &&
-    Object.keys(definition.wells).length ===
-      flatten(definition.ordering).length &&
-    Object.keys(definition.wells).every(well =>
-      flatten(definition.ordering).includes(well)
-    )
+    wellKeys.length === wellSet.size &&
+    wellKeys.every(well => wellSet.has(well))
   )
 }

--- a/shared-data/js/helpers/validateCustomLabwareHelper.ts
+++ b/shared-data/js/helpers/validateCustomLabwareHelper.ts
@@ -17,7 +17,6 @@ export const validateCustomLabwareHelper = (
   const wellKeys = Object.keys(definition.wells)
 
   return (
-    definition != null &&
     wellKeys.length === wellSet.size &&
     wellKeys.every(well => wellSet.has(well))
   )

--- a/shared-data/js/helpers/validateCustomLabwareHelper.ts
+++ b/shared-data/js/helpers/validateCustomLabwareHelper.ts
@@ -1,0 +1,22 @@
+import flatten from 'lodash/flatten'
+import type { LabwareDefinition2 } from '..'
+
+/**
+ * This function is used to help validate that the wells and ordering matches in
+ * a custom labware definition in terms of the wellName and the wells length
+ *
+ * @param definition - a labware definition
+ * @returns A boolean for if they exist
+ */
+export const validateCustomLabwareHelper = (
+  definition: LabwareDefinition2 | null
+): boolean => {
+  return (
+    definition != null &&
+    Object.keys(definition.wells).length ===
+      flatten(definition.ordering).length &&
+    Object.keys(definition.wells).every(well =>
+      flatten(definition.ordering).includes(well)
+    )
+  )
+}


### PR DESCRIPTION
closes AUTH-1463

# Overview

The custom labware that the user tried to upload was made from AI and it was wrong even though the schema matches. The labware was so wrong that it caused their app to severely crash - like they had to uninstall and reinstall their app and delete some hidden cache on their laptop apparently (this is according to Mike). 

This pr adds more robust validation to check if the custom labware is correct or not for the app by checking the length of the ordered wells vs wells and that the wellNames match

## Test Plan and Hands on Testing

try uploading the bugged and fixed version into the app and make sure the fixed works and the bugged one doesn't

[FIXED_full_skirted_96_wellplate_100ul_fixed (1).json](https://github.com/user-attachments/files/19557045/FIXED_full_skirted_96_wellplate_100ul_fixed.1.json)
[BUGGED_full_skirted_96_wellplate_100ul_fixed (1).json](https://github.com/user-attachments/files/19557046/BUGGED_full_skirted_96_wellplate_100ul_fixed.1.json)



## Changelog

- validate that all the wells match between wells key and ordering key and the lengths

## Risk assessment

low
