### PR TITLE
fix(app): Fix local state issues when "resetting to default" in LPC

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useSaveWorkingOffsets.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useSaveWorkingOffsets.test.ts
@@ -48,6 +48,11 @@ describe('useSaveWorkingOffsets', () => {
     { id: 'offset-2', labwareId: 'labware-2', vector: { x: 2, y: 2, z: 2 } },
   ]
 
+  const mockDeletedOffsets = [
+    { id: '', labwareId: '', vector: { x: 0, y: 0, z: 0 } },
+    { id: '', labwareId: '', vector: { x: 0, y: 0, z: 0 } },
+  ]
+
   beforeEach(() => {
     vi.clearAllMocks()
 
@@ -100,11 +105,7 @@ describe('useSaveWorkingOffsets', () => {
     expect(mockDeleteLabwareOffset).toHaveBeenCalledWith('offset-3')
     expect(mockDeleteLabwareOffset).toHaveBeenCalledWith('offset-4')
     expect(mockDeleteLabwareOffset).toHaveBeenCalledTimes(2)
-    expect(returnValue).toEqual([
-      ...mockStoredOffsets,
-      { id: '', labwareId: '', vector: { x: 0, y: 0, z: 0 } },
-      { id: '', labwareId: '', vector: { x: 0, y: 0, z: 0 } },
-    ])
+    expect(returnValue).toEqual([mockStoredOffsets, mockDeletedOffsets])
   })
 
   it('should set isLoading to true during operation and false afterwards', async () => {
@@ -148,11 +149,7 @@ describe('useSaveWorkingOffsets', () => {
       returnValue = await result.current.saveWorkingOffsets()
     })
 
-    expect(returnValue).toEqual([
-      singleOffset,
-      { id: '', labwareId: '', vector: { x: 0, y: 0, z: 0 } },
-      { id: '', labwareId: '', vector: { x: 0, y: 0, z: 0 } },
-    ])
+    expect(returnValue).toEqual([[singleOffset], mockDeletedOffsets])
   })
 
   it('should handle errors during save operation', async () => {
@@ -167,7 +164,7 @@ describe('useSaveWorkingOffsets', () => {
     })
 
     expect(result.current.isSavingWorkingOffsetsLoading).toBe(false)
-    expect(returnValue).toEqual([])
+    expect(returnValue).toEqual([[], []])
   })
 
   it('should handle empty toUpdate and toDelete arrays', async () => {
@@ -177,8 +174,6 @@ describe('useSaveWorkingOffsets', () => {
       }
     })
 
-    mockCreateLabwareOffsets.mockResolvedValueOnce([])
-
     const { result } = renderHook(() => useSaveWorkingOffsets(mockProps))
 
     let returnValue: any
@@ -187,8 +182,8 @@ describe('useSaveWorkingOffsets', () => {
       returnValue = await result.current.saveWorkingOffsets()
     })
 
-    expect(mockCreateLabwareOffsets).toHaveBeenCalledWith([])
+    expect(mockCreateLabwareOffsets).not.toHaveBeenCalled()
     expect(mockDeleteLabwareOffset).not.toHaveBeenCalled()
-    expect(returnValue).toEqual([])
+    expect(returnValue).toEqual([[], []])
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useSaveWorkingOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useSaveWorkingOffsets.ts
@@ -29,15 +29,30 @@ export function useSaveWorkingOffsets({
   const { deleteLabwareOffset } = useDeleteLabwareOffsetMutation()
 
   const deleteLabwareOffsets = (): Promise<StoredLabwareOffset[]> => {
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-    const deletePromises = toDelete.map(id => deleteLabwareOffset(id))
-    return Promise.all(deletePromises)
+    if (toDelete.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      const deletePromises = toDelete.map(id => deleteLabwareOffset(id))
+      return Promise.all(deletePromises)
+    } else {
+      return Promise.resolve([])
+    }
+  }
+
+  const createNecessaryLabwareOffsets = (): Promise<StoredLabwareOffset[]> => {
+    if (toUpdate.length > 0) {
+      return createLabwareOffsets(toUpdate) as Promise<StoredLabwareOffset[]>
+    } else {
+      return Promise.resolve([])
+    }
   }
 
   const saveWorkingOffsets = (): Promise<StoredLabwareOffset[]> => {
     setIsLoading(true)
 
-    return Promise.all([createLabwareOffsets(toUpdate), deleteLabwareOffsets()])
+    return Promise.all([
+      createNecessaryLabwareOffsets(),
+      deleteLabwareOffsets(),
+    ])
       .then(([createRes, deleteRes]) => {
         setIsLoading(false)
 

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useSaveWorkingOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useSaveWorkingOffsets.ts
@@ -9,11 +9,12 @@ import {
 import { selectPendingOffsetOperations } from '/app/redux/protocol-runs'
 
 import type { StoredLabwareOffset } from '@opentrons/api-client'
+import type { SavedOffsets } from '/app/redux/protocol-runs'
 import type { UseLPCCommandChildProps } from '/app/organisms/LabwarePositionCheck/hooks/useLPCCommands/types'
 
 export interface UseBuildOffsetsToApplyResult {
   // Update the server with the current working offsets, returning the updated offsets.
-  saveWorkingOffsets: () => Promise<StoredLabwareOffset[]>
+  saveWorkingOffsets: () => Promise<SavedOffsets>
   isSavingWorkingOffsetsLoading: boolean
 }
 
@@ -40,32 +41,30 @@ export function useSaveWorkingOffsets({
 
   const createNecessaryLabwareOffsets = (): Promise<StoredLabwareOffset[]> => {
     if (toUpdate.length > 0) {
-      return createLabwareOffsets(toUpdate) as Promise<StoredLabwareOffset[]>
+      return createLabwareOffsets(toUpdate).then(res => {
+        return Array.isArray(res) ? res : [res]
+      })
     } else {
       return Promise.resolve([])
     }
   }
 
-  const saveWorkingOffsets = (): Promise<StoredLabwareOffset[]> => {
+  const saveWorkingOffsets = (): Promise<SavedOffsets> => {
     setIsLoading(true)
 
     return Promise.all([
       createNecessaryLabwareOffsets(),
       deleteLabwareOffsets(),
     ])
-      .then(([createRes, deleteRes]) => {
+      .then(res => {
         setIsLoading(false)
 
-        if (Array.isArray(createRes)) {
-          return [...createRes, ...deleteRes]
-        } else {
-          return [createRes, ...deleteRes]
-        }
+        return res
       })
       .catch(() => {
         setIsLoading(false)
 
-        return []
+        return [[], []]
       })
   }
 

--- a/app/src/redux/protocol-runs/actions/lpc.ts
+++ b/app/src/redux/protocol-runs/actions/lpc.ts
@@ -47,8 +47,8 @@ import type {
   UpdateLPCDeckAction,
   LPCLabwareInfo,
   UpdateLPCLabwareAction,
+  SavedOffsets,
 } from '../types'
-import type { StoredLabwareOffset } from '@opentrons/api-client'
 import type { DeckConfiguration } from '@opentrons/shared-data'
 
 export const proceedStep = (
@@ -123,7 +123,7 @@ export const clearSelectedLabwareWorkingOffsets = (
 
 export const applyWorkingOffsets = (
   runId: string,
-  saveResult: StoredLabwareOffset[]
+  saveResult: SavedOffsets
 ): ApplyWorkingOffsetsAction => ({
   type: APPLY_WORKING_OFFSETS,
   payload: { runId, saveResult },

--- a/app/src/redux/protocol-runs/reducer/transforms/lpc/handleApplyWorkingOffsets.ts
+++ b/app/src/redux/protocol-runs/reducer/transforms/lpc/handleApplyWorkingOffsets.ts
@@ -4,80 +4,161 @@ import { ANY_LOCATION } from '@opentrons/api-client'
 
 import type {
   ApplyWorkingOffsetsAction,
+  LocationSpecificOffsetDetails,
   LPCLabwareInfo,
   LPCWizardState,
+  LwGeometryDetails,
 } from '/app/redux/protocol-runs'
+import type {
+  StoredLabwareOffset,
+  VectorOffset,
+  LabwareOffsetLocationSequenceComponent,
+} from '@opentrons/api-client'
 
-// Apply any working offsets to make them the new existing offsets.
 export function handleApplyWorkingOffsets(
   state: LPCWizardState,
   action: ApplyWorkingOffsetsAction
 ): LPCLabwareInfo['labware'] {
   const { saveResult } = action.payload
+  const [updatedOffsets, deletedOffsets] = saveResult
 
   return Object.entries(state.labwareInfo.labware).reduce<
     LPCLabwareInfo['labware']
   >((acc, [definitionUri, details]) => {
-    const updatedDetails = { ...details }
+    let updatedDetails = { ...details }
 
-    // Find if this labware has any updates from the saveResult
-    const updates = saveResult.filter(
-      updatedLw => updatedLw.definitionUri === definitionUri
+    // Find offset updates.
+    const updates = updatedOffsets.filter(
+      offset => offset.definitionUri === definitionUri
     )
 
-    // If no updates for this labware, just keep it as is.
-    if (updates.length === 0) {
-      acc[definitionUri] = updatedDetails
-      return acc
+    // Process offset updates, if any.
+    if (updates.length > 0) {
+      updatedDetails = processOffsetUpdates(updatedDetails, updates)
     }
 
-    // Else, process updates for this labware.
-    updates.forEach(updatedLw => {
-      const { vector, id, createdAt, locationSequence } = updatedLw
+    // Find offset deletions.
+    const deletions = deletedOffsets.filter(
+      offset => offset.definitionUri === definitionUri
+    )
 
-      // Process default offset.
-      if (updatedLw.locationSequence === ANY_LOCATION) {
-        updatedDetails.defaultOffsetDetails = {
-          ...updatedDetails.defaultOffsetDetails,
-          workingOffset: null,
-          existingOffset: { vector, id, createdAt },
-          locationDetails: {
-            ...updatedDetails.defaultOffsetDetails.locationDetails,
-          },
-        }
-      }
-      // Process location-specific offsets.
-      else {
-        const lsDetails = updatedDetails.locationSpecificOffsetDetails
-        const matchIndex = lsDetails.findIndex(lsDetail =>
-          isEqual(lsDetail.locationDetails.lwOffsetLocSeq, locationSequence)
-        )
-
-        if (matchIndex === -1) {
-          console.error(
-            'Expected to find matching location sequence for server-saved offset but did not.'
-          )
-        } else {
-          const nonMatchingDetails = [
-            ...lsDetails.slice(0, matchIndex),
-            ...lsDetails.slice(matchIndex + 1),
-          ]
-
-          const updatedMatchingDetail = {
-            ...lsDetails[matchIndex],
-            workingOffset: null,
-            existingOffset: { vector, id, createdAt },
-          }
-
-          updatedDetails.locationSpecificOffsetDetails = [
-            ...nonMatchingDetails,
-            updatedMatchingDetail,
-          ]
-        }
-      }
-    })
+    // Process offset deletions, if any.
+    if (deletions.length > 0) {
+      updatedDetails = processOffsetDeletions(updatedDetails, deletions)
+    }
 
     acc[definitionUri] = updatedDetails
     return acc
   }, {})
+}
+
+function processOffsetUpdates(
+  updatedDetails: LwGeometryDetails,
+  updatedOffsets: StoredLabwareOffset[]
+): LwGeometryDetails {
+  updatedOffsets.forEach(updatedOffset => {
+    const { vector, id, createdAt, locationSequence } = updatedOffset
+    const offsetData = { vector, id, createdAt }
+
+    if (locationSequence === ANY_LOCATION) {
+      updatedDetails = updateDefaultOffset(updatedDetails, updatedOffset)
+    } else {
+      updatedDetails = updateLocationSpecificOffset(
+        updatedDetails,
+        updatedOffset,
+        offsetData
+      )
+    }
+  })
+
+  return updatedDetails
+}
+
+function processOffsetDeletions(
+  updatedDetails: LwGeometryDetails,
+  deletions: StoredLabwareOffset[]
+): LwGeometryDetails {
+  // There is currently no support for deleting a default offset.
+  deletions.forEach(deletion => {
+    updatedDetails = updateLocationSpecificOffset(
+      updatedDetails,
+      deletion,
+      null
+    )
+  })
+
+  return updatedDetails
+}
+
+function updateDefaultOffset(
+  details: LwGeometryDetails,
+  offset: StoredLabwareOffset
+): LwGeometryDetails {
+  const { vector, id, createdAt } = offset
+
+  return {
+    ...details,
+    defaultOffsetDetails: {
+      ...details.defaultOffsetDetails,
+      workingOffset: null,
+      existingOffset: { vector, id, createdAt },
+      locationDetails: {
+        ...details.defaultOffsetDetails.locationDetails,
+      },
+    },
+  }
+}
+
+interface OffsetData {
+  vector: VectorOffset
+  id: string
+  createdAt: string
+}
+
+function updateLocationSpecificOffset(
+  details: LwGeometryDetails,
+  offset: StoredLabwareOffset,
+  existingOffset: OffsetData | null
+): LwGeometryDetails {
+  const { locationSequence } = offset
+  const lsDetails = details.locationSpecificOffsetDetails
+  const matchIndex = findMatchingLocationOffset(
+    lsDetails,
+    locationSequence as LabwareOffsetLocationSequenceComponent[]
+  )
+
+  if (matchIndex === -1) {
+    console.error(
+      'Expected to find matching location sequence for offset but did not.'
+    )
+    return details
+  }
+
+  const nonMatchingDetails = [
+    ...lsDetails.slice(0, matchIndex),
+    ...lsDetails.slice(matchIndex + 1),
+  ]
+
+  const updatedMatchingDetail = {
+    ...lsDetails[matchIndex],
+    workingOffset: null,
+    existingOffset,
+  }
+
+  return {
+    ...details,
+    locationSpecificOffsetDetails: [
+      ...nonMatchingDetails,
+      updatedMatchingDetail,
+    ],
+  }
+}
+
+function findMatchingLocationOffset(
+  locationOffsets: LocationSpecificOffsetDetails[],
+  locationSequence: LabwareOffsetLocationSequenceComponent[]
+): number {
+  return locationOffsets.findIndex(detail =>
+    isEqual(detail.locationDetails.lwOffsetLocSeq, locationSequence)
+  )
 }

--- a/app/src/redux/protocol-runs/types/lpc/actions.ts
+++ b/app/src/redux/protocol-runs/types/lpc/actions.ts
@@ -5,8 +5,9 @@ import type {
   LPCStep,
   LPCWizardState,
   OffsetLocationDetails,
+  SavedOffsets,
 } from '/app/redux/protocol-runs/types/lpc'
-import type { StoredLabwareOffset, VectorOffset } from '@opentrons/api-client'
+import type { VectorOffset } from '@opentrons/api-client'
 import type { DeckConfiguration } from '@opentrons/shared-data'
 
 export interface PositionParams {
@@ -88,7 +89,7 @@ export interface ResetLocationSpecificOffsetToDefaultAction {
 
 export interface ApplyWorkingOffsetsAction {
   type: 'APPLY_WORKING_OFFSETS'
-  payload: { runId: string; saveResult: StoredLabwareOffset[] }
+  payload: { runId: string; saveResult: SavedOffsets }
 }
 
 export interface ProceedHandleLwSubstepAction {

--- a/app/src/redux/protocol-runs/types/lpc/offsets.ts
+++ b/app/src/redux/protocol-runs/types/lpc/offsets.ts
@@ -1,6 +1,7 @@
 import type {
   ANY_LOCATION,
   LabwareOffsetLocationSequence,
+  StoredLabwareOffset,
   VectorOffset,
 } from '@opentrons/api-client'
 import type {
@@ -122,3 +123,5 @@ interface WorkingBaseOffset {
   finalPosition: VectorOffset | null
   confirmedVector: VectorOffset | 'RESET_TO_DEFAULT' | null
 }
+
+export type SavedOffsets = [StoredLabwareOffset[], StoredLabwareOffset[]] // tuple of [updatedOffsets, deletedOffsets]


### PR DESCRIPTION
Closes [RQA-4028](https://opentrons.atlassian.net/browse/RQA-4028) and [RQA-4027](https://opentrons.atlassian.net/browse/RQA-4027) and [RQA-4035](https://opentrons.atlassian.net/browse/RQA-4035)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a bug in which the app would not delineate between "deleted offsets" and "updated offsets" when updating Redux state. In the `saveWorkingOffsets` command, after creating/deleting offsets, the server responses are added to a single array, so for example, "location C2 offset: 1,2,3". How do we know that this location + offset combo was updated to this value or this was the location + offset combo that was deleted? We don't, woops, so the client just assumed that all values were updated, and it didn't handle the delete case.

This also closes a ticket that may not seem related at first: [RQA-4028](https://opentrons.atlassian.net/browse/RQA-4028). The white screening was caused by reset to default not updating internal state properly, leading to downstream effects such as this one.

995141217561d174f63b18c78ba17084cc3245f7 - Slight cleanup. Saves making an extra POST request if it's not needed.

### Current Behavior

https://github.com/user-attachments/assets/c3f3ba6a-20ae-4f97-b873-6984ceb47ef6


### Fixed Behavior

https://github.com/user-attachments/assets/7e64b694-8be5-495d-b897-e54eff3816c7

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
- Smoked tested the app a bit.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed "reset to default" not updating local app state appropriately.
- Fixed white-screening when updating a location-speicifc offset that was reset to default earlier.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4028]: https://opentrons.atlassian.net/browse/RQA-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-4027]: https://opentrons.atlassian.net/browse/RQA-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-4028]: https://opentrons.atlassian.net/browse/RQA-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-4035]: https://opentrons.atlassian.net/browse/RQA-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ