### PR TITLE
fix(app): fix applying offsets implicitly when navigating on the desktop app

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -64,6 +64,7 @@ import { SetupStep } from './SetupStep'
 import { EmptySetupStep } from './EmptySetupStep'
 import { LearnAboutOffsetsLink } from './LearnAboutOffsetsLink'
 import { useLPCFlows } from '/app/organisms/LabwarePositionCheck'
+import { useUpdateClientLPC } from '/app/resources/client_data'
 
 import type { RefObject } from 'react'
 import type { Dispatch, State } from '/app/redux/types'
@@ -129,6 +130,7 @@ export function ProtocolRunSetup({
   const flexOffsetsMissing = useSelector(
     selectIsAnyNecessaryDefaultOffsetMissing(runId)
   )
+  const { updateWithRunId: updateLPCStatusWithRunId } = useUpdateClientLPC()
   const flexOffsetsApplied = useSelector(selectAreOffsetsApplied(runId))
   const noLwOffsetsInRun =
     useSelector(selectTotalCountLocationSpecificOffsets(runId)) === 0 && isFlex
@@ -275,6 +277,7 @@ export function ProtocolRunSetup({
           setOffsetsConfirmed={confirmed => {
             if (confirmed) {
               dispatch(appliedOffsetsToRun(runId))
+              updateLPCStatusWithRunId(runId)
 
               setExpandedStepKey(LABWARE_SETUP_STEP_KEY)
             }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/__tests__/useHandleClientAppliedOffsets.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/__tests__/useHandleClientAppliedOffsets.test.ts
@@ -6,10 +6,7 @@ import {
   useClientDataLPC,
   useUpdateClientLPC,
 } from '/app/resources/client_data/'
-import {
-  appliedOffsetsToRun,
-  selectAreOffsetsApplied,
-} from '/app/redux/protocol-runs'
+import { appliedOffsetsToRun } from '/app/redux/protocol-runs'
 import { useIsRunCurrent } from '/app/resources/runs'
 
 vi.mock('react-redux')
@@ -24,7 +21,6 @@ describe('useHandleClientAppliedOffsets', () => {
 
   const mockDispatch = vi.fn()
   const mockClearClientData = vi.fn()
-  const mockUpdateWithRunId = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -40,10 +36,6 @@ describe('useHandleClientAppliedOffsets', () => {
       (runId: string | null) => false
     )
 
-    vi.mocked(
-      selectAreOffsetsApplied
-    ).mockImplementation((runId: string) => (state: any) => false)
-
     vi.mocked(useClientDataLPC).mockReturnValue({
       runId: null,
       userId: null,
@@ -51,7 +43,6 @@ describe('useHandleClientAppliedOffsets', () => {
 
     vi.mocked(useUpdateClientLPC).mockReturnValue({
       clearClientData: mockClearClientData,
-      updateWithRunId: mockUpdateWithRunId,
     } as any)
 
     vi.mocked(useSelector).mockImplementation(selector => {
@@ -74,7 +65,6 @@ describe('useHandleClientAppliedOffsets', () => {
     })
 
     expect(mockClearClientData).not.toHaveBeenCalled()
-    expect(mockUpdateWithRunId).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
@@ -90,7 +80,6 @@ describe('useHandleClientAppliedOffsets', () => {
     })
 
     expect(mockClearClientData).toHaveBeenCalledTimes(1)
-    expect(mockUpdateWithRunId).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
@@ -106,15 +95,11 @@ describe('useHandleClientAppliedOffsets', () => {
     })
 
     expect(mockClearClientData).toHaveBeenCalledTimes(1)
-    expect(mockUpdateWithRunId).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('should update client data when offsets are applied locally but not by another user', () => {
+  it('should not take any action when run IDs match but no user ID is present', () => {
     vi.mocked(useIsRunCurrent).mockReturnValue(true)
-    vi.mocked(
-      selectAreOffsetsApplied
-    ).mockImplementation((runId: string) => (state: any) => true)
     vi.mocked(useClientDataLPC).mockReturnValue({
       runId: RUN_ID,
       userId: null,
@@ -125,15 +110,11 @@ describe('useHandleClientAppliedOffsets', () => {
     })
 
     expect(mockClearClientData).not.toHaveBeenCalled()
-    expect(mockUpdateWithRunId).toHaveBeenCalledWith(RUN_ID)
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('should dispatch applied offsets when offsets are applied by another user but not locally', () => {
+  it('should dispatch applied offsets when run IDs match and user ID is present', () => {
     vi.mocked(useIsRunCurrent).mockReturnValue(true)
-    vi.mocked(
-      selectAreOffsetsApplied
-    ).mockImplementation((runId: string) => (state: any) => false)
     vi.mocked(useClientDataLPC).mockReturnValue({
       runId: RUN_ID,
       userId: USER_ID,
@@ -144,15 +125,26 @@ describe('useHandleClientAppliedOffsets', () => {
     })
 
     expect(mockClearClientData).not.toHaveBeenCalled()
-    expect(mockUpdateWithRunId).not.toHaveBeenCalled()
     expect(mockDispatch).toHaveBeenCalledWith(appliedOffsetsToRun(RUN_ID))
   })
 
-  it('should do nothing when run is current, client data has the same run ID, and offsets are already applied', () => {
+  it('should not dispatch applied offsets when run IDs do not match, even if user ID is present', () => {
     vi.mocked(useIsRunCurrent).mockReturnValue(true)
-    vi.mocked(
-      selectAreOffsetsApplied
-    ).mockImplementation((runId: string) => (state: any) => true)
+    vi.mocked(useClientDataLPC).mockReturnValue({
+      runId: OTHER_RUN_ID,
+      userId: USER_ID,
+    })
+
+    renderHook(() => {
+      useHandleClientAppliedOffsets(RUN_ID)
+    })
+
+    expect(mockClearClientData).toHaveBeenCalledTimes(1)
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('should do nothing when run is current, client data has the same run ID and user ID, and offsets are already applied', () => {
+    vi.mocked(useIsRunCurrent).mockReturnValue(true)
     vi.mocked(useClientDataLPC).mockReturnValue({
       runId: RUN_ID,
       userId: USER_ID,
@@ -163,11 +155,10 @@ describe('useHandleClientAppliedOffsets', () => {
     })
 
     expect(mockClearClientData).not.toHaveBeenCalled()
-    expect(mockUpdateWithRunId).not.toHaveBeenCalled()
-    expect(mockDispatch).not.toHaveBeenCalled()
+    expect(mockDispatch).toHaveBeenCalledWith(appliedOffsetsToRun(RUN_ID))
   })
 
-  it('should call clearClientData with null thisRunId when not current', () => {
+  it('should call clearClientData when not current with null thisRunId', () => {
     vi.mocked(useIsRunCurrent).mockReturnValue(false)
     vi.mocked(useClientDataLPC).mockReturnValue({
       runId: null,
@@ -178,19 +169,15 @@ describe('useHandleClientAppliedOffsets', () => {
       useHandleClientAppliedOffsets(null)
     })
 
-    expect(mockClearClientData).toHaveBeenCalledTimes(1)
-    expect(mockUpdateWithRunId).not.toHaveBeenCalled()
+    expect(mockClearClientData).toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('should call updateWithRunId with null thisRunId when current and offsets applied', () => {
+  it('should dispatch when run is current with null thisRunId and user ID is present', () => {
     vi.mocked(useIsRunCurrent).mockReturnValue(true)
-    vi.mocked(
-      selectAreOffsetsApplied
-    ).mockImplementation((runId: string) => (state: any) => true)
     vi.mocked(useClientDataLPC).mockReturnValue({
       runId: null,
-      userId: null,
+      userId: USER_ID,
     })
 
     renderHook(() => {
@@ -198,7 +185,6 @@ describe('useHandleClientAppliedOffsets', () => {
     })
 
     expect(mockClearClientData).not.toHaveBeenCalled()
-    expect(mockUpdateWithRunId).toHaveBeenCalledWith(null)
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useHandleClientAppliedOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useHandleClientAppliedOffsets.ts
@@ -1,13 +1,10 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { useEffect } from 'react'
 import {
   useClientDataLPC,
   useUpdateClientLPC,
 } from '/app/resources/client_data/'
-import {
-  appliedOffsetsToRun,
-  selectAreOffsetsApplied,
-} from '/app/redux/protocol-runs'
+import { appliedOffsetsToRun } from '/app/redux/protocol-runs'
 import { useIsRunCurrent } from '/app/resources/runs'
 
 const CLIENT_DATA_INTERVAL_MS = 5000
@@ -15,12 +12,9 @@ const CLIENT_DATA_INTERVAL_MS = 5000
 // Keep the applied offset state in sync between various apps using the same robot.
 export function useHandleClientAppliedOffsets(thisRunId: string | null): void {
   const dispatch = useDispatch()
-  const areOffsetsApplied = useSelector(
-    selectAreOffsetsApplied(thisRunId ?? '')
-  )
   const isThisRunCurrent = useIsRunCurrent(thisRunId)
 
-  const { clearClientData, updateWithRunId } = useUpdateClientLPC()
+  const { clearClientData } = useUpdateClientLPC()
   const { runId: clientDataRunId, userId: clientDataUserId } = useClientDataLPC(
     {
       refetchInterval: CLIENT_DATA_INTERVAL_MS,
@@ -32,14 +26,10 @@ export function useHandleClientAppliedOffsets(thisRunId: string | null): void {
       if (clientDataRunId !== thisRunId && clientDataRunId != null) {
         clearClientData()
       }
-      // Offsets applied locally but not by another user - update client data
-      else if (areOffsetsApplied && clientDataUserId == null) {
-        updateWithRunId(thisRunId)
-      }
       // Offsets applied by another user but not locally - mark as applied locally
       else if (
         clientDataUserId != null &&
-        !areOffsetsApplied &&
+        clientDataRunId === thisRunId &&
         thisRunId != null
       ) {
         dispatch(appliedOffsetsToRun(thisRunId))
@@ -49,11 +39,5 @@ export function useHandleClientAppliedOffsets(thisRunId: string | null): void {
         clearClientData()
       }
     }
-  }, [
-    isThisRunCurrent,
-    clientDataRunId,
-    areOffsetsApplied,
-    clientDataUserId,
-    thisRunId,
-  ])
+  }, [isThisRunCurrent, clientDataRunId, clientDataUserId, thisRunId])
 }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsHeader.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsHeader.tsx
@@ -18,6 +18,7 @@ import {
 } from '/app/redux/protocol-runs'
 import { useAddLabwareOffsetToRunMutation } from '@opentrons/react-api-client'
 import { useState } from 'react'
+import { useUpdateClientLPC } from '/app/resources/client_data'
 
 export function SetupOffsetsHeader({
   runId,
@@ -32,6 +33,7 @@ export function SetupOffsetsHeader({
     selectIsAnyNecessaryDefaultOffsetMissing(runId)
   )
   const lwOffsetsForRun = useSelector(selectLabwareOffsetsToAddToRun(runId))
+  const { updateWithRunId } = useUpdateClientLPC()
 
   const [isApplyOffsets, setIsApplyingOffsets] = useState(false)
 
@@ -48,6 +50,7 @@ export function SetupOffsetsHeader({
         )
           .then(() => {
             dispatch(appliedOffsetsToRun(runId))
+            updateWithRunId(runId)
             setSetupScreen('prepare to run')
           })
           .catch(() => {


### PR DESCRIPTION
Closes [RQA-4032](https://opentrons.atlassian.net/browse/RQA-4032)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Woops, the `clientData` effect for applying offsets for apps that did not do LPC had some logic issues. It was possible to navigate back and forth on the desktop app quickly and cause offsets to automatically apply, because some of the state used in the effect hadn't had the chance to properly initialize.

To fix, let's not update the client store as an effect. Since only one user can actually click the apply offsets button, that user should do the client store update on the CTA itself. This simplies the effect a bit and everything works.

### Current Behavior

https://github.com/user-attachments/assets/4c15f213-677b-4375-b8b7-126c4f105ce6

### Fixed Behavior

https://github.com/user-attachments/assets/92240661-eac9-49c9-951d-3d5158505f41

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
- Ran the exact test case in the ticket (same protocol, etc), and the issue no longer occurs.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed offsets sometimes getting automatically applied on the desktop app when navigating back to a run.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4032]: https://opentrons.atlassian.net/browse/RQA-4032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ