### PR TITLE
fix(app): fix accumulating offsets on run record

### DIFF
--- a/app/src/resources/runs/__tests__/useCloneRun.test.tsx
+++ b/app/src/resources/runs/__tests__/useCloneRun.test.tsx
@@ -13,7 +13,7 @@ import { useCloneRun } from '../useCloneRun'
 import { useNotifyRunQuery } from '../useNotifyRunQuery'
 
 import type { FunctionComponent, ReactNode } from 'react'
-import type { HostConfig } from '@opentrons/api-client'
+import type { HostConfig, LabwareOffset } from '@opentrons/api-client'
 
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/runs/useNotifyRunQuery')
@@ -21,6 +21,7 @@ vi.mock('/app/resources/runs/useNotifyRunQuery')
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
 const RUN_ID_NO_RTP: string = 'run_id_no_rtp'
 const RUN_ID_RTP: string = 'run_id_rtp'
+const RUN_ID_DUPLICATE_OFFSETS: string = 'run_id_duplicate_offsets'
 
 describe('useCloneRun hook', () => {
   let wrapper: FunctionComponent<{ children: ReactNode }>
@@ -34,7 +35,13 @@ describe('useCloneRun hook', () => {
           data: {
             id: RUN_ID_NO_RTP,
             protocolId: 'protocolId',
-            labwareOffsets: 'someOffset',
+            labwareOffsets: [
+              {
+                definitionUri: 'uri1',
+                locationSequence: [1, 2],
+                offset: { x: 1, y: 1, z: 1 },
+              },
+            ],
             runTimeParameters: [
               {
                 type: 'int',
@@ -59,7 +66,13 @@ describe('useCloneRun hook', () => {
           data: {
             id: RUN_ID_RTP,
             protocolId: 'protocolId',
-            labwareOffsets: 'someOffset',
+            labwareOffsets: [
+              {
+                definitionUri: 'uri1',
+                locationSequence: [1, 2],
+                offset: { x: 1, y: 1, z: 1 },
+              },
+            ],
             runTimeParameters: [
               {
                 type: 'int',
@@ -82,6 +95,38 @@ describe('useCloneRun hook', () => {
           },
         },
       } as any)
+
+    const duplicateOffsets: LabwareOffset[] = [
+      {
+        definitionUri: 'uri1',
+        locationSequence: [1, 2],
+        offset: { x: 1, y: 1, z: 1 },
+      },
+      {
+        definitionUri: 'uri2',
+        locationSequence: [3, 4],
+        offset: { x: 2, y: 2, z: 2 },
+      },
+      {
+        definitionUri: 'uri1',
+        locationSequence: [1, 2],
+        offset: { x: 3, y: 3, z: 3 },
+      },
+    ] as any
+
+    when(vi.mocked(useNotifyRunQuery))
+      .calledWith(RUN_ID_DUPLICATE_OFFSETS)
+      .thenReturn({
+        data: {
+          data: {
+            id: RUN_ID_DUPLICATE_OFFSETS,
+            protocolId: 'protocolId',
+            labwareOffsets: duplicateOffsets,
+            runTimeParameters: [],
+          },
+        },
+      } as any)
+
     when(vi.mocked(useCreateRunMutation))
       .calledWith(expect.anything())
       .thenReturn({ createRun: vi.fn() } as any)
@@ -111,11 +156,18 @@ describe('useCloneRun hook', () => {
     result.current && result.current.cloneRun()
     expect(mockCreateRun).toHaveBeenCalledWith({
       protocolId: 'protocolId',
-      labwareOffsets: 'someOffset',
+      labwareOffsets: [
+        {
+          definitionUri: 'uri1',
+          locationSequence: [1, 2],
+          offset: { x: 1, y: 1, z: 1 },
+        },
+      ],
       runTimeParameterValues: {},
       runTimeParameterFiles: {},
     })
   })
+
   it('should return a function that when called, calls createRun run with runTimeParameterValues overrides', async () => {
     const mockCreateRun = vi.fn()
     vi.mocked(useCreateRunMutation).mockReturnValue({
@@ -126,7 +178,74 @@ describe('useCloneRun hook', () => {
     result.current && result.current.cloneRun()
     expect(mockCreateRun).toHaveBeenCalledWith({
       protocolId: 'protocolId',
-      labwareOffsets: 'someOffset',
+      labwareOffsets: [
+        {
+          definitionUri: 'uri1',
+          locationSequence: [1, 2],
+          offset: { x: 1, y: 1, z: 1 },
+        },
+      ],
+      runTimeParameterValues: {
+        number_param: 2,
+        boolean_param: false,
+      },
+      runTimeParameterFiles: {
+        file_param: 'fileId_123',
+      },
+    })
+  })
+
+  it('should filter duplicate labware offsets and keep only the most recent ones', async () => {
+    const mockCreateRun = vi.fn()
+    vi.mocked(useCreateRunMutation).mockReturnValue({
+      createRun: mockCreateRun,
+    } as any)
+
+    const { result } = renderHook(() => useCloneRun(RUN_ID_DUPLICATE_OFFSETS), {
+      wrapper,
+    })
+    result.current && result.current.cloneRun()
+
+    const expectedOffsets = [
+      {
+        definitionUri: 'uri2',
+        locationSequence: [3, 4],
+        offset: { x: 2, y: 2, z: 2 },
+      },
+      {
+        definitionUri: 'uri1',
+        locationSequence: [1, 2],
+        offset: { x: 3, y: 3, z: 3 },
+      },
+    ]
+
+    expect(mockCreateRun).toHaveBeenCalledWith({
+      protocolId: 'protocolId',
+      labwareOffsets: expectedOffsets,
+      runTimeParameterValues: {},
+      runTimeParameterFiles: {},
+    })
+  })
+
+  it('should handle analysis trigger when specified', async () => {
+    const mockCreateRun = vi.fn()
+    const mockCreateProtocolAnalysis = vi.fn()
+
+    vi.mocked(useCreateRunMutation).mockReturnValue({
+      createRun: mockCreateRun,
+    } as any)
+    vi.mocked(useCreateProtocolAnalysisMutation).mockReturnValue({
+      createProtocolAnalysis: mockCreateProtocolAnalysis,
+    } as any)
+
+    const { result } = renderHook(
+      () => useCloneRun(RUN_ID_RTP, undefined, true),
+      { wrapper }
+    )
+    result.current && result.current.cloneRun()
+
+    expect(mockCreateProtocolAnalysis).toHaveBeenCalledWith({
+      protocolKey: 'protocolId',
       runTimeParameterValues: {
         number_param: 2,
         boolean_param: false,

--- a/app/src/resources/runs/useCloneRun.ts
+++ b/app/src/resources/runs/useCloneRun.ts
@@ -11,7 +11,8 @@ import {
   getRunTimeParameterFilesForRun,
 } from '/app/transformations/runs'
 
-import type { Run } from '@opentrons/api-client'
+import type { LabwareOffset, Run } from '@opentrons/api-client'
+import isEqual from 'lodash/isEqual'
 
 interface UseCloneRunResult {
   cloneRun: () => void
@@ -70,7 +71,7 @@ export function useCloneRun(
       }
       createRun({
         protocolId,
-        labwareOffsets,
+        labwareOffsets: mostRecentUniqueLabwareOffsets(labwareOffsets),
         runTimeParameterValues,
         runTimeParameterFiles,
       })
@@ -80,4 +81,20 @@ export function useCloneRun(
   }
 
   return { cloneRun, isLoadingRun, isCloning }
+}
+
+// Returns the most recent, unique offsets for each labware uri + location pair.
+// Assumes the most recent labware offsets are appended to the end of the list.
+function mostRecentUniqueLabwareOffsets(
+  offsets: LabwareOffset[] | undefined
+): LabwareOffset[] | undefined {
+  return offsets?.filter((offset, index, array) => {
+    return (
+      array.findLastIndex(
+        firstOffset =>
+          isEqual(firstOffset.locationSequence, offset.locationSequence) &&
+          isEqual(firstOffset.definitionUri, offset.definitionUri)
+      ) === index
+    )
+  })
 }


### PR DESCRIPTION
Closes [EXEC-1411](https://opentrons.atlassian.net/browse/EXEC-1411)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When "cloning" a run on the app, the app quite literally creates a run with some predefined values gleaned from the historical run record of the run being cloned, and the new run reflects those old values. One of those values is `labwareOffsets`. 

In the new LPC, a user clicks the "apply offsets" button, and this applies all the offsets utilized in the run to the run record. If a run is cloned, this mean that all the old offset values are present on the run record, and now the list increases by all the offsets utilized in this run. By cloning the run repeatedly, this list can grow unbounded. 

This PR adds a filter when cloning a run so that only the most recent and unique labware offsets are preserved. In other words, the labware offsets field on the run record now can only ever be 2x the amount of unique offests possible for a run: the cloned run list of offsets + the offsets that are applied when clicking applied offsets.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Tested this on a robot, cloning a run 4 times and applying offsets each time. Here is an example of the before behavior ([before.json](https://github.com/user-attachments/files/19574409/before.json))  and here is an example of the fixed behavior ([after.json](https://github.com/user-attachments/files/19574411/after.json)). Grep for `slotName: D1`. You'll notice in the before case, it occurs 4 times. With the fix, after cloning a run 4 times, you only ever the same offset apply twice (for the reasons explained above).
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a potential performance issue in which the run record grows unbounded. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- This logic assumes that for any given unique offset, the most recent offsets are appended to end of the list. That's right, yeah?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low, assuming the logic is correct
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1411]: https://opentrons.atlassian.net/browse/EXEC-1411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ