### PR TITLE
fix(app): ER tip selection crashes when trying to get labware def

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -252,7 +252,10 @@ function useTipSelectionUtils(
 
   // Use this labware to represent all tip racks for manual tip selection.
   const tipSelectorDef = useMemo(
-    () => getAllLabwareDefs()['opentrons/thermoscientificnunc_96_wellplate_1300ul/1'],
+    () =>
+      getAllLabwareDefs()[
+        'opentrons/thermoscientificnunc_96_wellplate_1300ul/1'
+      ],
     []
   )
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -252,7 +252,7 @@ function useTipSelectionUtils(
 
   // Use this labware to represent all tip racks for manual tip selection.
   const tipSelectorDef = useMemo(
-    () => getAllLabwareDefs().thermoscientificnunc96Wellplate1300UlV1,
+    () => getAllLabwareDefs()['opentrons/thermoscientificnunc_96_wellplate_1300ul/1'],
     []
   )
 


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-4029.
fix get labware definition for tip selection in ER. 

## Test Plan and Hands on Testing

details are in the ticket.
tested and works as expected!

## Changelog

access the labware def by full name. 
