### PR TITLE
docs(api): use correct `delay()` method in `prepare_to_aspirate()` docstring

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2314,19 +2314,19 @@ class InstrumentContext(publisher.CommandPublisher):
               If the pipette is in a well, it will move out of the well, move the plunger,
               and then move back.
 
-        Use ``prepare_to_aspirate`` when you need to control exactly when the plunger
+        Use ``prepare_to_aspirate()`` when you need to control exactly when the plunger
         motion will happen. A common use case is a pre-wetting routine, which requires
         preparing for aspiration, moving into a well, and then aspirating *without
         leaving the well*::
 
              pipette.move_to(well.bottom(z=2))
-             pipette.delay(5)
+             protocol.delay(5)
              pipette.mix(10, 10)
              pipette.move_to(well.top(z=5))
              pipette.blow_out()
              pipette.prepare_to_aspirate()
              pipette.move_to(well.bottom(z=2))
-             pipette.delay(5)
+             protocol.delay(5)
              pipette.aspirate(10, well.bottom(z=2))
 
         The call to ``prepare_to_aspirate()`` means that the plunger will be in the


### PR DESCRIPTION


# Overview

@ddcc4 spotted a typo in the code sample in this docstring. We accidentally used the deprecated pipette delay method, instead of the proper protocol delay method.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/fix-delay-in-prepare_to_aspirate-docstring/v2/new_protocol_api.html#opentrons.protocol_api.InstrumentContext.prepare_to_aspirate)

## Changelog

- Use the right method
- Parentheses on method name 🧐 

## Review requests

best to put this in `edge`, no?

## Risk assessment

nil