### PR TITLE
fix(app): do not show post run drop tip prompt if just handled in Error Recovery

### DIFF
--- a/app/src/local-resources/commands/utils/lastRunCommandPromptedErrorRecovery.ts
+++ b/app/src/local-resources/commands/utils/lastRunCommandPromptedErrorRecovery.ts
@@ -1,10 +1,10 @@
 import type { RunCommandSummary } from '@opentrons/api-client'
 // Whether the last run protocol command prompted Error Recovery, if Error Recovery is enabled.
 export function lastRunCommandPromptedErrorRecovery(
-  summary: RunCommandSummary[] | null,
+  summary: RunCommandSummary[],
   isEREnabled: boolean
 ): boolean {
-  const lastProtocolCommand = summary?.findLast(
+  const lastProtocolCommand = summary.findLast(
     command => command.intent !== 'fixit' && command.error != null
   )
   // All recoverable protocol commands have defined errors.

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
@@ -124,6 +124,7 @@ export function useRunHeaderDropTip({
       }
       // Only run tip checking if it wasn't *just* handled during Error Recovery.
       else if (
+        runSummaryNoFixit != null &&
         !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit, isEREnabled) &&
         isRunCurrent &&
         isTerminalRunStatus(runStatus)

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -245,7 +245,10 @@ export function RunSummary(): JSX.Element {
 
   useEffect(() => {
     // Only run tip checking if it wasn't *just* handled during Error Recovery.
-    if (!lastRunCommandPromptedErrorRecovery(runSummaryNoFixit, isEREnabled)) {
+    if (
+      runSummaryNoFixit != null &&
+      !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit, isEREnabled)
+    ) {
       void determineTipStatus()
     }
   }, [isRunCurrent, runSummaryNoFixit, isEREnabled])


### PR DESCRIPTION
Closes [RQA-3880](https://opentrons.atlassian.net/browse/RQA-3880)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Woops, after a run finished, we'd immediately run the tip detection logic before `runSummaryNoFixit` initialized with correct data.  We'd ultimately pop the modal prematurely.

### Current Behavior

https://github.com/user-attachments/assets/fbf122cd-5a2f-4ce7-8385-e0c43c75e9ab

### Fixed Behavior

https://github.com/user-attachments/assets/a0de7ebf-9aa2-4bad-a914-31a6b20708c0

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
- Verified correct behavior on the ODD.
- Verified cancelling a run with tips attached still pops the post-run drop tip wizard.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the post-run drop tip CTA displaying after completing drop tip wizard in Error Recovery.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3880]: https://opentrons.atlassian.net/browse/RQA-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ