### PR TITLE
fix(api): check flex stacker shuttle in the retracted location only for now

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -375,6 +375,14 @@ class FlexStacker(mod_abc.AbstractModule):
 
         # Move platform along the X then Z axis
         await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, OFFSET_SM)
+
+        # TODO: (AA 2025-04-03) - The EVT Flex Stacker hardware has issues
+        # reading the platform sensor on the extended side. This is a temporary
+        # workaround to avoid the sensor check on the extended side and should be
+        # removed once dvt hardware is available. We should move this check
+        # to `prepare_for_action` instead
+        await self.verify_shuttle_location(PlatformState.RETRACTED)
+
         await self._move_and_home_axis(StackerAxis.Z, Direction.EXTEND, OFFSET_SM)
 
         # Transfer
@@ -403,6 +411,13 @@ class FlexStacker(mod_abc.AbstractModule):
         offset = OFFSET_MD if labware_height < MEDIUM_LABWARE_Z_LIMIT else OFFSET_LG * 2
         distance = MAX_TRAVEL[StackerAxis.Z] - (labware_height / 2) - offset
         await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, OFFSET_SM)
+
+        # TODO: (AA 2025-04-03) - The EVT Flex Stacker hardware has issues
+        # reading the platform sensor on the extended side. This is a temporary
+        # workaround to avoid the sensor check on the extended side and should be
+        # removed once dvt hardware is available. We should move this check
+        # to `prepare_for_action` instead
+        await self.verify_shuttle_location(PlatformState.RETRACTED)
 
         if enforce_shuttle_lw_sensing:
             await self.verify_shuttle_labware_presence(Direction.RETRACT, True)
@@ -441,7 +456,6 @@ class FlexStacker(mod_abc.AbstractModule):
         await self.home_axis(StackerAxis.X, Direction.EXTEND)
         await self.home_axis(StackerAxis.Z, Direction.RETRACT)
         await self.close_latch()
-        await self.verify_shuttle_location(PlatformState.EXTENDED)
         return True
 
     async def home_all(self, ignore_latch: bool = False) -> None:
@@ -466,19 +480,11 @@ class FlexStacker(mod_abc.AbstractModule):
 
     async def verify_shuttle_location(self, expected: PlatformState) -> None:
         """Verify the shuttle is present and in the expected location."""
-        # TODO: (AA 2025-03-31) - The EVT Flex Stacker hardware has issues
-        # reading the platform sensor on the extended side. This is a temporary
-        # workaround to avoid the sensor check on the extended side and should be
-        # removed once dvt hardware is available.
-        if self.platform_state == expected:
-            await self.home_axis(StackerAxis.X, Direction.RETRACT)
-            await self.verify_shuttle_location(PlatformState.RETRACTED)
-        else:
-            await self._reader.read()
-            if self.platform_state != expected:
-                raise FlexStackerShuttleMissingError(
-                    self.device_info["serial"], expected, self.platform_state
-                )
+        await self._reader.read()
+        if self.platform_state != expected:
+            raise FlexStackerShuttleMissingError(
+                self.device_info["serial"], expected, self.platform_state
+            )
 
     async def verify_shuttle_labware_presence(
         self, direction: Direction, labware_expected: bool


### PR DESCRIPTION
# Overview
The previous workaround for stacker EVT introduced some motion-related issues.

Currently, the `verify_shuttle_location` function always homes the x-axis to the retracted position to check for shuttle presence. While this approach technically works, it causes the motor driver to detect a stall during the next move command, since the axis is already at the limit switch.

A better solution is to eliminate this redundant movement from `verify_shuttle_location`. Instead, we should perform the verification only after the x-axis reaches the endstop as part of the normal dispense and store routines.

It's annoying but these workarounds will be removed once we receive DVT hardware!!