### PR TITLE
refactor(app): adjust protocol setup offsets table header

### DIFF
--- a/app/src/organisms/LabwareOffsetsTable/AccordionHeader.tsx
+++ b/app/src/organisms/LabwareOffsetsTable/AccordionHeader.tsx
@@ -9,6 +9,7 @@ import {
   StyledText,
   RESPONSIVENESS,
   COLORS,
+  NO_WRAP,
 } from '@opentrons/components'
 
 import { selectTotalOrMissingOffsetRequiredCountForLwCopy } from '/app/redux/protocol-runs'
@@ -57,7 +58,11 @@ const ACCORDION_HEADER_CONTAINER_STYLE = css`
 `
 
 const OFFSET_COPY_STYLE = css`
+  width: 6.85rem;
+  text-wrap: ${NO_WRAP};
+
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    width: 10.25rem;
     color: ${COLORS.grey60};
   }
 `

--- a/app/src/organisms/LabwareOffsetsTable/index.tsx
+++ b/app/src/organisms/LabwareOffsetsTable/index.tsx
@@ -9,6 +9,8 @@ import {
   RESPONSIVENESS,
   Flex,
   SPACING,
+  COLORS,
+  JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
 
 import { selectAllLabwareInfoAndDefaultStatusSorted } from '/app/redux/protocol-runs'
@@ -39,7 +41,7 @@ export function LabwareOffsetsTable(
 
   return (
     <Flex css={CONTAINER_STYLE}>
-      <ListTable headers={[t('labware_type'), t('total_offsets')]}>
+      <ListTable headers={[<TableHeaders key="1" />]}>
         {labwareInfo.map(aLwInfo => (
           <ListAccordion
             key={aLwInfo.uri}
@@ -90,5 +92,45 @@ const OFFSET_COLUMN_STYLE = css`
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     padding-right: 0;
+  }
+`
+
+function TableHeaders(): JSX.Element {
+  const { t } = useTranslation('protocol_setup')
+
+  return (
+    <Flex css={TABLE_HEADER_CONTAINER_STYLE}>
+      <StyledText
+        css={TABLE_HEADER_COLUMN_ONE_TEXT_STYLE}
+        desktopStyle="bodyDefaultRegular"
+      >
+        {t('labware_type')}
+      </StyledText>
+      <StyledText
+        css={TABLE_HEADER_COLUMN_TWO_TEXT_STYLE}
+        desktopStyle="bodyDefaultRegular"
+      >
+        {t('total_offsets')}
+      </StyledText>
+    </Flex>
+  )
+}
+
+const TABLE_HEADER_CONTAINER_STYLE = css`
+  justify-content: ${JUSTIFY_SPACE_BETWEEN};
+  padding: 0 ${SPACING.spacing12};
+  gap: ${SPACING.spacing24};
+`
+
+const TABLE_HEADER_COLUMN_ONE_TEXT_STYLE = css`
+  color: ${COLORS.grey60};
+`
+
+const TABLE_HEADER_COLUMN_TWO_TEXT_STYLE = css`
+  color: ${COLORS.grey60};
+  padding-right: 4rem;
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    padding-right: 7.5rem;
   }
 `

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
@@ -18,6 +18,7 @@ import {
   DIRECTION_ROW,
   DISPLAY_FLEX,
   RadioButton,
+  NO_WRAP,
 } from '@opentrons/components'
 
 import {
@@ -208,6 +209,7 @@ const TEXT_CONTAINER_STYLE = css`
 
 const SUBTEXT_STYLE = css`
   color: ${COLORS.grey60};
+  text-wrap: ${NO_WRAP};
 `
 
 const ICON_STYLE = css`


### PR DESCRIPTION
Closes [RQA-4045](https://opentrons.atlassian.net/browse/RQA-4045)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Sometimes designs have to be special-cased for the sake of UI, and this is one of those times. In our `ListTable` component, per component designs, the headers should be left aligned to the start of their respective column. However, in this one instance, Design has decided to offset the headers using special widths/margins. This is intentional. Yes, it's possible that if a translation string significantly longer than the current width accommodations occurs, headers will be somewhat wonky, but Design is ok with this: there is an extra padding buffer in place to prevent this from happening in most real instances (we're definitely covered for Chinese).

I also worked with Design to come up with a buffer that reasonably accommodates copy that is "XXX offsets missing" (3 digit missing offsets), so I don't think we're at risk of any odd table UI due to copy length.

<img width="1020" alt="Screenshot 2025-04-03 at 5 45 26 PM" src="https://github.com/user-attachments/assets/d7582dd2-2f7a-4334-95a2-151d3467484a" />

<img width="936" alt="Screenshot 2025-04-03 at 5 40 08 PM" src="https://github.com/user-attachments/assets/ca3cc4a6-b1b1-43f7-ab25-ec55361544bd" />

Note that the exact offsets are different than what is shown in Figma, but in code, these are correct given Design feedback!

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
no risk, just styling
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4045]: https://opentrons.atlassian.net/browse/RQA-4045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ