### PR TITLE
fix(app): Labware setup UI fixes

### DIFF
--- a/app/src/molecules/LabwareStackContents/index.tsx
+++ b/app/src/molecules/LabwareStackContents/index.tsx
@@ -65,7 +65,8 @@ export function LabwareStackContents(
             key={index}
             radioButtonType="small"
             buttonLabel={truncateString(labware.displayName, MAX_CHARS)}
-            buttonValue={index}
+            buttonValue={labware.labwareId}
+            id={labware.labwareId}
             isSelected={isSelected}
             tagText={(labwareInStack.length - index).toString()}
             maxLines={2}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -6,6 +6,7 @@ import {
   ALIGN_CENTER,
   Btn,
   Tag,
+  Box,
   COLORS,
   DeckInfoLabel,
   ListButton,
@@ -35,7 +36,6 @@ import {
 } from '@opentrons/shared-data'
 import { getLabwareLiquidRenderInfoFromStack } from '/app/transformations/commands'
 import { ToggleButton } from '/app/atoms/buttons'
-import { Divider } from '/app/atoms/structure'
 import { SecureLabwareModal } from './SecureLabwareModal'
 
 import type { MouseEvent } from 'react'
@@ -223,7 +223,12 @@ export function LabwareListItem(
   }
 
   return (
-    <ListButton onClick={onClick} type="noActive" gridGap={SPACING.spacing24}>
+    <ListButton
+      onClick={onClick}
+      type="noActive"
+      gridGap={SPACING.spacing24}
+      padding={SPACING.spacing12}
+    >
       <Flex
         alignItems={ALIGN_CENTER}
         gridGap={SPACING.spacing2}
@@ -312,7 +317,11 @@ export function LabwareListItem(
                   </Flex>
                 </Flex>
                 {index !== labwareLiquidRenderInfo.length - 1 ? (
-                  <Divider marginY="0" width="100%" />
+                  <Box
+                    borderBottom={`1px solid ${String(COLORS.grey40)}`}
+                    marginY="0"
+                    width="100%"
+                  />
                 ) : null}
               </>
             ))}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/OffDeckLabwareList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/OffDeckLabwareList.tsx
@@ -34,7 +34,7 @@ export function OffDeckLabwareList(
       >
         {t('additional_off_deck_labware')}
       </LegacyStyledText>
-      <Flex gridGap={SPACING.spacing8} flexDirection={DIRECTION_COLUMN}>
+      <Flex gridGap={SPACING.spacing4} flexDirection={DIRECTION_COLUMN}>
         {labwareItems.map((labwareItem, index) => (
           <LabwareListItem
             key={index}

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
@@ -39,12 +39,17 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
   const allDefinitions = getAllDefinitions()
   const modulesOnDeck = attachedProtocolModuleMatches.map(module => {
     const { moduleDef, slotName } = module
-    const stackOnModule = Object.entries(startingDeck).find(([key, value]) =>
+    const slotAndStackOnModule = Object.entries(
+      startingDeck
+    ).find(([key, value]) =>
       value.some(
         (stackItem): stackItem is ModuleInStack =>
           'moduleId' in stackItem && stackItem.moduleId === module.moduleId
       )
-    )?.[1]
+    )
+    const slotDisplayName = slotAndStackOnModule?.[0]
+    const stackOnModule = slotAndStackOnModule?.[1]
+
     const topLabwareInfo = stackOnModule != null ? stackOnModule[0] : null
     const topLabwareDefinition =
       topLabwareInfo != null && 'labwareId' in topLabwareInfo
@@ -70,7 +75,7 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
       nestedLabwareDef: topLabwareDefinition,
       nestedLabwareWellFill: wellFill,
       onLabwareClick: () => {
-        handleLabwareClick([slotName, stackOnModule ?? []])
+        handleLabwareClick([slotDisplayName ?? slotName, stackOnModule ?? []])
       },
       highlightLabware: true,
       moduleChildren: null,

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
@@ -80,7 +80,10 @@ export function getLabwareLocationFromSequence(
           ...acc,
           slotName: sequenceItem.logicalLocationName,
         }
-      } else if (sequenceItem.kind === 'onCutoutFixture') {
+      } else if (
+        sequenceItem.kind === 'onCutoutFixture' &&
+        acc.slotName == null
+      ) {
         return {
           ...acc,
           slotName: getCutoutDisplayName(sequenceItem.cutoutId as CutoutId),
@@ -98,10 +101,7 @@ export function getLabwareLocationFromSequence(
           ...acc,
           slotName: sequenceItem.addressableAreaName,
         }
-      } else if (
-        sequenceItem.kind === 'onAddressableArea' &&
-        index === locationSequence.length - 1
-      ) {
+      } else if (sequenceItem.kind === 'onAddressableArea') {
         const slotName = getSlotFromAddressableAreaName(
           sequenceItem.addressableAreaName as AddressableAreaName
         )


### PR DESCRIPTION
fix RQA-4036, RQA-4043, RQA-4039
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fix a few UI bugs with the new labware setup experience.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->
1. Look at the ODD and Desktop modals that use `LabwareStackContents` and see that they are properly selectable even when multiple have the same label.
2. See that when you press on a labware in a thermocycler, the location is displayed as A1+B1 in the resulting modal
3. Look at the run log for protocol with labware loaded into a staging area slot and see the location correctly presented as in column 4

https://github.com/user-attachments/assets/77e45693-677f-4195-b537-6fc87d5365b7
<img width="1004" alt="Screenshot 2025-04-03 at 9 09 21 PM" src="https://github.com/user-attachments/assets/e05944a6-95e2-45a2-8f85-3a1def46b88f" />
<img width="1023" alt="Screenshot 2025-04-03 at 10 03 21 PM" src="https://github.com/user-attachments/assets/5269de9a-07eb-4481-8e3b-64ff0a5a6d78" />

## Changelog
1. Make labware stack radio buttons that have the same labels clickable
2. Ensure we display labware location on thermocycler as A1+B1 in ODD modal
4. Grab slot name from addressable area name instead of cutout config to account for staging area slots in run log.
5. Address some design feedback for desktop labware list items

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick code check
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
