### PR TITLE
fix(api, shared-data): Flex Stacker engine command optional fields

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/empty.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/empty.py
@@ -7,6 +7,7 @@ from typing import Optional, Literal, TYPE_CHECKING
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ...errors import (
@@ -39,12 +40,12 @@ class EmptyParams(BaseModel):
         ),
     )
 
-    message: str | None = Field(
+    message: str | SkipJsonSchema[None] = Field(
         None,
         description="The message to display on connected clients during a manualWithPause strategy empty.",
     )
 
-    count: int | None = Field(
+    count: int | SkipJsonSchema[None] = Field(
         None,
         description=(
             "The new count of labware in the pool. If None, default to an empty pool. If this number is "
@@ -66,11 +67,11 @@ class EmptyResult(BaseModel):
         ...,
         description="The labware definition URI of the primary labware.",
     )
-    adapterLabwareURI: str | None = Field(
+    adapterLabwareURI: str | SkipJsonSchema[None] = Field(
         None,
         description="The labware definition URI of the adapter labware.",
     )
-    lidLabwareURI: str | None = Field(
+    lidLabwareURI: str | SkipJsonSchema[None] = Field(
         None,
         description="The labware definition URI of the lid labware.",
     )

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/empty.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/empty.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from __future__ import annotations
-from typing import Optional, Literal, TYPE_CHECKING
+from typing import Optional, Literal, TYPE_CHECKING, Annotated
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
@@ -45,7 +45,7 @@ class EmptyParams(BaseModel):
         description="The message to display on connected clients during a manualWithPause strategy empty.",
     )
 
-    count: int | SkipJsonSchema[None] = Field(
+    count: Optional[Annotated[int, Field(ge=0)]] = Field(
         None,
         description=(
             "The new count of labware in the pool. If None, default to an empty pool. If this number is "
@@ -53,7 +53,6 @@ class EmptyParams(BaseModel):
             "Do not use the value in the parameters as an outside observer; instead, use the count value "
             "from the results."
         ),
-        ge=0,
     )
 
 

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
@@ -1,7 +1,7 @@
 """Command models to engage a user to empty a Flex Stacker."""
 
 from __future__ import annotations
-from typing import Optional, Literal, TYPE_CHECKING
+from typing import Optional, Literal, TYPE_CHECKING, Annotated
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
@@ -43,7 +43,7 @@ class FillParams(BaseModel):
         description="The message to display on connected clients during a manualWithPause strategy fill.",
     )
 
-    count: int | SkipJsonSchema[None] = Field(
+    count: Optional[Annotated[int, Field(ge=1)]] = Field(
         None,
         description=(
             "How full the labware pool should now be. If None, default to the maximum amount "
@@ -53,7 +53,6 @@ class FillParams(BaseModel):
             "holds, it will be clamped to that minimum. Do not use the value in the parameters as "
             "an outside observer; instead, use the count value from the results."
         ),
-        ge=1,
     )
 
 

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
@@ -5,6 +5,7 @@ from typing import Optional, Literal, TYPE_CHECKING
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ...errors import (
@@ -37,12 +38,12 @@ class FillParams(BaseModel):
         ),
     )
 
-    message: str | None = Field(
+    message: str | SkipJsonSchema[None] = Field(
         None,
         description="The message to display on connected clients during a manualWithPause strategy fill.",
     )
 
-    count: int | None = Field(
+    count: int | SkipJsonSchema[None] = Field(
         None,
         description=(
             "How full the labware pool should now be. If None, default to the maximum amount "
@@ -66,11 +67,11 @@ class FillResult(BaseModel):
         ...,
         description="The labware definition URI of the primary labware.",
     )
-    adapterLabwareURI: str | None = Field(
+    adapterLabwareURI: str | SkipJsonSchema[None] = Field(
         None,
         description="The labware definition URI of the adapter labware.",
     )
-    lidLabwareURI: str | None = Field(
+    lidLabwareURI: str | SkipJsonSchema[None] = Field(
         None,
         description="The labware definition URI of the lid labware.",
     )

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
@@ -86,33 +86,33 @@ class RetrieveResult(BaseModel):
         ...,
         description="The labware ID of the primary retrieved labware.",
     )
-    adapterId: str | None = Field(
+    adapterId: str | SkipJsonSchema[None] = Field(
         None,
         description="The optional Adapter Labware ID of the adapter under a primary labware.",
     )
-    lidId: str | None = Field(
+    lidId: str | SkipJsonSchema[None] = Field(
         None,
         description="The optional Lid Labware ID of the lid on a primary labware.",
     )
     primaryLocationSequence: LabwareLocationSequence = Field(
         ..., description="The origin location of the primary labware."
     )
-    lidLocationSequence: LabwareLocationSequence | None = Field(
+    lidLocationSequence: LabwareLocationSequence | SkipJsonSchema[None] = Field(
         None,
         description="The origin location of the adapter labware under a primary labware.",
     )
-    adapterLocationSequence: LabwareLocationSequence | None = Field(
+    adapterLocationSequence: LabwareLocationSequence | SkipJsonSchema[None] = Field(
         None, description="The origin location of the lid labware on a primary labware."
     )
     primaryLabwareURI: str = Field(
         ...,
         description="The labware definition URI of the primary labware.",
     )
-    adapterLabwareURI: str | None = Field(
+    adapterLabwareURI: str | SkipJsonSchema[None] = Field(
         None,
         description="The labware definition URI of the adapter labware.",
     )
-    lidLabwareURI: str | None = Field(
+    lidLabwareURI: str | SkipJsonSchema[None] = Field(
         None,
         description="The labware definition URI of the lid labware.",
     )

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -5,6 +5,7 @@ from typing import Optional, Literal, TYPE_CHECKING
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
@@ -45,15 +46,15 @@ class SetStoredLabwareParams(BaseModel):
         ...,
         description="The details of the primary labware (i.e. not the lid or adapter, if any) stored in the stacker.",
     )
-    lidLabware: StackerStoredLabwareDetails | None = Field(
+    lidLabware: StackerStoredLabwareDetails | SkipJsonSchema[None] = Field(
         default=None,
         description="The details of the lid on the primary labware, if any.",
     )
-    adapterLabware: StackerStoredLabwareDetails | None = Field(
+    adapterLabware: StackerStoredLabwareDetails | SkipJsonSchema[None] = Field(
         default=None,
         description="The details of the adapter under the primary labware, if any.",
     )
-    initialCount: int | None = Field(
+    initialCount: int | SkipJsonSchema[None] = Field(
         None,
         description=(
             "The number of labware that should be initially stored in the stacker. This number will be silently clamped to "
@@ -69,11 +70,11 @@ class SetStoredLabwareResult(BaseModel):
     primaryLabwareDefinition: LabwareDefinition = Field(
         ..., description="The definition of the primary labware."
     )
-    lidLabwareDefinition: LabwareDefinition | None = Field(
-        ..., description="The definition of the lid on the primary labware, if any."
+    lidLabwareDefinition: LabwareDefinition | SkipJsonSchema[None] = Field(
+        None, description="The definition of the lid on the primary labware, if any."
     )
-    adapterLabwareDefinition: LabwareDefinition | None = Field(
-        ...,
+    adapterLabwareDefinition: LabwareDefinition | SkipJsonSchema[None] = Field(
+        None,
         description="The definition of the adapter under the primary labware, if any.",
     )
     count: int = Field(

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -1,7 +1,7 @@
 """Command models to configure the stored labware pool of a Flex Stacker.."""
 
 from __future__ import annotations
-from typing import Optional, Literal, TYPE_CHECKING
+from typing import Optional, Literal, TYPE_CHECKING, Annotated
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
@@ -54,13 +54,12 @@ class SetStoredLabwareParams(BaseModel):
         default=None,
         description="The details of the adapter under the primary labware, if any.",
     )
-    initialCount: int | SkipJsonSchema[None] = Field(
+    initialCount: Optional[Annotated[int, Field(ge=0)]] = Field(
         None,
         description=(
             "The number of labware that should be initially stored in the stacker. This number will be silently clamped to "
             "the maximum number of labware that will fit; do not rely on the parameter to know how many labware are in the stacker."
         ),
-        ge=0,
     )
 
 

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Optional, Literal, TYPE_CHECKING, Type, Union
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from ..command import (
     AbstractCommandImpl,
@@ -51,39 +52,41 @@ class StoreParams(BaseModel):
 class StoreResult(BaseModel):
     """Result data from a labware storage command."""
 
-    eventualDestinationLocationSequence: LabwareLocationSequence | None = Field(
+    eventualDestinationLocationSequence: LabwareLocationSequence | SkipJsonSchema[
+        None
+    ] = Field(
         None,
         description=(
             "The full location in which all labware moved by this command will eventually reside."
         ),
     )
-    primaryOriginLocationSequence: LabwareLocationSequence | None = Field(
-        None, description=("The origin location of the primary labware.")
-    )
-    primaryLabwareId: str | None = Field(
+    primaryOriginLocationSequence: LabwareLocationSequence | SkipJsonSchema[
+        None
+    ] = Field(None, description=("The origin location of the primary labware."))
+    primaryLabwareId: str | SkipJsonSchema[None] = Field(
         None, description="The primary labware in the stack that was stored."
     )
-    adapterOriginLocationSequence: LabwareLocationSequence | None = Field(
-        None, description=("The origin location of the adapter labware, if any.")
-    )
-    adapterLabwareId: str | None = Field(
+    adapterOriginLocationSequence: LabwareLocationSequence | SkipJsonSchema[
+        None
+    ] = Field(None, description=("The origin location of the adapter labware, if any."))
+    adapterLabwareId: str | SkipJsonSchema[None] = Field(
         None, description="The adapter in the stack that was stored, if any."
     )
-    lidOriginLocationSequence: LabwareLocationSequence | None = Field(
+    lidOriginLocationSequence: LabwareLocationSequence | SkipJsonSchema[None] = Field(
         None, description=("The origin location of the lid labware, if any.")
     )
-    lidLabwareId: str | None = Field(
+    lidLabwareId: str | SkipJsonSchema[None] = Field(
         None, description="The lid in the stack that was stored, if any."
     )
     primaryLabwareURI: str = Field(
         ...,
         description="The labware definition URI of the primary labware.",
     )
-    adapterLabwareURI: str | None = Field(
+    adapterLabwareURI: str | SkipJsonSchema[None] = Field(
         None,
         description="The labware definition URI of the adapter labware.",
     )
-    lidLabwareURI: str | None = Field(
+    lidLabwareURI: str | SkipJsonSchema[None] = Field(
         None,
         description="The labware definition URI of the lid labware.",
     )

--- a/api/src/opentrons/protocol_engine/types/location.py
+++ b/api/src/opentrons/protocol_engine/types/location.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Literal, Union, TypeGuard
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from opentrons.types import DeckSlotName, StagingSlotName
 
@@ -107,7 +108,7 @@ class OnLabwareLocationSequenceComponent(BaseModel):
 
     kind: Literal["onLabware"] = "onLabware"
     labwareId: str
-    lidId: str | None
+    lidId: str | SkipJsonSchema[None] = Field(None)
 
 
 class OnModuleLocationSequenceComponent(BaseModel):

--- a/shared-data/command/schemas/12.json
+++ b/shared-data/command/schemas/12.json
@@ -1851,31 +1851,17 @@
       "description": "The parameters defining how a stacker should be emptied.",
       "properties": {
         "count": {
-          "anyOf": [
-            {
-              "minimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": null,
           "description": "The new count of labware in the pool. If None, default to an empty pool. If this number is larger than the amount of labware currently in the pool, default to the smaller amount. Do not use the value in the parameters as an outside observer; instead, use the count value from the results.",
-          "title": "Count"
+          "ge": 0,
+          "title": "Count",
+          "type": "integer"
         },
         "message": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": null,
           "description": "The message to display on connected clients during a manualWithPause strategy empty.",
-          "title": "Message"
+          "title": "Message",
+          "type": "string"
         },
         "moduleId": {
           "description": "Unique ID of the Flex Stacker",
@@ -2171,31 +2157,17 @@
       "description": "The parameters defining how a stacker should be filled.",
       "properties": {
         "count": {
-          "anyOf": [
-            {
-              "minimum": 1,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": null,
           "description": "How full the labware pool should now be. If None, default to the maximum amount of the currently-configured labware the pool can hold. If this number is larger than the maximum the pool can hold, it will be clamped to the maximum. If this number is smaller than the current amount of labware the pool holds, it will be clamped to that minimum. Do not use the value in the parameters as an outside observer; instead, use the count value from the results.",
-          "title": "Count"
+          "ge": 1,
+          "title": "Count",
+          "type": "integer"
         },
         "message": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": null,
           "description": "The message to display on connected clients during a manualWithPause strategy fill.",
-          "title": "Message"
+          "title": "Message",
+          "type": "string"
         },
         "moduleId": {
           "description": "Unique ID of the Flex Stacker",
@@ -5092,42 +5064,23 @@
       "description": "Input parameters for a setStoredLabware command.",
       "properties": {
         "adapterLabware": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StackerStoredLabwareDetails"
-            },
-            {
-              "type": "null"
-            }
-          ],
+          "$ref": "#/$defs/StackerStoredLabwareDetails",
           "default": null,
-          "description": "The details of the adapter under the primary labware, if any."
+          "description": "The details of the adapter under the primary labware, if any.",
+          "title": "Adapterlabware"
         },
         "initialCount": {
-          "anyOf": [
-            {
-              "minimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": null,
           "description": "The number of labware that should be initially stored in the stacker. This number will be silently clamped to the maximum number of labware that will fit; do not rely on the parameter to know how many labware are in the stacker.",
-          "title": "Initialcount"
+          "ge": 0,
+          "title": "Initialcount",
+          "type": "integer"
         },
         "lidLabware": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StackerStoredLabwareDetails"
-            },
-            {
-              "type": "null"
-            }
-          ],
+          "$ref": "#/$defs/StackerStoredLabwareDetails",
           "default": null,
-          "description": "The details of the lid on the primary labware, if any."
+          "description": "The details of the lid on the primary labware, if any.",
+          "title": "Lidlabware"
         },
         "moduleId": {
           "description": "Unique ID of the Flex Stacker.",

--- a/shared-data/command/schemas/12.json
+++ b/shared-data/command/schemas/12.json
@@ -1851,11 +1851,18 @@
       "description": "The parameters defining how a stacker should be emptied.",
       "properties": {
         "count": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "default": null,
           "description": "The new count of labware in the pool. If None, default to an empty pool. If this number is larger than the amount of labware currently in the pool, default to the smaller amount. Do not use the value in the parameters as an outside observer; instead, use the count value from the results.",
-          "ge": 0,
-          "title": "Count",
-          "type": "integer"
+          "title": "Count"
         },
         "message": {
           "default": null,
@@ -2157,11 +2164,18 @@
       "description": "The parameters defining how a stacker should be filled.",
       "properties": {
         "count": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "default": null,
           "description": "How full the labware pool should now be. If None, default to the maximum amount of the currently-configured labware the pool can hold. If this number is larger than the maximum the pool can hold, it will be clamped to the maximum. If this number is smaller than the current amount of labware the pool holds, it will be clamped to that minimum. Do not use the value in the parameters as an outside observer; instead, use the count value from the results.",
-          "ge": 1,
-          "title": "Count",
-          "type": "integer"
+          "title": "Count"
         },
         "message": {
           "default": null,
@@ -5070,11 +5084,18 @@
           "title": "Adapterlabware"
         },
         "initialCount": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "default": null,
           "description": "The number of labware that should be initially stored in the stacker. This number will be silently clamped to the maximum number of labware that will fit; do not rely on the parameter to know how many labware are in the stacker.",
-          "ge": 0,
-          "title": "Initialcount",
-          "type": "integer"
+          "title": "Initialcount"
         },
         "lidLabware": {
           "$ref": "#/$defs/StackerStoredLabwareDetails",


### PR DESCRIPTION
# Overview
This fixes a bug where downloading a Flex Stacker protocol run log always fails because of pydantic validation errors. We need to make sure the optional params in our pydantic models are properly annotated with `SkipJsonSchem`? 

# Review Request
I've only updated schema 12, since this is targeting the release branch. I will need to make the same changes to schema 13 eventually for edge.

```shell
{
    "errors": [
        {
            "id": "UnexpectedError",
            "title": "Unexpected Internal Error",
            "detail": "pydantic_core._pydantic_core.ValidationError: 1 validation error for tagged-union[AirGapInPlace,Aspirate,AspirateInPlace,AspirateWhileTracking,Comment,Custom,Dispense,DispenseInPlace,DispenseWhileTracking,BlowOut,BlowOutInPlace,ConfigureForVolume,ConfigureNozzleLayout,DropTip,DropTipInPlace,Home,RetractAxis,LoadLabware,ReloadLabware,LoadLiquid,LoadLiquidClass,LoadModule,LoadPipette,LoadLidStack,LoadLid,MoveLabware,MoveRelative,MoveToCoordinates,MoveToWell,MoveToAddressableArea,MoveToAddressableAreaForDropTip,PrepareToAspirate,WaitForResume,WaitForResume,WaitForDuration,PickUpTip,SavePosition,SetRailLights,TouchTip,SetStatusBar,VerifyTipPresence,GetTipPresence,GetNextTip,LiquidProbe,TryLiquidProbe,EvotipSealPipette,EvotipDispense,EvotipUnsealPipette,WaitForTemperature,SetTargetTemperature,DeactivateHeater,SetAndWaitForShakeSpeed,DeactivateShaker,OpenLabwareLatch,CloseLabwareLatch,Disengage,Engage,SetTargetTemperature,WaitForTemperature,DeactivateTemperature,SetTargetBlockTemperature,WaitForBlockTemperature,SetTargetLidTemperature,WaitForLidTemperature,DeactivateBlock,DeactivateLid,OpenLid,CloseLid,RunProfile,RunExtendedProfile,CloseLid,OpenLid,Initialize,ReadAbsorbance,Retrieve,Store,SetStoredLabware,Fill,Empty,CloseLatch,OpenLatch,PrepareShuttle,CalibrateGripper,CalibratePipette,CalibrateModule,MoveToMaintenancePosition,UnsafeBlowOutInPlace,UnsafeDropTipInPlace,UpdatePositionEstimators,UnsafeEngageAxes,UnsafeUngripLabware,UnsafePlaceLabware,UnsafeManualRetrieve,MoveTo,MoveAxesRelative,MoveAxesTo,openGripperJaw,closeGripperJaw]\nflexStacker/setStoredLabware.result.adapterLabwareDefinition\n  Field required [type=missing, input_value={'primaryLabwareDefinitio...k_1000ul']}, 'count': 1}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.9/v/missing",
            "meta": {
                "type": "ValidationError",
                "code": "4000",
                "message": "pydantic_core._pydantic_core.ValidationError: 1 validation error for tagged-union[AirGapInPlace,Aspirate,AspirateInPlace,AspirateWhileTracking,Comment,Custom,Dispense,DispenseInPlace,DispenseWhileTracking,BlowOut,BlowOutInPlace,ConfigureForVolume,ConfigureNozzleLayout,DropTip,DropTipInPlace,Home,RetractAxis,LoadLabware,ReloadLabware,LoadLiquid,LoadLiquidClass,LoadModule,LoadPipette,LoadLidStack,LoadLid,MoveLabware,MoveRelative,MoveToCoordinates,MoveToWell,MoveToAddressableArea,MoveToAddressableAreaForDropTip,PrepareToAspirate,WaitForResume,WaitForResume,WaitForDuration,PickUpTip,SavePosition,SetRailLights,TouchTip,SetStatusBar,VerifyTipPresence,GetTipPresence,GetNextTip,LiquidProbe,TryLiquidProbe,EvotipSealPipette,EvotipDispense,EvotipUnsealPipette,WaitForTemperature,SetTargetTemperature,DeactivateHeater,SetAndWaitForShakeSpeed,DeactivateShaker,OpenLabwareLatch,CloseLabwareLatch,Disengage,Engage,SetTargetTemperature,WaitForTemperature,DeactivateTemperature,SetTargetBlockTemperature,WaitForBlockTemperature,SetTargetLidTemperature,WaitForLidTemperature,DeactivateBlock,DeactivateLid,OpenLid,CloseLid,RunProfile,RunExtendedProfile,CloseLid,OpenLid,Initialize,ReadAbsorbance,Retrieve,Store,SetStoredLabware,Fill,Empty,CloseLatch,OpenLatch,PrepareShuttle,CalibrateGripper,CalibratePipette,CalibrateModule,MoveToMaintenancePosition,UnsafeBlowOutInPlace,UnsafeDropTipInPlace,UpdatePositionEstimators,UnsafeEngageAxes,UnsafeUngripLabware,UnsafePlaceLabware,UnsafeManualRetrieve,MoveTo,MoveAxesRelative,MoveAxesTo,openGripperJaw,closeGripperJaw]\nflexStacker/setStoredLabware.result.adapterLabwareDefinition\n  Field required [type=missing, input_value={'primaryLabwareDefinitio...k_1000ul']}, 'count': 1}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.9/v/missing",
                "detail": {
                    "args": "()",
                    "title": "tagged-union[AirGapInPlace,Aspirate,AspirateInPlace,AspirateWhileTracking,Comment,Custom,Dispense,DispenseInPlace,DispenseWhileTracking,BlowOut,BlowOutInPlace,ConfigureForVolume,ConfigureNozzleLayout,DropTip,DropTipInPlace,Home,RetractAxis,LoadLabware,ReloadLabware,LoadLiquid,LoadLiquidClass,LoadModule,LoadPipette,LoadLidStack,LoadLid,MoveLabware,MoveRelative,MoveToCoordinates,MoveToWell,MoveToAddressableArea,MoveToAddressableAreaForDropTip,PrepareToAspirate,WaitForResume,WaitForResume,WaitForDuration,PickUpTip,SavePosition,SetRailLights,TouchTip,SetStatusBar,VerifyTipPresence,GetTipPresence,GetNextTip,LiquidProbe,TryLiquidProbe,EvotipSealPipette,EvotipDispense,EvotipUnsealPipette,WaitForTemperature,SetTargetTemperature,DeactivateHeater,SetAndWaitForShakeSpeed,DeactivateShaker,OpenLabwareLatch,CloseLabwareLatch,Disengage,Engage,SetTargetTemperature,WaitForTemperature,DeactivateTemperature,SetTargetBlockTemperature,WaitForBlockTemperature,SetTargetLidTemperature,WaitForLidTemperature,DeactivateBlock,DeactivateLid,OpenLid,CloseLid,RunProfile,RunExtendedProfile,CloseLid,OpenLid,Initialize,ReadAbsorbance,Retrieve,Store,SetStoredLabware,Fill,Empty,CloseLatch,OpenLatch,PrepareShuttle,CalibrateGripper,CalibratePipette,CalibrateModule,MoveToMaintenancePosition,UnsafeBlowOutInPlace,UnsafeDropTipInPlace,UpdatePositionEstimators,UnsafeEngageAxes,UnsafeUngripLabware,UnsafePlaceLabware,UnsafeManualRetrieve,MoveTo,MoveAxesRelative,MoveAxesTo,openGripperJaw,closeGripperJaw]",
                    "traceback": "  File \"/opt/opentrons-robot-server/starlette/middleware/errors.py\", line 162, in __call__\n    await self.app(scope, receive, _send)\n\n  File \"/opt/opentrons-robot-server/starlette/middleware/cors.py\", line 83, in __call__\n    await self.app(scope, receive, send)\n\n  File \"/opt/opentrons-robot-server/starlette/middleware/exceptions.py\", line 79, in __call__\n    raise exc\n\n  File \"/opt/opentrons-robot-server/starlette/middleware/exceptions.py\", line 68, in __call__\n    await self.app(scope, receive, sender)\n\n  File \"/opt/opentrons-robot-server/fastapi/middleware/asyncexitstack.py\", line 20, in __call__\n    raise e\n\n  File \"/opt/opentrons-robot-server/fastapi/middleware/asyncexitstack.py\", line 17, in __call__\n    await self.app(scope, receive, send)\n\n  File \"/opt/opentrons-robot-server/starlette/routing.py\", line 718, in __call__\n    await route.handle(scope, receive, send)\n\n  File \"/opt/opentrons-robot-server/starlette/routing.py\", line 276, in handle\n    await self.app(scope, receive, send)\n\n  File \"/opt/opentrons-robot-server/starlette/routing.py\", line 66, in app\n    response = await func(request)\n\n  File \"/opt/opentrons-robot-server/fastapi/routing.py\", line 273, in app\n    raw_response = await run_endpoint_function(\n\n  File \"/opt/opentrons-robot-server/fastapi/routing.py\", line 190, in run_endpoint_function\n    return await dependant.call(**values)\n\n  File \"/opt/opentrons-robot-server/robot_server/runs/router/commands_router.py\", line 306, in get_run_commands\n    command_slice = run_data_manager.get_commands_slice(\n\n  File \"/opt/opentrons-robot-server/robot_server/runs/run_data_manager.py\", line 431, in get_commands_slice\n    return self._run_store.get_commands_slice(\n\n  File \"/opt/opentrons-robot-server/robot_server/runs/run_store.py\", line 519, in get_commands_slice\n    sliced_commands: List[Command] = [\n\n  File \"/opt/opentrons-robot-server/robot_server/runs/run_store.py\", line 520, in <listcomp>\n    _parse_command(row.command) for row in slice_result\n\n  File \"/opt/opentrons-robot-server/robot_server/runs/run_store.py\", line 835, in _parse_command\n    return json_to_pydantic(CommandAdapter, json_str)\n\n  File \"/opt/opentrons-robot-server/robot_server/persistence/pydantic.py\", line 46, in json_to_pydantic\n    return model.validate_json(json_str)\n\n  File \"/opt/opentrons-robot-server/pydantic/type_adapter.py\", line 144, in wrapped\n    return func(self, *args, **kwargs)\n\n  File \"/opt/opentrons-robot-server/pydantic/type_adapter.py\", line 393, in validate_json\n    return self.validator.validate_json(data, strict=strict, context=context)\n",
                    "class": "ValidationError"
                },
                "wrapping": []
            },
            "errorCode": "4000"
        }
    ]
}
```


