### PR TITLE
feat(protocol-designer): Add a confirmation modal for reset settings button

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -13,6 +13,10 @@
   "blowout_position": "Blowout position from top",
   "change_tips": "Change tips",
   "column": "Column",
+  "comfirm_reset_settings": {
+    "no_liquid_class": "Continuing will undo any changes and restore the settings to the default values.",
+    "liquid_class_selected": "Continuing will undo any changes and restore the settings to the values associated with the {{liquidClass}} liquid class."
+  },
   "default_flow_rate": "The default flow rate is {{flowRate}}",
   "default_tip_option": "Default - get next tip",
   "delay_duration": "Delay duration",

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -15,7 +15,7 @@
   "column": "Column",
   "comfirm_reset_settings": {
     "no_liquid_class": "Continuing will undo any changes and restore the settings to the default values.",
-    "liquid_class_selected": "Continuing will undo any changes and restore the settings to the values associated with the {{liquidClass}} liquid class."
+    "liquid_class_selected": "Continuing will undo any changes and restore the settings to the values associated with the {{liquidClassName}} liquid class."
   },
   "default_flow_rate": "The default flow rate is {{flowRate}}",
   "default_tip_option": "Default - get next tip",

--- a/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
+++ b/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
@@ -13,9 +13,8 @@ import {
   StyledText,
   Icon,
 } from '@opentrons/components'
-
-import { getMainPagePortalEl } from './Portal'
 import { getLiquidClassDisplayName } from '../../liquid-defs/utils'
+import { getMainPagePortalEl } from './Portal'
 
 interface ResetSettingsModalProps {
   tab: 'aspirate' | 'dispense'

--- a/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
+++ b/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
@@ -15,6 +15,7 @@ import {
 } from '@opentrons/components'
 
 import { getMainPagePortalEl } from './Portal'
+import { getLiquidClassDisplayName } from '../../liquid-defs/utils'
 
 interface ResetSettingsModalProps {
   tab: 'aspirate' | 'dispense'
@@ -27,6 +28,10 @@ export function ResetSettingsModal(
 ): JSX.Element {
   const { tab, liquidClass, onClose, onScroll } = props
   const { t, i18n } = useTranslation('protocol_steps')
+
+  // TODO: Update to check liquidClass !== 'none' for Don't use a liquid class
+  const isLiquidClassSelected = liquidClass !== null && liquidClass !== ''
+  const liquidClassName = getLiquidClassDisplayName(String(liquidClass))
 
   const handleContinue = (): void => {
     console.log('TODO: Wire up reset settings modal.')
@@ -68,11 +73,11 @@ export function ResetSettingsModal(
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
           <StyledText color={COLORS.grey60} desktopStyle="captionRegular">
-            {liquidClass !== null && liquidClass !== ''
+            {isLiquidClassSelected
               ? t(
                   'protocol_steps:comfirm_reset_settings.liquid_class_selected',
                   {
-                    liquidClass,
+                    liquidClassName,
                   }
                 )
               : t('protocol_steps:comfirm_reset_settings.no_liquid_class')}

--- a/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
+++ b/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
@@ -19,19 +19,19 @@ import { getMainPagePortalEl } from './Portal'
 interface ResetSettingsModalProps {
   tab: 'aspirate' | 'dispense'
   onClose: () => void
-  onScoll: () => void
+  onScroll: () => void
   liquidClass?: string | null
 }
 export function ResetSettingsModal(
   props: ResetSettingsModalProps
 ): JSX.Element {
-  const { tab, liquidClass, onClose, onScoll } = props
-  const { t } = useTranslation('protocol_steps')
+  const { tab, liquidClass, onClose, onScroll } = props
+  const { t, i18n } = useTranslation('protocol_steps')
 
   const handleContinue = (): void => {
     console.log('TODO: Wire up reset settings modal.')
     onClose()
-    onScoll()
+    onScroll()
   }
 
   return createPortal(
@@ -60,7 +60,7 @@ export function ResetSettingsModal(
               handleContinue()
             }}
           >
-            {t('shared:continue')}
+            {i18n.format(t('shared:continue'), 'capitalize')}
           </PrimaryButton>
         </Flex>
       }

--- a/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
+++ b/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
@@ -1,0 +1,85 @@
+import { useTranslation } from 'react-i18next'
+import { createPortal } from 'react-dom'
+
+import {
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  JUSTIFY_END,
+  Modal,
+  PrimaryButton,
+  SecondaryButton,
+  SPACING,
+  StyledText,
+  Icon,
+} from '@opentrons/components'
+
+import { getMainPagePortalEl } from './Portal'
+
+interface ResetSettingsModalProps {
+  tab: 'aspirate' | 'dispense'
+  onClose: () => void
+  onScoll: () => void
+  liquidClass?: string | null
+}
+export function ResetSettingsModal(
+  props: ResetSettingsModalProps
+): JSX.Element {
+  const { tab, liquidClass, onClose, onScoll } = props
+  const { t } = useTranslation('protocol_steps')
+
+  const handleContinue = (): void => {
+    console.log('TODO: Wire up reset settings modal.')
+    onClose()
+    onScoll()
+  }
+
+  return createPortal(
+    <Modal
+      marginLeft="0"
+      title={t(`protocol_steps:reset_settings`, { tab })}
+      titleElement1={
+        <Icon name="alert-circle" color={COLORS.yellow50} size="1.25rem" />
+      }
+      type="info"
+      closeOnOutsideClick
+      onClose={onClose}
+      childrenPadding={SPACING.spacing24}
+      footer={
+        <Flex
+          justifyContent={JUSTIFY_END}
+          padding={`0 ${SPACING.spacing24} ${SPACING.spacing24}`}
+          gridGap={SPACING.spacing8}
+        >
+          <SecondaryButton onClick={onClose}>
+            {t('shared:cancel')}
+          </SecondaryButton>
+          <PrimaryButton
+            data-testid="ResetSettingsModal_continueButton"
+            onClick={() => {
+              handleContinue()
+            }}
+          >
+            {t('shared:continue')}
+          </PrimaryButton>
+        </Flex>
+      }
+    >
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
+        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+          <StyledText color={COLORS.grey60} desktopStyle="captionRegular">
+            {liquidClass !== null && liquidClass !== ''
+              ? t(
+                  'protocol_steps:comfirm_reset_settings.liquid_class_selected',
+                  {
+                    liquidClass,
+                  }
+                )
+              : t('protocol_steps:comfirm_reset_settings.no_liquid_class')}
+          </StyledText>
+        </Flex>
+      </Flex>
+    </Modal>,
+    getMainPagePortalEl()
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
@@ -53,7 +53,7 @@ export function SecondStepMixTools({
   const { t, i18n } = useTranslation(['application', 'form'])
   const toolsComponentRef = useRef<HTMLDivElement | null>(null)
   const enableLiquidClasses = useSelector(getEnableLiquidClasses)
-  const [isResetModal, setIsResetModal] = useState<boolean>(false)
+  const [showResetModal, setShowResetModal] = useState<boolean>(false)
   const aspirateTab = {
     text: i18n.format(t('aspirate'), 'capitalize'),
     isActive: tab === 'aspirate',
@@ -86,13 +86,13 @@ export function SecondStepMixTools({
 
   return (
     <>
-      {isResetModal ? (
+      {showResetModal ? (
         <ResetSettingsModal
           tab={tab}
           onClose={() => {
-            setIsResetModal(false)
+            setShowResetModal(false)
           }}
-          onScoll={() => {
+          onScroll={() => {
             handleScrollToTop()
           }}
           liquidClass={liquidClassName}
@@ -251,7 +251,7 @@ export function SecondStepMixTools({
             tab={tab}
             onClick={() => {
               console.log('TODO: wire up onClick handler')
-              setIsResetModal(true)
+              setShowResetModal(true)
             }}
           />
         ) : null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
@@ -79,11 +79,6 @@ export function SecondStepMixTools({
     }
   }
 
-  const liquidClassName =
-    formData.liquidClass !== ''
-      ? getLiquidClassDisplayName(String(formData.liquidClass))
-      : ''
-
   return (
     <>
       {showResetModal ? (
@@ -95,7 +90,7 @@ export function SecondStepMixTools({
           onScroll={() => {
             handleScrollToTop()
           }}
-          liquidClass={liquidClassName}
+          liquidClass={formData.liquidClass}
         />
       ) : null}
       <Flex

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import {
@@ -9,7 +9,9 @@ import {
   StyledText,
   Tabs,
 } from '@opentrons/components'
+import { ResetSettingsModal } from '../../../../../../components/organisms/ResetSettingsModal'
 import { getEnableLiquidClasses } from '../../../../../../feature-flags/selectors'
+import { getLiquidClassDisplayName } from '../../../../../../liquid-defs/utils'
 import {
   CheckboxExpandStepFormField,
   InputStepFormField,
@@ -51,6 +53,7 @@ export function SecondStepMixTools({
   const { t, i18n } = useTranslation(['application', 'form'])
   const toolsComponentRef = useRef<HTMLDivElement | null>(null)
   const enableLiquidClasses = useSelector(getEnableLiquidClasses)
+  const [isResetModal, setIsResetModal] = useState<boolean>(false)
   const aspirateTab = {
     text: i18n.format(t('aspirate'), 'capitalize'),
     isActive: tab === 'aspirate',
@@ -76,164 +79,183 @@ export function SecondStepMixTools({
     }
   }
 
+  const liquidClassName =
+    formData.liquidClass !== ''
+      ? getLiquidClassDisplayName(String(formData.liquidClass))
+      : ''
+
   return (
-    <Flex
-      ref={toolsComponentRef}
-      flexDirection={DIRECTION_COLUMN}
-      width="100%"
-      paddingY={SPACING.spacing16}
-      gridGap={SPACING.spacing12}
-    >
-      <Flex padding={`0 ${SPACING.spacing16}`}>
-        <Tabs tabs={[aspirateTab, dispenseTab]} />
-      </Flex>
-      <Divider marginY="0" />
-      <FlowRateField
-        key={`${tab}_flowRate`}
-        {...propsForFields[`${tab}_flowRate`]}
-        pipetteId={formData.pipette}
-        flowRateType={tab}
-        volume={propsForFields.volume?.value ?? 0}
-        tiprack={propsForFields.tipRack.value}
-      />
-      <Divider marginY="0" />
-      {tab === 'aspirate' ? (
-        <>
-          <WellsOrderField
-            prefix={tab}
-            updateFirstWellOrder={
-              propsForFields.mix_wellOrder_first.updateValue
-            }
-            updateSecondWellOrder={
-              propsForFields.mix_wellOrder_second.updateValue
-            }
-            firstValue={formData.mix_wellOrder_first}
-            secondValue={formData.mix_wellOrder_second}
-            firstName="mix_wellOrder_first"
-            secondName="mix_wellOrder_second"
-          />
-          <Divider marginY="0" />
-          <PositionField
-            prefix="mix"
-            propsForFields={propsForFields}
-            zField="mix_mmFromBottom"
-            xField="mix_x_position"
-            yField="mix_y_position"
-            labwareId={
-              formData[getLabwareFieldForPositioningField('mix_mmFromBottom')]
-            }
-          />
-          <Divider marginY="0" />
-        </>
-      ) : null}
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        padding={`0 ${SPACING.spacing16}`}
-        gridGap={SPACING.spacing8}
-      >
-        <StyledText desktopStyle="bodyDefaultSemiBold">
-          {t('protocol_steps:advanced_settings')}
-        </StyledText>
-        <CheckboxExpandStepFormField
-          title={i18n.format(
-            t('form:step_edit_form.field.delay.label'),
-            'capitalize'
-          )}
-          testId="delay_checkbox"
-          fieldProps={propsForFields[`${tab}_delay_checkbox`]}
-        >
-          {formData[`${tab}_delay_checkbox`] === true ? (
-            <InputStepFormField
-              showTooltip={false}
-              padding="0"
-              title={t('protocol_steps:delay_duration')}
-              {...propsForFields[`${tab}_delay_seconds`]}
-              units={t('application:units.seconds')}
-              errorToShow={getFormLevelError(
-                `${tab}_delay_checkbox`,
-                mappedErrorsToField
-              )}
-            />
-          ) : null}
-        </CheckboxExpandStepFormField>
-        {tab === 'dispense' ? (
-          <>
-            <CheckboxExpandStepFormField
-              title={i18n.format(
-                t('form:step_edit_form.field.blowout.label'),
-                'capitalize'
-              )}
-              testId="blowout_checkbox"
-              fieldProps={propsForFields.blowout_checkbox}
-            >
-              {formData.blowout_checkbox === true ? (
-                <Flex
-                  flexDirection={DIRECTION_COLUMN}
-                  gridGap={SPACING.spacing6}
-                >
-                  <BlowoutLocationField
-                    {...propsForFields.blowout_location}
-                    options={getBlowoutLocationOptionsForForm({
-                      stepType: formData.stepType,
-                    })}
-                    errorToShow={getFormLevelError(
-                      'blowout_location',
-                      mappedErrorsToField
-                    )}
-                    padding="0"
-                  />
-                  <FlowRateField
-                    key="blowout_flowRate"
-                    {...propsForFields.blowout_flowRate}
-                    pipetteId={formData.pipette}
-                    flowRateType="blowout"
-                    volume={propsForFields.volume?.value ?? 0}
-                    tiprack={propsForFields.tipRack.value}
-                    padding="0"
-                  />
-                  <BlowoutOffsetField
-                    {...propsForFields.blowout_z_offset}
-                    destLabwareId={propsForFields.labware.value}
-                    blowoutLabwareId={propsForFields.blowout_location.value}
-                  />
-                </Flex>
-              ) : null}
-            </CheckboxExpandStepFormField>
-            <CheckboxExpandStepFormField
-              title={i18n.format(
-                t('form:step_edit_form.field.touchTip.label'),
-                'capitalize'
-              )}
-              testId="touchTip_checkbox"
-              fieldProps={propsForFields.mix_touchTip_checkbox}
-            >
-              {formData.mix_touchTip_checkbox === true ? (
-                <PositionField
-                  prefix={tab}
-                  propsForFields={propsForFields}
-                  zField="mix_touchTip_mmFromTop"
-                  labwareId={
-                    formData[
-                      getLabwareFieldForPositioningField(
-                        'mix_touchTip_mmFromTop'
-                      )
-                    ]
-                  }
-                />
-              ) : null}
-            </CheckboxExpandStepFormField>
-          </>
-        ) : null}
-      </Flex>
-      {enableLiquidClasses ? (
-        <ResetSettingsField
+    <>
+      {isResetModal ? (
+        <ResetSettingsModal
           tab={tab}
-          onClick={() => {
-            console.log('TODO: wire up onClick handler')
+          onClose={() => {
+            setIsResetModal(false)
+          }}
+          onScoll={() => {
             handleScrollToTop()
           }}
+          liquidClass={liquidClassName}
         />
       ) : null}
-    </Flex>
+      <Flex
+        ref={toolsComponentRef}
+        flexDirection={DIRECTION_COLUMN}
+        width="100%"
+        paddingY={SPACING.spacing16}
+        gridGap={SPACING.spacing12}
+      >
+        <Flex padding={`0 ${SPACING.spacing16}`}>
+          <Tabs tabs={[aspirateTab, dispenseTab]} />
+        </Flex>
+        <Divider marginY="0" />
+        <FlowRateField
+          key={`${tab}_flowRate`}
+          {...propsForFields[`${tab}_flowRate`]}
+          pipetteId={formData.pipette}
+          flowRateType={tab}
+          volume={propsForFields.volume?.value ?? 0}
+          tiprack={propsForFields.tipRack.value}
+        />
+        <Divider marginY="0" />
+        {tab === 'aspirate' ? (
+          <>
+            <WellsOrderField
+              prefix={tab}
+              updateFirstWellOrder={
+                propsForFields.mix_wellOrder_first.updateValue
+              }
+              updateSecondWellOrder={
+                propsForFields.mix_wellOrder_second.updateValue
+              }
+              firstValue={formData.mix_wellOrder_first}
+              secondValue={formData.mix_wellOrder_second}
+              firstName="mix_wellOrder_first"
+              secondName="mix_wellOrder_second"
+            />
+            <Divider marginY="0" />
+            <PositionField
+              prefix="mix"
+              propsForFields={propsForFields}
+              zField="mix_mmFromBottom"
+              xField="mix_x_position"
+              yField="mix_y_position"
+              labwareId={
+                formData[getLabwareFieldForPositioningField('mix_mmFromBottom')]
+              }
+            />
+            <Divider marginY="0" />
+          </>
+        ) : null}
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          padding={`0 ${SPACING.spacing16}`}
+          gridGap={SPACING.spacing8}
+        >
+          <StyledText desktopStyle="bodyDefaultSemiBold">
+            {t('protocol_steps:advanced_settings')}
+          </StyledText>
+          <CheckboxExpandStepFormField
+            title={i18n.format(
+              t('form:step_edit_form.field.delay.label'),
+              'capitalize'
+            )}
+            testId="delay_checkbox"
+            fieldProps={propsForFields[`${tab}_delay_checkbox`]}
+          >
+            {formData[`${tab}_delay_checkbox`] === true ? (
+              <InputStepFormField
+                showTooltip={false}
+                padding="0"
+                title={t('protocol_steps:delay_duration')}
+                {...propsForFields[`${tab}_delay_seconds`]}
+                units={t('application:units.seconds')}
+                errorToShow={getFormLevelError(
+                  `${tab}_delay_checkbox`,
+                  mappedErrorsToField
+                )}
+              />
+            ) : null}
+          </CheckboxExpandStepFormField>
+          {tab === 'dispense' ? (
+            <>
+              <CheckboxExpandStepFormField
+                title={i18n.format(
+                  t('form:step_edit_form.field.blowout.label'),
+                  'capitalize'
+                )}
+                testId="blowout_checkbox"
+                fieldProps={propsForFields.blowout_checkbox}
+              >
+                {formData.blowout_checkbox === true ? (
+                  <Flex
+                    flexDirection={DIRECTION_COLUMN}
+                    gridGap={SPACING.spacing6}
+                  >
+                    <BlowoutLocationField
+                      {...propsForFields.blowout_location}
+                      options={getBlowoutLocationOptionsForForm({
+                        stepType: formData.stepType,
+                      })}
+                      errorToShow={getFormLevelError(
+                        'blowout_location',
+                        mappedErrorsToField
+                      )}
+                      padding="0"
+                    />
+                    <FlowRateField
+                      key="blowout_flowRate"
+                      {...propsForFields.blowout_flowRate}
+                      pipetteId={formData.pipette}
+                      flowRateType="blowout"
+                      volume={propsForFields.volume?.value ?? 0}
+                      tiprack={propsForFields.tipRack.value}
+                      padding="0"
+                    />
+                    <BlowoutOffsetField
+                      {...propsForFields.blowout_z_offset}
+                      destLabwareId={propsForFields.labware.value}
+                      blowoutLabwareId={propsForFields.blowout_location.value}
+                    />
+                  </Flex>
+                ) : null}
+              </CheckboxExpandStepFormField>
+              <CheckboxExpandStepFormField
+                title={i18n.format(
+                  t('form:step_edit_form.field.touchTip.label'),
+                  'capitalize'
+                )}
+                testId="touchTip_checkbox"
+                fieldProps={propsForFields.mix_touchTip_checkbox}
+              >
+                {formData.mix_touchTip_checkbox === true ? (
+                  <PositionField
+                    prefix={tab}
+                    propsForFields={propsForFields}
+                    zField="mix_touchTip_mmFromTop"
+                    labwareId={
+                      formData[
+                        getLabwareFieldForPositioningField(
+                          'mix_touchTip_mmFromTop'
+                        )
+                      ]
+                    }
+                  />
+                ) : null}
+              </CheckboxExpandStepFormField>
+            </>
+          ) : null}
+        </Flex>
+        {enableLiquidClasses ? (
+          <ResetSettingsField
+            tab={tab}
+            onClick={() => {
+              console.log('TODO: wire up onClick handler')
+              setIsResetModal(true)
+            }}
+          />
+        ) : null}
+      </Flex>
+    </>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
@@ -11,7 +11,6 @@ import {
 } from '@opentrons/components'
 import { ResetSettingsModal } from '../../../../../../components/organisms/ResetSettingsModal'
 import { getEnableLiquidClasses } from '../../../../../../feature-flags/selectors'
-import { getLiquidClassDisplayName } from '../../../../../../liquid-defs/utils'
 import {
   CheckboxExpandStepFormField,
   InputStepFormField,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -81,7 +81,7 @@ export const SecondStepsMoveLiquidTools = ({
   )
   const enableLiquidClasses = useSelector(getEnableLiquidClasses)
   const pipetteSpec = useSelector(getPipetteEntities)[formData.pipette]?.spec
-  const [isResetModal, setIsResetModal] = useState<boolean>(false)
+  const [showResetModal, setShowResetModal] = useState<boolean>(false)
 
   const addFieldNamePrefix = addPrefix(tab)
   const isWasteChuteSelected =
@@ -202,13 +202,13 @@ export const SecondStepsMoveLiquidTools = ({
 
   return (
     <>
-      {isResetModal ? (
+      {showResetModal ? (
         <ResetSettingsModal
           tab={tab}
           onClose={() => {
-            setIsResetModal(false)
+            setShowResetModal(false)
           }}
-          onScoll={() => {
+          onScroll={() => {
             handleScrollToTop()
           }}
           liquidClass={liquidClassName}
@@ -588,7 +588,7 @@ export const SecondStepsMoveLiquidTools = ({
             tab={tab}
             onClick={() => {
               console.log('TODO: wire up onClick handler')
-              setIsResetModal(true)
+              setShowResetModal(true)
             }}
           />
         ) : null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { round } from 'lodash'
@@ -12,15 +12,7 @@ import {
 } from '@opentrons/components'
 import { getMinXYDimension } from '@opentrons/shared-data'
 import { getTrashOrLabware } from '@opentrons/step-generation'
-
-import {
-  BlowoutLocationField,
-  BlowoutOffsetField,
-  DisposalField,
-  FlowRateField,
-  PositionField,
-  WellsOrderField,
-} from '../../PipetteFields'
+import { ResetSettingsModal } from '../../../../../../components/organisms/ResetSettingsModal'
 import { getEnableLiquidClasses } from '../../../../../../feature-flags/selectors'
 import {
   CheckboxExpandStepFormField,
@@ -32,6 +24,8 @@ import {
   getLabwareEntities,
   getPipetteEntities,
 } from '../../../../../../step-forms/selectors'
+import { getLiquidClassDisplayName } from '../../../../../../liquid-defs/utils'
+
 import {
   getMaxConditioningVolume,
   getMaxPushOutVolume,
@@ -42,6 +36,14 @@ import {
   getFormLevelError,
   getLabwareFieldForPositioningField,
 } from '../../utils'
+import {
+  BlowoutLocationField,
+  BlowoutOffsetField,
+  DisposalField,
+  FlowRateField,
+  PositionField,
+  WellsOrderField,
+} from '../../PipetteFields'
 import { MultiInputField } from './MultiInputField'
 import { ResetSettingsField } from './ResetSettingsField'
 
@@ -79,6 +81,8 @@ export const SecondStepsMoveLiquidTools = ({
   )
   const enableLiquidClasses = useSelector(getEnableLiquidClasses)
   const pipetteSpec = useSelector(getPipetteEntities)[formData.pipette]?.spec
+  const [isResetModal, setIsResetModal] = useState<boolean>(false)
+
   const addFieldNamePrefix = addPrefix(tab)
   const isWasteChuteSelected =
     propsForFields.dispense_labware?.value != null
@@ -191,380 +195,404 @@ export const SecondStepsMoveLiquidTools = ({
     }
   }
 
+  const liquidClassName =
+    formData.liquidClass !== ''
+      ? getLiquidClassDisplayName(String(formData.liquidClass))
+      : ''
+
   return (
-    <Flex
-      ref={toolsComponentRef}
-      flexDirection={DIRECTION_COLUMN}
-      width="100%"
-      paddingY={SPACING.spacing16}
-      gridGap={SPACING.spacing12}
-    >
-      <Flex padding={`0 ${SPACING.spacing16}`}>
-        <Tabs tabs={[aspirateTab, dispenseTab]} />
-      </Flex>
-      <Divider marginY="0" />
-      <FlowRateField
-        key={`${addFieldNamePrefix('flowRate')}_flowRateField`}
-        {...propsForFields[addFieldNamePrefix('flowRate')]}
-        pipetteId={formData.pipette}
-        flowRateType={tab}
-        volume={propsForFields.volume?.value ?? 0}
-        tiprack={propsForFields.tipRack.value}
-        showTooltip={false}
-      />
-      <Divider marginY="0" />
-      {hideWellOrderField ? null : (
-        <WellsOrderField
-          prefix={tab}
-          updateFirstWellOrder={
-            propsForFields[addFieldNamePrefix('wellOrder_first')].updateValue
-          }
-          updateSecondWellOrder={
-            propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
-          }
-          firstValue={formData[addFieldNamePrefix('wellOrder_first')]}
-          secondValue={formData[addFieldNamePrefix('wellOrder_second')]}
-          firstName={addFieldNamePrefix('wellOrder_first')}
-          secondName={addFieldNamePrefix('wellOrder_second')}
+    <>
+      {isResetModal ? (
+        <ResetSettingsModal
+          tab={tab}
+          onClose={() => {
+            setIsResetModal(false)
+          }}
+          onScoll={() => {
+            handleScrollToTop()
+          }}
+          liquidClass={liquidClassName}
         />
-      )}
-      <Divider marginY="0" />
-      <PositionField
-        prefix={tab}
-        propsForFields={propsForFields}
-        zField={`${tab}_mmFromBottom`}
-        xField={`${tab}_x_position`}
-        yField={`${tab}_y_position`}
-        labwareId={
-          formData[
-            getLabwareFieldForPositioningField(
-              addFieldNamePrefix('mmFromBottom')
-            )
-          ]
-        }
-        referenceField={`${tab}_position_reference`}
-      />
-      {enableLiquidClasses ? (
-        <>
-          <Divider marginY="0" />
-          <MultiInputField
-            name={t('submerge')}
-            prefix={`${tab}_submerge`}
-            tooltipContent={t(`tooltip:step_fields.defaults.${tab}_submerge`)}
-            propsForFields={propsForFields}
-            fields={getFields('submerge')}
-            isWellPosition
-            labwareId={
-              formData[
-                getLabwareFieldForPositioningField(
-                  addFieldNamePrefix('submerge_mmFromBottom')
-                )
-              ]
-            }
-            referenceField={`${tab}_submerge_position_reference`}
-          />
-          <Divider marginY="0" />
-          <MultiInputField
-            name={t('retract')}
-            prefix={`${tab}_retract`}
-            tooltipContent={t(`tooltip:step_fields.defaults.${tab}_retract`)}
-            propsForFields={propsForFields}
-            fields={getFields('retract')}
-            isWellPosition
-            labwareId={
-              formData[
-                getLabwareFieldForPositioningField(
-                  addFieldNamePrefix('retract_mmFromBottom')
-                )
-              ]
-            }
-            referenceField={`${tab}_retract_position_reference`}
-          />
-        </>
       ) : null}
-      <Divider marginY="0" />
       <Flex
+        ref={toolsComponentRef}
         flexDirection={DIRECTION_COLUMN}
-        gridGap={SPACING.spacing4}
-        padding={`0 ${SPACING.spacing16}`}
+        width="100%"
+        paddingY={SPACING.spacing16}
+        gridGap={SPACING.spacing12}
       >
-        <StyledText desktopStyle="bodyDefaultSemiBold">
-          {t('protocol_steps:advanced_settings')}
-        </StyledText>
-        {tab === 'aspirate' ? (
-          <ToggleStepFormField
-            title={i18n.format(
-              t('form:step_edit_form.field.preWetTip.label'),
-              'capitalize'
-            )}
-            toggleValue={propsForFields.preWetTip.value}
-            isSelected={propsForFields.preWetTip.value === true}
-            toggleUpdateValue={propsForFields.preWetTip.updateValue}
-            toggleElement="checkbox"
-            tooltipContent={propsForFields.preWetTip.tooltipContent ?? null}
+        <Flex padding={`0 ${SPACING.spacing16}`}>
+          <Tabs tabs={[aspirateTab, dispenseTab]} />
+        </Flex>
+        <Divider marginY="0" />
+        <FlowRateField
+          key={`${addFieldNamePrefix('flowRate')}_flowRateField`}
+          {...propsForFields[addFieldNamePrefix('flowRate')]}
+          pipetteId={formData.pipette}
+          flowRateType={tab}
+          volume={propsForFields.volume?.value ?? 0}
+          tiprack={propsForFields.tipRack.value}
+          showTooltip={false}
+        />
+        <Divider marginY="0" />
+        {hideWellOrderField ? null : (
+          <WellsOrderField
+            prefix={tab}
+            updateFirstWellOrder={
+              propsForFields[addFieldNamePrefix('wellOrder_first')].updateValue
+            }
+            updateSecondWellOrder={
+              propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
+            }
+            firstValue={formData[addFieldNamePrefix('wellOrder_first')]}
+            secondValue={formData[addFieldNamePrefix('wellOrder_second')]}
+            firstName={addFieldNamePrefix('wellOrder_first')}
+            secondName={addFieldNamePrefix('wellOrder_second')}
           />
-        ) : null}
-        <CheckboxExpandStepFormField
-          title={i18n.format(
-            t('form:step_edit_form.field.mix.label'),
-            'capitalize'
-          )}
-          fieldProps={propsForFields[`${tab}_mix_checkbox`]}
-          tooltipOverride={
-            tab === 'dispense' ? dispenseMixDisabledTooltipText : null
+        )}
+        <Divider marginY="0" />
+        <PositionField
+          prefix={tab}
+          propsForFields={propsForFields}
+          zField={`${tab}_mmFromBottom`}
+          xField={`${tab}_x_position`}
+          yField={`${tab}_y_position`}
+          labwareId={
+            formData[
+              getLabwareFieldForPositioningField(
+                addFieldNamePrefix('mmFromBottom')
+              )
+            ]
           }
+          referenceField={`${tab}_position_reference`}
+        />
+        {enableLiquidClasses ? (
+          <>
+            <Divider marginY="0" />
+            <MultiInputField
+              name={t('submerge')}
+              prefix={`${tab}_submerge`}
+              tooltipContent={t(`tooltip:step_fields.defaults.${tab}_submerge`)}
+              propsForFields={propsForFields}
+              fields={getFields('submerge')}
+              isWellPosition
+              labwareId={
+                formData[
+                  getLabwareFieldForPositioningField(
+                    addFieldNamePrefix('submerge_mmFromBottom')
+                  )
+                ]
+              }
+              referenceField={`${tab}_submerge_position_reference`}
+            />
+            <Divider marginY="0" />
+            <MultiInputField
+              name={t('retract')}
+              prefix={`${tab}_retract`}
+              tooltipContent={t(`tooltip:step_fields.defaults.${tab}_retract`)}
+              propsForFields={propsForFields}
+              fields={getFields('retract')}
+              isWellPosition
+              labwareId={
+                formData[
+                  getLabwareFieldForPositioningField(
+                    addFieldNamePrefix('retract_mmFromBottom')
+                  )
+                ]
+              }
+              referenceField={`${tab}_retract_position_reference`}
+            />
+          </>
+        ) : null}
+        <Divider marginY="0" />
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          gridGap={SPACING.spacing4}
+          padding={`0 ${SPACING.spacing16}`}
         >
-          {formData[`${tab}_mix_checkbox`] === true ? (
-            <Flex
-              flexDirection={DIRECTION_COLUMN}
-              gridGap={SPACING.spacing6}
-              width="100^"
-            >
-              <InputStepFormField
-                showTooltip={false}
-                padding="0"
-                title={t('protocol_steps:mix_volume')}
-                {...propsForFields[`${tab}_mix_volume`]}
-                units={t('application:units.microliter')}
-                errorToShow={getFormLevelError(
-                  `${tab}_mix_volume`,
-                  mappedErrorsToField
-                )}
-              />
-              <InputStepFormField
-                showTooltip={false}
-                padding="0"
-                title={t('protocol_steps:mix_times')}
-                {...propsForFields[`${tab}_mix_times`]}
-                units={t('application:units.times')}
-                errorToShow={getFormLevelError(
-                  `${tab}_mix_times`,
-                  mappedErrorsToField
-                )}
-              />
-            </Flex>
+          <StyledText desktopStyle="bodyDefaultSemiBold">
+            {t('protocol_steps:advanced_settings')}
+          </StyledText>
+          {tab === 'aspirate' ? (
+            <ToggleStepFormField
+              title={i18n.format(
+                t('form:step_edit_form.field.preWetTip.label'),
+                'capitalize'
+              )}
+              toggleValue={propsForFields.preWetTip.value}
+              isSelected={propsForFields.preWetTip.value === true}
+              toggleUpdateValue={propsForFields.preWetTip.updateValue}
+              toggleElement="checkbox"
+              tooltipContent={propsForFields.preWetTip.tooltipContent ?? null}
+            />
           ) : null}
-        </CheckboxExpandStepFormField>
-        {tab === 'dispense' ? (
           <CheckboxExpandStepFormField
             title={i18n.format(
-              t('form:step_edit_form.field.pushOut.title'),
+              t('form:step_edit_form.field.mix.label'),
               'capitalize'
             )}
-            fieldProps={propsForFields.pushOut_checkbox}
+            fieldProps={propsForFields[`${tab}_mix_checkbox`]}
+            tooltipOverride={
+              tab === 'dispense' ? dispenseMixDisabledTooltipText : null
+            }
           >
-            {formData.pushOut_checkbox === true ? (
-              <InputStepFormField
-                showTooltip={false}
-                padding="0"
-                title={t(
-                  'form:step_edit_form.field.pushOut.pushOut_volume.label'
-                )}
-                caption={t(
-                  'form:step_edit_form.field.pushOut.pushOut_volume.caption',
-                  { min: 0, max: maxPushoutVolume }
-                )}
-                {...propsForFields.pushOut_volume}
-                units={t('application:units.microliter')}
-                errorToShow={getFormLevelError(
-                  'pushOut_volume',
-                  mappedErrorsToField
-                )}
-              />
-            ) : null}
-          </CheckboxExpandStepFormField>
-        ) : null}
-        <CheckboxExpandStepFormField
-          title={i18n.format(
-            t('form:step_edit_form.field.delay.label'),
-            'capitalize'
-          )}
-          fieldProps={propsForFields[`${tab}_delay_checkbox`]}
-        >
-          {formData[`${tab}_delay_checkbox`] === true ? (
-            <Flex
-              flexDirection={DIRECTION_COLUMN}
-              gridGap={SPACING.spacing6}
-              width="100^"
-            >
-              <InputStepFormField
-                showTooltip={false}
-                padding="0"
-                title={t('protocol_steps:delay_duration')}
-                {...propsForFields[`${tab}_delay_seconds`]}
-                units={t('application:units.seconds')}
-                errorToShow={getFormLevelError(
-                  `${tab}_delay_seconds`,
-                  mappedErrorsToField
-                )}
-              />
-            </Flex>
-          ) : null}
-        </CheckboxExpandStepFormField>
-        {tab === 'dispense' && formData.path === 'multiDispense' ? (
-          <CheckboxExpandStepFormField
-            title={t('form:step_edit_form.field.conditioning.title')}
-            fieldProps={propsForFields.conditioning_checkbox}
-          >
-            {formData.conditioning_checkbox === true ? (
-              <InputStepFormField
-                title={t(
-                  'form:step_edit_form.field.conditioning.conditioning_volume.label'
-                )}
-                caption={t(
-                  'form:step_edit_form.field.conditioning.conditioning_volume.caption',
-                  { min: 0, max: maxConditioningVolume }
-                )}
-                padding="0"
-                {...propsForFields.conditioning_volume}
-                showTooltip={false}
-                errorToShow={getFormLevelError(
-                  'conditioning_volume',
-                  mappedErrorsToField
-                )}
-              />
-            ) : null}
-          </CheckboxExpandStepFormField>
-        ) : null}
-        {tab === 'dispense' ? (
-          <CheckboxExpandStepFormField
-            title={i18n.format(
-              t('form:step_edit_form.field.blowout.label'),
-              'capitalize'
-            )}
-            fieldProps={propsForFields.blowout_checkbox}
-          >
-            {formData.blowout_checkbox === true ? (
+            {formData[`${tab}_mix_checkbox`] === true ? (
               <Flex
                 flexDirection={DIRECTION_COLUMN}
                 gridGap={SPACING.spacing6}
                 width="100^"
               >
-                <BlowoutLocationField
-                  {...propsForFields.blowout_location}
-                  options={getBlowoutLocationOptionsForForm({
-                    path: formData.path,
-                    stepType: formData.stepType,
-                  })}
+                <InputStepFormField
+                  showTooltip={false}
                   padding="0"
+                  title={t('protocol_steps:mix_volume')}
+                  {...propsForFields[`${tab}_mix_volume`]}
+                  units={t('application:units.microliter')}
+                  errorToShow={getFormLevelError(
+                    `${tab}_mix_volume`,
+                    mappedErrorsToField
+                  )}
                 />
-                <FlowRateField
-                  key="blowout_flowRate"
-                  {...propsForFields.blowout_flowRate}
-                  pipetteId={formData.pipette}
-                  flowRateType="blowout"
-                  volume={propsForFields.volume?.value ?? 0}
-                  tiprack={propsForFields.tipRack.value}
+                <InputStepFormField
+                  showTooltip={false}
                   padding="0"
-                />
-                <BlowoutOffsetField
-                  {...propsForFields.blowout_z_offset}
-                  sourceLabwareId={propsForFields.aspirate_labware.value}
-                  destLabwareId={propsForFields.dispense_labware.value}
-                  blowoutLabwareId={propsForFields.blowout_location.value}
+                  title={t('protocol_steps:mix_times')}
+                  {...propsForFields[`${tab}_mix_times`]}
+                  units={t('application:units.times')}
+                  errorToShow={getFormLevelError(
+                    `${tab}_mix_times`,
+                    mappedErrorsToField
+                  )}
                 />
               </Flex>
             ) : null}
           </CheckboxExpandStepFormField>
-        ) : null}
-        <CheckboxExpandStepFormField
-          title={i18n.format(
-            t('form:step_edit_form.field.touchTip.label'),
-            'capitalize'
-          )}
-          fieldProps={propsForFields[`${tab}_touchTip_checkbox`]}
-        >
-          {formData[`${tab}_touchTip_checkbox`] === true ? (
-            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing10}>
-              <InputStepFormField
-                showTooltip={false}
-                padding="0"
-                title={t('form:step_edit_form.field.touchTip_speed.label')}
-                {...propsForFields[`${tab}_touchTip_speed`]}
-                errorToShow={getFormLevelError(
-                  `${tab}_touchTip_speed`,
-                  mappedErrorsToField
-                )}
-                units={t('application:units.millimeterPerSec')}
-              />
-              <InputStepFormField
-                showTooltip={false}
-                padding="0"
-                title={t('form:step_edit_form.field.touchTip_mmFromEdge.label')}
-                {...propsForFields[`${tab}_touchTip_mmFromEdge`]}
-                errorToShow={getFormLevelError(
-                  `${tab}_touchTip_mmFromEdge`,
-                  mappedErrorsToField
-                )}
-                caption={t(
-                  `form:step_edit_form.field.touchTip_mmFromEdge.caption`,
-                  {
-                    min: 0,
-                    max: minRadiusForTouchTip,
-                  }
-                )}
-                units={t('application:units.millimeter')}
-              />
-              <PositionField
-                prefix={tab}
-                propsForFields={propsForFields}
-                zField={`${tab}_touchTip_mmFromTop`}
-                labwareId={
-                  formData[
-                    getLabwareFieldForPositioningField(
-                      addFieldNamePrefix('touchTip_mmFromTop')
-                    )
-                  ]
-                }
-                showButton
-                padding="0"
-                isNested
-              />
-            </Flex>
-          ) : null}
-        </CheckboxExpandStepFormField>
-        <CheckboxExpandStepFormField
-          title={i18n.format(
-            t('form:step_edit_form.field.airGap.label'),
-            'capitalize'
-          )}
-          fieldProps={propsForFields[`${tab}_airGap_checkbox`]}
-        >
-          {formData[`${tab}_airGap_checkbox`] === true ? (
-            <InputStepFormField
-              showTooltip={false}
-              padding="0"
-              title={t('protocol_steps:air_gap_volume')}
-              {...propsForFields[`${tab}_airGap_volume`]}
-              units={t('application:units.microliter')}
-              errorToShow={getFormLevelError(
-                `${tab}_airGap_volume`,
-                mappedErrorsToField
+          {tab === 'dispense' ? (
+            <CheckboxExpandStepFormField
+              title={i18n.format(
+                t('form:step_edit_form.field.pushOut.title'),
+                'capitalize'
               )}
-            />
+              fieldProps={propsForFields.pushOut_checkbox}
+            >
+              {formData.pushOut_checkbox === true ? (
+                <InputStepFormField
+                  showTooltip={false}
+                  padding="0"
+                  title={t(
+                    'form:step_edit_form.field.pushOut.pushOut_volume.label'
+                  )}
+                  caption={t(
+                    'form:step_edit_form.field.pushOut.pushOut_volume.caption',
+                    { min: 0, max: maxPushoutVolume }
+                  )}
+                  {...propsForFields.pushOut_volume}
+                  units={t('application:units.microliter')}
+                  errorToShow={getFormLevelError(
+                    'pushOut_volume',
+                    mappedErrorsToField
+                  )}
+                />
+              ) : null}
+            </CheckboxExpandStepFormField>
           ) : null}
-        </CheckboxExpandStepFormField>
-        {formData.path === 'multiDispense' && tab === 'dispense' && (
-          <DisposalField
-            aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
-            aspirate_airGap_volume={formData.aspirate_airGap_volume}
-            path={formData.path}
-            pipette={formData.pipette}
-            propsForFields={propsForFields}
-            stepType={formData.stepType}
-            volume={formData.volume}
+          <CheckboxExpandStepFormField
+            title={i18n.format(
+              t('form:step_edit_form.field.delay.label'),
+              'capitalize'
+            )}
+            fieldProps={propsForFields[`${tab}_delay_checkbox`]}
+          >
+            {formData[`${tab}_delay_checkbox`] === true ? (
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                gridGap={SPACING.spacing6}
+                width="100^"
+              >
+                <InputStepFormField
+                  showTooltip={false}
+                  padding="0"
+                  title={t('protocol_steps:delay_duration')}
+                  {...propsForFields[`${tab}_delay_seconds`]}
+                  units={t('application:units.seconds')}
+                  errorToShow={getFormLevelError(
+                    `${tab}_delay_seconds`,
+                    mappedErrorsToField
+                  )}
+                />
+              </Flex>
+            ) : null}
+          </CheckboxExpandStepFormField>
+          {tab === 'dispense' && formData.path === 'multiDispense' ? (
+            <CheckboxExpandStepFormField
+              title={t('form:step_edit_form.field.conditioning.title')}
+              fieldProps={propsForFields.conditioning_checkbox}
+            >
+              {formData.conditioning_checkbox === true ? (
+                <InputStepFormField
+                  title={t(
+                    'form:step_edit_form.field.conditioning.conditioning_volume.label'
+                  )}
+                  caption={t(
+                    'form:step_edit_form.field.conditioning.conditioning_volume.caption',
+                    { min: 0, max: maxConditioningVolume }
+                  )}
+                  padding="0"
+                  {...propsForFields.conditioning_volume}
+                  showTooltip={false}
+                  errorToShow={getFormLevelError(
+                    'conditioning_volume',
+                    mappedErrorsToField
+                  )}
+                />
+              ) : null}
+            </CheckboxExpandStepFormField>
+          ) : null}
+          {tab === 'dispense' ? (
+            <CheckboxExpandStepFormField
+              title={i18n.format(
+                t('form:step_edit_form.field.blowout.label'),
+                'capitalize'
+              )}
+              fieldProps={propsForFields.blowout_checkbox}
+            >
+              {formData.blowout_checkbox === true ? (
+                <Flex
+                  flexDirection={DIRECTION_COLUMN}
+                  gridGap={SPACING.spacing6}
+                  width="100^"
+                >
+                  <BlowoutLocationField
+                    {...propsForFields.blowout_location}
+                    options={getBlowoutLocationOptionsForForm({
+                      path: formData.path,
+                      stepType: formData.stepType,
+                    })}
+                    padding="0"
+                  />
+                  <FlowRateField
+                    key="blowout_flowRate"
+                    {...propsForFields.blowout_flowRate}
+                    pipetteId={formData.pipette}
+                    flowRateType="blowout"
+                    volume={propsForFields.volume?.value ?? 0}
+                    tiprack={propsForFields.tipRack.value}
+                    padding="0"
+                  />
+                  <BlowoutOffsetField
+                    {...propsForFields.blowout_z_offset}
+                    sourceLabwareId={propsForFields.aspirate_labware.value}
+                    destLabwareId={propsForFields.dispense_labware.value}
+                    blowoutLabwareId={propsForFields.blowout_location.value}
+                  />
+                </Flex>
+              ) : null}
+            </CheckboxExpandStepFormField>
+          ) : null}
+          <CheckboxExpandStepFormField
+            title={i18n.format(
+              t('form:step_edit_form.field.touchTip.label'),
+              'capitalize'
+            )}
+            fieldProps={propsForFields[`${tab}_touchTip_checkbox`]}
+          >
+            {formData[`${tab}_touchTip_checkbox`] === true ? (
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                gridGap={SPACING.spacing10}
+              >
+                <InputStepFormField
+                  showTooltip={false}
+                  padding="0"
+                  title={t('form:step_edit_form.field.touchTip_speed.label')}
+                  {...propsForFields[`${tab}_touchTip_speed`]}
+                  errorToShow={getFormLevelError(
+                    `${tab}_touchTip_speed`,
+                    mappedErrorsToField
+                  )}
+                  units={t('application:units.millimeterPerSec')}
+                />
+                <InputStepFormField
+                  showTooltip={false}
+                  padding="0"
+                  title={t(
+                    'form:step_edit_form.field.touchTip_mmFromEdge.label'
+                  )}
+                  {...propsForFields[`${tab}_touchTip_mmFromEdge`]}
+                  errorToShow={getFormLevelError(
+                    `${tab}_touchTip_mmFromEdge`,
+                    mappedErrorsToField
+                  )}
+                  caption={t(
+                    `form:step_edit_form.field.touchTip_mmFromEdge.caption`,
+                    {
+                      min: 0,
+                      max: minRadiusForTouchTip,
+                    }
+                  )}
+                  units={t('application:units.millimeter')}
+                />
+                <PositionField
+                  prefix={tab}
+                  propsForFields={propsForFields}
+                  zField={`${tab}_touchTip_mmFromTop`}
+                  labwareId={
+                    formData[
+                      getLabwareFieldForPositioningField(
+                        addFieldNamePrefix('touchTip_mmFromTop')
+                      )
+                    ]
+                  }
+                  showButton
+                  padding="0"
+                  isNested
+                />
+              </Flex>
+            ) : null}
+          </CheckboxExpandStepFormField>
+          <CheckboxExpandStepFormField
+            title={i18n.format(
+              t('form:step_edit_form.field.airGap.label'),
+              'capitalize'
+            )}
+            fieldProps={propsForFields[`${tab}_airGap_checkbox`]}
+          >
+            {formData[`${tab}_airGap_checkbox`] === true ? (
+              <InputStepFormField
+                showTooltip={false}
+                padding="0"
+                title={t('protocol_steps:air_gap_volume')}
+                {...propsForFields[`${tab}_airGap_volume`]}
+                units={t('application:units.microliter')}
+                errorToShow={getFormLevelError(
+                  `${tab}_airGap_volume`,
+                  mappedErrorsToField
+                )}
+              />
+            ) : null}
+          </CheckboxExpandStepFormField>
+          {formData.path === 'multiDispense' && tab === 'dispense' && (
+            <DisposalField
+              aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
+              aspirate_airGap_volume={formData.aspirate_airGap_volume}
+              path={formData.path}
+              pipette={formData.pipette}
+              propsForFields={propsForFields}
+              stepType={formData.stepType}
+              volume={formData.volume}
+            />
+          )}
+        </Flex>
+        {enableLiquidClasses ? (
+          <ResetSettingsField
+            tab={tab}
+            onClick={() => {
+              console.log('TODO: wire up onClick handler')
+              setIsResetModal(true)
+            }}
           />
-        )}
+        ) : null}
       </Flex>
-      {enableLiquidClasses ? (
-        <ResetSettingsField
-          tab={tab}
-          onClick={() => {
-            console.log('TODO: wire up onClick handler')
-            handleScrollToTop()
-          }}
-        />
-      ) : null}
-    </Flex>
+    </>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -195,11 +195,6 @@ export const SecondStepsMoveLiquidTools = ({
     }
   }
 
-  const liquidClassName =
-    formData.liquidClass !== ''
-      ? getLiquidClassDisplayName(String(formData.liquidClass))
-      : ''
-
   return (
     <>
       {showResetModal ? (
@@ -211,7 +206,7 @@ export const SecondStepsMoveLiquidTools = ({
           onScroll={() => {
             handleScrollToTop()
           }}
-          liquidClass={liquidClassName}
+          liquidClass={formData.liquidClass}
         />
       ) : null}
       <Flex

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -24,7 +24,6 @@ import {
   getLabwareEntities,
   getPipetteEntities,
 } from '../../../../../../step-forms/selectors'
-import { getLiquidClassDisplayName } from '../../../../../../liquid-defs/utils'
 
 import {
   getMaxConditioningVolume,


### PR DESCRIPTION
re AUTH-1674

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->
This PR is adding a reset confirmation modal that appears when users click the “Reset aspirate/dispense settings” button. Currently, the reset action isn’t triggered when users choose to continue, since the logic hasn’t been wired up yet.

The modal behavior depends on whether a liquid class is selected:
-With liquid class selected: Users see a confirmation modal that shows which settings will be reset (e.g., aspirate/dispense values).
![image](https://github.com/user-attachments/assets/6ac29d31-aaf7-44cc-bfb4-3d4ef1798a1f)
-Without liquid class selected: Users see a different modal informing them that no liquid class is selected, and settings will be reset to default.
![image](https://github.com/user-attachments/assets/71e8543c-725c-49d8-9347-c2fae5393299)

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->
1. Create or import a protocol and enable the Liquid Classes feature flag.
2. Add a Transfer and a Mix step.
3. Proceed to Page 3 of the step form and scroll to the bottom.
4. Click on the “Reset Aspirate/Dispense Settings” button.
5. Verify: A modal should pop up asking for confirmation before resetting.


## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
-Added a ResetSettingsModal component that display a confirmation modal
-Update Transfer and Mix step form

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
