### PR TITLE
refactor(api): stop mocking protocol_api.validation in test_instrument_context.py

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -231,7 +231,7 @@ class InstrumentContext(publisher.CommandPublisher):
         )
 
         move_to_location: types.Location
-        well: Optional[labware.Well] = None
+        well: Optional[labware.Well]
         last_location = self._get_last_location_by_api_version()
         try:
             target = validation.validate_location(

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -47,7 +47,6 @@ from opentrons.protocol_api import (
     labware,
     LiquidClass,
 )
-from opentrons.protocol_api.validation import WellTarget, PointTarget
 from opentrons.protocol_api.core.common import InstrumentCore, ProtocolCore
 from opentrons.protocol_api.core.legacy.legacy_instrument_core import (
     LegacyInstrumentCore,

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import ContextManager, Optional, Any
 from unittest.mock import sentinel
 
-from decoy import Decoy
+from decoy import Decoy, matchers
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
 from opentrons.protocol_engine.commands.pipetting_common import LiquidNotFoundError
@@ -45,7 +45,6 @@ from opentrons.protocol_api import (
     Labware,
     Well,
     labware,
-    validation as mock_validation,
     LiquidClass,
 )
 from opentrons.protocol_api.validation import WellTarget, PointTarget
@@ -67,12 +66,6 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
 )
 from opentrons_shared_data.robot.types import RobotType
 from . import versions_at_or_above, versions_between
-
-
-@pytest.fixture(autouse=True)
-def _mock_validation_module(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
-    for name, func in inspect.getmembers(mock_validation, inspect.isfunction):
-        monkeypatch.setattr(mock_validation, name, decoy.mock(func=func))
 
 
 @pytest.fixture(autouse=True)
@@ -323,24 +316,22 @@ def test_aspirate(
     mock_protocol_core: ProtocolCore,
 ) -> None:
     """It should aspirate to a well."""
+    # Before PR #12105, this function tested calling aspirate(location=Well).
+    # Then this function was changed to call aspirate(location=Location), but that's
+    # the same thing that test_aspirate_well_location() is testing for.
+    # So we're restoring this function to test for aspirate(location=Well).
     mock_well = decoy.mock(cls=Well)
     bottom_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    input_location = Location(point=Point(2, 2, 2), labware=None)
     last_location = Location(point=Point(9, 9, 9), labware=None)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
     decoy.when(mock_well.bottom(z=1.0)).then_return(bottom_location)
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
 
-    subject.aspirate(volume=42.0, location=input_location, rate=1.23)
+    subject.aspirate(volume=42.0, location=mock_well, rate=1.23)
 
     decoy.verify(
         mock_instrument_core.aspirate(
@@ -371,11 +362,6 @@ def test_aspirate_well_location(
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=input_location, in_place=False))
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
 
     subject.aspirate(volume=42.0, location=input_location, rate=1.23)
@@ -409,11 +395,6 @@ def test_aspirate_meniscus_well_location(
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=input_location, in_place=False))
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
 
     subject.aspirate(volume=42.0, location=input_location, rate=1.23)
@@ -440,17 +421,12 @@ def test_aspirate_from_coordinates(
 ) -> None:
     """It should aspirate from given coordinates."""
     input_location = Location(point=Point(2, 2, 2), labware=None)
-    last_location = Location(point=Point(9, 9, 9), labware=None)
+    last_location = input_location  # to demonstrate in_place=True
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(PointTarget(location=input_location, in_place=True))
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
 
     subject.aspirate(volume=42.0, location=input_location, rate=1.23)
@@ -475,13 +451,10 @@ def test_aspirate_raises_no_location(
     subject: InstrumentContext,
     mock_protocol_core: ProtocolCore,
 ) -> None:
-    """Shound raise a RuntimeError error."""
+    """Should raise a RuntimeError error."""
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(None)
 
-    decoy.when(
-        mock_validation.validate_location(location=None, last_location=None)
-    ).then_raise(mock_validation.NoLocationError())
     with pytest.raises(RuntimeError):
         subject.aspirate(location=None)
 
@@ -495,20 +468,14 @@ def test_blow_out_to_well(
     """It should blow out to a well."""
     mock_well = decoy.mock(cls=Well)
     top_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    input_location = Location(point=Point(2, 2, 2), labware=None)
     last_location = Location(point=Point(9, 9, 9), labware=None)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
     decoy.when(mock_well.top()).then_return(top_location)
-    subject.blow_out(location=input_location)
+    subject.blow_out(location=mock_well)
 
     decoy.verify(
         mock_instrument_core.blow_out(
@@ -526,18 +493,13 @@ def test_blow_out_to_well_location(
 ) -> None:
     """It should blow out to a well location."""
     mock_well = decoy.mock(cls=Well)
-    input_location = Location(point=Point(2, 2, 2), labware=None)
+    input_location = Location(point=Point(2, 2, 2), labware=mock_well)
     last_location = Location(point=Point(9, 9, 9), labware=None)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=input_location, in_place=False))
     subject.blow_out(location=input_location)
 
     decoy.verify(
@@ -555,20 +517,13 @@ def test_blow_out_to_location(
     mock_protocol_core: ProtocolCore,
 ) -> None:
     """It should blow out to a location."""
-    mock_well = decoy.mock(cls=Well)
-    input_location = Location(point=Point(2, 2, 2), labware=mock_well)
-    last_location = Location(point=Point(9, 9, 9), labware=None)
-    point_target = PointTarget(location=input_location, in_place=True)
+    input_location = Location(point=Point(2, 2, 2), labware=None)
+    last_location = input_location  # to demonstrate how we set in_place=True
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(point_target)
 
     subject.blow_out(location=input_location)
 
@@ -590,9 +545,6 @@ def test_blow_out_raises_no_location(
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(None)
 
-    decoy.when(
-        mock_validation.validate_location(location=None, last_location=None)
-    ).then_raise(mock_validation.NoLocationError())
     with pytest.raises(RuntimeError):
         subject.blow_out(location=None)
 
@@ -953,17 +905,12 @@ def test_dispense_with_location(
 ) -> None:
     """It should dispense to a given location."""
     input_location = Location(point=Point(2, 2, 2), labware=None)
-    last_location = Location(point=Point(9, 9, 9), labware=None)
+    last_location = input_location  # to demonstrate in_place=True
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(PointTarget(location=input_location, in_place=True))
     decoy.when(mock_instrument_core.get_dispense_flow_rate(1.23)).then_return(5.67)
 
     subject.dispense(volume=42.0, location=input_location, rate=1.23)
@@ -991,18 +938,13 @@ def test_dispense_with_well_location(
 ) -> None:
     """It should dispense to a well location."""
     mock_well = decoy.mock(cls=Well)
-    input_location = Location(point=Point(2, 2, 2), labware=None)
+    input_location = Location(point=Point(2, 2, 2), labware=mock_well)
     last_location = Location(point=Point(9, 9, 9), labware=None)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=input_location, in_place=False))
     decoy.when(mock_instrument_core.get_dispense_flow_rate(1.23)).then_return(3.0)
 
     subject.dispense(volume=42.0, location=input_location, rate=1.23, push_out=7)
@@ -1031,22 +973,16 @@ def test_dispense_with_well(
     """It should dispense to a well."""
     mock_well = decoy.mock(cls=Well)
     bottom_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    input_location = Location(point=Point(2, 2, 2), labware=None)
     last_location = Location(point=Point(9, 9, 9), labware=None)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
     decoy.when(mock_well.bottom(z=1.0)).then_return(bottom_location)
     decoy.when(mock_instrument_core.get_dispense_flow_rate(1.23)).then_return(5.67)
 
-    subject.dispense(volume=42.0, location=input_location, rate=1.23, push_out=None)
+    subject.dispense(volume=42.0, location=mock_well, rate=1.23, push_out=None)
 
     decoy.verify(
         mock_instrument_core.dispense(
@@ -1073,9 +1009,6 @@ def test_dispense_raises_no_location(
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(None)
 
-    decoy.when(
-        mock_validation.validate_location(location=None, last_location=None)
-    ).then_raise(mock_validation.NoLocationError())
     with pytest.raises(RuntimeError):
         subject.dispense(location=None)
 
@@ -1091,9 +1024,6 @@ def test_dispense_push_out_on_not_allowed_version(
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(None)
 
-    decoy.when(
-        mock_validation.validate_location(location=None, last_location=None)
-    ).then_raise(mock_validation.NoLocationError())
     with pytest.raises(APIVersionError):
         subject.dispense(push_out=3)
 
@@ -1296,9 +1226,6 @@ def test_dispense_0_volume_means_dispense_everything(
 ) -> None:
     """It should dispense all liquid to a well."""
     input_location = Location(point=Point(2, 2, 2), labware=None)
-    decoy.when(
-        mock_validation.validate_location(location=input_location, last_location=None)
-    ).then_return(mock_validation.PointTarget(location=input_location, in_place=False))
     decoy.when(mock_instrument_core.get_current_volume()).then_return(100)
     decoy.when(mock_instrument_core.get_dispense_flow_rate(1.23)).then_return(5.67)
     subject.dispense(volume=0, location=input_location, rate=1.23, push_out=None)
@@ -1327,9 +1254,6 @@ def test_dispense_0_volume_means_dispense_nothing(
 ) -> None:
     """It should dispense no liquid to a well."""
     input_location = Location(point=Point(2, 2, 2), labware=None)
-    decoy.when(
-        mock_validation.validate_location(location=input_location, last_location=None)
-    ).then_return(mock_validation.PointTarget(location=input_location, in_place=False))
     decoy.when(mock_instrument_core.get_dispense_flow_rate(1.23)).then_return(5.67)
     subject.dispense(volume=0, location=input_location, rate=1.23, push_out=None)
 
@@ -1365,11 +1289,6 @@ def test_aspirate_0_volume_means_aspirate_everything(
         last_location
     )
 
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=input_location, in_place=False))
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
     decoy.when(mock_instrument_core.get_available_volume()).then_return(200)
     subject.aspirate(volume=0, location=input_location, rate=1.23)
@@ -1405,11 +1324,6 @@ def test_aspirate_0_volume_means_aspirate_nothing(
         last_location
     )
 
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=input_location, in_place=False))
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
 
     subject.aspirate(volume=0, location=input_location, rate=1.23)
@@ -1515,20 +1429,14 @@ def test_mix_no_lpd(
 
     bottom_location = Location(point=Point(1, 2, 3), labware=mock_well)
     top_location = Location(point=Point(3, 2, 1), labware=None)
-    input_location = Location(point=Point(2, 2, 2), labware=None)
     last_location = Location(point=Point(9, 9, 9), labware=None)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.LEFT)).then_return(
-        last_location
+        # We start at last_location, then we're at bottom_location for the
+        # subsequent dispenses/aspirates
+        last_location,
+        bottom_location,
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
-    decoy.when(
-        mock_validation.validate_location(location=None, last_location=last_location)
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
     decoy.when(mock_well.bottom(z=1.0)).then_return(bottom_location)
     decoy.when(mock_well.top()).then_return(top_location)
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
@@ -1536,7 +1444,7 @@ def test_mix_no_lpd(
     decoy.when(mock_instrument_core.has_tip()).then_return(True)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0.0)
 
-    subject.mix(repetitions=10, volume=10.0, location=input_location, rate=1.23)
+    subject.mix(repetitions=10, volume=10.0, location=mock_well, rate=1.23)
     decoy.verify(
         mock_instrument_core.aspirate(
             bottom_location,
@@ -1544,7 +1452,7 @@ def test_mix_no_lpd(
             10.0,
             1.23,
             5.67,
-            False,
+            matchers.Anything(),  # first one is not in_place, the other 9 are in_place
             None,
         ),
         times=10,
@@ -1559,7 +1467,7 @@ def test_mix_no_lpd(
                 10.0,
                 1.23,
                 5.67,
-                False,
+                True,
                 None,
                 None,
             ),
@@ -1573,7 +1481,7 @@ def test_mix_no_lpd(
                 10.0,
                 1.23,
                 5.67,
-                False,
+                True,
                 0.0,
                 None,
             ),
@@ -1586,7 +1494,7 @@ def test_mix_no_lpd(
                 10.0,
                 1.23,
                 5.67,
-                False,
+                True,
                 None,
                 None,
             ),
@@ -1611,20 +1519,14 @@ def test_mix_with_lpd(
     mock_well = decoy.mock(cls=Well)
     bottom_location = Location(point=Point(1, 2, 3), labware=mock_well)
     top_location = Location(point=Point(3, 2, 1), labware=None)
-    input_location = Location(point=Point(2, 2, 2), labware=None)
     last_location = Location(point=Point(9, 9, 9), labware=None)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.LEFT)).then_return(
-        last_location
+        # We start at last_location, then we're at bottom_location for the
+        # subsequent dispenses/aspirates
+        last_location,
+        bottom_location,
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
-    decoy.when(
-        mock_validation.validate_location(location=None, last_location=last_location)
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
     decoy.when(mock_well.bottom(z=1.0)).then_return(bottom_location)
     decoy.when(mock_well.top()).then_return(top_location)
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
@@ -1637,7 +1539,7 @@ def test_mix_with_lpd(
     )
 
     subject.liquid_presence_detection = True
-    subject.mix(repetitions=10, volume=10.0, location=input_location, rate=1.23)
+    subject.mix(repetitions=10, volume=10.0, location=mock_well, rate=1.23)
     decoy.verify(
         mock_instrument_core.aspirate(
             bottom_location,
@@ -1645,7 +1547,7 @@ def test_mix_with_lpd(
             10.0,
             1.23,
             5.67,
-            False,
+            matchers.Anything(),  # first one is not in_place, the other 9 are in_place
             None,
         ),
         times=10,
@@ -1657,7 +1559,7 @@ def test_mix_with_lpd(
             10.0,
             1.23,
             5.67,
-            False,
+            True,
             0.0,
             None,
         ),
@@ -1670,7 +1572,7 @@ def test_mix_with_lpd(
             10.0,
             1.23,
             5.67,
-            False,
+            True,
             None,
             None,
         ),
@@ -1696,20 +1598,11 @@ def test_aspirate_with_lpd(
     mock_well = decoy.mock(cls=Well)
     bottom_location = Location(point=Point(1, 2, 3), labware=mock_well)
     top_location = Location(point=Point(3, 2, 1), labware=None)
-    input_location = Location(point=Point(2, 2, 2), labware=None)
     last_location = Location(point=Point(9, 9, 9), labware=None)
 
     decoy.when(mock_protocol_core.get_last_location(Mount.LEFT)).then_return(
         last_location
     )
-    decoy.when(
-        mock_validation.validate_location(
-            location=input_location, last_location=last_location
-        )
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
-    decoy.when(
-        mock_validation.validate_location(location=None, last_location=last_location)
-    ).then_return(WellTarget(well=mock_well, location=None, in_place=False))
     decoy.when(mock_well.bottom(z=1.0)).then_return(bottom_location)
     decoy.when(mock_well.top()).then_return(top_location)
     decoy.when(mock_instrument_core.get_aspirate_flow_rate(1.23)).then_return(5.67)
@@ -1722,7 +1615,7 @@ def test_aspirate_with_lpd(
     )
 
     subject.liquid_presence_detection = True
-    subject.aspirate(volume=10.0, location=input_location, rate=1.23)
+    subject.aspirate(volume=10.0, location=mock_well, rate=1.23)
     decoy.verify(
         mock_instrument_core.aspirate(
             bottom_location,
@@ -1811,14 +1704,11 @@ def test_transfer_liquid_raises_for_invalid_locations(
     test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_raise(ValueError("Oh no"))
     with pytest.raises(ValueError):
         subject.transfer_liquid(
             liquid_class=test_liq_class,
             volume=10,
-            source=[mock_well],
+            source=[],
             dest=[[mock_well]],
         )
 
@@ -1840,16 +1730,7 @@ def test_transfer_liquid_raises_for_unequal_source_and_dest(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well, mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     with pytest.raises(
         ValueError, match="Sources and destinations should be of the same length"
     ):
@@ -1857,7 +1738,7 @@ def test_transfer_liquid_raises_for_unequal_source_and_dest(
             liquid_class=test_liq_class,
             volume=10,
             source=mock_well,
-            dest=[mock_well],
+            dest=[mock_well, mock_well],
             trash_location=trash_location,
         )
 
@@ -1878,9 +1759,6 @@ def test_transfer_liquid_raises_for_non_liquid_handling_locations(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
     decoy.when(
         mock_instrument_support.validate_takes_liquid(
             mock_well.top(), reject_module=True, reject_adapter=True
@@ -1908,19 +1786,13 @@ def test_transfer_liquid_raises_for_bad_tip_policy(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("once")).then_raise(
-        ValueError("Uh oh")
-    )
-    with pytest.raises(ValueError, match="Uh oh"):
+    with pytest.raises(ValueError, match="invalid value for 'new_tip'"):
         subject.transfer_liquid(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
             dest=[mock_well],
-            new_tip="once",
+            new_tip="twice",  # type: ignore[arg-type]
         )
 
 
@@ -1940,12 +1812,6 @@ def test_transfer_liquid_raises_for_no_tip(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.NEVER
-    )
     with pytest.raises(RuntimeError, match="Pipette has no tip"):
         subject.transfer_liquid(
             liquid_class=test_liq_class,
@@ -1974,12 +1840,6 @@ def test_transfer_liquid_raises_if_tip_has_liquid(
     subject.tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(
@@ -1997,7 +1857,7 @@ def test_transfer_liquid_raises_if_tip_has_liquid(
             volume=10,
             source=[mock_well],
             dest=[mock_well],
-            new_tip="never",
+            new_tip="once",
         )
 
 
@@ -2020,18 +1880,9 @@ def test_transfer_liquid_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.transfer_liquid(
@@ -2039,7 +1890,7 @@ def test_transfer_liquid_delegates_to_engine_core(
         volume=10,
         source=[mock_well],
         dest=[mock_well],
-        new_tip="never",
+        new_tip="once",
         trash_location=trash_location,
         return_tip=True,
     )
@@ -2051,7 +1902,7 @@ def test_transfer_liquid_delegates_to_engine_core(
             dest=[(Location(Point(), labware=mock_well), mock_well._core)],
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
-            trash_location=trash_location.move(Point(1, 2, 3)),
+            trash_location=trash_location,
             return_tip=True,
         )
     )
@@ -2076,14 +1927,6 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(
-            [[mock_well, mock_well]]
-        )
-    ).then_return([mock_well, mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(2)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
@@ -2095,9 +1938,6 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
 
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.transfer_liquid(
@@ -2105,7 +1945,7 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
         volume=10,
         source=[[mock_well, mock_well]],
         dest=[[mock_well, mock_well]],
-        new_tip="never",
+        new_tip="once",
         trash_location=trash_location,
         return_tip=True,
     )
@@ -2117,7 +1957,7 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
             dest=[(Location(Point(), labware=mock_well), mock_well._core)],
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
-            trash_location=trash_location.move(Point(1, 2, 3)),
+            trash_location=trash_location,
             return_tip=True,
         )
     )
@@ -2139,21 +1979,7 @@ def test_distribute_liquid_raises_if_more_than_one_source(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(
-            [mock_well, mock_well]
-        )
-    ).then_return([mock_well, mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("once")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location)
     with pytest.raises(ValueError, match="Source should be a single well"):
         subject.distribute_liquid(
             liquid_class=test_liq_class,
@@ -2181,12 +2007,6 @@ def test_distribute_liquid_raises_for_non_liquid_handling_locations(
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
     decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(
         mock_instrument_support.validate_takes_liquid(
             mock_well.top(), reject_module=True, reject_adapter=True
         )
@@ -2213,22 +2033,13 @@ def test_distribute_liquid_raises_for_bad_tip_policy(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("once")).then_raise(
-        ValueError("Uh oh")
-    )
-    with pytest.raises(ValueError, match="Uh oh"):
+    with pytest.raises(ValueError, match="invalid value for 'new_tip'"):
         subject.distribute_liquid(
             liquid_class=test_liq_class,
             volume=10,
             source=mock_well,
             dest=[mock_well],
-            new_tip="once",
+            new_tip="twice",  # type: ignore[arg-type]
         )
 
 
@@ -2248,15 +2059,6 @@ def test_distribute_liquid_raises_for_no_tip(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.NEVER
-    )
     with pytest.raises(RuntimeError, match="Pipette has no tip"):
         subject.distribute_liquid(
             liquid_class=test_liq_class,
@@ -2285,15 +2087,6 @@ def test_distribute_liquid_raises_if_tip_has_liquid(
     subject.tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(
@@ -2311,7 +2104,7 @@ def test_distribute_liquid_raises_if_tip_has_liquid(
             volume=10,
             source=mock_well,
             dest=[mock_well],
-            new_tip="never",
+            new_tip="once",
         )
 
 
@@ -2331,19 +2124,7 @@ def test_distribute_liquid_raises_if_tip_policy_per_source(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("per source")).then_return(
-        TransferTipPolicyV2.PER_SOURCE
-    )
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     with pytest.raises(
         RuntimeError, match='"per source" incompatible with distribute.'
     ):
@@ -2376,21 +2157,9 @@ def test_distribute_liquid_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.distribute_liquid(
@@ -2398,7 +2167,7 @@ def test_distribute_liquid_delegates_to_engine_core(
         volume=10,
         source=mock_well,
         dest=[mock_well],
-        new_tip="never",
+        new_tip="once",
         trash_location=trash_location,
         return_tip=True,
     )
@@ -2410,7 +2179,7 @@ def test_distribute_liquid_delegates_to_engine_core(
             dest=[(Location(Point(), labware=mock_well), mock_well._core)],
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
-            trash_location=trash_location.move(Point(1, 2, 3)),
+            trash_location=trash_location,
             return_tip=True,
         )
     )
@@ -2435,19 +2204,6 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(
-            [mock_well, mock_well, mock_well]
-        )
-    ).then_return([mock_well, mock_well, mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(
-            [[mock_well, mock_well]]
-        )
-    ).then_return([mock_well, mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(2)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
@@ -2464,9 +2220,6 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
 
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.distribute_liquid(
@@ -2474,7 +2227,7 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
         volume=10,
         source=[mock_well, mock_well, mock_well],
         dest=[[mock_well, mock_well]],
-        new_tip="never",
+        new_tip="once",
         trash_location=trash_location,
         return_tip=True,
     )
@@ -2489,7 +2242,7 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
             ],
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
-            trash_location=trash_location.move(Point(1, 2, 3)),
+            trash_location=trash_location,
             return_tip=True,
         )
     )
@@ -2511,18 +2264,7 @@ def test_consolidate_liquid_raises_if_more_than_one_destination(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(
-            [mock_well, mock_well]
-        )
-    ).then_return([mock_well, mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("once")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location)
     with pytest.raises(ValueError, match="Destination should be a single well"):
         subject.consolidate_liquid(
             liquid_class=test_liq_class,
@@ -2550,12 +2292,6 @@ def test_consolidate_liquid_raises_for_non_liquid_handling_locations(
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
     decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(
         mock_instrument_support.validate_takes_liquid(
             mock_well.top(), reject_module=True, reject_adapter=True
         )
@@ -2582,22 +2318,13 @@ def test_consolidate_liquid_raises_for_bad_tip_policy(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("once")).then_raise(
-        ValueError("Uh oh")
-    )
-    with pytest.raises(ValueError, match="Uh oh"):
+    with pytest.raises(ValueError, match="invalid value for 'new_tip'"):
         subject.consolidate_liquid(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
             dest=mock_well,
-            new_tip="once",
+            new_tip="twice",  # type: ignore[arg-type]
         )
 
 
@@ -2617,15 +2344,6 @@ def test_consolidate_liquid_raises_for_no_tip(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.NEVER
-    )
     with pytest.raises(RuntimeError, match="Pipette has no tip"):
         subject.consolidate_liquid(
             liquid_class=test_liq_class,
@@ -2657,15 +2375,6 @@ def test_consolidate_liquid_raises_if_tip_has_liquid(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     decoy.when(mock_instrument_core.get_current_volume()).then_return(1000)
     with pytest.raises(RuntimeError, match="liquid already in the tip"):
         subject.consolidate_liquid(
@@ -2673,7 +2382,7 @@ def test_consolidate_liquid_raises_if_tip_has_liquid(
             volume=10,
             source=[mock_well],
             dest=mock_well,
-            new_tip="never",
+            new_tip="once",
         )
 
 
@@ -2693,19 +2402,7 @@ def test_consolidate_liquid_raises_if_tip_policy_per_source(
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(1)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("per source")).then_return(
-        TransferTipPolicyV2.PER_SOURCE
-    )
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     with pytest.raises(
         RuntimeError, match='"per source" incompatible with consolidate.'
     ):
@@ -2738,21 +2435,9 @@ def test_consolidate_liquid_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
-    ).then_return([mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(mock_well)
-    ).then_return([mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
 
@@ -2761,7 +2446,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
         volume=10,
         source=[mock_well],
         dest=mock_well,
-        new_tip="never",
+        new_tip="once",
         trash_location=trash_location,
         return_tip=True,
     )
@@ -2773,7 +2458,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
             dest=(Location(Point(), labware=mock_well), mock_well._core),
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
-            trash_location=trash_location.move(Point(1, 2, 3)),
+            trash_location=trash_location,
             return_tip=True,
         )
     )
@@ -2798,19 +2483,6 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
     subject._tip_racks = tip_racks
 
     decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(
-            [mock_well, mock_well, mock_well]
-        )
-    ).then_return([mock_well, mock_well, mock_well])
-    decoy.when(
-        mock_validation.ensure_valid_flat_wells_list_for_transfer_v2(
-            [[mock_well, mock_well]]
-        )
-    ).then_return([mock_well, mock_well])
-    decoy.when(mock_validation.ensure_new_tip_policy("never")).then_return(
-        TransferTipPolicyV2.ONCE
-    )
     mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
     decoy.when(mock_nozzle_map.tip_count).then_return(2)
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
@@ -2827,9 +2499,6 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
 
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(
-        mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
-    ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
 
@@ -2838,7 +2507,7 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
         volume=10,
         source=[[mock_well, mock_well]],
         dest=[mock_well, mock_well, mock_well],
-        new_tip="never",
+        new_tip="once",
         trash_location=trash_location,
         return_tip=True,
     )
@@ -2853,7 +2522,7 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
             dest=(Location(Point(), labware=mock_well), mock_well._core),
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
-            trash_location=trash_location.move(Point(1, 2, 3)),
+            trash_location=trash_location,
             return_tip=True,
         )
     )


### PR DESCRIPTION
# Overview

For some reason, we were mocking out the entire `protocol_api/validation.py` module in `test_instrument_context.py`. There is no reason to do that, since the validation functions are pure functions that don't rely on external objects, and we really ought to test the validation functions in our tests.

Furthermore, we were abusing the mocks to make the validation functions do wild things: like mistranslating `Location`s into `WellTarget`s, or turning the `"never"` tip-replacement policy into `TransferTipPolicyV2.ONCE`. There is no good reason to do that, and it just makes the test logic ridiculously hard to follow.

I need to fix this because I want to write a test for my change to the `mix()` function, but it was very hard to do so given how we were using `mock_validation`.

## Test Plan and Hands on Testing

I examined all the usages of `mock_validation` by hand. It was very painful.

## Risk assessment

Low. This is a test-only change.