### PR TITLE
feat(api): allow hardware modules listen for FLEX status bar update events

### DIFF
--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -36,6 +36,8 @@ from opentrons.hardware_control.types import (
     HepaFanState,
     HepaUVState,
     StatusBarState,
+    StatusBarUpdateListener,
+    StatusBarUpdateUnsubscriber,
     PipetteSensorResponseQueue,
 )
 from opentrons.hardware_control.module_control import AttachedModulesControl
@@ -422,6 +424,11 @@ class FlexBackend(Protocol):
         ...
 
     def get_status_bar_state(self) -> StatusBarState:
+        ...
+
+    def add_status_bar_listener(
+        self, listener: StatusBarUpdateListener
+    ) -> StatusBarUpdateUnsubscriber:
         ...
 
     @property

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -145,6 +145,11 @@ from opentrons.hardware_control.types import (
     PipetteSensorType,
     PipetteSensorData,
     PipetteSensorResponseQueue,
+    StatusBarState,
+    StatusBarUpdateListener,
+    StatusBarUpdateUnsubscriber,
+    HepaFanState,
+    HepaUVState,
 )
 from opentrons.hardware_control.errors import (
     InvalidPipetteName,
@@ -210,7 +215,6 @@ from ..dev_types import (
     AttachedGripper,
     OT3AttachedInstruments,
 )
-from ..types import HepaFanState, HepaUVState, StatusBarState
 
 from .types import HWStopCondition
 from .flex_protocol import FlexBackend
@@ -1704,6 +1708,12 @@ class OT3Controller(FlexBackend):
 
     def get_status_bar_state(self) -> StatusBarState:
         return self._status_bar_controller.get_current_state()
+
+    def add_status_bar_listener(
+        self, listener: StatusBarUpdateListener
+    ) -> StatusBarUpdateUnsubscriber:
+        remove_cb = self._status_bar_controller.add_listener(listener)
+        return remove_cb
 
     @property
     def estop_status(self) -> EstopOverallStatus:

--- a/api/src/opentrons/hardware_control/backends/status_bar_state.py
+++ b/api/src/opentrons/hardware_control/backends/status_bar_state.py
@@ -1,4 +1,9 @@
-from opentrons.hardware_control.types import StatusBarState
+from opentrons.hardware_control.types import (
+    StatusBarState,
+    StatusBarUpdateEvent,
+    StatusBarUpdateListener,
+    StatusBarUpdateUnsubscriber,
+)
 from opentrons_hardware.hardware_control import status_bar
 from opentrons_hardware.firmware_bindings.binary_constants import (
     LightAnimationType,
@@ -22,6 +27,24 @@ class StatusBarStateController:
         self._status_bar_state = StatusBarState.IDLE
         self._controller = controller
         self._enabled = True
+        self._listeners: List[StatusBarUpdateListener] = []
+
+    def add_listener(
+        self, listener: StatusBarUpdateListener
+    ) -> StatusBarUpdateUnsubscriber:
+        """Add a listener to the status bar state."""
+        if listener not in self._listeners:
+            self._listeners.append(listener)
+
+        def _remove_listener() -> None:
+            self._listeners.remove(listener)
+
+        return _remove_listener
+
+    def emit_event(self) -> None:
+        """Emit an event to all listeners."""
+        for listener in self._listeners:
+            listener(StatusBarUpdateEvent(self._status_bar_state, self._enabled))
 
     async def _status_bar_idle(self) -> None:
         self._status_bar_state = StatusBarState.IDLE
@@ -177,6 +200,7 @@ class StatusBarStateController:
             StatusBarState.OFF: self._status_bar_off,
         }
         await callbacks[state]()
+        self.emit_event()
 
     def get_current_state(self) -> StatusBarState:
         """Get the current state."""

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -56,6 +56,9 @@ class AttachedModulesControl:
         self._api = api
         self._usb = usb
 
+    def subscribe_to_api_event(self, module: modules.AbstractModule) -> None:
+        self._api.add_status_bar_listener(module.event_listener)
+
     @classmethod
     async def build(
         cls,
@@ -92,7 +95,7 @@ class AttachedModulesControl:
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
     ) -> modules.AbstractModule:
-        return await modules.build(
+        mod = await modules.build(
             port=port,
             usb_port=usb_port,
             type=type,
@@ -103,6 +106,8 @@ class AttachedModulesControl:
             sim_serial_number=sim_serial_number,
             disconnected_callback=self._disconnected_callback,
         )
+        self.subscribe_to_api_event(mod)
+        return mod
 
     def _disconnected_callback(self, port: str, serial: Optional[str]) -> None:
         """Used by the module to indicate that it was disconnected and should be deleted."""

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Dict, Optional, Mapping
+from typing import Any, Dict, Optional, Mapping
 
 from opentrons.drivers.flex_stacker.types import (
     Direction,
@@ -35,6 +35,7 @@ from opentrons.hardware_control.modules.types import (
     LiveData,
     FlexStackerData,
 )
+from opentrons.hardware_control.types import StatusBarState, StatusBarUpdateEvent
 
 from opentrons_shared_data.errors.exceptions import (
     FlexStackerStallError,
@@ -508,6 +509,36 @@ class FlexStacker(mod_abc.AbstractModule):
                 self.device_info["serial"],
                 labware_expected=labware_expected,
             )
+
+    def event_listener(self, event: Any) -> None:
+        if isinstance(event, StatusBarUpdateEvent):
+            print(f"Received status bar event: {event}")
+            asyncio.run_coroutine_threadsafe(
+                self._handle_status_bar_event(event), self._loop
+            )
+
+    async def _handle_status_bar_event(self, event: StatusBarUpdateEvent) -> None:
+        print(f"Received status bar event: {event}")
+        if event.enabled:
+            match event.state:
+                case StatusBarState.RUNNING:
+                    await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.STATIC)
+                case StatusBarState.PAUSED:
+                    await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
+                case StatusBarState.IDLE:
+                    await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
+                case StatusBarState.HARDWARE_ERROR:
+                    await self.set_led_state(0.5, LEDColor.RED, LEDPattern.FLASH)
+                case StatusBarState.SOFTWARE_ERROR:
+                    await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.STATIC)
+                case StatusBarState.ERROR_RECOVERY:
+                    await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.PULSE)
+                case StatusBarState.RUN_COMPLETED:
+                    await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.PULSE)
+                case StatusBarState.UPDATING:
+                    await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.PULSE)
+                case _:
+                    await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
 
 
 class FlexStackerReader(Reader):

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -512,13 +512,11 @@ class FlexStacker(mod_abc.AbstractModule):
 
     def event_listener(self, event: Any) -> None:
         if isinstance(event, StatusBarUpdateEvent):
-            print(f"Received status bar event: {event}")
             asyncio.run_coroutine_threadsafe(
                 self._handle_status_bar_event(event), self._loop
             )
 
     async def _handle_status_bar_event(self, event: StatusBarUpdateEvent) -> None:
-        print(f"Received status bar event: {event}")
         if event.enabled:
             match event.state:
                 case StatusBarState.RUNNING:

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -247,12 +247,6 @@ class FlexStacker(mod_abc.AbstractModule):
     async def deactivate(self, must_be_running: bool = True) -> None:
         await self._driver.stop_motors()
 
-    async def reset_stall_detected(self) -> None:
-        """Sets the statusbar to normal."""
-        if self._stall_detected:
-            await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.STATIC)
-            self._stall_detected = False
-
     async def set_led_state(
         self,
         power: float,
@@ -276,7 +270,6 @@ class FlexStacker(mod_abc.AbstractModule):
         current: Optional[float] = None,
     ) -> bool:
         """Move the axis in a direction by the given distance in mm."""
-        await self.reset_stall_detected()
         default = STACKER_MOTION_CONFIG[axis]["move"]
         await self._driver.set_run_current(
             axis, current if current is not None else default.run_current
@@ -300,7 +293,6 @@ class FlexStacker(mod_abc.AbstractModule):
         acceleration: Optional[float] = None,
         current: Optional[float] = None,
     ) -> bool:
-        await self.reset_stall_detected()
         default = STACKER_MOTION_CONFIG[axis]["home"]
         await self._driver.set_run_current(
             axis, current if current is not None else default.run_current

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -7,7 +7,6 @@ from packaging.version import InvalidVersion, parse, Version
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.drivers.rpi_drivers.types import USBPort
 
-from ..types import StatusBarUpdateListener, StatusBarUpdateEvent
 from ..execution_manager import ExecutionManager
 from .types import (
     BundledFirmware,

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -2,11 +2,12 @@ import abc
 import asyncio
 import logging
 import re
-from typing import ClassVar, Mapping, Optional, TypeVar
+from typing import Any, ClassVar, Mapping, Optional, TypeVar
 from packaging.version import InvalidVersion, parse, Version
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.drivers.rpi_drivers.types import USBPort
 
+from ..types import StatusBarUpdateListener, StatusBarUpdateEvent
 from ..execution_manager import ExecutionManager
 from .types import (
     BundledFirmware,
@@ -223,4 +224,8 @@ class AbstractModule(abc.ABC):
         Clean up, i.e. stop pollers, disconnect serial, etc in preparation for
         object destruction.
         """
+        pass
+
+    def event_listener(self, event: Any) -> None:
+        """Listen for events and update the module state."""
         pass

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -91,6 +91,8 @@ from .types import (
     GripperProbe,
     UpdateStatus,
     StatusBarState,
+    StatusBarUpdateListener,
+    StatusBarUpdateUnsubscriber,
     SubSystemState,
     TipStateType,
     EstopOverallStatus,
@@ -575,6 +577,7 @@ class OT3API(
         await self.set_lights(button=True)
 
     async def set_status_bar_state(self, state: StatusBarState) -> None:
+        self._log.info(f"Setting status bar state to {state}")
         await self._backend.set_status_bar_state(state)
 
     async def set_status_bar_enabled(self, enabled: bool) -> None:
@@ -582,6 +585,11 @@ class OT3API(
 
     def get_status_bar_state(self) -> StatusBarState:
         return self._backend.get_status_bar_state()
+
+    def add_status_bar_listener(
+        self, listener: StatusBarUpdateListener
+    ) -> StatusBarUpdateUnsubscriber:
+        return self._backend.add_status_bar_listener(listener)
 
     @ExecutionManagerProvider.wait_for_running
     async def delay(self, duration_s: float) -> None:

--- a/api/src/opentrons/hardware_control/protocols/chassis_accessory_manager.py
+++ b/api/src/opentrons/hardware_control/protocols/chassis_accessory_manager.py
@@ -1,6 +1,12 @@
 from typing import Dict, Optional
 from typing_extensions import Protocol
-from ..types import DoorState, StatusBarState, EstopState
+from ..types import (
+    DoorState,
+    StatusBarState,
+    EstopState,
+    StatusBarUpdateListener,
+    StatusBarUpdateUnsubscriber,
+)
 from .event_sourcer import EventSourcer
 
 
@@ -59,6 +65,15 @@ class ChassisAccessoryManager(EventSourcer, Protocol):
         """Get the current status bar state.
 
         :returns: The current status bar state enumeration."""
+        ...
+
+    def add_status_bar_listener(
+        self, listener: StatusBarUpdateListener
+    ) -> StatusBarUpdateUnsubscriber:
+        """Add a listener to the status bar state.
+
+        listener: The listener to add.
+        :returns: A callback function that removes the listener."""
         ...
 
     def get_estop_state(self) -> EstopState:

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -2,7 +2,7 @@ from asyncio import Queue
 import enum
 import logging
 from dataclasses import dataclass
-from typing import cast, Tuple, Union, List, Callable, Dict, TypeVar, Type, Awaitable
+from typing import cast, Tuple, Union, List, Callable, Dict, TypeVar, Type
 from typing_extensions import Literal
 from opentrons import types as top_types
 from opentrons_shared_data.pipette.types import PipetteChannelType

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -2,7 +2,7 @@ from asyncio import Queue
 import enum
 import logging
 from dataclasses import dataclass
-from typing import cast, Tuple, Union, List, Callable, Dict, TypeVar, Type
+from typing import cast, Tuple, Union, List, Callable, Dict, TypeVar, Type, Awaitable
 from typing_extensions import Literal
 from opentrons import types as top_types
 from opentrons_shared_data.pipette.types import PipetteChannelType
@@ -598,6 +598,16 @@ class StatusBarState(enum.Enum):
             StatusBarState.ACTIVATION.value,
             StatusBarState.DISCO.value,
         }
+
+
+@dataclass(frozen=True)
+class StatusBarUpdateEvent:
+    state: StatusBarState
+    enabled: bool
+
+
+StatusBarUpdateListener = Callable[[StatusBarUpdateEvent], None]
+StatusBarUpdateUnsubscriber = Callable[[], None]
 
 
 @dataclass

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_status_bar.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_status_bar.py
@@ -1,6 +1,6 @@
 import pytest
 from decoy import Decoy
-from opentrons.hardware_control.types import StatusBarState
+from opentrons.hardware_control.types import StatusBarState, StatusBarUpdateEvent
 from opentrons.hardware_control.backends.status_bar_state import (
     StatusBarStateController,
 )
@@ -17,27 +17,42 @@ def subject(mock_status_bar_controller: StatusBar) -> StatusBarStateController:
     return StatusBarStateController(mock_status_bar_controller)
 
 
+SETTINGS = {
+    StatusBarState.IDLE: StatusBarState.IDLE,
+    StatusBarState.RUNNING: StatusBarState.RUNNING,
+    StatusBarState.PAUSED: StatusBarState.PAUSED,
+    StatusBarState.HARDWARE_ERROR: StatusBarState.HARDWARE_ERROR,
+    StatusBarState.SOFTWARE_ERROR: StatusBarState.SOFTWARE_ERROR,
+    StatusBarState.CONFIRMATION: StatusBarState.IDLE,
+    StatusBarState.RUN_COMPLETED: StatusBarState.RUN_COMPLETED,
+    StatusBarState.UPDATING: StatusBarState.UPDATING,
+    StatusBarState.ACTIVATION: StatusBarState.IDLE,
+    StatusBarState.DISCO: StatusBarState.IDLE,
+    StatusBarState.OFF: StatusBarState.OFF,
+}
+
+
 @pytest.mark.parametrize(argnames=["enabled"], argvalues=[[True], [False]])
+@pytest.mark.parametrize("setting", list(SETTINGS.keys()))
 async def test_status_bar_interface(
-    subject: StatusBarStateController, enabled: bool
+    decoy: Decoy,
+    subject: StatusBarStateController,
+    enabled: bool,
+    setting: StatusBarState,
 ) -> None:
-    """Test setting status bar statuses and make sure the cached status is correct."""
+    """Test setting status bar statuses and make sure the cached status is correct. Also
+    verify that the listeners are called with the correct status bar state and enabled
+    status."""
+    listener_1 = decoy.mock(name="listener_1")
+    listener_2 = decoy.mock(name="listener_2")
+    subject.add_listener(listener_1)
+    subject.add_listener(listener_2)
+
     await subject.set_enabled(enabled)
+    await subject.set_status_bar_state(state=setting)
+    assert subject.get_current_state() == SETTINGS[setting]
 
-    settings = {
-        StatusBarState.IDLE: StatusBarState.IDLE,
-        StatusBarState.RUNNING: StatusBarState.RUNNING,
-        StatusBarState.PAUSED: StatusBarState.PAUSED,
-        StatusBarState.HARDWARE_ERROR: StatusBarState.HARDWARE_ERROR,
-        StatusBarState.SOFTWARE_ERROR: StatusBarState.SOFTWARE_ERROR,
-        StatusBarState.CONFIRMATION: StatusBarState.IDLE,
-        StatusBarState.RUN_COMPLETED: StatusBarState.RUN_COMPLETED,
-        StatusBarState.UPDATING: StatusBarState.UPDATING,
-        StatusBarState.ACTIVATION: StatusBarState.IDLE,
-        StatusBarState.DISCO: StatusBarState.IDLE,
-        StatusBarState.OFF: StatusBarState.OFF,
-    }
-
-    for setting, response in settings.items():
-        await subject.set_status_bar_state(state=setting)
-        assert subject.get_current_state() == response
+    decoy.verify(
+        listener_1(StatusBarUpdateEvent(SETTINGS[setting], enabled)),
+        listener_2(StatusBarUpdateEvent(SETTINGS[setting], enabled)),
+    )


### PR DESCRIPTION
# Overview
It's always been a pipe dream for some of us that one day the LEDs on the connected hardware modules can align with the Opentrons robot's status bar. We should make it happen!

This PR enables status bar state updates on the FLEX to become listenable events and allows hardware modules to subscribe to relevant API events. By leveraging event listeners, each module type gains the flexibility to choose which events to respond to and handle them in a way that best suits their needs.

We will most likely have to add firmware changes to other hardware modules so this behavior will only be available for the FLEX Stacker for now.

# Review Request
Could you think of any reason why we shouldn't do it this way? 