### PR TITLE
fix(api): make error message clearer for lld issues

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -484,20 +484,20 @@ class GeometryView:
             if z_offset < lld_min_height:
                 if isinstance(well_location, PickUpTipWellLocation):
                     raise OperationLocationNotInWellError(
-                        f"Specifying {well_location.origin} with an offset of {well_location.offset} results in an operation location that could be below the bottom of the well"
+                        f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset}mm; the minimum allowed height for liquid tracking is {lld_min_height}mm"
                     )
                 else:
                     raise OperationLocationNotInWellError(
-                        f"Specifying {well_location.origin} with an offset of {well_location.offset} and a volume offset of {well_location.volumeOffset} results in an operation location that could be below the bottom of the well"
+                        f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset}mm; the minimum allowed height for liquid tracking is {lld_min_height}mm"
                     )
         elif z_offset < 0:
             if isinstance(well_location, PickUpTipWellLocation):
                 raise OperationLocationNotInWellError(
-                    f"Specifying {well_location.origin} with an offset of {well_location.offset} results in an operation location below the bottom of the well"
+                    f"Specifying {well_location.origin} with an offset of {well_location.offset.z} results in a location below the bottom of the well"
                 )
             else:
                 raise OperationLocationNotInWellError(
-                    f"Specifying {well_location.origin} with an offset of {well_location.offset} and a volume offset of {well_location.volumeOffset} results in an operation location below the bottom of the well"
+                    f"Specifying {well_location.origin} with an offset of {well_location.offset.z} and a volume offset of {well_location.volumeOffset} results in a location below the bottom of the well"
                 )
 
     def get_well_position(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -484,11 +484,11 @@ class GeometryView:
             if z_offset < lld_min_height:
                 if isinstance(well_location, PickUpTipWellLocation):
                     raise OperationLocationNotInWellError(
-                        f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset}mm; the minimum allowed height for liquid tracking is {lld_min_height}mm"
+                        f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset} mm; the minimum allowed height for liquid tracking is {lld_min_height} mm"
                     )
                 else:
                     raise OperationLocationNotInWellError(
-                        f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset}mm; the minimum allowed height for liquid tracking is {lld_min_height}mm"
+                        f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset} mm; the minimum allowed height for liquid tracking is {lld_min_height} mm"
                     )
         elif z_offset < 0:
             if isinstance(well_location, PickUpTipWellLocation):


### PR DESCRIPTION
## Overview
If you load a well to be empty, then try and dispense at the meniscus, you should only be allowed to do so if the z offset makes it such that the commanded tip height is above the pipette's minimum allowed lld height. 

This was implemented fine, but the error message for the case where you'd try and dispense from below the lld height makes it seem as though the tip height might be below the bottom of the well. This is what the new error message will look like:

<img width="505" alt="image" src="https://github.com/user-attachments/assets/bff45809-b541-4b3f-837f-9554bea70ae5" />
