### PR TITLE
refactor(api): change the names of liquid classes based transfers

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1141,7 +1141,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             result.nextTipInfo if isinstance(result.nextTipInfo, NextTipInfo) else None
         )
 
-    def transfer_liquid(  # noqa: C901
+    def transfer_with_liquid_class(  # noqa: C901
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -1335,7 +1335,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             _drop_tip()
 
     # TODO(spp, 2025-02-25): wire up return tip
-    def distribute_liquid(  # noqa: C901
+    def distribute_with_liquid_class(  # noqa: C901
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -1417,7 +1417,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 tip_working_volume=working_volume,
             )
         ):
-            self.transfer_liquid(
+            self.transfer_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[source for _ in range(len(dest))],
@@ -1657,7 +1657,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             <= tip_working_volume
         )
 
-    def consolidate_liquid(  # noqa: C901
+    def consolidate_with_liquid_class(  # noqa: C901
         self,
         liquid_class: LiquidClass,
         volume: float,

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -359,7 +359,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         ...
 
     @abstractmethod
-    def transfer_liquid(
+    def transfer_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -374,7 +374,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         ...
 
     @abstractmethod
-    def distribute_liquid(
+    def distribute_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -392,7 +392,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         ...
 
     @abstractmethod
-    def consolidate_liquid(
+    def consolidate_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -624,7 +624,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         """This will never be called because it was added in API 2.16."""
         pass
 
-    def transfer_liquid(
+    def transfer_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -638,7 +638,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         """This will never be called because it was added in API 2.23"""
         assert False, "transfer_liquid is not supported in legacy context"
 
-    def distribute_liquid(
+    def distribute_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -652,7 +652,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
 
-    def consolidate_liquid(
+    def consolidate_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -513,7 +513,7 @@ class LegacyInstrumentCoreSimulator(
         """This will never be called because it was added in API 2.15."""
         pass
 
-    def transfer_liquid(
+    def transfer_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -527,7 +527,7 @@ class LegacyInstrumentCoreSimulator(
         """This will never be called because it was added in API 2.23."""
         assert False, "transfer_liquid is not supported in legacy context"
 
-    def distribute_liquid(
+    def distribute_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -541,7 +541,7 @@ class LegacyInstrumentCoreSimulator(
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
 
-    def consolidate_liquid(
+    def consolidate_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1509,7 +1509,7 @@ class InstrumentContext(publisher.CommandPublisher):
             getattr(self, cmd["method"])(*cmd["args"], **cmd["kwargs"])
 
     @requires_version(2, 23)
-    def transfer_liquid(
+    def transfer_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -1552,7 +1552,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 " to transfer liquid onto one destinations from many sources, use 'consolidate_liquid'."
             )
 
-        self._core.transfer_liquid(
+        self._core.transfer_with_liquid_class(
             liquid_class=liquid_class,
             volume=volume,
             source=[
@@ -1574,7 +1574,7 @@ class InstrumentContext(publisher.CommandPublisher):
         return self
 
     @requires_version(2, 23)
-    def distribute_liquid(
+    def distribute_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -1621,7 +1621,7 @@ class InstrumentContext(publisher.CommandPublisher):
             )
 
         verified_source = transfer_args.sources_list[0]
-        self._core.distribute_liquid(
+        self._core.distribute_with_liquid_class(
             liquid_class=liquid_class,
             volume=volume,
             source=(
@@ -1643,7 +1643,7 @@ class InstrumentContext(publisher.CommandPublisher):
         return self
 
     @requires_version(2, 23)
-    def consolidate_liquid(
+    def consolidate_with_liquid_class(
         self,
         liquid_class: LiquidClass,
         volume: float,
@@ -1690,7 +1690,7 @@ class InstrumentContext(publisher.CommandPublisher):
             )
 
         verified_dest = transfer_args.destinations_list[0]
-        self._core.consolidate_liquid(
+        self._core.consolidate_with_liquid_class(
             liquid_class=liquid_class,
             volume=volume,
             source=[

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1815,7 +1815,7 @@ def test_transfer_liquid_raises_for_invalid_locations(
         mock_validation.ensure_valid_flat_wells_list_for_transfer_v2([mock_well])
     ).then_raise(ValueError("Oh no"))
     with pytest.raises(ValueError):
-        subject.transfer_liquid(
+        subject.transfer_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
@@ -1853,7 +1853,7 @@ def test_transfer_liquid_raises_for_unequal_source_and_dest(
     with pytest.raises(
         ValueError, match="Sources and destinations should be of the same length"
     ):
-        subject.transfer_liquid(
+        subject.transfer_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=mock_well,
@@ -1887,7 +1887,7 @@ def test_transfer_liquid_raises_for_non_liquid_handling_locations(
         )
     ).then_raise(ValueError("Uh oh"))
     with pytest.raises(ValueError, match="Uh oh"):
-        subject.transfer_liquid(
+        subject.transfer_with_liquid_class(
             liquid_class=test_liq_class, volume=10, source=[mock_well], dest=[mock_well]
         )
 
@@ -1915,7 +1915,7 @@ def test_transfer_liquid_raises_for_bad_tip_policy(
         ValueError("Uh oh")
     )
     with pytest.raises(ValueError, match="Uh oh"):
-        subject.transfer_liquid(
+        subject.transfer_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
@@ -1947,7 +1947,7 @@ def test_transfer_liquid_raises_for_no_tip(
         TransferTipPolicyV2.NEVER
     )
     with pytest.raises(RuntimeError, match="Pipette has no tip"):
-        subject.transfer_liquid(
+        subject.transfer_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
@@ -1992,7 +1992,7 @@ def test_transfer_liquid_raises_if_tip_has_liquid(
     ).then_return((decoy.mock(cls=Labware), decoy.mock(cls=Well)))
     decoy.when(mock_instrument_core.get_current_volume()).then_return(1000)
     with pytest.raises(RuntimeError, match="liquid already in the tip"):
-        subject.transfer_liquid(
+        subject.transfer_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
@@ -2034,7 +2034,7 @@ def test_transfer_liquid_delegates_to_engine_core(
     ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
-    subject.transfer_liquid(
+    subject.transfer_with_liquid_class(
         liquid_class=test_liq_class,
         volume=10,
         source=[mock_well],
@@ -2044,7 +2044,7 @@ def test_transfer_liquid_delegates_to_engine_core(
         return_tip=True,
     )
     decoy.verify(
-        mock_instrument_core.transfer_liquid(
+        mock_instrument_core.transfer_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[(Location(Point(), labware=mock_well), mock_well._core)],
@@ -2100,7 +2100,7 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
     ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
-    subject.transfer_liquid(
+    subject.transfer_with_liquid_class(
         liquid_class=test_liq_class,
         volume=10,
         source=[[mock_well, mock_well]],
@@ -2110,7 +2110,7 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
         return_tip=True,
     )
     decoy.verify(
-        mock_instrument_core.transfer_liquid(
+        mock_instrument_core.transfer_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[(Location(Point(), labware=mock_well), mock_well._core)],
@@ -2155,7 +2155,7 @@ def test_distribute_liquid_raises_if_more_than_one_source(
         mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
     ).then_return(trash_location)
     with pytest.raises(ValueError, match="Source should be a single well"):
-        subject.distribute_liquid(
+        subject.distribute_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well, mock_well],
@@ -2192,7 +2192,7 @@ def test_distribute_liquid_raises_for_non_liquid_handling_locations(
         )
     ).then_raise(ValueError("Uh oh"))
     with pytest.raises(ValueError, match="Uh oh"):
-        subject.distribute_liquid(
+        subject.distribute_with_liquid_class(
             liquid_class=test_liq_class, volume=10, source=mock_well, dest=[mock_well]
         )
 
@@ -2223,7 +2223,7 @@ def test_distribute_liquid_raises_for_bad_tip_policy(
         ValueError("Uh oh")
     )
     with pytest.raises(ValueError, match="Uh oh"):
-        subject.distribute_liquid(
+        subject.distribute_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=mock_well,
@@ -2258,7 +2258,7 @@ def test_distribute_liquid_raises_for_no_tip(
         TransferTipPolicyV2.NEVER
     )
     with pytest.raises(RuntimeError, match="Pipette has no tip"):
-        subject.distribute_liquid(
+        subject.distribute_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=mock_well,
@@ -2306,7 +2306,7 @@ def test_distribute_liquid_raises_if_tip_has_liquid(
     ).then_return((decoy.mock(cls=Labware), decoy.mock(cls=Well)))
     decoy.when(mock_instrument_core.get_current_volume()).then_return(1000)
     with pytest.raises(RuntimeError, match="liquid already in the tip"):
-        subject.distribute_liquid(
+        subject.distribute_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=mock_well,
@@ -2347,7 +2347,7 @@ def test_distribute_liquid_raises_if_tip_policy_per_source(
     with pytest.raises(
         RuntimeError, match='"per source" incompatible with distribute.'
     ):
-        subject.distribute_liquid(
+        subject.distribute_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=mock_well,
@@ -2393,7 +2393,7 @@ def test_distribute_liquid_delegates_to_engine_core(
     ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
-    subject.distribute_liquid(
+    subject.distribute_with_liquid_class(
         liquid_class=test_liq_class,
         volume=10,
         source=mock_well,
@@ -2403,7 +2403,7 @@ def test_distribute_liquid_delegates_to_engine_core(
         return_tip=True,
     )
     decoy.verify(
-        mock_instrument_core.distribute_liquid(
+        mock_instrument_core.distribute_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=(Location(Point(), labware=mock_well), mock_well._core),
@@ -2469,7 +2469,7 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
     ).then_return(trash_location.move(Point(1, 2, 3)))
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
-    subject.distribute_liquid(
+    subject.distribute_with_liquid_class(
         liquid_class=test_liq_class,
         volume=10,
         source=[mock_well, mock_well, mock_well],
@@ -2479,7 +2479,7 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
         return_tip=True,
     )
     decoy.verify(
-        mock_instrument_core.distribute_liquid(
+        mock_instrument_core.distribute_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=(Location(Point(), labware=mock_well), mock_well._core),
@@ -2524,7 +2524,7 @@ def test_consolidate_liquid_raises_if_more_than_one_destination(
         mock_validation.ensure_valid_trash_location_for_transfer_v2(trash_location)
     ).then_return(trash_location)
     with pytest.raises(ValueError, match="Destination should be a single well"):
-        subject.consolidate_liquid(
+        subject.consolidate_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well, mock_well],
@@ -2561,7 +2561,7 @@ def test_consolidate_liquid_raises_for_non_liquid_handling_locations(
         )
     ).then_raise(ValueError("Uh oh"))
     with pytest.raises(ValueError, match="Uh oh"):
-        subject.consolidate_liquid(
+        subject.consolidate_with_liquid_class(
             liquid_class=test_liq_class, volume=10, source=[mock_well], dest=mock_well
         )
 
@@ -2592,7 +2592,7 @@ def test_consolidate_liquid_raises_for_bad_tip_policy(
         ValueError("Uh oh")
     )
     with pytest.raises(ValueError, match="Uh oh"):
-        subject.consolidate_liquid(
+        subject.consolidate_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
@@ -2627,7 +2627,7 @@ def test_consolidate_liquid_raises_for_no_tip(
         TransferTipPolicyV2.NEVER
     )
     with pytest.raises(RuntimeError, match="Pipette has no tip"):
-        subject.consolidate_liquid(
+        subject.consolidate_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
@@ -2668,7 +2668,7 @@ def test_consolidate_liquid_raises_if_tip_has_liquid(
     )
     decoy.when(mock_instrument_core.get_current_volume()).then_return(1000)
     with pytest.raises(RuntimeError, match="liquid already in the tip"):
-        subject.consolidate_liquid(
+        subject.consolidate_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
@@ -2709,7 +2709,7 @@ def test_consolidate_liquid_raises_if_tip_policy_per_source(
     with pytest.raises(
         RuntimeError, match='"per source" incompatible with consolidate.'
     ):
-        subject.consolidate_liquid(
+        subject.consolidate_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[mock_well],
@@ -2756,7 +2756,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
 
-    subject.consolidate_liquid(
+    subject.consolidate_with_liquid_class(
         liquid_class=test_liq_class,
         volume=10,
         source=[mock_well],
@@ -2766,7 +2766,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
         return_tip=True,
     )
     decoy.verify(
-        mock_instrument_core.consolidate_liquid(
+        mock_instrument_core.consolidate_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[(Location(Point(), labware=mock_well), mock_well._core)],
@@ -2833,7 +2833,7 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
 
-    subject.consolidate_liquid(
+    subject.consolidate_with_liquid_class(
         liquid_class=test_liq_class,
         volume=10,
         source=[[mock_well, mock_well]],
@@ -2843,7 +2843,7 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
         return_tip=True,
     )
     decoy.verify(
-        mock_instrument_core.consolidate_liquid(
+        mock_instrument_core.consolidate_with_liquid_class(
             liquid_class=test_liq_class,
             volume=10,
             source=[

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -50,7 +50,7 @@ def test_water_transfer_with_volume_more_than_tip_max(
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
 
-        pipette_1k.transfer_liquid(
+        pipette_1k.transfer_with_liquid_class(
             liquid_class=water,
             volume=60,
             source=nest_plate.rows()[0],
@@ -61,7 +61,7 @@ def test_water_transfer_with_volume_more_than_tip_max(
         assert patched_pick_up_tip.call_count == 24
         patched_pick_up_tip.reset_mock()
 
-        pipette_1k.transfer_liquid(
+        pipette_1k.transfer_with_liquid_class(
             liquid_class=water,
             volume=100,
             source=nest_plate.rows()[0],
@@ -73,7 +73,7 @@ def test_water_transfer_with_volume_more_than_tip_max(
         patched_pick_up_tip.reset_mock()
 
         pipette_1k.pick_up_tip()
-        pipette_1k.transfer_liquid(
+        pipette_1k.transfer_with_liquid_class(
             liquid_class=water,
             volume=50,
             source=nest_plate.rows()[0],
@@ -151,7 +151,7 @@ def test_order_of_water_transfer_steps(
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        pipette_50.transfer_liquid(
+        pipette_50.transfer_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0][:2],
@@ -303,7 +303,7 @@ def test_order_of_water_transfer_steps_with_return_tip(
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip")
-        pipette_50.transfer_liquid(
+        pipette_50.transfer_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0][:2],
@@ -459,7 +459,7 @@ def test_order_of_water_transfer_steps_with_no_new_tips(
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        pipette_50.transfer_liquid(
+        pipette_50.transfer_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0][:2],
@@ -585,7 +585,7 @@ def test_order_of_water_consolidate_steps(
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        pipette_50.consolidate_liquid(
+        pipette_50.consolidate_with_liquid_class(
             liquid_class=water,
             volume=25,
             source=nest_plate.rows()[0][:2],
@@ -713,7 +713,7 @@ def test_order_of_water_consolidate_steps_larger_volume_then_tip(
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        pipette_50.consolidate_liquid(
+        pipette_50.consolidate_with_liquid_class(
             liquid_class=water,
             volume=30,
             source=nest_plate.rows()[0][:2],
@@ -866,7 +866,7 @@ def test_order_of_water_consolidate_steps_with_no_new_tips(
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        pipette_50.consolidate_liquid(
+        pipette_50.consolidate_with_liquid_class(
             liquid_class=water,
             volume=25,
             source=nest_plate.rows()[0][:2],
@@ -981,7 +981,7 @@ def test_order_of_water_consolidate_steps_with_return_tip(
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip")
-        pipette_50.consolidate_liquid(
+        pipette_50.consolidate_with_liquid_class(
             liquid_class=water,
             volume=25,
             source=nest_plate.rows()[0][:2],
@@ -1081,7 +1081,7 @@ def test_water_distribution_with_volume_more_than_tip_max(
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
 
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=60,
             source=nest_plate.rows()[0][0],
@@ -1092,7 +1092,7 @@ def test_water_distribution_with_volume_more_than_tip_max(
         assert patched_pick_up_tip.call_count == 1
         patched_pick_up_tip.reset_mock()
 
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=100,
             source=nest_plate.rows()[0][0],
@@ -1104,7 +1104,7 @@ def test_water_distribution_with_volume_more_than_tip_max(
         patched_pick_up_tip.reset_mock()
 
         pipette_1k.pick_up_tip()
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=50,
             source=nest_plate.rows()[0][0],
@@ -1187,7 +1187,7 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
             patched_dispense, "dispense_liquid_class_during_multi_dispense"
         )
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0][1],
@@ -1351,7 +1351,7 @@ def test_order_of_water_distribute_steps_using_one_to_one_transfers(
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        pipette_50.distribute_liquid(
+        pipette_50.distribute_with_liquid_class(
             liquid_class=water,
             volume=distribute_volume,
             source=nest_plate.rows()[0][2],
@@ -1524,7 +1524,7 @@ def test_order_of_water_distribution_steps_using_mixed_dispense(
             patched_multi_dispense, "dispense_liquid_class_during_multi_dispense"
         )
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=400,
             source=nest_plate.rows()[0][1],
@@ -1685,7 +1685,7 @@ def test_water_distribute_steps_with_return_tip(
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip")
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=400,
             source=nest_plate.rows()[0][1],
@@ -1752,7 +1752,7 @@ def test_water_distribution_raises_error_for_disposal_vol_without_blowout(
         RuntimeError,
         match="Specify a blowout location and enable blowout when using a disposal volume",
     ):
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=140,
             source=nest_plate.rows()[0][0],
@@ -1804,7 +1804,7 @@ def test_water_transfer_with_lpd(
     ):
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.transfer_liquid(
+        pipette_1k.transfer_with_liquid_class(
             liquid_class=water,
             volume=1100,
             source=nest_plate.rows()[0],
@@ -1856,7 +1856,7 @@ def test_water_transfer_does_lpd_only_once_for_a_source_well(
     ):
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.transfer_liquid(
+        pipette_1k.transfer_with_liquid_class(
             liquid_class=water,
             volume=1100,
             source=[nest_plate.wells_by_name()["A1"] for _ in range(3)],
@@ -1911,7 +1911,7 @@ def test_water_distribution_with_lpd(
     ):
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0][1],
@@ -1964,7 +1964,7 @@ def test_incompatible_transfers_skip_probing_even_with_lpd_on(
     ):
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.transfer_liquid(
+        pipette_1k.transfer_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0],
@@ -1972,7 +1972,7 @@ def test_incompatible_transfers_skip_probing_even_with_lpd_on(
             new_tip="never",
             trash_location=trash,
         )
-        pipette_1k.distribute_liquid(
+        pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0][1],
@@ -1980,7 +1980,7 @@ def test_incompatible_transfers_skip_probing_even_with_lpd_on(
             new_tip="never",
             trash_location=trash,
         )
-        pipette_1k.consolidate_liquid(
+        pipette_1k.consolidate_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0],
@@ -1989,7 +1989,7 @@ def test_incompatible_transfers_skip_probing_even_with_lpd_on(
             trash_location=trash,
         )
         pipette_1k.drop_tip()
-        pipette_1k.consolidate_liquid(
+        pipette_1k.consolidate_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0],
@@ -1997,7 +1997,7 @@ def test_incompatible_transfers_skip_probing_even_with_lpd_on(
             new_tip="once",
             trash_location=trash,
         )
-        pipette_1k.consolidate_liquid(
+        pipette_1k.consolidate_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.rows()[0],
@@ -2053,7 +2053,7 @@ def test_water_transfer_with_multi_channel_pipette(
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
-        pipette_50.transfer_liquid(
+        pipette_50.transfer_with_liquid_class(
             liquid_class=water,
             volume=40,
             source=nest_plate.columns()[:2],


### PR DESCRIPTION
# Overview

To reduce confusion with `Liquid` class and `LiquidClass` class and their respective usages, we have decided to rename all LC-based transfers to `.._with_liquid_class`.

## Test Plan and Hands on Testing

None needed. Refactor only

## Review requests

- I guess look for any typos
- We'll need to update the snapshot tests. Do we need to do that in this PR?

## Risk assessment

None.
