### PR TITLE
refactor(app-shell-odd): fix lint complaints that show up at the bottom of every PR

### DIFF
--- a/app-shell-odd/src/actions.ts
+++ b/app-shell-odd/src/actions.ts
@@ -357,7 +357,7 @@ export const usbRequestsStop = (): UsbRequestsAction => ({
 export const appRestart = (message: string): AppRestartAction => ({
   type: APP_RESTART,
   payload: {
-    message: message,
+    message,
   },
   meta: { shell: true },
 })
@@ -365,7 +365,7 @@ export const appRestart = (message: string): AppRestartAction => ({
 export const reloadUi = (message: string): ReloadUiAction => ({
   type: RELOAD_UI,
   payload: {
-    message: message,
+    message,
   },
   meta: { shell: true },
 })
@@ -373,7 +373,7 @@ export const reloadUi = (message: string): ReloadUiAction => ({
 export const sendLog = (message: string): SendLogAction => ({
   type: SEND_LOG,
   payload: {
-    message: message,
+    message,
   },
   meta: { shell: true },
 })
@@ -381,7 +381,7 @@ export const sendLog = (message: string): SendLogAction => ({
 export const updateBrightness = (message: string): UpdateBrightnessAction => ({
   type: UPDATE_BRIGHTNESS,
   payload: {
-    message: message,
+    message,
   },
   meta: { shell: true },
 })

--- a/app-shell-odd/src/dialogs/index.ts
+++ b/app-shell-odd/src/dialogs/index.ts
@@ -24,7 +24,7 @@ const BASE_FILE_OPTS = {
 export function showOpenDirectoryDialog(
   browserWindow: BrowserWindow,
   options: Partial<BaseDialogOptions> = {}
-): Promise<String[]> {
+): Promise<string[]> {
   let openDialogOpts: OpenDialogOptions = BASE_DIRECTORY_OPTS
 
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
@@ -35,7 +35,7 @@ export function showOpenDirectoryDialog(
   return dialog
     .showOpenDialog(browserWindow, openDialogOpts)
     .then((result: OpenDialogReturnValue) => {
-      return result.canceled ? [] : (result.filePaths as string[])
+      return result.canceled ? [] : result.filePaths
     })
 }
 
@@ -58,7 +58,7 @@ export function showOpenFileDialog(
   return dialog
     .showOpenDialog(browserWindow, openDialogOpts)
     .then((result: OpenDialogReturnValue) => {
-      return result.canceled ? [] : (result.filePaths as string[])
+      return result.canceled ? [] : result.filePaths
     })
 }
 

--- a/app-shell-odd/src/http.ts
+++ b/app-shell-odd/src/http.ts
@@ -72,7 +72,7 @@ export function fetchToFile(
 ): Promise<string> {
   return fetch(input, { signal: options?.signal }).then(response => {
     let downloaded = 0
-    const size = Number(response.headers.get('Content-Length')) || null
+    const size = Number(response.headers.get('Content-Length')) ?? null
 
     // with node-fetch, response.body will be a Node.js readable stream
     // rather than a browser-land ReadableStream


### PR DESCRIPTION
# Overview

At the bottom of every PR in Github, it shows a bunch of lint errors for `Unchanged files with check annotations`. This clutters up the code review, and makes it hard to quickly find the bottom of the changed code that I actually care about.

This PR fixes the lint errors:
- "Expected property shorthand"
- "Don't use `String` as a type. Use string instead"
- "This assertion is unnecessary since it does not change the type of the expression"
- "Unexpected number value in conditional. An explicit zero/NaN check is required"

## Test Plan and Hands on Testing

I'm relying on the existing CI tests.

## Risk assessment

Low. There should be no change in behavior. This is just a cleanup to make lint happy.