### PR TITLE
fix(components): fix z-index of labware jog renderer in LPC

### DIFF
--- a/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
+++ b/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
@@ -69,22 +69,30 @@ export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
     )
     wholeDeckViewBox = `${viewBoxOriginX} ${viewBoxOriginY} ${deckXDimension} ${deckYDimension}`
   }
+
+  const activeViewBox = viewBox ?? wholeDeckViewBox
+
   return (
-    <Svg
-      viewBox={viewBox || wholeDeckViewBox}
-      ref={wrapperRef}
-      id={id}
-      /* reflect horizontally about the center of the DOM elem */
-      transform="scale(1, -1)"
-      {...styleProps}
-    >
-      {showDeckLayers ? (
-        <DeckFromLayers
-          layerBlocklist={deckLayerBlocklist}
-          robotType={OT2_ROBOT_TYPE}
-        />
-      ) : null}
-      {children?.({ deckSlotsById, getRobotCoordsFromDOMCoords })}
+    <Svg viewBox={activeViewBox} ref={wrapperRef} id={id} {...styleProps}>
+      <g
+        transform={
+          activeViewBox
+            ? `scale(1, -1) translate(0, ${
+                -1 *
+                (Number(activeViewBox?.split(' ')[3]) +
+                  2 * Number(activeViewBox?.split(' ')[1]))
+              })`
+            : undefined
+        }
+      >
+        {showDeckLayers ? (
+          <DeckFromLayers
+            layerBlocklist={deckLayerBlocklist}
+            robotType={OT2_ROBOT_TYPE}
+          />
+        ) : null}
+        {children?.({ deckSlotsById, getRobotCoordsFromDOMCoords })}
+      </g>
     </Svg>
   )
 }


### PR DESCRIPTION
Closes [RQA-4054](https://opentrons.atlassian.net/browse/RQA-4054)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

CSS `transform` creates a new stacking context when applied to an HTML element. However, when applied directly to a true SVG element , the transform is treated as an SVG `transform`, which behaves differently (it does not create a stacking context).

We don't want to create new stacking contexts in such a low level component abstraction layer, because this effectively breaks proper z-indexing that cannot be solved at higher abstraction layers. We have to address it here.

### Current Behavior


https://github.com/user-attachments/assets/2fe16363-fbc4-44ee-8e75-50188a6d0d4c


### Fixed Behavior

https://github.com/user-attachments/assets/a724093b-2ae9-4955-8d74-791c66134777


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed labware rendering outside of expected content wrappers.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
mediumish - We have to fix the component here, but this does mean that uses of `RobotWorkSpace` could potentially break if they were dependent on the inherent z-index that existed prior. That being said, I don't think any usages are dependent upon this bug.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4054]: https://opentrons.atlassian.net/browse/RQA-4054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ