### PR TITLE
feat(protocol-designer): bump apiLevel in PD-generated Python from 2.23 to 2.24

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -133,7 +133,7 @@ metadata = {
 
 requirements = {
     "robotType": "OT-2",
-    "apiLevel": "2.23",
+    "apiLevel": "2.24",
 }
 
 def run(protocol: protocol_api.ProtocolContext):

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -75,7 +75,7 @@ describe('pythonRequirements', () => {
       `
 requirements = {
     "robotType": "OT-2",
-    "apiLevel": "2.23",
+    "apiLevel": "2.24",
 }`.trimStart()
     )
 
@@ -83,7 +83,7 @@ requirements = {
       `
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.23",
+    "apiLevel": "2.24",
 }`.trimStart()
     )
   })

--- a/step-generation/src/commandCreators/atomic/touchTip.ts
+++ b/step-generation/src/commandCreators/atomic/touchTip.ts
@@ -62,7 +62,6 @@ export const touchTip: CommandCreator<TouchTipAtomicParams> = (
     ...(mmFromEdge != null ? [`mm_from_edge=${mmFromEdge}`] : []),
   ]
 
-  //  TODO: add mmFromEdge to python and commandCreator
   const python = `${pipettePythonName}.touch_tip(${pythonArgs.join(', ')})`
 
   const commands: CreateCommand[] = [

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -38,7 +38,7 @@ export const getFlexNameConversion = (pipetteSpec: PipetteV2Specs): string => {
   return `flex_${channels}channel_${maxVolume}`
 }
 
-const PAPI_VERSION = '2.23' // latest version from api/src/opentrons/protocols/api_support/definitions.py
+const PAPI_VERSION = '2.24' // latest version from api/src/opentrons/protocols/api_support/definitions.py
 
 export function pythonImports(): string {
   return [


### PR DESCRIPTION
# Overview

We want PD Python export to start using PAPI calls that are only available in API version 2.24.

Note that this means the generated Python from PD may not run on the robots if the robots have an older software release.

(And PD was already generating Python code that called `touch_tip(mm_from_edge)`, even though `mm_from_edge` wasn't available until API 2.24.)

## Test Plan and Hands on Testing

Updated unit tests.

## Risk assessment

Low-ish. Python export is still hidden behind a feature flag.