### PR TITLE
refactor(app, step-generation): use `getLabwareDefIsStandard()` to check if labware is standard

### DIFF
--- a/app-shell/src/labware/validation.ts
+++ b/app-shell/src/labware/validation.ts
@@ -1,6 +1,7 @@
 import Ajv from 'ajv'
 import sortBy from 'lodash/sortBy'
 import {
+  getLabwareDefIsStandard,
   labwareSchemaV2 as labwareSchema,
   validateCustomLabwareHelper,
 } from '@opentrons/shared-data'
@@ -46,9 +47,9 @@ export function validateLabwareFiles(
 
     const props = { filename, modified, definition }
 
-    return definition.namespace !== 'opentrons'
-      ? { ...props, type: VALID_LABWARE_FILE }
-      : { ...props, type: OPENTRONS_LABWARE_FILE }
+    return getLabwareDefIsStandard(definition)
+      ? { ...props, type: OPENTRONS_LABWARE_FILE }
+      : { ...props, type: VALID_LABWARE_FILE }
   })
 
   return validated.map(v => {

--- a/app/src/organisms/Desktop/Labware/LabwareCard/index.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareCard/index.tsx
@@ -19,7 +19,7 @@ import {
   TYPOGRAPHY,
   DISPLAY_GRID,
 } from '@opentrons/components'
-
+import { getLabwareDefIsStandard } from '@opentrons/shared-data'
 import { UNIVERSAL_FLAT_ADAPTER_X_DIMENSION } from '../LabwareDetails/Gallery'
 import { CustomLabwareOverflowMenu } from './CustomLabwareOverflowMenu'
 import type { LabwareDefAndDate } from '/app/local-resources/labware'
@@ -35,7 +35,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
   const apiName = definition.parameters.loadName
   const displayName = definition?.metadata.displayName
   const displayCategory = startCase(definition.metadata.displayCategory)
-  const isCustomDefinition = definition.namespace !== 'opentrons'
+  const isCustomDefinition = !getLabwareDefIsStandard(definition)
   const xDimensionOverride =
     definition.parameters.loadName === 'opentrons_universal_flat_adapter'
       ? UNIVERSAL_FLAT_ADAPTER_X_DIMENSION

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/index.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/index.tsx
@@ -23,7 +23,10 @@ import {
   TYPOGRAPHY,
   useHoverTooltip,
 } from '@opentrons/components'
-import { getUniqueWellProperties } from '@opentrons/shared-data'
+import {
+  getLabwareDefIsStandard,
+  getUniqueWellProperties,
+} from '@opentrons/shared-data'
 import { Slideout } from '/app/atoms/Slideout'
 import { getWellLabel } from './helpers/labels'
 import { WellCount } from './WellCount'
@@ -77,7 +80,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
   const insertCategory = insert?.metadata.displayCategory
   const irregular = wellGroups.length > 1
   const isMultiRow = ordering.some(row => row.length > 1)
-  const isCustomDefinition = definition.namespace !== 'opentrons'
+  const isCustomDefinition = !getLabwareDefIsStandard(definition)
   const [showToolTip, setShowToolTip] = useState<boolean>(false)
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP_START,

--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -18,6 +18,7 @@ import {
   StyledText,
   useMenuHandleClickOutside,
 } from '@opentrons/components'
+import { getLabwareDefIsStandard } from '@opentrons/shared-data'
 import { Divider } from '/app/atoms/structure'
 import { getTopPortalEl } from '/app/App/portal'
 import { LabwareDetails } from '/app/organisms/Desktop/Labware/LabwareDetails'
@@ -61,7 +62,7 @@ export const ProtocolLabwareDetails = (props: {
           {labwareAndLidDetails?.map((labware, index) => (
             <ProtocolLabwareDetailItem
               key={index}
-              namespace={labware.labwareDef.namespace}
+              isStandard={getLabwareDefIsStandard(labware.labwareDef)}
               displayName={labware.labwareDef.metadata.displayName}
               quantity={labware.quantity}
               labware={{ definition: labware.labwareDef }}
@@ -78,7 +79,7 @@ export const ProtocolLabwareDetails = (props: {
 }
 
 interface ProtocolLabwareDetailItemProps {
-  namespace: string
+  isStandard: boolean
   displayName: string
   quantity: number
   lidDisplayName?: string
@@ -89,7 +90,7 @@ export const ProtocolLabwareDetailItem = (
   props: ProtocolLabwareDetailItemProps
 ): JSX.Element => {
   const { t } = useTranslation('protocol_details')
-  const { namespace, displayName, quantity, labware, lidDisplayName } = props
+  const { isStandard, displayName, quantity, labware, lidDisplayName } = props
   return (
     <>
       <Divider width="100%" />
@@ -104,7 +105,7 @@ export const ProtocolLabwareDetailItem = (
           width="66%"
           marginRight={SPACING.spacing20}
         >
-          {namespace === 'opentrons' ? (
+          {isStandard ? (
             <Icon
               color={COLORS.blue50}
               name="check-decagram"

--- a/app/src/pages/ODD/ProtocolDetails/Labware.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/Labware.tsx
@@ -13,6 +13,7 @@ import {
   WRAP,
   DIRECTION_COLUMN,
 } from '@opentrons/components'
+import { getLabwareDefIsStandard } from '@opentrons/shared-data'
 
 import { useRequiredProtocolLabware } from '/app/resources/protocols'
 import { EmptySection } from './EmptySection'
@@ -95,7 +96,7 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
                   paddingLeft={SPACING.spacing24}
                   alignItems={ALIGN_CENTER}
                 >
-                  {labware.labwareDef.namespace === 'opentrons' ? (
+                  {getLabwareDefIsStandard(labware.labwareDef) ? (
                     <Icon
                       color={COLORS.blue50}
                       name="check-decagram"

--- a/app/src/pages/ODD/QuickTransferDetails/Labware.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/Labware.tsx
@@ -12,7 +12,7 @@ import {
   TYPOGRAPHY,
   WRAP,
 } from '@opentrons/components'
-
+import { getLabwareDefIsStandard } from '@opentrons/shared-data'
 import { useRequiredProtocolLabware } from '/app/resources/protocols'
 
 const Table = styled('table')`
@@ -89,7 +89,7 @@ export const Labware = (props: { transferId: string }): JSX.Element => {
                   flexDirection={DIRECTION_ROW}
                   paddingLeft={SPACING.spacing24}
                 >
-                  {labware.labwareDef.namespace === 'opentrons' ? (
+                  {getLabwareDefIsStandard(labware.labwareDef) ? (
                     <Icon
                       color={COLORS.blue50}
                       name="check-decagram"

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -9,6 +9,7 @@ import {
   orderWells,
   THERMOCYCLER_MODULE_TYPE,
   SINGLE,
+  getLabwareDefIsStandard,
 } from '@opentrons/shared-data'
 import { COLUMN_4_SLOTS } from './constants'
 import type {
@@ -133,7 +134,7 @@ export function getNextTiprack(
       const has96TiprackAdapterId =
         adapterEntity?.def.parameters.loadName ===
           'opentrons_flex_96_tiprack_adapter' &&
-        adapterEntity?.def.namespace === 'opentrons'
+        getLabwareDefIsStandard(adapterEntity?.def)
 
       return nozzles === ALL ? has96TiprackAdapterId : !has96TiprackAdapterId
     }


### PR DESCRIPTION
# Overview

We have a couple of places in the code where we say `labwareDefinition.namespace === 'opentrons'` to check if something is standard labware. But we have the shared-data function `getLabwareDefIsStandard()` to do that, so let's use that everywhere.

(I'm doing this cleanup to prepare for custom labware in PD Python export.)

## Test Plan and Hands on Testing

I'm relying on CI tests to make sure this works.

## Risk assessment

Low. There should be no functional change at all.