### PR TITLE
fix(api): refactor get relative well location

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -763,6 +763,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 location_type=WellLocationFunction.LIQUID_HANDLING,
             )
             assert isinstance(well_location, LiquidHandlingWellLocation)
+            if well_location.volumeOffset and well_location.volumeOffset != 0:
+                raise ValueError("volume offset not supported with move_to")
             self._engine_client.execute_command(
                 cmd.MoveToWellParams(
                     pipetteId=self._pipette_id,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -49,8 +49,13 @@ from opentrons.protocol_engine.types import (
     AddressableOffsetVector,
     LiquidClassRecord,
     NextTipInfo,
+    PickUpTipWellLocation,
+    LiquidHandlingWellLocation,
 )
-from opentrons.protocol_engine.types.liquid_level_detection import LiquidTrackingType
+from opentrons.protocol_engine.types import (
+    LiquidTrackingType,
+    WellLocationFunction,
+)
 from opentrons.protocol_engine.types.automatic_tip_selection import (
     NoTipAvailable,
     NoTipReason,
@@ -228,10 +233,11 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             (
                 well_location,
                 dynamic_liquid_tracking,
-            ) = self._engine_client.state.geometry.get_relative_liquid_handling_well_location(
+            ) = self._engine_client.state.geometry.get_relative_well_location(
                 labware_id=labware_id,
                 well_name=well_name,
                 absolute_point=location.point,
+                location_type=WellLocationFunction.LIQUID_HANDLING,
                 meniscus_tracking=meniscus_tracking,
             )
             pipette_movement_conflict.check_safe_for_pipette_movement(
@@ -241,8 +247,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 well_name=well_name,
                 well_location=well_location,
             )
+            assert isinstance(well_location, LiquidHandlingWellLocation)
             if dynamic_liquid_tracking:
-
                 self._engine_client.execute_command(
                     cmd.AspirateWhileTrackingParams(
                         pipetteId=self._pipette_id,
@@ -340,12 +346,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             (
                 well_location,
                 dynamic_liquid_tracking,
-            ) = self._engine_client.state.geometry.get_relative_liquid_handling_well_location(
+            ) = self._engine_client.state.geometry.get_relative_well_location(
                 labware_id=labware_id,
                 well_name=well_name,
                 absolute_point=location.point,
+                location_type=WellLocationFunction.LIQUID_HANDLING,
                 meniscus_tracking=meniscus_tracking,
             )
+            assert isinstance(well_location, LiquidHandlingWellLocation)
             pipette_movement_conflict.check_safe_for_pipette_movement(
                 engine_state=self._engine_client.state,
                 pipette_id=self._pipette_id,
@@ -431,13 +439,16 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             well_name = well_core.get_name()
             labware_id = well_core.labware_id
 
-            well_location = (
-                self._engine_client.state.geometry.get_relative_well_location(
-                    labware_id=labware_id,
-                    well_name=well_name,
-                    absolute_point=location.point,
-                )
+            (
+                well_location,
+                _,
+            ) = self._engine_client.state.geometry.get_relative_well_location(
+                labware_id=labware_id,
+                well_name=well_name,
+                absolute_point=location.point,
+                location_type=WellLocationFunction.BASE,
             )
+
             pipette_movement_conflict.check_safe_for_pipette_movement(
                 engine_state=self._engine_client.state,
                 pipette_id=self._pipette_id,
@@ -445,6 +456,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 well_name=well_name,
                 well_location=well_location,
             )
+            assert isinstance(well_location, WellLocation)
             self._engine_client.execute_command(
                 cmd.BlowOutParams(
                     pipetteId=self._pipette_id,
@@ -539,12 +551,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         well_name = well_core.get_name()
         labware_id = well_core.labware_id
 
-        well_location = (
-            self._engine_client.state.geometry.get_relative_pick_up_tip_well_location(
-                labware_id=labware_id,
-                well_name=well_name,
-                absolute_point=location.point,
-            )
+        (
+            well_location,
+            _,
+        ) = self._engine_client.state.geometry.get_relative_well_location(
+            labware_id=labware_id,
+            well_name=well_name,
+            absolute_point=location.point,
+            location_type=WellLocationFunction.PICK_UP_TIP,
         )
         pipette_movement_conflict.check_safe_for_tip_pickup_and_return(
             engine_state=self._engine_client.state,
@@ -558,7 +572,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             well_name=well_name,
             well_location=well_location,
         )
-
+        assert isinstance(well_location, PickUpTipWellLocation)
         self._engine_client.execute_command(
             cmd.PickUpTipParams(
                 pipetteId=self._pipette_id,
@@ -596,12 +610,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         scrape_tips = False
 
         if location is not None:
-            relative_well_location = (
-                self._engine_client.state.geometry.get_relative_well_location(
-                    labware_id=labware_id,
-                    well_name=well_name,
-                    absolute_point=location.point,
-                )
+            (
+                relative_well_location,
+                _,
+            ) = self._engine_client.state.geometry.get_relative_well_location(
+                labware_id=labware_id,
+                well_name=well_name,
+                absolute_point=location.point,
+                location_type=WellLocationFunction.DROP_TIP,
             )
 
             well_location = DropTipWellLocation(
@@ -737,14 +753,16 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 raise ValueError("Trash Bin and Waste Chute have no Wells.")
             labware_id = well_core.labware_id
             well_name = well_core.get_name()
-            well_location = (
-                self._engine_client.state.geometry.get_relative_well_location(
-                    labware_id=labware_id,
-                    well_name=well_name,
-                    absolute_point=location.point,
-                )
+            (
+                well_location,
+                _,
+            ) = self._engine_client.state.geometry.get_relative_well_location(
+                labware_id=labware_id,
+                well_name=well_name,
+                absolute_point=location.point,
+                location_type=WellLocationFunction.LIQUID_HANDLING,
             )
-
+            assert isinstance(well_location, LiquidHandlingWellLocation)
             self._engine_client.execute_command(
                 cmd.MoveToWellParams(
                     pipetteId=self._pipette_id,
@@ -785,14 +803,16 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     ) -> None:
         labware_id = well_core.labware_id
         well_name = well_core.get_name()
-        well_location = (
-            self._engine_client.state.geometry.get_relative_pick_up_tip_well_location(
-                labware_id=labware_id,
-                well_name=well_name,
-                absolute_point=location.point,
-            )
+        (
+            well_location,
+            _,
+        ) = self._engine_client.state.geometry.get_relative_well_location(
+            labware_id=labware_id,
+            well_name=well_name,
+            absolute_point=location.point,
+            location_type=WellLocationFunction.PICK_UP_TIP,
         )
-
+        assert isinstance(well_location, PickUpTipWellLocation)
         self._engine_client.execute_command(
             cmd.SealPipetteToTipParams(
                 pipetteId=self._pipette_id,
@@ -807,12 +827,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         labware_id = well_core.labware_id
 
         if location is not None:
-            relative_well_location = (
-                self._engine_client.state.geometry.get_relative_well_location(
-                    labware_id=labware_id,
-                    well_name=well_name,
-                    absolute_point=location.point,
-                )
+            (
+                relative_well_location,
+                _,
+            ) = self._engine_client.state.geometry.get_relative_well_location(
+                labware_id=labware_id,
+                well_name=well_name,
+                absolute_point=location.point,
+                location_type=WellLocationFunction.BASE,
             )
 
             well_location = DropTipWellLocation(
@@ -866,10 +888,11 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         (
             well_location,
             dynamic_tracking,
-        ) = self._engine_client.state.geometry.get_relative_liquid_handling_well_location(
+        ) = self._engine_client.state.geometry.get_relative_well_location(
             labware_id=labware_id,
             well_name=well_name,
             absolute_point=location.point,
+            location_type=WellLocationFunction.LIQUID_HANDLING,
         )
         pipette_movement_conflict.check_safe_for_pipette_movement(
             engine_state=self._engine_client.state,
@@ -878,6 +901,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             well_name=well_name,
             well_location=well_location,
         )
+        assert isinstance(well_location, LiquidHandlingWellLocation)
         self._engine_client.execute_command(
             cmd.PressureDispenseParams(
                 pipetteId=self._pipette_id,

--- a/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
@@ -19,14 +19,9 @@ from opentrons.protocol_engine import (
     StateView,
     DeckSlotLocation,
     OnLabwareLocation,
-    WellLocation,
-    LiquidHandlingWellLocation,
-    PickUpTipWellLocation,
     DropTipWellLocation,
 )
-from opentrons.protocol_engine.types import (
-    StagingSlotLocation,
-)
+from opentrons.protocol_engine.types import StagingSlotLocation, WellLocationType
 from opentrons.types import DeckSlotName, StagingSlotName, Point
 from . import point_calculations
 
@@ -69,12 +64,7 @@ def check_safe_for_pipette_movement(  # noqa: C901
     pipette_id: str,
     labware_id: str,
     well_name: str,
-    well_location: Union[
-        WellLocation,
-        LiquidHandlingWellLocation,
-        PickUpTipWellLocation,
-        DropTipWellLocation,
-    ],
+    well_location: WellLocationType,
 ) -> None:
     """Check if the labware is safe to move to with a pipette in partial tip configuration.
 

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -11,7 +11,7 @@ from opentrons.protocols.api_support.util import FlowRates
 from opentrons.protocols.advanced_control.transfers.common import TransferTipPolicyV2
 from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocol_api._liquid import LiquidClass
-from opentrons.protocol_engine.types.liquid_level_detection import LiquidTrackingType
+from opentrons.protocol_engine.types import LiquidTrackingType
 
 from ..disposal_locations import TrashBin, WasteChute
 from .well import WellCoreType

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -22,7 +22,7 @@ from opentrons.protocols.geometry import planning
 from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocol_api._liquid import LiquidClass
 
-from opentrons.protocol_engine.types.liquid_level_detection import LiquidTrackingType
+from opentrons.protocol_engine.types import LiquidTrackingType
 
 from ...disposal_locations import TrashBin, WasteChute
 from ..instrument import AbstractInstrument

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -23,7 +23,7 @@ from opentrons_shared_data.errors.exceptions import (
     UnexpectedTipAttachError,
 )
 
-from opentrons.protocol_engine.types.liquid_level_detection import LiquidTrackingType
+from opentrons.protocol_engine.types import LiquidTrackingType
 
 from ..legacy.legacy_labware_core import LegacyLabwareCore
 from ...disposal_locations import TrashBin, WasteChute

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from typing import TypeVar, Optional, Union
 
 from opentrons.types import Point
-from opentrons.protocol_engine.types.liquid_level_detection import LiquidTrackingType
+from opentrons.protocol_engine.types import LiquidTrackingType
 
 from .._liquid import Liquid
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -42,7 +42,7 @@ from ..protocols.advanced_control.transfers.common import (
     TransferTipPolicyV2,
     TransferTipPolicyV2Type,
 )
-from ..protocol_engine.types.liquid_level_detection import LiquidTrackingType
+from ..protocol_engine.types import LiquidTrackingType
 
 _DEFAULT_ASPIRATE_CLEARANCE = 1.0
 _DEFAULT_DISPENSE_CLEARANCE = 1.0

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -46,7 +46,7 @@ from opentrons.protocols.api_support.util import (
     APIVersionError,
     UnsupportedAPIError,
 )
-from opentrons.protocol_engine.types.liquid_level_detection import LiquidTrackingType
+from opentrons.protocol_engine.types import LiquidTrackingType
 
 # TODO(mc, 2022-09-02): re-exports provided for backwards compatibility
 # remove when their usage is no longer needed

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -22,8 +22,7 @@ from opentrons_shared_data.errors.exceptions import (
     PipetteOverpressureError,
 )
 
-from ..types import DeckPoint
-from ..types.liquid_level_detection import LiquidTrackingType
+from ..types import DeckPoint, LiquidTrackingType
 from .pipetting_common import (
     LiquidNotFoundError,
     PipetteIdMixin,

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -71,6 +71,8 @@ class MoveToWellImplementation(
         well_name = params.wellName
         well_location = params.wellLocation
 
+        if well_location.volumeOffset and well_location.volumeOffset != 0:
+            raise ValueError("volume offset not supported with MoveToWell")
         if (
             self._state_view.labware.is_tiprack(labware_id)
             and well_location.volumeOffset

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -21,7 +21,6 @@ from .command import (
     SuccessData,
     DefinedErrorData,
 )
-from ..errors import LabwareIsTipRackError
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -70,16 +69,9 @@ class MoveToWellImplementation(
         labware_id = params.labwareId
         well_name = params.wellName
         well_location = params.wellLocation
-
+        # TODO(cm): implement move_to_well with meniscus + volume offset
         if well_location.volumeOffset and well_location.volumeOffset != 0:
             raise ValueError("volume offset not supported with MoveToWell")
-        if (
-            self._state_view.labware.is_tiprack(labware_id)
-            and well_location.volumeOffset
-        ):
-            raise LabwareIsTipRackError(
-                "Cannot specify a WellLocation with a volumeOffset with movement to a tip rack"
-            )
 
         move_result = await move_to_well(
             model_utils=self._model_utils,

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -8,7 +8,7 @@ from .pipetting_common import (
     PipetteIdMixin,
 )
 from .movement_common import (
-    WellLocationMixin,
+    LiquidHandlingWellLocationMixin,
     MovementMixin,
     DestinationPositionResult,
     StallOrCollisionError,
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 MoveToWellCommandType = Literal["moveToWell"]
 
 
-class MoveToWellParams(PipetteIdMixin, WellLocationMixin, MovementMixin):
+class MoveToWellParams(PipetteIdMixin, LiquidHandlingWellLocationMixin, MovementMixin):
     """Payload required to move a pipette to a specific well."""
 
     pass

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -313,7 +313,6 @@ class GeometryView:
             child_definition=self._labware.get_definition(labware_id),
             parent=self._labware.get(labware_id).location,
         )
-
         return Point(
             parent_pos.x + offset_from_parent.x,
             parent_pos.y + offset_from_parent.y,
@@ -458,7 +457,6 @@ class GeometryView:
         """Get the calibrated origin of the labware."""
         origin_pos = self.get_labware_origin_position(labware_id)
         cal_offset = self._labware.get_labware_offset_vector(labware_id)
-
         return Point(
             x=origin_pos.x + cal_offset.x,
             y=origin_pos.y + cal_offset.y,
@@ -769,7 +767,6 @@ class GeometryView:
         """Get the slot name of the labware or the module that the labware is on."""
         labware = self._labware.get(labware_id)
         slot_name: Union[DeckSlotName, StagingSlotName]
-
         if isinstance(labware.location, DeckSlotLocation):
             slot_name = labware.location.slotName
         elif isinstance(labware.location, ModuleLocation):

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1896,6 +1896,7 @@ class GeometryView:
             and not well_location.volumeOffset
         ):
             return initial_handling_height
+        volume: Optional[float] = None
         if isinstance(well_location, PickUpTipWellLocation):
             volume = 0.0
         elif isinstance(well_location, LiquidHandlingWellLocation):

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -80,6 +80,8 @@ from ..types import (
     AreaType,
     labware_location_is_off_deck,
     labware_location_is_system,
+    WellLocationType,
+    WellLocationFunction,
 )
 from ..types.liquid_level_detection import SimulatedProbeResult, LiquidTrackingType
 from .config import Config
@@ -463,13 +465,9 @@ class GeometryView:
             z=origin_pos.z + cal_offset.z,
         )
 
-    WellLocations = Union[
-        WellLocation, LiquidHandlingWellLocation, PickUpTipWellLocation
-    ]
-
     def validate_well_position(
         self,
-        well_location: WellLocations,
+        well_location: WellLocationType,
         z_offset: float,
         pipette_id: Optional[str] = None,
     ) -> None:
@@ -483,29 +481,29 @@ class GeometryView:
                 pipette_id=pipette_id
             )
             if z_offset < lld_min_height:
-                if isinstance(well_location, PickUpTipWellLocation):
+                if isinstance(well_location, LiquidHandlingWellLocation):
                     raise OperationLocationNotInWellError(
                         f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset} mm; the minimum allowed height for liquid tracking is {lld_min_height} mm"
                     )
                 else:
                     raise OperationLocationNotInWellError(
-                        f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset} mm; the minimum allowed height for liquid tracking is {lld_min_height} mm"
+                        f"Specifying {well_location.origin} with an offset of {well_location.offset} results in an operation location that could be below the bottom of the well"
                     )
         elif z_offset < 0:
-            if isinstance(well_location, PickUpTipWellLocation):
+            if isinstance(well_location, LiquidHandlingWellLocation):
                 raise OperationLocationNotInWellError(
-                    f"Specifying {well_location.origin} with an offset of {well_location.offset.z} results in a location below the bottom of the well"
+                    f"Specifying {well_location.origin} with an offset of {well_location.offset} and a volume offset of {well_location.volumeOffset} results in an operation location below the bottom of the well"
                 )
             else:
                 raise OperationLocationNotInWellError(
-                    f"Specifying {well_location.origin} with an offset of {well_location.offset.z} and a volume offset of {well_location.volumeOffset} results in a location below the bottom of the well"
+                    f"Specifying {well_location.origin} with an offset of {well_location.offset} results in an operation location below the bottom of the well"
                 )
 
     def get_well_position(
         self,
         labware_id: str,
         well_name: str,
-        well_location: Optional[WellLocations] = None,
+        well_location: Optional[WellLocationType] = None,
         operation_volume: Optional[float] = None,
         pipette_id: Optional[str] = None,
     ) -> Point:
@@ -552,25 +550,14 @@ class GeometryView:
             z=parent_pos.z + origin_offset.z + well_def.z + well_def.depth,
         )
 
-    def get_relative_well_location(
+    def _get_relative_liquid_handling_well_location(
         self,
         labware_id: str,
         well_name: str,
         absolute_point: Point,
-    ) -> WellLocation:
-        """Given absolute position, get relative location of a well in a labware."""
-        well_absolute_point = self.get_well_position(labware_id, well_name)
-        delta = absolute_point - well_absolute_point
-
-        return WellLocation(offset=WellOffset(x=delta.x, y=delta.y, z=delta.z))
-
-    def get_relative_liquid_handling_well_location(
-        self,
-        labware_id: str,
-        well_name: str,
-        absolute_point: Point,
+        delta: Point,
         meniscus_tracking: Optional[MeniscusTrackingTarget] = None,
-    ) -> Tuple[LiquidHandlingWellLocation, bool]:
+    ) -> Tuple[WellLocationType, bool]:
         """Given absolute position, get relative location of a well in a labware."""
         dynamic_liquid_tracking = False
         if meniscus_tracking:
@@ -578,29 +565,50 @@ class GeometryView:
                 origin=WellOrigin.MENISCUS,
                 offset=WellOffset(x=0, y=0, z=absolute_point.z),
             )
+            # TODO(cm): handle operationVolume being a float other than 0
             if meniscus_tracking == MeniscusTrackingTarget.END:
                 location.volumeOffset = "operationVolume"
             elif meniscus_tracking == MeniscusTrackingTarget.DYNAMIC:
                 dynamic_liquid_tracking = True
         else:
-            well_absolute_point = self.get_well_position(labware_id, well_name)
-            delta = absolute_point - well_absolute_point
             location = LiquidHandlingWellLocation(
                 offset=WellOffset(x=delta.x, y=delta.y, z=delta.z)
             )
         return location, dynamic_liquid_tracking
 
-    def get_relative_pick_up_tip_well_location(
+    def get_relative_well_location(
         self,
         labware_id: str,
         well_name: str,
         absolute_point: Point,
-    ) -> PickUpTipWellLocation:
+        location_type: WellLocationFunction,
+        meniscus_tracking: Optional[MeniscusTrackingTarget] = None,
+    ) -> Tuple[WellLocationType, bool]:
         """Given absolute position, get relative location of a well in a labware."""
         well_absolute_point = self.get_well_position(labware_id, well_name)
         delta = absolute_point - well_absolute_point
-
-        return PickUpTipWellLocation(offset=WellOffset(x=delta.x, y=delta.y, z=delta.z))
+        match location_type:
+            case WellLocationFunction.BASE | WellLocationFunction.DROP_TIP:
+                return (
+                    WellLocation(offset=WellOffset(x=delta.x, y=delta.y, z=delta.z)),
+                    False,
+                )
+            case WellLocationFunction.PICK_UP_TIP:
+                return (
+                    PickUpTipWellLocation(
+                        offset=WellOffset(x=delta.x, y=delta.y, z=delta.z)
+                    ),
+                    False,
+                )
+            case WellLocationFunction.LIQUID_HANDLING:
+                return self._get_relative_liquid_handling_well_location(
+                    labware_id=labware_id,
+                    well_name=well_name,
+                    absolute_point=absolute_point,
+                    delta=delta,
+                    meniscus_tracking=meniscus_tracking,
+                )
+        return NotImplemented
 
     def get_well_height(
         self,
@@ -1865,7 +1873,7 @@ class GeometryView:
         self,
         labware_id: str,
         well_name: str,
-        well_location: WellLocations,
+        well_location: WellLocationType,
         well_depth: float,
         operation_volume: Optional[float] = None,
     ) -> LiquidTrackingType:
@@ -1890,10 +1898,13 @@ class GeometryView:
             return initial_handling_height
         if isinstance(well_location, PickUpTipWellLocation):
             volume = 0.0
-        elif isinstance(well_location.volumeOffset, float):
-            volume = well_location.volumeOffset
-        elif well_location.volumeOffset == "operationVolume":
-            volume = operation_volume or 0.0
+        elif isinstance(well_location, LiquidHandlingWellLocation):
+            if well_location.volumeOffset == "operationVolume":
+                volume = operation_volume or 0.0
+            else:
+                if not isinstance(well_location.volumeOffset, float):
+                    raise ValueError("Invalid volume offset.")
+                volume = well_location.volumeOffset
 
         if volume:
             liquid_height_after = self.get_well_height_after_liquid_handling(
@@ -2001,7 +2012,7 @@ class GeometryView:
         self,
         labware_id: str,
         well_name: str,
-        well_location: WellLocations,
+        well_location: WellLocationType,
         well_depth: float,
     ) -> LiquidTrackingType:
         """Return the handling height for a labware well (with reference to the well bottom)."""
@@ -2113,7 +2124,7 @@ class GeometryView:
         self,
         labware_id: str,
         well_name: str,
-        well_location: WellLocations,
+        well_location: WellLocationType,
         volume: float,
     ) -> None:
         """Raise InvalidDispenseVolumeError if planned dispense volume will overflow well."""

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -18,8 +18,8 @@ from opentrons.protocol_engine.types import (
     AspiratedFluid,
     LiquidClassRecord,
     ABSMeasureMode,
+    LiquidTrackingType,
 )
-from opentrons.protocol_engine.types.liquid_level_detection import LiquidTrackingType
 from opentrons.types import MountType
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.pipette.types import PipetteNameType

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -117,6 +117,8 @@ from .well_position import (
     LiquidHandlingWellLocation,
     PickUpTipWellLocation,
     DropTipWellLocation,
+    WellLocationType,
+    WellLocationFunction,
 )
 from .instrument import (
     LoadedPipette,
@@ -132,6 +134,7 @@ from .liquid_level_detection import (
     ProbedVolumeInfo,
     WellInfoSummary,
     WellLiquidInfo,
+    LiquidTrackingType,
 )
 from .liquid_handling import FlowRates
 from .labware_movement import LabwareMovementStrategy, LabwareMovementOffsetData
@@ -259,6 +262,8 @@ __all__ = [
     "LiquidHandlingWellLocation",
     "PickUpTipWellLocation",
     "DropTipWellLocation",
+    "WellLocationType",
+    "WellLocationFunction",
     # Execution
     "EngineStatus",
     "PostRunHardwareState",
@@ -274,6 +279,7 @@ __all__ = [
     "ProbedVolumeInfo",
     "WellInfoSummary",
     "WellLiquidInfo",
+    "LiquidTrackingType",
     # Liquid handling
     "FlowRates",
     # Labware movement

--- a/api/src/opentrons/protocol_engine/types/well_position.py
+++ b/api/src/opentrons/protocol_engine/types/well_position.py
@@ -1,5 +1,5 @@
 """Protocol engine types to do with positions inside wells."""
-from enum import Enum
+from enum import Enum, auto
 from typing import Union, Literal
 
 from pydantic import BaseModel, Field
@@ -50,6 +50,15 @@ class DropTipWellOrigin(str, Enum):
     BOTTOM = "bottom"
     CENTER = "center"
     DEFAULT = "default"
+
+
+class WellLocationFunction(int, Enum):
+    """The type of well location object to be created."""
+
+    BASE = auto()
+    LIQUID_HANDLING = auto()
+    PICK_UP_TIP = auto()
+    DROP_TIP = auto()
 
 
 # This is deliberately a separate type from Vec3f to let components default to 0.
@@ -105,3 +114,11 @@ class DropTipWellLocation(BaseModel):
 
     origin: DropTipWellOrigin = DropTipWellOrigin.DEFAULT
     offset: WellOffset = Field(default_factory=WellOffset)
+
+
+WellLocationType = Union[
+    WellLocation,
+    LiquidHandlingWellLocation,
+    PickUpTipWellLocation,
+    DropTipWellLocation,
+]

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -309,7 +309,12 @@ def test_move_to_well(
             location_type=WellLocationFunction.LIQUID_HANDLING,
         )
     ).then_return(
-        (WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)), False)
+        (
+            LiquidHandlingWellLocation(
+                origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
+            ),
+            False,
+        )
     )
 
     subject.move_to(

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -57,6 +57,7 @@ from opentrons.protocol_engine.types import (
     NextTipInfo,
     NoTipAvailable,
     NoTipReason,
+    WellLocationFunction,
 )
 from opentrons.protocol_api.disposal_locations import (
     TrashBin,
@@ -305,8 +306,11 @@ def test_move_to_well(
             labware_id="labware-id",
             well_name="well-name",
             absolute_point=Point(1, 2, 3),
+            location_type=WellLocationFunction.LIQUID_HANDLING,
         )
-    ).then_return(WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)))
+    ).then_return(
+        (WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)), False)
+    )
 
     subject.move_to(
         location=location,
@@ -322,7 +326,7 @@ def test_move_to_well(
                 pipetteId="abc123",
                 labwareId="labware-id",
                 wellName="well-name",
-                wellLocation=WellLocation(
+                wellLocation=LiquidHandlingWellLocation(
                     origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
                 ),
                 forceDirect=True,
@@ -381,14 +385,18 @@ def test_pick_up_tip(
     )
 
     decoy.when(
-        mock_engine_client.state.geometry.get_relative_pick_up_tip_well_location(
+        mock_engine_client.state.geometry.get_relative_well_location(
             labware_id="labware-id",
             well_name="well-name",
             absolute_point=Point(1, 2, 3),
+            location_type=WellLocationFunction.PICK_UP_TIP,
         )
     ).then_return(
-        PickUpTipWellLocation(
-            origin=PickUpTipWellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
+        (
+            PickUpTipWellLocation(
+                origin=PickUpTipWellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
+            ),
+            False,
         )
     )
 
@@ -499,8 +507,11 @@ def test_drop_tip_with_location(
             labware_id="labware-id",
             well_name="well-name",
             absolute_point=Point(1, 2, 3),
+            location_type=WellLocationFunction.DROP_TIP,
         )
-    ).then_return(WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)))
+    ).then_return(
+        (WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)), False)
+    )
     decoy.when(
         mock_engine_client.state.tips.get_pipette_channels("abc123")
     ).then_return(8)
@@ -625,10 +636,11 @@ def test_aspirate_from_well(
     )
 
     decoy.when(
-        mock_engine_client.state.geometry.get_relative_liquid_handling_well_location(
+        mock_engine_client.state.geometry.get_relative_well_location(
             labware_id="123abc",
             well_name="my cool well",
             absolute_point=Point(1, 2, 3),
+            location_type=WellLocationFunction.LIQUID_HANDLING,
             meniscus_tracking=None,
         )
     ).then_return(
@@ -732,10 +744,11 @@ def test_aspirate_from_meniscus(
     )
 
     decoy.when(
-        mock_engine_client.state.geometry.get_relative_liquid_handling_well_location(
+        mock_engine_client.state.geometry.get_relative_well_location(
             labware_id="123abc",
             well_name="my cool well",
             absolute_point=Point(1, 2, 3),
+            location_type=WellLocationFunction.LIQUID_HANDLING,
             meniscus_tracking=MeniscusTrackingTarget.END,
         )
     ).then_return(
@@ -836,9 +849,14 @@ def test_blow_out_to_well(
 
     decoy.when(
         mock_engine_client.state.geometry.get_relative_well_location(
-            labware_id="123abc", well_name="my cool well", absolute_point=Point(1, 2, 3)
+            labware_id="123abc",
+            well_name="my cool well",
+            absolute_point=Point(1, 2, 3),
+            location_type=WellLocationFunction.BASE,
         )
-    ).then_return(WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)))
+    ).then_return(
+        (WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)), False)
+    )
 
     subject.blow_out(location=location, well_core=well_core, in_place=False)
 
@@ -938,10 +956,11 @@ def test_dispense_to_well(
     decoy.when(mock_protocol_core.api_version).then_return(MAX_SUPPORTED_VERSION)
 
     decoy.when(
-        mock_engine_client.state.geometry.get_relative_liquid_handling_well_location(
+        mock_engine_client.state.geometry.get_relative_well_location(
             labware_id="123abc",
             well_name="my cool well",
             absolute_point=Point(1, 2, 3),
+            location_type=WellLocationFunction.LIQUID_HANDLING,
             meniscus_tracking=None,
         )
     ).then_return(

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -26,6 +26,7 @@ from opentrons.protocol_engine.commands.move_to_well import (
 from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
+from opentrons.protocol_engine.types import LiquidHandlingWellLocation
 
 
 @pytest.fixture
@@ -55,7 +56,7 @@ async def test_move_to_well_implementation(
         pipetteId="abc",
         labwareId="123",
         wellName="A3",
-        wellLocation=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+        wellLocation=LiquidHandlingWellLocation(offset=WellOffset(x=1, y=2, z=3)),
         forceDirect=True,
         minimumZHeight=4.56,
         speed=7.89,
@@ -66,7 +67,7 @@ async def test_move_to_well_implementation(
             pipette_id="abc",
             labware_id="123",
             well_name="A3",
-            well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+            well_location=LiquidHandlingWellLocation(offset=WellOffset(x=1, y=2, z=3)),
             force_direct=True,
             minimum_z_height=4.56,
             speed=7.89,
@@ -104,7 +105,9 @@ async def test_move_to_well_with_tip_rack_and_volume_offset(
         pipetteId="abc",
         labwareId="123",
         wellName="A3",
-        wellLocation=WellLocation(offset=WellOffset(x=1, y=2, z=3), volumeOffset=-40.0),
+        wellLocation=LiquidHandlingWellLocation(
+            offset=WellOffset(x=1, y=2, z=3), volumeOffset=-40.0
+        ),
         forceDirect=True,
         minimumZHeight=4.56,
         speed=7.89,
@@ -149,7 +152,7 @@ async def test_move_to_well_stall_defined_error(
         pipetteId="abc",
         labwareId="123",
         wellName="A3",
-        wellLocation=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+        wellLocation=LiquidHandlingWellLocation(offset=WellOffset(x=1, y=2, z=3)),
         forceDirect=True,
         minimumZHeight=4.56,
         speed=7.89,

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -10,7 +10,6 @@ from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedErro
 from opentrons.protocol_engine import (
     WellOffset,
     DeckPoint,
-    errors,
 )
 from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.protocol_engine.state import update_types
@@ -114,7 +113,7 @@ async def test_move_to_well_with_tip_rack_and_volume_offset(
 
     decoy.when(mock_state_view.labware.is_tiprack("123")).then_return(True)
 
-    with pytest.raises(errors.LabwareIsTipRackError):
+    with pytest.raises(ValueError):
         await subject.execute(data)
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -8,7 +8,6 @@ from decoy import Decoy, matchers
 from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 
 from opentrons.protocol_engine import (
-    WellLocation,
     WellOffset,
     DeckPoint,
     errors,
@@ -133,7 +132,7 @@ async def test_move_to_well_stall_defined_error(
             pipette_id="abc",
             labware_id="123",
             well_name="A3",
-            well_location=WellLocation(offset=WellOffset(x=1, y=2, z=3)),
+            well_location=LiquidHandlingWellLocation(offset=WellOffset(x=1, y=2, z=3)),
             force_direct=True,
             minimum_z_height=4.56,
             speed=7.89,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2062,6 +2062,12 @@ def test_get_relative_well_location(
     decoy.when(mock_labware_view.get_well_definition("labware-id", "B2")).then_return(
         well_def
     )
+    decoy.when(subject.get_labware_origin_position("labware-id")).then_return(
+        Point(1, 2, 3)
+    )
+    decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
+        well_plate_def
+    )
 
     result, _ = subject.get_relative_well_location(
         labware_id="labware-id",
@@ -2073,8 +2079,7 @@ def test_get_relative_well_location(
         ),
         location_type=WellLocationFunction.BASE,
     )
-
-    assert result == LiquidHandlingWellLocation(
+    assert result == WellLocation(
         origin=WellOrigin.TOP,
         offset=WellOffset.model_construct(
             x=cast(float, pytest.approx(7)),
@@ -2092,7 +2097,38 @@ def test_get_relative_liquid_handling_well_location(
     subject: GeometryView,
 ) -> None:
     """It should get the relative location of a well given an absolute position."""
-    (result, dynamic_liquid_tracking,) = subject.get_relative_well_location(
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="b",
+        definitionUri=uri_from_details(namespace="a", load_name="b", version=1),
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+        offsetId=None,
+    )
+    decoy.when(mock_labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(
+        mock_addressable_area_view.get_addressable_area_position("3")
+    ).then_return(Point(1, 2, 3))
+    decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
+        well_plate_def
+    )
+    decoy.when(subject.get_labware_origin_position("labware-id")).then_return(
+        Point(1, 2, 3)
+    )
+    decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
+        well_plate_def
+    )
+    calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+    decoy.when(mock_labware_view.get_labware_offset_vector("labware-id")).then_return(
+        calibration_offset
+    )
+
+    well_def = well_plate_def.wells["B2"]
+
+    decoy.when(mock_labware_view.get_well_definition("labware-id", "B2")).then_return(
+        well_def
+    )
+
+    (result, dynamic_liquid_tracking) = subject.get_relative_well_location(
         labware_id="labware-id",
         well_name="B2",
         absolute_point=Point(x=0, y=0, z=-2),

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -91,6 +91,7 @@ from opentrons.protocol_engine.types import (
     AddressableArea,
     AreaType,
     AddressableOffsetVector,
+    WellLocationFunction,
 )
 from opentrons.protocol_engine.commands import (
     CommandStatus,
@@ -2062,7 +2063,7 @@ def test_get_relative_well_location(
         well_def
     )
 
-    result = subject.get_relative_well_location(
+    result, _ = subject.get_relative_well_location(
         labware_id="labware-id",
         well_name="B2",
         absolute_point=Point(
@@ -2070,9 +2071,10 @@ def test_get_relative_well_location(
             y=slot_pos[1] - 2 + well_def.y + 8,
             z=slot_pos[2] + 3 + well_def.z + well_def.depth + 9,
         ),
+        location_type=WellLocationFunction.BASE,
     )
 
-    assert result == WellLocation(
+    assert result == LiquidHandlingWellLocation(
         origin=WellOrigin.TOP,
         offset=WellOffset.model_construct(
             x=cast(float, pytest.approx(7)),
@@ -2090,14 +2092,12 @@ def test_get_relative_liquid_handling_well_location(
     subject: GeometryView,
 ) -> None:
     """It should get the relative location of a well given an absolute position."""
-    (
-        result,
-        dynamic_liquid_tracking,
-    ) = subject.get_relative_liquid_handling_well_location(
+    (result, dynamic_liquid_tracking,) = subject.get_relative_well_location(
         labware_id="labware-id",
         well_name="B2",
         absolute_point=Point(x=0, y=0, z=-2),
         meniscus_tracking=MeniscusTrackingTarget.END,
+        location_type=WellLocationFunction.LIQUID_HANDLING,
     )
 
     assert result == LiquidHandlingWellLocation(

--- a/shared-data/command/schemas/12.json
+++ b/shared-data/command/schemas/12.json
@@ -3596,7 +3596,7 @@
           "type": "number"
         },
         "wellLocation": {
-          "$ref": "#/$defs/WellLocation",
+          "$ref": "#/$defs/LiquidHandlingWellLocation",
           "description": "Relative well location at which to perform the operation"
         },
         "wellName": {


### PR DESCRIPTION
## Overview
Refactor `get_well_position` so you now have to specify what kind of `WellLocation` you want to be created

## Changelog
- create a `WellLocationFunction` to differentiate between getting `WellLocation, LiquidHandlingWellLocation, ...etc`
- have `move_to_well` take in a `WellLocationFunction` without a default so you need to specify. This should prevent bugs like this from popping up in the future. 