### PR TITLE
fix(api): airgap flowrate, zero sec delays

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -780,8 +780,8 @@ class TransferComponentsExecutor:
         correction_volume = aspirate_props.correction_by_volume.get_for_volume(
             air_gap_volume
         )
-        # The maximum flow rate should be air_gap_volume per second
-        flow_rate = min(
+        # The minimum flow rate should be air_gap_volume per second
+        flow_rate = max(
             aspirate_props.flow_rate_by_volume.get_for_volume(air_gap_volume),
             air_gap_volume,
         )
@@ -807,8 +807,8 @@ class TransferComponentsExecutor:
         correction_volume = dispense_props.correction_by_volume.get_for_volume(
             last_air_gap
         )
-        # The maximum flow rate should be air_gap_volume per second
-        flow_rate = min(
+        # The minimum flow rate should be air_gap_volume per second
+        flow_rate = max(
             dispense_props.flow_rate_by_volume.get_for_volume(last_air_gap),
             last_air_gap,
         )

--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -207,8 +207,7 @@ class TransferComponentsExecutor:
             minimum_z_height=None,
             speed=submerge_properties.speed,
         )
-        if submerge_properties.delay.enabled:
-            assert submerge_properties.delay.duration is not None
+        if submerge_properties.delay.enabled and submerge_properties.delay.duration:
             self._instrument.delay(submerge_properties.delay.duration)
 
     def aspirate_and_wait(self, volume: float) -> None:
@@ -227,9 +226,7 @@ class TransferComponentsExecutor:
         )
         self._tip_state.append_liquid(volume)
         delay_props = aspirate_props.delay
-        if delay_props.enabled:
-            # Assertion only for mypy purposes
-            assert delay_props.duration is not None
+        if delay_props.enabled and delay_props.duration:
             self._instrument.delay(delay_props.duration)
 
     def dispense_and_wait(
@@ -257,8 +254,7 @@ class TransferComponentsExecutor:
             self._tip_state.ready_to_aspirate = False
         self._tip_state.delete_liquid(volume)
         dispense_delay = dispense_properties.delay
-        if dispense_delay.enabled:
-            assert dispense_delay.duration is not None
+        if dispense_delay.enabled and dispense_delay.duration:
             self._instrument.delay(dispense_delay.duration)
 
     def mix(self, mix_properties: MixProperties, last_dispense_push_out: bool) -> None:
@@ -361,8 +357,7 @@ class TransferComponentsExecutor:
             speed=retract_props.speed,
         )
         retract_delay = retract_props.delay
-        if retract_delay.enabled:
-            assert retract_delay.duration is not None
+        if retract_delay.enabled and retract_delay.duration:
             self._instrument.delay(retract_delay.duration)
         touch_tip_props = retract_props.touch_tip
         if touch_tip_props.enabled:
@@ -459,8 +454,7 @@ class TransferComponentsExecutor:
             speed=retract_props.speed,
         )
         retract_delay = retract_props.delay
-        if retract_delay.enabled:
-            assert retract_delay.duration is not None
+        if retract_delay.enabled and retract_delay.duration:
             self._instrument.delay(retract_delay.duration)
 
         blowout_props = retract_props.blowout
@@ -599,8 +593,7 @@ class TransferComponentsExecutor:
             speed=retract_props.speed,
         )
         retract_delay = retract_props.delay
-        if retract_delay.enabled:
-            assert retract_delay.duration is not None
+        if retract_delay.enabled and retract_delay.duration:
             self._instrument.delay(retract_delay.duration)
 
         blowout_props = retract_props.blowout
@@ -791,9 +784,7 @@ class TransferComponentsExecutor:
             correction_volume=correction_volume,
         )
         delay_props = aspirate_props.delay
-        if delay_props.enabled:
-            # Assertion only for mypy purposes
-            assert delay_props.duration is not None
+        if delay_props.enabled and delay_props.duration:
             self._instrument.delay(delay_props.duration)
         self._tip_state.append_air_gap(air_gap_volume)
 
@@ -824,8 +815,7 @@ class TransferComponentsExecutor:
         )
         self._tip_state.delete_air_gap(last_air_gap)
         dispense_delay = dispense_props.delay
-        if dispense_delay.enabled:
-            assert dispense_delay.duration is not None
+        if dispense_delay.enabled and dispense_delay.duration:
             self._instrument.delay(dispense_delay.duration)
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -87,8 +87,8 @@ def test_submerge_without_lpd(
     source_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 4)
     well_bottom_point = Point(4, 5, 6)
-    air_gap_removal_flow_rate = (
-        sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(123)
+    air_gap_removal_flow_rate = max(
+        123, sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(123)
     )
     air_gap_correction_vol = (
         sample_transfer_props.dispense.correction_by_volume.get_for_volume(123)
@@ -173,8 +173,8 @@ def test_submerge_with_lpd(
     source_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 4)
     well_bottom_point = Point(4, 5, 6)
-    air_gap_removal_flow_rate = (
-        sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(123)
+    air_gap_removal_flow_rate = max(
+        123, sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(123)
     )
     air_gap_correction_vol = (
         sample_transfer_props.dispense.correction_by_volume.get_for_volume(123)
@@ -634,6 +634,12 @@ def test_retract_after_aspiration(
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(40)
     )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
+    )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
             air_gap_volume
@@ -688,7 +694,7 @@ def test_retract_after_aspiration(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_volume,
+            flow_rate=air_gap_flow_rate,
             correction_volume=air_gap_correction_vol,
         ),
         mock_instrument_core.delay(0.2),
@@ -746,6 +752,12 @@ def test_retract_after_aspiration_without_touch_tip_and_delay(
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(40)
     )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
+    )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
             air_gap_volume
@@ -780,7 +792,7 @@ def test_retract_after_aspiration_without_touch_tip_and_delay(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_volume,
+            flow_rate=air_gap_flow_rate,
             correction_volume=air_gap_correction_vol,
         ),
         mock_instrument_core.delay(0.2),
@@ -800,6 +812,12 @@ def test_retract_after_aspiration_for_consolidate(
     decoy.when(mock_instrument_core.get_current_volume()).then_return(12.3)
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(12.3)
+    )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
     )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
@@ -846,7 +864,7 @@ def test_retract_after_aspiration_for_consolidate(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_volume,
+            flow_rate=air_gap_flow_rate,
             correction_volume=air_gap_correction_vol,
         ),
         mock_instrument_core.delay(0.2),
@@ -902,6 +920,12 @@ def test_retract_after_dispense_with_blowout_in_source(
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
     )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
+    )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
             air_gap_volume
@@ -950,7 +974,7 @@ def test_retract_after_dispense_with_blowout_in_source(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_volume,
+            flow_rate=air_gap_flow_rate,
             correction_volume=air_gap_correction_vol,
         ),
         mock_instrument_core.delay(0.2),
@@ -981,7 +1005,7 @@ def test_retract_after_dispense_with_blowout_in_source(
             and [
                 mock_instrument_core.air_gap_in_place(  # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_volume,
+                    flow_rate=air_gap_flow_rate,
                     correction_volume=air_gap_correction_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
@@ -1008,6 +1032,12 @@ def test_retract_after_dispense_with_blowout_in_destination(
     well_bottom_point = Point(4, 5, 6)
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
     )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
@@ -1076,7 +1106,7 @@ def test_retract_after_dispense_with_blowout_in_destination(
             and [
                 mock_instrument_core.air_gap_in_place(  # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_volume,
+                    flow_rate=air_gap_flow_rate,
                     correction_volume=air_gap_correction_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
@@ -1107,6 +1137,12 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
     well_bottom_point = Point(4, 5, 6)
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
     )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
@@ -1158,7 +1194,7 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_volume,
+            flow_rate=air_gap_flow_rate,
             correction_volume=air_gap_correction_vol,
         ),
         mock_instrument_core.delay(0.2),
@@ -1188,7 +1224,7 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
             and [
                 mock_instrument_core.air_gap_in_place(  # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_volume,
+                    flow_rate=air_gap_flow_rate,
                     correction_volume=air_gap_correction_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
@@ -1217,6 +1253,12 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
     well_bottom_point = Point(4, 5, 6)
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
     )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
@@ -1267,7 +1309,7 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_volume,
+            flow_rate=air_gap_flow_rate,
             correction_volume=air_gap_correction_vol,
         ),
         mock_instrument_core.delay(0.2),
@@ -1282,7 +1324,7 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
             and [
                 mock_instrument_core.air_gap_in_place(  # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_volume,
+                    flow_rate=air_gap_flow_rate,
                     correction_volume=air_gap_correction_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
@@ -1365,6 +1407,12 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
     )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
+    )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
             air_gap_volume
@@ -1426,7 +1474,7 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
                 mock_instrument_core.air_gap_in_place(
                     # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_volume,
+                    flow_rate=air_gap_flow_rate,
                     correction_volume=air_gap_correction_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
@@ -1472,6 +1520,12 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
     sample_transfer_props.multi_dispense.retract.blowout.enabled = True  # type: ignore[union-attr]
     air_gap_volume = (
         sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    )
+    air_gap_flow_rate = max(
+        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
+            air_gap_volume
+        ),
+        air_gap_volume,
     )
     air_gap_correction_vol = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
@@ -1552,7 +1606,7 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
                 mock_instrument_core.air_gap_in_place(
                     # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_volume,
+                    flow_rate=air_gap_flow_rate,
                     correction_volume=air_gap_correction_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -78,20 +78,32 @@ def patch_mock_raise_if_location_inside_liquid(
 """
 
 
+@pytest.mark.parametrize(
+    argnames=[
+        "air_gap_volume",
+        "air_gap_flow_rate_by_vol",
+        "expected_air_gap_flow_rate",
+    ],
+    argvalues=[(0.123, 123, 123), (1.23, 0.123, 1.23)],
+)
 def test_submerge_without_lpd(
     decoy: Decoy,
     mock_instrument_core: InstrumentCore,
     sample_transfer_props: TransferProperties,
+    air_gap_volume: float,
+    air_gap_flow_rate_by_vol: float,
+    expected_air_gap_flow_rate: float,
 ) -> None:
     """Should perform the expected submerge steps."""
     source_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 4)
     well_bottom_point = Point(4, 5, 6)
-    air_gap_removal_flow_rate = max(
-        123, sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(123)
+    air_gap_correction_by_vol = 0.321
+    sample_transfer_props.dispense.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.dispense.correction_by_volume.get_for_volume(123)
+    sample_transfer_props.dispense.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
     )
 
     subject = TransferComponentsExecutor(
@@ -101,7 +113,9 @@ def test_submerge_without_lpd(
         target_well=source_well,
         tip_state=TipState(
             ready_to_aspirate=True,
-            last_liquid_and_air_gap_in_tip=LiquidAndAirGapPair(liquid=0, air_gap=123),
+            last_liquid_and_air_gap_in_tip=LiquidAndAirGapPair(
+                liquid=0, air_gap=air_gap_volume
+            ),
         ),
         transfer_type=TransferType.ONE_TO_ONE,
     )
@@ -126,12 +140,12 @@ def test_submerge_without_lpd(
         mock_instrument_core.dispense(
             location=Location(Point(x=2, y=4, z=7), labware=None),
             well_core=None,
-            volume=123,
+            volume=air_gap_volume,
             rate=1,
-            flow_rate=air_gap_removal_flow_rate,
+            flow_rate=expected_air_gap_flow_rate,
             in_place=True,
             push_out=0,
-            correction_volume=air_gap_correction_vol,
+            correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.5),
         mock_instrument_core.configure_for_volume(123),
@@ -173,12 +187,16 @@ def test_submerge_with_lpd(
     source_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 4)
     well_bottom_point = Point(4, 5, 6)
-    air_gap_removal_flow_rate = max(
-        123, sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(123)
+    air_gap_flow_rate_by_vol = 1234
+    air_gap_correction_by_vol = 0.321
+
+    sample_transfer_props.dispense.flow_rate_by_volume.set_for_volume(
+        123, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.dispense.correction_by_volume.get_for_volume(123)
+    sample_transfer_props.dispense.correction_by_volume.set_for_volume(
+        123, air_gap_correction_by_vol
     )
+
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
         transfer_properties=sample_transfer_props,
@@ -213,10 +231,10 @@ def test_submerge_with_lpd(
             well_core=None,
             volume=123,
             rate=1,
-            flow_rate=air_gap_removal_flow_rate,
+            flow_rate=air_gap_flow_rate_by_vol,
             in_place=True,
             push_out=0,
-            correction_volume=air_gap_correction_vol,
+            correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.5),
         mock_instrument_core.liquid_probe_with_recovery(
@@ -621,29 +639,36 @@ def test_pre_wet_disabled(
     )
 
 
+@pytest.mark.parametrize(
+    argnames=[
+        "air_gap_volume",
+        "air_gap_flow_rate_by_vol",
+        "expected_air_gap_flow_rate",
+    ],
+    argvalues=[(0.123, 123, 123), (1.23, 0.123, 1.23)],
+)
 def test_retract_after_aspiration(
     decoy: Decoy,
     mock_instrument_core: InstrumentCore,
     sample_transfer_props: TransferProperties,
+    air_gap_volume: float,
+    air_gap_flow_rate_by_vol: float,
+    expected_air_gap_flow_rate: float,
 ) -> None:
     """It should execute steps to retract from well after an aspiration."""
     source_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 3)
     well_bottom_point = Point(4, 5, 6)
+    air_gap_correction_by_vol = 0.321
 
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(40)
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        40, air_gap_volume
     )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
     )
 
     subject = TransferComponentsExecutor(
@@ -694,8 +719,8 @@ def test_retract_after_aspiration(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_flow_rate,
-            correction_volume=air_gap_correction_vol,
+            flow_rate=expected_air_gap_flow_rate,
+            correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
     )
@@ -745,24 +770,23 @@ def test_retract_after_aspiration_without_touch_tip_and_delay(
     source_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 3)
     well_bottom_point = Point(4, 5, 6)
+    air_gap_volume = 0.123
+    air_gap_flow_rate_by_vol = 123
+    air_gap_correction_by_vol = 0.321
+
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        40, air_gap_volume
+    )
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
+    )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
+    )
 
     sample_transfer_props.aspirate.retract.touch_tip.enabled = False
     sample_transfer_props.aspirate.retract.delay.enabled = False
 
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(40)
-    )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
-    )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
-    )
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
         transfer_properties=sample_transfer_props,
@@ -792,8 +816,8 @@ def test_retract_after_aspiration_without_touch_tip_and_delay(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_flow_rate,
-            correction_volume=air_gap_correction_vol,
+            flow_rate=air_gap_flow_rate_by_vol,
+            correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
     )
@@ -808,21 +832,19 @@ def test_retract_after_aspiration_for_consolidate(
     source_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 3)
     well_bottom_point = Point(4, 5, 6)
+    air_gap_volume = 0.123
+    air_gap_flow_rate_by_vol = 123
+    air_gap_correction_by_vol = 0.321
 
     decoy.when(mock_instrument_core.get_current_volume()).then_return(12.3)
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(12.3)
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        12.3, air_gap_volume
     )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
     )
 
     subject = TransferComponentsExecutor(
@@ -864,8 +886,8 @@ def test_retract_after_aspiration_for_consolidate(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_flow_rate,
-            correction_volume=air_gap_correction_vol,
+            flow_rate=air_gap_flow_rate_by_vol,
+            correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
     )
@@ -917,20 +939,20 @@ def test_retract_after_dispense_with_blowout_in_source(
     dest_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 3)
     well_bottom_point = Point(4, 5, 6)
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    air_gap_volume = 0.123
+    air_gap_flow_rate_by_vol = 123
+    air_gap_correction_by_vol = 0.321
+
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        0, air_gap_volume
     )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
     )
+
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
         transfer_properties=sample_transfer_props,
@@ -974,8 +996,8 @@ def test_retract_after_dispense_with_blowout_in_source(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_flow_rate,
-            correction_volume=air_gap_correction_vol,
+            flow_rate=air_gap_flow_rate_by_vol,
+            correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
         mock_instrument_core.set_flow_rate(blow_out=100),
@@ -1005,8 +1027,8 @@ def test_retract_after_dispense_with_blowout_in_source(
             and [
                 mock_instrument_core.air_gap_in_place(  # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_flow_rate,
-                    correction_volume=air_gap_correction_vol,
+                    flow_rate=air_gap_flow_rate_by_vol,
+                    correction_volume=air_gap_correction_by_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
             ]
@@ -1030,20 +1052,20 @@ def test_retract_after_dispense_with_blowout_in_destination(
     dest_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 3)
     well_bottom_point = Point(4, 5, 6)
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    air_gap_volume = 0.123
+    air_gap_flow_rate_by_vol = 123
+    air_gap_correction_by_vol = 0.321
+
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        0, air_gap_volume
     )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
     )
+
     sample_transfer_props.dispense.retract.blowout.location = (
         BlowoutLocation.DESTINATION
     )
@@ -1106,8 +1128,8 @@ def test_retract_after_dispense_with_blowout_in_destination(
             and [
                 mock_instrument_core.air_gap_in_place(  # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_flow_rate,
-                    correction_volume=air_gap_correction_vol,
+                    flow_rate=air_gap_flow_rate_by_vol,
+                    correction_volume=air_gap_correction_by_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
             ]
@@ -1135,20 +1157,20 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
     trash_location = Location(Point(7, 8, 9), labware=trash_well)
     well_top_point = Point(1, 2, 3)
     well_bottom_point = Point(4, 5, 6)
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    air_gap_volume = 0.123
+    air_gap_flow_rate_by_vol = 123
+    air_gap_correction_by_vol = 0.321
+
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        0, air_gap_volume
     )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
     )
+
     sample_transfer_props.dispense.retract.blowout.location = BlowoutLocation.TRASH
 
     subject = TransferComponentsExecutor(
@@ -1194,8 +1216,8 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_flow_rate,
-            correction_volume=air_gap_correction_vol,
+            flow_rate=air_gap_flow_rate_by_vol,
+            correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
         mock_instrument_core.set_flow_rate(blow_out=100),
@@ -1224,8 +1246,8 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
             and [
                 mock_instrument_core.air_gap_in_place(  # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_flow_rate,
-                    correction_volume=air_gap_correction_vol,
+                    flow_rate=air_gap_flow_rate_by_vol,
+                    correction_volume=air_gap_correction_by_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
             ]
@@ -1251,20 +1273,20 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
     trash_location = decoy.mock(cls=TrashBin)
     well_top_point = Point(1, 2, 3)
     well_bottom_point = Point(4, 5, 6)
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    air_gap_volume = 0.123
+    air_gap_flow_rate_by_vol = 123
+    air_gap_correction_by_vol = 0.321
+
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        0, air_gap_volume
     )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
     )
+
     sample_transfer_props.dispense.retract.blowout.location = BlowoutLocation.TRASH
 
     subject = TransferComponentsExecutor(
@@ -1309,8 +1331,8 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
         ),
         mock_instrument_core.air_gap_in_place(
             volume=air_gap_volume,
-            flow_rate=air_gap_flow_rate,
-            correction_volume=air_gap_correction_vol,
+            flow_rate=air_gap_flow_rate_by_vol,
+            correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
         mock_instrument_core.set_flow_rate(blow_out=100),
@@ -1324,8 +1346,8 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
             and [
                 mock_instrument_core.air_gap_in_place(  # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_flow_rate,
-                    correction_volume=air_gap_correction_vol,
+                    flow_rate=air_gap_flow_rate_by_vol,
+                    correction_volume=air_gap_correction_by_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
             ]
@@ -1404,20 +1426,20 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
     dest_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 3)
     sample_transfer_props.multi_dispense.retract.touch_tip.enabled = True  # type: ignore[union-attr]
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
+    air_gap_volume = 0.123
+    air_gap_flow_rate_by_vol = 123
+    air_gap_correction_by_vol = 0.321
+
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        0, air_gap_volume
     )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
     )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
     )
+
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
         transfer_properties=sample_transfer_props,
@@ -1474,8 +1496,8 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
                 mock_instrument_core.air_gap_in_place(
                     # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_flow_rate,
-                    correction_volume=air_gap_correction_vol,
+                    flow_rate=air_gap_flow_rate_by_vol,
+                    correction_volume=air_gap_correction_by_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
             ]
@@ -1516,22 +1538,23 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
     source_well = decoy.mock(cls=WellCore)
     dest_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 3)
+    air_gap_volume = 0.123
+    air_gap_flow_rate_by_vol = 123
+    air_gap_correction_by_vol = 0.321
+
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        0, air_gap_volume
+    )
+    sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
+        air_gap_volume, air_gap_flow_rate_by_vol
+    )
+    sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
+        air_gap_volume, air_gap_correction_by_vol
+    )
+
     sample_transfer_props.multi_dispense.retract.touch_tip.enabled = True  # type: ignore[union-attr]
     sample_transfer_props.multi_dispense.retract.blowout.enabled = True  # type: ignore[union-attr]
-    air_gap_volume = (
-        sample_transfer_props.aspirate.retract.air_gap_by_volume.get_for_volume(0)
-    )
-    air_gap_flow_rate = max(
-        sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(
-            air_gap_volume
-        ),
-        air_gap_volume,
-    )
-    air_gap_correction_vol = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(
-            air_gap_volume
-        )
-    )
+
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
         transfer_properties=sample_transfer_props,
@@ -1606,8 +1629,8 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
                 mock_instrument_core.air_gap_in_place(
                     # type: ignore[func-returns-value]
                     volume=air_gap_volume,
-                    flow_rate=air_gap_flow_rate,
-                    correction_volume=air_gap_correction_vol,
+                    flow_rate=air_gap_flow_rate_by_vol,
+                    correction_volume=air_gap_correction_by_vol,
                 ),
                 mock_instrument_core.delay(0.2),  # type: ignore[func-returns-value]
             ]


### PR DESCRIPTION
Closes AUTH-1578, AUTH-1553

# Overview

Closes the two mentioned issues:
- fixes airgap flow rate so that the most time it will take to asp/ disp the air gap is 1 second
- removes delays from emitting if the duration is 0 sec

## Test Plan and Hands on Testing

Added/updates unit tests. Will be testing on-robot during hardware testing & QA

## Review requests

- check that code makes sense

## Risk assessment

Low. Bug fixes
