### PR TITLE
fix(app): fix Protocol Setup redirects on the ODD

### DIFF
--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -100,7 +100,7 @@ import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { FlattenSimpleInterpolation } from 'styled-components'
-import type { Run } from '@opentrons/api-client'
+import type { Run, RunStatus } from '@opentrons/api-client'
 import type { CutoutFixtureId, CutoutId } from '@opentrons/shared-data'
 import type { OnDeviceRouteParams } from '/app/App/types'
 import type { ProtocolModuleInfo } from '/app/transformations/analysis'
@@ -118,6 +118,7 @@ const FETCH_DURATION_MS = 5000
 const ANALYSIS_POLL_MS = 5000
 interface PrepareToRunProps {
   runId: string
+  runStatus: RunStatus | null
   setSetupScreen: Dispatch<SetStateAction<SetupScreens>>
   confirmAttachment: () => void
   confirmStepsComplete: () => void
@@ -131,6 +132,7 @@ interface PrepareToRunProps {
 
 function PrepareToRun({
   runId,
+  runStatus,
   setSetupScreen,
   confirmAttachment,
   play,
@@ -173,11 +175,6 @@ function PrepareToRun({
       refetchInterval: ANALYSIS_POLL_MS,
     }
   )
-
-  const runStatus = useRunStatus(runId)
-  if (runStatus === RUN_STATUS_STOPPED) {
-    navigate('/protocols')
-  }
 
   useEffect(() => {
     if (mostRecentAnalysis?.status === 'completed') {
@@ -709,6 +706,12 @@ export function ProtocolSetup(): JSX.Element {
     useNotifyCurrentMaintenanceRun({ refetchInterval: MAINTENANCE_RUN_POLL_MS })
       .data?.data.id != null
 
+  const navigate = useNavigate()
+  const runStatus = useRunStatus(runId)
+  if (runStatus === RUN_STATUS_STOPPED) {
+    navigate('/protocols')
+  }
+
   const {
     data: mostRecentAnalysis = null,
   } = useProtocolAnalysisAsDocumentQuery(
@@ -795,7 +798,6 @@ export function ProtocolSetup(): JSX.Element {
     showConfirmation: showMissingStepsConfirmation,
     cancel: cancelExitMissingStepsConfirmation,
   } = useConditionalConfirm(handleProceedToRunClick, !labwareConfirmed)
-  const runStatus = useRunStatus(runId)
   const isHeaterShakerInProtocol = useIsHeaterShakerInProtocol()
   const lpcLaunchProps = useLPCFlows({
     runId,
@@ -810,6 +812,7 @@ export function ProtocolSetup(): JSX.Element {
     'prepare to run': (
       <PrepareToRun
         runId={runId}
+        runStatus={runStatus}
         setSetupScreen={setSetupScreen}
         confirmAttachment={confirmAttachment}
         confirmStepsComplete={confirmMissingSteps}


### PR DESCRIPTION
Closes [RQA-4051](https://opentrons.atlassian.net/browse/RQA-4051)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If a user cancels the run on the desktop app, there was no redirect log on the ODD if the active view was any setup view that was not the option selection menu. The redirect logic simply needs hoisting: it currently exists in the option selection menu, but should really exist in the protocol setup view orchestrator component. 

### Current Behavior

https://github.com/user-attachments/assets/e2765c8a-5b40-46cc-b6a2-1792f3171d48

### Fixed Behavior

https://github.com/user-attachments/assets/d58bfe61-66eb-4796-b4ec-f90e3549701c

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the ODD not always rerouting to the protocols view if a run is cancelled on a desktop app.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4051]: https://opentrons.atlassian.net/browse/RQA-4051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ