### PR TITLE
feat(protocol-designer): finish logic for liquid class getter

### DIFF
--- a/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
+++ b/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
@@ -18,6 +18,7 @@ import { getMainPagePortalEl } from './Portal'
 
 interface ResetSettingsModalProps {
   tab: 'aspirate' | 'dispense'
+  onContinue: () => void
   onClose: () => void
   onScroll: () => void
   liquidClass?: string | null
@@ -25,15 +26,14 @@ interface ResetSettingsModalProps {
 export function ResetSettingsModal(
   props: ResetSettingsModalProps
 ): JSX.Element {
-  const { tab, liquidClass, onClose, onScroll } = props
+  const { tab, liquidClass, onContinue, onClose, onScroll } = props
   const { t, i18n } = useTranslation('protocol_steps')
 
-  // TODO: Update to check liquidClass !== 'none' for Don't use a liquid class
   const isLiquidClassSelected = liquidClass !== null && liquidClass !== ''
   const liquidClassName = getLiquidClassDisplayName(String(liquidClass))
 
   const handleContinue = (): void => {
-    console.log('TODO: Wire up reset settings modal.')
+    onContinue()
     onClose()
     onScroll()
   }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -172,6 +172,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   const [confirmedFieldUpdates, setConfirmedFieldUpdates] = useState<
     Record<string, any>
   >({})
+  console.log(confirmedFieldUpdates)
   const fieldsChangedRequiringConfirmation = FIELDS_REQUIRING_CONFIRMATION.filter(
     field => {
       // if field has been updated and confirmed in modal, check its most recent confirmed value
@@ -354,7 +355,11 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
       if (isConfirmationRequired) {
         setShowConfirmationModal(true)
       } else {
-        handleUpdateLiquidClassValues()
+        if (!hasSeenAdvancedSettings) {
+          handleUpdateLiquidClassValues()
+        } else {
+          setToolboxStep(toolboxStep + 1)
+        }
       }
     } else if (isMultiStepToolbox && toolboxStep < numStepFormPages - 1) {
       if (!isErrorOnCurrentPage) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -38,10 +38,11 @@ import {
   getCurrentFormIsPresaved,
   getDynamicFieldFormErrorsForUnsavedForm,
   getFormLevelErrorsForUnsavedForm,
+  getLabwareEntities,
   getPipetteEntities,
   getSavedStepForms,
 } from '../../../../step-forms/selectors'
-import { getDefaultLiquidClassesValues } from '../../../../steplist/formLevel/handleFormChange/utils'
+import { updateFieldsForLiquidClass } from '../../../../steplist/formLevel/handleFormChange/utils'
 import { getTimelineWarningsForSelectedStep } from '../../../../top-selectors/timelineWarnings'
 import {
   hoverSelection,
@@ -142,6 +143,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     false
   )
   const pipetteEntities = useSelector(getPipetteEntities)
+  const labwareEntities = useSelector(getLabwareEntities)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
@@ -284,18 +286,13 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   })
 
   const handleUpdateLiquidClassValues = (): void => {
-    const liquidClassValues = getDefaultLiquidClassesValues(
-      formData,
+    updateFieldsForLiquidClass({
+      propsForFields,
+      rawForm: formData,
       pipetteEntities,
-      additionalEquipmentEntities
-    )
-    if (liquidClassValues != null) {
-      Object.entries(liquidClassValues).forEach(([field, value]) => {
-        if (field in propsForFields) {
-          propsForFields[field].updateValue(value)
-        }
-      })
-    }
+      labwareEntities,
+      additionalEquipmentEntities,
+    })
     setToolboxStep(toolboxStep + 1)
     setShowConfirmationModal(false)
     handleConfirmValues()

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -172,7 +172,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   const [confirmedFieldUpdates, setConfirmedFieldUpdates] = useState<
     Record<string, any>
   >({})
-  console.log(confirmedFieldUpdates)
+
   const fieldsChangedRequiringConfirmation = FIELDS_REQUIRING_CONFIRMATION.filter(
     field => {
       // if field has been updated and confirmed in modal, check its most recent confirmed value

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
@@ -15,8 +15,13 @@ import {
   CheckboxExpandStepFormField,
   InputStepFormField,
 } from '../../../../../../components/molecules'
+import {
+  getAdditionalEquipmentEntities,
+  getLabwareEntities,
+  getPipetteEntities,
+} from '../../../../../../step-forms/selectors'
+import { updateFieldsForLiquidClass } from '../../../../../../steplist/formLevel/handleFormChange/utils'
 import { getMaxPushOutVolume } from '../../../../../../utils'
-import { getPipetteEntities } from '../../../../../../step-forms/selectors'
 import {
   BlowoutLocationField,
   BlowoutOffsetField,
@@ -54,6 +59,11 @@ export function SecondStepMixTools({
   const { t, i18n } = useTranslation(['application', 'form'])
   const toolsComponentRef = useRef<HTMLDivElement | null>(null)
   const enableLiquidClasses = useSelector(getEnableLiquidClasses)
+  const pipetteEntities = useSelector(getPipetteEntities)
+  const labwareEntities = useSelector(getLabwareEntities)
+  const additionalEquipmentEntities = useSelector(
+    getAdditionalEquipmentEntities
+  )
   const [showResetModal, setShowResetModal] = useState<boolean>(false)
   const aspirateTab = {
     text: i18n.format(t('aspirate'), 'capitalize'),
@@ -91,6 +101,16 @@ export function SecondStepMixTools({
       {showResetModal ? (
         <ResetSettingsModal
           tab={tab}
+          onContinue={() => {
+            updateFieldsForLiquidClass({
+              propsForFields,
+              rawForm: formData,
+              pipetteEntities,
+              labwareEntities,
+              additionalEquipmentEntities,
+              liquidHandlingAction: tab,
+            })
+          }}
           onClose={() => {
             setShowResetModal(false)
           }}
@@ -279,7 +299,6 @@ export function SecondStepMixTools({
           <ResetSettingsField
             tab={tab}
             onClick={() => {
-              console.log('TODO: wire up onClick handler')
               setShowResetModal(true)
             }}
           />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/ResetSettingsField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/ResetSettingsField.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import {
+  ALIGN_CENTER,
   DIRECTION_COLUMN,
   Flex,
+  FLEX_MAX_CONTENT,
+  JUSTIFY_CENTER,
   SPACING,
   StyledText,
   TertiaryButton,
@@ -24,8 +27,14 @@ export function ResetSettingsField(
       flexDirection={DIRECTION_COLUMN}
       padding={`0 ${SPACING.spacing16}`}
       paddingBottom={SPACING.spacing40}
+      justifyContent={JUSTIFY_CENTER}
+      alignItems={ALIGN_CENTER}
     >
-      <TertiaryButton onClick={onClick} buttonType="white">
+      <TertiaryButton
+        onClick={onClick}
+        buttonType="white"
+        width={FLEX_MAX_CONTENT}
+      >
         <StyledText desktopStyle="captionSemiBold">
           {t(`protocol_steps:reset_settings`, { tab })}
         </StyledText>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -20,6 +20,7 @@ import {
   ToggleStepFormField,
 } from '../../../../../../components/molecules'
 import {
+  getAdditionalEquipmentEntities,
   getInvariantContext,
   getLabwareEntities,
   getPipetteEntities,
@@ -51,6 +52,7 @@ import type { StepInputFieldProps } from './MultiInputField'
 import type { FieldPropsByName, LiquidHandlingTab } from '../../types'
 import type { FormData, StepFieldName } from '../../../../../../form-types'
 import type { StepFormErrors } from '../../../../../../steplist'
+import { updateFieldsForLiquidClass } from '../../../../../../steplist/formLevel/handleFormChange/utils'
 
 const addPrefix = (prefix: string) => (fieldName: string): StepFieldName =>
   `${prefix}_${fieldName}`
@@ -74,7 +76,11 @@ export const SecondStepsMoveLiquidTools = ({
 }: SecondStepsMoveLiquidToolsProps): JSX.Element => {
   const { t, i18n } = useTranslation(['protocol_steps', 'form', 'tooltip'])
   const toolsComponentRef = useRef<HTMLDivElement | null>(null)
-  const labwares = useSelector(getLabwareEntities)
+  const pipetteEntities = useSelector(getPipetteEntities)
+  const labwareEntities = useSelector(getLabwareEntities)
+  const additionalEquipmentEntities = useSelector(
+    getAdditionalEquipmentEntities
+  )
   const { trashBinEntities, wasteChuteEntities } = useSelector(
     getInvariantContext
   )
@@ -95,7 +101,7 @@ export const SecondStepsMoveLiquidTools = ({
   const destinationLabwareType =
     formData.dispense_labware != null
       ? getTrashOrLabware(
-          labwares,
+          labwareEntities,
           wasteChuteEntities,
           trashBinEntities,
           formData.dispense_labware as string
@@ -169,7 +175,7 @@ export const SecondStepsMoveLiquidTools = ({
             ? Number(formData.disposalVolume_volume)
             : 0,
         pipetteSpecs: pipetteSpec,
-        labwareEntities: labwares,
+        labwareEntities: labwareEntities,
         tiprackDefUri: formData.tipRack,
       }),
     [
@@ -181,7 +187,9 @@ export const SecondStepsMoveLiquidTools = ({
   )
   const minXYDimension = isDestinationTrash
     ? null
-    : getMinXYDimension(labwares[formData[`${tab}_labware`]]?.def, ['A1'])
+    : getMinXYDimension(labwareEntities[formData[`${tab}_labware`]]?.def, [
+        'A1',
+      ])
   const minRadiusForTouchTip =
     minXYDimension != null ? round(minXYDimension / 2, 1) : null
 
@@ -199,6 +207,16 @@ export const SecondStepsMoveLiquidTools = ({
       {showResetModal ? (
         <ResetSettingsModal
           tab={tab}
+          onContinue={() => {
+            updateFieldsForLiquidClass({
+              propsForFields,
+              rawForm: formData,
+              pipetteEntities,
+              labwareEntities,
+              additionalEquipmentEntities,
+              liquidHandlingAction: tab,
+            })
+          }}
           onClose={() => {
             setShowResetModal(false)
           }}
@@ -581,7 +599,6 @@ export const SecondStepsMoveLiquidTools = ({
           <ResetSettingsField
             tab={tab}
             onClick={() => {
-              console.log('TODO: wire up onClick handler')
               setShowResetModal(true)
             }}
           />

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -504,27 +504,49 @@ const getNoLiquidClassValuesMoveLiquid = (
       singleDispense.pushOutByVolume as Array<[number, number]>
     ) ?? 0
 
+  const aspirateOffsetFields = getOffsetFields(aspirate.offset, 'aspirate')
+  const dispenseOffsetFields = getOffsetFields(dispense.offset, 'dispense')
+  const aspiratePositionReferenceFields = getPositionReferenceFields(
+    aspirate.positionReference,
+    'aspirate'
+  )
+  const dispensePositionReferenceFields = getPositionReferenceFields(
+    dispense.positionReference,
+    'dispense'
+  )
+
   const aspirateFields = {
     ...aspirateFlowRateFields,
+    ...aspirateOffsetFields,
+    ...aspiratePositionReferenceFields,
     aspirate_submerge_mmFromBottom: 0,
     aspirate_submerge_position_reference: WELL_TOP,
     aspirate_submerge_x_position: 0,
     aspirate_submerge_y_position: 0,
     aspirate_submerge_speed: aspirate.submerge.speed,
-
     aspirate_retract_speed: aspirate.retract.speed,
+    aspirate_retract_mmFromBottom: 0,
+    aspirate_retract_position_reference: WELL_TOP,
+    aspirate_retract_x_position: 0,
+    aspirate_retract_y_position: 0,
     aspirate_touchTip_speed: aspirate.retract.touchTip.params?.speed,
     aspirate_touchTip_mmFromEdge: aspirate.retract.touchTip.params?.mmToEdge,
     aspirate_touchTip_mmFromTop: aspirate.retract.touchTip.params?.zOffset,
   }
   const dispenseFields = {
     ...dispenseFlowRateFields,
+    ...dispenseOffsetFields,
+    ...dispensePositionReferenceFields,
     dispense_submerge_mmFromBottom: 0,
     dispense_submerge_position_reference: WELL_TOP,
     dispense_submerge_x_position: 0,
     dispense_submerge_y_position: 0,
     dispense_submerge_speed: dispense.submerge.speed,
     dispense_retract_speed: dispense.retract.speed,
+    dispense_retract_mmFromBottom: 0,
+    dispense_retract_position_reference: WELL_TOP,
+    dispense_retract_x_position: 0,
+    dispense_retract_y_position: 0,
     pushOut_checkbox: pushOutVolume > 0,
     pushOut_volume: pushOutVolume,
     dispense_touchTip_speed: dispense.retract.touchTip.params?.speed,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -3,18 +3,22 @@ import uniq from 'lodash/uniq'
 import {
   getAllLiquidClassDefs,
   linearInterpolate,
+  WELL_TOP,
 } from '@opentrons/shared-data'
 import { getFlexNameConversion } from '@opentrons/step-generation'
 import { getWellSetForMultichannel, canPipetteUseLabware } from '../../../utils'
 import { getPipetteCapacity } from '../../../pipettes/pipetteData'
+import { getDefaultsForStepType } from '../getDefaultsForStepType'
 import type {
   BlowoutProperties,
+  ByTipTypeSetting,
   Coordinates,
   DelayProperties,
   LabwareDefinition2,
   LiquidHandlingPropertyByVolume,
   MixProperties,
   PipetteChannels,
+  PipetteV2Specs,
   PositionReference,
   RetractAspirate,
   RetractDispense,
@@ -26,8 +30,51 @@ import type {
   LabwareEntities,
   PipetteEntities,
 } from '@opentrons/step-generation'
-import type { FormPatch } from '../../actions/types'
 import type { FormData, PathOption, StepFieldName } from '../../../form-types'
+import type {
+  FieldPropsByName,
+  LiquidHandlingTab,
+} from '../../../pages/Designer/ProtocolSteps/StepForm/types'
+import type { FormPatch } from '../../actions/types'
+
+type LiquidClassSettingsType = 'aspirate' | 'dispense' | 'all'
+
+const STABLE_FIELDS_BY_FORM_TYPE: Record<'mix' | 'moveLiquid', string[]> = {
+  mix: [
+    'pipette',
+    'tipRack',
+    'nozzles',
+    'labware',
+    'wells',
+    'volume',
+    'times',
+    'path',
+    'changeTip',
+    'dropTip_location',
+    'dropTip_wellNames',
+    'liquidClass',
+    'mix_wellOrder_first',
+    'mix_wellOrder_second',
+  ],
+  moveLiquid: [
+    'pipette',
+    'tipRack',
+    'nozzles',
+    'aspirate_labware',
+    'aspirate_wells',
+    'dispense_labware',
+    'dispense_wells',
+    'volume',
+    'path',
+    'changeTip',
+    'dropTip_location',
+    'dropTip_wellNames',
+    'liquidClass',
+    'aspirate_wellOrder_first',
+    'aspirate_wellOrder_second',
+  ],
+}
+
 export function chainPatchUpdaters(
   initialPatch: FormPatch,
   fns: Array<(arg0: FormPatch) => FormPatch>
@@ -203,6 +250,25 @@ export function fieldHasChanged(
   )
 }
 
+const getStableFieldsAndValues = (
+  stepType: 'mix' | 'moveLiquid',
+  rawForm: FormData
+): Record<string, any> => {
+  return (
+    STABLE_FIELDS_BY_FORM_TYPE[stepType]?.reduce((acc, field) => {
+      return { ...acc, [field]: rawForm[field] }
+    }, {}) ?? {}
+  )
+}
+const getCurrentFormFields = (
+  rawForm: FormData,
+  fields: string[]
+): Record<string, any> => {
+  return fields.reduce((acc, field) => {
+    return { ...acc, [field]: rawForm[field] }
+  }, {})
+}
+
 type SubmergeRetractAspirateDispensePrefix =
   | 'aspirate_submerge'
   | 'aspirate_retract'
@@ -244,7 +310,7 @@ const getPositionReferenceFields = (
 const getFlowRateFields = (
   volume: number,
   flowRateByVolume: LiquidHandlingPropertyByVolume,
-  liquidHandlingAction: 'aspirate' | 'dispense'
+  liquidHandlingAction: LiquidHandlingTab
 ): Record<string, number | null> => {
   const interpolatedFlowRate = linearInterpolate(
     volume,
@@ -264,7 +330,7 @@ const getSpeedFields = (
 
 const getTouchTipFields = (
   touchTip: TouchTipProperties,
-  liquidHandlingAction: 'aspirate' | 'dispense'
+  liquidHandlingAction: LiquidHandlingTab
 ): Record<string, any> => {
   const { enable, params } = touchTip
   return {
@@ -296,9 +362,12 @@ const getBlowoutFields = (
 }
 
 const getMixFields = (
-  mix: MixProperties,
+  mix: MixProperties | null,
   prefix: string
 ): Record<string, any> => {
+  if (mix == null) {
+    return {}
+  }
   const { enable, params } = mix
   return {
     [`${prefix}_mix_checkbox`]: enable,
@@ -329,7 +398,7 @@ const getByVolumeField = (args: {
 const getSubmergeRetractFields = (args: {
   submergeRetractLookup: Submerge | RetractAspirate | RetractDispense
   volume: number
-  liquidHandlingAction: 'aspirate' | 'dispense'
+  liquidHandlingAction: LiquidHandlingTab
   tipMovement: 'submerge' | 'retract'
   additionalEquipmentEntities?: AdditionalEquipmentEntities
   isDisposalVolumeEnabled?: boolean
@@ -392,43 +461,196 @@ const getSubmergeRetractFields = (args: {
   }
 }
 
-export const getDefaultLiquidClassesValues = (
+const getNoLiquidClassValuesMoveLiquid = (
   rawForm: FormData,
-  pipetteEntities: PipetteEntities,
-  additionalEquipmentEntities: AdditionalEquipmentEntities,
-  liquidHandlingAction: 'aspirate' | 'dispense' | 'all' = 'all'
-): Record<string, any> | null => {
-  // TODO (nd 04/07/2025): add logic for "none" liquid class
-  const { liquidClass, pipette, tipRack, volume, path } = rawForm
-  const pipetteEntity = pipetteEntities[pipette]
-  const liquidClasses = getAllLiquidClassDefs()
-  const liquidClassDef = liquidClasses[liquidClass]
-  if (liquidClassDef == null || pipetteEntity == null) {
+  convertedPipetteName: string,
+  liquidHandlingAction: LiquidClassSettingsType
+): Record<string, any> => {
+  const { tipRack: tiprack, path, volume: rawVolume, stepType } = rawForm
+  if (stepType !== 'moveLiquid') {
+    console.warn(`invalid step type for liquid classes: ${stepType}`)
     return {}
   }
-  const convertedPipetteName = getFlexNameConversion(pipetteEntity.spec)
-  const liquidClassValuesForPipette = liquidClassDef.byPipette.find(
+  const volume = Number(rawVolume)
+  const referenceLiquidClass = getAllLiquidClassDefs().waterV1
+  const liquidClassValuesForPipette = referenceLiquidClass.byPipette.find(
     ({ pipetteModel }) => convertedPipetteName === pipetteModel
   )
   const liquidClassValuesForTip = liquidClassValuesForPipette?.byTipType.find(
-    ({ tiprack }) => tiprack === tipRack
+    tipObject => tipObject.tiprack === tiprack
   )
   if (liquidClassValuesForTip == null) {
-    return null
+    return {}
   }
   const { aspirate, singleDispense, multiDispense } = liquidClassValuesForTip
+  const dispense =
+    multiDispense != null && path === 'multiDispense'
+      ? multiDispense
+      : singleDispense
+  const aspirateFlowRateFields = getFlowRateFields(
+    volume,
+    aspirate.flowRateByVolume,
+    'aspirate'
+  )
 
+  const dispenseFlowRateFields = getFlowRateFields(
+    volume,
+    dispense.flowRateByVolume,
+    'dispense'
+  )
+  const pushOutVolume =
+    linearInterpolate(
+      volume,
+      singleDispense.pushOutByVolume as Array<[number, number]>
+    ) ?? 0
+
+  const aspirateFields = {
+    ...aspirateFlowRateFields,
+    aspirate_submerge_mmFromBottom: 0,
+    aspirate_submerge_position_reference: WELL_TOP,
+    aspirate_submerge_x_position: 0,
+    aspirate_submerge_y_position: 0,
+    aspirate_submerge_speed: aspirate.submerge.speed,
+
+    aspirate_retract_speed: aspirate.retract.speed,
+    aspirate_touchTip_speed: aspirate.retract.touchTip.params?.speed,
+    aspirate_touchTip_mmFromEdge: aspirate.retract.touchTip.params?.mmToEdge,
+    aspirate_touchTip_mmFromTop: aspirate.retract.touchTip.params?.zOffset,
+  }
+  const dispenseFields = {
+    ...dispenseFlowRateFields,
+    dispense_submerge_mmFromBottom: 0,
+    dispense_submerge_position_reference: WELL_TOP,
+    dispense_submerge_x_position: 0,
+    dispense_submerge_y_position: 0,
+    dispense_submerge_speed: dispense.submerge.speed,
+    dispense_retract_speed: dispense.retract.speed,
+    pushOut_checkbox: pushOutVolume > 0,
+    pushOut_volume: pushOutVolume,
+    dispense_touchTip_speed: dispense.retract.touchTip.params?.speed,
+    dispense_touchTip_mmFromEdge: dispense.retract.touchTip.params?.mmToEdge,
+    dispense_touchTip_mmFromTop: dispense.retract.touchTip.params?.zOffset,
+  }
+  return {
+    ...getDefaultsForStepType(stepType),
+    ...getStableFieldsAndValues('moveLiquid', rawForm),
+    // update liquid class values for specified tab(s)
+    ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'aspirate'
+      ? aspirateFields
+      : {}),
+    ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'dispense'
+      ? dispenseFields
+      : {}),
+    // keep current tab form data if only updating one tab
+    ...(liquidHandlingAction === 'aspirate'
+      ? getCurrentFormFields(rawForm, Object.keys(dispenseFields))
+      : {}),
+    ...(liquidHandlingAction === 'dispense'
+      ? getCurrentFormFields(rawForm, Object.keys(aspirateFields))
+      : {}),
+  }
+}
+
+const getNoLiquidClassValuesMix = (
+  rawForm: FormData,
+  convertedPipetteName: string,
+  liquidHandlingAction: LiquidClassSettingsType
+): Record<string, any> => {
+  const { tipRack: tiprack, volume: rawVolume, stepType } = rawForm
+  if (stepType !== 'mix') {
+    console.warn(`invalid step type for liquid classes: ${stepType}`)
+    return {}
+  }
+  const volume = Number(rawVolume)
+  const referenceLiquidClass = getAllLiquidClassDefs().waterV1
+  const liquidClassValuesForPipette = referenceLiquidClass.byPipette.find(
+    ({ pipetteModel }) => convertedPipetteName === pipetteModel
+  )
+  const liquidClassValuesForTip = liquidClassValuesForPipette?.byTipType.find(
+    tipObject => tipObject.tiprack === tiprack
+  )
+  if (liquidClassValuesForTip == null) {
+    return {}
+  }
+  const { aspirate, singleDispense } = liquidClassValuesForTip
+  const aspirateFlowRateFields = getFlowRateFields(
+    volume,
+    aspirate.flowRateByVolume,
+    'aspirate'
+  )
+  const dispenseFlowRateFields = getFlowRateFields(
+    volume,
+    singleDispense.flowRateByVolume,
+    'dispense'
+  )
+
+  const pushOutVolume =
+    linearInterpolate(
+      volume,
+      singleDispense.pushOutByVolume as Array<[number, number]>
+    ) ?? 0
+
+  const aspirateFields = {
+    ...aspirateFlowRateFields,
+  }
+  const dispenseFields = {
+    ...dispenseFlowRateFields,
+    pushOut_checkbox: pushOutVolume > 0,
+    pushOut_volume: pushOutVolume,
+    mix_touchTip_speed: singleDispense.retract.touchTip.params?.speed,
+    mix_touchTip_mmFromEdge: singleDispense.retract.touchTip.params?.mmToEdge,
+    mix_touchTip_mmFromTop: singleDispense.retract.touchTip.params?.zOffset,
+  }
+
+  return {
+    ...getDefaultsForStepType(stepType),
+    ...getStableFieldsAndValues('mix', rawForm),
+    // update liquid class values for specified tab(s)
+    ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'aspirate'
+      ? aspirateFields
+      : {}),
+    ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'dispense'
+      ? dispenseFields
+      : {}),
+    // keep current tab form data if only updating one tab
+    ...(liquidHandlingAction === 'aspirate'
+      ? getCurrentFormFields(rawForm, Object.keys(dispenseFields))
+      : {}),
+    ...(liquidHandlingAction === 'dispense'
+      ? getCurrentFormFields(rawForm, Object.keys(aspirateFields))
+      : {}),
+  }
+}
+
+const getLiquidClassValuesMoveLiquid = (args: {
+  rawForm: FormData
+  liquidClassValuesForTip: ByTipTypeSetting
+  pipetteSpecs: PipetteV2Specs
+  labwareEntities: LabwareEntities
+  additionalEquipmentEntities: AdditionalEquipmentEntities
+  liquidHandlingAction: LiquidClassSettingsType
+}): Record<string, any> => {
+  const {
+    rawForm,
+    liquidClassValuesForTip,
+    pipetteSpecs,
+    labwareEntities,
+    additionalEquipmentEntities,
+    liquidHandlingAction,
+  } = args
+  const { aspirate, singleDispense, multiDispense } = liquidClassValuesForTip
+  const { path, tipRack, volume: rawVolume } = rawForm
+  const volume = Number(rawVolume)
   const {
     positionReference: aspiratePositionReference,
     offset: aspirateOffset,
     flowRateByVolume: aspirateFlowRateByVolume,
-    // correctionByVolume: aspirateCorrectionByVolume,
     preWet,
     mix: aspirateMix,
     delay: aspirateDelay,
   } = aspirate
 
-  const dispenseObject =
+  const dispense =
     multiDispense != null && path === 'multiDispense'
       ? multiDispense
       : singleDispense
@@ -437,12 +659,28 @@ export const getDefaultLiquidClassesValues = (
     offset: dispenseOffset,
     flowRateByVolume: dispenseFlowRateByVolume,
     delay: dispenseDelay,
-  } = dispenseObject
+  } = dispense
   const { pushOutByVolume } = singleDispense // always get pushOut from singleDispense
-  const dispenseMix = 'mix' in dispenseObject ? dispenseObject.mix : null
-  const { conditioningByVolume = [], disposalByVolume = [] } =
-    multiDispense ?? {}
-
+  const dispenseMix = 'mix' in dispense ? dispense.mix : null
+  const {
+    conditioningByVolume: rawConditioningByVolume = [],
+    disposalByVolume: rawDisposalByVolume = [],
+  } = multiDispense ?? {}
+  const conditioningByVolume = rawConditioningByVolume as Array<
+    [number, number]
+  >
+  const disposalByVolume = rawDisposalByVolume as Array<[number, number]>
+  const tiprackDefinition =
+    Object.values(labwareEntities).find(
+      ({ labwareDefURI }) => labwareDefURI === tipRack
+    )?.def ?? null
+  const byVolumeLookup = getReferenceVolumesForByVolumeInterpolation({
+    rawForm,
+    pipetteSpecs,
+    tiprackDefinition,
+    conditioningByVolume,
+    disposalByVolume,
+  })
   // top-level aspirate fields
   const aspiratePositionReferenceFields = getPositionReferenceFields(
     aspiratePositionReference,
@@ -450,7 +688,7 @@ export const getDefaultLiquidClassesValues = (
   )
   const aspirateOffsetFields = getOffsetFields(aspirateOffset, 'aspirate')
   const aspirateFlowRateFields = getFlowRateFields(
-    Number(volume),
+    byVolumeLookup.flowRateAspirate,
     aspirateFlowRateByVolume,
     'aspirate'
   )
@@ -465,17 +703,16 @@ export const getDefaultLiquidClassesValues = (
   )
   const dispenseOffsetFields = getOffsetFields(dispenseOffset, 'dispense')
   const dispenseFlowRateFields = getFlowRateFields(
-    Number(volume),
+    byVolumeLookup.flowRateDispense,
     dispenseFlowRateByVolume,
     'dispense'
   )
-  const dispenseMixFields =
-    dispenseMix != null ? getMixFields(dispenseMix, 'dispense') : {}
+  const dispenseMixFields = getMixFields(dispenseMix, 'dispense')
   const dispenseDelayFields = getDelayFields(dispenseDelay, 'dispense')
   const pushOutFields =
     pushOutByVolume != null
       ? getByVolumeField({
-          volume: Number(volume),
+          volume: byVolumeLookup.pushOut,
           byVolume: pushOutByVolume,
           field: 'pushOut',
         })
@@ -483,7 +720,7 @@ export const getDefaultLiquidClassesValues = (
   const conditioningFields =
     multiDispense != null
       ? getByVolumeField({
-          volume: Number(volume),
+          volume: byVolumeLookup.conditioning,
           byVolume: conditioningByVolume,
           field: 'conditioning',
         })
@@ -491,7 +728,7 @@ export const getDefaultLiquidClassesValues = (
   const disposalFields =
     multiDispense != null
       ? getByVolumeField({
-          volume: Number(volume),
+          volume: byVolumeLookup.disposal,
           byVolume: disposalByVolume,
           field: 'disposalVolume',
         })
@@ -562,11 +799,341 @@ export const getDefaultLiquidClassesValues = (
   }
 
   return {
+    ...getDefaultsForStepType(rawForm.stepType),
+    ...getStableFieldsAndValues('moveLiquid', rawForm), // replace fields unaffected by liquid class-related changes
+    // update liquid class values for specified tab(s)
     ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'aspirate'
       ? aspirateFields
       : {}),
     ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'dispense'
       ? dispenseFields
       : {}),
+    // keep current tab form data if only updating one tab
+    ...(liquidHandlingAction === 'aspirate'
+      ? getCurrentFormFields(rawForm, Object.keys(dispenseFields))
+      : {}),
+    ...(liquidHandlingAction === 'dispense'
+      ? getCurrentFormFields(rawForm, Object.keys(aspirateFields))
+      : {}),
   }
+}
+
+const getLiquidClassValuesMix = (args: {
+  rawForm: FormData
+  liquidClassValuesForTip: ByTipTypeSetting
+  additionalEquipmentEntities: AdditionalEquipmentEntities
+  liquidHandlingAction: LiquidClassSettingsType
+}): Record<string, any> => {
+  const {
+    rawForm,
+    liquidClassValuesForTip,
+    additionalEquipmentEntities,
+    liquidHandlingAction,
+  } = args
+  const { volume: rawVolume } = rawForm
+  const volume = Number(rawVolume)
+  const { aspirate, singleDispense } = liquidClassValuesForTip
+  const {
+    positionReference,
+    offset,
+    flowRateByVolume: aspirateFlowRateByVolume,
+    delay: aspirateDelay,
+  } = aspirate
+  const {
+    flowRateByVolume: dispenseFlowRateByVolume,
+    delay: dispenseDelay,
+    retract: dispenseRetract,
+    pushOutByVolume,
+  } = singleDispense
+  const aspirateFlowRateFields = getFlowRateFields(
+    volume,
+    aspirateFlowRateByVolume,
+    'aspirate'
+  )
+  const mixPositionReferenceFields = getPositionReferenceFields(
+    positionReference,
+    'mix'
+  )
+  const mixOffsetFields = getOffsetFields(offset, 'mix')
+  const dispenseFlowRateFields = getFlowRateFields(
+    volume,
+    dispenseFlowRateByVolume,
+    'dispense'
+  )
+  const aspirateDelayFields = getDelayFields(aspirateDelay, 'aspirate')
+  const dispenseDelayFields = getDelayFields(dispenseDelay, 'dispense')
+  const blowoutFields = getBlowoutFields(
+    dispenseRetract.blowout,
+    additionalEquipmentEntities
+  )
+  const pushOutFields = getByVolumeField({
+    volume,
+    byVolume: pushOutByVolume,
+    field: 'pushOut',
+  })
+  const touchTipFields = getTouchTipFields(
+    singleDispense.retract.touchTip,
+    'dispense'
+  )
+  const aspirateFields = {
+    ...aspirateFlowRateFields,
+    ...mixPositionReferenceFields,
+    ...mixOffsetFields,
+    ...aspirateDelayFields,
+  }
+  const dispenseFields = {
+    ...dispenseFlowRateFields,
+    ...dispenseDelayFields,
+    ...blowoutFields,
+    ...pushOutFields,
+    ...touchTipFields,
+  }
+  const values = {
+    ...getDefaultsForStepType('mix'),
+    ...getStableFieldsAndValues('mix', rawForm), // replace fields unaffected by liquid class-related changes
+    // update liquid class values for specified tab(s)
+    ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'aspirate'
+      ? aspirateFields
+      : {}),
+    ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'dispense'
+      ? dispenseFields
+      : {}),
+    // keep current tab form data if only updating one tab
+    ...(liquidHandlingAction === 'aspirate'
+      ? getCurrentFormFields(rawForm, Object.keys(dispenseFields))
+      : {}),
+    ...(liquidHandlingAction === 'dispense'
+      ? getCurrentFormFields(rawForm, Object.keys(aspirateFields))
+      : {}),
+  }
+  return values
+}
+
+const getReferenceVolumesForByVolumeInterpolation = (args: {
+  rawForm: FormData
+  pipetteSpecs: PipetteV2Specs
+  tiprackDefinition: LabwareDefinition2 | null
+  conditioningByVolume: Array<[number, number]>
+  disposalByVolume: Array<[number, number]>
+}): {
+  airGap: number
+  correctionAspirate: number
+  correctionDispense: number
+  pushOut: number
+  flowRateAspirate: number
+  flowRateDispense: number
+  conditioning: number
+  disposal: number
+} => {
+  const {
+    rawForm,
+    pipetteSpecs,
+    tiprackDefinition,
+    conditioningByVolume,
+    disposalByVolume,
+  } = args
+  const { volume: rawVolume, path: rawPath, aspirate_wells } = rawForm
+  const volume = Number(rawVolume)
+  const path = rawPath as PathOption
+  const { liquids } = pipetteSpecs
+  const isInLowVolumeMode =
+    volume < liquids.default.minVolume && 'lowVolumeDefault' in liquids
+  const maxWorkingVolumePipette = isInLowVolumeMode
+    ? liquids.lowVolumeDefault.maxVolume
+    : liquids.default.maxVolume
+  const maxWorkingVolumeTip = tiprackDefinition?.wells.A1.totalLiquidVolume
+  const maxWorkingVolume =
+    maxWorkingVolumeTip == null
+      ? maxWorkingVolumePipette
+      : Math.min(maxWorkingVolumePipette, maxWorkingVolumeTip)
+  const numAspirations = Math.ceil(volume / maxWorkingVolume)
+  const minVolumeForMultiAspirateDispense = volume * 2
+  const isMultiDispenseAvailable =
+    minVolumeForMultiAspirateDispense >=
+    minVolumeForMultiAspirateDispense +
+      (linearInterpolate(
+        minVolumeForMultiAspirateDispense,
+        conditioningByVolume
+      ) ?? 0) +
+      (linearInterpolate(minVolumeForMultiAspirateDispense, disposalByVolume) ??
+        0)
+  const isMultiAspirateAvailable =
+    maxWorkingVolume > minVolumeForMultiAspirateDispense
+
+  const getTotalVolumeForMultiDispense = (
+    targetVol: number,
+    includeConditioning: boolean = true
+  ): number => {
+    const interpolatedConditioningVolume =
+      linearInterpolate(targetVol, conditioningByVolume) ?? 0
+    const interpolatedDisposalVolume =
+      linearInterpolate(targetVol, disposalByVolume) ?? 0
+    return (
+      targetVol +
+      (includeConditioning ? interpolatedConditioningVolume : 0) +
+      interpolatedDisposalVolume
+    )
+  }
+
+  // early return if multiAspirate/multiDispense cannot be accommodated
+  if (
+    path === 'single' ||
+    (path === 'multiDispense' && !isMultiDispenseAvailable) ||
+    (path === 'multiAspirate' && !isMultiAspirateAvailable)
+  ) {
+    const volumePerAspiration = volume / numAspirations
+    return {
+      airGap: volumePerAspiration,
+      correctionAspirate: volumePerAspiration,
+      correctionDispense: volumePerAspiration,
+      pushOut: volumePerAspiration,
+      flowRateAspirate: volumePerAspiration,
+      flowRateDispense: volumePerAspiration,
+      conditioning: 0,
+      disposal: 0,
+    }
+  }
+
+  if (path === 'multiDispense') {
+    let totalVolumeForMultiDispense: number = 0
+    for (let i = 0; i < aspirate_wells.length; i++) {
+      const next = getTotalVolumeForMultiDispense((i + 1) * volume)
+      if (next > maxWorkingVolume) {
+        break
+      } else {
+        totalVolumeForMultiDispense = (i + 1) * volume
+      }
+    }
+    return {
+      airGap: getTotalVolumeForMultiDispense(
+        totalVolumeForMultiDispense,
+        false
+      ),
+      correctionAspirate: getTotalVolumeForMultiDispense(
+        totalVolumeForMultiDispense
+      ),
+      correctionDispense: volume,
+      pushOut: volume,
+      conditioning: totalVolumeForMultiDispense,
+      disposal: totalVolumeForMultiDispense,
+      flowRateAspirate: getTotalVolumeForMultiDispense(
+        totalVolumeForMultiDispense
+      ),
+      flowRateDispense: volume,
+    }
+  }
+  // path is valid multiAspirate
+  const maxSourcesPerAspiration = Math.floor(maxWorkingVolume / volume)
+  const volumeTotalAspiration = maxSourcesPerAspiration * volume
+  return {
+    airGap: volumeTotalAspiration,
+    correctionAspirate: volumeTotalAspiration,
+    correctionDispense: volumeTotalAspiration,
+    pushOut: volumeTotalAspiration,
+    flowRateAspirate: volume,
+    flowRateDispense: volumeTotalAspiration,
+    conditioning: volumeTotalAspiration,
+    disposal: volumeTotalAspiration,
+  }
+}
+
+export const getLiquidClassesValues = (args: {
+  rawForm: FormData
+  pipetteEntities: PipetteEntities
+  labwareEntities: LabwareEntities
+  additionalEquipmentEntities: AdditionalEquipmentEntities
+  liquidHandlingAction?: LiquidClassSettingsType
+}): Record<string, any> => {
+  const {
+    rawForm,
+    pipetteEntities,
+    labwareEntities,
+    additionalEquipmentEntities,
+    liquidHandlingAction = 'all',
+  } = args
+  const { liquidClass, pipette, tipRack, stepType } = rawForm
+  if (stepType !== 'mix' && stepType !== 'moveLiquid') {
+    console.warn(`invalid step type for liquid classes: ${stepType}`)
+    return {}
+  }
+
+  const pipetteEntity = pipetteEntities[pipette]
+  const liquidClasses = getAllLiquidClassDefs()
+  const liquidClassDef = liquidClasses[liquidClass]
+  if (pipetteEntity == null) {
+    return {}
+  }
+  const { spec: pipetteSpecs } = pipetteEntity
+  const convertedPipetteName = getFlexNameConversion(pipetteEntity.spec)
+  if (liquidClass === 'none') {
+    return stepType === 'moveLiquid'
+      ? getNoLiquidClassValuesMoveLiquid(
+          rawForm,
+          convertedPipetteName,
+          liquidHandlingAction
+        )
+      : getNoLiquidClassValuesMix(
+          rawForm,
+          convertedPipetteName,
+          liquidHandlingAction
+        )
+  }
+  if (liquidClassDef == null) {
+    return {}
+  }
+  const liquidClassValuesForPipette = liquidClassDef.byPipette.find(
+    ({ pipetteModel }) => convertedPipetteName === pipetteModel
+  )
+  const liquidClassValuesForTip = liquidClassValuesForPipette?.byTipType.find(
+    ({ tiprack }) => tiprack === tipRack
+  )
+  if (liquidClassValuesForTip == null) {
+    return {}
+  }
+  if (stepType === 'mix') {
+    return getLiquidClassValuesMix({
+      rawForm,
+      liquidClassValuesForTip,
+      additionalEquipmentEntities,
+      liquidHandlingAction,
+    })
+  }
+  return getLiquidClassValuesMoveLiquid({
+    rawForm,
+    liquidClassValuesForTip,
+    pipetteSpecs,
+    labwareEntities,
+    additionalEquipmentEntities,
+    liquidHandlingAction,
+  })
+}
+
+export const updateFieldsForLiquidClass = (args: {
+  propsForFields: FieldPropsByName
+  rawForm: FormData
+  pipetteEntities: PipetteEntities
+  labwareEntities: LabwareEntities
+  additionalEquipmentEntities: AdditionalEquipmentEntities
+  liquidHandlingAction?: LiquidClassSettingsType
+}): void => {
+  const {
+    propsForFields,
+    rawForm,
+    pipetteEntities,
+    labwareEntities,
+    additionalEquipmentEntities,
+    liquidHandlingAction = 'all',
+  } = args
+  const fieldUpdates = getLiquidClassesValues({
+    rawForm,
+    pipetteEntities,
+    labwareEntities,
+    additionalEquipmentEntities,
+    liquidHandlingAction,
+  })
+  Object.entries(fieldUpdates).forEach(([field, value]) => {
+    if (field in propsForFields) {
+      propsForFields[field].updateValue(value)
+    }
+  })
 }

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -799,7 +799,7 @@ export interface MultiDispenseProperties
   conditioningByVolume: LiquidHandlingPropertyByVolume
   disposalByVolume: LiquidHandlingPropertyByVolume
 }
-interface ByTipTypeSetting {
+export interface ByTipTypeSetting {
   tiprack: string
   aspirate: AspirateProperties
   singleDispense: SingleDispenseProperties


### PR DESCRIPTION
# Overview

This PR finishes the logic for retrieving liquid class values and unpacking them into a moveLiquid or mix step form. `updateFieldsForLiquidClass` directly updates the fields with values gotten from `getLiquidClassesValues`. This util also handles 'none' as the selected liquid class according to the form logic agreed upon by the liquid class project stakeholders. Also, I wire up the field updater in StepFormToolbox and in the advanced settings pages of both the moveLiquid and mix step forms.

Closes AUTH-1655

## Test Plan and Hands on Testing

I am working on a full set of tests for these utilities. In the meantime, the best way to test this is to create or edit a mix or transfer form. Change various fields that affect liquid class settings on pages 1 and 2 including:
- pipette
- tiprack
- volume
- path
- liquid class

Upon clicking "continue" on page 2 and updating values when prompted in the modal, you should be brought to a filled out advanced settings page. (NOTE: if you select "Don't use a liquid class," not all advanced settings will be filled out by design— reference "Conclusion for new form auto-fill" column of bottom table in [this doc](https://opentrons.atlassian.net/wiki/x/CADEIwE).)

Once on advanced settings, change some settings on aspirate or dispense tab. At the bottom of the page, click "reset aspirate/dispense settings" and confirm the modal. Verify that the values for only the selected tab were reset.



## Changelog

- update liquid class getter to handle no liquid class
- wire up reset settings modal

## Review requests

see test plan

## Risk assessment

low-medium