### PR TITLE
fix(api): make sure we're not checking stale states on the stacker before a move

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -315,9 +315,6 @@ class FlexStacker(mod_abc.AbstractModule):
         acceleration: Optional[float] = None,
     ) -> bool:
         """Close the latch, dropping any labware its holding."""
-        # Dont move the latch if its already closed.
-        if self.limit_switch_status[StackerAxis.L] == StackerAxisState.EXTENDED:
-            return True
         success = await self.home_axis(
             StackerAxis.L,
             Direction.RETRACT,
@@ -337,9 +334,6 @@ class FlexStacker(mod_abc.AbstractModule):
         acceleration: Optional[float] = None,
     ) -> bool:
         """Open the latch."""
-        # Dont move the latch if its already opened.
-        if self.limit_switch_status[StackerAxis.L] == StackerAxisState.RETRACTED:
-            return True
         # The latch only has one limit switch, so we have to travel a fixed distance
         # to open the latch.
         success = await self.move_axis(
@@ -351,8 +345,10 @@ class FlexStacker(mod_abc.AbstractModule):
         )
         # Check that the latch is opened.
         await self._reader.get_limit_switch_status()
-        axis_state = self.limit_switch_status[StackerAxis.L]
-        return success and axis_state == StackerAxisState.RETRACTED
+        return (
+            success
+            and self.limit_switch_status[StackerAxis.L] == StackerAxisState.RETRACTED
+        )
 
     async def dispense_labware(
         self,
@@ -439,6 +435,11 @@ class FlexStacker(mod_abc.AbstractModule):
     async def _move_and_home_axis(
         self, axis: StackerAxis, direction: Direction, offset: float = 0
     ) -> bool:
+        """Move the axis in a direction by the given offset in mm and home it.
+
+        Warning: It is assumed that the axis is already in a known state
+        before this function gets called. Do not use this function if the axis
+        has not been homed/has recently stalled."""
         distance = MAX_TRAVEL[axis] - offset
         await self.move_axis(axis, direction, distance)
         return await self.home_axis(axis, direction)


### PR DESCRIPTION
# Overview
This PR fixes a bug where the stacker labware latch wouldn’t open or close as expected during a protocol. The issue happened because we were skipping latch movements based on the last known state. We did that intentionally, since stall guard doesn’t work on the latch motor and we didn’t want to risk pushing it past its physical limits.

But that approach has problems — mainly, we don’t know how old that cached state is. On top of that, because there’s only one limit switch on the axis, the latch can drift just enough to give a false “open” signal even when it’s not fully open.

To fix this, we had two options:
1. Always check the live state of the limit switch before moving
2. Just command the move without checking

I went with option 2, since it’s simpler and still safe. As long as we home the latch once before using the stacker, we’ll have an accurate state. And even if we accidentally move it while it’s already at the limit, the move is tiny (only 22mm), so there’s no real risk of hardware damage.
