### PR TITLE
feat(step-generation): custom labware Python export

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -70,9 +70,27 @@ describe('createFile selector', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
+
+  // The labware in the fixtures have namespace "fixture", which makes them
+  // custom labware. Change their namespace to "opentrons" so that they're
+  // treated as standard labware.
+  const labwareEntitiesOpentrons = {
+    ...labwareEntities,
+    tiprackId: {
+      ...labwareEntities['tiprackId'],
+      def: { ...labwareEntities['tiprackId'].def, namespace: 'opentrons' },
+    },
+    plateId: {
+      ...labwareEntities['plateId'],
+      def: { ...labwareEntities['plateId'].def, namespace: 'opentrons' },
+    },
+    // We'll leave labwareEntities['fixedTrash'] with the "fixture" namespace,
+    // to demonstrate what custom labware loading looks like.
+  }
+
   const entities = {
     moduleEntities: v7Fixture.moduleEntities,
-    labwareEntities,
+    labwareEntities: labwareEntitiesOpentrons,
     pipetteEntities,
     liquidEntities: ingredients,
   }
@@ -119,6 +137,7 @@ describe('createFile selector', () => {
     // generated Python will be tested in separate unit tests.
     expect(result.pythonProtocol).toBe(
       `
+import json
 from contextlib import nullcontext as pd_step
 from opentrons import protocol_api, types
 
@@ -138,25 +157,23 @@ requirements = {
 
 def run(protocol: protocol_api.ProtocolContext):
     # Load Labware:
-    mock_python_name_1 = protocol.load_labware(
-        "fixture_trash",
+    mock_python_name_1 = protocol.load_labware_from_definition(
+        CUSTOM_LABWARE["fixture/fixture_trash/1"],
         location="12",
         label="Trash",
-        namespace="fixture",
-        version=1,
     )
     mock_python_name_2 = protocol.load_labware(
         "fixture_tiprack_10_ul",
         location="1",
         label="Opentrons 96 Tip Rack 10 µL",
-        namespace="fixture",
+        namespace="opentrons",
         version=1,
     )
     mock_python_name_3 = protocol.load_labware(
         "fixture_96_plate",
         location="7",
         label="NEST 96 Well Plate 100 µL PCR Full Skirt",
-        namespace="fixture",
+        namespace="opentrons",
         version=1,
     )
 
@@ -167,6 +184,8 @@ def run(protocol: protocol_api.ProtocolContext):
 
     # Step 1:
     pass
+
+CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"schemaVersion":2,"version":1,"namespace":"fixture","metadata":{"displayCategory":"trash","displayVolumeUnits":"L","displayName":"Tall Fixed Trash","tags":["trash","opentrons","tall"]},"dimensions":{"xDimension":172.86,"yDimension":165.86,"zDimension":82},"parameters":{"format":"trash","isTiprack":false,"loadName":"fixture_trash","isMagneticModuleCompatible":false,"quirks":["fixedTrash","centerMultichannelOnWells","touchTipDisabled"]},"wells":{"A1":{"shape":"rectangular","yDimension":165.67,"xDimension":107.11,"totalLiquidVolume":1100000,"depth":77,"x":82.84,"y":53.56,"z":5}},"brand":{"brand":"Opentrons"},"groups":[{"wells":["A1"],"metadata":{}}],"cornerOffsetFromSlot":{"x":0,"y":0,"z":0}}}""")
 `.trimStart()
     )
 

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -77,12 +77,12 @@ describe('createFile selector', () => {
   const labwareEntitiesOpentrons = {
     ...labwareEntities,
     tiprackId: {
-      ...labwareEntities['tiprackId'],
-      def: { ...labwareEntities['tiprackId'].def, namespace: 'opentrons' },
+      ...labwareEntities.tiprackId,
+      def: { ...labwareEntities.tiprackId.def, namespace: 'opentrons' },
     },
     plateId: {
-      ...labwareEntities['plateId'],
-      def: { ...labwareEntities['plateId'].def, namespace: 'opentrons' },
+      ...labwareEntities.plateId,
+      def: { ...labwareEntities.plateId.def, namespace: 'opentrons' },
     },
     // We'll leave labwareEntities['fixedTrash'] with the "fixture" namespace,
     // to demonstrate what custom labware loading looks like.

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -11,6 +11,7 @@ import {
   FLEX_STANDARD_DECKID,
 } from '@opentrons/shared-data'
 import {
+  pythonCustomLabwareDict,
   pythonDefRun,
   pythonImports,
   pythonMetadata,
@@ -392,6 +393,7 @@ export const createPythonFile: Selector<PDPythonFile> = createSelector(
           labwareNicknamesById,
           robotType
         ),
+        pythonCustomLabwareDict(invariantContext.labwareEntities),
       ]
         .filter(section => section) // skip any blank sections
         .join('\n\n') + '\n'

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -37,6 +37,17 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
+// The labware fixtures use namespace "fixture", with is treated as custom labware.
+// Modify the labware fixtures to change them to the "opentrons" namespace.
+const opentrons96Plate = {
+  ...fixture96Plate,
+  namespace: 'opentrons',
+} as LabwareDefinition2
+const opentronsTiprackAdapter = {
+  ...fixtureTiprackAdapter,
+  namespace: 'opentrons',
+} as LabwareDefinition2
+
 describe('pythonMetadata', () => {
   it('should generate metadata section', () => {
     expect(
@@ -121,8 +132,8 @@ const labwareId5 = 'labwareId5'
 const mockLabwareEntities: LabwareEntities = {
   [labwareId1]: {
     id: labwareId1,
-    labwareDefURI: 'fixture/fixture_flex_96_tiprack_adapter/1',
-    def: fixtureTiprackAdapter as LabwareDefinition2,
+    labwareDefURI: 'opentrons/fixture_flex_96_tiprack_adapter/1',
+    def: opentronsTiprackAdapter,
     pythonName: 'adapter_1',
   },
   [labwareId2]: {
@@ -133,14 +144,14 @@ const mockLabwareEntities: LabwareEntities = {
   },
   [labwareId3]: {
     id: labwareId3,
-    labwareDefURI: 'fixture/fixture_96_plate/1',
-    def: fixture96Plate as LabwareDefinition2,
+    labwareDefURI: 'opentrons/fixture_96_plate/1',
+    def: opentrons96Plate,
     pythonName: 'well_plate_1',
   },
   [labwareId4]: {
     id: labwareId4,
-    labwareDefURI: 'fixture/fixture_96_plate/1',
-    def: fixture96Plate as LabwareDefinition2,
+    labwareDefURI: 'opentrons/fixture_96_plate/1',
+    def: opentrons96Plate as LabwareDefinition2,
     pythonName: 'well_plate_2',
   },
   [labwareId5]: {
@@ -202,14 +213,12 @@ describe('getLoadAdapters', () => {
 # Load Adapters:
 adapter_1 = magnetic_block_1.load_adapter(
     "fixture_flex_96_tiprack_adapter",
-    namespace="fixture",
+    namespace="opentrons",
     version=1,
 )
-adapter_2 = protocol.load_adapter(
-    "fixture_flex_96_tiprack_adapter",
+adapter_2 = protocol.load_adapter_from_definition(
+    CUSTOM_LABWARE["fixture/fixture_flex_96_tiprack_adapter/1"],
     location="B2",
-    namespace="fixture",
-    version=1,
 )`.trimStart()
     )
   })
@@ -230,20 +239,18 @@ describe('getLoadLabware', () => {
 well_plate_1 = adapter_2.load_labware(
     "fixture_96_plate",
     label="reagent plate",
-    namespace="fixture",
+    namespace="opentrons",
     version=1,
 )
 well_plate_2 = magnetic_block_2.load_labware(
     "fixture_96_plate",
-    namespace="fixture",
+    namespace="opentrons",
     version=1,
 )
-well_plate_3 = protocol.load_labware(
-    "fixture_96_plate",
+well_plate_3 = protocol.load_labware_from_definition(
+    CUSTOM_LABWARE["fixture/fixture_96_plate/1"],
     location="C2",
     label="sample plate",
-    namespace="fixture",
-    version=1,
 )`.trimStart()
     )
   })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -1,5 +1,7 @@
 import {
   getCutoutDisplayName,
+  getLabwareDefIsStandard,
+  getLabwareDefURI,
   isFlexPipette,
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
@@ -8,6 +10,7 @@ import {
   formatPyDict,
   formatPyStr,
   indentPyLines,
+  CUSTOM_LABWARE_DICT_NAME,
   OFF_DECK,
   PROTOCOL_CONTEXT_NAME,
 } from './pythonFormat'
@@ -43,6 +46,7 @@ const PAPI_VERSION = '2.24' // latest version from api/src/opentrons/protocols/a
 
 export function pythonImports(): string {
   return [
+    'import json',
     'from contextlib import nullcontext as pd_step',
     'from opentrons import protocol_api, types',
   ].join('\n')
@@ -121,28 +125,43 @@ export function getLoadAdapters(
       const { parameters, namespace, version } = def
       const adapterSlot = labwareRobotState[id].slot
       const onModule = moduleEntities[adapterSlot] != null
-      const location = onModule
-        ? moduleEntities[adapterSlot].pythonName
-        : PROTOCOL_CONTEXT_NAME
 
-      const adapterArgs = [
-        `${formatPyStr(parameters.loadName)}`,
-        ...(!onModule
-          ? [
-              `location=${formatPyStr(
-                adapterSlot === 'offDeck' ? OFF_DECK : adapterSlot
-              )}`,
-            ]
-          : []),
-        `namespace=${formatPyStr(namespace)}`,
-        `version=${version}`,
-      ].join(',\n')
+      let parentName: string
+      let locationArg: string | undefined
+      if (onModule) {
+        parentName = moduleEntities[adapterSlot].pythonName
+      } else {
+        parentName = PROTOCOL_CONTEXT_NAME
+        locationArg = `location=${formatPyStr(
+          adapterSlot === 'offDeck' ? OFF_DECK : adapterSlot
+        )}`
+      }
 
-      return (
-        `${pythonName} = ${location}.load_adapter(\n` +
-        `${indentPyLines(adapterArgs)},\n` +
-        `)`
-      )
+      const isStandard = getLabwareDefIsStandard(def)
+      if (isStandard) {
+        const adapterArgs = [
+          `${formatPyStr(parameters.loadName)}`,
+          ...(locationArg ? [locationArg] : []),
+          `namespace=${formatPyStr(namespace)}`,
+          `version=${version}`,
+        ].join(',\n')
+        return (
+          `${pythonName} = ${parentName}.load_adapter(\n` +
+          `${indentPyLines(adapterArgs)},\n` +
+          `)`
+        )
+      } else {
+        // custom adapter
+        const adapterArgs = [
+          `${CUSTOM_LABWARE_DICT_NAME}[${formatPyStr(getLabwareDefURI(def))}]`,
+          ...(locationArg ? [locationArg] : []),
+        ].join(',\n')
+        return (
+          `${pythonName} = ${parentName}.load_adapter_from_definition(\n` +
+          `${indentPyLines(adapterArgs)},\n` +
+          `)`
+        )
+      }
     })
     .join('\n')
 
@@ -163,40 +182,55 @@ export function getLoadLabware(
       const { id, def, pythonName } = labware
       const { metadata, parameters, namespace, version } = def
       const hasNickname =
-        labwareNicknamesById[id] != null
-          ? labwareNicknamesById[id] !== metadata.displayName
-          : false
+        labwareNicknamesById[id] != null &&
+        labwareNicknamesById[id] !== metadata.displayName
       const labwareSlot = labwareRobotState[id].slot
       const onModule = moduleEntities[labwareSlot] != null
       const onAdapter = allLabwareEntities[labwareSlot] != null
-      let location = PROTOCOL_CONTEXT_NAME
+
+      let parentName: string
+      let locationArg: string | undefined
       if (onAdapter) {
-        location = allLabwareEntities[labwareSlot].pythonName
+        parentName = allLabwareEntities[labwareSlot].pythonName
       } else if (onModule) {
-        location = moduleEntities[labwareSlot].pythonName
+        parentName = moduleEntities[labwareSlot].pythonName
+      } else {
+        parentName = PROTOCOL_CONTEXT_NAME
+        locationArg = `location=${formatPyStr(
+          labwareSlot === 'offDeck' ? OFF_DECK : labwareSlot
+        )}`
       }
+      const labelArg = hasNickname
+        ? `label=${formatPyStr(labwareNicknamesById[id])}`
+        : undefined
 
-      const labwareArgs = [
-        `${formatPyStr(parameters.loadName)}`,
-        ...(!onModule && !onAdapter
-          ? [
-              `location=${formatPyStr(
-                labwareSlot === 'offDeck' ? OFF_DECK : labwareSlot
-              )}`,
-            ]
-          : []),
-        ...(hasNickname
-          ? [`label=${formatPyStr(labwareNicknamesById[id])}`]
-          : []),
-        `namespace=${formatPyStr(namespace)}`,
-        `version=${version}`,
-      ].join(',\n')
-
-      return (
-        `${pythonName} = ${location}.load_labware(\n` +
-        `${indentPyLines(labwareArgs)},\n` +
-        `)`
-      )
+      const isStandard = getLabwareDefIsStandard(def)
+      if (isStandard) {
+        const loadLabwareArgs = [
+          `${formatPyStr(parameters.loadName)}`,
+          ...(locationArg ? [locationArg] : []),
+          ...(labelArg ? [labelArg] : []),
+          `namespace=${formatPyStr(namespace)}`,
+          `version=${version}`,
+        ].join(',\n')
+        return (
+          `${pythonName} = ${parentName}.load_labware(\n` +
+          `${indentPyLines(loadLabwareArgs)},\n` +
+          `)`
+        )
+      } else {
+        // custom labware
+        const loadFromDefnArgs = [
+          `${CUSTOM_LABWARE_DICT_NAME}[${formatPyStr(getLabwareDefURI(def))}]`,
+          ...(locationArg ? [locationArg] : []),
+          ...(labelArg ? [labelArg] : []),
+        ].join(',\n')
+        return (
+          `${pythonName} = ${parentName}.load_labware_from_definition(\n` +
+          `${indentPyLines(loadFromDefnArgs)},\n` +
+          `)`
+        )
+      }
     })
     .join('\n')
 
@@ -365,4 +399,25 @@ export function pythonDefRun(
     `def run(${PROTOCOL_CONTEXT_NAME}: protocol_api.ProtocolContext):\n` +
     `${indentPyLines(functionBody)}`
   )
+}
+
+export function pythonCustomLabwareDict(
+  labwareEntities: LabwareEntities
+): string {
+  const customLabwareDefs = Object.values(labwareEntities)
+    .filter(labwareEntity => !getLabwareDefIsStandard(labwareEntity.def))
+    .map(labwareEntity => labwareEntity.def)
+  if (customLabwareDefs.length > 0) {
+    const customLabwareDict = Object.fromEntries(
+      customLabwareDefs.map(labwareDef => [
+        getLabwareDefURI(labwareDef),
+        labwareDef,
+      ])
+    )
+    return `${CUSTOM_LABWARE_DICT_NAME} = json.loads("""${JSON.stringify(
+      customLabwareDict
+    )}""")`
+  } else {
+    return ''
+  }
 }

--- a/step-generation/src/utils/pythonFormat.ts
+++ b/step-generation/src/utils/pythonFormat.ts
@@ -11,6 +11,9 @@ export const PROTOCOL_CONTEXT_NAME = 'protocol'
 /** The variable name for defining a labware that is off-deck or being moved to off-deck */
 export const OFF_DECK = 'protocol_api.OFF_DECK'
 
+/** The variable name for the Python dict containing the custom labware defintions. */
+export const CUSTOM_LABWARE_DICT_NAME = 'CUSTOM_LABWARE'
+
 const INDENT = '    '
 
 /** Indent each of the lines in `text`. */


### PR DESCRIPTION
# Overview

Add support for custom labware in PD Python export. Custom labware is loaded with the API functions `load_labware_from_definition()` and `load_adapter_from_definition()`.

Those functions take a **Python dict**, not a JSON string. But if we emitted the labware definitions as Python dicts, PD would not be able to use the labware definitions when importing the Python file, because PD does not have a Python parser. (The biggest difference between Python dicts and JSON is that Python uses `True`/`False`, whereas JSON uses `true`/`false`.)

Our solution is that we will embed the custom labware definitions as JSON strings in the Python file, and the Python code will call `json.loads()` to parse the JSON into a Python dict. So our Python file will look like this:

```
def run(protocol: protocol_api.ProtocolContext):
    well_plate_1 = protocol.load_labware_from_definition(
        CUSTOM_LABWARE["namespace/custom_labware/1"],
        location="B1",
        label="My labware",
    )

CUSTOM_LABWARE = json.loads("""
    {
        "namespace/custom_labware/1": { ... }
    }
""")
```

## Test Plan and Hands on Testing

Added unit tests.

I also tried it in PD with a piece of custom labware, and confirmed that the generated protocol works in `simulate`.

## Risk assessment

Low-ish. Python export is behind a feature flag.