### PR TITLE
fix(shared-data): use "Tip Rack" in display name of lid

### DIFF
--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -352,7 +352,7 @@ async def test_retrieve_primary_and_lid(
                 offset_ids_by_id={"labware-id": None, "lid-id": None},
                 display_names_by_id={
                     "labware-id": "Opentrons Flex 96 Filter Tip Rack 50 µL",
-                    "lid-id": "Opentrons Flex Tiprack Lid",
+                    "lid-id": "Opentrons Flex Tip Rack Lid",
                 },
                 definitions_by_id={
                     "labware-id": flex_50uL_tiprack,
@@ -771,7 +771,7 @@ async def test_retrieve_primary_adapter_and_lid(
                 display_names_by_id={
                     "labware-id": "Opentrons Flex 96 Filter Tip Rack 50 µL",
                     "adapter-id": "Opentrons Flex 96 Tip Rack Adapter",
-                    "lid-id": "Opentrons Flex Tiprack Lid",
+                    "lid-id": "Opentrons Flex Tip Rack Lid",
                 },
                 definitions_by_id={
                     "labware-id": flex_50uL_tiprack,

--- a/shared-data/labware/definitions/2/opentrons_flex_tiprack_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_tiprack_lid/1.json
@@ -6,7 +6,7 @@
     "brandId": []
   },
   "metadata": {
-    "displayName": "Opentrons Flex Tiprack Lid",
+    "displayName": "Opentrons Flex Tip Rack Lid",
     "displayCategory": "lid",
     "displayVolumeUnits": "µL",
     "tags": []


### PR DESCRIPTION

# Overview

The product name for our tip rack lids should be "Opentrons Flex Tip Rack Lid", with a space in "Tip Rack".

This matches the tip rack names, the name of the Opentrons Flex 96 Tip Rack Adapter, and our general [style guidance](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/980746400/Opentrons+UX+Style+Guide) on the phrase "tip rack".

## Test Plan and Hands on Testing

automated tests

## Changelog

`Tiprack` -> `Tip Rack`

## Review requests

Any LL ramifications of this, or should it pull from shared-data?

## Risk assessment

v low