### PR TITLE
fix(app): Fix "prevent robot caching" toggle

### DIFF
--- a/app/src/organisms/Desktop/AdvancedSettings/PreventRobotCaching.tsx
+++ b/app/src/organisms/Desktop/AdvancedSettings/PreventRobotCaching.tsx
@@ -18,7 +18,7 @@ import type { Dispatch, State } from '/app/redux/types'
 
 export function PreventRobotCaching(): JSX.Element {
   const { t } = useTranslation('app_settings')
-  const displayUnavailRobots = useSelector((state: State) => {
+  const disableRobotCache = useSelector((state: State) => {
     return getConfig(state)?.discovery.disableCache ?? false
   })
   const dispatch = useDispatch<Dispatch>()
@@ -29,7 +29,7 @@ export function PreventRobotCaching(): JSX.Element {
         <LegacyStyledText
           css={TYPOGRAPHY.h3SemiBold}
           paddingBottom={SPACING.spacing8}
-          id="AdvancedSettings_unavailableRobots"
+          id="AdvancedSettings_disableRobotCache"
         >
           {t('prevent_robot_caching')}
         </LegacyStyledText>
@@ -49,10 +49,10 @@ export function PreventRobotCaching(): JSX.Element {
         </LegacyStyledText>
       </Box>
       <ToggleButton
-        label="display_unavailable_robots"
-        toggledOn={!displayUnavailRobots}
+        label="disable_robot_cache"
+        toggledOn={disableRobotCache}
         onClick={() => dispatch(toggleConfigValue('discovery.disableCache'))}
-        id="AdvancedSettings_unavailableRobotsToggleButton"
+        id="AdvancedSettings_disableRobotCacheToggleButton"
       />
     </Flex>
   )

--- a/app/src/organisms/Desktop/AdvancedSettings/__tests__/PreventRobotCaching.test.tsx
+++ b/app/src/organisms/Desktop/AdvancedSettings/__tests__/PreventRobotCaching.test.tsx
@@ -37,13 +37,13 @@ describe('PreventRobotCaching', () => {
     screen.queryByText(
       'The app will immediately clear unavailable robots and will not remember unavailable robots while this is enabled. On networks with many robots, preventing caching may improve network performance at the expense of slower and less reliable robot discovery on app launch.'
     )
-    screen.getByRole('switch', { name: 'display_unavailable_robots' })
+    screen.getByRole('switch', { name: 'disable_robot_cache' })
   })
 
   it('should call mock toggleConfigValue when clicking the toggle button', () => {
     render()
     const toggleButton = screen.getByRole('switch', {
-      name: 'display_unavailable_robots',
+      name: 'disable_robot_cache',
     })
     fireEvent.click(toggleButton)
     expect(vi.mocked(toggleConfigValue)).toHaveBeenCalledWith(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Woops, the toggle behavior is backwards given the copy. The "on" toggle should disable the cache and clear it. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified the "on" toggle behavior is what clears the cache and disables caching.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the "prevent robot caching" setting toggle reflecting the opposite of the actual behavior.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
