### PR TITLE
fix(api): Fix migration of labware offsets whose location involves a Thermocycler

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/labware_handling_common.py
+++ b/api/src/opentrons/protocol_engine/commands/labware_handling_common.py
@@ -11,7 +11,12 @@ class LabwareHandlingResultMixin(BaseModel):
     labwareId: str = Field(..., description="The id of the labware.")
     locationSequence: LabwareLocationSequence | None = Field(
         None,
-        description="The full location down to the deck on which this labware exists.",
+        description=(
+            "The full location down to the deck on which this labware exists."
+            " The reason this can be `null` or omitted is just backwards compatibility,"
+            " for older runs and analyses. This should always be present"
+            " for new runs and analyses, even for labware whose location is off-deck."
+        ),
     )
 
 

--- a/api/src/opentrons/protocol_engine/labware_offset_standardization.py
+++ b/api/src/opentrons/protocol_engine/labware_offset_standardization.py
@@ -60,11 +60,6 @@ def legacy_offset_location_to_offset_location_sequence(
             possible_cutout_fixture_id = location.moduleModel.value
 
         try:
-            # This is raising FixtureDoesNotExistError.
-            # (Pdb) cutout_id
-            # 'cutoutB1'
-            # (Pdb) possible_cutout_fixture_id
-            # 'thermocyclerModuleV2'
             addressable_area = deck_configuration_provider.get_labware_hosting_addressable_area_name_for_cutout_and_cutout_fixture(
                 cutout_id, possible_cutout_fixture_id, deck_definition
             )

--- a/api/src/opentrons/protocol_engine/labware_offset_standardization.py
+++ b/api/src/opentrons/protocol_engine/labware_offset_standardization.py
@@ -53,8 +53,18 @@ def legacy_offset_location_to_offset_location_sequence(
         cutout_id = deck_configuration_provider.get_cutout_id_by_deck_slot_name(
             location.slotName
         )
-        possible_cutout_fixture_id = location.moduleModel.value
+
+        if location.moduleModel == ModuleModel.THERMOCYCLER_MODULE_V2:
+            possible_cutout_fixture_id = "thermocyclerModuleV2Front"
+        else:
+            possible_cutout_fixture_id = location.moduleModel.value
+
         try:
+            # This is raising FixtureDoesNotExistError.
+            # (Pdb) cutout_id
+            # 'cutoutB1'
+            # (Pdb) possible_cutout_fixture_id
+            # 'thermocyclerModuleV2'
             addressable_area = deck_configuration_provider.get_labware_hosting_addressable_area_name_for_cutout_and_cutout_fixture(
                 cutout_id, possible_cutout_fixture_id, deck_definition
             )

--- a/api/src/opentrons/protocol_engine/labware_offset_standardization.py
+++ b/api/src/opentrons/protocol_engine/labware_offset_standardization.py
@@ -54,7 +54,23 @@ def legacy_offset_location_to_offset_location_sequence(
             location.slotName
         )
 
-        if location.moduleModel == ModuleModel.THERMOCYCLER_MODULE_V2:
+        # Given a module model, try to figure out the equivalent cutout fixture.
+        #
+        # The Thermocycler is special. A single Thermocycler is represented in a deck
+        # configuration as two separate cutout fixtures, because it spans two separate
+        # cutouts. This makes it the only module whose module model string does not map
+        # 1:1 with a cutout fixture ID string.
+        #
+        # TODO(mm, 2025-04-11): This is fragile, and the failure mode when it does the
+        # wrong thing can mean labware offsets don't apply, which is pretty bad. We
+        # either need a more explicit module<->cutout-fixture mapping, or we need to
+        # avoid this mapping entirely.
+        if (
+            # Check for v2 specifically because v1 is OT-2-only and OT-2s don't have
+            # modules in their deck definitions; and v3 does not exist at the time of writing.
+            location.moduleModel
+            == ModuleModel.THERMOCYCLER_MODULE_V2
+        ):
             possible_cutout_fixture_id = "thermocyclerModuleV2Front"
         else:
             possible_cutout_fixture_id = location.moduleModel.value

--- a/api/src/opentrons/protocol_engine/resources/deck_configuration_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_configuration_provider.py
@@ -144,16 +144,20 @@ def get_deck_slot_for_cutout_id(cutout_id: str) -> DeckSlotName:
     """Get the corresponding deck slot for an addressable area."""
     try:
         return CUTOUT_TO_DECK_SLOT_MAP[cutout_id]
-    except KeyError:
-        raise CutoutDoesNotExistError(f"Could not find data for cutout {cutout_id}")
+    except KeyError as e:
+        raise CutoutDoesNotExistError(
+            f"Could not find data for cutout {cutout_id}"
+        ) from e
 
 
 def get_cutout_id_by_deck_slot_name(slot_name: DeckSlotName) -> str:
     """Get the Cutout ID of a given Deck Slot by Deck Slot Name."""
     try:
         return DECK_SLOT_TO_CUTOUT_MAP[slot_name]
-    except KeyError:
-        raise SlotDoesNotExistError(f"Could not find data for slot {slot_name.value}")
+    except KeyError as e:
+        raise SlotDoesNotExistError(
+            f"Could not find data for slot {slot_name.value}"
+        ) from e
 
 
 def get_labware_hosting_addressable_area_name_for_cutout_and_cutout_fixture(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1748,7 +1748,13 @@ class GeometryView:
         labware_location: LabwareLocation,
         labware_pending_load: dict[str, LoadedLabware] | None = None,
     ) -> Optional[LabwareOffsetLocationSequence]:
-        """Get the offset location that a labware loaded into this location would match."""
+        """Get the offset location that a labware loaded into this location would match.
+
+        `None` indicates that the very concept of a labware offset would not make sense
+        for the given location, such as if it's some kind of off-deck location. This
+        is a difference from `get_predicted_location_sequence()`, where off-deck
+        locations are still represented as lists, but with special final elements.
+        """
         return self._recurse_labware_offset_location(
             labware_location, [], labware_pending_load or {}
         )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1800,8 +1800,6 @@ class GeometryView:
             )
 
             module_location = self._modules.get_location(module_id=module_id)
-            # TODO: A little unclear if the app is correctly mirroring both of these cases.
-            # Also a little unclear if our migration code is correctly mirroring both of these cases.
             if self._modules.get_deck_supports_module_fixtures():
                 module_aa = self._modules.ensure_and_convert_module_fixture_location(
                     module_location.slotName, module_model

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1800,6 +1800,8 @@ class GeometryView:
             )
 
             module_location = self._modules.get_location(module_id=module_id)
+            # TODO: A little unclear if the app is correctly mirroring both of these cases.
+            # Also a little unclear if our migration code is correctly mirroring both of these cases.
             if self._modules.get_deck_supports_module_fixtures():
                 module_aa = self._modules.ensure_and_convert_module_fixture_location(
                     module_location.slotName, module_model

--- a/api/src/opentrons/protocol_engine/types/labware_offset_location.py
+++ b/api/src/opentrons/protocol_engine/types/labware_offset_location.py
@@ -38,6 +38,10 @@ class OnAddressableAreaOffsetLocationSequenceComponent(BaseModel):
     """Offset location sequence component for a labware on an addressable area."""
 
     kind: Literal["onAddressableArea"] = "onAddressableArea"
+    # TODO: Can we simplify these semantics so, on Flex, a labware on a module just has
+    # [{"kind": "onAddressableArea", "addressableAreaName": "temperatureModuleV2A1"}]
+    # instead of
+    # [{"kind": "onModule", "moduleModel": "temperatureModuleV2"}, {"kind": "onAddressableArea", "addressableAreaName": "temperatureModuleV2A1"}]
     addressableAreaName: str = Field(
         ...,
         description=(

--- a/api/src/opentrons/protocol_engine/types/labware_offset_location.py
+++ b/api/src/opentrons/protocol_engine/types/labware_offset_location.py
@@ -38,10 +38,6 @@ class OnAddressableAreaOffsetLocationSequenceComponent(BaseModel):
     """Offset location sequence component for a labware on an addressable area."""
 
     kind: Literal["onAddressableArea"] = "onAddressableArea"
-    # TODO: Can we simplify these semantics so, on Flex, a labware on a module just has
-    # [{"kind": "onAddressableArea", "addressableAreaName": "temperatureModuleV2A1"}]
-    # instead of
-    # [{"kind": "onModule", "moduleModel": "temperatureModuleV2"}, {"kind": "onAddressableArea", "addressableAreaName": "temperatureModuleV2A1"}]
     addressableAreaName: str = Field(
         ...,
         description=(

--- a/api/tests/opentrons/protocol_engine/test_labware_offset_standardization.py
+++ b/api/tests/opentrons/protocol_engine/test_labware_offset_standardization.py
@@ -152,6 +152,29 @@ def load_from_robot_type(robot_type: RobotType) -> DeckDefinitionV5:
             ),
             id="module-ot2-native",
         ),
+        # On a module with no adapter, and specificially the module is a Thermocycler.
+        # The Thermocycler is special because the deck definition splits it into two
+        # fixtures. :(
+        pytest.param(
+            LegacyLabwareOffsetLocation(
+                slotName=DeckSlotName.SLOT_B1,
+                moduleModel=ModuleModel.THERMOCYCLER_MODULE_V2,
+            ),
+            "OT-3 Standard",
+            [
+                OnModuleOffsetLocationSequenceComponent(
+                    moduleModel=ModuleModel.THERMOCYCLER_MODULE_V2
+                ),
+                OnAddressableAreaOffsetLocationSequenceComponent(
+                    addressableAreaName="thermocyclerModuleV2",
+                ),
+            ],
+            LegacyLabwareOffsetLocation(
+                slotName=DeckSlotName.SLOT_B1,
+                moduleModel=ModuleModel.THERMOCYCLER_MODULE_V2,
+            ),
+            id="tc-module-flex-native",
+        ),
         # On a labware (or stack...) on a slot
         pytest.param(
             LegacyLabwareOffsetLocation(


### PR DESCRIPTION
## Overview

Fixes [RABR-756](https://opentrons.atlassian.net/browse/RABR-756).

## Test Plan and Hands on Testing

I've done this:

1. Be on v8.3.0.
2. Do a device-reset of run history.
3. Run a simple protocol, like the one below, that has a labware in the Thermocycler. Give it some obvious labware offset.
4. Upgrade to this branch.
5. Re-run the protocol from the desktop app or ODD. It should prepopulate the same labware offset that you specified in step 3.

## Fix details

This fixes migration of the old labware offset shape to the new one.

The old shape looks like this:

```json
{
  "location": {
      "slotName": "B1",
      "moduleModel": "thermocyclerModuleV2"
  }
}
```

The new shape is supposed to look like this:

```json
{
  "locationSequence": [
      {
          "kind": "onModule",
          "moduleModel": "thermocyclerModuleV2"
      },
      {
          "kind": "onAddressableArea",
          "addressableAreaName": "thermocyclerModuleV2"
      }
  ]
}
```

But for the Thermocycler specifically, we were accidentally setting `addressableAreaName` to `"B1"`, the name of the underlying deck slot. This was because the Thermocycler is a special case in the deck definition that we weren't handling—see the Python comments in the diff.

The `locationSequence` being incorrect meant that the offset wasn't returned in the search queries that the frontend issues to the server (`POST /labwareOffsets/searches`). It would therefore not show up in protocol setup.

## Review requests

* Is there a fundamentally better way of doing this?
* If not, are there any other places in Python where we're doing this module<->cutout-fixture mapping? I suspect the answer is yes, but I couldn't find them. They really need to go through common code for this, since we won't be able to remember to handle this special case everywhere.

## Risk assessment

Low risk for this fix, but this whole situation seems pretty precarious, as described in the Python comment.

[RABR-756]: https://opentrons.atlassian.net/browse/RABR-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ