### PR TITLE
fix(protocol-designer): get all labware defs instead of latest when z…

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedHoveredItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedHoveredItems.tsx
@@ -1,11 +1,11 @@
 import { useSelector } from 'react-redux'
 import { Module } from '@opentrons/components'
 import {
+  getAllLabwareDefs,
   getModuleDef2,
   inferModuleOrientationFromXCoordinate,
 } from '@opentrons/shared-data'
 import { selectors } from '../../../labware-ingred/selectors'
-import { getOnlyLatestDefs } from '../../../labware-defs'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { getInitialDeckSetup } from '../../../step-forms/selectors'
 import { ModuleLabel } from './ModuleLabel'
@@ -49,7 +49,7 @@ export const SelectedHoveredItems = (
     selectedNestedLabwareDefUri,
   } = selectedSlotInfo
   const customLabwareDefs = useSelector(getCustomLabwareDefsByURI)
-  const defs = getOnlyLatestDefs()
+  const defs = getAllLabwareDefs()
   const deckSetup = useSelector(getInitialDeckSetup)
   const { labware, modules } = deckSetup
   const matchingSelectedLabwareOnDeck = Object.values(labware).find(labware => {

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
@@ -21,7 +21,6 @@ import { SelectedHoveredItems } from '../SelectedHoveredItems'
 import type { ComponentProps } from 'react'
 import type * as OpentronsComponents from '@opentrons/components'
 import type * as OpentronsSharedData from '@opentrons/shared-data'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 vi.mock('../../../../file-data/selectors')
 vi.mock('../../../../step-forms/selectors')
@@ -77,7 +76,7 @@ describe('SelectedHoveredItems', () => {
       labware: {
         labware: {
           id: 'mockId',
-          def: fixture24Tuberack as LabwareDefinition2,
+          def: fixture24Tuberack as OpentronsSharedData.LabwareDefinition2,
           labwareDefURI: mockAdapterURI,
           slot: 'D3',
           pythonName: 'mockPythonName',
@@ -150,14 +149,14 @@ describe('SelectedHoveredItems', () => {
       labware: {
         labware: {
           id: 'mockId',
-          def: fixture24Tuberack as LabwareDefinition2,
+          def: fixture24Tuberack as OpentronsSharedData.LabwareDefinition2,
           labwareDefURI: mockAdapterURI,
           slot: 'D3',
           pythonName: 'mockPythonName',
         },
         labware2: {
           id: 'mockId2',
-          def: fixture24Tuberack as LabwareDefinition2,
+          def: fixture24Tuberack as OpentronsSharedData.LabwareDefinition2,
           labwareDefURI: mockAdapterURI,
           slot: 'mockId',
           pythonName: 'mockPythonName',

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
@@ -19,8 +19,7 @@ import { FixtureRender } from '../FixtureRender'
 import { SelectedHoveredItems } from '../SelectedHoveredItems'
 
 import type { ComponentProps } from 'react'
-import type * as OpentronsComponents from '@opentrons/components'
-import type * as OpentronsSharedData from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 vi.mock('../../../../file-data/selectors')
 vi.mock('../../../../step-forms/selectors')
@@ -29,14 +28,14 @@ vi.mock('../../../../labware-ingred/selectors')
 vi.mock('../../../../labware-defs/selectors')
 vi.mock('../../../../components/organisms')
 vi.mock('@opentrons/components', async importOriginal => {
-  const actual = await importOriginal<typeof OpentronsComponents>()
+  const actual = await importOriginal<typeof Module>()
   return {
     ...actual,
     Module: vi.fn(),
   }
 })
 vi.mock('@opentrons/shared-data', async importOriginal => {
-  const actual = await importOriginal<typeof OpentronsSharedData>()
+  const actual = await importOriginal<typeof getAllLabwareDefs>()
   return {
     ...actual,
     getAllLabwareDefs: vi.fn(),
@@ -76,7 +75,7 @@ describe('SelectedHoveredItems', () => {
       labware: {
         labware: {
           id: 'mockId',
-          def: fixture24Tuberack as OpentronsSharedData.LabwareDefinition2,
+          def: fixture24Tuberack as LabwareDefinition2,
           labwareDefURI: mockAdapterURI,
           slot: 'D3',
           pythonName: 'mockPythonName',
@@ -149,14 +148,14 @@ describe('SelectedHoveredItems', () => {
       labware: {
         labware: {
           id: 'mockId',
-          def: fixture24Tuberack as OpentronsSharedData.LabwareDefinition2,
+          def: fixture24Tuberack as LabwareDefinition2,
           labwareDefURI: mockAdapterURI,
           slot: 'D3',
           pythonName: 'mockPythonName',
         },
         labware2: {
           id: 'mockId2',
-          def: fixture24Tuberack as OpentronsSharedData.LabwareDefinition2,
+          def: fixture24Tuberack as LabwareDefinition2,
           labwareDefURI: mockAdapterURI,
           slot: 'mockId',
           pythonName: 'mockPythonName',

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedHoveredItems.test.tsx
@@ -7,6 +7,7 @@ import {
   HEATERSHAKER_MODULE_V1,
   fixture24Tuberack,
   getDeckDefFromRobotType,
+  getAllLabwareDefs,
 } from '@opentrons/shared-data'
 import { Module } from '@opentrons/components'
 import { selectors } from '../../../../labware-ingred/selectors'
@@ -19,6 +20,7 @@ import { SelectedHoveredItems } from '../SelectedHoveredItems'
 
 import type { ComponentProps } from 'react'
 import type * as OpentronsComponents from '@opentrons/components'
+import type * as OpentronsSharedData from '@opentrons/shared-data'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 vi.mock('../../../../file-data/selectors')
@@ -34,11 +36,19 @@ vi.mock('@opentrons/components', async importOriginal => {
     Module: vi.fn(),
   }
 })
+vi.mock('@opentrons/shared-data', async importOriginal => {
+  const actual = await importOriginal<typeof OpentronsSharedData>()
+  return {
+    ...actual,
+    getAllLabwareDefs: vi.fn(),
+  }
+})
 
 const render = (props: ComponentProps<typeof SelectedHoveredItems>) => {
   return renderWithProviders(<SelectedHoveredItems {...props} />)[0]
 }
 
+const mockAdapterURI = 'fixture/fixture_universal_flat_bottom_adapter/1'
 describe('SelectedHoveredItems', () => {
   let props: ComponentProps<typeof SelectedHoveredItems>
 
@@ -51,6 +61,14 @@ describe('SelectedHoveredItems', () => {
       hoveredFixture: null,
       slotPosition: [0, 0, 0],
     }
+    vi.mocked(getAllLabwareDefs).mockReturnValue({
+      [mockAdapterURI]: {
+        ...fixture24Tuberack,
+        metadata: {
+          displayName: 'Fixture Opentrons Universal Flat Heater-Shaker Adapter',
+        },
+      } as any,
+    })
     vi.mocked(getDesignerTab).mockReturnValue('startingDeck')
     vi.mocked(getInitialDeckSetup).mockReturnValue({
       modules: {},
@@ -60,7 +78,7 @@ describe('SelectedHoveredItems', () => {
         labware: {
           id: 'mockId',
           def: fixture24Tuberack as LabwareDefinition2,
-          labwareDefURI: 'fixture/fixture_universal_flat_bottom_adapter/1',
+          labwareDefURI: mockAdapterURI,
           slot: 'D3',
           pythonName: 'mockPythonName',
         },
@@ -85,7 +103,7 @@ describe('SelectedHoveredItems', () => {
   })
   it('renders a selected fixture with a selected labware', () => {
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
-      selectedLabwareDefUri: 'fixture/fixture_universal_flat_bottom_adapter/1',
+      selectedLabwareDefUri: mockAdapterURI,
       selectedNestedLabwareDefUri: null,
       selectedFixture: 'trashBin',
       selectedModuleModel: null,
@@ -112,7 +130,7 @@ describe('SelectedHoveredItems', () => {
   })
   it('renders a selected module and a selected labware', () => {
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
-      selectedLabwareDefUri: 'fixture/fixture_universal_flat_bottom_adapter/1',
+      selectedLabwareDefUri: mockAdapterURI,
       selectedNestedLabwareDefUri: null,
       selectedFixture: null,
       selectedModuleModel: HEATERSHAKER_MODULE_V1,
@@ -133,23 +151,22 @@ describe('SelectedHoveredItems', () => {
         labware: {
           id: 'mockId',
           def: fixture24Tuberack as LabwareDefinition2,
-          labwareDefURI: 'fixture/fixture_universal_flat_bottom_adapter/1',
+          labwareDefURI: mockAdapterURI,
           slot: 'D3',
           pythonName: 'mockPythonName',
         },
         labware2: {
           id: 'mockId2',
           def: fixture24Tuberack as LabwareDefinition2,
-          labwareDefURI: 'fixture/fixture_universal_flat_bottom_adapter/1',
+          labwareDefURI: mockAdapterURI,
           slot: 'mockId',
           pythonName: 'mockPythonName',
         },
       },
     })
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
-      selectedLabwareDefUri: 'fixture/fixture_universal_flat_bottom_adapter/1',
-      selectedNestedLabwareDefUri:
-        'fixture/fixture_universal_flat_bottom_adapter/1',
+      selectedLabwareDefUri: mockAdapterURI,
+      selectedNestedLabwareDefUri: mockAdapterURI,
       selectedFixture: 'trashBin',
       selectedModuleModel: null,
       selectedSlot: { slot: 'D3', cutout: 'cutoutD3' },


### PR DESCRIPTION
…ooming into slot

closes AUTH-1730

# Overview

As documented in the ticket, there was a white screen if you upload a protocol to PD that has an older labware definition version and then try to zoom into that slot. The error specifically occurred with the highlight overlay that shows the labware display name.

This PR fixes it by refactoring the component to return all labware definitions instead of just latest. This does not affect selecting new labware though, that utility just returns the latest versions - this prevents users from selecting older versions with new steps/new deck setups

## Test Plan and Hands on Testing

Upload the attached protocol and zoom into the thermocycler slot or the 1 well reservoir slot. See that it does not white screen.

Note that it looks like the labware selected isn't selected in the labware toolbox but that is because it is showing only latest defs. i think that is fine. the user will be regenerating their labware anyway if they make any changes

[doItAllV8 (29).json](https://github.com/user-attachments/files/19735984/doItAllV8.29.json)


## Changelog

- get all defs instead of latest defs
- fix test

## Risk assessment

low, doesn't touch much code