### PR TITLE
fix(api): blank assert error in validate_well_position

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
@@ -100,7 +100,10 @@ def check_safe_for_pipette_movement(  # noqa: C901
             partially_configured=True,
         )
     well_location_point = engine_state.geometry.get_well_position(
-        labware_id=labware_id, well_name=well_name, well_location=well_location
+        labware_id=labware_id,
+        well_name=well_name,
+        well_location=well_location,
+        pipette_id=pipette_id,
     )
     primary_nozzle = engine_state.pipettes.get_primary_nozzle(pipette_id)
 

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -478,7 +478,7 @@ class GeometryView:
         Primarily this checks if there is not enough liquid in a well to do meniscus-relative static aspiration.
         """
         if well_location.origin == WellOrigin.MENISCUS:
-            assert pipette_id is not None
+            assert pipette_id is not None, "pipette id is None"
             lld_min_height = self._pipettes.get_current_tip_lld_settings(
                 pipette_id=pipette_id
             )
@@ -1848,8 +1848,12 @@ class GeometryView:
         # this function is only called by
         # HardwarePipetteHandler::aspirate/dispense while_tracking, and shouldn't
         # be reached in the case of a simulated liquid_probe
-        assert not isinstance(initial_handling_height, SimulatedProbeResult)
-        assert not isinstance(final_height, SimulatedProbeResult)
+        assert not isinstance(
+            initial_handling_height, SimulatedProbeResult
+        ), "Initial handling height got SimulatedProbeResult"
+        assert not isinstance(
+            final_height, SimulatedProbeResult
+        ), "final height is SimulatedProbeResult"
         return final_height - initial_handling_height
 
     def get_well_offset_adjustment(

--- a/api/src/opentrons/protocol_engine/state/wells.py
+++ b/api/src/opentrons/protocol_engine/state/wells.py
@@ -116,7 +116,7 @@ class WellStore(HasState[WellState], HandlesActions):
                 del self._state.loaded_volumes[labware_id][well_name]
             else:
                 prev_loaded_vol_info = self._state.loaded_volumes[labware_id][well_name]
-                assert prev_loaded_vol_info.volume is not None
+                assert prev_loaded_vol_info.volume is not None, "volume info not loaded"
                 self._state.loaded_volumes[labware_id][well_name] = LoadedVolumeInfo(
                     volume=prev_loaded_vol_info.volume + volume_added,
                     last_loaded=prev_loaded_vol_info.last_loaded,


### PR DESCRIPTION
## Overview
There was a blank assertion error that was stopping complex transfers in analysis. It turns out `validate_well_position` was getting called with no `pipette_id` since it's optional in `get_well_position`. 

## Changelog

- pass in `pipette_id` to `validate_well_position` to get rid of the error
- add messages to `assert`s so hopefully this doesn't happen again