### PR TITLE
fix(shared-data): hide protocol engine lid stack object from all user views

### DIFF
--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -44,6 +44,7 @@ export const LABWAREV2_DO_NOT_LIST = [
   'opentrons_ot3_96_tiprack_1000ul',
   'opentrons_ot3_96_tiprack_50ul',
   'opentrons_flex_lid_absorbance_plate_reader_module',
+  'protocol_engine_lid_stack_object',
   // temporarily blocking 20 uL Flex tip racks until they launch
   'opentrons_flex_96_tiprack_20ul',
   'opentrons_flex_96_filtertiprack_20ul',
@@ -65,6 +66,7 @@ export const PD_DO_NOT_LIST = [
   'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat',
   'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
   'opentrons_96_pcr_adapter_armadillo_wellplate_200ul',
+  'protocol_engine_lid_stack_object',
   //  temporarily blocking TC lid adapter and deck riser until it is supported in PD
   'opentrons_tough_pcr_auto_sealing_lid',
   'opentrons_flex_deck_riser',


### PR DESCRIPTION
fix RQA-4061

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
There is a labware definition in shared data for the imaginary lid stack object that sits below a stack of lids. We need to add this definition to our block lists so it isn't shown in labware library, the labware tab of the app, or any other UI.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Check labware library and labware tab, see that System category and lid stack object are no longer visible. Before shots are in the tickets
<img width="435" alt="Screenshot 2025-04-14 at 12 01 37 PM" src="https://github.com/user-attachments/assets/21820c4e-6e8f-4f8f-8a98-13ce8bb3a538" />
<img width="354" alt="Screenshot 2025-04-14 at 11 57 42 AM" src="https://github.com/user-attachments/assets/dc8f298f-1472-4469-99f2-3c703993287a" />

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Add definition to both blocklists in shared data
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick check
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
