### PR TITLE
fix(api): reset encoders after seal

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/evotip_seal_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/evotip_seal_pipette.py
@@ -7,7 +7,7 @@ from opentrons.types import MountType
 from opentrons.protocol_engine.types import MotorAxis
 from typing_extensions import Literal
 
-from ..resources import ModelUtils
+from ..resources import ModelUtils, ensure_ot3_hardware
 from ..types import PickUpTipWellLocation, FluidKind, AspiratedFluid
 from .pipetting_common import (
     PipetteIdMixin,
@@ -157,6 +157,11 @@ class EvotipSealPipetteImplementation(
         # retract cam : 11.05
         await self._gantry_mover.move_axes(
             axis_map={mount_axis: retract_distance}, speed=5.5, relative_move=True
+        )
+
+        ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
+        await ot3_hardware_api.update_axis_position_estimations(
+            self._gantry_mover.motor_axes_to_present_hardware_axes([mount_axis])
         )
 
     async def cam_action_relative_pickup_tip(

--- a/api/tests/opentrons/protocol_engine/commands/test_evotip_seal_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_evotip_seal_pipette.py
@@ -38,7 +38,7 @@ from opentrons.protocol_engine.commands.evotip_seal_pipette import (
 from opentrons.protocol_engine.execution import (
     PipettingHandler,
 )
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import OT3HardwareControlAPI
 
 from opentrons_shared_data.labware import load_definition
 
@@ -60,7 +60,7 @@ async def test_success(
     model_utils: ModelUtils,
     gantry_mover: GantryMover,
     evotips_definition: LabwareDefinition,
-    hardware_api: HardwareControlAPI,
+    ot3_hardware_api: OT3HardwareControlAPI,
     pipetting: PipettingHandler,
 ) -> None:
     """A PickUpTip command should have an execution implementation."""
@@ -70,7 +70,7 @@ async def test_success(
         tip_handler=tip_handler,
         model_utils=model_utils,
         gantry_mover=gantry_mover,
-        hardware_api=hardware_api,
+        hardware_api=ot3_hardware_api,
         pipetting=pipetting,
     )
 
@@ -146,7 +146,7 @@ async def test_no_tip_physically_missing_error(
     tip_handler: TipHandler,
     model_utils: ModelUtils,
     gantry_mover: GantryMover,
-    hardware_api: HardwareControlAPI,
+    ot3_hardware_api: OT3HardwareControlAPI,
     pipetting: PipettingHandler,
     evotips_definition: LabwareDefinition,
 ) -> None:
@@ -157,7 +157,7 @@ async def test_no_tip_physically_missing_error(
         tip_handler=tip_handler,
         model_utils=model_utils,
         gantry_mover=gantry_mover,
-        hardware_api=hardware_api,
+        hardware_api=ot3_hardware_api,
         pipetting=pipetting,
     )
 
@@ -234,7 +234,7 @@ async def test_stall_error(
     tip_handler: TipHandler,
     model_utils: ModelUtils,
     gantry_mover: GantryMover,
-    hardware_api: HardwareControlAPI,
+    ot3_hardware_api: OT3HardwareControlAPI,
     pipetting: PipettingHandler,
     evotips_definition: LabwareDefinition,
 ) -> None:
@@ -245,7 +245,7 @@ async def test_stall_error(
         tip_handler=tip_handler,
         model_utils=model_utils,
         gantry_mover=gantry_mover,
-        hardware_api=hardware_api,
+        hardware_api=ot3_hardware_api,
         pipetting=pipetting,
     )
 


### PR DESCRIPTION
this can cause a stall, as a pickup does, and like a pickup we should reset encoders afterward. since all the robot context style things ignore encoders, this causes a failure on a subsequent tip pickup move.

Tested on a reproducing machine with the original problem.