### PR TITLE
refactor(api): height from volume binary search

### DIFF
--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -140,7 +140,7 @@ def _height_from_volume_circular(
     target_volume: float, segment: ConicalFrustum
 ) -> float:
     """Find the height given a volume within a squared cone segment."""
-    return segment.height_from_volume_binary_search(target_volume)
+    return segment.height_from_volume_search(target_volume)
 
 
 def _height_from_volume_rectangular(

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -88,13 +88,6 @@ def _circular_frustum_polynomial_roots(
 def _volume_from_height_circular(
     target_height: float, segment: ConicalFrustum
 ) -> float:
-    """Find the volume given a height within a circular frustum."""
-    # ret = segment.volume_from_height_circular(
-    #     top_radius=segment.topDiameter / 2,
-    #     bottom_radius=segment.bottomDiameter / 2,
-    #     target_height=target_height,
-    # )
-    # reveal_type(ret)
     return segment.volume_from_height_circular(
         top_radius=segment.topDiameter / 2,
         bottom_radius=segment.bottomDiameter / 2,
@@ -147,7 +140,6 @@ def _height_from_volume_circular(
     target_volume: float, segment: ConicalFrustum
 ) -> float:
     """Find the height given a volume within a squared cone segment."""
-
     return segment.height_from_volume_binary_search(target_volume)
 
 
@@ -211,14 +203,6 @@ def _get_segment_capacity(segment: WellSegment) -> float:
     section_height = segment.topHeight - segment.bottomHeight
     match segment:
         case SphericalSegment():
-            # ret = (
-            #     _volume_from_height_spherical(
-            #         target_height=segment.topHeight,
-            #         radius_of_curvature=segment.radiusOfCurvature,
-            #     )
-            #     * segment.count
-            # )
-            # breakpoint()
             return (
                 _volume_from_height_spherical(
                     target_height=segment.topHeight,
@@ -227,18 +211,6 @@ def _get_segment_capacity(segment: WellSegment) -> float:
                 * segment.count
             )
         case CuboidalFrustum():
-            # ret = (
-            #     _volume_from_height_rectangular(
-            #         target_height=section_height,
-            #         bottom_length=segment.bottomYDimension,
-            #         bottom_width=segment.bottomXDimension,
-            #         top_length=segment.topYDimension,
-            #         top_width=segment.topXDimension,
-            #         total_frustum_height=section_height,
-            #     )
-            #     * segment.count
-            # )
-            # breakpoint()
             return (
                 _volume_from_height_rectangular(
                     target_height=section_height,
@@ -282,7 +254,6 @@ def get_well_volumetric_capacity(
 
     for segment in sorted_well:
         section_volume = _get_segment_capacity(segment)
-        # breakoint()
         well_volume.append((segment.topHeight, section_volume))
     return well_volume
 
@@ -407,7 +378,6 @@ def find_volume_at_well_height(
     # beneath the target height
     closed_section_volume = 0.0
     for boundary_height, section_volume in volumetric_capacity:
-        # breakpoint()
         if boundary_height > target_height:
             break
         closed_section_volume += section_volume
@@ -435,8 +405,6 @@ def _find_height_in_partial_frustum(
         return 0.0
     for section, capacity in zip(sorted_well, volumetric_capacity):
         section_top_height, section_volume = capacity
-        # if isclose(target_volume, 404.16666667):
-        #     breakpoint()
         if target_volume == section_volume + bottom_section_volume:
             return section_top_height
         if (
@@ -487,12 +455,6 @@ def find_height_at_well_volume(
 
     sorted_well = sorted(well_geometry.sections, key=lambda section: section.topHeight)
     # find the section the target volume is in and compute the height
-    ret = _find_height_in_partial_frustum(
-        sorted_well=sorted_well,
-        volumetric_capacity=volumetric_capacity,
-        target_volume=target_volume,
-    )
-    # breakpoint()
     return _find_height_in_partial_frustum(
         sorted_well=sorted_well,
         volumetric_capacity=volumetric_capacity,

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -89,9 +89,18 @@ def _volume_from_height_circular(
     target_height: float, segment: ConicalFrustum
 ) -> float:
     """Find the volume given a height within a circular frustum."""
-    heights = segment.height_to_volume_table.keys()
-    best_fit_height = min(heights, key=lambda x: abs(x - target_height))
-    return segment.height_to_volume_table[best_fit_height]
+    # ret = segment.volume_from_height_circular(
+    #     top_radius=segment.topDiameter / 2,
+    #     bottom_radius=segment.bottomDiameter / 2,
+    #     target_height=target_height,
+    # )
+    # reveal_type(ret)
+    return segment.volume_from_height_circular(
+        top_radius=segment.topDiameter / 2,
+        bottom_radius=segment.bottomDiameter / 2,
+        target_height=target_height,
+        total_height=segment.topHeight - segment.bottomHeight,
+    )
 
 
 def _volume_from_height_rectangular(
@@ -138,9 +147,8 @@ def _height_from_volume_circular(
     target_volume: float, segment: ConicalFrustum
 ) -> float:
     """Find the height given a volume within a squared cone segment."""
-    volumes = segment.volume_to_height_table.keys()
-    best_fit_volume = min(volumes, key=lambda x: abs(x - target_volume))
-    return segment.volume_to_height_table[best_fit_volume]
+
+    return segment.height_from_volume_binary_search(target_volume)
 
 
 def _height_from_volume_rectangular(
@@ -203,6 +211,14 @@ def _get_segment_capacity(segment: WellSegment) -> float:
     section_height = segment.topHeight - segment.bottomHeight
     match segment:
         case SphericalSegment():
+            # ret = (
+            #     _volume_from_height_spherical(
+            #         target_height=segment.topHeight,
+            #         radius_of_curvature=segment.radiusOfCurvature,
+            #     )
+            #     * segment.count
+            # )
+            # breakpoint()
             return (
                 _volume_from_height_spherical(
                     target_height=segment.topHeight,
@@ -211,6 +227,18 @@ def _get_segment_capacity(segment: WellSegment) -> float:
                 * segment.count
             )
         case CuboidalFrustum():
+            # ret = (
+            #     _volume_from_height_rectangular(
+            #         target_height=section_height,
+            #         bottom_length=segment.bottomYDimension,
+            #         bottom_width=segment.bottomXDimension,
+            #         top_length=segment.topYDimension,
+            #         top_width=segment.topXDimension,
+            #         total_frustum_height=section_height,
+            #     )
+            #     * segment.count
+            # )
+            # breakpoint()
             return (
                 _volume_from_height_rectangular(
                     target_height=section_height,
@@ -254,6 +282,7 @@ def get_well_volumetric_capacity(
 
     for segment in sorted_well:
         section_volume = _get_segment_capacity(segment)
+        # breakoint()
         well_volume.append((segment.topHeight, section_volume))
     return well_volume
 
@@ -378,6 +407,7 @@ def find_volume_at_well_height(
     # beneath the target height
     closed_section_volume = 0.0
     for boundary_height, section_volume in volumetric_capacity:
+        # breakpoint()
         if boundary_height > target_height:
             break
         closed_section_volume += section_volume
@@ -401,8 +431,14 @@ def _find_height_in_partial_frustum(
 ) -> float:
     """Look through a sorted list of frusta for a target volume, and find the height at that volume."""
     bottom_section_volume = 0.0
+    if target_volume == 0.0:
+        return 0.0
     for section, capacity in zip(sorted_well, volumetric_capacity):
         section_top_height, section_volume = capacity
+        # if isclose(target_volume, 404.16666667):
+        #     breakpoint()
+        if target_volume == section_volume + bottom_section_volume:
+            return section_top_height
         if (
             bottom_section_volume
             <= target_volume
@@ -451,6 +487,12 @@ def find_height_at_well_volume(
 
     sorted_well = sorted(well_geometry.sections, key=lambda section: section.topHeight)
     # find the section the target volume is in and compute the height
+    ret = _find_height_in_partial_frustum(
+        sorted_well=sorted_well,
+        volumetric_capacity=volumetric_capacity,
+        target_volume=target_volume,
+    )
+    # breakpoint()
     return _find_height_in_partial_frustum(
         sorted_well=sorted_well,
         volumetric_capacity=volumetric_capacity,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -4,9 +4,10 @@ import inspect
 import json
 from datetime import datetime
 from math import isclose
-from typing import cast, List, Tuple, Optional, NamedTuple, Dict
+from typing import cast, List, Tuple, Optional, NamedTuple, Dict, Any
 from unittest.mock import sentinel
 from os import listdir, path
+from hypothesis.strategies import data, floats
 
 import pytest
 from decoy import Decoy
@@ -3484,9 +3485,11 @@ def test_rectangular_frustum_math_helpers(
         _find_volume_from_height_(i)
 
 
+@given(data())
 @pytest.mark.parametrize("frustum", CIRCULAR_TEST_EXAMPLES)
 def test_circular_frustum_math_helpers(
     frustum: Dict[str, List[float]],
+    heights_st: Any=get_well_heights_strategy
 ) -> None:
     """Test both height and volume calculation within a given circular frustum."""
     total_frustum_height = frustum["height"][0]
@@ -3515,10 +3518,18 @@ def test_circular_frustum_math_helpers(
             segment=segment,
         )
 
-        assert isclose(found_height, frustum["height"][index])
+        assert isclose(found_height, frustum["height"][index], abs_tol=0.001)
 
-    for i in range(len(frustum["height"])):
-        _find_volume_from_height_(i)
+    # for i in range(len(frustum["height"])):
+    for i in range(50):
+        target_height = data.draw(
+            floats(
+                min_value=0, max_value=total_frustum_height, allow_infinity=False, allow_nan=False
+            )
+        )
+        breakpoint()
+
+        # _find_volume_from_height_(i)
 
 
 def test_validate_dispense_volume_into_well_bottom(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -4,10 +4,9 @@ import inspect
 import json
 from datetime import datetime
 from math import isclose
-from typing import cast, List, Tuple, Optional, NamedTuple, Dict, Any
+from typing import cast, List, Tuple, Optional, NamedTuple, Dict
 from unittest.mock import sentinel
 from os import listdir, path
-from hypothesis.strategies import data, floats
 
 import pytest
 from decoy import Decoy
@@ -3485,11 +3484,9 @@ def test_rectangular_frustum_math_helpers(
         _find_volume_from_height_(i)
 
 
-@given(data())
 @pytest.mark.parametrize("frustum", CIRCULAR_TEST_EXAMPLES)
 def test_circular_frustum_math_helpers(
     frustum: Dict[str, List[float]],
-    heights_st: Any=get_well_heights_strategy
 ) -> None:
     """Test both height and volume calculation within a given circular frustum."""
     total_frustum_height = frustum["height"][0]
@@ -3520,16 +3517,8 @@ def test_circular_frustum_math_helpers(
 
         assert isclose(found_height, frustum["height"][index], abs_tol=0.001)
 
-    # for i in range(len(frustum["height"])):
-    for i in range(50):
-        target_height = data.draw(
-            floats(
-                min_value=0, max_value=total_frustum_height, allow_infinity=False, allow_nan=False
-            )
-        )
-        breakpoint()
-
-        # _find_volume_from_height_(i)
+    for i in range(len(frustum["height"])):
+        _find_volume_from_height_(i)
 
 
 def test_validate_dispense_volume_into_well_bottom(

--- a/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
+++ b/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 from math import pi, isclose
 from typing import Any, List, cast
+from hypothesis import given, strategies as st
 
 from opentrons_shared_data.labware.labware_definition import (
     ConicalFrustum,
@@ -206,9 +207,9 @@ def test_cross_section_area_rectangular(x_dimension: float, y_dimension: float) 
         == expected_area
     )
 
-
 @pytest.mark.parametrize("well", fake_frusta())
-def test_volume_and_height_circular(well: List[Any]) -> None:
+@given(target_height_st=st.data())
+def test_volume_and_height_circular(well: List[Any], target_height_st: Any) -> None:
     """Test both volume and height calculations for circular frusta."""
     if well[-1].shape == "spherical":
         return
@@ -218,7 +219,16 @@ def test_volume_and_height_circular(well: List[Any]) -> None:
             b = segment.bottomDiameter / 2
             # test volume within a bunch of arbitrary heights
             segment_height = segment.topHeight - segment.bottomHeight
-            for target_height in range(round(segment_height)):
+            for i in range(50):
+                target_height = target_height_st.draw(
+                    st.floats(
+                        min_value=0,
+                        max_value=segment_height,
+                        allow_infinity=False,
+                        allow_nan=False
+                    )
+                )
+                # breakpoint()
                 r_y = (target_height / segment_height) * (a - b) + b
                 expected_volume = (pi * target_height / 3) * (
                     b**2 + b * r_y + r_y**2
@@ -227,6 +237,7 @@ def test_volume_and_height_circular(well: List[Any]) -> None:
                     target_height=target_height,
                     segment=segment,
                 )
+                # breakpoint()
                 assert isclose(found_volume, expected_volume)
                 # test going backwards to get height back
                 found_height = _height_from_volume_circular(

--- a/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
+++ b/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
@@ -19,11 +19,9 @@ from opentrons.protocol_engine.state.frustum_helpers import (
     _height_from_volume_circular,
     _height_from_volume_rectangular,
     _height_from_volume_spherical,
-    height_at_volume_within_section,
     find_height_at_well_volume,
     find_volume_at_well_height,
     _get_segment_capacity,
-    find_volume_at_well_height,
 )
 from opentrons.protocol_engine.errors.exceptions import InvalidLiquidHeightFound
 
@@ -329,14 +327,15 @@ def test_height_at_volume_at_section_boundaries(well: List[Any]) -> None:
     height = find_height_at_well_volume(
         target_volume=0.0, well_geometry=inner_well_geometry
     )
+    assert isinstance(height, float)
     assert isclose(height, 0.0)
     for segment in sorted_well:
-        segment_height = segment.topHeight - segment.bottomHeight
         running_volume += _get_segment_capacity(segment)
         height = find_height_at_well_volume(
             target_volume=running_volume,
             well_geometry=inner_well_geometry,
         )
+        assert isinstance(height, float)
         assert isclose(height, segment.topHeight)
 
 

--- a/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
+++ b/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
@@ -20,6 +20,8 @@ from opentrons.protocol_engine.state.frustum_helpers import (
     _height_from_volume_rectangular,
     _height_from_volume_spherical,
     height_at_volume_within_section,
+    find_height_at_well_volume,
+    find_volume_at_well_height,
     _get_segment_capacity,
     find_volume_at_well_height,
 )
@@ -232,7 +234,7 @@ def test_volume_and_height_circular(well: List[Any]) -> None:
                 found_height = _height_from_volume_circular(
                     target_volume=found_volume, segment=segment
                 )
-                assert isclose(found_height, target_height)
+                assert isclose(found_height, target_height, abs_tol=0.001)
 
 
 @pytest.mark.parametrize("well", fake_frusta())
@@ -319,14 +321,23 @@ def test_volume_and_height_spherical(well: List[Any]) -> None:
 @pytest.mark.parametrize("well", fake_frusta())
 def test_height_at_volume_at_section_boundaries(well: List[Any]) -> None:
     """Test that finding the height when volume 0 or ~= capacity  works."""
-    for segment in well:
+    inner_well_geometry = InnerWellGeometry(sections=well)
+    sorted_well = sorted(
+        inner_well_geometry.sections, key=lambda section: section.topHeight
+    )
+    running_volume = 0.0
+    height = find_height_at_well_volume(
+        target_volume=0.0, well_geometry=inner_well_geometry
+    )
+    assert isclose(height, 0.0)
+    for segment in sorted_well:
         segment_height = segment.topHeight - segment.bottomHeight
-        height = height_at_volume_within_section(segment, 0.0, segment_height)
-        assert isclose(height, 0.0)
-        height = height_at_volume_within_section(
-            segment, _get_segment_capacity(segment), segment_height
+        running_volume += _get_segment_capacity(segment)
+        height = find_height_at_well_volume(
+            target_volume=running_volume,
+            well_geometry=inner_well_geometry,
         )
-        assert isclose(height, segment_height)
+        assert isclose(height, segment.topHeight)
 
 
 @pytest.mark.parametrize("well", fake_frusta())

--- a/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
+++ b/api/tests/opentrons/protocols/geometry/test_frustum_helpers.py
@@ -207,11 +207,14 @@ def test_cross_section_area_rectangular(x_dimension: float, y_dimension: float) 
         == expected_area
     )
 
+
 @pytest.mark.parametrize("well", fake_frusta())
 @given(target_height_st=st.data())
 def test_volume_and_height_circular(well: List[Any], target_height_st: Any) -> None:
     """Test both volume and height calculations for circular frusta."""
     if well[-1].shape == "spherical":
+        return
+    if any([seg.shape != "conical" for seg in well]):
         return
     for segment in well:
         if segment.shape == "conical":
@@ -225,10 +228,10 @@ def test_volume_and_height_circular(well: List[Any], target_height_st: Any) -> N
                         min_value=0,
                         max_value=segment_height,
                         allow_infinity=False,
-                        allow_nan=False
+                        allow_nan=False,
+                        width=32,
                     )
                 )
-                # breakpoint()
                 r_y = (target_height / segment_height) * (a - b) + b
                 expected_volume = (pi * target_height / 3) * (
                     b**2 + b * r_y + r_y**2
@@ -237,7 +240,6 @@ def test_volume_and_height_circular(well: List[Any], target_height_st: Any) -> N
                     target_height=target_height,
                     segment=segment,
                 )
-                # breakpoint()
                 assert isclose(found_volume, expected_volume)
                 # test going backwards to get height back
                 found_height = _height_from_volume_circular(

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -202,26 +202,6 @@ class ConicalFrustum(BaseModel):
     xCount: _StrictNonNegativeInt = 1
     yCount: _StrictNonNegativeInt = 1
 
-    @cached_property
-    def height_to_volume_table(self) -> dict[float, float]:
-        """Return a lookup table of heights to volumes."""
-        # the accuracy of this method is approximately +- 10*dx so for dx of 0.001 we have a +- 0.01 ul
-        dx = 0.005
-        total_height = self.topHeight - self.bottomHeight
-        y = 0.0
-        table: dict[float, float] = {}
-        # fill in the table
-        a = self.topDiameter / 2
-        b = self.bottomDiameter / 2
-        while y < total_height:
-            r_y = (y / total_height) * (a - b) + b
-            table[y] = (pi * y / 3) * (b**2 + b * r_y + r_y**2)
-            y = y + dx
-
-        # we always want to include the volume at the max height
-        table[total_height] = (pi * total_height / 3) * (b**2 + a * b + a**2)
-        return table
-
     def height_from_volume_search(self, target_volume: float) -> float:
         total_height = self.topHeight - self.bottomHeight
         max_height, min_height = total_height, 0.0
@@ -286,10 +266,6 @@ class ConicalFrustum(BaseModel):
         return (pi * target_height / 3) * (
             bottom_radius**2 + bottom_radius * r_y + r_y**2
         )
-
-    @cached_property
-    def volume_to_height_table(self) -> dict[float, float]:
-        return dict((v, k) for k, v in self.height_to_volume_table.items())
 
     @cached_property
     def count(self) -> int:

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -222,6 +222,63 @@ class ConicalFrustum(BaseModel):
         return table
 
     @cached_property
+    def height_from_volume_binary_search(self, target_volume: float) -> float:
+        total_height = self.topHeight - self.bottomHeight
+        
+        y = prev_y = total_height / 2
+        volume_at_y = self._volume_from_height_circular(
+            top_radius=self.topDiameter / 2,
+            bottom_radius=self.bottomDiameter / 2,
+            target_height=y
+        )
+        volume_at_prev_y = self.volume_from_height_circular(
+            top_radius=self.topDiameter/2,
+            bottom_radius=self.bottomDiameter/2,
+            target_height=prev_y
+        )
+        while abs(volume_at_y - target_volume) > 0.005:
+            target_above_last_two_guesses = volume_at_y > target_volume and volume_at_y > volume_at_prev_y
+            if target_above_last_two_guesses:
+                y = round(
+                    (total_height + y) / 2, 3
+                )
+            
+            target_between_last_two_guesses = (volume_at_y < target_volume and volume_at_y > volume_at_prev_y) or \
+            (volume_at_y > target_volume and volume_at_y < volume_at_prev_y)
+            elif target_between_last_two_guesses:
+                y = round(
+                   (y + prev_y) / 2, 3
+                )
+            target_below_last_two_guesses = volume_at_y < target_volume and volume_at_y < volume_at_prev_y
+            elif target_below_last_two_guesses:
+                y = round(
+                    (y / 2), 3
+                )     
+
+            volume_at_y = self.volume_from_height_circular(
+            top_radius=self.topDiameter / 2,
+            bottom_radius=self.bottomDiameter / 2,
+            target_height=y
+            ) 
+            prev_y = y
+        return volume_at_y
+
+
+    @cached_property
+    def volume_from_height_circular(
+        self, 
+        top_radius: float,
+        bottom_radius: float,
+        target_height: float
+    ) -> float:
+        # return volume at the target height.
+        r_y = (y / total_height) * (a - b) + b
+        return (pi * y / 3) * (b**2 + b * r_y + r_y**2)
+
+
+
+
+    @cached_property
     def volume_to_height_table(self) -> dict[float, float]:
         return dict((v, k) for k, v in self.height_to_volume_table.items())
 

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -34,6 +34,7 @@ from .constants import (
 )
 
 SAFE_STRING_REGEX = "^[a-z0-9._]+$"
+RECURSIVE_SEARCH_VOLUME_TOLERANCE = 0.001
 
 
 _StrictNonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
@@ -221,7 +222,7 @@ class ConicalFrustum(BaseModel):
         table[total_height] = (pi * total_height / 3) * (b**2 + a * b + a**2)
         return table
 
-    def height_from_volume_binary_search(self, target_volume: float) -> float:
+    def height_from_volume_search(self, target_volume: float) -> float:
         total_height = self.topHeight - self.bottomHeight
         y = prev_y = total_height / 2
         volume_at_y = volume_at_prev_y = self.volume_from_height_circular(
@@ -232,7 +233,7 @@ class ConicalFrustum(BaseModel):
         )
         guesses = [(volume_at_y, y)]
         max_height, min_height = total_height, 0.0
-        while abs(volume_at_y - target_volume) > 0.001:
+        while abs(volume_at_y - target_volume) > RECURSIVE_SEARCH_VOLUME_TOLERANCE:
             target_above_last_two_guesses = (
                 target_volume > volume_at_y and target_volume > volume_at_prev_y
             )
@@ -251,6 +252,7 @@ class ConicalFrustum(BaseModel):
                 target_between_last_two_guesses,
                 target_below_last_two_guesses
             )
+            # breakpoint()
 
             prev_y_copy = y
             if target_above_last_two_guesses:
@@ -259,6 +261,7 @@ class ConicalFrustum(BaseModel):
             elif target_between_last_two_guesses:
                 y = (y + prev_y) / 2
             elif target_below_last_two_guesses:
+                # breakpoint()
                 max_height = y
                 y = (y + min_height)/ 2
             prev_y = prev_y_copy

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -9,7 +9,7 @@ from enum import Enum
 from math import sqrt, asin
 from typing import Final
 from numpy import pi, trapz
-from functools import cached_property, lru_cache
+from functools import cached_property
 
 from pydantic import (
     ConfigDict,
@@ -250,19 +250,19 @@ class ConicalFrustum(BaseModel):
             total_height=total_height,
         )
         guesses = [
-            (volume_at_min_height, min_height), (volume_at_max_height, max_height)
+            (volume_at_min_height, min_height),
+            (volume_at_max_height, max_height),
         ]
         while abs(volume_at_y - target_volume) > RECURSIVE_SEARCH_VOLUME_TOLERANCE:
             max_height, max_volume = guesses[-1][1], guesses[-1][0]
             min_height, min_volume = guesses[0][1], guesses[0][0]
-        
 
             # between volume_at_y and max value- undershot
             if volume_at_y < target_volume < max_volume:
                 guesses = [(volume_at_y, y), (max_volume, max_height)]
             # overshot
             elif min_volume < target_volume < volume_at_y:
-                guesses = [(min_volume, min_height),  (volume_at_y, y)]
+                guesses = [(min_volume, min_height), (volume_at_y, y)]
             y = (guesses[0][1] + guesses[1][1]) / 2
 
             volume_at_y = self.volume_from_height_circular(

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -233,18 +233,17 @@ class ConicalFrustum(BaseModel):
         )
         while abs(volume_at_y - target_volume) > 0.005:
             target_above_last_two_guesses = volume_at_y > target_volume and volume_at_y > volume_at_prev_y
+            target_between_last_two_guesses = (volume_at_y < target_volume and volume_at_y > volume_at_prev_y) or (volume_at_y > target_volume and volume_at_y < volume_at_prev_y)
+            target_below_last_two_guesses = volume_at_y < target_volume and volume_at_y < volume_at_prev_y
             if target_above_last_two_guesses:
                 y = round(
                     (total_height + y) / 2, 3
                 )
             
-            target_between_last_two_guesses = (volume_at_y < target_volume and volume_at_y > volume_at_prev_y) or \
-            (volume_at_y > target_volume and volume_at_y < volume_at_prev_y)
             elif target_between_last_two_guesses:
                 y = round(
                    (y + prev_y) / 2, 3
                 )
-            target_below_last_two_guesses = volume_at_y < target_volume and volume_at_y < volume_at_prev_y
             elif target_below_last_two_guesses:
                 y = round(
                     (y / 2), 3

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -9,7 +9,7 @@ from enum import Enum
 from math import sqrt, asin
 from typing import Final
 from numpy import pi, trapz
-from functools import cached_property
+from functools import cached_property, lru_cache
 
 from pydantic import (
     ConfigDict,
@@ -221,56 +221,76 @@ class ConicalFrustum(BaseModel):
         table[total_height] = (pi * total_height / 3) * (b**2 + a * b + a**2)
         return table
 
-    @cached_property
     def height_from_volume_binary_search(self, target_volume: float) -> float:
         total_height = self.topHeight - self.bottomHeight
-        
         y = prev_y = total_height / 2
-        volume_at_y = volume_at_prev_y = self._volume_from_height_circular(
+        volume_at_y = volume_at_prev_y = self.volume_from_height_circular(
             top_radius=self.topDiameter / 2,
             bottom_radius=self.bottomDiameter / 2,
-            target_height=y
+            target_height=y,
+            total_height=total_height,
         )
-        while abs(volume_at_y - target_volume) > 0.005:
-            target_above_last_two_guesses = volume_at_y > target_volume and volume_at_y > volume_at_prev_y
-            target_between_last_two_guesses = (volume_at_y < target_volume and volume_at_y > volume_at_prev_y) or (volume_at_y > target_volume and volume_at_y < volume_at_prev_y)
-            target_below_last_two_guesses = volume_at_y < target_volume and volume_at_y < volume_at_prev_y
-            if target_above_last_two_guesses:
-                y = round(
-                    (total_height + y) / 2, 3
-                )
+        guesses = [(volume_at_y, y)]
+        max_height, min_height = total_height, 0.0
+        while abs(volume_at_y - target_volume) > 0.001:
+            target_above_last_two_guesses = (
+                target_volume > volume_at_y and target_volume > volume_at_prev_y
+            )
+
+            target_between_last_two_guesses = (
+                volume_at_y < target_volume < volume_at_prev_y or
+                volume_at_prev_y < target_volume < volume_at_y
+            )
             
+            target_below_last_two_guesses = (
+                target_volume < volume_at_y and target_volume < volume_at_prev_y
+            )
+
+            a, b, c = (
+                target_above_last_two_guesses,
+                target_between_last_two_guesses,
+                target_below_last_two_guesses
+            )
+
+            prev_y_copy = y
+            if target_above_last_two_guesses:
+                min_height = y
+                y = (max_height + y) / 2
             elif target_between_last_two_guesses:
-                y = round(
-                   (y + prev_y) / 2, 3
-                )
+                y = (y + prev_y) / 2
             elif target_below_last_two_guesses:
-                y = round(
-                    (y / 2), 3
-                )     
+                max_height = y
+                y = (y + min_height)/ 2
+            prev_y = prev_y_copy
             volume_at_prev_y = volume_at_y
+            volume_at_next_y = self.volume_from_height_circular(
+                top_radius=self.topDiameter / 2,
+                bottom_radius=self.bottomDiameter / 2,
+                target_height=y,
+                total_height=total_height,
+            )
             volume_at_y = self.volume_from_height_circular(
-            top_radius=self.topDiameter / 2,
-            bottom_radius=self.bottomDiameter / 2,
-            target_height=y
-            ) 
-            prev_y = y
-        return volume_at_y
+                top_radius=self.topDiameter / 2,
+                bottom_radius=self.bottomDiameter / 2,
+                target_height=y,
+                total_height=total_height,
+            )
+            guesses.append((volume_at_y, y))
+        return y
 
-
-    @cached_property
     def volume_from_height_circular(
-        self, 
+        self,
         top_radius: float,
         bottom_radius: float,
-        target_height: float
+        target_height: float,
+        total_height: float,
     ) -> float:
-        # return volume at the target height.
-        r_y = (y / total_height) * (a - b) + b
-        return (pi * y / 3) * (b**2 + b * r_y + r_y**2)
-
-
-
+        r_y = (target_height / total_height) * (
+            top_radius - bottom_radius
+        ) + bottom_radius
+        return (pi * target_height / 3) * (
+            bottom_radius**2 + bottom_radius * r_y + r_y**2
+        )
 
     @cached_property
     def volume_to_height_table(self) -> dict[float, float]:

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -224,61 +224,53 @@ class ConicalFrustum(BaseModel):
 
     def height_from_volume_search(self, target_volume: float) -> float:
         total_height = self.topHeight - self.bottomHeight
-        y = prev_y = total_height / 2
-        volume_at_y = volume_at_prev_y = self.volume_from_height_circular(
+        max_height, min_height = total_height, 0.0
+        volume_at_max_height = self.volume_from_height_circular(
+            top_radius=self.topDiameter / 2,
+            bottom_radius=self.bottomDiameter / 2,
+            target_height=total_height,
+            total_height=total_height,
+        )
+        if target_volume == volume_at_max_height:
+            return max_height
+        volume_at_min_height = self.volume_from_height_circular(
+            top_radius=self.topDiameter / 2,
+            bottom_radius=self.bottomDiameter / 2,
+            target_height=0,
+            total_height=total_height,
+        )
+        if target_volume == volume_at_min_height:
+            return min_height
+
+        y = total_height / 2
+        volume_at_y = self.volume_from_height_circular(
             top_radius=self.topDiameter / 2,
             bottom_radius=self.bottomDiameter / 2,
             target_height=y,
             total_height=total_height,
         )
-        guesses = [(volume_at_y, y)]
-        max_height, min_height = total_height, 0.0
+        guesses = [
+            (volume_at_min_height, min_height), (volume_at_max_height, max_height)
+        ]
         while abs(volume_at_y - target_volume) > RECURSIVE_SEARCH_VOLUME_TOLERANCE:
-            target_above_last_two_guesses = (
-                target_volume > volume_at_y and target_volume > volume_at_prev_y
-            )
+            max_height, max_volume = guesses[-1][1], guesses[-1][0]
+            min_height, min_volume = guesses[0][1], guesses[0][0]
+        
 
-            target_between_last_two_guesses = (
-                volume_at_y < target_volume < volume_at_prev_y or
-                volume_at_prev_y < target_volume < volume_at_y
-            )
-            
-            target_below_last_two_guesses = (
-                target_volume < volume_at_y and target_volume < volume_at_prev_y
-            )
+            # between volume_at_y and max value- undershot
+            if volume_at_y < target_volume < max_volume:
+                guesses = [(volume_at_y, y), (max_volume, max_height)]
+            # overshot
+            elif min_volume < target_volume < volume_at_y:
+                guesses = [(min_volume, min_height),  (volume_at_y, y)]
+            y = (guesses[0][1] + guesses[1][1]) / 2
 
-            a, b, c = (
-                target_above_last_two_guesses,
-                target_between_last_two_guesses,
-                target_below_last_two_guesses
-            )
-            # breakpoint()
-
-            prev_y_copy = y
-            if target_above_last_two_guesses:
-                min_height = y
-                y = (max_height + y) / 2
-            elif target_between_last_two_guesses:
-                y = (y + prev_y) / 2
-            elif target_below_last_two_guesses:
-                # breakpoint()
-                max_height = y
-                y = (y + min_height)/ 2
-            prev_y = prev_y_copy
-            volume_at_prev_y = volume_at_y
-            volume_at_next_y = self.volume_from_height_circular(
-                top_radius=self.topDiameter / 2,
-                bottom_radius=self.bottomDiameter / 2,
-                target_height=y,
-                total_height=total_height,
-            )
             volume_at_y = self.volume_from_height_circular(
                 top_radius=self.topDiameter / 2,
                 bottom_radius=self.bottomDiameter / 2,
                 target_height=y,
                 total_height=total_height,
             )
-            guesses.append((volume_at_y, y))
         return y
 
     def volume_from_height_circular(

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -226,15 +226,10 @@ class ConicalFrustum(BaseModel):
         total_height = self.topHeight - self.bottomHeight
         
         y = prev_y = total_height / 2
-        volume_at_y = self._volume_from_height_circular(
+        volume_at_y = volume_at_prev_y = self._volume_from_height_circular(
             top_radius=self.topDiameter / 2,
             bottom_radius=self.bottomDiameter / 2,
             target_height=y
-        )
-        volume_at_prev_y = self.volume_from_height_circular(
-            top_radius=self.topDiameter/2,
-            bottom_radius=self.bottomDiameter/2,
-            target_height=prev_y
         )
         while abs(volume_at_y - target_volume) > 0.005:
             target_above_last_two_guesses = volume_at_y > target_volume and volume_at_y > volume_at_prev_y
@@ -254,7 +249,7 @@ class ConicalFrustum(BaseModel):
                 y = round(
                     (y / 2), 3
                 )     
-
+            volume_at_prev_y = volume_at_y
             volume_at_y = self.volume_from_height_circular(
             top_radius=self.topDiameter / 2,
             bottom_radius=self.bottomDiameter / 2,


### PR DESCRIPTION
## Overview
For circular frusta, you can use calculus to determine a volume from a height, and not a height from a volume (the equation isolating height is a higher degree polynomial and gets pretty gross to try and solve analytically). The way we were getting around this before was by creating a lookup table during a protocol run, when a labware was loaded with a `CircularFrustum`, at a fixed interval of every 0.5 mm to maintain accuracy. This became a problem for very tall circular frusta (like test tubes), and protocols that used them with this code would silently pause for 2 minutes at the start to fill out these very large tables.

This implements a binary search instead to find a height from a volume within a circular frustum, upon request.