### PR TITLE
fix(api): bad volume tracking with dynamic

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
@@ -11,6 +11,7 @@ from .pipetting_common import (
     FlowRateMixin,
     BaseLiquidHandlingResult,
     aspirate_while_tracking,
+    prepare_for_aspirate,
 )
 from .movement_common import (
     LiquidHandlingWellLocationMixin,
@@ -26,10 +27,9 @@ from .command import (
     SuccessData,
 )
 from ..state.update_types import StateUpdate
-from ..errors.exceptions import PipetteNotReadyToAspirateError
 from opentrons.hardware_control import HardwareControlAPI
 from ..state.update_types import CLEAR
-from ..types import CurrentWell, DeckPoint
+from ..types import WellLocation, WellOrigin, CurrentWell, DeckPoint
 
 if TYPE_CHECKING:
     from ..execution import PipettingHandler, GantryMover, MovementHandler
@@ -95,27 +95,68 @@ class AspirateWhileTrackingImplementation(
             TipNotAttachedError: if no tip is attached to the pipette.
             PipetteNotReadyToAspirateError: pipette plunger is not ready.
         """
+        pipette_id = params.pipetteId
+        labware_id = params.labwareId
+        well_name = params.wellName
+        well_location = params.wellLocation
+
         ready_to_aspirate = self._state_view.pipettes.get_ready_to_aspirate(
-            pipette_id=params.pipetteId
+            pipette_id=pipette_id
         )
+        current_well = None
+        state_update = StateUpdate()
+        final_location = self._state_view.geometry.get_well_position(
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+            operation_volume=-params.volume,
+            pipette_id=pipette_id,
+        )
+
         if not ready_to_aspirate:
-            raise PipetteNotReadyToAspirateError(
-                "Pipette cannot aspirate while tracking because of a previous blow out."
-                " The first aspirate following a blow-out must be from a specific well"
-                " so the plunger can be reset in a known safe position."
+            move_result = await move_to_well(
+                movement=self._movement,
+                model_utils=self._model_utils,
+                pipette_id=pipette_id,
+                labware_id=labware_id,
+                well_name=well_name,
+                well_location=WellLocation(origin=WellOrigin.TOP),
+            )
+            state_update.append(move_result.state_update)
+            if isinstance(move_result, DefinedErrorData):
+                return DefinedErrorData(move_result.public, state_update=state_update)
+
+            prepare_result = await prepare_for_aspirate(
+                pipette_id=pipette_id,
+                pipetting=self._pipetting,
+                model_utils=self._model_utils,
+                # Note that the retryLocation is the final location, inside the liquid,
+                # because that's where we'd want the client to try re-aspirating if this
+                # command fails and the run enters error recovery.
+                location_if_error={"retryLocation": final_location},
+            )
+            state_update.append(prepare_result.state_update)
+            if isinstance(prepare_result, DefinedErrorData):
+                return DefinedErrorData(
+                    public=prepare_result.public, state_update=state_update
+                )
+
+            # set our current deck location to the well now that we've made
+            # an intermediate move for the "prepare for aspirate" step
+            current_well = CurrentWell(
+                pipette_id=pipette_id,
+                labware_id=labware_id,
+                well_name=well_name,
             )
 
-        current_position = await self._gantry_mover.get_position(params.pipetteId)
-        current_location = self._state_view.pipettes.get_current_location()
-
-        state_update = StateUpdate()
         move_result = await move_to_well(
             movement=self._movement,
             model_utils=self._model_utils,
-            pipette_id=params.pipetteId,
-            labware_id=params.labwareId,
-            well_name=params.wellName,
-            well_location=params.wellLocation,
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+            current_well=current_well,
             operation_volume=-params.volume,
         )
         state_update.append(move_result.state_update)
@@ -125,83 +166,61 @@ class AspirateWhileTrackingImplementation(
             )
 
         aspirate_result = await aspirate_while_tracking(
-            pipette_id=params.pipetteId,
-            labware_id=params.labwareId,
-            well_name=params.wellName,
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
             volume=params.volume,
             flow_rate=params.flowRate,
-            location_if_error={
-                "retryLocation": (
-                    current_position.x,
-                    current_position.y,
-                    current_position.z,
-                )
-            },
+            location_if_error={"retryLocation": final_location},
             command_note_adder=self._command_note_adder,
             pipetting=self._pipetting,
             model_utils=self._model_utils,
         )
-        position_after_aspirate = await self._gantry_mover.get_position(
-            params.pipetteId
-        )
+        position_after_aspirate = await self._gantry_mover.get_position(pipette_id)
         result_deck_point = DeckPoint.model_construct(
             x=position_after_aspirate.x,
             y=position_after_aspirate.y,
             z=position_after_aspirate.z,
         )
+        state_update.append(aspirate_result.state_update)
+
         if isinstance(aspirate_result, DefinedErrorData):
-            if (
-                isinstance(current_location, CurrentWell)
-                and current_location.pipette_id == params.pipetteId
-            ):
-                return DefinedErrorData(
-                    public=aspirate_result.public,
-                    state_update=aspirate_result.state_update.set_liquid_operated(
-                        labware_id=current_location.labware_id,
-                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                            current_location.labware_id,
-                            current_location.well_name,
-                            params.pipetteId,
-                        ),
-                        volume_added=CLEAR,
-                    ),
-                    state_update_if_false_positive=aspirate_result.state_update_if_false_positive,
-                )
-            else:
-                return aspirate_result
-        else:
-            if (
-                isinstance(current_location, CurrentWell)
-                and current_location.pipette_id == params.pipetteId
-            ):
-                return SuccessData(
-                    public=AspirateWhileTrackingResult(
-                        volume=aspirate_result.public.volume,
-                        position=result_deck_point,
-                    ),
-                    state_update=aspirate_result.state_update.set_liquid_operated(
-                        labware_id=current_location.labware_id,
-                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                            current_location.labware_id,
-                            current_location.well_name,
-                            params.pipetteId,
-                        ),
-                        volume_added=-aspirate_result.public.volume
-                        * self._state_view.geometry.get_nozzles_per_well(
-                            current_location.labware_id,
-                            current_location.well_name,
-                            params.pipetteId,
-                        ),
-                    ),
-                )
-            else:
-                return SuccessData(
-                    public=AspirateWhileTrackingResult(
-                        volume=aspirate_result.public.volume,
-                        position=result_deck_point,
-                    ),
-                    state_update=aspirate_result.state_update,
-                )
+            state_update.set_liquid_operated(
+                labware_id=labware_id,
+                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                    labware_id,
+                    well_name,
+                    pipette_id,
+                ),
+                volume_added=CLEAR,
+            )
+            return DefinedErrorData(
+                public=aspirate_result.public,
+                state_update=state_update,
+                state_update_if_false_positive=aspirate_result.state_update_if_false_positive,
+            )
+
+        state_update.set_liquid_operated(
+            labware_id=labware_id,
+            well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                labware_id,
+                well_name,
+                pipette_id,
+            ),
+            volume_added=-aspirate_result.public.volume
+            * self._state_view.geometry.get_nozzles_per_well(
+                labware_id,
+                well_name,
+                pipette_id,
+            ),
+        )
+        return SuccessData(
+            public=AspirateWhileTrackingResult(
+                volume=aspirate_result.public.volume,
+                position=result_deck_point,
+            ),
+            state_update=state_update,
+        )
 
 
 class AspirateWhileTracking(

--- a/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
@@ -9,7 +9,7 @@ from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
 
 from ..state.update_types import CLEAR, StateUpdate
-from ..types import CurrentWell, DeckPoint
+from ..types import DeckPoint
 from .pipetting_common import (
     PipetteIdMixin,
     DispenseVolumeMixin,
@@ -94,22 +94,23 @@ class DispenseWhileTrackingImplementation(
 
     async def execute(self, params: DispenseWhileTrackingParams) -> _ExecuteReturn:
         """Move to and dispense to the requested well."""
+        pipette_id = params.pipetteId
         labware_id = params.labwareId
         well_name = params.wellName
+        well_location = params.wellLocation
 
         # TODO(pbm, 10-15-24): call self._state_view.geometry.validate_dispense_volume_into_well()
 
-        current_location = self._state_view.pipettes.get_current_location()
-        current_position = await self._gantry_mover.get_position(params.pipetteId)
+        current_position = await self._gantry_mover.get_position(pipette_id)
 
         state_update = StateUpdate()
         move_result = await move_to_well(
             movement=self._movement,
             model_utils=self._model_utils,
-            pipette_id=params.pipetteId,
-            labware_id=params.labwareId,
-            well_name=params.wellName,
-            well_location=params.wellLocation,
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
             operation_volume=-params.volume,
         )
         state_update.append(move_result.state_update)
@@ -119,7 +120,7 @@ class DispenseWhileTrackingImplementation(
             )
 
         dispense_result = await dispense_while_tracking(
-            pipette_id=params.pipetteId,
+            pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
             volume=params.volume,
@@ -135,77 +136,56 @@ class DispenseWhileTrackingImplementation(
             pipetting=self._pipetting,
             model_utils=self._model_utils,
         )
-        position_after_dispense = await self._gantry_mover.get_position(
-            params.pipetteId
-        )
+        position_after_dispense = await self._gantry_mover.get_position(pipette_id)
         result_deck_point = DeckPoint.model_construct(
             x=position_after_dispense.x,
             y=position_after_dispense.y,
             z=position_after_dispense.z,
         )
-
+        state_update.append(dispense_result.state_update)
         if isinstance(dispense_result, DefinedErrorData):
-            if (
-                isinstance(current_location, CurrentWell)
-                and current_location.pipette_id == params.pipetteId
-            ):
-                return DefinedErrorData(
-                    public=dispense_result.public,
-                    state_update=dispense_result.state_update.set_liquid_operated(
-                        labware_id=current_location.labware_id,
-                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                            current_location.labware_id,
-                            current_location.well_name,
-                            params.pipetteId,
-                        ),
-                        volume_added=CLEAR,
-                    ),
-                    state_update_if_false_positive=dispense_result.state_update_if_false_positive,
-                )
-            else:
-                return dispense_result
-        else:
-            if (
-                isinstance(current_location, CurrentWell)
-                and current_location.pipette_id == params.pipetteId
-            ):
-                volume_added = (
-                    self._state_view.pipettes.get_liquid_dispensed_by_ejecting_volume(
-                        pipette_id=params.pipetteId,
-                        volume=dispense_result.public.volume,
-                    )
-                )
-                if volume_added is not None:
-                    volume_added *= self._state_view.geometry.get_nozzles_per_well(
-                        current_location.labware_id,
-                        current_location.well_name,
-                        params.pipetteId,
-                    )
-                return SuccessData(
-                    public=DispenseWhileTrackingResult(
-                        volume=dispense_result.public.volume,
-                        position=result_deck_point,
-                    ),
-                    state_update=dispense_result.state_update.set_liquid_operated(
-                        labware_id=current_location.labware_id,
-                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                            current_location.labware_id,
-                            current_location.well_name,
-                            params.pipetteId,
-                        ),
-                        volume_added=volume_added
-                        if volume_added is not None
-                        else CLEAR,
-                    ),
-                )
-            else:
-                return SuccessData(
-                    public=DispenseWhileTrackingResult(
-                        volume=dispense_result.public.volume,
-                        position=result_deck_point,
-                    ),
-                    state_update=dispense_result.state_update,
-                )
+            state_update.set_liquid_operated(
+                labware_id=labware_id,
+                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                    labware_id,
+                    well_name,
+                    pipette_id,
+                ),
+                volume_added=CLEAR,
+            )
+            return DefinedErrorData(
+                public=dispense_result.public,
+                state_update=state_update,
+                state_update_if_false_positive=dispense_result.state_update_if_false_positive,
+            )
+        volume_added = (
+            self._state_view.pipettes.get_liquid_dispensed_by_ejecting_volume(
+                pipette_id=pipette_id,
+                volume=dispense_result.public.volume,
+            )
+        )
+        if volume_added is not None:
+            volume_added *= self._state_view.geometry.get_nozzles_per_well(
+                labware_id,
+                well_name,
+                pipette_id,
+            )
+        state_update.set_liquid_operated(
+            labware_id=labware_id,
+            well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                labware_id,
+                well_name,
+                pipette_id,
+            ),
+            volume_added=volume_added if volume_added is not None else CLEAR,
+        )
+        return SuccessData(
+            public=DispenseWhileTrackingResult(
+                volume=dispense_result.public.volume,
+                position=result_deck_point,
+            ),
+            state_update=state_update,
+        )
 
 
 class DispenseWhileTracking(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
