### PR TITLE
fix(api): perform pipette movement checks in engine core move_to

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -747,6 +747,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         force_direct: bool,
         minimum_z_height: Optional[float],
         speed: Optional[float],
+        check_for_movement_conflicts: bool = True,
     ) -> None:
         if well_core is not None:
             if isinstance(location, (TrashBin, WasteChute)):
@@ -765,6 +766,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             assert isinstance(well_location, LiquidHandlingWellLocation)
             if well_location.volumeOffset and well_location.volumeOffset != 0:
                 raise ValueError("volume offset not supported with move_to")
+            if check_for_movement_conflicts:
+                pipette_movement_conflict.check_safe_for_pipette_movement(
+                    engine_state=self._engine_client.state,
+                    pipette_id=self._pipette_id,
+                    labware_id=labware_id,
+                    well_name=well_name,
+                    well_location=well_location,
+                )
             self._engine_client.execute_command(
                 cmd.MoveToWellParams(
                     pipetteId=self._pipette_id,

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -190,6 +190,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         force_direct: bool,
         minimum_z_height: Optional[float],
         speed: Optional[float],
+        check_for_movement_conflicts: bool,
     ) -> None:
         ...
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -367,6 +367,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         force_direct: bool = False,
         minimum_z_height: Optional[float] = None,
         speed: Optional[float] = None,
+        check_for_movement_conflicts: bool = False,
     ) -> None:
         """Move the instrument.
 
@@ -376,6 +377,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
             force_direct: Force a direct movement instead of an arc.
             minimum_z_height: Set a minimum travel height for a movement arc.
             speed: Override the travel speed in mm/s.
+            check_for_movement_conflicts: Not used in legacy implementation
 
         Raises:
             LabwareHeightError: An item on the deck is taller than

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -325,6 +325,7 @@ class LegacyInstrumentCoreSimulator(
         force_direct: bool = False,
         minimum_z_height: Optional[float] = None,
         speed: Optional[float] = None,
+        check_for_movement_conflicts: bool = False  # Not used in this implementation
     ) -> None:
         """Simulation of only the motion planning portion of move_to."""
         if isinstance(location, (TrashBin, WasteChute)):

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -325,7 +325,7 @@ class LegacyInstrumentCoreSimulator(
         force_direct: bool = False,
         minimum_z_height: Optional[float] = None,
         speed: Optional[float] = None,
-        check_for_movement_conflicts: bool = False  # Not used in this implementation
+        check_for_movement_conflicts: bool = False,  # Not used in this implementation
     ) -> None:
         """Simulation of only the motion planning portion of move_to."""
         if isinstance(location, (TrashBin, WasteChute)):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1907,6 +1907,7 @@ class InstrumentContext(publisher.CommandPublisher):
                     force_direct=force_direct,
                     minimum_z_height=minimum_z_height,
                     speed=speed,
+                    check_for_movement_conflicts=False,
                 )
             else:
                 if publish:
@@ -1925,6 +1926,7 @@ class InstrumentContext(publisher.CommandPublisher):
                     force_direct=force_direct,
                     minimum_z_height=minimum_z_height,
                     speed=speed,
+                    check_for_movement_conflicts=False,
                 )
 
         return self

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -255,6 +255,7 @@ def test_move_to(
             force_direct=False,
             minimum_z_height=None,
             speed=None,
+            check_for_movement_conflicts=False,
         ),
         times=1,
     )
@@ -276,6 +277,7 @@ def test_move_to_well(
             force_direct=False,
             minimum_z_height=None,
             speed=None,
+            check_for_movement_conflicts=False,
         ),
         times=1,
     )


### PR DESCRIPTION
# Overview

Closes RQA-4089.

An issue was found in QA where we are not surfacing unsafe movement while in partial tip configuration in `transfer_with_liquid_class`, `distribute_with_liquid_class`, and `consolidate_with_liquid_class`. Upon further investigation, these checks were being skipped because we were calling the engine `aspirate`, `dispense`, and `blow_out` without a `well_core` argument, which performs them in-place but skips the movement checks. `touch_tip`, `pick_up_tip` and `drop_tip` do not have this issue as they perform this check unconditionally.

In order to fix this, this PR introduces the movement check to the engine `move_to`, which the `transfer_components_executor` calls before the in-place liquid handling commands. This will ensure that those movement checks are performed each time the pipette moves (it no-ops if in a full configuration, so it will only potentially introduce analysis errors when in partial tip configuration). `move_to` is also called by the public `InstrumentContext` `move_to`, and in order to preserve existing behavior, a boolean check was put in and set to `False` when called in `InstrumentContext`.

## Test Plan and Hands on Testing

Protocol provided in the RQA ticket now correctly fails with a `PartialTipMovementNotAllowedError`

## Changelog

- add `pipette_movement_conflict.check_safe_for_pipette_movement` in engine core `move_to`
- gate check with boolean when called from `InstrumentContext.move_to`

## Review requests

Do we want to introduce the check to be called from `InstrumentContext` or do we want to keep existing behavior the same?

## Risk assessment

Lowish-medium.