### PR TITLE
fix(app): Fix Error Recovery failed labware transformations

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -293,6 +293,33 @@ describe('useRecoveryCommands', () => {
     )
   })
 
+  it('should reject with error and call proceedToRouteAndStep when pickUpTips has invalid input', async () => {
+    const testProps = {
+      ...props,
+      failedLabwareUtils: {
+        ...mockFailedLabwareUtils,
+        selectedTipLocations: null,
+        relevantPickUpTipLabware: null,
+      },
+    }
+
+    const { result } = renderHook(() => useRecoveryCommands(testProps))
+
+    await act(async () => {
+      await expect(result.current.pickUpTips()).rejects.toThrow(
+        'Invalid use of pickUpTips command'
+      )
+    })
+
+    expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
+      RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE
+    )
+    expect(mockReportActionSelectedResult).toHaveBeenCalledWith(
+      RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE,
+      'failed'
+    )
+  })
+
   it('should call releaseGripperJaws and resolve the promise', async () => {
     const { result } = renderHook(() => useRecoveryCommands(props))
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -95,7 +95,6 @@ export function useERUtils({
   // Note that pageLength: 999 is ok only because we fetch this on mount. We use 999 because it should hopefully
   // provide the commands necessary for ER without taxing the server too heavily. This is NOT intended for produciton!
   const { data: runCommands } = useNotifyAllCommandsQuery(runId, {
-    cursor: 0,
     pageLength: 999,
   })
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -105,7 +105,7 @@ export function useERUtils({
         protocolAnalysis?.commands ?? [],
         failedCommand?.byRunRecord ?? null
       ),
-    [protocolAnalysis != null, failedCommand]
+    [protocolAnalysis, failedCommand]
   )
 
   const analytics = useRecoveryAnalytics()

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -95,7 +95,7 @@ export function useFailedLabwareUtils({
         failedCommand,
         runCommands,
       }),
-    [failedCommandByRunRecord?.key, runCommands?.meta.totalLength]
+    [failedCommandByRunRecord, runCommands]
   )
   const relevantPickUpTipCommand = getRelevantPickUpTipCommand(
     failedCommandByRunRecord,
@@ -110,7 +110,7 @@ export function useFailedLabwareUtils({
         recentRelevantFailedLabwareCmd,
         runRecord
       ),
-    [protocolAnalysis?.id, recentRelevantFailedLabwareCmd?.key]
+    [protocolAnalysis, recentRelevantFailedLabwareCmd]
   )
   const relevantPickUpTipCmdDetails = useMemo(
     () =>
@@ -119,16 +119,16 @@ export function useFailedLabwareUtils({
         relevantPickUpTipCommand,
         runRecord
       ),
-    [protocolAnalysis?.id, relevantPickUpTipCommand?.key]
+    [protocolAnalysis, relevantPickUpTipCommand]
   )
 
   const failedLabware = useMemo(
     () => getLabwareInfoFrom(recentRelevantFailedLabwareCmd, runRecord),
-    [recentRelevantFailedLabwareCmd?.key]
+    [recentRelevantFailedLabwareCmd]
   )
   const relevantPickUpTipLabware = useMemo(
     () => getLabwareInfoFrom(relevantPickUpTipCommand, runRecord),
-    [recentRelevantFailedLabwareCmd?.key]
+    [recentRelevantFailedLabwareCmd]
   )
   const relevantPickUpTipLwLocs = useRelevantFailedLwLocations({
     failedLabware: relevantPickUpTipLabware,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -103,19 +103,23 @@ export function useRecoveryCommands({
   const updateErrorRecoveryPolicy = useUpdateRecoveryPolicyWithStrategy(runId)
   const { makeSuccessToast } = recoveryToastUtils
 
+  const reportAndRouteFailedCmd = (e: Error): Promise<never> => {
+    console.warn(`Error executing "fixit" command: ${e}`)
+    analytics.reportActionSelectedResult(selectedRecoveryOption, 'failed')
+    void proceedToRouteAndStep(RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE)
+
+    return Promise.reject(new Error(`Could not execute command: ${e}`))
+  }
+
   // TODO(jh, 11-21-24): Some commands return a 200 with an error body. We should catch these and propagate the error.
   const chainRunRecoveryCommands = useCallback(
     (
       commands: CreateCommand[],
       continuePastFailure: boolean = false
     ): Promise<CommandData[]> =>
-      chainRunCommands(commands, continuePastFailure).catch(e => {
-        console.warn(`Error executing "fixit" command: ${e}`)
-        analytics.reportActionSelectedResult(selectedRecoveryOption, 'failed')
+      chainRunCommands(commands, continuePastFailure)
         // the catch never occurs if continuePastCommandFailure is "true"
-        void proceedToRouteAndStep(RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE)
-        return Promise.reject(new Error(`Could not execute command: ${e}`))
-      }),
+        .catch((e: Error) => reportAndRouteFailedCmd(e)),
     [analytics, selectedRecoveryOption]
   )
 
@@ -204,7 +208,9 @@ export function useRecoveryCommands({
     )
 
     if (pickUpTipCmd == null) {
-      return Promise.reject(new Error('Invalid use of pickUpTips command'))
+      return reportAndRouteFailedCmd(
+        new Error('Invalid use of pickUpTips command')
+      )
     } else {
       return chainRunRecoveryCommands([pickUpTipCmd])
     }
@@ -235,13 +241,12 @@ export function useRecoveryCommands({
         return updateErrorRecoveryPolicy(ignorePolicyRules, 'append')
           .then(() => Promise.resolve())
           .catch((e: Error) =>
-            Promise.reject(
+            reportAndRouteFailedCmd(
               new Error(`Failed to update recovery policy: ${e.message}`)
             )
           )
       } else {
-        void proceedToRouteAndStep(RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE)
-        return Promise.reject(
+        return reportAndRouteFailedCmd(
           new Error('Could not execute command. No failed command.')
         )
       }
@@ -321,7 +326,9 @@ export function useRecoveryCommands({
       unvalidatedFailedCommand
     )
     if (moveLabwareCmd == null) {
-      return Promise.reject(new Error('Invalid use of MoveLabware command'))
+      return reportAndRouteFailedCmd(
+        new Error('Invalid use of MoveLabware command')
+      )
     } else {
       return chainRunRecoveryCommands([moveLabwareCmd])
     }


### PR DESCRIPTION
Closes [RESC-427](https://opentrons.atlassian.net/browse/RESC-427)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Whenever a command fails and Error Recovery initializes, the app builds a lot of internal recovery state including the location of the last pick up tip command. Because the state that initializes Error Recovery (run status) is inherently different than a lot of the state used to compute this internal state (run commands, run records, protocol analysis, and lots more), there's a potential for torn state.

In this case, what's is possibly happening (the most likely issue is the last commit fix, see below) is that some of the internal ER state transformations surrounding tip pick up locations are memoized over-aggressively, and even though Error Recovery has launched, the underlying network requests have not time to fully resolve with finalized values. We've seen variations of this problem earlier, and the solution has been to ensure that the underlying data is properly memoized farther upstream and just memoize object references. In this case, all the underlying data from which ER does its transforms upon is properly memoized to begin with, so for the purpose of re-memoization of transformed values, we can simply check pure object references of instead of scalars that exist on those objects. It's probably no coincidence that this bug is the only one of it's type that's been reported: no other "scalars on object" re-memoization checks occurs in ER outside of the tip pickup transformation logic - everything else is just object reference checking.

Additionally, in 0ed145a2ac152ee01d6295a0e1209fda06f858d3, we were never redirecting users to the "failed recovery action" route for recovery actions that did _not_ utilize the underlying `chainRunRecoveryCommands` wrapper. Not all recovery actions actually chain run commands or throw errors in a standard way and we have to handle those, too. This doesn't solve the underlying problem, but it prevents an infinite "robot in action" spinner.

Lastly in [7f771db](https://github.com/Opentrons/opentrons/pull/18098/commits/7f771db70287290dcd5b975f490250ddab9adfe0), there was definitely a bug: we don't want cursor here. This always gives us the first 999 commands, but not the 999 most recent commands.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that failing a recovery action for both commands that utilize `chainRunRecoveryCommands` and those that do not properly route to the "failed recovery action" view.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a bug in which attempting to pick up tips during Error Recovery would sometimes hang indefinitely. 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
 low - 1e33c402b27da76dd222b76aba8565a53c9f9b5e carries no risk after verifying the underlying data sources are memoized already, and 0ed145a2ac152ee01d6295a0e1209fda06f858d3 and [7f771db](https://github.com/Opentrons/opentrons/pull/18098/commits/7f771db70287290dcd5b975f490250ddab9adfe0) are easy to verify via testing.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RESC-427]: https://opentrons.atlassian.net/browse/RESC-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ