### PR TITLE
fix(protocol-designer): properly find defs for adapter/labware combo split defs

### DIFF
--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -1,14 +1,13 @@
 import mapValues from 'lodash/mapValues'
+import { getAllLabwareDefs } from '@opentrons/shared-data'
 import { uuid } from '../../utils'
-import { getOnlyLatestDefs } from '../../labware-defs'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import { getAdapterAndLabwareSplitInfo } from './utils/getAdapterAndLabwareSplitInfo'
-import {
-  getAllLabwareDefs,
-  type LabwareDefinition2,
-  type LabwareDefinitionsByUri,
-  type LoadLiquidCreateCommand,
-  type ProtocolFileV6,
+import type {
+  LabwareDefinition2,
+  LabwareDefinitionsByUri,
+  LoadLiquidCreateCommand,
+  ProtocolFileV6,
 } from '@opentrons/shared-data'
 import type {
   LoadPipetteCreateCommand,

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -3,11 +3,12 @@ import { uuid } from '../../utils'
 import { getOnlyLatestDefs } from '../../labware-defs'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import { getAdapterAndLabwareSplitInfo } from './utils/getAdapterAndLabwareSplitInfo'
-import type {
-  LabwareDefinition2,
-  LabwareDefinitionsByUri,
-  LoadLiquidCreateCommand,
-  ProtocolFileV6,
+import {
+  getAllLabwareDefs,
+  type LabwareDefinition2,
+  type LabwareDefinitionsByUri,
+  type LoadLiquidCreateCommand,
+  type ProtocolFileV6,
 } from '@opentrons/shared-data'
 import type {
   LoadPipetteCreateCommand,
@@ -62,7 +63,7 @@ export const migrateFile = (
     ].labwareLocationUpdate
   const ingredLocations = appData.designerApplication?.data?.ingredLocations
 
-  const allLatestDefs = getOnlyLatestDefs()
+  const allLabwareDefs = getAllLabwareDefs()
 
   const getIsAdapter = (labwareId: string): boolean => {
     const labwareEntity = labware[labwareId]
@@ -149,11 +150,11 @@ export const migrateFile = (
       const {
         parameters: adapterParameters,
         version: adapterVersion,
-      } = allLatestDefs[adapterUri]
+      } = allLabwareDefs[adapterUri]
       const {
         parameters: labwareParameters,
         version: labwareVersion,
-      } = allLatestDefs[labwareUri]
+      } = allLabwareDefs[labwareUri]
       const adapterId = mappedLabwareIds[command.params.labwareId].newAdapterId
 
       const loadAdapterCommand: LoadLabwareCreateCommand = {
@@ -196,8 +197,8 @@ export const migrateFile = (
     const loadName = labwareDefinition.parameters.loadName
     if (ADAPTER_LABWARE_COMBO_LOAD_NAMES.includes(loadName)) {
       const { adapterUri, labwareUri } = getAdapterAndLabwareSplitInfo(defId)
-      const adapterLabwareDef = allLatestDefs[adapterUri]
-      const labwareDef = allLatestDefs[labwareUri]
+      const adapterLabwareDef = allLabwareDefs[adapterUri]
+      const labwareDef = allLabwareDefs[labwareUri]
       acc[adapterUri] = adapterLabwareDef
       acc[labwareUri] = labwareDef
     } else {


### PR DESCRIPTION
closes AUTH-1745

# Overview

As explained in the ticket, a customer had a bug where their labware wasn't properly being split into the adapter labware combo defs because the 2 defs were not the latest versions

## Test Plan and Hands on Testing
[drug.plate.final.json](https://github.com/user-attachments/files/19783105/drug.plate.final.json)

Upload the protocol on this branch and it should pass
upload it to pd in prod and it should fail

## Changelog

- get all defs instead of latest

## Risk assessment

low
