### PR TITLE
feat(protocol-designer): support custom labware when uploading a .py

### DIFF
--- a/protocol-designer/src/file-types.ts
+++ b/protocol-designer/src/file-types.ts
@@ -1,4 +1,5 @@
 import type {
+  LabwareDefinition2,
   ModuleModel,
   PipetteName,
   ProtocolFile,
@@ -38,7 +39,11 @@ export interface PDMetadata {
 }
 
 export interface DesignerApplication {
-  designerApplication: { version: string; name: string; data: PDMetadata }
+  designerApplication: {
+    version: string
+    name: string
+    data: PDMetadata
+  }
 }
 
 export interface PythonDesignerApplication extends DesignerApplication {
@@ -46,6 +51,7 @@ export interface PythonDesignerApplication extends DesignerApplication {
     model: RobotType
   }
   metadata: FileMetadataFields
+  labwareDefinitions?: Record<string, LabwareDefinition2>
 }
 
 export interface PDPythonFile {
@@ -55,7 +61,9 @@ export interface PDPythonFile {
 
 export type PDProtocolFile = ProtocolFile<PDMetadata>
 
-export function getPDMetadata(file: PDProtocolFile): PDMetadata {
+export function getPDMetadata(
+  file: PDProtocolFile | PythonDesignerApplication
+): PDMetadata {
   const metadata = file.designerApplication?.data
 
   if (!metadata) {

--- a/protocol-designer/src/labware-defs/reducers.ts
+++ b/protocol-designer/src/labware-defs/reducers.ts
@@ -34,7 +34,6 @@ const customDefs: Reducer<LabwareDefByDefURI, Action> = handleActions(
       [getLabwareDefURI(action.payload.newDef)]: action.payload.newDef,
     }),
     LOAD_FILE: (state: LabwareDefByDefURI, action: LoadFileAction) => {
-      //  TODO: add support for python files that have custom labware
       const customDefsFromFile =
         action.payload.file?.labwareDefinitions != null
           ? pickBy(

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -102,6 +102,9 @@ export const loadProtocolFile = (
               (customLabwareJson != null
                 ? {
                     ...designerApplicationJson,
+                    //  NOTE: labwareDefinitions contain custom labware only
+                    //  other labwareDefinitions are populated via mapping through
+                    //  the labware key in the labwareInvariantProperties reducer
                     labwareDefinitions: customLabwareJson,
                   }
                 : designerApplicationJson) as PythonDesignerApplication

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -1,3 +1,4 @@
+import { CUSTOM_LABWARE_DICT_NAME } from '@opentrons/step-generation'
 import { migration } from './migration'
 import { selectors as fileDataSelectors } from '../file-data'
 import { saveFile, savePythonFile } from './utils'
@@ -89,9 +90,11 @@ export const loadProtocolFile = (
           const designerApplicationString = designerApplication[1]
           const designerApplicationJson = JSON.parse(designerApplicationString) // Convert to JSON
 
-          const customLabware = result.match(
-            /=\s*json\.loads\s*\("""([\s\S]*?)"""\)/m
+          const customLabwareRegex = new RegExp(
+            `^${CUSTOM_LABWARE_DICT_NAME}\\s*=\\s*json.loads\\("""(.*)"""\\)`,
+            'm'
           )
+          const customLabware = result.match(customLabwareRegex)
           let customLabwareJson
           if (customLabware != null && customLabware[1]) {
             const customLabwareString = customLabware[1]

--- a/protocol-designer/src/load-file/actions.ts
+++ b/protocol-designer/src/load-file/actions.ts
@@ -3,7 +3,7 @@ import { selectors as fileDataSelectors } from '../file-data'
 import { saveFile, savePythonFile } from './utils'
 
 import type { SyntheticEvent } from 'react'
-import type { PDProtocolFile, PDPythonFile } from '../file-types'
+import type { PDProtocolFile, PythonDesignerApplication } from '../file-types'
 import type { GetState, ThunkAction, ThunkDispatch } from '../types'
 import type {
   FileUploadErrorType,
@@ -29,7 +29,7 @@ export const dismissFileUploadMessage = (): DismissFileUploadMessageAction => ({
 })
 // expects valid, parsed JSON protocol.
 export const loadFileAction = (
-  payload: PDProtocolFile | PDPythonFile
+  payload: PDProtocolFile | PythonDesignerApplication
 ): LoadFileAction => ({
   type: 'LOAD_FILE',
   payload: migration(payload),
@@ -89,7 +89,24 @@ export const loadProtocolFile = (
           const designerApplicationString = designerApplication[1]
           const designerApplicationJson = JSON.parse(designerApplicationString) // Convert to JSON
 
-          dispatch(loadFileAction(designerApplicationJson as PDPythonFile))
+          const customLabware = result.match(
+            /=\s*json\.loads\s*\("""([\s\S]*?)"""\)/m
+          )
+          let customLabwareJson
+          if (customLabware != null && customLabware[1]) {
+            const customLabwareString = customLabware[1]
+            customLabwareJson = JSON.parse(customLabwareString)
+          }
+          dispatch(
+            loadFileAction(
+              (customLabwareJson != null
+                ? {
+                    ...designerApplicationJson,
+                    labwareDefinitions: customLabwareJson,
+                  }
+                : designerApplicationJson) as PythonDesignerApplication
+            )
+          )
         } else {
           fileError('INVALID_PYTHON_FILE')
         }

--- a/protocol-designer/src/load-file/migration/index.ts
+++ b/protocol-designer/src/load-file/migration/index.ts
@@ -15,7 +15,10 @@ import { migrateFile as migrateFileEightTwo } from './8_2_0'
 import { migrateFile as migrateFileEightTwoPointTwo } from './8_2_2'
 import { migrateFile as migrateFileEightFive } from './8_5_0'
 
-import type { PDProtocolFile } from '../../file-types'
+import type {
+  PDProtocolFile,
+  PythonDesignerApplication,
+} from '../../file-types'
 
 export const OLDEST_MIGRATEABLE_VERSION = '1.0.0'
 type Version = string
@@ -65,12 +68,12 @@ const allMigrationsByVersion: MigrationsByVersion = {
 export const migration = (
   file: any
 ): {
-  file: PDProtocolFile
+  file: PDProtocolFile | PythonDesignerApplication
   didMigrate: boolean
   migrationsRan: string[]
 } => {
   const designerApplication =
-    file.designerApplication || file['designer-application']
+    file.designerApplication || file['designer-application'] || file
   // NOTE: default exists because any protocol that doesn't include the application version
   // key will be treated as the oldest migrateable version ('1.0.0')
   const applicationVersion: string =

--- a/protocol-designer/src/load-file/types.ts
+++ b/protocol-designer/src/load-file/types.ts
@@ -1,4 +1,4 @@
-import type { PDProtocolFile } from '../file-types'
+import type { PDProtocolFile, PythonDesignerApplication } from '../file-types'
 import type { RobotType } from '@opentrons/shared-data'
 
 export type FileUploadErrorType =
@@ -26,7 +26,7 @@ export interface NewProtocolFields {
 export interface LoadFileAction {
   type: 'LOAD_FILE'
   payload: {
-    file: PDProtocolFile
+    file: PDProtocolFile | PythonDesignerApplication
     didMigrate: boolean
     migrationsRan: string[]
   }

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1017,72 +1017,46 @@ export const labwareInvariantProperties: Reducer<
     ): NormalizedLabwareById => {
       const { file } = action.payload
       const metadata = getPDMetadata(file)
-      const labwareDefinitions = file?.labwareDefinitions
+      const labwareDefinitionsFromFile = file.labwareDefinitions
       const allLabware = getAllDefinitions()
       let labware: NormalizedLabwareById = {}
-      if (labwareDefinitions != null) {
-        labware = Object.entries(metadata.labware).reduce(
-          (acc: NormalizedLabwareById, [id, labwareLoadInfo]) => {
-            if (labwareDefinitions[labwareLoadInfo.labwareDefURI] == null) {
-              console.error(
-                `expected to find matching labware definiton with labwareDefURI ${labwareLoadInfo.labwareDefURI} but could not`
-              )
-            }
-            const displayCategory =
-              labwareDefinitions[labwareLoadInfo.labwareDefURI]?.metadata
-                .displayCategory ?? 'otherLabware'
 
-            const displayCategoryCount = Object.values(acc).filter(
-              lw => lw.displayCategory === displayCategory
-            ).length
+      labware = Object.entries(metadata.labware).reduce(
+        (acc: NormalizedLabwareById, [id, labwareLoadInfo]) => {
+          const labwareDefURI = labwareLoadInfo.labwareDefURI
+          const definition =
+            //  labwareDefinitionsFromFile from file are either customLabware for py
+            //  or all labwareDefs for JSON
+            labwareDefinitionsFromFile?.[labwareDefURI] ??
+            allLabware[labwareDefURI]
 
-            acc[id] = {
-              labwareDefURI: labwareLoadInfo.labwareDefURI,
-              pythonName: getLabwarePythonName(
-                displayCategory,
-                displayCategoryCount + 1
-              ),
+          if (definition == null) {
+            console.error(
+              `Expected to find matching labware definition in the JSON file or Opentrons labware library but could not with labwareDefUri ${labwareDefURI}`
+            )
+          }
+
+          const displayCategory =
+            definition?.metadata.displayCategory ?? 'otherLabware'
+
+          const displayCategoryCount = Object.values(acc).filter(
+            lw => lw.displayCategory === displayCategory
+          ).length
+
+          acc[id] = {
+            labwareDefURI,
+            pythonName: getLabwarePythonName(
               displayCategory,
-            }
+              displayCategoryCount + 1
+            ),
+            displayCategory,
+          }
 
-            return acc
-          },
-          {}
-        )
-        //  if loading a python file - should include all labwares that are
-        //  not custom labwares
-      } else {
-        labware = Object.entries(metadata.labware).reduce(
-          (acc: NormalizedLabwareById, [id, labwareLoadInfo]) => {
-            const labwareDefinition = allLabware[labwareLoadInfo.labwareDefURI]
+          return acc
+        },
+        {}
+      )
 
-            if (labwareDefinition == null) {
-              console.error(
-                `expected to find matching labware definition in the opentrons labware library but could not with labwareDefUri ${labwareLoadInfo.labwareDefURI}`
-              )
-            }
-
-            const displayCategory =
-              labwareDefinition?.metadata.displayCategory ?? 'otherLabware'
-
-            const displayCategoryCount = Object.values(acc).filter(
-              lw => lw.displayCategory === displayCategory
-            ).length
-
-            acc[id] = {
-              labwareDefURI: labwareLoadInfo.labwareDefURI,
-              pythonName: getLabwarePythonName(
-                displayCategory,
-                displayCategoryCount + 1
-              ),
-              displayCategory,
-            }
-
-            return acc
-          },
-          {}
-        )
-      }
       return { ...labware, ...state }
     },
     EDIT_MULTIPLE_LABWARE_PYTHON_NAME: (


### PR DESCRIPTION
closes AUTH-1689

# Overview

Support custom labware when uploading a python protocol. This is the final piece for python import to be fully supported in PD!

## Changelog

- Fix the file type for importing py protocol and adjust that type for all the shared utils. 
- refactor the `labwareInvariantProperties` `LOAD_FILE` so that it can accept both `labwareDefinitions` key from custom labware and not having a `labwareDefinitions` key.

NOTE: it is weird that the unit test for the `createFile` didn't fail after i adjusted the `designerApplication` type - sort of feels like it was a bug that `name` and `version` were outside of the `data` object 🤔 

## Review requests

Review the code and test it out for yourself! here is a custom labware

https://github.com/user-attachments/files/19794154/corninglowbind_384_wellplate_50ul.3.1.json


## Risk assessment

low, behind ff
