### PR TITLE
fix(protocol-designer): show correct waste chute fixture options and …

### DIFF
--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -185,6 +185,7 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
           (cutoutConfig.type != null && FIXTURES.includes(cutoutConfig.type)) ||
           cutoutConfig.type === 'stagingAreaAndMagneticBlock'
       )
+
       if (newModule != null) {
         const filteredModules = Object.fromEntries(
           Object.entries(modules).filter(
@@ -216,11 +217,26 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
         setValue('modules', updatedModules)
       }
       if (newFixture != null) {
+        const isStagingAreaAndWasteChute =
+          newFixture.cutoutFixtureId ===
+          'stagingAreaSlotWithWasteChuteRightAdapterNoCover'
+
         const filteredFixtures = Object.fromEntries(
           Object.entries(fixtures).filter(
             ([, fixture]) => fixture.cutoutId !== newFixture.cutoutId
           )
         )
+
+        let additionalFixture: WizardFixtureType | undefined
+        if (isStagingAreaAndWasteChute) {
+          additionalFixture = {
+            [uuid()]: {
+              name: 'stagingArea',
+              cutoutFixtureId: 'stagingAreaRightSlot',
+              cutoutId: 'cutoutD3',
+            },
+          }
+        }
 
         const updatedFixtures: WizardFixtureType = {
           ...filteredFixtures,
@@ -229,9 +245,12 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
               newFixture.type === 'stagingAreaAndMagneticBlock'
                 ? 'stagingArea'
                 : (newFixture.type as FixtureName),
-            cutoutFixtureId: newFixture.cutoutFixtureId,
+            cutoutFixtureId: isStagingAreaAndWasteChute
+              ? 'wasteChuteRightAdapterNoCover'
+              : newFixture.cutoutFixtureId,
             cutoutId: newFixture.cutoutId,
           },
+          ...additionalFixture,
         }
         setValue('fixtures', updatedFixtures)
       }

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/useDeckConfigurationEditing.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/useDeckConfigurationEditing.tsx
@@ -27,7 +27,7 @@ import {
   THERMOCYCLER_V2_FRONT_FIXTURE,
   THERMOCYCLER_V2_REAR_FIXTURE,
   TRASH_BIN_ADAPTER_FIXTURE,
-  WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
+  WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
 } from '@opentrons/shared-data'
 import { AddFixtureModal } from './AddFixtureModal'
 import type { Dispatch, ReactNode, SetStateAction } from 'react'
@@ -285,7 +285,7 @@ export const getAvailableOptions = (
     }
   } else if (optionStage === 'wasteChuteOptions') {
     availableOptions = [
-      WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
+      WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
       STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
     ].map(fixture => [
       {


### PR DESCRIPTION
…generate stagingArea

# Overview

Fixes a bug where it incorreclty showed the waste chute with cover option and if you chose "waste chute with staging" the staging area wasn't added

## Test Plan and Hands on Testing

Go through the onboarding flow and add a waste chute. see that the options are "waste chute only" and the waste chute with staging area. If you click on "waste chute with staging area", see that the waste chute and staging area are generated when you complete the onboarding flow

## Changelog

- fix logic for adding in the staging area
- update the waste chute fixture

## Risk assessment

low
