### PR TITLE
fix(app): fix adjust location specific offset after resetting to default

### DIFF
--- a/app/src/redux/protocol-runs/reducer/transforms/lpc/updateOffsetsForURI.ts
+++ b/app/src/redux/protocol-runs/reducer/transforms/lpc/updateOffsetsForURI.ts
@@ -194,68 +194,60 @@ function updateLocationSpecificOffsetDetails(
         ...locationSpecificOffsetDetails.slice(relevantDetailsIdx + 1),
       ]
 
-      // Safety check for unexpected reset
-      if (relevantDetail?.workingOffset?.confirmedVector === RESET_TO_DEFAULT) {
-        console.error(
-          'Unexpected reset to default supplied when vector value expected.'
-        )
-        return locationSpecificOffsetDetails
-      } else {
-        // Get the most valid vector for the relevant location-specific offset.
-        const mostValidVector = findLocationSpecificOffsetWithFallbacks(
-          relevantDetail,
-          lwDetails.defaultOffsetDetails
+      // Get the most valid vector for the relevant location-specific offset.
+      const mostValidVector = findLocationSpecificOffsetWithFallbacks(
+        relevantDetail,
+        lwDetails.defaultOffsetDetails
+      )
+
+      // Create updated working offset.
+      const newWorkingDetail = createUpdatedWorkingLocationSpecificOffset(
+        type,
+        position,
+        relevantDetail?.workingOffset ?? null,
+        mostValidVector
+      )
+
+      // Get current default vector for comparison.
+      const currentDefaultVector =
+        lwDetails.defaultOffsetDetails.workingOffset?.confirmedVector ??
+        lwDetails.defaultOffsetDetails.existingOffset?.vector ??
+        null
+      const newVectorEqualsDefaultVector =
+        type === SET_FINAL_POSITION &&
+        vectorEqualsDefault(
+          newWorkingDetail.confirmedVector,
+          currentDefaultVector
         )
 
-        // Create updated working offset.
-        const newWorkingDetail = createUpdatedWorkingLocationSpecificOffset(
-          type,
-          position,
-          relevantDetail?.workingOffset ?? null,
-          mostValidVector
-        )
-
-        // Get current default vector for comparison.
-        const currentDefaultVector =
-          lwDetails.defaultOffsetDetails.workingOffset?.confirmedVector ??
-          lwDetails.defaultOffsetDetails.existingOffset?.vector ??
-          null
-        const newVectorEqualsDefaultVector =
-          type === SET_FINAL_POSITION &&
-          vectorEqualsDefault(
-            newWorkingDetail.confirmedVector,
-            currentDefaultVector
-          )
-
-        if (newVectorEqualsDefaultVector) {
-          // If we have an existing offset, mark it for reset.
-          if (relevantDetail?.existingOffset != null) {
-            return [
-              ...newOffsetDetails,
-              {
-                ...relevantDetail,
-                workingOffset: {
-                  ...newWorkingDetail,
-                  confirmedVector: RESET_TO_DEFAULT,
-                },
+      if (newVectorEqualsDefaultVector) {
+        // If we have an existing offset, mark it for reset.
+        if (relevantDetail?.existingOffset != null) {
+          return [
+            ...newOffsetDetails,
+            {
+              ...relevantDetail,
+              workingOffset: {
+                ...newWorkingDetail,
+                confirmedVector: RESET_TO_DEFAULT,
               },
-            ]
-          }
-          // If there's no existing offset, just remove the working offset.
-          else {
-            return [
-              ...newOffsetDetails,
-              { ...relevantDetail, workingOffset: null },
-            ]
-          }
+            },
+          ]
         }
-        // Use the calculated vector.
+        // If there's no existing offset, just remove the working offset.
         else {
           return [
             ...newOffsetDetails,
-            { ...relevantDetail, workingOffset: newWorkingDetail },
+            { ...relevantDetail, workingOffset: null },
           ]
         }
+      }
+      // Use the calculated vector.
+      else {
+        return [
+          ...newOffsetDetails,
+          { ...relevantDetail, workingOffset: newWorkingDetail },
+        ]
       }
     }
   }
@@ -291,10 +283,8 @@ function handleResetToDefault(
       workingOffset:
         relevantDetail.existingOffset != null
           ? {
-              initialPosition:
-                relevantDetail.workingOffset?.initialPosition ?? null,
-              finalPosition:
-                relevantDetail.workingOffset?.finalPosition ?? null,
+              initialPosition: null,
+              finalPosition: null,
               confirmedVector: RESET_TO_DEFAULT,
             }
           : null,

--- a/app/src/redux/protocol-runs/utils/lpc.ts
+++ b/app/src/redux/protocol-runs/utils/lpc.ts
@@ -125,24 +125,21 @@ export function createUpdatedWorkingLocationSpecificOffset(
       initialPosition: position,
       finalPosition: null,
     }
-  } else if (currentWorkingOffset.confirmedVector === RESET_TO_DEFAULT) {
-    return {
-      ...currentWorkingOffset,
-      finalPosition: null,
-      confirmedVector: RESET_TO_DEFAULT,
-    }
   }
   // Update final position and calculate confirmed vector.
   else {
+    const validConfirmedVector =
+      currentWorkingOffset.confirmedVector !== RESET_TO_DEFAULT
+        ? currentWorkingOffset.confirmedVector
+        : null
+
     return {
       ...currentWorkingOffset,
       finalPosition: position,
       confirmedVector: calculateConfirmedVector(
         currentWorkingOffset.initialPosition,
         position,
-        currentWorkingOffset.confirmedVector ??
-          mostValidVector ??
-          IDENTITY_VECTOR
+        validConfirmedVector ?? mostValidVector ?? IDENTITY_VECTOR
       ),
     }
   }


### PR DESCRIPTION
Closes [RQA-4098](https://opentrons.atlassian.net/browse/RQA-4098)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If a user resets to a default offset and subsequently adjusts that offset before saving (and only before saving), the app crashes, because there was some pre-existing logic in the reducer that didn't expect location specific offsets that were reset to default. Initially in designs, "reset to default" would block the "adjust" flow until save, but that was changed a while back.

To fix, we need to unblock the offset initial/final position cases within the reducer. If a user clicks reset to default and then attempts to adjust an offset, the initial location must be the most recently updated default offset vector. 

The changes within `handleResetToDefault` are nonfunctional, but current behavior of storing initial + final location offsets alongside a reset to default vector look strange/bug-prone to those debugging via redux.


https://github.com/user-attachments/assets/c77a2920-e10c-4765-8991-f563a2036170



<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
- Tested several other offset flows with and without resetting to default.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the app white-screening when a user would click "reset to default" and then "adjust" during applied location offset calibration.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4098]: https://opentrons.atlassian.net/browse/RQA-4098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ