### PR TITLE
fix(step-generation): do not quote `protocol_api.OFF_DECK` in load_labware()

### DIFF
--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -254,6 +254,35 @@ well_plate_3 = protocol.load_labware_from_definition(
 )`.trimStart()
     )
   })
+
+  describe('getLoadLabware off-deck', () => {
+    it('should generate loadLabware for off-deck', () => {
+      expect(
+        getLoadLabware(
+          {},
+          {
+            plateId: {
+              id: 'plateId',
+              labwareDefURI: 'opentrons/fixture_96_plate/1',
+              def: opentrons96Plate,
+              pythonName: 'well_plate_5',
+            },
+          },
+          { plateId: { slot: 'offDeck' } },
+          {}
+        )
+      ).toBe(
+        `
+# Load Labware:
+well_plate_5 = protocol.load_labware(
+    "fixture_96_plate",
+    location=protocol_api.OFF_DECK,
+    namespace="opentrons",
+    version=1,
+)`.trimStart()
+      )
+    })
+  })
 })
 
 describe('getLoadPipettes', () => {

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -119,9 +119,9 @@ export function getLoadAdapters(
         parentName = moduleEntities[adapterSlot].pythonName
       } else {
         parentName = PROTOCOL_CONTEXT_NAME
-        locationArg = `location=${formatPyStr(
-          adapterSlot === 'offDeck' ? OFF_DECK : adapterSlot
-        )}`
+        locationArg = `location=${
+          adapterSlot === 'offDeck' ? OFF_DECK : formatPyStr(adapterSlot)
+        }`
       }
 
       const isStandard = getLabwareDefIsStandard(def)
@@ -183,9 +183,9 @@ export function getLoadLabware(
         parentName = moduleEntities[labwareSlot].pythonName
       } else {
         parentName = PROTOCOL_CONTEXT_NAME
-        locationArg = `location=${formatPyStr(
-          labwareSlot === 'offDeck' ? OFF_DECK : labwareSlot
-        )}`
+        locationArg = `location=${
+          labwareSlot === 'offDeck' ? OFF_DECK : formatPyStr(labwareSlot)
+        }`
       }
       const labelArg = hasNickname
         ? `label=${formatPyStr(labwareNicknamesById[id])}`


### PR DESCRIPTION
# Overview

Fix syntax error in generated Python code for loading labware off-deck. `protocol_api.OFF_DECK` is a constant, and should not be quoted.

Before:
```
tube_rack_1 = protocol.load_labware(
    "opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical",
    location="protocol_api.OFF_DECK",
    namespace="opentrons",
    version=2,
)
```

After:
```
tube_rack_1 = protocol.load_labware(
    "opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical",
    location=protocol_api.OFF_DECK,
    namespace="opentrons",
    version=2,
)
```

## Test Plan and Hands on Testing

I added a unit test for off-deck modules, and confirmed that the generated Python passes analysis.

## Risk assessment

Low. Fixes formerly incorrect behavior.