### PR TITLE
fix(protocol-designer): liquid overflow menu positioning

### DIFF
--- a/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
@@ -54,7 +54,7 @@ export function LiquidsOverflowMenu(
           ? '23.4rem'
           : SPACING.spacing12
       }
-      top={`calc(${NAV_BAR_HEIGHT_REM} + 3.1rem)`}
+      top={`calc(${NAV_BAR_HEIGHT_REM}rem + 3.1rem)`}
       ref={overflowWrapperRef}
       borderRadius={BORDERS.borderRadius8}
       boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"


### PR DESCRIPTION
# Overview

Fix overflow menu positioning

Before: 
<img width="208" alt="Screenshot 2025-04-18 at 11 11 49" src="https://github.com/user-attachments/assets/ae418815-be53-4570-87ca-67d2c48c9193" />


After:
<img width="193" alt="Screenshot 2025-04-18 at 11 10 54" src="https://github.com/user-attachments/assets/c31a06b3-ef03-4b3d-8e54-a734da5aa138" />

## Test Plan and Hands on Testing

Test the liquid overflow menu positioning when editing a protocol

## Changelog

add forgotten rem. i think i forgot to add it when i refactored to using the const

## Risk assessment

low