### PR TITLE
fix(app): reset position handling in 96 flows

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -35,6 +35,12 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
             axes: ['rightZ'],
           },
         },
+        {
+          commandType: 'unsafe/updatePositionEstimators' as const,
+          params: {
+            axes: ['x', 'y'],
+          },
+        },
       ],
       false
     )

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -106,6 +106,15 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
             axes: ['leftZ'],
           },
         },
+        // if the user shoved the gantry while detaching the pipette
+        // the gantry axes have lost position, so account for it without
+        // doing an annoying home
+        {
+          commandType: 'unsafe/updatePositionEstimators' as const,
+          params: {
+            axes: ['x', 'y'],
+          },
+        },
         {
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {


### PR DESCRIPTION
Otherwise, if you do a shove in between pulling/attaching the pipette and pressing next, you get an error.

Closes RQA-4020

