### PR TITLE
fix(protocol-designer): show blockedSlot when trying to drop over a trash

### DIFF
--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -52,7 +52,7 @@ export function getNextAvailableDeckSlot(
     const addressableAreaName = stagingAreaAddressableAreaNames.find(
       aa => aa === slot.id
     )
-    let isSlotEmpty: boolean = getSlotIsEmpty(initialDeckSetup, slot.id)
+    let isSlotEmpty: boolean = getSlotIsEmpty(initialDeckSetup, slot.id, true)
     if (addressableAreaName == null && COLUMN_4_SLOTS.includes(slot.id)) {
       isSlotEmpty = false
     } else if (

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -367,7 +367,11 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
           return (
             addressableAreas &&
             !slotIdsBlockedBySpanning.includes(addressableArea.id) &&
-            getSlotIsEmpty(activeDeckSetup, addressableArea.id, false, true)
+            getSlotIsEmpty(
+              activeDeckSetup,
+              addressableArea.id,
+              draggedLabware == null
+            )
           )
         })
         .map(addressableArea => {

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -35,7 +35,6 @@ import type {
 import type { DeckSlot } from '../../types'
 import type { FormData, HydratedFormData } from '../../form-types'
 import type {
-  AdditionalEquipmentOnDeck,
   InitialDeckSetup,
   ModuleOnDeck,
   FormPipettesByMount,

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -175,18 +175,12 @@ export const getSlotIdsBlockedBySpanningForThermocycler = (
   return []
 }
 
-//  TODO(ja, 3/7/25): this util is very outdated, much of it is probably
-//  not even in use. we should refactor this!!!
 export const getSlotIsEmpty = (
   initialDeckSetup: InitialDeckSetup,
   slot: string,
-  /* we don't always want to count the slot as full if there is a staging area present
-     since labware/wasteChute can still go on top of staging areas  **/
-  includeStagingAreas?: boolean,
-  /* optional disallowing for additionalEquipmentAreas or not **/
-  discountAdditionalEquipmentAreas?: boolean
+  discountTrash: boolean
 ): boolean => {
-  //   special-casing the TC's slot A1 for the Flex
+  //  special-casing the TC's slot A1 for the Flex
   if (
     slot === 'cutoutA1' &&
     Object.values(initialDeckSetup.modules).find(
@@ -199,29 +193,12 @@ export const getSlotIsEmpty = (
       ae =>
         (ae.name === 'trashBin' || ae.name === 'wasteChute') &&
         ae.location.includes(slot)
-    )
+    ) &&
+    discountTrash
   ) {
     return false
   }
 
-  const filteredAdditionalEquipmentOnDeck = values(
-    initialDeckSetup.additionalEquipmentOnDeck
-  ).filter((additionalEquipment: AdditionalEquipmentOnDeck) => {
-    const cutoutForSlotOt2 = slotToCutoutOt2Map[slot]
-    const includeStaging = includeStagingAreas
-      ? true
-      : additionalEquipment.name !== 'stagingArea'
-    if (cutoutForSlotOt2 != null) {
-      //  for Ot-2
-      return additionalEquipment.location === cutoutForSlotOt2 && includeStaging
-    } else {
-      //  for Flex
-      return additionalEquipment.location?.includes(slot) && includeStaging
-    }
-  })
-  const additionalEquipment = discountAdditionalEquipmentAreas
-    ? []
-    : filteredAdditionalEquipmentOnDeck
   return (
     [
       ...values(initialDeckSetup.modules).filter(
@@ -235,7 +212,6 @@ export const getSlotIsEmpty = (
       ...values(initialDeckSetup.labware).filter(
         (labware: LabwareOnDeckType) => labware.slot === slot
       ),
-      ...additionalEquipment,
     ].length === 0
   )
 }


### PR DESCRIPTION
closes AUTH-1749

# Overview

Cleans up the `getSlotEmpty` util but also fixes a bug where when you are trying to drop a labware into a trash bin or waste chute, the `blockedSlot` container wasn't showing up.

## Test Plan and Hands on Testing

Create a flex protocol. Go to the initial deck setup for editing the deck. Hover over the slots and see that the trash bin does not allow you to hover to edit the slot. Then, try to drag the tiprack to the trash bin and see that there is a `blockedSlot` container that disallows you from dropping the tiprack into the trash bin

## Changelog

- clean up the `getSlotEmpty` util since a lot of logic in there is no longer in use
- fix logic in `protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx` which allows for the `blockedSlot` to occur

## Risk assessment

low, pretty contained