### PR TITLE
fix(app): disable the run action button when uncurrenting a run

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionBtnDisabledUtils.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionBtnDisabledUtils.ts
@@ -8,6 +8,7 @@ import {
   isCancellableStatus,
   isDisabledStatus,
   isStartRunStatus,
+  isWaitingForAppUncurrentRun,
 } from '../../../utils'
 
 import type { BaseActionButtonProps } from '..'
@@ -55,6 +56,7 @@ export function useActionBtnDisabledUtils(
 
   const isDisabled =
     (isCurrentRun && !isSetupComplete) ||
+    isWaitingForAppUncurrentRun(runStatus, isCurrentRun) ||
     isPlayRunActionLoading ||
     isPauseRunActionLoading ||
     isResetRunLoading ||

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -22,6 +22,7 @@ import {
   isRecoveryStatus,
   isRunAgainStatus,
   isStartRunStatus,
+  isWaitingForAppUncurrentRun,
 } from '../../../utils'
 
 import type { IconName } from '@opentrons/components'
@@ -48,6 +49,7 @@ export function useActionButtonProperties({
   runStatus,
   robotName,
   runId,
+  currentRunId,
   confirmAttachment,
   confirmMissingSteps,
   robotAnalyticsData,
@@ -90,7 +92,10 @@ export function useActionButtonProperties({
       pause()
       trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.PAUSE })
     }
-  } else if (runStatus === RUN_STATUS_STOP_REQUESTED) {
+  } else if (
+    runStatus === RUN_STATUS_STOP_REQUESTED ||
+    isWaitingForAppUncurrentRun(runStatus, runId === currentRunId)
+  ) {
     buttonIconName = 'ot-spinner'
     buttonText = t('canceling_run')
   } else if (isStartRunStatus(runStatus)) {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
@@ -25,7 +25,11 @@ import {
   useModuleCalibrationStatus,
 } from '/app/resources/runs'
 import { useActionBtnDisabledUtils, useActionButtonProperties } from './hooks'
-import { getFallbackRobotSerialNumber, isRunAgainStatus } from '../../utils'
+import {
+  getFallbackRobotSerialNumber,
+  isValidRunAgainStatus,
+  isWaitingForAppUncurrentRun,
+} from '../../utils'
 import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
 import { selectAreOffsetsApplied } from '/app/redux/protocol-runs'
 
@@ -79,7 +83,7 @@ export function ActionButton(props: ActionButtonProps): JSX.Element {
   const isCurrentRun = currentRunId === runId
   const isOtherRunCurrent = currentRunId != null && currentRunId !== runId
   const isProtocolNotReady = protocolData == null || !!isProtocolAnalyzing
-  const isValidRunAgain = isRunAgainStatus(runStatus)
+  const isValidRunAgain = isValidRunAgainStatus(runStatus, isCurrentRun)
   const { isClosingCurrentRun } = useCloseCurrentRun()
 
   const { isDisabled, disabledReason } = useActionBtnDisabledUtils({
@@ -139,6 +143,7 @@ export function ActionButton(props: ActionButtonProps): JSX.Element {
             spin={
               isProtocolNotReady ||
               runStatus === RUN_STATUS_STOP_REQUESTED ||
+              isWaitingForAppUncurrentRun(runStatus, isCurrentRun) ||
               isResetRunLoadingRef.current ||
               isClosingCurrentRun
             }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import { RUN_STATUS_IDLE, RUN_STATUS_STOPPED } from '@opentrons/api-client'
+import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import { useErrorRecoverySettings } from '@opentrons/react-api-client'
 
@@ -11,7 +11,7 @@ import {
   useCurrentRunCommands,
   useIsRunCurrent,
 } from '/app/resources/runs'
-import { isTerminalRunStatus } from '../../utils'
+import { isTerminalRunStatus, isWaitingForAppUncurrentRun } from '../../utils'
 import { useTipAttachmentStatus } from '/app/resources/instruments'
 import { lastRunCommandPromptedErrorRecovery } from '/app/local-resources/commands'
 
@@ -138,8 +138,7 @@ export function useRunHeaderDropTip({
   // This marks the robot as "not busy" if drop tip CTAs are unnecessary.
   useEffect(() => {
     if (
-      runStatus === RUN_STATUS_STOPPED &&
-      isRunCurrent &&
+      isWaitingForAppUncurrentRun(runStatus, isRunCurrent) &&
       (initialPipettesWithTipsCount === 0 || robotType === OT2_ROBOT_TYPE)
     ) {
       closeCurrentRun()

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/utils.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/utils.ts
@@ -67,6 +67,30 @@ export function isRunAgainStatus(runStatus: RunStatus | null): boolean {
   return runStatus !== null && RUN_AGAIN_STATUSES.includes(runStatus)
 }
 
+// The desktop app uncurrents the run when stopped, and to prevent server-side race conditions, we should wait
+// until the run uncurrenting completes.
+export function isWaitingForAppUncurrentRun(
+  runStatus: RunStatus | null,
+  isCurrentRun: boolean
+): boolean {
+  return runStatus === RUN_STATUS_STOPPED && isCurrentRun
+}
+
+export function isValidRunAgainStatus(
+  runStatus: RunStatus | null,
+  isCurrentRun: boolean
+): boolean {
+  if (runStatus !== null && RUN_AGAIN_STATUSES.includes(runStatus)) {
+    if (runStatus === RUN_STATUS_STOPPED) {
+      return !isWaitingForAppUncurrentRun(runStatus, isCurrentRun)
+    } else {
+      return true
+    }
+  }
+
+  return false
+}
+
 export function isRecoveryStatus(runStatus: RunStatus | null): boolean {
   return runStatus !== null && RECOVERY_STATUSES.includes(runStatus)
 }


### PR DESCRIPTION
Closes [RQA-4118](https://opentrons.atlassian.net/browse/RQA-4118)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

On the desktop app, we implicitly uncurrent the run if the run has a cancelled run status. There's a brief window that's quite noticeable on the OT-2 in which the run has a "cancelled" run status but is still uncurrenting. If a user tries to create a new run during this window, the POST request fails due to server internals currently updating in light of the ongoing run uncurrenting.

To fix, let's block this intermediate state until the run is uncurrented.

### Current Behavior

https://github.com/user-attachments/assets/37809704-b166-466a-b43b-6e221d8dd8a1

### Fixed Behavior

https://github.com/user-attachments/assets/47f1dd60-bea1-403a-9168-dabd979e8a9e

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a bug in which clicking "run again" too quickly causes the run to load indefinitely.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4118]: https://opentrons.atlassian.net/browse/RQA-4118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ