### PR TITLE
refactor(opentrons-ai-client, opentrons-ai-server): do not stub response when updating protocol

### DIFF
--- a/opentrons-ai-client/src/molecules/ChatDisplay/index.tsx
+++ b/opentrons-ai-client/src/molecules/ChatDisplay/index.tsx
@@ -215,6 +215,10 @@ export function ChatDisplay({ chat, chatId }: ChatDisplayProps): JSX.Element {
     return <CodeWrapper {...props} id={chatId} />
   }
 
+  const protocolName =
+    chatdata.findLast(chat => chat.protocol_content != null)?.protocol_content
+      ?.metadata.protocolName ?? 'protocol.json'
+
   const ProtocolContentBadge = (props: {
     onClick: () => void
   }): JSX.Element => {
@@ -225,7 +229,7 @@ export function ChatDisplay({ chat, chatId }: ChatDisplayProps): JSX.Element {
           <IconWrapper>
             <img src={smallLogo} alt="Opentrons logo" width="24" height="24" />
           </IconWrapper>
-          <FileName>protocol.json</FileName>
+          <FileName>{protocolName}</FileName>
           <HoverShadow
             onClick={(e: Event) => {
               e.stopPropagation()

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -122,16 +122,18 @@ export function InputPrompt(): JSX.Element {
         ? getCreateOrUpdateEndpoint()
         : getChatEndpoint()
 
+      const promptData = getUpdateOrCreatePrompt(isRegenerateRequest)
+
       const config = {
         url,
         method: 'POST',
         headers,
         data: isUpdateOrCreateRequest
-          ? getUpdateOrCreatePrompt(isRegenerateRequest)
+          ? promptData
           : {
               message: watchUserPrompt,
               history: chatHistory,
-              fake: true,
+              fake: false,
               chat_options: isUpdateOrCreateRequest ? 'create' : 'update',
             },
       }

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../resources/atoms'
 import { useApiCall } from '../../resources/hooks'
 import { calcTextAreaHeight } from '../../resources/utils'
+import { useTrackEvent } from '../../resources/hooks/useTrackEvent'
 import {
   STAGING_END_POINT,
   PROD_END_POINT,
@@ -44,7 +45,7 @@ import type {
   CreatePrompt,
   UpdatePrompt,
 } from '../../resources/types'
-import { useTrackEvent } from '../../resources/hooks/useTrackEvent'
+import type { ProtocolFile } from '@opentrons/shared-data'
 
 export function InputPrompt(): JSX.Element {
   const { t } = useTranslation('protocol_generator')
@@ -68,6 +69,12 @@ export function InputPrompt(): JSX.Element {
   const watchUserPrompt = watch('userPrompt') ?? ''
 
   const { data, isLoading, callApi } = useApiCall()
+
+  let pdProtocolContent: null | ProtocolFile = null
+  if (data != null && typeof data === 'object' && 'protocol_content' in data) {
+    pdProtocolContent = data.protocol_content as ProtocolFile
+  }
+
   const [requestId, setRequestId] = useState<string>(uuidv4())
 
   // This is to autofill the input field for when we navigate to the chat page from the existing/new protocol generator pages
@@ -123,16 +130,6 @@ export function InputPrompt(): JSX.Element {
         : getChatEndpoint()
 
       const promptData = getUpdateOrCreatePrompt(isRegenerateRequest)
-      // attach PD protocol as separate part of request, this is so the backend can pull out the PD protocol
-      // so we dont flood the LLM model with a million unnecessary tokens
-      let pd_protocol_content = null
-      if (
-        data != null &&
-        typeof data === 'object' &&
-        'protocol_content' in data
-      ) {
-        pd_protocol_content = data.protocol_content
-      }
 
       const config = {
         url,
@@ -145,7 +142,7 @@ export function InputPrompt(): JSX.Element {
               history: chatHistory,
               fake: false,
               chat_options: isUpdateOrCreateRequest ? 'create' : 'update',
-              pd_protocol_content,
+              pd_protocol_content: pdProtocolContent,
             },
       }
 

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -123,6 +123,16 @@ export function InputPrompt(): JSX.Element {
         : getChatEndpoint()
 
       const promptData = getUpdateOrCreatePrompt(isRegenerateRequest)
+      // attach PD protocol as separate part of request, this is so the backend can pull out the PD protocol
+      // so we dont flood the LLM model with a million unnecessary tokens
+      let pd_protocol_content = null
+      if (
+        data != null &&
+        typeof data === 'object' &&
+        'protocol_content' in data
+      ) {
+        pd_protocol_content = data.protocol_content
+      }
 
       const config = {
         url,
@@ -135,6 +145,7 @@ export function InputPrompt(): JSX.Element {
               history: chatHistory,
               fake: false,
               chat_options: isUpdateOrCreateRequest ? 'create' : 'update',
+              pd_protocol_content,
             },
       }
 

--- a/opentrons-ai-client/src/pages/CreateProtocol/index.tsx
+++ b/opentrons-ai-client/src/pages/CreateProtocol/index.tsx
@@ -107,7 +107,6 @@ export function CreateProtocol(): JSX.Element | null {
       liquids: [],
       steps: [],
       fake: false,
-      fake_id: 0,
     })
     setUpdateProtocolChatAtom({
       prompt: '',
@@ -116,7 +115,6 @@ export function CreateProtocol(): JSX.Element | null {
       update_type: 'adapt_python_protocol',
       update_details: '',
       fake: false,
-      fake_id: 0,
     })
     setChatHistoryAtom([])
     setChatData([])

--- a/opentrons-ai-client/src/pages/UpdateProtocol/index.tsx
+++ b/opentrons-ai-client/src/pages/UpdateProtocol/index.tsx
@@ -130,7 +130,6 @@ export function UpdateProtocol(): JSX.Element {
       liquids: [],
       steps: [],
       fake: false,
-      fake_id: 0,
     })
     setUpdateProtocolChatAtom({
       prompt: '',
@@ -139,7 +138,6 @@ export function UpdateProtocol(): JSX.Element {
       update_type: 'adapt_python_protocol',
       update_details: '',
       fake: false,
-      fake_id: 0,
     })
     setChatHistoryAtom([])
     setChatData([])
@@ -216,7 +214,6 @@ export function UpdateProtocol(): JSX.Element {
       update_type: (updateType?.value ?? 'other') as UpdateOptions,
       update_details: detailsValue,
       fake: false,
-      fake_id: 0,
     })
 
     trackEvent({

--- a/opentrons-ai-client/src/resources/atoms.ts
+++ b/opentrons-ai-client/src/resources/atoms.ts
@@ -27,7 +27,6 @@ export const createProtocolChatAtom = atom<CreatePrompt>({
   liquids: [],
   steps: [],
   fake: true,
-  fake_id: 0,
 })
 
 /** CreateProtocolChatAtom is for the prefilled userprompt when navigating to the chat page from Update Protocol page */
@@ -38,7 +37,6 @@ export const updateProtocolChatAtom = atom<UpdatePrompt>({
   update_type: 'adapt_python_protocol',
   update_details: '',
   fake: false,
-  fake_id: 0,
 })
 
 /** Regenerate protocol atom */

--- a/opentrons-ai-client/src/resources/types.ts
+++ b/opentrons-ai-client/src/resources/types.ts
@@ -1,3 +1,4 @@
+import type { ProtocolFile } from '@opentrons/shared-data'
 import type { FC } from 'react'
 
 /** assistant: ChatGPT API, user: user */
@@ -13,7 +14,7 @@ export interface ChatData {
   /** uuid to map the chat prompt request to the response from the LLM */
   requestId: string
   /** structured JSON protocol content */
-  protocol_content?: { [key: string]: any }
+  protocol_content?: ProtocolFile
 }
 
 export interface CreatePrompt {

--- a/opentrons-ai-client/src/resources/types.ts
+++ b/opentrons-ai-client/src/resources/types.ts
@@ -30,7 +30,6 @@ export interface CreatePrompt {
   liquids: string[]
   steps: string[]
   fake?: boolean
-  fake_id?: number
   fake_key?: string
 }
 
@@ -48,7 +47,6 @@ export interface UpdatePrompt {
   update_type: UpdateOptions
   update_details: string
   fake: boolean
-  fake_id: number
 }
 
 export interface Chat {

--- a/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
@@ -395,7 +395,6 @@ export function generateChatPrompt(
       values.protocol_format === 'Protocol Designer'
         ? 'pd serial diliution'
         : undefined,
-    fake_id: 0,
   })
 
   return prompt

--- a/opentrons-ai-server/api/domain/fixtures/PDSerialDilution.json
+++ b/opentrons-ai-server/api/domain/fixtures/PDSerialDilution.json
@@ -5,8 +5,8 @@
     "protocolName": "Serial-dilution-6",
     "author": "",
     "description": "",
-    "created": 1738265012908,
-    "lastModified": 1738266572975,
+    "created": 1745434920000,
+    "lastModified": 1745434920000,
     "category": null,
     "subcategory": null,
     "tags": []

--- a/opentrons-ai-server/api/domain/fixtures/PDSerialDilution.json
+++ b/opentrons-ai-server/api/domain/fixtures/PDSerialDilution.json
@@ -2,7 +2,7 @@
   "$otSharedSchema": "#/protocol/schemas/8",
   "schemaVersion": 8,
   "metadata": {
-    "protocolName": "Serial-dilution-6",
+    "protocolName": "Serial Dilution",
     "author": "",
     "description": "",
     "created": 1745434920000,

--- a/opentrons-ai-server/api/models/chat_request.py
+++ b/opentrons-ai-server/api/models/chat_request.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Literal, Optional
+from typing import Annotated, Any, Dict, List, Literal, Optional
 
 from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel, Field
@@ -34,4 +34,4 @@ class ChatRequest(BaseModel):
     fake: bool = Field(True, description="When set to true, the response will be a fake. OpenAI API is not used.")
     fake_key: FakeKeyType
     chat_options: ChatOptionType
-    json_protocol: Optional[str] = None
+    pd_protocol_content: Optional[Dict[str, Any]] = Field(None, description="PD protocol that was previously generated")

--- a/opentrons-ai-server/api/models/create_protocol.py
+++ b/opentrons-ai-server/api/models/create_protocol.py
@@ -16,5 +16,4 @@ class CreateProtocol(BaseModel):
     liquids: List[str] = Field(..., description="List of required liquids")
     steps: List[str] = Field(..., description="The steps of the protocol")
     fake: Optional[bool] = Field(False, description="Fake response?")
-    fake_id: Optional[int] = Field(..., description="type of response")
     fake_key: Optional[str] = None

--- a/opentrons-ai-server/api/models/update_protocol.py
+++ b/opentrons-ai-server/api/models/update_protocol.py
@@ -10,4 +10,4 @@ class UpdateProtocol(BaseModel):
     update_type: Literal["adapt_python_protocol", "change_labware", "change_pipettes", "other"] = Field(..., description="Type of update")
     update_details: str = Field(..., description="Details of the update")
     fake: Optional[bool] = Field(False, description="Fake response?")
-    fake_id: Optional[int] = Field(..., description="type of response")
+    fake_key: Optional[int] = Field(None, description="type of response")


### PR DESCRIPTION
# Overview

This PR:
1.  removes the `fake_id` key in the request payloads since they were not being used
2. stops stubbing responses from the backend on protocol chat completion requests
3. attaches the last generated PD protocol to the request body for chat completion requests

## Risk assessment

Low
