### PR TITLE
fix(app): fix OT-2 LPC Offset Summary table displaying incorrect values

### DIFF
--- a/app/src/organisms/LegacyLabwarePositionCheck/LegacyLabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/LegacyLabwarePositionCheckComponent.tsx
@@ -193,17 +193,14 @@ export const LegacyLabwarePositionCheckComponent = (
     { workingOffsets: [], tipPickUpOffset: null }
   )
 
-  const allWorkingOffsets = useMemo(() => {
+  const allAppliedOffsets = useMemo(() => {
     return workingOffsets.reduce<LegacyLabwareOffsetCreateData[]>(
-      (acc, { initialPosition, finalPosition, labwareId, location }) => {
+      (acc, { labwareId, location }) => {
         const definitionUri =
           protocolData?.labware.find(l => l.id === labwareId)?.definitionUri ??
           null
-        if (
-          finalPosition == null ||
-          initialPosition == null ||
-          definitionUri == null
-        ) {
+
+        if (definitionUri == null) {
           return acc
         }
 
@@ -213,11 +210,7 @@ export const LegacyLabwarePositionCheckComponent = (
             definitionUri,
             location
           )?.vector ?? IDENTITY_VECTOR
-        const vector = getVectorSum(
-          existingOffset,
-          getVectorDifference(finalPosition, initialPosition)
-        )
-        return [...acc, { definitionUri, location, vector }]
+        return [...acc, { definitionUri, location, vector: existingOffset }]
       },
       []
     )
@@ -471,7 +464,7 @@ export const LegacyLabwarePositionCheckComponent = (
       <ResultsSummary
         {...currentStep}
         protocolData={protocolData}
-        allAppliedOffsets={allWorkingOffsets}
+        allAppliedOffsets={allAppliedOffsets}
         onCloseClick={onCloseClick}
         {...{
           workingOffsets,


### PR DESCRIPTION
Closes [RQA-4126](https://opentrons.atlassian.net/browse/RQA-4126)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In the updated OT-2 LPC, the offsets we display in the offset summary view are no longer a summation of the existing offset + the "working" offset, because by the time the user gets to the summary view, the existing offset has been updated on the server. We only need to consider the existing offset now when showing these values. This was just a visual bug: we are sending the correct offset values to the server.

### Current Behavior

https://github.com/user-attachments/assets/66342c1b-6d04-4632-a845-b63699809051

### Fixed Behavior

https://github.com/user-attachments/assets/106980fe-d728-4ce7-9b4d-22dcc033f0e5

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

- See videos.

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the OT-2 LPC offset summary table displaying incorrect offset values.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4126]: https://opentrons.atlassian.net/browse/RQA-4126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ