### PR TITLE
docs(api): add 'internal only' docstrings to liquid classes based methods

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1556,7 +1556,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
 
-            :meta private:
+        :meta private:
         """
         if volume == 0.0:
             _log.info(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1528,6 +1528,8 @@ class InstrumentContext(publisher.CommandPublisher):
     ) -> InstrumentContext:
         """Move a particular type of liquid from one well or group of wells to another.
 
+        This is intended for Opentrons internal use only and is not a guaranteed API.
+
         :param liquid_class: The type of liquid to move. You must specify the liquid class,
             even if you have used :py:meth:`.Labware.load_liquid` to indicate what liquid the
             source contains.
@@ -1634,6 +1636,8 @@ class InstrumentContext(publisher.CommandPublisher):
     ) -> InstrumentContext:
         """
         Distribute a particular type of liquid from one well to a group of wells.
+
+        This is intended for Opentrons internal use only and is not a guaranteed API.
 
         :param liquid_class: The type of liquid to move. You must specify the liquid class,
             even if you have used :py:meth:`.Labware.load_liquid` to indicate what liquid the
@@ -1747,6 +1751,8 @@ class InstrumentContext(publisher.CommandPublisher):
     ) -> InstrumentContext:
         """
         Consolidate a particular type of liquid from a group of wells to one well.
+
+        This is intended for Opentrons internal use only and is not a guaranteed API.
 
         :param liquid_class: The type of liquid to move. You must specify the liquid class,
             even if you have used :py:meth:`.Labware.load_liquid` to indicate what liquid the

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1528,7 +1528,8 @@ class InstrumentContext(publisher.CommandPublisher):
     ) -> InstrumentContext:
         """Move a particular type of liquid from one well or group of wells to another.
 
-        This is intended for Opentrons internal use only and is not a guaranteed API.
+        ..
+            This is intended for Opentrons internal use only and is not a guaranteed API.
 
         :param liquid_class: The type of liquid to move. You must specify the liquid class,
             even if you have used :py:meth:`.Labware.load_liquid` to indicate what liquid the
@@ -1637,7 +1638,8 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Distribute a particular type of liquid from one well to a group of wells.
 
-        This is intended for Opentrons internal use only and is not a guaranteed API.
+        ..
+            This is intended for Opentrons internal use only and is not a guaranteed API.
 
         :param liquid_class: The type of liquid to move. You must specify the liquid class,
             even if you have used :py:meth:`.Labware.load_liquid` to indicate what liquid the
@@ -1661,7 +1663,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
 
-            :meta private:
+        :meta private:
         """
         if volume == 0.0:
             _log.info(
@@ -1752,7 +1754,8 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Consolidate a particular type of liquid from a group of wells to one well.
 
-        This is intended for Opentrons internal use only and is not a guaranteed API.
+        ..
+            This is intended for Opentrons internal use only and is not a guaranteed API.
 
         :param liquid_class: The type of liquid to move. You must specify the liquid class,
             even if you have used :py:meth:`.Labware.load_liquid` to indicate what liquid the
@@ -1776,7 +1779,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
 
-            :meta private:
+        :meta private:
         """
         if volume == 0.0:
             _log.info(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1365,6 +1365,8 @@ class ProtocolContext(CommandPublisher):
         Define a liquid class for use in the protocol.
 
         :meta private:
+
+        This is intended for Opentrons internal use only and is not a guaranteed API.
         """
         return self._core.define_liquid_class(name=name)
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1363,10 +1363,10 @@ class ProtocolContext(CommandPublisher):
     ) -> LiquidClass:
         """
         Define a liquid class for use in the protocol.
+        ..
+            This is intended for Opentrons internal use only and is not a guaranteed API.
 
         :meta private:
-
-        This is intended for Opentrons internal use only and is not a guaranteed API.
         """
         return self._core.define_liquid_class(name=name)
 


### PR DESCRIPTION
# Overview

Since we don't want to guarantee liquid classes API behavior in this release, we'll mention in the docstrings that they are for internal use only until we publicly release the feature.


## Risk assessment

None. Docs change only
