### PR TITLE
fix(protocol-designer): hardware page rerouting

### DIFF
--- a/protocol-designer/src/pages/Hardware/__tests__/Hardware.test.tsx
+++ b/protocol-designer/src/pages/Hardware/__tests__/Hardware.test.tsx
@@ -30,6 +30,7 @@ describe('Hardware', () => {
   beforeEach(() => {
     vi.mocked(getFileMetadata).mockReturnValue({
       protocolName: 'mockProtocolName',
+      created: 123,
     })
     vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
     vi.mocked(getAdditionalEquipmentEntities).mockReturnValue({})

--- a/protocol-designer/src/pages/Hardware/index.tsx
+++ b/protocol-designer/src/pages/Hardware/index.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux'
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -40,6 +41,16 @@ export function Hardware(): JSX.Element {
     fileMetadata.protocolName != null && fileMetadata.protocolName !== ''
       ? fileMetadata.protocolName
       : t('protocol_overview:untitled_protocol')
+
+  //  TODO: remove this when we do the routing refactor
+  useEffect(() => {
+    if (fileMetadata?.created == null) {
+      console.warn(
+        'fileMetadata was refreshed while on the hardware page, redirecting to landing page'
+      )
+      navigate('/')
+    }
+  }, [fileMetadata])
 
   return (
     <Flex


### PR DESCRIPTION
# Overview

Redirect back to the landing page if the redux tree is suddenly erased while on the hardware page. This avoids the empty state hardware page. 

Nick will be doing a large refactor of routing so this is a temp fix for the issue

## Test Plan and Hands on Testing

create a protocol and click on "edit" for the modules/hardware to get to the hardware page. Refresh and it should direct you back to the landing page

## Changelog

- add useEffect

## Risk assessment

low
