### PR TITLE
refactor(protocol-designer): order advanced settings chronologically

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DisposalField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DisposalField.tsx
@@ -23,10 +23,10 @@ interface DisposalFieldProps {
   propsForFields: FieldPropsByName
   stepType: StepType
   volume: string | null
+  mappedErrorsToField: Record<string, FormError>
   aspirate_airGap_checkbox?: boolean | null
   aspirate_airGap_volume?: string | null
   tipRack?: string | null
-  mappedErrorsToField: Record<string, FormError>
 }
 
 export function DisposalField(props: DisposalFieldProps): JSX.Element {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DisposalField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DisposalField.tsx
@@ -9,11 +9,12 @@ import {
   DropdownStepFormField,
   InputStepFormField,
 } from '../../../../../components/molecules'
-import { getBlowoutLocationOptionsForForm } from '../utils'
+import { getBlowoutLocationOptionsForForm, getFormLevelError } from '../utils'
 import { FlowRateField } from './FlowRateField'
 import { BlowoutOffsetField } from './BlowoutOffsetField'
 
 import type { PathOption, StepType } from '../../../../../form-types'
+import type { FormError } from '../../../../../steplist/formLevel/errors'
 import type { FieldPropsByName } from '../types'
 
 interface DisposalFieldProps {
@@ -25,6 +26,7 @@ interface DisposalFieldProps {
   aspirate_airGap_checkbox?: boolean | null
   aspirate_airGap_volume?: string | null
   tipRack?: string | null
+  mappedErrorsToField: Record<string, FormError>
 }
 
 export function DisposalField(props: DisposalFieldProps): JSX.Element {
@@ -37,6 +39,7 @@ export function DisposalField(props: DisposalFieldProps): JSX.Element {
     aspirate_airGap_checkbox,
     aspirate_airGap_volume,
     tipRack,
+    mappedErrorsToField,
   } = props
   const { t } = useTranslation(['application', 'form'])
 
@@ -88,6 +91,10 @@ export function DisposalField(props: DisposalFieldProps): JSX.Element {
           />
           <DropdownStepFormField
             {...propsForFields.blowout_location}
+            errorToShow={getFormLevelError(
+              'blowout_location',
+              mappedErrorsToField
+            )}
             options={disposalDestinationOptions}
             title={t('protocol_steps:blowout_location')}
             padding="0"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -411,46 +411,34 @@ export const SecondStepsMoveLiquidTools = ({
               tooltipContent={propsForFields.preWetTip.tooltipContent ?? null}
             />
           ) : null}
-          {tab === 'dispense' && formData.path === 'multiDispense' ? (
-            <>
-              <CheckboxExpandStepFormField
-                title={t('form:step_edit_form.field.conditioning.title')}
-                fieldProps={propsForFields.conditioning_checkbox}
-              >
-                {formData.conditioning_checkbox === true ? (
-                  <InputStepFormField
-                    title={t(
-                      'form:step_edit_form.field.conditioning.conditioning_volume.label'
-                    )}
-                    caption={t(
-                      'form:step_edit_form.field.conditioning.conditioning_volume.caption',
-                      { min: 0, max: maxConditioningVolume }
-                    )}
-                    padding="0"
-                    {...propsForFields.conditioning_volume}
-                    showTooltip={false}
-                    errorToShow={getFormLevelError(
-                      'conditioning_volume',
-                      mappedErrorsToField
-                    )}
-                  />
-                ) : null}
-              </CheckboxExpandStepFormField>
-              <DisposalField
-                aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
-                aspirate_airGap_volume={formData.aspirate_airGap_volume}
-                path={formData.path}
-                pipette={formData.pipette}
-                propsForFields={propsForFields}
-                stepType={formData.stepType}
-                volume={formData.volume}
-                mappedErrorsToField={mappedErrorsToField}
-              />
-            </>
-          ) : null}
           {tab === 'aspirate' ? (
             <>
               {mixComponent}
+              {formData.path === 'multiDispense' ? (
+                <CheckboxExpandStepFormField
+                  title={t('form:step_edit_form.field.conditioning.title')}
+                  fieldProps={propsForFields.conditioning_checkbox}
+                >
+                  {formData.conditioning_checkbox === true ? (
+                    <InputStepFormField
+                      title={t(
+                        'form:step_edit_form.field.conditioning.conditioning_volume.label'
+                      )}
+                      caption={t(
+                        'form:step_edit_form.field.conditioning.conditioning_volume.caption',
+                        { min: 0, max: maxConditioningVolume }
+                      )}
+                      padding="0"
+                      {...propsForFields.conditioning_volume}
+                      showTooltip={false}
+                      errorToShow={getFormLevelError(
+                        'conditioning_volume',
+                        mappedErrorsToField
+                      )}
+                    />
+                  ) : null}
+                </CheckboxExpandStepFormField>
+              ) : null}
               {delayComponent}
             </>
           ) : (
@@ -527,6 +515,18 @@ export const SecondStepsMoveLiquidTools = ({
                   </Flex>
                 ) : null}
               </CheckboxExpandStepFormField>
+              {formData.path === 'multiDispense' ? (
+                <DisposalField
+                  aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
+                  aspirate_airGap_volume={formData.aspirate_airGap_volume}
+                  path={formData.path}
+                  pipette={formData.pipette}
+                  propsForFields={propsForFields}
+                  stepType={formData.stepType}
+                  volume={formData.volume}
+                  mappedErrorsToField={mappedErrorsToField}
+                />
+              ) : null}
             </>
           )}
           <CheckboxExpandStepFormField

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -202,6 +202,79 @@ export const SecondStepsMoveLiquidTools = ({
     }
   }
 
+  const delayComponent = (
+    <CheckboxExpandStepFormField
+      title={i18n.format(
+        t('form:step_edit_form.field.delay.label'),
+        'capitalize'
+      )}
+      fieldProps={propsForFields[`${tab}_delay_checkbox`]}
+    >
+      {formData[`${tab}_delay_checkbox`] === true ? (
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          gridGap={SPACING.spacing6}
+          width="100^"
+        >
+          <InputStepFormField
+            showTooltip={false}
+            padding="0"
+            title={t('protocol_steps:delay_duration')}
+            {...propsForFields[`${tab}_delay_seconds`]}
+            units={t('application:units.seconds')}
+            errorToShow={getFormLevelError(
+              `${tab}_delay_seconds`,
+              mappedErrorsToField
+            )}
+          />
+        </Flex>
+      ) : null}
+    </CheckboxExpandStepFormField>
+  )
+  const mixComponent = (
+    <CheckboxExpandStepFormField
+      title={i18n.format(
+        t('form:step_edit_form.field.mix.label'),
+        'capitalize'
+      )}
+      fieldProps={propsForFields[`${tab}_mix_checkbox`]}
+      tooltipOverride={
+        tab === 'dispense' ? dispenseMixDisabledTooltipText : null
+      }
+    >
+      {formData[`${tab}_mix_checkbox`] === true ? (
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          gridGap={SPACING.spacing6}
+          width="100^"
+        >
+          <InputStepFormField
+            showTooltip={false}
+            padding="0"
+            title={t('protocol_steps:mix_volume')}
+            {...propsForFields[`${tab}_mix_volume`]}
+            units={t('application:units.microliter')}
+            errorToShow={getFormLevelError(
+              `${tab}_mix_volume`,
+              mappedErrorsToField
+            )}
+          />
+          <InputStepFormField
+            showTooltip={false}
+            padding="0"
+            title={t('protocol_steps:mix_times')}
+            {...propsForFields[`${tab}_mix_times`]}
+            units={t('application:units.times')}
+            errorToShow={getFormLevelError(
+              `${tab}_mix_times`,
+              mappedErrorsToField
+            )}
+          />
+        </Flex>
+      ) : null}
+    </CheckboxExpandStepFormField>
+  )
+
   return (
     <>
       {showResetModal ? (
@@ -338,169 +411,124 @@ export const SecondStepsMoveLiquidTools = ({
               tooltipContent={propsForFields.preWetTip.tooltipContent ?? null}
             />
           ) : null}
-          <CheckboxExpandStepFormField
-            title={i18n.format(
-              t('form:step_edit_form.field.mix.label'),
-              'capitalize'
-            )}
-            fieldProps={propsForFields[`${tab}_mix_checkbox`]}
-            tooltipOverride={
-              tab === 'dispense' ? dispenseMixDisabledTooltipText : null
-            }
-          >
-            {formData[`${tab}_mix_checkbox`] === true ? (
-              <Flex
-                flexDirection={DIRECTION_COLUMN}
-                gridGap={SPACING.spacing6}
-                width="100^"
-              >
-                <InputStepFormField
-                  showTooltip={false}
-                  padding="0"
-                  title={t('protocol_steps:mix_volume')}
-                  {...propsForFields[`${tab}_mix_volume`]}
-                  units={t('application:units.microliter')}
-                  errorToShow={getFormLevelError(
-                    `${tab}_mix_volume`,
-                    mappedErrorsToField
-                  )}
-                />
-                <InputStepFormField
-                  showTooltip={false}
-                  padding="0"
-                  title={t('protocol_steps:mix_times')}
-                  {...propsForFields[`${tab}_mix_times`]}
-                  units={t('application:units.times')}
-                  errorToShow={getFormLevelError(
-                    `${tab}_mix_times`,
-                    mappedErrorsToField
-                  )}
-                />
-              </Flex>
-            ) : null}
-          </CheckboxExpandStepFormField>
-          {tab === 'dispense' ? (
-            <CheckboxExpandStepFormField
-              title={i18n.format(
-                t('form:step_edit_form.field.pushOut.title'),
-                'capitalize'
-              )}
-              fieldProps={propsForFields.pushOut_checkbox}
-            >
-              {formData.pushOut_checkbox === true ? (
-                <InputStepFormField
-                  showTooltip={false}
-                  padding="0"
-                  title={t(
-                    'form:step_edit_form.field.pushOut.pushOut_volume.label'
-                  )}
-                  caption={t(
-                    'form:step_edit_form.field.pushOut.pushOut_volume.caption',
-                    { min: 0, max: maxPushoutVolume }
-                  )}
-                  {...propsForFields.pushOut_volume}
-                  units={t('application:units.microliter')}
-                  errorToShow={getFormLevelError(
-                    'pushOut_volume',
-                    mappedErrorsToField
-                  )}
-                />
-              ) : null}
-            </CheckboxExpandStepFormField>
-          ) : null}
-          <CheckboxExpandStepFormField
-            title={i18n.format(
-              t('form:step_edit_form.field.delay.label'),
-              'capitalize'
-            )}
-            fieldProps={propsForFields[`${tab}_delay_checkbox`]}
-          >
-            {formData[`${tab}_delay_checkbox`] === true ? (
-              <Flex
-                flexDirection={DIRECTION_COLUMN}
-                gridGap={SPACING.spacing6}
-                width="100^"
-              >
-                <InputStepFormField
-                  showTooltip={false}
-                  padding="0"
-                  title={t('protocol_steps:delay_duration')}
-                  {...propsForFields[`${tab}_delay_seconds`]}
-                  units={t('application:units.seconds')}
-                  errorToShow={getFormLevelError(
-                    `${tab}_delay_seconds`,
-                    mappedErrorsToField
-                  )}
-                />
-              </Flex>
-            ) : null}
-          </CheckboxExpandStepFormField>
           {tab === 'dispense' && formData.path === 'multiDispense' ? (
-            <CheckboxExpandStepFormField
-              title={t('form:step_edit_form.field.conditioning.title')}
-              fieldProps={propsForFields.conditioning_checkbox}
-            >
-              {formData.conditioning_checkbox === true ? (
-                <InputStepFormField
-                  title={t(
-                    'form:step_edit_form.field.conditioning.conditioning_volume.label'
-                  )}
-                  caption={t(
-                    'form:step_edit_form.field.conditioning.conditioning_volume.caption',
-                    { min: 0, max: maxConditioningVolume }
-                  )}
-                  padding="0"
-                  {...propsForFields.conditioning_volume}
-                  showTooltip={false}
-                  errorToShow={getFormLevelError(
-                    'conditioning_volume',
-                    mappedErrorsToField
-                  )}
-                />
-              ) : null}
-            </CheckboxExpandStepFormField>
-          ) : null}
-          {tab === 'dispense' ? (
-            <CheckboxExpandStepFormField
-              title={i18n.format(
-                t('form:step_edit_form.field.blowout.label'),
-                'capitalize'
-              )}
-              fieldProps={propsForFields.blowout_checkbox}
-            >
-              {formData.blowout_checkbox === true ? (
-                <Flex
-                  flexDirection={DIRECTION_COLUMN}
-                  gridGap={SPACING.spacing6}
-                  width="100^"
-                >
-                  <BlowoutLocationField
-                    {...propsForFields.blowout_location}
-                    options={getBlowoutLocationOptionsForForm({
-                      path: formData.path,
-                      stepType: formData.stepType,
-                    })}
+            <>
+              <CheckboxExpandStepFormField
+                title={t('form:step_edit_form.field.conditioning.title')}
+                fieldProps={propsForFields.conditioning_checkbox}
+              >
+                {formData.conditioning_checkbox === true ? (
+                  <InputStepFormField
+                    title={t(
+                      'form:step_edit_form.field.conditioning.conditioning_volume.label'
+                    )}
+                    caption={t(
+                      'form:step_edit_form.field.conditioning.conditioning_volume.caption',
+                      { min: 0, max: maxConditioningVolume }
+                    )}
                     padding="0"
+                    {...propsForFields.conditioning_volume}
+                    showTooltip={false}
+                    errorToShow={getFormLevelError(
+                      'conditioning_volume',
+                      mappedErrorsToField
+                    )}
                   />
-                  <FlowRateField
-                    key="blowout_flowRate"
-                    {...propsForFields.blowout_flowRate}
-                    pipetteId={formData.pipette}
-                    flowRateType="blowout"
-                    volume={propsForFields.volume?.value ?? 0}
-                    tiprack={propsForFields.tipRack.value}
-                    padding="0"
-                  />
-                  <BlowoutOffsetField
-                    {...propsForFields.blowout_z_offset}
-                    sourceLabwareId={propsForFields.aspirate_labware.value}
-                    destLabwareId={propsForFields.dispense_labware.value}
-                    blowoutLabwareId={propsForFields.blowout_location.value}
-                  />
-                </Flex>
-              ) : null}
-            </CheckboxExpandStepFormField>
+                ) : null}
+              </CheckboxExpandStepFormField>
+              <DisposalField
+                aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
+                aspirate_airGap_volume={formData.aspirate_airGap_volume}
+                path={formData.path}
+                pipette={formData.pipette}
+                propsForFields={propsForFields}
+                stepType={formData.stepType}
+                volume={formData.volume}
+                mappedErrorsToField={mappedErrorsToField}
+              />
+            </>
           ) : null}
+          {tab === 'aspirate' ? (
+            <>
+              {mixComponent}
+              {delayComponent}
+            </>
+          ) : (
+            <>
+              {delayComponent}
+              {mixComponent}
+              <CheckboxExpandStepFormField
+                title={i18n.format(
+                  t('form:step_edit_form.field.pushOut.title'),
+                  'capitalize'
+                )}
+                fieldProps={propsForFields.pushOut_checkbox}
+              >
+                {formData.pushOut_checkbox === true ? (
+                  <InputStepFormField
+                    showTooltip={false}
+                    padding="0"
+                    title={t(
+                      'form:step_edit_form.field.pushOut.pushOut_volume.label'
+                    )}
+                    caption={t(
+                      'form:step_edit_form.field.pushOut.pushOut_volume.caption',
+                      { min: 0, max: maxPushoutVolume }
+                    )}
+                    {...propsForFields.pushOut_volume}
+                    units={t('application:units.microliter')}
+                    errorToShow={getFormLevelError(
+                      'pushOut_volume',
+                      mappedErrorsToField
+                    )}
+                  />
+                ) : null}
+              </CheckboxExpandStepFormField>
+              <CheckboxExpandStepFormField
+                title={i18n.format(
+                  t('form:step_edit_form.field.blowout.label'),
+                  'capitalize'
+                )}
+                fieldProps={propsForFields.blowout_checkbox}
+              >
+                {formData.blowout_checkbox === true ? (
+                  <Flex
+                    flexDirection={DIRECTION_COLUMN}
+                    gridGap={SPACING.spacing6}
+                    width="100^"
+                  >
+                    <BlowoutLocationField
+                      {...propsForFields.blowout_location}
+                      options={getBlowoutLocationOptionsForForm({
+                        path: formData.path,
+                        stepType: formData.stepType,
+                      })}
+                      errorToShow={getFormLevelError(
+                        'blowout_location',
+                        mappedErrorsToField
+                      )}
+                      padding="0"
+                    />
+                    <FlowRateField
+                      key="blowout_flowRate"
+                      {...propsForFields.blowout_flowRate}
+                      pipetteId={formData.pipette}
+                      flowRateType="blowout"
+                      volume={propsForFields.volume?.value ?? 0}
+                      tiprack={propsForFields.tipRack.value}
+                      padding="0"
+                    />
+                    <BlowoutOffsetField
+                      {...propsForFields.blowout_z_offset}
+                      sourceLabwareId={propsForFields.aspirate_labware.value}
+                      destLabwareId={propsForFields.dispense_labware.value}
+                      blowoutLabwareId={propsForFields.blowout_location.value}
+                    />
+                  </Flex>
+                ) : null}
+              </CheckboxExpandStepFormField>
+            </>
+          )}
           <CheckboxExpandStepFormField
             title={i18n.format(
               t('form:step_edit_form.field.touchTip.label'),
@@ -583,17 +611,6 @@ export const SecondStepsMoveLiquidTools = ({
               />
             ) : null}
           </CheckboxExpandStepFormField>
-          {formData.path === 'multiDispense' && tab === 'dispense' && (
-            <DisposalField
-              aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
-              aspirate_airGap_volume={formData.aspirate_airGap_volume}
-              path={formData.path}
-              pipette={formData.pipette}
-              propsForFields={propsForFields}
-              stepType={formData.stepType}
-              volume={formData.volume}
-            />
-          )}
         </Flex>
         {enableLiquidClasses ? (
           <ResetSettingsField

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -377,7 +377,7 @@ const DISPENSE_AIRGAP_VOLUME_REQUIRED: FormError = {
   tab: 'dispense',
 }
 const BLOWOUT_LOCATION_REQUIRED: FormError = {
-  title: 'Volume required',
+  title: 'Blowout location required',
   dependentFields: ['blowout_checkbox', 'blowout_location'],
   showAtForm: false,
   showAtField: true,
@@ -962,7 +962,11 @@ export const blowoutLocationRequired = (
   fields: HydratedMixFormData | HydratedMoveLiquidFormData
 ): FormError | null => {
   const { blowout_checkbox, blowout_location } = fields
-  return blowout_checkbox && !blowout_location
+  const isDisposalChecked =
+    'disposalVolume_checkbox' in fields && 'path' in fields
+      ? fields.disposalVolume_checkbox && fields.path === 'multiDispense'
+      : false
+  return (blowout_checkbox || isDisposalChecked) && blowout_location == null
     ? BLOWOUT_LOCATION_REQUIRED
     : null
 }

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -377,7 +377,7 @@ const DISPENSE_AIRGAP_VOLUME_REQUIRED: FormError = {
   tab: 'dispense',
 }
 const BLOWOUT_LOCATION_REQUIRED: FormError = {
-  title: 'Blowout location required',
+  title: 'Volume required',
   dependentFields: ['blowout_checkbox', 'blowout_location'],
   showAtForm: false,
   showAtField: true,
@@ -962,11 +962,7 @@ export const blowoutLocationRequired = (
   fields: HydratedMixFormData | HydratedMoveLiquidFormData
 ): FormError | null => {
   const { blowout_checkbox, blowout_location } = fields
-  const isDisposalChecked =
-    'disposalVolume_checkbox' in fields && 'path' in fields
-      ? fields.disposalVolume_checkbox && fields.path === 'multiDispense'
-      : false
-  return (blowout_checkbox || isDisposalChecked) && blowout_location == null
+  return blowout_checkbox && !blowout_location
     ? BLOWOUT_LOCATION_REQUIRED
     : null
 }


### PR DESCRIPTION
# Overview

Reorder aspirate, dispense, and multiDispense advanced settings on moveLiquid tools according to their chronological execution in step-generation.

Also, fix and wire up `blowoutLocationRequired` form-level error. Check dipsosal volume checkbox in addition to blowout checkbox if needed in blowoutLocationRequired error

Closes [AUTH-1656](https://opentrons.atlassian.net/browse/AUTH-1656)

## Test Plan and Hands on Testing

- create or open a transfer step form ([example protocol](https://github.com/user-attachments/files/19851566/master.json))
- with path set to 'Single path', navigate to advanced settings
- verify that aspirate and dispense tab advanced settings order match that of designs
- change path to 'Distribute path' and verify that verify dispense tab advanced settings order match that of designs

## Changelog

- update ordering of advanced settings to match that of designs
- fix blowout error silent failure bug

## Review requests

- see test plan

## Risk assessment

low

[AUTH-1656]: https://opentrons.atlassian.net/browse/AUTH-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ