### PR TITLE
feat(api): allow height and volume calculations from protocols

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -210,3 +210,19 @@ class WellCore(AbstractWellCore):
         return self._engine_client.state.geometry.get_current_well_volume(
             labware_id=labware_id, well_name=well_name
         )
+
+    def height_from_volume(self, volume: LiquidTrackingType) -> LiquidTrackingType:
+        """Return the height in a well corresponding to a given volume."""
+        labware_id = self.labware_id
+        well_name = self._name
+        return self._engine_client.state.geometry.get_well_height_at_volume(
+            labware_id=labware_id, well_name=well_name, volume=volume
+        )
+
+    def volume_from_height(self, height: LiquidTrackingType) -> LiquidTrackingType:
+        """Return the volume contained in a well at any height."""
+        labware_id = self.labware_id
+        well_name = self._name
+        return self._engine_client.state.geometry.get_well_volume_at_height(
+            labware_id=labware_id, well_name=well_name, height=height
+        )

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_well_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_well_core.py
@@ -142,6 +142,14 @@ class LegacyWellCore(AbstractWellCore):
         """Get the current well volume."""
         return 0.0
 
+    def height_from_volume(self, volume: LiquidTrackingType) -> LiquidTrackingType:
+        """Return the height in a well corresponding to a given volume."""
+        return 0.0
+
+    def volume_from_height(self, height: LiquidTrackingType) -> LiquidTrackingType:
+        """Return the volume contained in a well at any height."""
+        return 0.0
+
     # TODO(mc, 2022-10-28): is this used and/or necessary?
     def __repr__(self) -> str:
         """Use the well's display name as its repr."""

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -103,5 +103,13 @@ class AbstractWellCore(ABC):
     def get_liquid_volume(self) -> LiquidTrackingType:
         """Get the current volume within a well."""
 
+    @abstractmethod
+    def height_from_volume(self, volume: LiquidTrackingType) -> LiquidTrackingType:
+        """Return the height in a well corresponding to a given volume."""
+
+    @abstractmethod
+    def volume_from_height(self, height: LiquidTrackingType) -> LiquidTrackingType:
+        """Return the volume contained in a well at any height."""
+
 
 WellCoreType = TypeVar("WellCoreType", bound=AbstractWellCore)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -346,6 +346,16 @@ class Well:
         return self._core.get_liquid_volume()
 
     @requires_version(2, 21)
+    def volume_from_height(self, height: LiquidTrackingType) -> LiquidTrackingType:
+        """Return the volume contained in a well at any height."""
+        return self._core.volume_from_height(height)
+
+    @requires_version(2, 21)
+    def height_from_volume(self, volume: LiquidTrackingType) -> LiquidTrackingType:
+        """Return the height in a well corresponding to a given volume."""
+        return self._core.height_from_volume(volume)
+
+    @requires_version(2, 21)
     def estimate_liquid_height_after_pipetting(
         self,
         operation_volume: float,


### PR DESCRIPTION
## Overview
Per hw testing feedback, it would be cool and useful if you calculate well heights from volumes and vice versa, so you could do something like:

- find a liquid height using `liquid_probe`
- get the current volume with `well.current_liquid_volume`
- determine the volume with `current_liquid_height`
- decide based on this what volume to aspirate/dispense
- look ahead to print out/log/look at the projected heights

This enables that from a protocol