### PR TITLE
chore(api): lint API doc example protocol files

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -124,12 +124,12 @@ test-ot2:
 .PHONY: lint
 lint:
 	$(python) -m mypy src tests
-	$(python) -m black --check src tests setup.py
-	$(python) -m flake8 src tests setup.py
+	$(python) -m black --check src tests docs/v2/example_protocols setup.py
+	$(python) -m flake8 src tests docs/v2/example_protocols setup.py
 
 .PHONY: format
 format:
-	$(python) -m black src tests setup.py
+	$(python) -m black src tests docs/v2/example_protocols setup.py
 
 docs/build/html/v%: docs/v%
 	$(sphinx_build) -b html -d docs/build/doctrees -n $< $@

--- a/api/Makefile
+++ b/api/Makefile
@@ -125,7 +125,7 @@ test-ot2:
 lint:
 	$(python) -m mypy src tests
 	$(python) -m black --check src tests docs/v2/example_protocols setup.py
-	$(python) -m flake8 src tests docs/v2/example_protocols setup.py
+	$(python) -m flake8 src tests setup.py
 
 .PHONY: format
 format:

--- a/api/docs/v2/example_protocols/dilution_tutorial.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial.py
@@ -8,26 +8,29 @@ metadata = {
                    https://docs.opentrons.com/v2/tutorial.html. It takes a
                    solution and progressively dilutes it by transferring it
                    stepwise across a plate.""",
-    "author": "New API User"
-    }
+    "author": "New API User",
+}
+
 
 def run(protocol: protocol_api.ProtocolContext):
-	tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
-	reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
-	plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
-	left_pipette = protocol.load_instrument("p300_single_gen2", "left", tip_racks=[tips])
+    tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+    reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
+    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
+    left_pipette = protocol.load_instrument(
+        "p300_single_gen2", "left", tip_racks=[tips]
+    )
 
-	# distribute diluent
-	left_pipette.transfer(100, reservoir["A1"], plate.wells())
+    # distribute diluent
+    left_pipette.transfer(100, reservoir["A1"], plate.wells())
 
-	# loop through each row
-	for i in range(8):
+    # loop through each row
+    for i in range(8):
 
-		# save the destination row to a variable
-		row = plate.rows()[i]
+        # save the destination row to a variable
+        row = plate.rows()[i]
 
-		# transfer solution to first well in column
-		left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
+        # transfer solution to first well in column
+        left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
 
-		# dilute the sample down the row
-		left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))
+        # dilute the sample down the row
+        left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))

--- a/api/docs/v2/example_protocols/dilution_tutorial_flex.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_flex.py
@@ -7,20 +7,20 @@ metadata = {
                    https://docs.opentrons.com/v2/tutorial.html. It takes a
                    solution and progressively dilutes it by transferring it
                    stepwise across a plate.""",
-    "author": "New API User"
-    }
-    
-requirements = {
-    "robotType": "Flex",
-    "apiLevel": "2.16"
-    }
+    "author": "New API User",
+}
+
+requirements = {"robotType": "Flex", "apiLevel": "2.16"}
+
 
 def run(protocol: protocol_api.ProtocolContext):
     tips = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
     reservoir = protocol.load_labware("nest_12_reservoir_15ml", "D2")
     plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D3")
     trash = protocol.load_trash_bin("A3")
-    left_pipette = protocol.load_instrument("flex_1channel_1000", "left", tip_racks=[tips])
+    left_pipette = protocol.load_instrument(
+        "flex_1channel_1000", "left", tip_racks=[tips]
+    )
 
     # distribute diluent
     left_pipette.transfer(100, reservoir["A1"], plate.wells())

--- a/api/docs/v2/example_protocols/dilution_tutorial_multi.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_multi.py
@@ -8,25 +8,28 @@ metadata = {
                    https://docs.opentrons.com/v2/tutorial.html. It takes a
                    solution and progressively dilutes it by transferring it
                    stepwise across a plate.""",
-    "author": "New API User"
-    }
-    
+    "author": "New API User",
+}
+
+
 def run(protocol: protocol_api.ProtocolContext):
-	tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
-	reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
-	plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
-	left_pipette = protocol.load_instrument("p300_multi_gen2", "right", tip_racks=[tips])
+    tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+    reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
+    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
+    left_pipette = protocol.load_instrument(
+        "p300_multi_gen2", "right", tip_racks=[tips]
+    )
 
-	# distribute diluent
-	left_pipette.transfer(100, reservoir["A1"], plate.rows()[0])  
+    # distribute diluent
+    left_pipette.transfer(100, reservoir["A1"], plate.rows()[0])
 
-	# no loop, 8-channel pipette
+    # no loop, 8-channel pipette
 
-	# save the destination row to a variable
-	row = plate.rows()[0]
+    # save the destination row to a variable
+    row = plate.rows()[0]
 
-	# transfer solution to first well in column
-	left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
+    # transfer solution to first well in column
+    left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
 
-	# dilute the sample down the row
-	left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))
+    # dilute the sample down the row
+    left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))

--- a/api/docs/v2/example_protocols/dilution_tutorial_multi_flex.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_multi_flex.py
@@ -7,23 +7,23 @@ metadata = {
                    https://docs.opentrons.com/v2/tutorial.html. It takes a
                    solution and progressively dilutes it by transferring it
                    stepwise across a plate.""",
-    "author": "New API User"
-    }
+    "author": "New API User",
+}
 
-requirements = {
-    "robotType": "Flex",
-    "apiLevel": "2.16"
-    }
-    
+requirements = {"robotType": "Flex", "apiLevel": "2.16"}
+
+
 def run(protocol: protocol_api.ProtocolContext):
     tips = protocol.load_labware("opentrons_96_tiprack_300ul", "D1")
     reservoir = protocol.load_labware("nest_12_reservoir_15ml", "D2")
     plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D3")
     trash = protocol.load_trash_bin("A3")
-    left_pipette = protocol.load_instrument("flex_8channel_1000", "right", tip_racks=[tips])
+    left_pipette = protocol.load_instrument(
+        "flex_8channel_1000", "right", tip_racks=[tips]
+    )
 
     # distribute diluent
-    left_pipette.transfer(100, reservoir["A1"], plate.rows()[0])  
+    left_pipette.transfer(100, reservoir["A1"], plate.rows()[0])
 
     # no loop, 8-channel pipette
 


### PR DESCRIPTION
# Overview

Lint the Python protocol files distributed as part of the v2 API docs. Addresses RTC-137. 

## Test Plan and Hands on Testing

1. Add `docs/v2/example_protocols` to the `black` command `make -C api lint` and `make -C api format`. Was going to add it to `flake` as well, but these files deliberately violate some `flake` rules, like never explicitly referring back to the trash bin but definitely requiring one to pass analysis.
2. Everything should fail because I formatted these files with tabs like a heathen.
3. Run `format` and hopefully everything works.

## Changelog

- [x] Update Makefile
- [x] Update Python protocols to pass new lint

## Review requests

Cool cool?

## Risk assessment

v low, shouldn't introduce any CI failures unless the example protocols are modified