### PR TITLE
refactor(protocol-designer): fix glitching and off-deck view

### DIFF
--- a/protocol-designer/src/components/organisms/LiquidsOverflowMenu/__tests__/LiquidsOverflowMenu.test.tsx
+++ b/protocol-designer/src/components/organisms/LiquidsOverflowMenu/__tests__/LiquidsOverflowMenu.test.tsx
@@ -5,6 +5,7 @@ import { i18n } from '../../../../assets/localization'
 import { getLiquidEntities } from '../../../../step-forms/selectors'
 import * as labwareIngredActions from '../../../../labware-ingred/actions'
 import { renderWithProviders } from '../../../../__testing-utils__'
+import { selectors } from '../../../../labware-ingred/selectors'
 import { LiquidsOverflowMenu } from '..'
 
 import type { ComponentProps } from 'react'
@@ -38,6 +39,10 @@ describe('SlotOverflowMenu', () => {
       showLiquidsModal: vi.fn(),
       overflowWrapperRef: createRef(),
     }
+    vi.mocked(selectors.getZoomedInSlot).mockReturnValue({
+      slot: null,
+      cutout: null,
+    })
     vi.mocked(getLiquidEntities).mockReturnValue({
       '0': {
         displayColor: 'mockColor',

--- a/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
@@ -19,6 +19,7 @@ import {
   StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { selectors } from '../../../labware-ingred/selectors'
 import { LINE_CLAMP_TEXT_STYLE, NAV_BAR_HEIGHT_REM } from '../../atoms'
 import {
   getLiquidEntities,
@@ -44,16 +45,19 @@ export function LiquidsOverflowMenu(
   const { t } = useTranslation(['starting_deck_state'])
   const liquids = useSelector(getLiquidEntities)
   const dispatch: ThunkDispatch<any> = useDispatch()
+  const zoomIn = useSelector(selectors.getZoomedInSlot)
 
+  let right: string = SPACING.spacing12
+  if (formData != null || location.pathname === '/liquids') {
+    right = '23.4rem'
+  } else if (zoomIn?.slot === 'offDeck') {
+    right = '24.75rem'
+  }
   return (
     <Flex
       position={POSITION_ABSOLUTE}
       zIndex={12}
-      right={
-        formData != null || location.pathname === '/liquids'
-          ? '23.4rem'
-          : SPACING.spacing12
-      }
+      right={right}
       top={`calc(${NAV_BAR_HEIGHT_REM}rem + 3.1rem)`}
       ref={overflowWrapperRef}
       borderRadius={BORDERS.borderRadius8}

--- a/protocol-designer/src/pages/Designer/OffDeck/OffDeckDetails.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/OffDeckDetails.tsx
@@ -58,144 +58,143 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
   const allWellContentsForActiveItem = useSelector(
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
-  const containerWidth = '75vw'
-
-  const stepDetailsContainerWidth = `calc(((${containerWidth} - ${OFF_DECK_MAP_WIDTH}) / 2) - (${SPACING.spacing24}  * 3))`
-  const paddingRight = `calc((100% - ${OFF_DECK_MAP_WIDTH}) / 2)`
 
   return (
-    <Flex
-      backgroundColor={COLORS.white}
-      borderRadius={BORDERS.borderRadius12}
-      width="100%"
-      height="100%"
-      padding={`${SPACING.spacing40} ${paddingRight} ${SPACING.spacing40} 0`}
-      gridGap={SPACING.spacing24}
-      alignItems={ALIGN_CENTER}
-      justifyContent={JUSTIFY_FLEX_END}
-    >
-      {hoverSlot != null ? (
-        <Flex width={stepDetailsContainerWidth} height="6.25rem">
+    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing20}>
+      <Flex
+        backgroundColor={COLORS.white}
+        borderRadius={BORDERS.borderRadius12}
+        width="100%"
+        height="100%"
+        padding={`${SPACING.spacing40} ${SPACING.spacing40} 0 ${SPACING.spacing40}`}
+        gridGap={SPACING.spacing24}
+        alignItems={ALIGN_CENTER}
+        justifyContent={JUSTIFY_FLEX_END}
+      >
+        <Flex
+          flex="0 0 auto"
+          width={OFF_DECK_MAP_WIDTH}
+          height="100%"
+          maxHeight={OFF_DECK_MAP_HEIGHT_FOR_STEP}
+          minHeight={OFF_DECK_MAP_HEIGHT_FOR_STEP}
+          alignItems={ALIGN_CENTER}
+          borderRadius={SPACING.spacing12}
+          padding={`${SPACING.spacing16} ${SPACING.spacing40}`}
+          backgroundColor={COLORS.grey20}
+          overflowY={OVERFLOW_AUTO}
+          flexDirection={DIRECTION_COLUMN}
+          gridGap={SPACING.spacing40}
+        >
+          <Flex
+            justifyContent={JUSTIFY_CENTER}
+            width="100%"
+            color={COLORS.grey60}
+          >
+            <StyledText desktopStyle="bodyDefaultSemiBold">
+              {i18n.format(t('off_deck_labware'), 'upperCase')}
+            </StyledText>
+          </Flex>
+          <LabwareWrapper>
+            {terminalItemId === START_TERMINAL_ITEM_ID ? (
+              <Flex width="9.5625rem" height="6.375rem">
+                <EmptySelectorButton
+                  onClick={addLabware}
+                  text={t('add_labware')}
+                  textAlignment="middle"
+                  iconName="plus"
+                />
+              </Flex>
+            ) : null}
+            {offDeckLabware.map(lw => {
+              const wellContents = allWellContentsForActiveItem
+                ? allWellContentsForActiveItem[lw.id]
+                : null
+              const definition = lw.def
+              const { dimensions } = definition
+              const xyzDimensions = {
+                xDimension: dimensions.xDimension ?? 0,
+                yDimension: dimensions.yDimension ?? 0,
+                zDimension: dimensions.zDimension ?? 0,
+              }
+              const isLabwareSelectionSelected = selectedDropdownSelection.some(
+                selected => selected.id === lw.id
+              )
+              const highlighted = hoveredDropdownItem.id === lw.id
+              return (
+                <Flex
+                  id={lw.id}
+                  flexDirection={DIRECTION_COLUMN}
+                  key={lw.id}
+                  paddingBottom={
+                    isLabwareSelectionSelected || highlighted ? '0px' : '0px'
+                  }
+                >
+                  <RobotWorkSpace
+                    key={lw.id}
+                    viewBox={`${definition.cornerOffsetFromSlot.x} ${definition.cornerOffsetFromSlot.y} ${dimensions.xDimension} ${dimensions.yDimension}`}
+                    width="9.5625rem"
+                    height="6.375rem"
+                  >
+                    {() => (
+                      <>
+                        <LabwareRender
+                          definition={definition}
+                          wellFill={wellFillFromWellContents(
+                            wellContents,
+                            liquidDisplayColors
+                          )}
+                        />
+
+                        <OffDeckControls
+                          hover={hoverSlot}
+                          setShowMenuListForId={setShowMenuListForId}
+                          menuListId={menuListId}
+                          setHover={setHoverSlot}
+                          slotBoundingBox={xyzDimensions}
+                          slotPosition={ZERO_SLOT_POSITION}
+                          labwareId={lw.id}
+                          terminalItemId={terminalItemId}
+                        />
+                      </>
+                    )}
+                  </RobotWorkSpace>
+                  <HighlightOffdeckSlot
+                    labwareOnDeck={lw}
+                    position={ZERO_SLOT_POSITION}
+                  />
+                  {menuListId === lw.id ? (
+                    <Flex
+                      marginTop={`-${SPACING.spacing32}`}
+                      marginLeft="4rem"
+                      zIndex={3}
+                    >
+                      <SlotOverflowMenu
+                        location={menuListId}
+                        addEquipment={addLabware}
+                        setShowMenuList={() => {
+                          setShowMenuListForId(null)
+                        }}
+                        menuListSlotPosition={ZERO_SLOT_POSITION}
+                        invertY
+                      />
+                    </Flex>
+                  ) : null}
+                </Flex>
+              )
+            })}
+            <HighlightOffdeckSlot position={ZERO_SLOT_POSITION} />
+          </LabwareWrapper>
+        </Flex>
+      </Flex>
+
+      <Flex width="100%" height="8rem">
+        {hoverSlot != null ? (
           <SlotDetailsContainer
             robotType={robotType}
             slot="offDeck"
             offDeckLabwareId={hoverSlot}
           />
-        </Flex>
-      ) : null}
-      <Flex
-        flex="0 0 auto"
-        width={OFF_DECK_MAP_WIDTH}
-        height="100%"
-        maxHeight={OFF_DECK_MAP_HEIGHT_FOR_STEP}
-        minHeight={OFF_DECK_MAP_HEIGHT_FOR_STEP}
-        alignItems={ALIGN_CENTER}
-        borderRadius={SPACING.spacing12}
-        padding={`${SPACING.spacing16} ${SPACING.spacing40}`}
-        backgroundColor={COLORS.grey20}
-        overflowY={OVERFLOW_AUTO}
-        flexDirection={DIRECTION_COLUMN}
-        gridGap={SPACING.spacing40}
-      >
-        <Flex
-          justifyContent={JUSTIFY_CENTER}
-          width="100%"
-          color={COLORS.grey60}
-        >
-          <StyledText desktopStyle="bodyDefaultSemiBold">
-            {i18n.format(t('off_deck_labware'), 'upperCase')}
-          </StyledText>
-        </Flex>
-        <LabwareWrapper>
-          {terminalItemId === START_TERMINAL_ITEM_ID ? (
-            <Flex width="9.5625rem" height="6.375rem">
-              <EmptySelectorButton
-                onClick={addLabware}
-                text={t('add_labware')}
-                textAlignment="middle"
-                iconName="plus"
-              />
-            </Flex>
-          ) : null}
-          {offDeckLabware.map(lw => {
-            const wellContents = allWellContentsForActiveItem
-              ? allWellContentsForActiveItem[lw.id]
-              : null
-            const definition = lw.def
-            const { dimensions } = definition
-            const xyzDimensions = {
-              xDimension: dimensions.xDimension ?? 0,
-              yDimension: dimensions.yDimension ?? 0,
-              zDimension: dimensions.zDimension ?? 0,
-            }
-            const isLabwareSelectionSelected = selectedDropdownSelection.some(
-              selected => selected.id === lw.id
-            )
-            const highlighted = hoveredDropdownItem.id === lw.id
-            return (
-              <Flex
-                id={lw.id}
-                flexDirection={DIRECTION_COLUMN}
-                key={lw.id}
-                paddingBottom={
-                  isLabwareSelectionSelected || highlighted ? '0px' : '0px'
-                }
-              >
-                <RobotWorkSpace
-                  key={lw.id}
-                  viewBox={`${definition.cornerOffsetFromSlot.x} ${definition.cornerOffsetFromSlot.y} ${dimensions.xDimension} ${dimensions.yDimension}`}
-                  width="9.5625rem"
-                  height="6.375rem"
-                >
-                  {() => (
-                    <>
-                      <LabwareRender
-                        definition={definition}
-                        wellFill={wellFillFromWellContents(
-                          wellContents,
-                          liquidDisplayColors
-                        )}
-                      />
-
-                      <OffDeckControls
-                        hover={hoverSlot}
-                        setShowMenuListForId={setShowMenuListForId}
-                        menuListId={menuListId}
-                        setHover={setHoverSlot}
-                        slotBoundingBox={xyzDimensions}
-                        slotPosition={ZERO_SLOT_POSITION}
-                        labwareId={lw.id}
-                        terminalItemId={terminalItemId}
-                      />
-                    </>
-                  )}
-                </RobotWorkSpace>
-                <HighlightOffdeckSlot
-                  labwareOnDeck={lw}
-                  position={ZERO_SLOT_POSITION}
-                />
-                {menuListId === lw.id ? (
-                  <Flex
-                    marginTop={`-${SPACING.spacing32}`}
-                    marginLeft="4rem"
-                    zIndex={3}
-                  >
-                    <SlotOverflowMenu
-                      location={menuListId}
-                      addEquipment={addLabware}
-                      setShowMenuList={() => {
-                        setShowMenuListForId(null)
-                      }}
-                      menuListSlotPosition={ZERO_SLOT_POSITION}
-                      invertY
-                    />
-                  </Flex>
-                ) : null}
-              </Flex>
-            )
-          })}
-          <HighlightOffdeckSlot position={ZERO_SLOT_POSITION} />
-        </LabwareWrapper>
+        ) : null}
       </Flex>
     </Flex>
   )

--- a/protocol-designer/src/pages/Designer/OffDeck/__tests__/OffDeck.test.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/__tests__/OffDeck.test.tsx
@@ -6,14 +6,19 @@ import { getCustomLabwareDefsByURI } from '../../../../labware-defs/selectors'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { getSelectedTerminalItemId } from '../../../../ui/steps'
 import { START_TERMINAL_ITEM_ID } from '../../../../steplist'
+import { LiquidButton } from '../../../../components/molecules'
+import { DeckSetupToolbox } from '../../DeckSetup/DeckSetupToolbox'
 import { OffDeckDetails } from '../OffDeckDetails'
 import { OffDeck } from '..'
+import type { ComponentProps } from 'react'
 import type * as Components from '@opentrons/components'
 
 vi.mock('../OffDeckDetails')
 vi.mock('../../../../ui/steps')
 vi.mock('../../../../labware-ingred/selectors')
 vi.mock('../../../../labware-defs/selectors')
+vi.mock('../../../../components/molecules')
+vi.mock('../../DeckSetup/DeckSetupToolbox')
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof Components>()
   return {
@@ -22,12 +27,16 @@ vi.mock('@opentrons/components', async importOriginal => {
   }
 })
 
-const render = () => {
-  return renderWithProviders(<OffDeck />)
+const render = (props: ComponentProps<typeof OffDeck>) => {
+  return renderWithProviders(<OffDeck {...props} />)
 }
 
 describe('OffDeck', () => {
+  let props: ComponentProps<typeof OffDeck>
   beforeEach(() => {
+    props = {
+      setOverflowMenu: vi.fn(),
+    }
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
       selectedLabwareDefUri: null,
       selectedNestedLabwareDefUri: null,
@@ -35,12 +44,28 @@ describe('OffDeck', () => {
       selectedModuleModel: null,
       selectedSlot: { slot: null, cutout: null },
     })
+    vi.mocked(LiquidButton).mockReturnValue(<div>mock LiquidButton</div>)
     vi.mocked(getCustomLabwareDefsByURI).mockReturnValue({})
     vi.mocked(getSelectedTerminalItemId).mockReturnValue(START_TERMINAL_ITEM_ID)
+    vi.mocked(DeckSetupToolbox).mockReturnValue(
+      <div>mock DeckSetupToolbox</div>
+    )
   })
   it('renders off deck details', () => {
     vi.mocked(OffDeckDetails).mockReturnValue(<div>mock off deck details</div>)
-    render()
+    render(props)
     screen.getByText('mock off deck details')
+  })
+  it('renders the off deck "zoomedIn" view', () => {
+    vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
+      selectedLabwareDefUri: null,
+      selectedNestedLabwareDefUri: null,
+      selectedFixture: null,
+      selectedModuleModel: null,
+      selectedSlot: { slot: 'offDeck', cutout: null },
+    })
+    render(props)
+    screen.getByText('mock LiquidButton')
+    screen.getByText('mock DeckSetupToolbox')
   })
 })

--- a/protocol-designer/src/pages/Designer/OffDeck/index.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/index.tsx
@@ -28,8 +28,9 @@ import { OffDeckDetails } from './OffDeckDetails'
 import { LiquidButton } from '../../../components/molecules'
 import type { Dispatch, SetStateAction } from 'react'
 
-const STANDARD_X_WIDTH = '127.76px'
-const STANDARD_Y_HEIGHT = '85.48px'
+const STANDARD_X_WIDTH = 127.76
+const STANDARD_Y_HEIGHT = 85.48
+const SCALER_TO_ACCOUNT_FOR_LABWARE_LABEL = 0.8
 
 interface OffDeckProps {
   setOverflowMenu: Dispatch<SetStateAction<boolean>>
@@ -56,14 +57,19 @@ export function OffDeck(props: OffDeckProps): JSX.Element {
     selectedLabwareDefUri != null ? defs[selectedLabwareDefUri] ?? null : null
 
   let labware = (
-    <RobotWorkSpace key="emptyState" viewBox={`-15 -22 159.75 106.875`}>
+    <RobotWorkSpace
+      key="emptyState"
+      viewBox={`-15 -22 ${
+        STANDARD_X_WIDTH / SCALER_TO_ACCOUNT_FOR_LABWARE_LABEL
+      } ${STANDARD_Y_HEIGHT / SCALER_TO_ACCOUNT_FOR_LABWARE_LABEL}`}
+    >
       {() => (
         <RobotCoordsForeignDiv>
           <Box
             backgroundColor={COLORS.grey40}
             borderRadius={BORDERS.borderRadius8}
-            width={STANDARD_X_WIDTH}
-            height={STANDARD_Y_HEIGHT}
+            width={`${STANDARD_X_WIDTH}px`}
+            height={`${STANDARD_Y_HEIGHT}px`}
           />
         </RobotCoordsForeignDiv>
       )}
@@ -73,8 +79,12 @@ export function OffDeck(props: OffDeckProps): JSX.Element {
     labware = (
       <RobotWorkSpace
         key={hoveredLabwareDef.parameters.loadName}
-        viewBox={`-15 -22 ${hoveredLabwareDef.dimensions.xDimension / 0.8} ${
-          hoveredLabwareDef.dimensions.yDimension / 0.8
+        viewBox={`-15 -22 ${
+          hoveredLabwareDef.dimensions.xDimension /
+          SCALER_TO_ACCOUNT_FOR_LABWARE_LABEL
+        } ${
+          hoveredLabwareDef.dimensions.yDimension /
+          SCALER_TO_ACCOUNT_FOR_LABWARE_LABEL
         }`}
       >
         {() => (
@@ -95,9 +105,9 @@ export function OffDeck(props: OffDeckProps): JSX.Element {
     labware = (
       <RobotWorkSpace
         key={def.parameters.loadName}
-        viewBox={`-15 -22 ${def.dimensions.xDimension / 0.8} ${
-          def.dimensions.yDimension / 0.8
-        }`}
+        viewBox={`-15 -22 ${
+          def.dimensions.xDimension / SCALER_TO_ACCOUNT_FOR_LABWARE_LABEL
+        } ${def.dimensions.yDimension / SCALER_TO_ACCOUNT_FOR_LABWARE_LABEL}`}
       >
         {() => (
           <>

--- a/protocol-designer/src/pages/Designer/OffDeck/index.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/index.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   JUSTIFY_CENTER,
   LabwareRender,
+  POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   RobotCoordsForeignDiv,
   RobotWorkSpace,
@@ -24,11 +25,17 @@ import { selectZoomedIntoSlot } from '../../../labware-ingred/actions'
 import { DeckSetupToolbox } from '../DeckSetup/DeckSetupToolbox'
 import { LabwareLabel } from '../LabwareLabel'
 import { OffDeckDetails } from './OffDeckDetails'
+import { LiquidButton } from '../../../components/molecules'
+import type { Dispatch, SetStateAction } from 'react'
 
 const STANDARD_X_WIDTH = '127.76px'
 const STANDARD_Y_HEIGHT = '85.48px'
 
-export function OffDeck(): JSX.Element {
+interface OffDeckProps {
+  setOverflowMenu: Dispatch<SetStateAction<boolean>>
+}
+export function OffDeck(props: OffDeckProps): JSX.Element {
+  const { setOverflowMenu } = props
   const { t, i18n } = useTranslation('starting_deck_state')
   const [hoveredLabware, setHoveredLabware] = useState<string | null>(null)
   const terminalItemId = useSelector(getSelectedTerminalItemId)
@@ -49,10 +56,7 @@ export function OffDeck(): JSX.Element {
     selectedLabwareDefUri != null ? defs[selectedLabwareDefUri] ?? null : null
 
   let labware = (
-    <RobotWorkSpace
-      key="emptyState"
-      viewBox={`-25 -32 182.5142857143 122.1142857143`}
-    >
+    <RobotWorkSpace key="emptyState" viewBox={`-15 -22 159.75 106.875`}>
       {() => (
         <RobotCoordsForeignDiv>
           <Box
@@ -69,8 +73,8 @@ export function OffDeck(): JSX.Element {
     labware = (
       <RobotWorkSpace
         key={hoveredLabwareDef.parameters.loadName}
-        viewBox={`-25 -32 ${hoveredLabwareDef.dimensions.xDimension / 0.7} ${
-          hoveredLabwareDef.dimensions.yDimension / 0.7
+        viewBox={`-15 -22 ${hoveredLabwareDef.dimensions.xDimension / 0.8} ${
+          hoveredLabwareDef.dimensions.yDimension / 0.8
         }`}
       >
         {() => (
@@ -91,8 +95,8 @@ export function OffDeck(): JSX.Element {
     labware = (
       <RobotWorkSpace
         key={def.parameters.loadName}
-        viewBox={`-25 -32 ${def.dimensions.xDimension / 0.7} ${
-          def.dimensions.yDimension / 0.7
+        viewBox={`-15 -22 ${def.dimensions.xDimension / 0.8} ${
+          def.dimensions.yDimension / 0.8
         }`}
       >
         {() => (
@@ -119,7 +123,19 @@ export function OffDeck(): JSX.Element {
           width="100%"
           padding={SPACING.spacing12}
           gridGap={SPACING.spacing12}
+          position={POSITION_RELATIVE}
         >
+          <Flex
+            position={POSITION_ABSOLUTE}
+            top={SPACING.spacing12}
+            right="24rem"
+          >
+            <LiquidButton
+              showLiquidOverflowMenu={() => {
+                setOverflowMenu(true)
+              }}
+            />
+          </Flex>
           <Flex justifyContent={JUSTIFY_CENTER} width="100%">
             <Flex
               width="39.4275rem"
@@ -145,17 +161,13 @@ export function OffDeck(): JSX.Element {
                     {i18n.format(t('off_deck_labware'), 'upperCase')}
                   </StyledText>
                 </Flex>
-                <Flex
-                  width="510.84px"
-                  height="342px"
-                  alignItems="center"
-                  justifyContent="center"
-                >
+                <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_CENTER}>
                   {labware}
                 </Flex>
               </Flex>
             </Flex>
           </Flex>
+
           <DeckSetupToolbox
             position={POSITION_RELATIVE}
             setHoveredLabware={setHoveredLabware}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -17,6 +17,7 @@ import {
   StyledText,
   ToggleGroup,
 } from '@opentrons/components'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import {
   getSavedStepForms,
   getUnsavedForm,
@@ -51,10 +52,9 @@ import { DraggableSidebar } from './DraggableSidebar'
 import { TimelineEditHardware } from './TimelineEditHardware'
 import type { Dispatch, SetStateAction } from 'react'
 import type { DeckSlot } from '../../../types'
-import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 const CONTENT_MAX_WIDTH = '46.9375rem'
-const STEP_SUMMARY_HEIGHT = '14.7rem'
+const STEP_SUMMARY_HEIGHT = '18.2rem'
 
 interface ProtocolStepsProps {
   isZoomedIn: boolean
@@ -80,6 +80,8 @@ export function ProtocolSteps(props: ProtocolStepsProps): JSX.Element {
   const [deckView, setDeckView] = useState<
     typeof leftString | typeof rightString
   >(leftString)
+  const isOffDeck = deckView === rightString
+
   // Note (02/03/25:kk) use DrraggableSidebar's initial width
   const [targetWidth, setTargetWidth] = useState<number>(235)
 
@@ -148,10 +150,12 @@ export function ProtocolSteps(props: ProtocolStepsProps): JSX.Element {
             flexDirection={DIRECTION_COLUMN}
             gridGap={SPACING.spacing24}
             width={
-              isZoomedIn ||
+              (isZoomedIn && !isOffDeck) ||
               (selectedTerminalItemId === HARDWARE_ID &&
                 robotType === OT2_ROBOT_TYPE)
                 ? '90%'
+                : isZoomedIn && isOffDeck
+                ? '100%'
                 : CONTENT_MAX_WIDTH
             }
             justifyContent={JUSTIFY_CENTER}
@@ -200,7 +204,7 @@ export function ProtocolSteps(props: ProtocolStepsProps): JSX.Element {
                   robotType={robotType}
                 />
               ) : (
-                <OffDeck />
+                <OffDeck setOverflowMenu={showLiquidOverflowMenu} />
               )}
               {isZoomedIn || selectedTerminalItemId === HARDWARE_ID ? null : (
                 <>


### PR DESCRIPTION
closes AUTH-1717 AUTH-1748

# Overview

this PR fixes the off-deck view positioning of things and adds the liquids button to be available when you're adding an off-deck labware. It also fixes the glitchiness when slot details is visible when hovering over a slot. 

NOTE that the slot details is actually temporary and Sue has a slot details modal we are going to implement later on so she told me not to worry too much about having the slot details match designs.

## Test Plan and Hands on Testing

Make sure there is no glitchiness when hovering over slots to view the slot details and check the off-deck labware view

## Changelog

- fix glitchiness
- add the liquids button when you're adding an off-deck labware
- fix UI for off-deck labware view in general
- fix tests


## Risk assessment

low