### PR TITLE
refactor(api): Flesh out developer documentation for unsafe commands

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
@@ -1,4 +1,20 @@
-"""Commands that will cause inaccuracy or incorrect behavior but are still necessary."""
+"""Commands that are "unsafe".
+
+"Unsafe" means that they can cause inaccuracy or incorrect behavior. They should
+therefore never be used in protocols, and should only be used otherwise as a last
+resort.
+
+These exist as a necessary evil for implementing things like error recovery.
+Even in those narrow contexts, these commands must be used with care.
+e.g. after an `UpdatePositionEstimators` command, there must be a `Home` command,
+or positioning will be subtly wrong. Each unsafe command should document its intended
+use case and its caveats.
+
+Because we don't expect unsafe commands to be used in any protocols whose behavior we
+must preserve, we may change the commands' semantics over time. We may also change
+their shapes if we're confident that it won't break something in robot-server's
+persistent storage.
+"""
 
 from .unsafe_blow_out_in_place import (
     UnsafeBlowOutInPlaceCommandType,

--- a/robot-server/robot_server/persistence/_migrations/v10_to_v11.py
+++ b/robot-server/robot_server/persistence/_migrations/v10_to_v11.py
@@ -44,7 +44,7 @@ _log = logging.getLogger(__name__)
 
 class Migration10to11(Migration):  # noqa: D101
     def migrate(self, source_dir: Path, dest_dir: Path) -> None:
-        """Migrate the persistence directory from schema 9 to 10."""
+        """Migrate the persistence directory from schema 10 to 11."""
         copy_contents(source_dir=source_dir, dest_dir=dest_dir)
 
         with sql_engine_ctx(


### PR DESCRIPTION
## Overview

Edit a docstring to elaborate on the meaning of "unsafe" Protocol Engine commands, following an in-person discussion with @sfoster1 and @ahiuchingau.

## Changelog

* Flesh out the `opentrons.protocol_engine.commands.unsafe` module docstring.
* Fix an unrelated copy-paste error in a comment in robot-server's migrations.

## Review requests

* Is this clearer? Anything else to add?
* This part is something that I'm adding on-the-fly. We haven't discussed it. Does this seem like a good expectation?

  > Because we don't expect unsafe commands to be used in any protocols whose behavior we must preserve, we may change the commands' semantics over time. We may also change their shapes if we're confident that it won't break something in robot-server's persistent storage.


## Risk assessment

No risk.