### PR TITLE
refactor(protocol-designer): ot-2 modules responsiveness

### DIFF
--- a/components/src/atoms/ListItem/ListItemChildren/ListItemCustomize.tsx
+++ b/components/src/atoms/ListItem/ListItemChildren/ListItemCustomize.tsx
@@ -34,7 +34,12 @@ export function ListItemCustomize(props: ListItemCustomizeProps): JSX.Element {
     menuPlacement = 'auto',
   } = props
   return (
-    <Flex width="100%" alignItems={ALIGN_CENTER} padding={SPACING.spacing12}>
+    <Flex
+      width="100%"
+      alignItems={ALIGN_CENTER}
+      padding={SPACING.spacing12}
+      gridGap={SPACING.spacing8}
+    >
       <Flex gridGap={SPACING.spacing16} width="50%" alignItems={ALIGN_CENTER}>
         {leftHeaderItem != null ? (
           <Flex size="3.75rem">{leftHeaderItem}</Flex>

--- a/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
+++ b/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
@@ -288,16 +288,21 @@ export function Ot2Modules(): JSX.Element {
         />
       ) : null}
       {changeModuleWarning}
-      <Flex justifyContent={JUSTIFY_FLEX_START} flexWrap={WRAP} width="100%">
+      <Flex flexWrap={WRAP} width="100%">
         <Flex
           flexDirection={DIRECTION_COLUMN}
           flex="1.27"
-          width="100%"
+          minWidth="30.375rem"
           paddingTop={SPACING.spacing120}
         >
-          <StyledText desktopStyle="headingSmallBold">
-            {t('protocol_overview:modules')}
-          </StyledText>
+          {filteredSupportedModules.length > 0 ? (
+            <StyledText
+              desktopStyle="headingSmallBold"
+              paddingBottom={SPACING.spacing20}
+            >
+              {t('protocol_overview:modules')}
+            </StyledText>
+          ) : null}
           <ModuleEmptySelectorButtons
             modules={filteredSupportedModules}
             addModule={moduleModel => {
@@ -378,9 +383,14 @@ export function Ot2Modules(): JSX.Element {
             </Flex>
           ) : null}
         </Flex>
-        <Flex flex="1.27" minWidth="50%">
+        <Flex
+          flex="1.27"
+          maxHeight="35rem"
+          minWidth="50%"
+          paddingTop={SPACING.spacing80}
+        >
           <RobotCoordinateSpaceWithRef
-            height="80%"
+            height="100%"
             width="100%"
             deckDef={deckDef}
             viewBox={`${deckDef.cornerOffsetFromOrigin[0]} ${deckDef.cornerOffsetFromOrigin[1]} ${deckDef.dimensions[0]} ${deckDef.dimensions[1]}`}

--- a/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
+++ b/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
@@ -8,7 +8,6 @@ import {
   DeckFromLayers,
   DIRECTION_COLUMN,
   Flex,
-  JUSTIFY_FLEX_START,
   ListItem,
   ListItemCustomize,
   Module,

--- a/protocol-designer/src/pages/Hardware/index.tsx
+++ b/protocol-designer/src/pages/Hardware/index.tsx
@@ -89,7 +89,7 @@ export function Hardware(): JSX.Element {
         <Flex
           flexDirection={DIRECTION_COLUMN}
           gridGap={SPACING.spacing16}
-          padding={SPACING.spacing80}
+          padding={`${SPACING.spacing80} ${SPACING.spacing80} 0 ${SPACING.spacing80}`}
         >
           <StyledText desktopStyle="displayBold">
             {robotType === FLEX_ROBOT_TYPE


### PR DESCRIPTION
closes AUTH-1754

# Overview

This fixes the responsiveness for the OT-2 edit modules component

## Test Plan and Hands on Testing

Create an ot-2 protocol and go to overview and edit the modules. Change your viewport and make sure responsiveness works correctly

Then go to timeline and click on the module button and check that responsiveness works correctly

## Changelog

- fix ot-2 modules responsiveness

## Risk assessment

low
