### PR TITLE
chore: make lpc analytics kind have a nicer name

### DIFF
--- a/app/src/redux/analytics/constants.ts
+++ b/app/src/redux/analytics/constants.ts
@@ -120,8 +120,7 @@ export const ANALYTICS_LANGUAGE_UPDATED_DESKTOP_APP_SETTINGS: 'languageUpdatedDe
  * LPC Analytics
  */
 
-export const ANALYTICS_LPC_ANALYSIS_KIND: 'lpcAnalysisKind' =
-  'lpcAnalysisKind'
+export const ANALYTICS_LPC_ANALYSIS_KIND: 'lpcAnalysisKind' = 'lpcAnalysisKind'
 
 /**
  * Module Actions Analytics

--- a/app/src/redux/analytics/constants.ts
+++ b/app/src/redux/analytics/constants.ts
@@ -120,8 +120,8 @@ export const ANALYTICS_LANGUAGE_UPDATED_DESKTOP_APP_SETTINGS: 'languageUpdatedDe
  * LPC Analytics
  */
 
-export const ANALYTICS_LPC_ANALYSIS_KIND: 'analytics:lpcAnalysisKind' =
-  'analytics:lpcAnalysisKind'
+export const ANALYTICS_LPC_ANALYSIS_KIND: 'lpcAnalysisKind' =
+  'lpcAnalysisKind'
 
 /**
  * Module Actions Analytics


### PR DESCRIPTION
none of the other ones are prefixed like this
