### PR TITLE
fix(api): update stacker axis motion param

### DIFF
--- a/api/src/opentrons/drivers/flex_stacker/driver.py
+++ b/api/src/opentrons/drivers/flex_stacker/driver.py
@@ -103,7 +103,7 @@ STACKER_MOTION_CONFIG = {
             ),
         ),
         "move": AxisParams(
-            run_current=1.0,
+            run_current=1.2,
             hold_current=0.75,
             move_params=MoveParams(
                 max_speed=200.0,
@@ -115,7 +115,7 @@ STACKER_MOTION_CONFIG = {
     StackerAxis.Z: {
         "home": AxisParams(
             run_current=1.5,
-            hold_current=1.8,
+            hold_current=1.5,
             move_params=MoveParams(
                 max_speed=10.0,
                 acceleration=100.0,
@@ -124,7 +124,7 @@ STACKER_MOTION_CONFIG = {
         ),
         "move": AxisParams(
             run_current=1.5,
-            hold_current=0.5,
+            hold_current=1.5,
             move_params=MoveParams(
                 max_speed=150.0,
                 acceleration=500.0,

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -368,7 +368,7 @@ class FlexStacker(mod_abc.AbstractModule):
         await self._prepare_for_action()
 
         # Move platform along the X then Z axis
-        await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, OFFSET_SM)
+        await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, OFFSET_MD)
 
         # TODO: (AA 2025-04-03) - The EVT Flex Stacker hardware has issues
         # reading the platform sensor on the extended side. This is a temporary
@@ -390,7 +390,7 @@ class FlexStacker(mod_abc.AbstractModule):
 
         if enforce_shuttle_lw_sensing:
             await self.verify_shuttle_labware_presence(Direction.RETRACT, True)
-        await self._move_and_home_axis(StackerAxis.X, Direction.EXTEND, OFFSET_SM)
+        await self._move_and_home_axis(StackerAxis.X, Direction.EXTEND, OFFSET_MD)
         return True
 
     async def store_labware(
@@ -404,7 +404,7 @@ class FlexStacker(mod_abc.AbstractModule):
         # Move X then Z axis
         offset = OFFSET_MD if labware_height < MEDIUM_LABWARE_Z_LIMIT else OFFSET_LG * 2
         distance = MAX_TRAVEL[StackerAxis.Z] - (labware_height / 2) - offset
-        await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, OFFSET_SM)
+        await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, OFFSET_MD)
 
         # TODO: (AA 2025-04-03) - The EVT Flex Stacker hardware has issues
         # reading the platform sensor on the extended side. This is a temporary
@@ -434,7 +434,7 @@ class FlexStacker(mod_abc.AbstractModule):
 
         if enforce_shuttle_lw_sensing:
             await self.verify_shuttle_labware_presence(Direction.RETRACT, False)
-        await self._move_and_home_axis(StackerAxis.X, Direction.EXTEND, OFFSET_SM)
+        await self._move_and_home_axis(StackerAxis.X, Direction.EXTEND, OFFSET_MD)
         return True
 
     async def _move_and_home_axis(


### PR DESCRIPTION
# Overview
Motion param changes per hardware request:
1. X-axis run current for move -> 1.2 A
2. Z-axis hold current for both move and homing -> 1.5 A
3. increase X slow home distance to 10 mm (`OFFSET_MD`)
