### PR TITLE
fix(api): raise error if specified labware count exceeds max capacity during stacker fill/set stored labware

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -723,7 +723,7 @@ def _count_from_lw_list_or_initial_count(
     if initial_count is not None:
         if initial_lw and len(initial_lw) != initial_count:
             raise CommandPreconditionViolated(
-                "If initialCount and initialStoredLabware are both specified, the number of labware must be less than or equal to the count"
+                "If initialCount and initialStoredLabware are both specified, the number of labware must equal the count"
             )
         to_store_count = initial_count
     elif initial_lw is not None:

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -717,31 +717,32 @@ def _count_from_lw_list_or_initial_count(
     max_pool_count: int,
     current_count: int,
 ) -> int:
-    if initial_count is None and initial_lw is None:
-        return max_pool_count - current_count
-    if initial_count is None and initial_lw is not None:
-        if len(initial_lw) > (max_pool_count - current_count):
+    """Count the number of labware to be added to the stacker."""
+    capacity = max(max_pool_count - current_count, 0)
+
+    if initial_count is not None:
+        if initial_lw and len(initial_lw) != initial_count:
             raise CommandPreconditionViolated(
-                f"{len(initial_lw)} labware groups were requested to be stored, but the stacker can store only {max_pool_count}"
+                "If initialCount and initialStoredLabware are both specified, the number of labware must be less than or equal to the count"
             )
-        return len(initial_lw)
-    if initial_count is not None and initial_lw is None:
-        return min(
-            max(initial_count - current_count, 0), (max_pool_count - current_count)
+        to_store_count = initial_count
+    elif initial_lw is not None:
+        to_store_count = len(initial_lw)
+    else:
+        # neither initialCount nor initialStoredLabware are specified
+        if not capacity:
+            raise CommandPreconditionViolated(
+                "No labware groups were specified to be stored, but the stacker is already full"
+            )
+        return capacity
+
+    if to_store_count > capacity:
+        error_text = f" and is already holding {current_count}" if current_count else ""
+        raise CommandPreconditionViolated(
+            f"{to_store_count} labware groups were requested to be stored, "
+            f"but the stacker can hold only {max_pool_count}{error_text}"
         )
-    if initial_count is not None and initial_lw is not None:
-        if len(initial_lw) != initial_count:
-            raise CommandPreconditionViolated(
-                "If initialCount and initialStoredLabware are both specified, the number of labware must equal the count"
-            )
-        if initial_count > (max_pool_count - current_count):
-            raise CommandPreconditionViolated(
-                f"{len(initial_lw)} labware groups were requested to be stored, but the stacker can store only {max_pool_count}"
-            )
-        return initial_count
-    raise CommandPreconditionViolated(
-        f"{initial_lw} and {initial_count} are not valid combinations of initialCount and initialStoredLabware"
-    )
+    return to_store_count
 
 
 def _build_one_labware_group(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
@@ -1791,55 +1791,6 @@ async def test_build_n_labware_happypath_primary_and_lid_and_adapter(
             id="generate-all-from-empty",
         ),
         pytest.param(
-            None,
-            3,
-            2,
-            [
-                StackerStoredLabwareGroup(
-                    primaryLabwareId="generated-1",
-                    adapterLabwareId=None,
-                    lidLabwareId=None,
-                ),
-            ],
-            id="generate-all-from-nonempty",
-        ),
-        pytest.param(
-            None,
-            4,
-            0,
-            [
-                StackerStoredLabwareGroup(
-                    primaryLabwareId="generated-1",
-                    adapterLabwareId=None,
-                    lidLabwareId=None,
-                ),
-                StackerStoredLabwareGroup(
-                    primaryLabwareId="generated-2",
-                    adapterLabwareId=None,
-                    lidLabwareId=None,
-                ),
-                StackerStoredLabwareGroup(
-                    primaryLabwareId="generated-3",
-                    adapterLabwareId=None,
-                    lidLabwareId=None,
-                ),
-            ],
-            id="generate-too-many-from-empty",
-        ),
-        pytest.param(
-            None,
-            4,
-            2,
-            [
-                StackerStoredLabwareGroup(
-                    primaryLabwareId="generated-1",
-                    adapterLabwareId=None,
-                    lidLabwareId=None,
-                ),
-            ],
-            id="generate-too-many-from-nonempty",
-        ),
-        pytest.param(
             [
                 StackerStoredLabwareGroup(
                     primaryLabwareId="specified-1",
@@ -1990,6 +1941,7 @@ def test_build_ids_to_fill_variants(
     )
 
 
+@pytest.mark.parametrize("using_list", [True, False])
 @pytest.mark.parametrize(
     "specified_count,current_count",
     [
@@ -2006,30 +1958,56 @@ def test_build_ids_to_fill_variants(
     ],
 )
 def test_build_ids_to_fill_fails_on_too_many_specified(
+    using_list: bool,
     specified_count: int,
     current_count: int,
     model_utils: ModelUtils,
 ) -> None:
     """It should prevent you from specifying too many labware."""
-    specified = [
-        StackerStoredLabwareGroup(
-            primaryLabwareId=f"primary-id-{idx}",
-            adapterLabwareId=None,
-            lidLabwareId=None,
-        )
-        for idx in range(specified_count)
-    ]
+    if using_list:
+        specified_labware_list = [
+            StackerStoredLabwareGroup(
+                primaryLabwareId=f"primary-id-{idx}",
+                adapterLabwareId=None,
+                lidLabwareId=None,
+            )
+            for idx in range(specified_count)
+        ]
+        specified_labware_count = None
+    else:
+        specified_labware_list = None
+        specified_labware_count = specified_count
+
     with pytest.raises(
         CommandPreconditionViolated,
-        match=".*were requested to be stored, but the stacker can store only.*",
+        match=".*were requested to be stored, but the stacker can hold only.*",
     ):
         subject.build_ids_to_fill(
             False,
             False,
-            specified,
-            None,
+            specified_labware_list,
+            specified_count,
             2,
             current_count,
+            model_utils,
+        )
+
+
+def test_build_ids_to_fill_fails_on_already_at_capacity(
+    model_utils: ModelUtils,
+) -> None:
+    """If nothing is specified but already at max, it should fail."""
+    with pytest.raises(
+        CommandPreconditionViolated,
+        match=".*already full.*",
+    ):
+        subject.build_ids_to_fill(
+            False,
+            False,
+            None,
+            None,
+            2,
+            2,
             model_utils,
         )
 

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
@@ -1986,7 +1986,7 @@ def test_build_ids_to_fill_fails_on_too_many_specified(
             False,
             False,
             specified_labware_list,
-            specified_count,
+            specified_labware_count,
             2,
             current_count,
             model_utils,

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_fill.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_fill.py
@@ -112,7 +112,7 @@ async def test_fill_by_count_exceeding_max(
         strategy=StackerFillEmptyStrategy.LOGICAL,
     )
     with pytest.raises(CommandPreconditionViolated):
-        result = await subject.execute(params)
+        await subject.execute(params)
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_fill.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_fill.py
@@ -40,6 +40,7 @@ from opentrons.protocol_engine.errors import (
     FlexStackerLabwarePoolNotYetDefinedError,
     ModuleNotLoadedError,
 )
+from opentrons_shared_data.errors.exceptions import CommandPreconditionViolated
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons.types import DeckSlotName
 
@@ -72,13 +73,52 @@ def _contained_labware(count: int) -> list[StackerStoredLabwareGroup]:
 
 
 @pytest.mark.parametrize(
+    "current_stored,count_param,max_pool_count",
+    [
+        pytest.param(_contained_labware(3), 3, 3, id="already-full"),
+        pytest.param(_contained_labware(0), 4, 3, id="empty-fill-more-than-max"),
+        pytest.param(_contained_labware(1), 3, 3, id="nonempty-fill-more-than-max"),
+    ],
+)
+async def test_fill_by_count_exceeding_max(
+    decoy: Decoy,
+    state_view: StateView,
+    model_utils: ModelUtils,
+    equipment: EquipmentHandler,
+    subject: FillImpl,
+    current_stored: list[StackerStoredLabwareGroup],
+    count_param: int,
+    max_pool_count: int,
+    flex_50uL_tiprack: LabwareDefinition,
+) -> None:
+    """It should fill a valid stacker's labware pool."""
+    module_id = "some-module-id"
+    stacker_state = FlexStackerSubState(
+        module_id=cast(FlexStackerId, module_id),
+        pool_primary_definition=flex_50uL_tiprack,
+        pool_adapter_definition=None,
+        pool_lid_definition=None,
+        contained_labware_bottom_first=current_stored,
+        max_pool_count=max_pool_count,
+        pool_overlap=0,
+    )
+    decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
+        stacker_state
+    )
+    params = FillParams(
+        moduleId=module_id,
+        count=count_param,
+        message="some-message",
+        strategy=StackerFillEmptyStrategy.LOGICAL,
+    )
+    with pytest.raises(CommandPreconditionViolated):
+        result = await subject.execute(params)
+
+
+@pytest.mark.parametrize(
     "current_stored,count_param,max_pool_count,expected_new_labware",
     [
         pytest.param([], 3, 3, 3, id="empty-to-full"),
-        pytest.param(_contained_labware(3), 3, 3, 0, id="full-noop"),
-        pytest.param(_contained_labware(3), 1, 3, 0, id="size-minimum"),
-        pytest.param(_contained_labware(1), 2, 3, 1, id="fill-not-to-full"),
-        pytest.param(_contained_labware(1), 4, 3, 2, id="capped-by-max"),
         pytest.param(
             _contained_labware(1),
             None,

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
@@ -890,4 +890,4 @@ async def test_set_stored_labware_exceeding_max(
     ).then_return(2)
 
     with pytest.raises(CommandPreconditionViolated):
-        result = await subject.execute(params)
+        await subject.execute(params)

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
@@ -47,6 +47,7 @@ from opentrons.protocol_engine.types import (
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
+from opentrons_shared_data.errors.exceptions import CommandPreconditionViolated
 from opentrons.protocol_engine.errors import (
     FlexStackerNotLogicallyEmptyError,
 )
@@ -620,23 +621,6 @@ async def test_set_stored_labware_requires_empty_hopper(
             ],
             does_not_raise(),
         ),
-        (
-            3,
-            None,
-            [
-                StackerStoredLabwareGroup(
-                    primaryLabwareId="labware-1",
-                    adapterLabwareId=None,
-                    lidLabwareId=None,
-                ),
-                StackerStoredLabwareGroup(
-                    primaryLabwareId="labware-2",
-                    adapterLabwareId=None,
-                    lidLabwareId=None,
-                ),
-            ],
-            does_not_raise(),
-        ),
     ],
 )
 async def test_set_stored_labware_limits_count(
@@ -815,3 +799,95 @@ async def test_set_stored_labware_limits_count(
             labware_lid=LabwareLidUpdate(parent_labware_ids=[], lid_ids=[]),
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "input_count,input_labware",
+    [
+        (3, None),
+        (
+            None,
+            [
+                StackerStoredLabwareGroup(
+                    primaryLabwareId="labware-1",
+                    adapterLabwareId=None,
+                    lidLabwareId=None,
+                ),
+                StackerStoredLabwareGroup(
+                    primaryLabwareId="labware-2",
+                    adapterLabwareId=None,
+                    lidLabwareId=None,
+                ),
+                StackerStoredLabwareGroup(
+                    primaryLabwareId="labware-3",
+                    adapterLabwareId=None,
+                    lidLabwareId=None,
+                ),
+            ],
+        ),
+    ],
+)
+async def test_set_stored_labware_exceeding_max(
+    input_count: int | None,
+    input_labware: list[StackerStoredLabwareGroup] | None,
+    decoy: Decoy,
+    state_view: StateView,
+    equipment: EquipmentHandler,
+    subject: SetStoredLabwareImpl,
+    model_utils: ModelUtils,
+    flex_50uL_tiprack: LabwareDefinition,
+) -> None:
+    """It should default and limit the input count."""
+    module_id = "module-id"
+    params = SetStoredLabwareParams(
+        moduleId=module_id,
+        primaryLabware=StackerStoredLabwareDetails(
+            loadName="opentrons_flex_96_filtertiprack_50ul",
+            namespace="opentrons",
+            version=1,
+        ),
+        lidLabware=None,
+        adapterLabware=None,
+        initialCount=input_count,
+        initialStoredLabware=input_labware,
+    )
+
+    decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
+        FlexStackerSubState(
+            module_id=cast(FlexStackerId, module_id),
+            pool_primary_definition=None,
+            pool_adapter_definition=None,
+            pool_lid_definition=None,
+            contained_labware_bottom_first=[],
+            max_pool_count=0,
+            pool_overlap=0,
+        )
+    )
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="opentrons_flex_96_filtertiprack_50ul",
+            namespace="opentrons",
+            version=1,
+        )
+    ).then_return(
+        (flex_50uL_tiprack, "opentrons/opentrons_flex_96_filtertiprack_50ul/1")
+    )
+
+    decoy.when(
+        state_view._labware.get_labware_overlap_offsets(
+            flex_50uL_tiprack, "opentrons_flex_96_filtertiprack_50ul"
+        )
+    ).then_return(OverlapOffset(x=0, y=0, z=0))
+
+    decoy.when(
+        state_view.geometry.get_height_of_labware_stack([flex_50uL_tiprack])
+    ).then_return(sentinel.pool_height)
+
+    decoy.when(
+        state_view.modules.stacker_max_pool_count_by_height(
+            module_id, sentinel.pool_height, 0.0
+        )
+    ).then_return(2)
+
+    with pytest.raises(CommandPreconditionViolated):
+        result = await subject.execute(params)


### PR DESCRIPTION
This PR refactors the the hopper labware counting logic for the Flex Stacker module. The changes focus on simplifying the `_count_from_lw_list_or_initial_count` function by making sure we're raising the appropriate error if the specified labware count or labware list exceeds the stacker's max capacity.


