### PR TITLE
fix(api): flex stacker store command should check labware configuration before hopper labware count

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -177,19 +177,20 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
         stacker_state = self._state_view.modules.get_flex_stacker_substate(
             params.moduleId
         )
+
         location = self._state_view.modules.get_location(params.moduleId)
+        pool_definitions = stacker_state.get_pool_definition_ordered_list()
+        if pool_definitions is None:
+            raise FlexStackerLabwarePoolNotYetDefinedError(
+                message=f"The Flex Stacker in {location} has not been configured yet and cannot be filled."
+            )
+
         if (
             len(stacker_state.contained_labware_bottom_first)
             == stacker_state.max_pool_count
         ):
             raise CannotPerformModuleAction(
                 f"Cannot store labware in Flex Stacker in {location} because it is full"
-            )
-
-        pool_definitions = stacker_state.get_pool_definition_ordered_list()
-        if pool_definitions is None:
-            raise FlexStackerLabwarePoolNotYetDefinedError(
-                message=f"The Flex Stacker in {location} has not been configured yet and cannot be filled."
             )
 
         primary_id, maybe_adapter_id, maybe_lid_id = self._verify_labware_to_store(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -137,7 +137,17 @@ async def test_store_raises_if_carriage_logically_empty(
         await subject.execute(data)
 
 
+@pytest.mark.parametrize(
+    "contained_labware_count,max_pool_count",
+    [
+        (0, 0),
+        (1, 0),
+        (0, 1),
+    ],
+)
 async def test_store_raises_if_not_configured(
+    contained_labware_count: int,
+    max_pool_count: int,
     decoy: Decoy,
     equipment: EquipmentHandler,
     state_view: StateView,
@@ -151,8 +161,8 @@ async def test_store_raises_if_not_configured(
         pool_primary_definition=None,
         pool_adapter_definition=None,
         pool_lid_definition=None,
-        contained_labware_bottom_first=_contained_labware(1),
-        max_pool_count=0,
+        contained_labware_bottom_first=_contained_labware(contained_labware_count),
+        max_pool_count=max_pool_count,
         pool_overlap=0,
     )
     decoy.when(


### PR DESCRIPTION
# Overview
If you tried to store a labware in a stacker without previously setting the labware configuration, the protocol would fail with 
```.shell
CannotPerformModuleAction: Cannot store labware in Flex Stacker in slotName=<> because it is full
```

This is not true because there should be nothing in the stacker at this point. This PR fixes this misleading error by check that there's a labware configuration first, before validating the labware count in the hopper. 

##  Test protocol

```.py
from opentrons.protocol_api import ProtocolContext, ParameterContext
from opentrons.protocol_api.module_contexts import (
    FlexStackerContext,
)

metadata = {
    "protocolName": "Flex Stacker DVT",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.24",
}


def run(protocol: ProtocolContext) -> None:
    """Protocol."""
    labware_name = "nest_96_wellplate_200ul_flat"
    labware_count = 3
    # ======================= SIMPLE SETUP ARRANGEMENT ======================
    stacker_A = protocol.load_module( "flexStackerModuleV1", "D4")
    stacker_A.set_stored_labware(
        load_name=labware_name,
        count=labware_count
    )
    
    stacker_B = protocol.load_module( "flexStackerModuleV1", "C4")

    labware_stack = stacker_A.retrieve()
    protocol.move_labware(labware_stack, stacker_B, True)
    stacker_B.store()

```

The error message should now make more sense:
```.shell
FlexStackerLabwarePoolNotYetDefinedError: The Flex Stacker in slotName=<> has not been configured yet and cannot be filled.
```
