### PR TITLE
fix(api): fix SimulatedProbeResult ser/deser

### DIFF
--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -135,6 +135,7 @@ from .liquid_level_detection import (
     WellInfoSummary,
     WellLiquidInfo,
     LiquidTrackingType,
+    SimulatedProbeResult,
 )
 from .liquid_handling import FlowRates
 from .labware_movement import LabwareMovementStrategy, LabwareMovementOffsetData
@@ -280,6 +281,7 @@ __all__ = [
     "WellInfoSummary",
     "WellLiquidInfo",
     "LiquidTrackingType",
+    "SimulatedProbeResult",
     # Liquid handling
     "FlowRates",
     # Labware movement

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, List, Any
-from pydantic import BaseModel, model_serializer, field_validator, model_validator
+from pydantic import BaseModel, model_serializer, model_validator
 
 
 class SimulatedProbeResult(BaseModel):
@@ -20,7 +20,7 @@ class SimulatedProbeResult(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def model_validator(cls, data: Any) -> Any:
+    def validate_model(cls, data: object) -> Any:
         """Handle deserializing from a simulated probe result."""
         if isinstance(data, str) and data == "SimulatedProbeResult":
             return {}
@@ -114,23 +114,6 @@ class ProbedVolumeInfo(BaseModel):
 
 class WellInfoSummary(BaseModel):
     """Payload for a well's liquid info in StateSummary."""
-
-    # TODO(cm): 3/21/25: refactor SimulatedLiquidProbe in a way that
-    # doesn't require models like this one that are just using it to
-    # need a custom validator
-    @field_validator("probed_height", "probed_volume", mode="before")
-    @classmethod
-    def validate_simulated_probe_result(
-        cls, input_val: object
-    ) -> LiquidTrackingType | None:
-        """Return the appropriate input to WellInfoSummary from json data."""
-        if input_val is None:
-            return None
-        if isinstance(input_val, LiquidTrackingType):
-            return input_val
-        if isinstance(input_val, str) and input_val == "SimulatedProbeResult":
-            return SimulatedProbeResult()
-        raise ValueError(f"Invalid input value {input_val} to WellInfoSummary")
 
     labware_id: str
     well_name: str

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -84,7 +84,9 @@ class SimulatedProbeResult(BaseModel):
         self.operations_after_probe.append(volume)
 
 
-LiquidTrackingType = SimulatedProbeResult | float
+# Work around https://github.com/pydantic/pydantic/issues/6830 - do not change the order of
+# this union
+LiquidTrackingType = float | SimulatedProbeResult
 
 
 class LoadedVolumeInfo(BaseModel):

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -1,9 +1,10 @@
 """Protocol Engine types to do with liquid level detection."""
+
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, List
-from pydantic import BaseModel, model_serializer, field_validator
+from typing import Optional, List, Any
+from pydantic import BaseModel, model_serializer, field_validator, model_validator
 
 
 class SimulatedProbeResult(BaseModel):
@@ -16,6 +17,14 @@ class SimulatedProbeResult(BaseModel):
     def serialize_model(self) -> str:
         """Serialize instances of this class as a string."""
         return "SimulatedProbeResult"
+
+    @model_validator(mode="before")
+    @classmethod
+    def model_validator(cls, data: Any) -> Any:
+        """Handle deserializing from a simulated probe result."""
+        if isinstance(data, str) and data == "SimulatedProbeResult":
+            return {}
+        return data
 
     def __add__(
         self, other: float | SimulatedProbeResult

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -24,6 +24,8 @@ def test_handles_invalid_hex(invalid_hex_color: str) -> None:
 
 
 class TestModel(BaseModel):
+    """Test model for deserializing SimulatedProbeResults."""
+
     value: float | SimulatedProbeResult
 
 

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -3,7 +3,11 @@
 import pytest
 from pydantic import ValidationError, BaseModel
 
-from opentrons.protocol_engine.types import HexColor, SimulatedProbeResult
+from opentrons.protocol_engine.types import (
+    HexColor,
+    SimulatedProbeResult,
+    LiquidTrackingType,
+)
 
 
 @pytest.mark.parametrize("hex_color", ["#F00", "#FFCC00CC", "#FC0C", "#98e2d1"])
@@ -23,15 +27,23 @@ def test_handles_invalid_hex(invalid_hex_color: str) -> None:
         HexColor.model_validate_json(f'"{invalid_hex_color}"')
 
 
-class TestModel(BaseModel):
+class _TestModel(BaseModel):
     """Test model for deserializing SimulatedProbeResults."""
 
-    value: float | SimulatedProbeResult
+    value: LiquidTrackingType
 
 
-def test_deserializes_simulated_liquid_probe() -> None:
+def test_roundtrips_simulated_liquid_probe() -> None:
     """Should be able to roundtrip our simulated results."""
-    base = TestModel(value=SimulatedProbeResult())
+    base = _TestModel(value=SimulatedProbeResult())
     serialized = base.model_dump_json()
-    deserialized = TestModel.model_validate_json(serialized)
+    deserialized = _TestModel.model_validate_json(serialized)
     assert isinstance(deserialized.value, SimulatedProbeResult)
+
+
+def test_roundtrips_nonsimulated_liquid_probe() -> None:
+    """Should be able to roundtrip our simulated results."""
+    base = _TestModel(value=10.0)
+    serialized = base.model_dump_json()
+    deserialized = _TestModel.model_validate_json(serialized)
+    assert deserialized.value == 10.0

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -1,8 +1,9 @@
 """Test protocol engine types."""
-import pytest
-from pydantic import ValidationError
 
-from opentrons.protocol_engine.types import HexColor
+import pytest
+from pydantic import ValidationError, BaseModel
+
+from opentrons.protocol_engine.types import HexColor, SimulatedProbeResult
 
 
 @pytest.mark.parametrize("hex_color", ["#F00", "#FFCC00CC", "#FC0C", "#98e2d1"])
@@ -20,3 +21,15 @@ def test_handles_invalid_hex(invalid_hex_color: str) -> None:
         HexColor(invalid_hex_color)
     with pytest.raises(ValidationError):
         HexColor.model_validate_json(f'"{invalid_hex_color}"')
+
+
+class TestModel(BaseModel):
+    value: float | SimulatedProbeResult
+
+
+def test_deserializes_simulated_liquid_probe() -> None:
+    """Should be able to roundtrip our simulated results."""
+    base = TestModel(value=SimulatedProbeResult())
+    serialized = base.model_dump_json()
+    deserialized = TestModel.model_validate_json(serialized)
+    assert isinstance(deserialized.value, SimulatedProbeResult)

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -50,6 +50,12 @@ def test_roundtrips_nonsimulated_liquid_probe() -> None:
     assert deserialized.value == 10.0
 
 
+def test_fails_deser_wrong_string() -> None:
+    """Should fail to deserialize the wrong string."""
+    with pytest.raises(ValidationError):
+        _TestModel.model_validate_json('{"value": "not the right string"}')
+
+
 @pytest.mark.parametrize("height", [None, 10.0, SimulatedProbeResult()])
 def test_roundtrips_well_info_summary(height: LiquidTrackingType | None) -> None:
     """It should round trip a WellInfoSummary."""

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -7,6 +7,7 @@ from opentrons.protocol_engine.types import (
     HexColor,
     SimulatedProbeResult,
     LiquidTrackingType,
+    WellInfoSummary,
 )
 
 
@@ -47,3 +48,23 @@ def test_roundtrips_nonsimulated_liquid_probe() -> None:
     serialized = base.model_dump_json()
     deserialized = _TestModel.model_validate_json(serialized)
     assert deserialized.value == 10.0
+
+
+@pytest.mark.parametrize("height", [None, 10.0, SimulatedProbeResult()])
+def test_roundtrips_well_info_summary(height: LiquidTrackingType | None) -> None:
+    """It should round trip a WellInfoSummary."""
+    inp = WellInfoSummary(
+        labware_id="hi",
+        well_name="lo",
+        loaded_volume=None,
+        probed_height=height,
+        probed_volume=height,
+    )
+    outp = WellInfoSummary.model_validate_json(inp.model_dump_json())
+    if isinstance(height, SimulatedProbeResult):
+        assert outp.labware_id == inp.labware_id
+        assert outp.well_name == inp.well_name
+        assert isinstance(outp.probed_height, SimulatedProbeResult)
+        assert isinstance(outp.probed_volume, SimulatedProbeResult)
+    else:
+        assert outp == inp


### PR DESCRIPTION
We weren't deserializing the simulation standin properly, which broke runlog downloading. Now we are.

Also, we shouldn't be dumping it to the runlog anymore. That was happening because of https://github.com/pydantic/pydantic/issues/6830 which causes mis-serialization of fields typed as `Model | NativeType`, where `NativeType` is some scalar python type (i.e. float, int) and `Model` is some pydantic model. With the model first, serializing the container will always result in the serialization of the default construction of the model, even if the attribute actually contained the native type. Flipping the order makes it work correctly, for some reason. Luckily this is consistent enough to be testable.

Closes RQA-4147
Closes EXEC-1429
Apparently,
Closes EXEC-1358