### PR TITLE
feat(labware-library): remove custom labware link from Labware Creator

### DIFF
--- a/labware-library/cypress/e2e/labware-creator/create.cy.js
+++ b/labware-library/cypress/e2e/labware-creator/create.cy.js
@@ -27,12 +27,6 @@ context('The Labware Creator Landing Page', () => {
       cy.contains('Labware Library').should('have.prop', 'href')
     })
 
-    it('contains a link to the request form', () => {
-      cy.contains('request form')
-        .should('have.prop', 'href')
-        .and('equal', 'https://lqilf9ng.paperform.co/')
-    })
-
     it('contains a second link to the labware guide', () => {
       cy.contains('this guide')
         .should('have.prop', 'href')

--- a/labware-library/cypress/e2e/labware-creator/reservoir.cy.js
+++ b/labware-library/cypress/e2e/labware-creator/reservoir.cy.js
@@ -43,19 +43,19 @@ context('Reservoirs', () => {
 
       cy.get("input[name='footprintXDimension']").type('150').blur()
       cy.contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
       ).should('exist')
       cy.get("input[name='footprintXDimension']").clear().type('127').blur()
       cy.contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
       ).should('not.exist')
       cy.get("input[name='footprintYDimension']").type('150').blur()
       cy.contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition'
       ).should('exist')
       cy.get("input[name='footprintYDimension']").clear().type('85').blur()
       cy.contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition'
       ).should('not.exist')
 
       // verify height

--- a/labware-library/cypress/e2e/labware-creator/tipRack.cy.js
+++ b/labware-library/cypress/e2e/labware-creator/tipRack.cy.js
@@ -110,7 +110,7 @@ describe('Create a Tip Rack', () => {
     cy.get('input[name="footprintXDimension"]').clear().type('20')
     cy.get('#Footprint span')
       .contains(
-        'Your labware is too small to fit in a slot properly. Please fill out this form to request an adapter.'
+        'Your labware is too small to fit in a slot properly. Please contact Opentrons Support to request an adapter.'
       )
       .should('exist')
 
@@ -118,7 +118,7 @@ describe('Create a Tip Rack', () => {
     cy.get('input[name="footprintXDimension"]').clear().type('2000')
     cy.get('#Footprint span')
       .contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
       )
       .should('exist')
 
@@ -126,7 +126,7 @@ describe('Create a Tip Rack', () => {
     cy.get('input[name="footprintYDimension"]').clear().type('20')
     cy.get('#Footprint span')
       .contains(
-        'Your labware is too small to fit in a slot properly. Please fill out this form to request an adapter.'
+        'Your labware is too small to fit in a slot properly. Please contact Opentrons Support to request an adapter.'
       )
       .should('exist')
 
@@ -134,7 +134,7 @@ describe('Create a Tip Rack', () => {
     cy.get('input[name="footprintYDimension"]').clear().type('2000')
     cy.get('#Footprint span')
       .contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
       )
       .should('exist')
 

--- a/labware-library/cypress/e2e/labware-creator/wellPlate.cy.js
+++ b/labware-library/cypress/e2e/labware-creator/wellPlate.cy.js
@@ -45,19 +45,19 @@ context('Well Plates', () => {
       // Verify footprint
       cy.get("input[name='footprintXDimension']").type('150').blur()
       cy.contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
       ).should('exist')
       cy.get("input[name='footprintXDimension']").clear().type('127').blur()
       cy.contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
       ).should('not.exist')
       cy.get("input[name='footprintYDimension']").type('150').blur()
       cy.contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
       ).should('exist')
       cy.get("input[name='footprintYDimension']").clear().type('85').blur()
       cy.contains(
-        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+        'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
       ).should('not.exist')
 
       // Verify height

--- a/labware-library/src/labware-creator/components/IntroCopy.tsx
+++ b/labware-library/src/labware-creator/components/IntroCopy.tsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom'
 
-import { LINK_CUSTOM_LABWARE_FORM } from '../fields'
 import styles from '../styles.module.css'
 import { LinkOut } from './LinkOut'
 
@@ -36,13 +35,7 @@ export const IntroCopy = (): JSX.Element => (
         an adapter.
       </li>
     </ol>
-    <p>
-      For all other custom labware, please use this{' '}
-      <LinkOut href={LINK_CUSTOM_LABWARE_FORM} className={styles.link}>
-        request form
-      </LinkOut>
-      .
-    </p>
+    <p>For all other custom labware, please contact Opentrons Support.</p>
 
     <div className={styles.callout}>
       <p>

--- a/labware-library/src/labware-creator/components/__tests__/FormAlerts.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/FormAlerts.test.tsx
@@ -62,7 +62,7 @@ describe('FormAlerts', () => {
     render(<FormAlerts {...props} />)
     const alertItem = screen.getByTestId('alert_item_title')
     expect(alertItem).toHaveTextContent(
-      'Your labware is not compatible with the Labware Creator. Please fill out this form to request a custom labware definition.'
+      'Your labware is not compatible with the Labware Creator. Please contact Opentrons Support to request a custom labware definition.'
     )
   })
 
@@ -110,7 +110,7 @@ describe('FormAlerts', () => {
     render(<FormAlerts {...props} />)
     const alertItem = screen.getByTestId('alert_item_title')
     expect(alertItem).toHaveTextContent(
-      'Your labware is too small to fit in a slot properly. Please fill out this form to request an adapter.'
+      'Your labware is too small to fit in a slot properly. Please contact Opentrons Support to request an adapter.'
     )
   })
 
@@ -134,7 +134,7 @@ describe('FormAlerts', () => {
     render(<FormAlerts {...props} />)
     const alertItem = screen.getByTestId('alert_item_title')
     expect(alertItem).toHaveTextContent(
-      'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
+      'Your labware is too large to fit in a single slot properly. Please contact Opentrons Support to request a custom labware definition.'
     )
   })
 })

--- a/labware-library/src/labware-creator/components/__tests__/sections/Footprint.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Footprint.test.tsx
@@ -87,7 +87,7 @@ describe('Footprint', () => {
       exact: false,
     })
     expect(warning.textContent).toEqual(
-      'Our recommended footprint for labware is 127.76 by 85.47 +/- 1mm. If you can fit your labware snugly into a single slot on the deck continue through the form. If not please request custom labware via this form.'
+      'Our recommended footprint for labware is 127.76 by 85.47 +/- 1mm. If you can fit your labware snugly into a single slot on the deck continue through the form. If not please contact Opentrons Support.'
     )
   })
 

--- a/labware-library/src/labware-creator/components/alerts/FormAlerts.tsx
+++ b/labware-library/src/labware-creator/components/alerts/FormAlerts.tsx
@@ -7,13 +7,10 @@ import {
   IRREGULAR_LABWARE_ERROR,
   LABWARE_TOO_LARGE_ERROR,
   LABWARE_TOO_SMALL_ERROR,
-  LINK_CUSTOM_LABWARE_FORM,
-  LINK_REQUEST_ADAPTER_FORM,
   LOOSE_TIP_FIT_ERROR,
   MUST_BE_A_NUMBER_ERROR,
   REQUIRED_FIELD_ERROR,
 } from '../../fields'
-import { LinkOut } from '../LinkOut'
 
 import type { FormikErrors, FormikTouched } from 'formik'
 import type { LabwareFields } from '../../fields'
@@ -30,9 +27,8 @@ export const IrregularLabwareAlert = (): JSX.Element => (
     type="error"
     title={
       <>
-        Your labware is not compatible with the Labware Creator. Please fill out{' '}
-        <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>this form</LinkOut> to request
-        a custom labware definition.
+        Your labware is not compatible with the Labware Creator. Please contact
+        Opentrons Support to request a custom labware definition.
       </>
     }
   />
@@ -43,9 +39,8 @@ export const LabwareTooSmallAlert = (): JSX.Element => (
     type="error"
     title={
       <>
-        Your labware is too small to fit in a slot properly. Please fill out{' '}
-        <LinkOut href={LINK_REQUEST_ADAPTER_FORM}>this form</LinkOut> to request
-        an adapter.
+        Your labware is too small to fit in a slot properly. Please contact
+        Opentrons Support to request an adapter.
       </>
     }
   />
@@ -56,9 +51,8 @@ export const LabwareTooLargeAlert = (): JSX.Element => (
     type="error"
     title={
       <>
-        Your labware is too large to fit in a single slot properly. Please fill
-        out <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>this form</LinkOut> to
-        request a custom labware definition.
+        Your labware is too large to fit in a single slot properly. Please
+        contact Opentrons Support to request a custom labware definition.
       </>
     }
   />

--- a/labware-library/src/labware-creator/components/alerts/XYDimensionAlerts.tsx
+++ b/labware-library/src/labware-creator/components/alerts/XYDimensionAlerts.tsx
@@ -1,12 +1,6 @@
 import { AlertItem } from '@opentrons/components'
 
-import {
-  LINK_CUSTOM_LABWARE_FORM,
-  SUGGESTED_X,
-  SUGGESTED_XY_RANGE,
-  SUGGESTED_Y,
-} from '../../fields'
-import { LinkOut } from '../LinkOut'
+import { SUGGESTED_X, SUGGESTED_XY_RANGE, SUGGESTED_Y } from '../../fields'
 
 import type { FormikTouched } from 'formik'
 import type { LabwareFields } from '../../fields'
@@ -15,8 +9,7 @@ const xyMessage = (
   <div>
     Our recommended footprint for labware is {SUGGESTED_X} by {SUGGESTED_Y} +/-
     1mm. If you can fit your labware snugly into a single slot on the deck
-    continue through the form. If not please request custom labware via{' '}
-    <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>this form</LinkOut>.
+    continue through the form. If not please contact Opentrons Support.
   </div>
 )
 

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -33,9 +33,6 @@ export const LOOSE_TIP_FIT_ERROR = 'LOOSE_TIP_FIT_ERROR'
 export const LABWARE_TOO_SMALL_ERROR = 'LABWARE_TOO_SMALL_ERROR'
 export const LABWARE_TOO_LARGE_ERROR = 'LABWARE_TOO_LARGE_ERROR'
 
-export const LINK_REQUEST_ADAPTER_FORM =
-  'https://docs.google.com/forms/d/e/1FAIpQLScvsHlXQrtIhIQYO0zr6mYwmzOCGpYPqepeDIorFIyj2jT-UQ/viewform'
-
 export type ImportErrorKey =
   | 'INVALID_FILE_TYPE'
   | 'INVALID_JSON_FILE'

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -33,8 +33,6 @@ export const LOOSE_TIP_FIT_ERROR = 'LOOSE_TIP_FIT_ERROR'
 export const LABWARE_TOO_SMALL_ERROR = 'LABWARE_TOO_SMALL_ERROR'
 export const LABWARE_TOO_LARGE_ERROR = 'LABWARE_TOO_LARGE_ERROR'
 
-export const LINK_CUSTOM_LABWARE_FORM = 'https://lqilf9ng.paperform.co/'
-
 export const LINK_REQUEST_ADAPTER_FORM =
   'https://docs.google.com/forms/d/e/1FAIpQLScvsHlXQrtIhIQYO0zr6mYwmzOCGpYPqepeDIorFIyj2jT-UQ/viewform'
 


### PR DESCRIPTION
closes RQA-4063

# Overview

Remove all instances that link to the `custom labware` or `custom adapter` request form and replace with copy to contact Opentrons Support.

## Test Plan and Hands on Testing

Check out Labware Creator and make sure the main page copy does not include a link to the custom labware. there are some modals that were updated too but i think its fine to just have QA check them

## Changelog

- fix copy and delete unused constants
- fix tests

## Risk assessment

low, LL is pretty low risk but also i'm only updating copy