### PR TITLE
refactor(labware-library, app, shared-data): add adapter/labware comb…

### DIFF
--- a/app/src/organisms/Desktop/Labware/LabwareCard/index.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareCard/index.tsx
@@ -18,7 +18,10 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { getLabwareDefIsStandard } from '@opentrons/shared-data'
+import {
+  getLabwareDefIsStandard,
+  getLabwareDisplayName,
+} from '@opentrons/shared-data'
 
 import { UNIVERSAL_FLAT_ADAPTER_X_DIMENSION } from '../LabwareDetails/Gallery'
 import { CustomLabwareOverflowMenu } from './CustomLabwareOverflowMenu'
@@ -34,7 +37,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
   const { t } = useTranslation(['labware_landing', 'branded'])
   const { definition, modified, filename } = props.labware
   const apiName = definition.parameters.loadName
-  const displayName = definition?.metadata.displayName
+  const displayName = getLabwareDisplayName(definition)
   const displayCategory = startCase(definition.metadata.displayCategory)
   const isCustomDefinition = !getLabwareDefIsStandard(definition)
   const xDimensionOverride =

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/index.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '@opentrons/components'
 import {
   getLabwareDefIsStandard,
+  getLabwareDisplayName,
   getUniqueWellProperties,
 } from '@opentrons/shared-data'
 
@@ -73,7 +74,8 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
   const { t } = useTranslation(['labware_landing', 'branded'])
   const { definition, modified, filename } = props.labware
   const { metadata, parameters, brand, wells, ordering } = definition
-  const apiName = definition.parameters.loadName
+  const displayName = getLabwareDisplayName(definition)
+  const apiName = parameters.loadName
   const { displayVolumeUnits } = metadata
   const wellGroups = getUniqueWellProperties(definition)
   const wellLabel = getWellLabel(definition)
@@ -114,7 +116,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
         justifyContent={JUSTIFY_SPACE_BETWEEN}
       >
         <LegacyStyledText css={TYPOGRAPHY.h2SemiBold}>
-          {props.labware.definition.metadata.displayName}
+          {displayName}
         </LegacyStyledText>
         <Link
           onClick={props.onClose}

--- a/labware-library/src/components/LabwareDetails/LabwareTitle.tsx
+++ b/labware-library/src/components/LabwareDetails/LabwareTitle.tsx
@@ -1,4 +1,6 @@
 // labware details page title and category
+import { getLabwareDisplayName } from '@opentrons/shared-data'
+
 import { CATEGORY, CATEGORY_LABELS_BY_CATEGORY } from '../../localization'
 import { LABEL_LEFT, LabelText, Value } from '../ui'
 import styles from './styles.module.css'
@@ -12,10 +14,9 @@ export interface LabwareTitleProps {
 
 export function LabwareTitle(props: LabwareTitleProps): JSX.Element {
   const { definition, className } = props
-  const { metadata } = definition
-  const { displayCategory } = definition.metadata
+  const displayName = getLabwareDisplayName(definition)
   const category =
-    CATEGORY_LABELS_BY_CATEGORY[displayCategory] ||
+    CATEGORY_LABELS_BY_CATEGORY[definition.metadata.displayCategory] ||
     CATEGORY_LABELS_BY_CATEGORY.other
 
   return (
@@ -24,7 +25,7 @@ export function LabwareTitle(props: LabwareTitleProps): JSX.Element {
         <LabelText position={LABEL_LEFT}>{CATEGORY}</LabelText>
         <Value>{category}</Value>
       </div>
-      <h2 className={styles.title}>{metadata.displayName}</h2>
+      <h2 className={styles.title}>{displayName}</h2>
     </div>
   )
 }

--- a/labware-library/src/components/LabwareList/LabwareCard.tsx
+++ b/labware-library/src/components/LabwareList/LabwareCard.tsx
@@ -1,6 +1,7 @@
 // labware display card
 import uniq from 'lodash/uniq'
 import { Icon } from '@opentrons/components'
+import { getLabwareDisplayName } from '@opentrons/shared-data'
 
 import { isNewLabware } from '../../definitions'
 import {
@@ -73,11 +74,11 @@ function TopBar(props: LabwareCardProps): JSX.Element {
 }
 
 function Title(props: LabwareCardProps): JSX.Element {
-  const { loadName } = props.definition.parameters
-  const { displayName } = props.definition.metadata
+  const { definition } = props
+  const displayName = getLabwareDisplayName(definition)
 
   return (
-    <Link to={'/'} search={`loadName=${loadName}`}>
+    <Link to={'/'} search={`loadName=${definition.parameters.loadName}`}>
       <h2 className={styles.title}>
         <span className={styles.title_text}>{displayName}</span>
         <Icon className={styles.title_icon} name="chevron-right" />

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -108,6 +108,12 @@ export const RETIRED_LABWARE = [
   // Replaced by opentrons_96_wellplate_200ul_pcr_full_skirt
   // https://opentrons.atlassian.net/browse/RLAB-230
   'armadillo_96_wellplate_200ul_pcr_full_skirt',
+  // adapter/labware combo defs
+  'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat',
+  'opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt',
+  'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat',
+  'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
+  'opentrons_96_pcr_adapter_armadillo_wellplate_200ul',
 ]
 
 export const getLabwareDisplayName = (


### PR DESCRIPTION
…os to retired labware

closes RQA-4107

# Overview

Update both Labware-library and App Labware to include `Retired` in labware definition display names that are listed in the `RETIRED_LABWARE` list and add the adapter/labware combos to the retired list.

## Test Plan and Hands on Testing

Search for Retired labware in Labware-library and when you click on the labware card, the labware details should show retired as well. And then do the same for the App Labware

## Changelog

- add the adapter/labware combo defs to the retired list
- use `getLabwareDisplayName` util in Labware-library and App Labware's LabwareCard and LabwareDetails

## Risk assessment

low, just adding `retired` to a few labware display names