### PR TITLE
docs(api): deprecate combination adapters

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -156,13 +156,17 @@ Use the ``adapter`` argument of ``load_labware()`` to load an adapter at the sam
 .. versionadded:: 2.15
     The ``adapter`` parameter.
 
-The API also has some "combination" labware definitions, which treat the adapter and labware as a unit::
+.. note::
 
-    hs_combo = hs_mod.load_labware(
-        "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat"
-    )
+    The API also has some "combination" labware definitions, which treat the adapter and labware as a unit::
 
-Loading labware this way prevents you from :ref:`moving the labware <moving-labware>` onto or off of the adapter, so it's less flexible than loading the two separately. Avoid using combination definitions unless your protocol specifies an ``apiLevel`` of 2.14 or lower.
+        hs_combo = hs_mod.load_labware(
+            "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat"
+        )
+
+    .. deprecated:: 2.15
+
+    Labware loaded with combination adapters no longer support all API features, such as moving the top labware or pipetting relative to liquid meniscus. These definitions are marked as "Retired" in version 8.5.0 of the Opentrons App and later. Avoid using combination definitions unless your protocol specifies an ``apiLevel`` of 2.14 or lower, in which case they are required.
 
 .. _new-well-access:
 


### PR DESCRIPTION


# Overview

Python API docs PR corresponding to changes in #18180. 

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-combo-adapters-retired/v2/new_labware.html#loading-together)

## Changelog

- Moves all mention of combination adapters into a note.
- Indicates that they are deprecated as of API version 2.15 (which they effectively have been, even if we didn't strongly discourage their use).
- List a couple features that will not work with them and say that future features are also not guaranteed. 

## Review requests

just accuracy

## Risk assessment

nil