### PR TITLE
refactor(app, api): Extend Error Recovery Policies to "fixit" commands

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -340,9 +340,9 @@ class CommandStore(HasState[CommandState], HandlesActions):
         succeeded_command = action.command
         self._state.command_history.set_command_succeeded(succeeded_command)
 
-    def _handle_fail_command_action(
+    def _handle_fail_command_action(  # noqa: C901
         self, action: FailCommandAction
-    ) -> None:  # noqa: C901
+    ) -> None:
         prev_entry = self.state.command_history.get(action.command_id)
 
         if isinstance(action.error, EnumeratedError):  # The error was undefined.

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -340,7 +340,9 @@ class CommandStore(HasState[CommandState], HandlesActions):
         succeeded_command = action.command
         self._state.command_history.set_command_succeeded(succeeded_command)
 
-    def _handle_fail_command_action(self, action: FailCommandAction) -> None:
+    def _handle_fail_command_action(
+        self, action: FailCommandAction
+    ) -> None:  # noqa: C901
         prev_entry = self.state.command_history.get(action.command_id)
 
         if isinstance(action.error, EnumeratedError):  # The error was undefined.
@@ -383,9 +385,15 @@ class CommandStore(HasState[CommandState], HandlesActions):
                 self._state.command_history.get_setup_queue_ids()
             )
         elif prev_entry.command.intent == CommandIntent.FIXIT:
-            other_command_ids_to_fail = list(
-                self._state.command_history.get_fixit_queue_ids()
-            )
+            if (
+                action.type == ErrorRecoveryType.CONTINUE_WITH_ERROR
+                or action.type == ErrorRecoveryType.ASSUME_FALSE_POSITIVE_AND_CONTINUE
+            ):
+                other_command_ids_to_fail = []
+            else:
+                other_command_ids_to_fail = list(
+                    self._state.command_history.get_fixit_queue_ids()
+                )
         elif (
             prev_entry.command.intent == CommandIntent.PROTOCOL
             or prev_entry.command.intent is None

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -389,6 +389,112 @@ def test_nonfatal_command_failure() -> None:
     assert subject_view.get_running_command_id() is None
 
 
+def test_fixit_command_failure_handling_by_recovery_type() -> None:
+    """Test that fixit command failures are handled differently based on error recovery type.
+
+    When a fixit command fails with permissible error recovery types, other queued fixit
+    commands should remain in the queue as is.
+
+    When a fixit command fails with other error recovery types, all queued fixit commands
+    should be marked as failed.
+    """
+
+    def test_with_recovery_type(
+        recovery_type: ErrorRecoveryType, should_fail_queued_cmds: bool
+    ) -> None:
+        subject = CommandStore(
+            is_door_open=False,
+            config=_make_config(),
+            error_recovery_policy=_placeholder_error_recovery_policy,
+        )
+        subject_view = CommandView(subject.state)
+
+        protocol_cmd = actions.QueueCommandAction(
+            request=commands.CommentCreate(
+                params=commands.CommentParams(message=""),
+                key="protocol-cmd",
+            ),
+            request_hash=None,
+            created_at=datetime(year=2021, month=1, day=1),
+            command_id="protocol-cmd-id",
+        )
+        subject.handle_action(protocol_cmd)
+        subject.handle_action(
+            actions.RunCommandAction(
+                command_id="protocol-cmd-id",
+                started_at=datetime(year=2021, month=1, day=2),
+            )
+        )
+        subject.handle_action(
+            actions.FailCommandAction(
+                command_id="protocol-cmd-id",
+                running_command=subject_view.get("protocol-cmd-id"),
+                error_id="error-1",
+                failed_at=datetime(year=2021, month=1, day=3),
+                error=errors.ProtocolEngineError(message="recovery needed"),
+                notes=[],
+                type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
+            )
+        )
+
+        for i in range(1, 4):
+            subject.handle_action(
+                actions.QueueCommandAction(
+                    request=commands.CommentCreate(
+                        params=commands.CommentParams(message=f"fixit {i}"),
+                        key=f"fixit-{i}",
+                        intent=commands.CommandIntent.FIXIT,
+                    ),
+                    request_hash=None,
+                    created_at=datetime(year=2021, month=2, day=i),
+                    command_id=f"fixit-id-{i}",
+                )
+            )
+
+        subject.handle_action(
+            actions.RunCommandAction(
+                command_id="fixit-id-1",
+                started_at=datetime(year=2021, month=2, day=10),
+            )
+        )
+        subject.handle_action(
+            actions.FailCommandAction(
+                command_id="fixit-id-1",
+                running_command=subject_view.get("fixit-id-1"),
+                error_id="error-2",
+                failed_at=datetime(year=2021, month=2, day=11),
+                error=errors.ProtocolEngineError(
+                    message=f"fixit failed with {recovery_type}"
+                ),
+                notes=[],
+                type=recovery_type,
+            )
+        )
+
+        if should_fail_queued_cmds:
+            assert all(
+                c.status == commands.CommandStatus.FAILED
+                for c in subject_view.get_all()
+            )
+        else:
+            assert [(c.id, c.status) for c in subject_view.get_all()] == [
+                ("protocol-cmd-id", commands.CommandStatus.FAILED),
+                ("fixit-id-1", commands.CommandStatus.FAILED),
+                ("fixit-id-2", commands.CommandStatus.QUEUED),
+                ("fixit-id-3", commands.CommandStatus.QUEUED),
+            ]
+            assert subject_view.get_next_to_execute() == "fixit-id-2"
+
+    test_with_recovery_type(
+        ErrorRecoveryType.CONTINUE_WITH_ERROR, should_fail_queued_cmds=False
+    )
+    test_with_recovery_type(
+        ErrorRecoveryType.ASSUME_FALSE_POSITIVE_AND_CONTINUE,
+        should_fail_queued_cmds=False,
+    )
+    test_with_recovery_type(ErrorRecoveryType.FAIL_RUN, should_fail_queued_cmds=True)
+
+
 def test_door_during_setup_phase() -> None:
     """Test behavior when the door is opened during the setup phase."""
     subject = CommandStore(

--- a/app/src/local-resources/commands/utils/__tests__/shouldCommandSucceedGivenRecoveryPolicy.test.ts
+++ b/app/src/local-resources/commands/utils/__tests__/shouldCommandSucceedGivenRecoveryPolicy.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldCommandSucceedGivenRecoveryPolicy } from '..'
+
+import type { ErrorRecoveryPolicy } from '@opentrons/api-client'
+
+describe('shouldCommandSucceedGivenRecoveryPolicy', () => {
+  const COMMAND_TYPE = 'pickUpTip'
+  const ERROR_TYPE = 'assumeFalsePositiveAndContinue'
+  const DIFFERENT_COMMAND_TYPE = 'dropTip'
+  const DIFFERENT_ERROR_TYPE = 'ignoreAndContinue'
+
+  const createCommand = (commandType: any, errorType: string | null): any => ({
+    commandType,
+    params: {},
+    ...(errorType
+      ? { error: { errorType, detail: {}, message: 'Test error' } }
+      : {}),
+  })
+
+  const createPolicy = (
+    commandType: any,
+    errorType: string,
+    ifMatch: string
+  ): ErrorRecoveryPolicy => ({
+    policyRules: [
+      {
+        matchCriteria: {
+          command: {
+            commandType,
+            error: {
+              errorType,
+            },
+          },
+        },
+        ifMatch: ifMatch as any,
+      },
+    ],
+  })
+
+  it('should return true for commands without errors, regardless of policy', () => {
+    const cmd = createCommand(COMMAND_TYPE, null)
+    const policy = createPolicy(COMMAND_TYPE, ERROR_TYPE, 'waitForRecovery')
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return true for commands with errors but no policy', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, undefined)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return true for commands with errors and matching policy with ifMatch = "ignoreAndContinue"', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy = createPolicy(COMMAND_TYPE, ERROR_TYPE, 'ignoreAndContinue')
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return true for commands with errors and matching policy with ifMatch = "assumeFalsePositiveAndContinue"', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy = createPolicy(
+      COMMAND_TYPE,
+      ERROR_TYPE,
+      'assumeFalsePositiveAndContinue'
+    )
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false for commands with errors and matching policy with ifMatch = "failRun"', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy = createPolicy(COMMAND_TYPE, ERROR_TYPE, 'failRun')
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false for commands with errors and matching policy with ifMatch = "waitForRecovery"', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy = createPolicy(COMMAND_TYPE, ERROR_TYPE, 'waitForRecovery')
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false for commands with errors and policy with non-matching commandType', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy = createPolicy(
+      DIFFERENT_COMMAND_TYPE,
+      ERROR_TYPE,
+      'ignoreAndContinue'
+    )
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false for commands with errors and policy with non-matching errorType', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy = createPolicy(
+      COMMAND_TYPE,
+      DIFFERENT_ERROR_TYPE,
+      'ignoreAndContinue'
+    )
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true if at least one policy rule matches and allows continuation', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy: ErrorRecoveryPolicy = {
+      policyRules: [
+        {
+          matchCriteria: {
+            command: {
+              commandType: DIFFERENT_COMMAND_TYPE,
+              error: {
+                errorType: ERROR_TYPE,
+              },
+            },
+          },
+          ifMatch: 'ignoreAndContinue',
+        },
+        {
+          matchCriteria: {
+            command: {
+              commandType: COMMAND_TYPE,
+              error: {
+                errorType: ERROR_TYPE,
+              },
+            },
+          },
+          ifMatch: 'ignoreAndContinue',
+        },
+      ],
+    }
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false if no policy rule matches', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy: ErrorRecoveryPolicy = {
+      policyRules: [
+        {
+          matchCriteria: {
+            command: {
+              commandType: DIFFERENT_COMMAND_TYPE,
+              error: {
+                errorType: ERROR_TYPE,
+              },
+            },
+          },
+          ifMatch: 'ignoreAndContinue',
+        },
+        {
+          matchCriteria: {
+            command: {
+              commandType: COMMAND_TYPE,
+              error: {
+                errorType: DIFFERENT_ERROR_TYPE,
+              },
+            },
+          },
+          ifMatch: 'ignoreAndContinue',
+        },
+      ],
+    }
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(false)
+  })
+
+  it('should work with an empty policy rules array', () => {
+    const cmd = createCommand(COMMAND_TYPE, ERROR_TYPE)
+    const policy: ErrorRecoveryPolicy = {
+      policyRules: [],
+    }
+
+    const result = shouldCommandSucceedGivenRecoveryPolicy(cmd, policy)
+
+    expect(result).toBe(false)
+  })
+})

--- a/app/src/local-resources/commands/utils/index.ts
+++ b/app/src/local-resources/commands/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './lastRunCommandPromptedErrorRecovery'
+export * from './shouldCommandSucceedGivenRecoveryPolicy'

--- a/app/src/local-resources/commands/utils/shouldCommandSucceedGivenRecoveryPolicy.ts
+++ b/app/src/local-resources/commands/utils/shouldCommandSucceedGivenRecoveryPolicy.ts
@@ -1,0 +1,28 @@
+import some from 'lodash/some'
+
+import type { ErrorRecoveryPolicy } from '@opentrons/api-client'
+import type { RunTimeCommand } from '@opentrons/shared-data'
+
+// Whether the command should succeed given the error recovery policy.
+export function shouldCommandSucceedGivenRecoveryPolicy(
+  cmd: RunTimeCommand,
+  policy: ErrorRecoveryPolicy | undefined
+): boolean {
+  if (!policy || !cmd.error) {
+    if (cmd.error) {
+      console.warn(
+        'Check for command errors before passing invoking isCommandErrorRecoveryPolicyException.'
+      )
+    }
+    return true
+  }
+
+  return some(
+    policy.policyRules,
+    rule =>
+      rule.matchCriteria.command.commandType === cmd.commandType &&
+      rule.matchCriteria.command.error.errorType === cmd.error?.errorType &&
+      (rule.ifMatch === 'assumeFalsePositiveAndContinue' ||
+        rule.ifMatch === 'ignoreAndContinue')
+  )
+}

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  useErrorRecoveryPolicy,
   useResumeRunFromRecoveryAssumingFalsePositiveMutation,
   useResumeRunFromRecoveryMutation,
   useStopRunMutation,
@@ -91,6 +92,7 @@ describe('useRecoveryCommands', () => {
     ).mockReturnValue({
       mutateAsync: mockResumeRunFromRecoveryAssumingFalsePositive,
     } as any)
+    vi.mocked(useErrorRecoveryPolicy).mockReturnValue({} as any)
   })
 
   it('should call chainRunRecoveryCommands with continuePastCommandFailure set to false', async () => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import head from 'lodash/head'
 
 import {
+  useErrorRecoveryPolicy,
   useResumeRunFromRecoveryAssumingFalsePositiveMutation,
   useResumeRunFromRecoveryMutation,
   useStopRunMutation,
@@ -95,10 +96,6 @@ export function useRecoveryCommands({
   const [ignoreErrors, setIgnoreErrors] = useState(false)
 
   const { proceedToRouteAndStep } = routeUpdateActions
-  const { chainRunCommands } = useChainRunCommands(
-    runId,
-    unvalidatedFailedCommand?.id
-  )
   const {
     mutateAsync: resumeRunFromRecovery,
   } = useResumeRunFromRecoveryMutation()
@@ -107,6 +104,13 @@ export function useRecoveryCommands({
   } = useResumeRunFromRecoveryAssumingFalsePositiveMutation()
   const { stopRun } = useStopRunMutation()
   const updateErrorRecoveryPolicy = useUpdateRecoveryPolicyWithStrategy(runId)
+  const currentRecoveryPolicy = useErrorRecoveryPolicy(runId)?.data?.data
+  const { chainRunCommands } = useChainRunCommands(
+    runId,
+    unvalidatedFailedCommand?.id,
+    currentRecoveryPolicy
+  )
+
   const { makeSuccessToast } = recoveryToastUtils
 
   const reportAndRouteFailedCmd = (e: Error): Promise<never> => {

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -18,7 +18,7 @@ import {
   setCommandIntent,
 } from './utils'
 
-import type { HostConfig } from '@opentrons/api-client'
+import type { ErrorRecoveryPolicy, HostConfig } from '@opentrons/api-client'
 import type {
   CreateMaintenanceRunType,
   useCreateMaintenanceCommandMutation,
@@ -66,7 +66,8 @@ export function useCreateRunCommandMutation(
 
 export function useChainRunCommands(
   runId: string,
-  failedCommandId?: string
+  failedCommandId?: string,
+  recoveryPolicy?: ErrorRecoveryPolicy
 ): {
   chainRunCommands: (
     commands: CreateCommand[],
@@ -89,7 +90,8 @@ export function useChainRunCommands(
         commands,
         createRunCommand,
         continuePastCommandFailure,
-        setIsLoading
+        setIsLoading,
+        recoveryPolicy
       ),
     isCommandMutationLoading: isLoading,
   }

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -1,8 +1,10 @@
 import { format } from 'date-fns'
 
+import { shouldCommandSucceedGivenRecoveryPolicy } from '/app/local-resources/commands/utils/shouldCommandSucceedGivenRecoveryPolicy'
+
 import type { Dispatch, SetStateAction } from 'react'
 import type { UseMutateAsyncFunction } from 'react-query'
-import type { CommandData } from '@opentrons/api-client'
+import type { CommandData, ErrorRecoveryPolicy } from '@opentrons/api-client'
 import type { CreateLiveCommandMutateParams } from '@opentrons/react-api-client/src/runs/useCreateLiveCommandMutation'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { CreateMaintenanceCommand, CreateRunCommand } from './hooks'
@@ -11,7 +13,8 @@ export const chainRunCommandsRecursive = (
   commands: CreateCommand[],
   createRunCommand: CreateRunCommand,
   continuePastCommandFailure: boolean = true,
-  setIsLoading: Dispatch<SetStateAction<boolean>>
+  setIsLoading: Dispatch<SetStateAction<boolean>>,
+  recoveryPolicy?: ErrorRecoveryPolicy
 ): Promise<CommandData[]> => {
   if (commands.length < 1) {
     return Promise.reject(new Error('no commands to execute'))
@@ -23,7 +26,11 @@ export const chainRunCommandsRecursive = (
     waitUntilComplete: true,
   })
     .then(response => {
-      if (!continuePastCommandFailure && response.data.status === 'failed') {
+      if (
+        !continuePastCommandFailure &&
+        response.data.status === 'failed' &&
+        !shouldCommandSucceedGivenRecoveryPolicy(response.data, recoveryPolicy)
+      ) {
         setIsLoading(false)
         return Promise.reject(
           new Error(response.data.error?.detail ?? 'command failed')


### PR DESCRIPTION
Closes [RQA-4121](https://opentrons.atlassian.net/browse/RQA-4121)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If a user performs a recovery flow and chooses to ignore an error type, and then re-enters Error Recovery at a later time (for a different error), we should probably apply existing error recovery policies to fixit commands. 

As a concrete example, this can happen when a user ignores tip pick up errors, enters Error Recovery for something like an overpressure error, and then attempts to pick up a tip during the flow.

### Current Behavior

https://github.com/user-attachments/assets/d6e249aa-6750-4ef9-a653-96d71c628375


### Updated Behavior

https://github.com/user-attachments/assets/5e6e8835-fd41-4aff-95fe-94e6e27636c5

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Failing a recovery command during error recovery that is associated with an existing error recovery policy correctly ignores the error. 

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- I think we only need to update the `CommandStore` in api, but is there anywhere else I may have missed?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- low...maybe? It seems better to target edge here instead of chore_release, just so we can dogfood this a bit. It doesn't seem critical enough to include at this stage in 8.4, anyway.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4121]: https://opentrons.atlassian.net/browse/RQA-4121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ