### PR TITLE
fix(api): correct the behavior of blowout when using a .meniscus target

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -606,7 +606,20 @@ class InstrumentContext(publisher.CommandPublisher):
                     "Blow_out being performed on a tiprack. "
                     "Please re-check your code"
                 )
-            move_to_location = target.location or target.well.top()
+            if target.location:
+                # because the lower levels of blowout don't handle LiquidHandlingWellLocation and
+                # there is no "operation_volume" for blowout we need to convert the relative location
+                # given with a .meniscus to an absolute point. To maintain the meniscus behavior
+                # we can just add the offset to the current liquid height.
+                if target.location.meniscus_tracking:
+                    move_to_location = target.well.bottom(
+                        target.well.current_liquid_height()  # type: ignore [arg-type]
+                        + target.location.point.z
+                    )
+                else:
+                    move_to_location = target.location
+            else:
+                move_to_location = target.well.top()
             well = target.well
         elif isinstance(target, validation.PointTarget):
             move_to_location = target.location

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -59,7 +59,13 @@ from opentrons.protocol_api.core.legacy.legacy_instrument_core import (
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
-from opentrons.types import Location, Mount, Point, NozzleMapInterface
+from opentrons.types import (
+    Location,
+    Mount,
+    Point,
+    NozzleMapInterface,
+    MeniscusTrackingTarget,
+)
 
 from opentrons_shared_data.pipette.pipette_definition import ValidNozzleMaps
 from opentrons_shared_data.errors.exceptions import (
@@ -550,6 +556,53 @@ def test_blow_out_to_well_location(
             location=input_location, well_core=mock_well._core, in_place=False
         ),
         times=1,
+    )
+
+
+def test_blow_out_to_well_meniscus_location(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    mock_protocol_core: ProtocolCore,
+) -> None:
+    """It should blow out to a well location."""
+    liquid_height = 10.0
+    well_bottom = Point(2, 2, 2)
+    relative_height = 3
+    mock_well = decoy.mock(cls=Well)
+    input_location_absolute = Location(
+        point=well_bottom + Point(0, 0, liquid_height) + Point(0, 0, relative_height),
+        labware=mock_well,
+    )
+    decoy.when(mock_well.current_liquid_height()).then_return(liquid_height)
+    decoy.when(mock_well.bottom(liquid_height + relative_height)).then_return(
+        Location(
+            point=well_bottom + Point(0, 0, liquid_height + relative_height),
+            labware=mock_well,
+        )
+    )
+
+    input_location = Location(
+        point=Point(0, 0, relative_height),
+        labware=mock_well,
+        _meniscus_tracking=MeniscusTrackingTarget.END,
+    )
+    last_location = Location(point=Point(9, 9, 9), labware=None)
+    decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
+
+    decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
+        last_location
+    )
+    decoy.when(
+        mock_validation.validate_location(
+            location=input_location, last_location=last_location
+        )
+    ).then_return(WellTarget(well=mock_well, location=input_location, in_place=False))
+
+    subject.blow_out(location=input_location)
+
+    mock_instrument_core.blow_out(
+        location=input_location_absolute, well_core=mock_well._core, in_place=False
     )
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Due to the way that the movement logic of blow out is handled, it expects an absolute point. So when a location is a meniscus relative type, then it miscalculates the "delta" of the point. The delta it computes is -1 * the absolute point of the well.top.

To correct this if the location passed into blowout is a meniscus relative location, we take the offset from that and apply it to the current well height instead. this gives us the correct absolute point.

The other option would have been to hook up all the layers to handle LiquidHandlingWellLocation types in addition to WellLocation but that has its own headaches since its not actually liquid handling, and there is no operational volume.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Using blowout with a meniscus relative location without a liquid-probe or load liquid will now fail analysis. there is no interaction with a "minimum liquid height" so there is no worries there. even with a liquid height of 0

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
