### PR TITLE
fix(app): Fix labware locations when in expansion slot and on thermocycler

### DIFF
--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
@@ -22,6 +22,9 @@ import {
 } from '@opentrons/components'
 import {
   FLEX_STACKER_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
   getLabwareDefURI,
   getLabwareDisplayName,
   getLoadedLabwareDefinitionsByUri,
@@ -30,6 +33,7 @@ import {
 import { useCsvFileQuery } from '@opentrons/react-api-client'
 import { DownloadCsvFileLink } from './DownloadCsvFileLink'
 import { useMostRecentCompletedAnalysis } from '/app/resources/runs'
+import { useIsFlex } from '/app/redux-resources/robots'
 import { useDeckCalibrationData } from './hooks'
 import { LegacyOffsetVector } from '/app/molecules/LegacyOffsetVector'
 
@@ -46,6 +50,7 @@ export function HistoricalProtocolRunDrawer(
 ): JSX.Element | null {
   const { i18n, t } = useTranslation('run_details')
   const { run, robotName } = props
+  const isFlex = useIsFlex(robotName)
   const allLabwareOffsets: LabwareOffset[] =
     run.labwareOffsets?.sort(
       (a, b) =>
@@ -197,7 +202,7 @@ export function HistoricalProtocolRunDrawer(
               as="p"
               datatest-id="RecentProtocolRun_Drawer_locationTitle"
             >
-              {i18n.format(t('location'), 'capitalize')}
+              {i18n.format(t('labware'), 'capitalize')}
             </LegacyStyledText>
           </Box>
           <Box width="25%" padding={`${SPACING.spacing4} 0`}>
@@ -205,7 +210,7 @@ export function HistoricalProtocolRunDrawer(
               as="p"
               datatest-id="RecentProtocolRun_Drawer_labwareTitle"
             >
-              {i18n.format(t('labware'), 'capitalize')}
+              {i18n.format(t('location'), 'capitalize')}
             </LegacyStyledText>
           </Box>
           <Box width="25%" padding={`${SPACING.spacing4} 0`}>
@@ -230,6 +235,15 @@ export function HistoricalProtocolRunDrawer(
               definition != null
                 ? getLabwareDisplayName(definition)
                 : offset.definitionUri
+            const thermocyclerLocation = isFlex
+              ? TC_MODULE_LOCATION_OT3
+              : TC_MODULE_LOCATION_OT2
+            const slotName =
+              offset.location.moduleModel != null &&
+              getModuleType(offset.location.moduleModel) ===
+                THERMOCYCLER_MODULE_TYPE
+                ? thermocyclerLocation
+                : offset.location.slotName
 
             return (
               <Flex
@@ -251,7 +265,7 @@ export function HistoricalProtocolRunDrawer(
                   gridGap={SPACING.spacing4}
                   alignItems={ALIGN_CENTER}
                 >
-                  <DeckInfoLabel deckLabel={offset.location.slotName} />
+                  <DeckInfoLabel deckLabel={slotName} />
                   {offset.locationSequence?.some(
                     seq => seq.kind === 'onLabware'
                   ) && (

--- a/app/src/transformations/commands/transformations/getStackedItemsOnStartingDeck.ts
+++ b/app/src/transformations/commands/transformations/getStackedItemsOnStartingDeck.ts
@@ -240,7 +240,17 @@ export function getStackedItemsOnStartingDeck(
           ): sequenceItem is OnCutoutFixtureLocationSequenceComponent =>
             sequenceItem.kind === 'onCutoutFixture'
         )?.cutoutId
-        location = getCutoutDisplayName(cutoutId as CutoutId)
+        const addressableArea = locationSequence.find(
+          (
+            sequenceItem
+          ): sequenceItem is OnAddressableAreaLocationSequenceComponent =>
+            sequenceItem.kind === 'onAddressableArea'
+        )?.addressableAreaName
+        if (cutoutId == null && addressableArea == null) return acc
+        location =
+          addressableArea != null
+            ? getSlotFromAddressableAreaName(addressableArea)
+            : getCutoutDisplayName(cutoutId as CutoutId)
         if (cutoutId == null || Object.keys(acc).includes(location)) {
           return acc
         }


### PR DESCRIPTION
fix RABR-766, RQA-4143
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->
This PR fixes a few bugs relating to how we display loaded labware locations
## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

- [ ] Look at run setup for the protocol linked in RABR-766 and see that the stack of TC lids and deck riser are now properly rendered as being in C4
- [ ] Look at a historical run with labware on a TC that has offsets applied, see the location presented as `A1+B1` and see the Labware and Location labels above the proper categories

## Changelog
This PR fixes two issues
1. When getting the slot name from a location sequence for an expansion slot, we need to look at the addressable area. I updated the `getStackedItemsOnStartingDeck` util to first reference the addressable area name, then cutout config if that doesn't exist. This update had already been made for `loadLabware` commands but was needed for `loadLidStack` commands
3. Update the slot display name for labware on thermocycler modules in the historical protocol run offset drawer and flip the copy of Labware and Location to the proper order
<img width="904" alt="Screenshot 2025-04-25 at 2 39 15 PM" src="https://github.com/user-attachments/assets/ce50d616-7ee0-4c45-8fd9-51822f16a278" />
<img width="885" alt="Screenshot 2025-04-25 at 2 39 23 PM" src="https://github.com/user-attachments/assets/e22ce986-b78b-46bd-948d-7e4d8bc6b099" />

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick code check 
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
