### PR TITLE
fix(api): discount labware in system location/hopper location when getting the deck height

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -196,14 +196,25 @@ class GeometryView:
 
         return self._get_highest_z_from_labware_data(labware_data)
 
+    def is_deck_obstacle(self, lw_data: LoadedLabware) -> bool:
+        """Check if the labware is a deck obstacle."""
+        # is it offdeck?
+        if isinstance(
+            lw_data.location, InStackerHopperLocation
+        ) or lw_data.location in [OFF_DECK_LOCATION, SYSTEM_LOCATION]:
+            return False
+        # is it a lid?
+        if self._labware.get_labware_by_lid_id(lw_data.id) is not None:
+            return False
+        return True
+
     def get_all_obstacle_highest_z(self) -> float:
         """Get the highest Z-point across all obstacles that the instruments need to fly over."""
         highest_labware_z = max(
             (
                 self._get_highest_z_from_labware_data(lw_data)
                 for lw_data in self._labware.get_all()
-                if lw_data.location != OFF_DECK_LOCATION
-                and not self._labware.get_labware_by_lid_id(lw_data.id)
+                if self.is_deck_obstacle(lw_data)
             ),
             default=0.0,
         )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -196,11 +196,11 @@ class GeometryView:
 
         return self._get_highest_z_from_labware_data(labware_data)
 
-    def _is_deck_obstacle(self, labware_id: str) -> bool:
+    def _is_obstacle_labware(self, labware_id: str) -> bool:
         """Check if the labware is a deck obstacle."""
         for loc in self.get_location_sequence(labware_id):
-            if isinstance(
-                loc, [InStackerHopperLocation, NotOnDeckLocationSequenceComponent]
+            if isinstance(loc, InStackerHopperLocation) or isinstance(
+                loc, NotOnDeckLocationSequenceComponent
             ):
                 return False
         # TODO: (AA 4/28/25) re-evaluate this logic, this doesn't make sense
@@ -209,29 +209,36 @@ class GeometryView:
             return False
         return True
 
-    def get_all_obstacle_highest_z(self) -> float:
-        """Get the highest Z-point across all obstacles that the instruments need to fly over."""
-        highest_labware_z = max(
+    def _get_tallest_obstacle_labware(self) -> float:
+        """Get the highest Z-point of all labware on the deck."""
+        all_labware = self._labware.get_all()
+        if not all_labware:
+            return 0.0
+        return max(
             (
                 self._get_highest_z_from_labware_data(lw_data)
-                for lw_data in self._labware.get_all()
-                if self._is_deck_obstacle(lw_data.id)
+                for lw_data in all_labware
+                if self._is_obstacle_labware(lw_data.id)
             ),
             default=0.0,
         )
 
+    def _get_tallest_obstacle_module(self) -> float:
+        """Get the highest Z-point of all modules on the deck."""
+        all_module = self._modules.get_all()
+        if not all_module:
+            return 0.0
         # Fixme (spp, 2023-12-04): the overall height is not the true highest z of modules
         #  on a Flex.
-        highest_module_z = max(
-            (
-                self._modules.get_overall_height(module.id)
-                for module in self._modules.get_all()
-            ),
+        return max(
+            (self._modules.get_overall_height(module.id) for module in all_module),
             default=0.0,
         )
 
-        cutout_fixture_names = self._addressable_areas.get_all_cutout_fixtures()
-        if cutout_fixture_names is None:
+    def _get_tallest_obstacle_fixture(self) -> float:
+        """Get the highest Z-point of all fixtures on the deck."""
+        all_fixtures = self._addressable_areas.get_all_cutout_fixtures()
+        if all_fixtures is None:
             # We're using a simulated deck config (see `Config.use_simulated_deck_config`).
             # We only know the addressable areas referenced by the protocol, not the fixtures
             # providing them. And there is more than one possible configuration of fixtures
@@ -242,20 +249,21 @@ class GeometryView:
             # fixture must be on the deck, and then it uses long tips that wouldn't be able to
             # clear the top of that fixture. We should perhaps raise an analysis error for that,
             # but defaulting to 0 here means we won't.
-            highest_fixture_z = 0.0
-        else:
-            highest_fixture_z = max(
-                (
-                    self._addressable_areas.get_fixture_height(cutout_fixture_name)
-                    for cutout_fixture_name in cutout_fixture_names
-                ),
-                default=0.0,
-            )
-
+            return 0.0
         return max(
-            highest_labware_z,
-            highest_module_z,
-            highest_fixture_z,
+            (
+                self._addressable_areas.get_fixture_height(cutout_fixture_name)
+                for cutout_fixture_name in all_fixtures
+            ),
+            default=0.0,
+        )
+
+    def get_all_obstacle_highest_z(self) -> float:
+        """Get the highest Z-point across all obstacles that the instruments need to fly over."""
+        return max(
+            self._get_tallest_obstacle_labware(),
+            self._get_tallest_obstacle_module(),
+            self._get_tallest_obstacle_fixture(),
         )
 
     def get_highest_z_in_slot(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -196,15 +196,16 @@ class GeometryView:
 
         return self._get_highest_z_from_labware_data(labware_data)
 
-    def is_deck_obstacle(self, lw_data: LoadedLabware) -> bool:
+    def _is_deck_obstacle(self, labware_id: str) -> bool:
         """Check if the labware is a deck obstacle."""
-        # is it offdeck?
-        if isinstance(
-            lw_data.location, InStackerHopperLocation
-        ) or lw_data.location in [OFF_DECK_LOCATION, SYSTEM_LOCATION]:
-            return False
-        # is it a lid?
-        if self._labware.get_labware_by_lid_id(lw_data.id) is not None:
+        for loc in self.get_location_sequence(labware_id):
+            if isinstance(
+                loc, [InStackerHopperLocation, NotOnDeckLocationSequenceComponent]
+            ):
+                return False
+        # TODO: (AA 4/28/25) re-evaluate this logic, this doesn't make sense
+        # to me but keeping it to preserve existing behavior
+        if self._labware.get_labware_by_lid_id(labware_id) is not None:
             return False
         return True
 
@@ -214,7 +215,7 @@ class GeometryView:
             (
                 self._get_highest_z_from_labware_data(lw_data)
                 for lw_data in self._labware.get_all()
-                if self.is_deck_obstacle(lw_data)
+                if self._is_deck_obstacle(lw_data.id)
             ),
             default=0.0,
         )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -193,7 +193,6 @@ class GeometryView:
     def get_labware_highest_z(self, labware_id: str) -> float:
         """Get the highest Z-point of a labware."""
         labware_data = self._labware.get(labware_id)
-
         return self._get_highest_z_from_labware_data(labware_data)
 
     def _is_obstacle_labware(self, labware_id: str) -> bool:
@@ -203,10 +202,6 @@ class GeometryView:
                 loc, NotOnDeckLocationSequenceComponent
             ):
                 return False
-        # TODO: (AA 4/28/25) re-evaluate this logic, this doesn't make sense
-        # to me but keeping it to preserve existing behavior
-        if self._labware.get_labware_by_lid_id(labware_id) is not None:
-            return False
         return True
 
     def _get_tallest_obstacle_labware(self) -> float:
@@ -222,11 +217,9 @@ class GeometryView:
 
     def _get_tallest_obstacle_module(self) -> float:
         """Get the highest Z-point of all modules on the deck."""
-        # Fixme (spp, 2023-12-04): the overall height is not the true highest z of modules
-        #  on a Flex.
         return max(
             (
-                self._modules.get_overall_height(module.id)
+                self._modules.get_module_highest_z(module.id, self._addressable_areas)
                 for module in self._modules.get_all()
             ),
             default=0.0,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -211,13 +211,10 @@ class GeometryView:
 
     def _get_tallest_obstacle_labware(self) -> float:
         """Get the highest Z-point of all labware on the deck."""
-        all_labware = self._labware.get_all()
-        if not all_labware:
-            return 0.0
         return max(
             (
                 self._get_highest_z_from_labware_data(lw_data)
-                for lw_data in all_labware
+                for lw_data in self._labware.get_all()
                 if self._is_obstacle_labware(lw_data.id)
             ),
             default=0.0,
@@ -225,13 +222,13 @@ class GeometryView:
 
     def _get_tallest_obstacle_module(self) -> float:
         """Get the highest Z-point of all modules on the deck."""
-        all_module = self._modules.get_all()
-        if not all_module:
-            return 0.0
         # Fixme (spp, 2023-12-04): the overall height is not the true highest z of modules
         #  on a Flex.
         return max(
-            (self._modules.get_overall_height(module.id) for module in all_module),
+            (
+                self._modules.get_overall_height(module.id)
+                for module in self._modules.get_all()
+            ),
             default=0.0,
         )
 

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -49,8 +49,6 @@ from opentrons_shared_data.labware import load_definition as load_labware_defini
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (
     OFF_DECK_LOCATION,
-    SYSTEM_LOCATION,
-    LabwareLocation,
     LabwareOffsetVector,
     DeckSlotLocation,
     ModuleLocation,
@@ -81,6 +79,7 @@ from opentrons.protocol_engine.types import (
     ProbedVolumeInfo,
     LoadedVolumeInfo,
     WellLiquidInfo,
+    LabwareLocationSequence,
     OnAddressableAreaOffsetLocationSequenceComponent,
     OnModuleOffsetLocationSequenceComponent,
     OnLabwareOffsetLocationSequenceComponent,
@@ -791,92 +790,66 @@ def test_get_all_obstacle_highest_z_no_equipment(
     assert result == 0
 
 
-@pytest.mark.parametrize(
-    "non_deck_location",
-    (
-        OFF_DECK_LOCATION,
-        SYSTEM_LOCATION,
-        InStackerHopperLocation(moduleId="stacker-module-id"),
-    ),
-)
-def test_get_all_obstacle_highest_z(
-    non_deck_location: LabwareLocation,
+def test_get_higest_z_for_all_labware(
     decoy: Decoy,
+    monkeypatch: pytest.MonkeyPatch,
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
     subject: GeometryView,
 ) -> None:
     """It should get the highest Z amongst all labware."""
-    plate = LoadedLabware(
-        id="plate-id",
-        loadName="plate-load-name",
-        definitionUri="plate-definition-uri",
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
-        offsetId="plate-offset-id",
-    )
-    non_deck_lw = LoadedLabware(
-        id="off-deck-plate-id",
-        loadName="off-deck-plate-load-name",
-        definitionUri="off-deck-plate-definition-uri",
-        location=non_deck_location,
-        offsetId="plate-offset-id",
-    )
-    reservoir = LoadedLabware(
-        id="reservoir-id",
-        loadName="reservoir-load-name",
-        definitionUri="reservoir-definition-uri",
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
-        offsetId="reservoir-offset-id",
+    plate_loc_seq: LabwareLocationSequence = [
+        OnAddressableAreaLocationSequenceComponent(
+            addressableAreaName=DeckSlotName.SLOT_3.id
+        )
+    ]
+
+    off_deck_loc_seq: LabwareLocationSequence = [
+        NotOnDeckLocationSequenceComponent(logicalLocationName=OFF_DECK_LOCATION),
+    ]
+
+    in_hopper_loq_seq: LabwareLocationSequence = [
+        InStackerHopperLocation(moduleId="stacker-id"),
+        OnAddressableAreaLocationSequenceComponent(
+            addressableAreaName="singleCenterSlot"
+        ),
+        OnCutoutFixtureLocationSequenceComponent(
+            cutoutId="cutoutC2", possibleCutoutFixtureIds=["singleCenterSlot"]
+        ),
+    ]
+
+    mock_get_location_seq = decoy.mock(func=subject.get_location_sequence)
+    monkeypatch.setattr(subject, "get_location_sequence", mock_get_location_seq)
+    mock_highest_z_from_lw = decoy.mock(func=subject._get_highest_z_from_labware_data)
+    monkeypatch.setattr(
+        subject, "_get_highest_z_from_labware_data", mock_highest_z_from_lw
     )
 
-    plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
-    non_deck_lw_offset = LabwareOffsetVector(x=1, y=-2, z=3)
-    reservoir_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+    decoy.when(mock_labware_view.get_all()).then_return(
+        [sentinel.on_deck_plate, sentinel.off_deck_labware, sentinel.hopper_labware],
+    )
+    sentinel.on_deck_plate.id = "on-deck-plate-id"
+    sentinel.off_deck_labware.id = "off-deck-labware-id"
+    sentinel.hopper_labware.id = "hopper-labware-id"
 
     decoy.when(mock_module_view.get_all()).then_return([])
     decoy.when(mock_addressable_area_view.get_all()).then_return([])
 
-    decoy.when(mock_labware_view.get_all()).then_return([plate, non_deck_lw, reservoir])
-    decoy.when(mock_labware_view.get("plate-id")).then_return(plate)
-    decoy.when(mock_labware_view.get("off-deck-plate-id")).then_return(non_deck_lw)
-    decoy.when(mock_labware_view.get("reservoir-id")).then_return(reservoir)
-
-    decoy.when(mock_labware_view.get_dimensions(labware_id="plate-id")).then_return(
-        Dimensions(x=0, y=0, z=10)
+    decoy.when(mock_get_location_seq("on-deck-plate-id")).then_return(plate_loc_seq)
+    decoy.when(mock_get_location_seq(sentinel.off_deck_labware.id)).then_return(
+        off_deck_loc_seq
     )
-    decoy.when(
-        mock_labware_view.get_dimensions(labware_id="off-deck-plate-id")
-    ).then_return(
-        Dimensions(x=0, y=0, z=10000)  # Something tall.
-    )
-    decoy.when(mock_labware_view.get_dimensions(labware_id="reservoir-id")).then_return(
-        Dimensions(x=0, y=0, z=20)
+    decoy.when(mock_get_location_seq(sentinel.hopper_labware.id)).then_return(
+        in_hopper_loq_seq
     )
 
-    decoy.when(mock_labware_view.get_labware_offset_vector("plate-id")).then_return(
-        plate_offset
-    )
-    decoy.when(
-        mock_labware_view.get_labware_offset_vector("off-deck-plate-id")
-    ).then_return(non_deck_lw_offset)
-    decoy.when(mock_labware_view.get_labware_offset_vector("reservoir-id")).then_return(
-        reservoir_offset
-    )
+    decoy.when(mock_highest_z_from_lw(sentinel.on_deck_plate)).then_return(20)
+    decoy.when(mock_highest_z_from_lw(sentinel.off_deck_labware)).then_return(50)
+    decoy.when(mock_highest_z_from_lw(sentinel.hopper_labware)).then_return(60)
 
-    decoy.when(
-        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_3.id)
-    ).then_return(Point(1, 2, 3))
-    decoy.when(
-        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_4.id)
-    ).then_return(Point(4, 5, 6))
-
-    plate_z = subject.get_labware_highest_z("plate-id")
-    reservoir_z = subject.get_labware_highest_z("reservoir-id")
-    all_z = subject.get_all_obstacle_highest_z()
-
-    # Should exclude the off-deck plate.
-    assert all_z == max(plate_z, reservoir_z)
+    # should only consider the on-deck labware
+    assert subject.get_all_obstacle_highest_z() == 20.0
 
 
 def test_get_all_obstacle_highest_z_with_staging_area(
@@ -4127,7 +4100,6 @@ def test_get_location_sequence_deck_slot(
             cutoutId="cutoutC2", possibleCutoutFixtureIds=["singleCenterSlot"]
         ),
     ]
-    assert subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4190,7 +4162,6 @@ def test_get_location_sequence_module(
             cutoutId="cutoutA3", possibleCutoutFixtureIds=["temperatureModuleV2"]
         ),
     ]
-    assert subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4267,7 +4238,6 @@ def test_get_location_sequence_module_with_adapter(
             cutoutId="cutoutA3", possibleCutoutFixtureIds=["temperatureModuleV2"]
         ),
     ]
-    assert subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4295,7 +4265,6 @@ def test_get_location_sequence_off_deck(
     assert location_sequence == [
         NotOnDeckLocationSequenceComponent(logicalLocationName=OFF_DECK_LOCATION)
     ]
-    assert not subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4359,7 +4328,6 @@ def test_get_location_sequence_stacker_hopper(
             cutoutId="cutoutA3",
         ),
     ]
-    assert not subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4421,7 +4389,6 @@ def test_get_predicted_location_sequence_with_pending_labware(
             cutoutId="cutoutA3", possibleCutoutFixtureIds=["temperatureModuleV2"]
         ),
     ]
-    assert subject._is_deck_obstacle("adapter-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -4,7 +4,7 @@ import inspect
 import json
 from datetime import datetime
 from math import isclose
-from typing import cast, List, Tuple, Optional, NamedTuple, Dict, Any, Callable
+from typing import cast, List, Tuple, Optional, NamedTuple, Dict
 from unittest.mock import sentinel
 from os import listdir, path
 
@@ -403,96 +403,74 @@ def _dummy_command() -> Command:
     return create_comment_command()
 
 
-@pytest.fixture
-def load_module_action() -> Callable[..., SucceedCommandAction]:
+def load_module_action(
+    module_id: str,
+    module_def: ModuleDefinition,
+    location: DeckSlotLocation,
+    used_addressable_area: str | None = None,
+) -> SucceedCommandAction:
     """Create a SucceedCommandAction for loading a module."""
-
-    def _create_action(
-        module_id: str,
-        module_def: ModuleDefinition,
-        location: DeckSlotLocation,
-        used_addressable_area: str | None = None,
-    ) -> SucceedCommandAction:
-        state_update = StateUpdate()
-        if used_addressable_area is not None:
-            state_update.addressable_area_used = AddressableAreaUsedUpdate(
-                addressable_area_name=used_addressable_area
-            )
-        return SucceedCommandAction(
-            command=LoadModule(
-                params=LoadModuleParams(
-                    location=location,
-                    model=module_def.model,
-                ),
-                id=f"load-module-{module_id}",
-                createdAt=datetime.now(),
-                key=f"load-module-{module_id}",
-                status=CommandStatus.SUCCEEDED,
-                result=LoadModuleResult(
-                    moduleId=module_id,
-                    definition=module_def,
-                    model=module_def.model,
-                ),
-            ),
-            state_update=state_update,
+    state_update = StateUpdate()
+    if used_addressable_area is not None:
+        state_update.addressable_area_used = AddressableAreaUsedUpdate(
+            addressable_area_name=used_addressable_area
         )
+    return SucceedCommandAction(
+        command=LoadModule(
+            params=LoadModuleParams(
+                location=location,
+                model=module_def.model,
+            ),
+            id=f"load-module-{module_id}",
+            createdAt=datetime.now(),
+            key=f"load-module-{module_id}",
+            status=CommandStatus.SUCCEEDED,
+            result=LoadModuleResult(
+                moduleId=module_id,
+                definition=module_def,
+                model=module_def.model,
+            ),
+        ),
+        state_update=state_update,
+    )
 
-    return _create_action
 
-
-@pytest.fixture
 def load_labware_action(
-    nice_labware_definition: LabwareDefinition,
-) -> Callable[..., SucceedCommandAction]:
+    labware_id: str,
+    labware_def: LabwareDefinition,
+    location: LabwareLocation,
+) -> SucceedCommandAction:
     """Create a SucceedCommandAction for loading a labware."""
-
-    def _create_action(
-        labware_id: str,
-        location: LabwareLocation,
-        definition_update: Optional[Dict[str, Any]] = None,
-    ) -> SucceedCommandAction:
-        definition = nice_labware_definition
-        if definition_update:
-            definition = nice_labware_definition.model_copy(update=definition_update)
-        return SucceedCommandAction(
-            command=_dummy_command(),
-            state_update=StateUpdate(
-                loaded_labware=LoadedLabwareUpdate(
-                    labware_id=labware_id,
-                    definition=definition,
-                    offset_id=None,
-                    new_location=location,
-                    display_name=None,
-                )
-            ),
-        )
-
-    return _create_action
+    return SucceedCommandAction(
+        command=_dummy_command(),
+        state_update=StateUpdate(
+            loaded_labware=LoadedLabwareUpdate(
+                labware_id=labware_id,
+                definition=labware_def,
+                offset_id=None,
+                new_location=location,
+                display_name=None,
+            )
+        ),
+    )
 
 
-@pytest.fixture
 def load_adapter_action(
-    nice_adapter_definition: LabwareDefinition,
-) -> Callable[..., SucceedCommandAction]:
+    adapter_id: str, adapter_def: LabwareDefinition, location: LabwareLocation
+) -> SucceedCommandAction:
     """Create a SucceedCommandAction for loading an adapter."""
-
-    def _create_action(
-        labware_id: str, location: LabwareLocation
-    ) -> SucceedCommandAction:
-        return SucceedCommandAction(
-            command=_dummy_command(),
-            state_update=StateUpdate(
-                loaded_labware=LoadedLabwareUpdate(
-                    labware_id=labware_id,
-                    definition=nice_adapter_definition,
-                    offset_id=None,
-                    new_location=location,
-                    display_name=None,
-                )
-            ),
-        )
-
-    return _create_action
+    return SucceedCommandAction(
+        command=_dummy_command(),
+        state_update=StateUpdate(
+            loaded_labware=LoadedLabwareUpdate(
+                labware_id=adapter_id,
+                definition=adapter_def,
+                offset_id=None,
+                new_location=location,
+                display_name=None,
+            )
+        ),
+    )
 
 
 def test_get_labware_parent_position(
@@ -887,14 +865,13 @@ def test_get_all_obstacle_highest_z_no_equipment(
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_obstacle_highest_z_with_labware(
-    decoy: Decoy,
     labware_store: LabwareStore,
     addressable_area_store: AddressableAreaStore,
     module_store: ModuleStore,
+    addressable_area_view: AddressableAreaView,
     subject: GeometryView,
     flex_stacker_v1_def: ModuleDefinition,
-    load_module_action: Callable[..., SucceedCommandAction],
-    load_labware_action: Callable[..., SucceedCommandAction],
+    nice_labware_definition: LabwareDefinition,
 ) -> None:
     """It should get the highest Z of the on-deck labware."""
     # load a flex stacker module
@@ -905,35 +882,46 @@ def test_get_obstacle_highest_z_with_labware(
         used_addressable_area="flexStackerModuleV1D4",
     )
     # in hopper labware is considered off-deck
-    load_hopper_labware = load_labware_action(
-        labware_id="hopper-lw-id",
-        location=InStackerHopperLocation(moduleId="module-id"),
-        definition_update={
+    hopper_lw_definition = nice_labware_definition.model_copy(
+        update={
             "version": "hopper-lw",  # this is to make sure definitionURI is unique
             "dimensions": LabwareDimensions(
                 xDimension=0, yDimension=0, zDimension=20000
-            ),  # something tall
-        },
+            ),
+        }
     )
+    load_hopper_labware = load_labware_action(
+        labware_id="hopper-lw-id",
+        labware_def=hopper_lw_definition,
+        location=InStackerHopperLocation(moduleId="module-id"),
+    )
+
     # shuttle labware is considered on-deck
+    shuttle_lw_definition = nice_labware_definition.model_copy(
+        update={
+            "version": "hopper-lw",  # this is to make sure definitionURI is unique
+            "dimensions": LabwareDimensions(xDimension=0, yDimension=0, zDimension=300),
+        }
+    )
     load_shuttle_labware = load_labware_action(
         labware_id="module-lw-id",
+        labware_def=shuttle_lw_definition,
         location=ModuleLocation(moduleId="module-id"),
-        definition_update={
-            "version": "module-lw",  # this is to make sure definitionURI is unique
-            "dimensions": LabwareDimensions(xDimension=0, yDimension=0, zDimension=300),
-        },
     )
+
     # load a offdeck labware
-    load_offdeck_labware = load_labware_action(
-        labware_id="offdeck-lw-id",
-        location=OFF_DECK_LOCATION,
-        definition_update={
+    offdeck_lw_definition = nice_labware_definition.model_copy(
+        update={
             "version": "offdeck-lw",  # this is to make sure definitionURI is unique
             "dimensions": LabwareDimensions(
                 xDimension=0, yDimension=0, zDimension=10000
-            ),  # something tall
-        },
+            ),
+        }
+    )
+    load_offdeck_labware = load_labware_action(
+        labware_id="offdeck-lw-id",
+        labware_def=offdeck_lw_definition,
+        location=OFF_DECK_LOCATION,
     )
 
     module_store.handle_action(load_module)
@@ -942,95 +930,84 @@ def test_get_obstacle_highest_z_with_labware(
     labware_store.handle_action(load_shuttle_labware)
     labware_store.handle_action(load_offdeck_labware)
 
-    assert subject._labware.get_dimensions(labware_id="hopper-lw-id").z == 20000
-    assert subject._labware.get_dimensions(labware_id="module-lw-id").z == 300
-    assert subject._labware.get_dimensions(labware_id="offdeck-lw-id").z == 10000
-    # the highest Z should be the max of the highest Z of the on-deck labware
-    assert (
-        subject.get_all_obstacle_highest_z() == subject._get_tallest_obstacle_labware()
-    )
-    assert subject.get_all_obstacle_highest_z() == subject.get_labware_highest_z(
-        "module-lw-id"
-    )
+    # the tallest labware is the one on the stacker shuttle
+    # the labware's highest z is the z dimension + height of the shuttle
+    shuttle_height = addressable_area_view.get_addressable_area_position(
+        "flexStackerModuleV1D4"
+    ).z
+    assert subject.get_all_obstacle_highest_z() == 300 + shuttle_height
 
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_obstacle_highest_z_with_lid(
-    decoy: Decoy,
     labware_store: LabwareStore,
+    labware_view: LabwareView,
     subject: GeometryView,
-    load_labware_action: Callable[..., SucceedCommandAction],
+    nice_labware_definition: LabwareDefinition,
 ) -> None:
     """It should get the highest Z including labware lids."""
     load_labware = load_labware_action(
         labware_id="labware-id",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        labware_def=nice_labware_definition,
+    )
+    lid_def = nice_labware_definition.model_copy(
+        update={
+            "version": "lid-lw",  # this is to make sure definitionURI is unique
+            "dimensions": LabwareDimensions(xDimension=0, yDimension=0, zDimension=100),
+        }
     )
     load_labware_lid = load_labware_action(
         labware_id="lid-id",
+        labware_def=lid_def,
         location=OnLabwareLocation(labwareId="labware-id"),
-        definition_update={
-            "version": "lid-lw",  # this is to make sure definitionURI is unique
-            "dimensions": LabwareDimensions(
-                xDimension=0, yDimension=0, zDimension=100
-            ),  # something tall
-        },
     )
     labware_store.handle_action(load_labware)
     labware_store.handle_action(load_labware_lid)
 
     # the highest Z should be the max of the highest Z of the on-deck labware
-    lid_highest_z = subject.get_labware_highest_z("lid-id")
-    labware_highest_z = subject.get_labware_highest_z("labware-id")
-    assert lid_highest_z > labware_highest_z
-    assert subject.get_all_obstacle_highest_z() == lid_highest_z
+    # the labware's highest z is the z dimension of the lid + labware's height
+    labware_height = labware_view.get_dimensions(labware_id="labware-id").z
+    assert subject.get_all_obstacle_highest_z() == 100 + labware_height
 
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_all_obstacle_highest_z_with_staging_area(
-    decoy: Decoy,
     labware_store: LabwareStore,
+    addressable_area_view: AddressableAreaView,
+    labware_view: LabwareView,
     subject: GeometryView,
-    load_labware_action: Callable[..., SucceedCommandAction],
+    nice_labware_definition: LabwareDefinition,
 ) -> None:
     """It should get the highest Z amongst all labware including staging area."""
     load_deck_labware = load_labware_action(
         "deck-lw-id",
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
-        definition_update={
-            "version": "deck-lw",  # this is to make sure definitionURI is unique
-            "dimensions": LabwareDimensions(xDimension=0, yDimension=0, zDimension=10),
-        },
+        labware_def=nice_labware_definition,
     )
+
     load_staging_labware = load_labware_action(
         "staging-lw-id",
         location=AddressableAreaLocation(addressableAreaName="D4"),
-        definition_update={
-            "version": "staging-lw",  # this is to make sure definitionURI is unique
-            "dimensions": LabwareDimensions(
-                xDimension=0, yDimension=0, zDimension=10000
-            ),  # something tall
-        },
+        labware_def=nice_labware_definition,
     )
     labware_store.handle_action(load_deck_labware)
     labware_store.handle_action(load_staging_labware)
 
-    staging_labware_z = subject.get_labware_highest_z("staging-lw-id")
-    deck_labware_z = subject.get_labware_highest_z("deck-lw-id")
-    assert staging_labware_z > deck_labware_z
-
-    assert subject.get_all_obstacle_highest_z() == staging_labware_z
+    # the tallest labware is the one in the staging area
+    # the labware's highest z is the z dimension + staging slot height
+    labware_height = labware_view.get_dimensions(labware_id="staging-lw-id").z
+    staging_slot_height = addressable_area_view.get_addressable_area_position("D4").z
+    assert subject.get_all_obstacle_highest_z() == labware_height + staging_slot_height
 
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_all_obstacle_highest_z_with_modules(
-    decoy: Decoy,
     module_store: ModuleStore,
     addressable_area_store: AddressableAreaStore,
     subject: GeometryView,
     thermocycler_v2_def: ModuleDefinition,
     flex_stacker_v1_def: ModuleDefinition,
-    load_module_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """It should get the module highest Z."""
     load_thermocycler = load_module_action(
@@ -1050,28 +1027,15 @@ def test_get_all_obstacle_highest_z_with_modules(
     addressable_area_store.handle_action(load_thermocycler)
     addressable_area_store.handle_action(load_stacker)
 
-    stacker_highest_z = subject._modules.get_module_highest_z(
-        "stacker-id", subject._addressable_areas
-    )
-    stacker_overall_z = subject._modules.get_overall_height("stacker-id")
-    # overall height should not be the same as the highest z because the overall z
-    # includes the height of the module outside of the deck
-    assert stacker_highest_z != stacker_overall_z
-
-    thermocycler_highest_z = subject._modules.get_module_highest_z(
-        "thermocycler-id", subject._addressable_areas
-    )
-    thermocycler_overall_z = subject._modules.get_overall_height("thermocycler-id")
-    assert thermocycler_highest_z != thermocycler_overall_z
-
-    result = subject.get_all_obstacle_highest_z()
-    assert result == subject._get_tallest_obstacle_module()
-    assert result == max(stacker_highest_z, thermocycler_highest_z)
+    # the tallest module is the flex stacker
+    # Note: since no labware are loaded on the modules, the thermocycler
+    # lid is considered open, so the thermocycler lid height is not included
+    # in the thermocycler height
+    assert isclose(subject.get_all_obstacle_highest_z(), 44.725)
 
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_all_obstacle_highest_z_with_fixtures(
-    decoy: Decoy,
     addressable_area_store: AddressableAreaStore,
     subject: GeometryView,
 ) -> None:
@@ -1084,13 +1048,8 @@ def test_get_all_obstacle_highest_z_with_fixtures(
             ],
         )
     )
-
-    result = subject.get_all_obstacle_highest_z()
-    assert result == subject._get_tallest_obstacle_fixture()
-    assert result == max(
-        subject._addressable_areas.get_fixture_height("trashBinAdapter"),
-        subject._addressable_areas.get_fixture_height("singleRightSlot"),
-    )
+    # the highest Z should be the height of the trash bin adapter
+    assert subject.get_all_obstacle_highest_z() == 40.0
 
 
 def test_get_highest_z_in_slot_with_single_labware(
@@ -3593,15 +3552,14 @@ def test_check_gripper_labware_tip_collision(
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_offset_location_deck_slot(
-    decoy: Decoy,
     labware_store: LabwareStore,
-    nice_labware_definition: LabwareDefinition,
     subject: GeometryView,
-    load_labware_action: Callable[..., SucceedCommandAction],
+    nice_labware_definition: LabwareDefinition,
 ) -> None:
     """Test if you can get the offset location of a labware in a deck slot."""
     action = load_labware_action(
         labware_id="labware-id-1",
+        labware_def=nice_labware_definition,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
     )
 
@@ -3614,20 +3572,20 @@ def test_get_offset_location_deck_slot(
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_offset_location_module(
-    decoy: Decoy,
     labware_store: LabwareStore,
     module_store: ModuleStore,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
-    load_module_action: Callable[..., SucceedCommandAction],
-    load_labware_action: Callable[..., SucceedCommandAction],
+    nice_labware_definition: LabwareDefinition,
 ) -> None:
     """Test if you can get the offset of a labware directly on a module."""
     load_module = load_module_action(
         "module-id-1", tempdeck_v2_def, DeckSlotLocation(slotName=DeckSlotName.SLOT_A3)
     )
     load_labware = load_labware_action(
-        labware_id="labware-id-1", location=ModuleLocation(moduleId="module-id-1")
+        labware_id="labware-id-1",
+        labware_def=nice_labware_definition,
+        location=ModuleLocation(moduleId="module-id-1"),
     )
 
     module_store.handle_action(load_module)
@@ -3645,31 +3603,31 @@ def test_get_offset_location_module(
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_offset_location_module_with_adapter(
-    decoy: Decoy,
     labware_store: LabwareStore,
     module_store: ModuleStore,
-    nice_adapter_definition: LabwareDefinition,
     tempdeck_v2_def: ModuleDefinition,
     labware_view: LabwareView,
     subject: GeometryView,
-    load_module_action: Callable[..., SucceedCommandAction],
-    load_adapter_action: Callable[..., SucceedCommandAction],
-    load_labware_action: Callable[..., SucceedCommandAction],
+    nice_adapter_definition: LabwareDefinition,
+    nice_labware_definition: LabwareDefinition,
 ) -> None:
     """Test if you can get the offset of a labware directly on a module."""
     load_module = load_module_action(
         "module-id-1", tempdeck_v2_def, DeckSlotLocation(slotName=DeckSlotName.SLOT_A3)
     )
     load_adapter = load_adapter_action(
-        "adapter-id-1", ModuleLocation(moduleId="module-id-1")
+        "adapter-id-1", nice_adapter_definition, ModuleLocation(moduleId="module-id-1")
     )
     load_labware = load_labware_action(
-        "labware-id-1", OnLabwareLocation(labwareId="adapter-id-1")
+        "labware-id-1",
+        nice_labware_definition,
+        OnLabwareLocation(labwareId="adapter-id-1"),
     )
 
     module_store.handle_action(load_module)
     labware_store.handle_action(load_adapter)
     labware_store.handle_action(load_labware)
+
     offset_location = subject.get_offset_location("labware-id-1")
     assert offset_location == [
         OnLabwareOffsetLocationSequenceComponent(
@@ -3689,10 +3647,14 @@ def test_get_offset_fails_with_off_deck_labware(
     decoy: Decoy,
     labware_store: LabwareStore,
     subject: GeometryView,
-    load_labware_action: Callable[..., SucceedCommandAction],
+    nice_labware_definition: LabwareDefinition,
 ) -> None:
     """You cannot get the offset location for a labware loaded OFF_DECK."""
-    action = load_labware_action(labware_id="labware-id-1", location=OFF_DECK_LOCATION)
+    action = load_labware_action(
+        labware_id="labware-id-1",
+        location=OFF_DECK_LOCATION,
+        labware_def=nice_labware_definition,
+    )
 
     labware_store.handle_action(action)
     offset_location = subject.get_offset_location("labware-id-1")
@@ -3705,7 +3667,6 @@ def test_get_projected_offset_location_pending_labware(
     module_store: ModuleStore,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
-    load_module_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the projected offset of a labware on a labware not yet loaded."""
     load_module = load_module_action(
@@ -4129,16 +4090,15 @@ def test_get_well_volume_at_height(
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_location_sequence_deck_slot(
-    decoy: Decoy,
     labware_store: LabwareStore,
     addressable_area_store: AddressableAreaStore,
     nice_labware_definition: LabwareDefinition,
     subject: GeometryView,
-    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the location sequence of a labware in a deck slot."""
     action = load_labware_action(
         labware_id="labware-id-1",
+        labware_def=nice_labware_definition,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
     )
     labware_store.handle_action(action)
@@ -4154,15 +4114,12 @@ def test_get_location_sequence_deck_slot(
 
 @pytest.mark.parametrize("use_mocks", [False])
 def test_get_location_sequence_module(
-    decoy: Decoy,
     labware_store: LabwareStore,
     module_store: ModuleStore,
     addressable_area_store: AddressableAreaStore,
     nice_labware_definition: LabwareDefinition,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
-    load_module_action: Callable[..., SucceedCommandAction],
-    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the location sequence of a labware directly on a module."""
     load_module = load_module_action(
@@ -4171,17 +4128,10 @@ def test_get_location_sequence_module(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
         used_addressable_area="temperatureModuleV2A3",
     )
-    load_labware = SucceedCommandAction(
-        command=_dummy_command(),
-        state_update=StateUpdate(
-            loaded_labware=LoadedLabwareUpdate(
-                labware_id="labware-id-1",
-                definition=nice_labware_definition,
-                offset_id=None,
-                new_location=ModuleLocation(moduleId="module-id-1"),
-                display_name=None,
-            )
-        ),
+    load_labware = load_labware_action(
+        labware_id="labware-id-1",
+        location=ModuleLocation(moduleId="module-id-1"),
+        labware_def=nice_labware_definition,
     )
 
     module_store.handle_action(load_module)
@@ -4312,7 +4262,6 @@ def test_get_location_sequence_stacker_hopper(
     nice_labware_definition: LabwareDefinition,
     flex_stacker_v1_def: ModuleDefinition,
     subject: GeometryView,
-    load_module_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the location sequence of a labware in the stacker hopper."""
     load_module = load_module_action(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -4127,6 +4127,7 @@ def test_get_location_sequence_deck_slot(
             cutoutId="cutoutC2", possibleCutoutFixtureIds=["singleCenterSlot"]
         ),
     ]
+    assert subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4189,6 +4190,7 @@ def test_get_location_sequence_module(
             cutoutId="cutoutA3", possibleCutoutFixtureIds=["temperatureModuleV2"]
         ),
     ]
+    assert subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4265,6 +4267,7 @@ def test_get_location_sequence_module_with_adapter(
             cutoutId="cutoutA3", possibleCutoutFixtureIds=["temperatureModuleV2"]
         ),
     ]
+    assert subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4292,6 +4295,7 @@ def test_get_location_sequence_off_deck(
     assert location_sequence == [
         NotOnDeckLocationSequenceComponent(logicalLocationName=OFF_DECK_LOCATION)
     ]
+    assert not subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4355,6 +4359,7 @@ def test_get_location_sequence_stacker_hopper(
             cutoutId="cutoutA3",
         ),
     ]
+    assert not subject._is_deck_obstacle("labware-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -4416,6 +4421,7 @@ def test_get_predicted_location_sequence_with_pending_labware(
             cutoutId="cutoutA3", possibleCutoutFixtureIds=["temperatureModuleV2"]
         ),
     ]
+    assert subject._is_deck_obstacle("adapter-id-1")
 
 
 @pytest.mark.parametrize("use_mocks", [False])

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -87,6 +87,7 @@ from opentrons.protocol_engine.types import (
     OnLabwareLocationSequenceComponent,
     NotOnDeckLocationSequenceComponent,
     OnCutoutFixtureLocationSequenceComponent,
+    LabwareLocation,
     InStackerHopperLocation,
     PotentialCutoutFixture,
     AddressableArea,
@@ -397,6 +398,89 @@ def subject(
 def _dummy_command() -> Command:
     """Return a placeholder command."""
     return create_comment_command()
+
+
+@pytest.fixture
+def load_module_action():
+    """Create a SucceedCommandAction for loading a module."""
+
+    def _create_action(
+        module_id: str,
+        module_def: ModuleDefinition,
+        location: DeckSlotLocation,
+        used_addressable_area: str | None = None,
+    ) -> SucceedCommandAction:
+        state_update = StateUpdate()
+        if used_addressable_area is not None:
+            state_update.addressable_area_used = AddressableAreaUsedUpdate(
+                addressable_area_name=used_addressable_area
+            )
+        return SucceedCommandAction(
+            command=LoadModule(
+                params=LoadModuleParams(
+                    location=location,
+                    model=module_def.model,
+                ),
+                id=f"load-module-{module_id}",
+                createdAt=datetime.now(),
+                key=f"load-module-{module_id}",
+                status=CommandStatus.SUCCEEDED,
+                result=LoadModuleResult(
+                    moduleId=module_id,
+                    definition=module_def,
+                    model=module_def.model,
+                ),
+            ),
+            state_update=state_update,
+        )
+
+    return _create_action
+
+
+@pytest.fixture
+def load_labware_action(nice_labware_definition: LabwareDefinition):
+    """Create a SucceedCommandAction for loading a labware."""
+
+    def _create_action(
+        labware_id: str, location: LabwareLocation
+    ) -> SucceedCommandAction:
+        return SucceedCommandAction(
+            command=_dummy_command(),
+            state_update=StateUpdate(
+                loaded_labware=LoadedLabwareUpdate(
+                    labware_id=labware_id,
+                    definition=nice_labware_definition,
+                    offset_id=None,
+                    new_location=location,
+                    display_name=None,
+                )
+            ),
+        )
+
+    return _create_action
+
+
+@pytest.fixture
+def load_adapter_action(nice_adapter_definition: LabwareDefinition):
+    """Create a SucceedCommandAction for loading an adapter."""
+
+    def _create_action(
+        labware_id: str, location: LabwareLocation
+    ) -> SucceedCommandAction:
+        return SucceedCommandAction(
+            command=_dummy_command(),
+            state_update=StateUpdate(
+                loaded_labware=LoadedLabwareUpdate(
+                    labware_id=labware_id,
+                    definition=nice_adapter_definition,
+                    offset_id=None,
+                    new_location=location,
+                    display_name=None,
+                )
+            ),
+        )
+
+    return _create_action
 
 
 def test_get_labware_parent_position(
@@ -3529,20 +3613,14 @@ def test_get_offset_location_deck_slot(
     labware_store: LabwareStore,
     nice_labware_definition: LabwareDefinition,
     subject: GeometryView,
+    load_labware_action: SucceedCommandAction,
 ) -> None:
     """Test if you can get the offset location of a labware in a deck slot."""
-    action = SucceedCommandAction(
-        command=_dummy_command(),
-        state_update=StateUpdate(
-            loaded_labware=LoadedLabwareUpdate(
-                labware_id="labware-id-1",
-                definition=nice_labware_definition,
-                offset_id=None,
-                new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
-                display_name=None,
-            )
-        ),
+    action = load_labware_action(
+        labware_id="labware-id-1",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
     )
+
     labware_store.handle_action(action)
     offset_location = subject.get_offset_location("labware-id-1")
     assert offset_location == [
@@ -3555,39 +3633,17 @@ def test_get_offset_location_module(
     decoy: Decoy,
     labware_store: LabwareStore,
     module_store: ModuleStore,
-    nice_labware_definition: LabwareDefinition,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
+    load_module_action: SucceedCommandAction,
+    load_labware_action: SucceedCommandAction,
 ) -> None:
     """Test if you can get the offset of a labware directly on a module."""
-    load_module = SucceedCommandAction(
-        command=LoadModule(
-            params=LoadModuleParams(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
-                model=ModuleModel.TEMPERATURE_MODULE_V2,
-            ),
-            id="load-module-1",
-            createdAt=datetime.now(),
-            key="load-module-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadModuleResult(
-                moduleId="module-id-1",
-                definition=tempdeck_v2_def,
-                model=tempdeck_v2_def.model,
-            ),
-        ),
+    load_module = load_module_action(
+        "module-id-1", tempdeck_v2_def, DeckSlotLocation(slotName=DeckSlotName.SLOT_A3)
     )
-    load_labware = SucceedCommandAction(
-        command=_dummy_command(),
-        state_update=StateUpdate(
-            loaded_labware=LoadedLabwareUpdate(
-                labware_id="labware-id-1",
-                definition=nice_labware_definition,
-                offset_id=None,
-                new_location=ModuleLocation(moduleId="module-id-1"),
-                display_name=None,
-            )
-        ),
+    load_labware = load_labware_action(
+        labware_id="labware-id-1", location=ModuleLocation(moduleId="module-id-1")
     )
 
     module_store.handle_action(load_module)
@@ -3608,54 +3664,25 @@ def test_get_offset_location_module_with_adapter(
     decoy: Decoy,
     labware_store: LabwareStore,
     module_store: ModuleStore,
-    nice_labware_definition: LabwareDefinition,
     nice_adapter_definition: LabwareDefinition,
     tempdeck_v2_def: ModuleDefinition,
     labware_view: LabwareView,
     subject: GeometryView,
+    load_module_action: SucceedCommandAction,
+    load_adapter_action: SucceedCommandAction,
+    load_labware_action: SucceedCommandAction,
 ) -> None:
     """Test if you can get the offset of a labware directly on a module."""
-    load_module = SucceedCommandAction(
-        command=LoadModule(
-            params=LoadModuleParams(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
-                model=ModuleModel.TEMPERATURE_MODULE_V2,
-            ),
-            id="load-module-1",
-            createdAt=datetime.now(),
-            key="load-module-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadModuleResult(
-                moduleId="module-id-1",
-                definition=tempdeck_v2_def,
-                model=tempdeck_v2_def.model,
-            ),
-        ),
+    load_module = load_module_action(
+        "module-id-1", tempdeck_v2_def, DeckSlotLocation(slotName=DeckSlotName.SLOT_A3)
     )
-    load_adapter = SucceedCommandAction(
-        command=_dummy_command(),
-        state_update=StateUpdate(
-            loaded_labware=LoadedLabwareUpdate(
-                labware_id="adapter-id-1",
-                definition=nice_adapter_definition,
-                offset_id=None,
-                new_location=ModuleLocation(moduleId="module-id-1"),
-                display_name=None,
-            )
-        ),
+    load_adapter = load_adapter_action(
+        "adapter-id-1", ModuleLocation(moduleId="module-id-1")
     )
-    load_labware = SucceedCommandAction(
-        command=_dummy_command(),
-        state_update=StateUpdate(
-            loaded_labware=LoadedLabwareUpdate(
-                labware_id="labware-id-1",
-                definition=nice_labware_definition,
-                offset_id=None,
-                new_location=OnLabwareLocation(labwareId="adapter-id-1"),
-                display_name=None,
-            )
-        ),
+    load_labware = load_labware_action(
+        "labware-id-1", OnLabwareLocation(labwareId="adapter-id-1")
     )
+
     module_store.handle_action(load_module)
     labware_store.handle_action(load_adapter)
     labware_store.handle_action(load_labware)
@@ -3677,22 +3704,12 @@ def test_get_offset_location_module_with_adapter(
 def test_get_offset_fails_with_off_deck_labware(
     decoy: Decoy,
     labware_store: LabwareStore,
-    nice_labware_definition: LabwareDefinition,
     subject: GeometryView,
+    load_labware_action: SucceedCommandAction,
 ) -> None:
     """You cannot get the offset location for a labware loaded OFF_DECK."""
-    action = SucceedCommandAction(
-        command=_dummy_command(),
-        state_update=StateUpdate(
-            loaded_labware=LoadedLabwareUpdate(
-                labware_id="labware-id-1",
-                definition=nice_labware_definition,
-                offset_id=None,
-                new_location=OFF_DECK_LOCATION,
-                display_name=None,
-            )
-        ),
-    )
+    action = load_labware_action(labware_id="labware-id-1", location=OFF_DECK_LOCATION)
+
     labware_store.handle_action(action)
     offset_location = subject.get_offset_location("labware-id-1")
     assert offset_location is None
@@ -3704,24 +3721,13 @@ def test_get_projected_offset_location_pending_labware(
     module_store: ModuleStore,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
+    load_module_action: SucceedCommandAction,
 ) -> None:
     """Test if you can get the projected offset of a labware on a labware not yet loaded."""
-    load_module = SucceedCommandAction(
-        command=LoadModule(
-            params=LoadModuleParams(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
-                model=ModuleModel.TEMPERATURE_MODULE_V2,
-            ),
-            id="load-module-1",
-            createdAt=datetime.now(),
-            key="load-module-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadModuleResult(
-                moduleId="module-id-1",
-                definition=tempdeck_v2_def,
-                model=tempdeck_v2_def.model,
-            ),
-        ),
+    load_module = load_module_action(
+        module_id="module-id-1",
+        module_def=tempdeck_v2_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
     )
 
     module_store.handle_action(load_module)
@@ -4144,20 +4150,12 @@ def test_get_location_sequence_deck_slot(
     addressable_area_store: AddressableAreaStore,
     nice_labware_definition: LabwareDefinition,
     subject: GeometryView,
+    load_labware_action: SucceedCommandAction,
 ) -> None:
     """Test if you can get the location sequence of a labware in a deck slot."""
-    action = SucceedCommandAction(
-        command=_dummy_command(),
-        state_update=StateUpdate(
-            loaded_labware=LoadedLabwareUpdate(
-                labware_id="labware-id-1",
-                definition=nice_labware_definition,
-                offset_id=None,
-                new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
-                display_name=None,
-            ),
-            addressable_area_used=AddressableAreaUsedUpdate(addressable_area_name="C2"),
-        ),
+    action = load_labware_action(
+        labware_id="labware-id-1",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
     )
     labware_store.handle_action(action)
     addressable_area_store.handle_action(action)
@@ -4179,29 +4177,15 @@ def test_get_location_sequence_module(
     nice_labware_definition: LabwareDefinition,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
+    load_module_action: SucceedCommandAction,
+    load_labware_action: SucceedCommandAction,
 ) -> None:
     """Test if you can get the location sequence of a labware directly on a module."""
-    load_module = SucceedCommandAction(
-        command=LoadModule(
-            params=LoadModuleParams(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
-                model=ModuleModel.TEMPERATURE_MODULE_V2,
-            ),
-            id="load-module-1",
-            createdAt=datetime.now(),
-            key="load-module-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadModuleResult(
-                moduleId="module-id-1",
-                definition=tempdeck_v2_def,
-                model=tempdeck_v2_def.model,
-            ),
-        ),
-        state_update=StateUpdate(
-            addressable_area_used=AddressableAreaUsedUpdate(
-                addressable_area_name="temperatureModuleV2A3"
-            )
-        ),
+    load_module = load_module_action(
+        module_id="module-id-1",
+        module_def=tempdeck_v2_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="temperatureModuleV2A3",
     )
     load_labware = SucceedCommandAction(
         command=_dummy_command(),
@@ -4344,30 +4328,16 @@ def test_get_location_sequence_stacker_hopper(
     nice_labware_definition: LabwareDefinition,
     flex_stacker_v1_def: ModuleDefinition,
     subject: GeometryView,
+    load_module_action: SucceedCommandAction,
 ) -> None:
     """Test if you can get the location sequence of a labware in the stacker hopper."""
-    load_module = SucceedCommandAction(
-        command=LoadModule(
-            params=LoadModuleParams(
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
-                model=ModuleModel.FLEX_STACKER_MODULE_V1,
-            ),
-            id="load-module-1",
-            createdAt=datetime.now(),
-            key="load-module-1",
-            status=CommandStatus.SUCCEEDED,
-            result=LoadModuleResult(
-                moduleId="module-id-1",
-                definition=flex_stacker_v1_def,
-                model=flex_stacker_v1_def.model,
-            ),
-        ),
-        state_update=StateUpdate(
-            addressable_area_used=AddressableAreaUsedUpdate(
-                addressable_area_name="flexStackerModuleV1A4"
-            )
-        ),
+    load_module = load_module_action(
+        module_id="module-id-1",
+        module_def=flex_stacker_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="flexStackerModuleV1A4",
     )
+
     load_labware = SucceedCommandAction(
         command=_dummy_command(),
         state_update=StateUpdate(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -49,6 +49,8 @@ from opentrons_shared_data.labware import load_definition as load_labware_defini
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (
     OFF_DECK_LOCATION,
+    SYSTEM_LOCATION,
+    LabwareLocation,
     LabwareOffsetVector,
     DeckSlotLocation,
     ModuleLocation,
@@ -789,7 +791,16 @@ def test_get_all_obstacle_highest_z_no_equipment(
     assert result == 0
 
 
+@pytest.mark.parametrize(
+    "non_deck_location",
+    (
+        OFF_DECK_LOCATION,
+        SYSTEM_LOCATION,
+        InStackerHopperLocation(moduleId="stacker-module-id"),
+    ),
+)
 def test_get_all_obstacle_highest_z(
+    non_deck_location: LabwareLocation,
     decoy: Decoy,
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
@@ -804,11 +815,11 @@ def test_get_all_obstacle_highest_z(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
         offsetId="plate-offset-id",
     )
-    off_deck_lw = LoadedLabware(
+    non_deck_lw = LoadedLabware(
         id="off-deck-plate-id",
         loadName="off-deck-plate-load-name",
         definitionUri="off-deck-plate-definition-uri",
-        location=OFF_DECK_LOCATION,
+        location=non_deck_location,
         offsetId="plate-offset-id",
     )
     reservoir = LoadedLabware(
@@ -820,15 +831,15 @@ def test_get_all_obstacle_highest_z(
     )
 
     plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
-    off_deck_lw_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+    non_deck_lw_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     reservoir_offset = LabwareOffsetVector(x=1, y=-2, z=3)
 
     decoy.when(mock_module_view.get_all()).then_return([])
     decoy.when(mock_addressable_area_view.get_all()).then_return([])
 
-    decoy.when(mock_labware_view.get_all()).then_return([plate, off_deck_lw, reservoir])
+    decoy.when(mock_labware_view.get_all()).then_return([plate, non_deck_lw, reservoir])
     decoy.when(mock_labware_view.get("plate-id")).then_return(plate)
-    decoy.when(mock_labware_view.get("off-deck-plate-id")).then_return(off_deck_lw)
+    decoy.when(mock_labware_view.get("off-deck-plate-id")).then_return(non_deck_lw)
     decoy.when(mock_labware_view.get("reservoir-id")).then_return(reservoir)
 
     decoy.when(mock_labware_view.get_dimensions(labware_id="plate-id")).then_return(
@@ -848,7 +859,7 @@ def test_get_all_obstacle_highest_z(
     )
     decoy.when(
         mock_labware_view.get_labware_offset_vector("off-deck-plate-id")
-    ).then_return(off_deck_lw_offset)
+    ).then_return(non_deck_lw_offset)
     decoy.when(mock_labware_view.get_labware_offset_vector("reservoir-id")).then_return(
         reservoir_offset
     )

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -79,7 +79,6 @@ from opentrons.protocol_engine.types import (
     ProbedVolumeInfo,
     LoadedVolumeInfo,
     WellLiquidInfo,
-    LabwareLocationSequence,
     OnAddressableAreaOffsetLocationSequenceComponent,
     OnModuleOffsetLocationSequenceComponent,
     OnLabwareOffsetLocationSequenceComponent,
@@ -790,66 +789,135 @@ def test_get_all_obstacle_highest_z_no_equipment(
     assert result == 0
 
 
-def test_get_higest_z_for_all_labware(
+def test_get_all_obstacle_highest_z(
     decoy: Decoy,
-    monkeypatch: pytest.MonkeyPatch,
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
     subject: GeometryView,
 ) -> None:
     """It should get the highest Z amongst all labware."""
-    plate_loc_seq: LabwareLocationSequence = [
-        OnAddressableAreaLocationSequenceComponent(
-            addressableAreaName=DeckSlotName.SLOT_3.id
-        )
-    ]
-
-    off_deck_loc_seq: LabwareLocationSequence = [
-        NotOnDeckLocationSequenceComponent(logicalLocationName=OFF_DECK_LOCATION),
-    ]
-
-    in_hopper_loq_seq: LabwareLocationSequence = [
-        InStackerHopperLocation(moduleId="stacker-id"),
-        OnAddressableAreaLocationSequenceComponent(
-            addressableAreaName="singleCenterSlot"
-        ),
-        OnCutoutFixtureLocationSequenceComponent(
-            cutoutId="cutoutC2", possibleCutoutFixtureIds=["singleCenterSlot"]
-        ),
-    ]
-
-    mock_get_location_seq = decoy.mock(func=subject.get_location_sequence)
-    monkeypatch.setattr(subject, "get_location_sequence", mock_get_location_seq)
-    mock_highest_z_from_lw = decoy.mock(func=subject._get_highest_z_from_labware_data)
-    monkeypatch.setattr(
-        subject, "_get_highest_z_from_labware_data", mock_highest_z_from_lw
+    plate = LoadedLabware(
+        id="plate-id",
+        loadName="plate-load-name",
+        definitionUri="plate-definition-uri",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+        offsetId="plate-offset-id",
+    )
+    off_deck_lw = LoadedLabware(
+        id="off-deck-plate-id",
+        loadName="off-deck-plate-load-name",
+        definitionUri="off-deck-plate-definition-uri",
+        location=OFF_DECK_LOCATION,
+        offsetId="offdeck-offset-id",
+    )
+    in_hopper_lw = LoadedLabware(
+        id="hopper-plate-id",
+        loadName="hopper-plate-load-name",
+        definitionUri="hopper-plate-definition-uri",
+        location=InStackerHopperLocation(moduleId="module-id"),
+        offsetId="hopper-plate-offset-id",
+    )
+    reservoir = LoadedLabware(
+        id="reservoir-id",
+        loadName="reservoir-load-name",
+        definitionUri="reservoir-definition-uri",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+        offsetId="reservoir-offset-id",
     )
 
-    decoy.when(mock_labware_view.get_all()).then_return(
-        [sentinel.on_deck_plate, sentinel.off_deck_labware, sentinel.hopper_labware],
-    )
-    sentinel.on_deck_plate.id = "on-deck-plate-id"
-    sentinel.off_deck_labware.id = "off-deck-labware-id"
-    sentinel.hopper_labware.id = "hopper-labware-id"
+    lw_offset = LabwareOffsetVector(x=1, y=-2, z=3)
 
     decoy.when(mock_module_view.get_all()).then_return([])
     decoy.when(mock_addressable_area_view.get_all()).then_return([])
 
-    decoy.when(mock_get_location_seq("on-deck-plate-id")).then_return(plate_loc_seq)
-    decoy.when(mock_get_location_seq(sentinel.off_deck_labware.id)).then_return(
-        off_deck_loc_seq
+    decoy.when(mock_labware_view.get_all()).then_return(
+        [plate, off_deck_lw, reservoir, in_hopper_lw]
     )
-    decoy.when(mock_get_location_seq(sentinel.hopper_labware.id)).then_return(
-        in_hopper_loq_seq
+    decoy.when(mock_labware_view.get("plate-id")).then_return(plate)
+    decoy.when(mock_labware_view.get("off-deck-plate-id")).then_return(off_deck_lw)
+    decoy.when(mock_labware_view.get("reservoir-id")).then_return(reservoir)
+    decoy.when(mock_labware_view.get("hopper-plate-id")).then_return(in_hopper_lw)
+
+    decoy.when(mock_labware_view.get_location("off-deck-plate-id")).then_return(
+        OFF_DECK_LOCATION
+    )
+    decoy.when(mock_labware_view.get_location("hopper-plate-id")).then_return(
+        InStackerHopperLocation(moduleId="module-id")
     )
 
-    decoy.when(mock_highest_z_from_lw(sentinel.on_deck_plate)).then_return(20)
-    decoy.when(mock_highest_z_from_lw(sentinel.off_deck_labware)).then_return(50)
-    decoy.when(mock_highest_z_from_lw(sentinel.hopper_labware)).then_return(60)
+    decoy.when(mock_labware_view.get_dimensions(labware_id="plate-id")).then_return(
+        Dimensions(x=0, y=0, z=10)
+    )
+    decoy.when(
+        mock_labware_view.get_dimensions(labware_id="off-deck-plate-id")
+    ).then_return(
+        Dimensions(x=0, y=0, z=10000)  # Something tall.
+    )
+    decoy.when(mock_labware_view.get_dimensions(labware_id="reservoir-id")).then_return(
+        Dimensions(x=0, y=0, z=20)
+    )
+    decoy.when(
+        mock_labware_view.get_dimensions(labware_id="hopper-plate-id")
+    ).then_return(
+        Dimensions(x=0, y=0, z=20000)  # Something tall.
+    )
 
-    # should only consider the on-deck labware
-    assert subject.get_all_obstacle_highest_z() == 20.0
+    decoy.when(mock_labware_view.get_labware_offset_vector("plate-id")).then_return(
+        lw_offset
+    )
+    decoy.when(
+        mock_labware_view.get_labware_offset_vector("off-deck-plate-id")
+    ).then_return(lw_offset)
+    decoy.when(mock_labware_view.get_labware_offset_vector("reservoir-id")).then_return(
+        lw_offset
+    )
+    decoy.when(
+        mock_labware_view.get_labware_offset_vector("hopper-plate-id")
+    ).then_return(lw_offset)
+
+    decoy.when(
+        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_3.id)
+    ).then_return(Point(1, 2, 3))
+    decoy.when(
+        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_4.id)
+    ).then_return(Point(4, 5, 6))
+
+    decoy.when(mock_module_view.get_location("module-id")).then_return(
+        DeckSlotLocation(slotName=DeckSlotName.SLOT_D3.id)
+    )
+    decoy.when(mock_module_view.get_provided_addressable_area("module-id")).then_return(
+        AddressableAreaLocation(addressableAreaName="flexStackerV1D4")
+    )
+    decoy.when(mock_module_view.get_connected_model("module-id")).then_return("model")
+    decoy.when(
+        mock_module_view.ensure_and_convert_module_fixture_location(
+            DeckSlotName.SLOT_D3, "model"
+        )
+    ).then_return("flexStackerV1D4")
+
+    decoy.when(
+        mock_addressable_area_view.get_current_potential_cutout_fixtures_for_addressable_area(
+            "flexStackerV1D4"
+        )
+    ).then_return(
+        (
+            "cutoutD3",
+            [
+                PotentialCutoutFixture(
+                    cutout_id="cutoutD3",
+                    cutout_fixture_id="flexStackerModuleV1",
+                    provided_addressable_areas=frozenset(),
+                )
+            ],
+        )
+    )
+    plate_z = subject.get_labware_highest_z("plate-id")
+    reservoir_z = subject.get_labware_highest_z("reservoir-id")
+    all_z = subject.get_all_obstacle_highest_z()
+
+    # Should exclude the off-deck or hopper plate.
+    assert all_z == max(plate_z, reservoir_z)
 
 
 def test_get_all_obstacle_highest_z_with_staging_area(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -4,7 +4,7 @@ import inspect
 import json
 from datetime import datetime
 from math import isclose
-from typing import cast, List, Tuple, Optional, NamedTuple, Dict
+from typing import cast, List, Tuple, Optional, NamedTuple, Dict, Any, Callable
 from unittest.mock import sentinel
 from os import listdir, path
 
@@ -102,7 +102,10 @@ from opentrons.protocol_engine.commands import (
     LoadModule,
     LoadModuleParams,
 )
-from opentrons.protocol_engine.actions import SucceedCommandAction
+from opentrons.protocol_engine.actions import (
+    SucceedCommandAction,
+    SetDeckConfigurationAction,
+)
 from opentrons.protocol_engine.state import _move_types
 from opentrons.protocol_engine.state.config import Config
 from opentrons.protocol_engine.state.labware import LabwareView, LabwareStore
@@ -401,7 +404,7 @@ def _dummy_command() -> Command:
 
 
 @pytest.fixture
-def load_module_action():
+def load_module_action() -> Callable[..., SucceedCommandAction]:
     """Create a SucceedCommandAction for loading a module."""
 
     def _create_action(
@@ -438,18 +441,25 @@ def load_module_action():
 
 
 @pytest.fixture
-def load_labware_action(nice_labware_definition: LabwareDefinition):
+def load_labware_action(
+    nice_labware_definition: LabwareDefinition,
+) -> Callable[..., SucceedCommandAction]:
     """Create a SucceedCommandAction for loading a labware."""
 
     def _create_action(
-        labware_id: str, location: LabwareLocation
+        labware_id: str,
+        location: LabwareLocation,
+        definition_update: Optional[Dict[str, Any]] = None,
     ) -> SucceedCommandAction:
+        definition = nice_labware_definition
+        if definition_update:
+            definition = nice_labware_definition.model_copy(update=definition_update)
         return SucceedCommandAction(
             command=_dummy_command(),
             state_update=StateUpdate(
                 loaded_labware=LoadedLabwareUpdate(
                     labware_id=labware_id,
-                    definition=nice_labware_definition,
+                    definition=definition,
                     offset_id=None,
                     new_location=location,
                     display_name=None,
@@ -461,7 +471,9 @@ def load_labware_action(nice_labware_definition: LabwareDefinition):
 
 
 @pytest.fixture
-def load_adapter_action(nice_adapter_definition: LabwareDefinition):
+def load_adapter_action(
+    nice_adapter_definition: LabwareDefinition,
+) -> Callable[..., SucceedCommandAction]:
     """Create a SucceedCommandAction for loading an adapter."""
 
     def _create_action(
@@ -873,240 +885,212 @@ def test_get_all_obstacle_highest_z_no_equipment(
     assert result == 0
 
 
-def test_get_all_obstacle_highest_z(
+@pytest.mark.parametrize("use_mocks", [False])
+def test_get_obstacle_highest_z_with_labware(
     decoy: Decoy,
-    mock_labware_view: LabwareView,
-    mock_module_view: ModuleView,
-    mock_addressable_area_view: AddressableAreaView,
+    labware_store: LabwareStore,
+    addressable_area_store: AddressableAreaStore,
+    module_store: ModuleStore,
     subject: GeometryView,
+    flex_stacker_v1_def: ModuleDefinition,
+    load_module_action: Callable[..., SucceedCommandAction],
+    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
-    """It should get the highest Z amongst all labware."""
-    plate = LoadedLabware(
-        id="plate-id",
-        loadName="plate-load-name",
-        definitionUri="plate-definition-uri",
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
-        offsetId="plate-offset-id",
+    """It should get the highest Z of the on-deck labware."""
+    # load a flex stacker module
+    load_module = load_module_action(
+        module_id="module-id",
+        module_def=flex_stacker_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_D3),
+        used_addressable_area="flexStackerModuleV1D4",
     )
-    off_deck_lw = LoadedLabware(
-        id="off-deck-plate-id",
-        loadName="off-deck-plate-load-name",
-        definitionUri="off-deck-plate-definition-uri",
-        location=OFF_DECK_LOCATION,
-        offsetId="offdeck-offset-id",
-    )
-    in_hopper_lw = LoadedLabware(
-        id="hopper-plate-id",
-        loadName="hopper-plate-load-name",
-        definitionUri="hopper-plate-definition-uri",
+    # in hopper labware is considered off-deck
+    load_hopper_labware = load_labware_action(
+        labware_id="hopper-lw-id",
         location=InStackerHopperLocation(moduleId="module-id"),
-        offsetId="hopper-plate-offset-id",
+        definition_update={
+            "version": "hopper-lw",  # this is to make sure definitionURI is unique
+            "dimensions": LabwareDimensions(
+                xDimension=0, yDimension=0, zDimension=20000
+            ),  # something tall
+        },
     )
-    reservoir = LoadedLabware(
-        id="reservoir-id",
-        loadName="reservoir-load-name",
-        definitionUri="reservoir-definition-uri",
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
-        offsetId="reservoir-offset-id",
+    # shuttle labware is considered on-deck
+    load_shuttle_labware = load_labware_action(
+        labware_id="module-lw-id",
+        location=ModuleLocation(moduleId="module-id"),
+        definition_update={
+            "version": "module-lw",  # this is to make sure definitionURI is unique
+            "dimensions": LabwareDimensions(xDimension=0, yDimension=0, zDimension=300),
+        },
     )
-
-    lw_offset = LabwareOffsetVector(x=1, y=-2, z=3)
-
-    decoy.when(mock_module_view.get_all()).then_return([])
-    decoy.when(mock_addressable_area_view.get_all()).then_return([])
-
-    decoy.when(mock_labware_view.get_all()).then_return(
-        [plate, off_deck_lw, reservoir, in_hopper_lw]
-    )
-    decoy.when(mock_labware_view.get("plate-id")).then_return(plate)
-    decoy.when(mock_labware_view.get("off-deck-plate-id")).then_return(off_deck_lw)
-    decoy.when(mock_labware_view.get("reservoir-id")).then_return(reservoir)
-    decoy.when(mock_labware_view.get("hopper-plate-id")).then_return(in_hopper_lw)
-
-    decoy.when(mock_labware_view.get_location("off-deck-plate-id")).then_return(
-        OFF_DECK_LOCATION
-    )
-    decoy.when(mock_labware_view.get_location("hopper-plate-id")).then_return(
-        InStackerHopperLocation(moduleId="module-id")
+    # load a offdeck labware
+    load_offdeck_labware = load_labware_action(
+        labware_id="offdeck-lw-id",
+        location=OFF_DECK_LOCATION,
+        definition_update={
+            "version": "offdeck-lw",  # this is to make sure definitionURI is unique
+            "dimensions": LabwareDimensions(
+                xDimension=0, yDimension=0, zDimension=10000
+            ),  # something tall
+        },
     )
 
-    decoy.when(mock_labware_view.get_dimensions(labware_id="plate-id")).then_return(
-        Dimensions(x=0, y=0, z=10)
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_hopper_labware)
+    labware_store.handle_action(load_shuttle_labware)
+    labware_store.handle_action(load_offdeck_labware)
+
+    assert subject._labware.get_dimensions(labware_id="hopper-lw-id").z == 20000
+    assert subject._labware.get_dimensions(labware_id="module-lw-id").z == 300
+    assert subject._labware.get_dimensions(labware_id="offdeck-lw-id").z == 10000
+    # the highest Z should be the max of the highest Z of the on-deck labware
+    assert (
+        subject.get_all_obstacle_highest_z() == subject._get_tallest_obstacle_labware()
     )
-    decoy.when(
-        mock_labware_view.get_dimensions(labware_id="off-deck-plate-id")
-    ).then_return(
-        Dimensions(x=0, y=0, z=10000)  # Something tall.
-    )
-    decoy.when(mock_labware_view.get_dimensions(labware_id="reservoir-id")).then_return(
-        Dimensions(x=0, y=0, z=20)
-    )
-    decoy.when(
-        mock_labware_view.get_dimensions(labware_id="hopper-plate-id")
-    ).then_return(
-        Dimensions(x=0, y=0, z=20000)  # Something tall.
+    assert subject.get_all_obstacle_highest_z() == subject.get_labware_highest_z(
+        "module-lw-id"
     )
 
-    decoy.when(mock_labware_view.get_labware_offset_vector("plate-id")).then_return(
-        lw_offset
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_get_obstacle_highest_z_with_lid(
+    decoy: Decoy,
+    labware_store: LabwareStore,
+    subject: GeometryView,
+    load_labware_action: Callable[..., SucceedCommandAction],
+) -> None:
+    """It should get the highest Z including labware lids."""
+    load_labware = load_labware_action(
+        labware_id="labware-id",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
     )
-    decoy.when(
-        mock_labware_view.get_labware_offset_vector("off-deck-plate-id")
-    ).then_return(lw_offset)
-    decoy.when(mock_labware_view.get_labware_offset_vector("reservoir-id")).then_return(
-        lw_offset
+    load_labware_lid = load_labware_action(
+        labware_id="lid-id",
+        location=OnLabwareLocation(labwareId="labware-id"),
+        definition_update={
+            "version": "lid-lw",  # this is to make sure definitionURI is unique
+            "dimensions": LabwareDimensions(
+                xDimension=0, yDimension=0, zDimension=100
+            ),  # something tall
+        },
     )
-    decoy.when(
-        mock_labware_view.get_labware_offset_vector("hopper-plate-id")
-    ).then_return(lw_offset)
+    labware_store.handle_action(load_labware)
+    labware_store.handle_action(load_labware_lid)
 
-    decoy.when(
-        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_3.id)
-    ).then_return(Point(1, 2, 3))
-    decoy.when(
-        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_4.id)
-    ).then_return(Point(4, 5, 6))
-
-    decoy.when(mock_module_view.get_location("module-id")).then_return(
-        DeckSlotLocation(slotName=DeckSlotName.SLOT_D3.id)
-    )
-    decoy.when(mock_module_view.get_provided_addressable_area("module-id")).then_return(
-        AddressableAreaLocation(addressableAreaName="flexStackerV1D4")
-    )
-    decoy.when(mock_module_view.get_connected_model("module-id")).then_return("model")
-    decoy.when(
-        mock_module_view.ensure_and_convert_module_fixture_location(
-            DeckSlotName.SLOT_D3, "model"
-        )
-    ).then_return("flexStackerV1D4")
-
-    decoy.when(
-        mock_addressable_area_view.get_current_potential_cutout_fixtures_for_addressable_area(
-            "flexStackerV1D4"
-        )
-    ).then_return(
-        (
-            "cutoutD3",
-            [
-                PotentialCutoutFixture(
-                    cutout_id="cutoutD3",
-                    cutout_fixture_id="flexStackerModuleV1",
-                    provided_addressable_areas=frozenset(),
-                )
-            ],
-        )
-    )
-    plate_z = subject.get_labware_highest_z("plate-id")
-    reservoir_z = subject.get_labware_highest_z("reservoir-id")
-    all_z = subject.get_all_obstacle_highest_z()
-
-    # Should exclude the off-deck or hopper plate.
-    assert all_z == max(plate_z, reservoir_z)
+    # the highest Z should be the max of the highest Z of the on-deck labware
+    lid_highest_z = subject.get_labware_highest_z("lid-id")
+    labware_highest_z = subject.get_labware_highest_z("labware-id")
+    assert lid_highest_z > labware_highest_z
+    assert subject.get_all_obstacle_highest_z() == lid_highest_z
 
 
+@pytest.mark.parametrize("use_mocks", [False])
 def test_get_all_obstacle_highest_z_with_staging_area(
     decoy: Decoy,
-    mock_labware_view: LabwareView,
-    mock_module_view: ModuleView,
-    mock_addressable_area_view: AddressableAreaView,
+    labware_store: LabwareStore,
     subject: GeometryView,
+    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """It should get the highest Z amongst all labware including staging area."""
-    plate = LoadedLabware(
-        id="plate-id",
-        loadName="plate-load-name",
-        definitionUri="plate-definition-uri",
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
-        offsetId="plate-offset-id",
+    load_deck_labware = load_labware_action(
+        "deck-lw-id",
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        definition_update={
+            "version": "deck-lw",  # this is to make sure definitionURI is unique
+            "dimensions": LabwareDimensions(xDimension=0, yDimension=0, zDimension=10),
+        },
     )
-    staging_lw = LoadedLabware(
-        id="staging-id",
-        loadName="staging-load-name",
-        definitionUri="staging-definition-uri",
+    load_staging_labware = load_labware_action(
+        "staging-lw-id",
         location=AddressableAreaLocation(addressableAreaName="D4"),
-        offsetId="plate-offset-id",
+        definition_update={
+            "version": "staging-lw",  # this is to make sure definitionURI is unique
+            "dimensions": LabwareDimensions(
+                xDimension=0, yDimension=0, zDimension=10000
+            ),  # something tall
+        },
     )
+    labware_store.handle_action(load_deck_labware)
+    labware_store.handle_action(load_staging_labware)
 
-    plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
-    staging_lw_offset = LabwareOffsetVector(x=1, y=-2, z=3)
+    staging_labware_z = subject.get_labware_highest_z("staging-lw-id")
+    deck_labware_z = subject.get_labware_highest_z("deck-lw-id")
+    assert staging_labware_z > deck_labware_z
 
-    decoy.when(mock_module_view.get_all()).then_return([])
-    decoy.when(mock_addressable_area_view.get_all()).then_return([])
-
-    decoy.when(mock_labware_view.get_all()).then_return([plate, staging_lw])
-    decoy.when(mock_labware_view.get("plate-id")).then_return(plate)
-    decoy.when(mock_labware_view.get("staging-id")).then_return(staging_lw)
-
-    decoy.when(mock_labware_view.get_dimensions(labware_id="plate-id")).then_return(
-        Dimensions(x=0, y=0, z=10)
-    )
-    decoy.when(mock_labware_view.get_dimensions(labware_id="staging-id")).then_return(
-        Dimensions(x=0, y=0, z=10000)  # Something tall.
-    )
-
-    decoy.when(mock_labware_view.get_labware_offset_vector("plate-id")).then_return(
-        plate_offset
-    )
-    decoy.when(mock_labware_view.get_labware_offset_vector("staging-id")).then_return(
-        staging_lw_offset
-    )
-
-    decoy.when(
-        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_3.id)
-    ).then_return(Point(1, 2, 3))
-    decoy.when(
-        mock_addressable_area_view.get_addressable_area_position("D4")
-    ).then_return(Point(4, 5, 6))
-
-    staging_z = subject.get_labware_highest_z("staging-id")
-    all_z = subject.get_all_obstacle_highest_z()
-
-    assert all_z == staging_z
+    assert subject.get_all_obstacle_highest_z() == staging_labware_z
 
 
+@pytest.mark.parametrize("use_mocks", [False])
 def test_get_all_obstacle_highest_z_with_modules(
     decoy: Decoy,
-    mock_labware_view: LabwareView,
-    mock_module_view: ModuleView,
-    mock_addressable_area_view: AddressableAreaView,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
     subject: GeometryView,
+    thermocycler_v2_def: ModuleDefinition,
+    flex_stacker_v1_def: ModuleDefinition,
+    load_module_action: Callable[..., SucceedCommandAction],
 ) -> None:
-    """It should get the highest Z including modules."""
-    module_1 = LoadedModule.model_construct(id="module-id-1")  # type: ignore[call-arg]
-    module_2 = LoadedModule.model_construct(id="module-id-2")  # type: ignore[call-arg]
+    """It should get the module highest Z."""
+    load_thermocycler = load_module_action(
+        "thermocycler-id",
+        thermocycler_v2_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
+    )
 
-    decoy.when(mock_labware_view.get_all()).then_return([])
-    decoy.when(mock_addressable_area_view.get_all()).then_return([])
+    load_stacker = load_module_action(
+        "stacker-id",
+        flex_stacker_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_D3),
+        used_addressable_area="flexStackerModuleV1D4",
+    )
+    module_store.handle_action(load_thermocycler)
+    module_store.handle_action(load_stacker)
+    addressable_area_store.handle_action(load_thermocycler)
+    addressable_area_store.handle_action(load_stacker)
 
-    decoy.when(mock_module_view.get_all()).then_return([module_1, module_2])
-    decoy.when(mock_module_view.get_overall_height("module-id-1")).then_return(42.0)
-    decoy.when(mock_module_view.get_overall_height("module-id-2")).then_return(1337.0)
+    stacker_highest_z = subject._modules.get_module_highest_z(
+        "stacker-id", subject._addressable_areas
+    )
+    stacker_overall_z = subject._modules.get_overall_height("stacker-id")
+    # overall height should not be the same as the highest z because the overall z
+    # includes the height of the module outside of the deck
+    assert stacker_highest_z != stacker_overall_z
+
+    thermocycler_highest_z = subject._modules.get_module_highest_z(
+        "thermocycler-id", subject._addressable_areas
+    )
+    thermocycler_overall_z = subject._modules.get_overall_height("thermocycler-id")
+    assert thermocycler_highest_z != thermocycler_overall_z
 
     result = subject.get_all_obstacle_highest_z()
+    assert result == subject._get_tallest_obstacle_module()
+    assert result == max(stacker_highest_z, thermocycler_highest_z)
 
-    assert result == 1337.0
 
-
+@pytest.mark.parametrize("use_mocks", [False])
 def test_get_all_obstacle_highest_z_with_fixtures(
     decoy: Decoy,
-    mock_labware_view: LabwareView,
-    mock_module_view: ModuleView,
-    mock_addressable_area_view: AddressableAreaView,
+    addressable_area_store: AddressableAreaStore,
     subject: GeometryView,
 ) -> None:
     """It should get the highest Z including fixtures."""
-    decoy.when(mock_labware_view.get_all()).then_return([])
-    decoy.when(mock_module_view.get_all()).then_return([])
-
-    decoy.when(mock_addressable_area_view.get_all_cutout_fixtures()).then_return(
-        ["abc", "xyz"]
+    addressable_area_store.handle_action(
+        SetDeckConfigurationAction(
+            deck_configuration=[
+                ("cutoutA3", "trashBinAdapter", None),
+                ("cutoutB3", "singleRightSlot", None),
+            ],
+        )
     )
-    decoy.when(mock_addressable_area_view.get_fixture_height("abc")).then_return(42.0)
-    decoy.when(mock_addressable_area_view.get_fixture_height("xyz")).then_return(1337.0)
 
     result = subject.get_all_obstacle_highest_z()
-
-    assert result == 1337.0
+    assert result == subject._get_tallest_obstacle_fixture()
+    assert result == max(
+        subject._addressable_areas.get_fixture_height("trashBinAdapter"),
+        subject._addressable_areas.get_fixture_height("singleRightSlot"),
+    )
 
 
 def test_get_highest_z_in_slot_with_single_labware(
@@ -3613,7 +3597,7 @@ def test_get_offset_location_deck_slot(
     labware_store: LabwareStore,
     nice_labware_definition: LabwareDefinition,
     subject: GeometryView,
-    load_labware_action: SucceedCommandAction,
+    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the offset location of a labware in a deck slot."""
     action = load_labware_action(
@@ -3635,8 +3619,8 @@ def test_get_offset_location_module(
     module_store: ModuleStore,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
-    load_module_action: SucceedCommandAction,
-    load_labware_action: SucceedCommandAction,
+    load_module_action: Callable[..., SucceedCommandAction],
+    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the offset of a labware directly on a module."""
     load_module = load_module_action(
@@ -3668,9 +3652,9 @@ def test_get_offset_location_module_with_adapter(
     tempdeck_v2_def: ModuleDefinition,
     labware_view: LabwareView,
     subject: GeometryView,
-    load_module_action: SucceedCommandAction,
-    load_adapter_action: SucceedCommandAction,
-    load_labware_action: SucceedCommandAction,
+    load_module_action: Callable[..., SucceedCommandAction],
+    load_adapter_action: Callable[..., SucceedCommandAction],
+    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the offset of a labware directly on a module."""
     load_module = load_module_action(
@@ -3705,7 +3689,7 @@ def test_get_offset_fails_with_off_deck_labware(
     decoy: Decoy,
     labware_store: LabwareStore,
     subject: GeometryView,
-    load_labware_action: SucceedCommandAction,
+    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """You cannot get the offset location for a labware loaded OFF_DECK."""
     action = load_labware_action(labware_id="labware-id-1", location=OFF_DECK_LOCATION)
@@ -3721,7 +3705,7 @@ def test_get_projected_offset_location_pending_labware(
     module_store: ModuleStore,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
-    load_module_action: SucceedCommandAction,
+    load_module_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the projected offset of a labware on a labware not yet loaded."""
     load_module = load_module_action(
@@ -4150,7 +4134,7 @@ def test_get_location_sequence_deck_slot(
     addressable_area_store: AddressableAreaStore,
     nice_labware_definition: LabwareDefinition,
     subject: GeometryView,
-    load_labware_action: SucceedCommandAction,
+    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the location sequence of a labware in a deck slot."""
     action = load_labware_action(
@@ -4177,8 +4161,8 @@ def test_get_location_sequence_module(
     nice_labware_definition: LabwareDefinition,
     tempdeck_v2_def: ModuleDefinition,
     subject: GeometryView,
-    load_module_action: SucceedCommandAction,
-    load_labware_action: SucceedCommandAction,
+    load_module_action: Callable[..., SucceedCommandAction],
+    load_labware_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the location sequence of a labware directly on a module."""
     load_module = load_module_action(
@@ -4328,7 +4312,7 @@ def test_get_location_sequence_stacker_hopper(
     nice_labware_definition: LabwareDefinition,
     flex_stacker_v1_def: ModuleDefinition,
     subject: GeometryView,
-    load_module_action: SucceedCommandAction,
+    load_module_action: Callable[..., SucceedCommandAction],
 ) -> None:
     """Test if you can get the location sequence of a labware in the stacker hopper."""
     load_module = load_module_action(


### PR DESCRIPTION
This PR adds a new geometry method to determine if labware is a deck obstacle and updates the logic for calculating the highest Z-point on the deck. 

While refactoring the tests, I discovered that the we're also using the wrong z for modules. We should only consider the module height within the robot's deck, and not the overall height of the module.   