### PR TITLE
refactor(protocol-deisgner): addFixtureModal in a portal

### DIFF
--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from 'styled-components'
@@ -31,6 +32,7 @@ import { uuid } from '@opentrons/step-generation'
 import { editDeckConfiguration } from '../../../step-forms/actions'
 import { getInitialDeckSetup } from '../../../step-forms/selectors'
 import { useKitchen } from '../Kitchen/hooks'
+import { getMainPagePortalEl } from '../Portal'
 import { getLabwareNotCompatibleWithModule, getSlotHasLabware } from '../utils'
 import { getAvailableOptions } from './useDeckConfigurationEditing'
 
@@ -321,7 +323,7 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     )
   })
 
-  return (
+  return createPortal(
     <Modal {...modalProps}>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
         {fixtureOptions}
@@ -345,7 +347,8 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
           </StyledText>
         </Btn>
       ) : null}
-    </Modal>
+    </Modal>,
+    getMainPagePortalEl()
   )
 }
 


### PR DESCRIPTION


# Overview

AddFixtureModal wasn't wrapped in a portal

Before:
<img width="1531" alt="Screenshot 2025-04-28 at 10 18 44" src="https://github.com/user-attachments/assets/5dce4db2-9574-4063-8b24-e90a5f02829d" />

After:
<img width="1528" alt="Screenshot 2025-04-28 at 10 18 25" src="https://github.com/user-attachments/assets/bc7ed8a6-fb74-481c-b92a-4aec857a75c1" />


## Test Plan and Hands on Testing

Check code, you can smoke test too between edge and this branch

## Changelog

wrap modal in a portal

## Risk assessment

low