### PR TITLE
refactor(api): Delete unused `SIMULATED` sentinel

### DIFF
--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -62,16 +62,6 @@ Unfortunately, mypy doesn't let us write `Literal[CLEAR]`. Use this instead.
 """
 
 
-class _SimulatedEnum(enum.Enum):
-    SIMULATED = enum.auto()
-
-
-SIMULATED: typing.Final = _SimulatedEnum.SIMULATED
-"""A sentinel value to indicate that a liquid probe return value is simulated.
-
-Useful to avoid throwing unnecessary errors in protocol analysis."""
-
-
 @dataclasses.dataclass(frozen=True)
 class Well:
     """Designates a well in a labware."""


### PR DESCRIPTION
## Overview

This deletes the `opentrons.protocol_engine.state.update_types.SIMULATED` sentinel object, which was not used for anything.

## Test Plan and Hands on Testing

Just CI.

## Review requests

Any reason to keep this?

## Risk assessment

No risk if CI passes.
