### PR TITLE
fix(app): add "manual fill" recovery success toasts

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/constants.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/constants.ts
@@ -1,12 +1,12 @@
 import { css } from 'styled-components'
 
 import {
-  RESPONSIVENESS,
-  SPACING,
-  DIRECTION_COLUMN,
   ALIGN_CENTER,
+  DIRECTION_COLUMN,
   JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
+  RESPONSIVENESS,
+  SPACING,
   TEXT_ALIGN_CENTER,
 } from '@opentrons/components'
 
@@ -174,7 +174,6 @@ export const RECOVERY_MAP = {
       RETRY: 'retry',
     },
   },
-  REFILL_AND_RESUME: { ROUTE: 'refill-and-resume', STEPS: {} },
   RETRY_STEP: {
     ROUTE: 'retry-step',
     STEPS: { CONFIRM_RETRY: 'confirm-retry' },
@@ -224,7 +223,6 @@ const {
   ROBOT_DOOR_OPEN,
   ROBOT_DOOR_OPEN_SPECIAL,
   DROP_TIP_FLOWS,
-  REFILL_AND_RESUME,
   IGNORE_AND_SKIP,
   CANCEL_RUN,
   RETRY_NEW_TIPS,
@@ -274,7 +272,6 @@ export const STEP_ORDER: StepOrder = {
     DROP_TIP_FLOWS.STEPS.CHOOSE_BLOWOUT,
     DROP_TIP_FLOWS.STEPS.CHOOSE_TIP_DROP,
   ],
-  [REFILL_AND_RESUME.ROUTE]: [],
   [IGNORE_AND_SKIP.ROUTE]: [
     IGNORE_AND_SKIP.STEPS.SELECT_IGNORE_KIND,
     IGNORE_AND_SKIP.STEPS.SKIP_STEP,
@@ -455,7 +452,6 @@ export const RECOVERY_MAP_METADATA: RecoveryRouteStepMetadata = {
     [MANUAL_REPLACE_AND_RETRY.STEPS.MANUAL_REPLACE]: { allowDoorOpen: true },
     [MANUAL_REPLACE_AND_RETRY.STEPS.RETRY]: { allowDoorOpen: true },
   },
-  [REFILL_AND_RESUME.ROUTE]: {},
   [RETRY_STEP.ROUTE]: {
     [RETRY_STEP.STEPS.CONFIRM_RETRY]: {
       allowDoorOpen: false,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryToasts.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryToasts.test.tsx
@@ -1,22 +1,20 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest'
-import { I18nextProvider } from 'react-i18next'
-import { i18n } from '/app/i18n'
-import { renderHook, render, screen } from '@testing-library/react'
-
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
-
+import { render, renderHook, screen } from '@testing-library/react'
+import { i18n } from '/app/i18n'
+import { useCommandTextString } from '/app/local-resources/commands'
+import type { ReactElement } from 'react'
+import { I18nextProvider } from 'react-i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { useToaster } from '../../../ToasterOven'
+import { RECOVERY_MAP } from '../../constants'
 import {
+  getStepNumber,
+  handleRecoveryOptionAction,
+  useRecoveryFullCommandText,
   useRecoveryToasts,
   useRecoveryToastText,
-  getStepNumber,
-  useRecoveryFullCommandText,
 } from '../useRecoveryToasts'
-import { RECOVERY_MAP } from '../../constants'
-import { useToaster } from '../../../ToasterOven'
-import { useCommandTextString } from '/app/local-resources/commands'
-
-import type { ReactElement } from 'react'
-import type { Mock } from 'vitest'
 import type { BuildToast } from '../useRecoveryToasts'
 
 vi.mock('../../../ToasterOven')
@@ -287,5 +285,106 @@ describe('useRecoveryFullCommandText', () => {
       })
     )
     expect(result.current).toBe('tc starting profile of 1231231 element steps')
+  })
+})
+
+describe('handleRecoveryOptionAction', () => {
+  const CURRENT_STEP_VALUE = 'currentStepValue'
+  const NEXT_STEP_VALUE = 'nextStepValue'
+
+  // Routes that should return the nextStepReturnVal toasts.
+  const NEXT_STEP_ROUTES = [
+    RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE,
+    RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE,
+    RECOVERY_MAP.IGNORE_AND_SKIP.ROUTE,
+    RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE,
+  ]
+
+  // Routes that should return the currentStepReturnVal toasts.
+  const CURRENT_STEP_ROUTES = [
+    RECOVERY_MAP.CANCEL_RUN.ROUTE,
+    RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE,
+    RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE,
+    RECOVERY_MAP.RETRY_STEP.ROUTE,
+    RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.ROUTE,
+    RECOVERY_MAP.HOME_AND_RETRY.ROUTE,
+    RECOVERY_MAP.MANUAL_FILL_AND_RETRY_NEW_TIPS.ROUTE,
+    RECOVERY_MAP.MANUAL_FILL_AND_RETRY_SAME_TIPS.ROUTE,
+  ]
+
+  // Routes that should return no toasts.
+  const NULL_ROUTES = [
+    RECOVERY_MAP.DROP_TIP_FLOWS.ROUTE,
+    RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE,
+    RECOVERY_MAP.ROBOT_CANCELING.ROUTE,
+    RECOVERY_MAP.ROBOT_IN_MOTION.ROUTE,
+    RECOVERY_MAP.ROBOT_PICKING_UP_TIPS.ROUTE,
+    RECOVERY_MAP.ROBOT_RELEASING_LABWARE.ROUTE,
+    RECOVERY_MAP.ROBOT_RESUMING.ROUTE,
+    RECOVERY_MAP.ROBOT_RETRYING_STEP.ROUTE,
+    RECOVERY_MAP.ROBOT_SKIPPING_STEP.ROUTE,
+    RECOVERY_MAP.ROBOT_DOOR_OPEN.ROUTE,
+    RECOVERY_MAP.ROBOT_DOOR_OPEN_SPECIAL.ROUTE,
+    RECOVERY_MAP.OPTION_SELECTION.ROUTE,
+  ]
+
+  it.each(NEXT_STEP_ROUTES)('should return nextStepReturnVal for %s', route => {
+    const result = handleRecoveryOptionAction(
+      route,
+      CURRENT_STEP_VALUE,
+      NEXT_STEP_VALUE
+    )
+    expect(result).toBe(NEXT_STEP_VALUE)
+  })
+
+  it.each(CURRENT_STEP_ROUTES)(
+    'should return currentStepReturnVal for %s',
+    route => {
+      const result = handleRecoveryOptionAction(
+        route,
+        CURRENT_STEP_VALUE,
+        NEXT_STEP_VALUE
+      )
+      expect(result).toBe(CURRENT_STEP_VALUE)
+    }
+  )
+
+  it.each(NULL_ROUTES)('should return null for %s', route => {
+    const result = handleRecoveryOptionAction(
+      route,
+      CURRENT_STEP_VALUE,
+      NEXT_STEP_VALUE
+    )
+    expect(result).toBeNull()
+  })
+
+  it('should return null for unknown recovery options', () => {
+    const result = handleRecoveryOptionAction(
+      'UNKNOWN_OPTION' as any,
+      CURRENT_STEP_VALUE,
+      NEXT_STEP_VALUE
+    )
+    expect(result).toBeNull()
+  })
+
+  it('should ensure all routes are tested and there are no duplicated routes', () => {
+    const allRoutes = Object.values(RECOVERY_MAP).map(item => item.ROUTE)
+
+    const testedRoutes = [
+      ...NEXT_STEP_ROUTES,
+      ...CURRENT_STEP_ROUTES,
+      ...NULL_ROUTES,
+    ]
+
+    const untestedRoutes = allRoutes.filter(
+      route => !testedRoutes.includes(route)
+    )
+
+    if (untestedRoutes.length > 0) {
+      throw new Error(`Untested routes: ${untestedRoutes.join(', ')}`)
+    }
+
+    const allTestedRoutesSet = new Set(testedRoutes)
+    expect(allTestedRoutesSet.size).toBe(testedRoutes.length)
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
@@ -1,12 +1,10 @@
+import { useCommandTextString } from '/app/local-resources/commands'
+import type { UseCommandTextStringParams } from '/app/local-resources/commands'
+import type { StepCounts } from '/app/resources/protocols/hooks'
 import { useTranslation } from 'react-i18next'
-
 import { useToaster } from '../../ToasterOven'
 import { RECOVERY_MAP } from '../constants'
-import { useCommandTextString } from '/app/local-resources/commands'
-
-import type { StepCounts } from '/app/resources/protocols/hooks'
 import type { CurrentRecoveryOptionUtils } from './useRecoveryRouting'
-import type { UseCommandTextStringParams } from '/app/local-resources/commands'
 
 export type BuildToast = Omit<UseCommandTextStringParams, 'command'> & {
   isOnDevice: boolean
@@ -158,13 +156,12 @@ export function getStepNumber(
 
 // Recovery options can be categorized into broad categories of behavior, currently performing the same step again
 // or skipping to the next step.
-function handleRecoveryOptionAction<T>(
+export function handleRecoveryOptionAction<T>(
   selectedRecoveryOption: CurrentRecoveryOptionUtils['selectedRecoveryOption'],
   currentStepReturnVal: T,
   nextStepReturnVal: T
 ): T | null {
   switch (selectedRecoveryOption) {
-    case RECOVERY_MAP.MANUAL_FILL_AND_RETRY_SAME_TIPS.ROUTE:
     case RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE:
     case RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE:
     case RECOVERY_MAP.IGNORE_AND_SKIP.ROUTE:
@@ -176,8 +173,11 @@ function handleRecoveryOptionAction<T>(
     case RECOVERY_MAP.RETRY_STEP.ROUTE:
     case RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.ROUTE:
     case RECOVERY_MAP.HOME_AND_RETRY.ROUTE:
+    case RECOVERY_MAP.MANUAL_FILL_AND_RETRY_NEW_TIPS.ROUTE:
+    case RECOVERY_MAP.MANUAL_FILL_AND_RETRY_SAME_TIPS.ROUTE:
       return currentStepReturnVal
     default: {
+      console.error('Unhandled recovery toast case. Handle explicitly.')
       return null
     }
   }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

After updating the "liquid not detected" recovery flows for meniscus pipetting support, I did not add all routes to the recovery success toast wire-up interface (a route recently refactored for the static meniscus changes is in the wrong toast type, too). This PR does that, and more importantly, testing now fails if an added recovery route does not explicitly have a toast associated with it (or is explicitly marked as a "null toast"), so this shouldn't happen again.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Covered by testing.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Review requests

- Is there any reason we wouldn't want this in 8.4 at this stage? Seems ok, since we're cutting another alpha anyway.

## Changelog
- "No liquid detected" recovery options now properly display the correct toasts.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
basically none
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
