### PR TITLE
chore: fix api and hardware_test lint failures in edge

### DIFF
--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -334,7 +334,7 @@ async def test_hw_aspirate_while_tracking(
         mock_state_view.geometry.get_liquid_handling_z_change(
             labware_id="labware-id",
             well_name="A1",
-            pipette_id="pipette_id",
+            pipette_id="pipette-id",
             operation_volume=-25.0,
         )
     ).then_return(4.544)
@@ -349,6 +349,11 @@ async def test_hw_aspirate_while_tracking(
     )
     # make sure hw aspirate_while_tracking runs without error
     assert result == 25
+    decoy.verify(
+        await mock_hardware_api.aspirate_while_tracking(
+            mount=Mount.LEFT, z_distance=4.544, flow_rate=2.5, volume=25
+        )
+    )
 
 
 async def test_hw_aspirate_in_place(

--- a/shared-data/python/opentrons_shared_data/labware/__init__.py
+++ b/shared-data/python/opentrons_shared_data/labware/__init__.py
@@ -4,7 +4,7 @@ opentrons_shared_data.labware: types and functions for accessing labware defs
 
 from __future__ import annotations
 import json
-from typing import Any, Dict, NewType, TYPE_CHECKING, overload
+from typing import Any, Dict, NewType, TYPE_CHECKING, overload, Literal
 
 from .. import load_shared_data
 
@@ -17,13 +17,15 @@ Schema = NewType("Schema", Dict[str, Any])
 @overload
 def load_definition(
     loadname: str, version: int, schema: Literal[2] = 2
-) -> LabwareDefinition2: ...
+) -> LabwareDefinition2:
+    ...
 
 
 @overload
 def load_definition(
     loadname: str, version: int, schema: Literal[3]
-) -> LabwareDefinition3: ...
+) -> LabwareDefinition3:
+    ...
 
 
 def load_definition(loadname: str, version: int, schema: int = 2) -> LabwareDefinition:

--- a/shared-data/python/opentrons_shared_data/labware/__init__.py
+++ b/shared-data/python/opentrons_shared_data/labware/__init__.py
@@ -1,20 +1,32 @@
 """
 opentrons_shared_data.labware: types and functions for accessing labware defs
 """
+
+from __future__ import annotations
 import json
-from typing import Any, Dict, NewType, TYPE_CHECKING
+from typing import Any, Dict, NewType, TYPE_CHECKING, overload
 
 from .. import load_shared_data
 
 if TYPE_CHECKING:
-    from .types import LabwareDefinition
+    from .types import LabwareDefinition, LabwareDefinition2, LabwareDefinition3
 
 Schema = NewType("Schema", Dict[str, Any])
 
 
+@overload
 def load_definition(
-    loadname: str, version: int, schema: int = 2
-) -> "LabwareDefinition":
+    loadname: str, version: int, schema: Literal[2] = 2
+) -> LabwareDefinition2: ...
+
+
+@overload
+def load_definition(
+    loadname: str, version: int, schema: Literal[3]
+) -> LabwareDefinition3: ...
+
+
+def load_definition(loadname: str, version: int, schema: int = 2) -> LabwareDefinition:
     return json.loads(
         load_shared_data(f"labware/definitions/{schema}/{loadname}/{version}.json")
     )

--- a/shared-data/python/tests/labware/test_typechecks.py
+++ b/shared-data/python/tests/labware/test_typechecks.py
@@ -1,5 +1,6 @@
 """Test that our bindings can validate and parse our standard labware definitions."""
 
+from typing import Literal
 
 import pytest
 import typeguard
@@ -45,7 +46,7 @@ def test_schema_3_types(loadname: str, version: int) -> None:
     + [(loadname, version, 3) for loadname, version in get_ot_defs(schema=3)],
 )
 def test_all_schema_union_types(
-    loadname: str, version: int, schema_version: int
+    loadname: str, version: int, schema_version: Literal[2, 3]
 ) -> None:
     """Test parsing and validating into the types that represent a union of all schemas."""
     defdict = load_definition(


### PR DESCRIPTION
Fix a couple lint failures in edge in API (~merge conflict from #18189~ fixed in another pr ), hardware testing (introducing schema 3 again - may be old), and engine (bad decoy)

