### PR TITLE
feat(api): validate probed liquid height before completing command

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -188,6 +188,12 @@ async def _execute_common(  # noqa: C901
             well_name=well_name,
             well_location=params.wellLocation,
         )
+        state_view.geometry.validate_probed_height(
+            labware_id=labware_id,
+            well_name=well_name,
+            pipette_id=pipette_id,
+            probed_height=z_pos,
+        )
     except PipetteLiquidNotFoundError as exception:
         move_result.state_update.set_pipette_ready_to_aspirate(
             pipette_id=pipette_id, ready_to_aspirate=True

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -326,7 +326,7 @@ class HardwarePipettingHandler(PipettingHandler):
         well_name: str,
         well_location: WellLocation,
     ) -> LiquidTrackingType:
-        """Detect liquid level."""
+        """Return liquid level relative to the bottom of the well."""
         hw_pipette = self._state_view.pipettes.get_hardware_pipette(
             pipette_id=pipette_id,
             attached_pipettes=self._hardware_api.attached_instruments,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -17,7 +17,10 @@ from opentrons.types import (
     MeniscusTrackingTarget,
 )
 
-from opentrons_shared_data.errors.exceptions import InvalidStoredData
+from opentrons_shared_data.errors.exceptions import (
+    InvalidStoredData,
+    PipetteLiquidNotFoundError,
+)
 from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.deck.types import CutoutFixture
@@ -497,6 +500,30 @@ class GeometryView:
                 raise OperationLocationNotInWellError(
                     f"Specifying {well_location.origin} with an offset of {well_location.offset} results in an operation location below the bottom of the well"
                 )
+
+    def validate_probed_height(
+        self,
+        labware_id: str,
+        well_name: str,
+        pipette_id: str,
+        probed_height: LiquidTrackingType,
+    ) -> None:
+        """Raise an error if a probed liquid height is not within well bounds."""
+        if isinstance(probed_height, SimulatedProbeResult):
+            return
+        lld_min_height = self._pipettes.get_current_tip_lld_settings(
+            pipette_id=pipette_id
+        )
+        well_def = self._labware.get_well_definition(labware_id, well_name)
+        well_depth = well_def.depth
+        if probed_height < lld_min_height:
+            raise PipetteLiquidNotFoundError(
+                f"Liquid Height of {probed_height} mm is lower minumum allowed lld height {lld_min_height} mm."
+            )
+        if probed_height > well_depth:
+            raise PipetteLiquidNotFoundError(
+                f"Liquid Height of {probed_height} mm is greater than maximum well height {well_depth} mm."
+            )
 
     def get_well_position(
         self,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -44,6 +44,7 @@ from opentrons_shared_data.labware.labware_definition import (
     ConicalFrustum,
     labware_definition_type_adapter,
 )
+from opentrons_shared_data.errors.exceptions import PipetteLiquidNotFoundError
 from opentrons_shared_data.labware import load_definition as load_labware_definition
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (
@@ -1388,6 +1389,50 @@ def test_get_well_position(
         y=slot_pos[1] - 2 + well_def.y,
         z=slot_pos[2] + 3 + well_def.z + well_def.depth,
     )
+
+
+@pytest.mark.parametrize(
+    "probed_height", [-1.0, 0.0, 5.0, 10.0, 1000.0, SimulatedProbeResult()]
+)
+def test_validate_probed_height(
+    decoy: Decoy,
+    subject: GeometryView,
+    well_plate_def: LabwareDefinition,
+    mock_labware_view: LabwareView,
+    mock_pipette_view: PipetteView,
+    probed_height: LiquidTrackingType,
+) -> None:
+    """Test validation for probed liquid heights."""
+    labware_id = "labware-id"
+    pipette_id = "pipette-id"
+    well_name = "B2"
+    well_def = well_plate_def.wells[well_name]
+    decoy.when(
+        mock_labware_view.get_well_definition(labware_id, well_name)
+    ).then_return(well_def)
+    fake_min_height = 0.5
+    well_depth = well_def.depth
+    decoy.when(
+        mock_pipette_view.get_current_tip_lld_settings(pipette_id=pipette_id)
+    ).then_return(fake_min_height)
+    # Only invalid floats should raise an error
+    if isinstance(probed_height, float):
+        if probed_height < fake_min_height or probed_height > well_depth:
+            with pytest.raises(PipetteLiquidNotFoundError):
+                subject.validate_probed_height(
+                    labware_id=labware_id,
+                    well_name=well_name,
+                    pipette_id=pipette_id,
+                    probed_height=probed_height,
+                )
+    # floats within bounds and SimulatedProbeResult should not cause an error
+    else:
+        subject.validate_probed_height(
+            labware_id=labware_id,
+            well_name=well_name,
+            pipette_id=pipette_id,
+            probed_height=probed_height,
+        )
 
 
 def test_get_well_height(


### PR DESCRIPTION
## Overview
There are cases of non-recoverable errors in testing scenarios related to the initial probed position of liquid. Some of these can be prevented by raising a recoverable error from the liquid probed command, either if the probed liquid is too low or too high. Before, the command would finish and the protocol would proceed until an `OperationLocationNotInWellError` would be reached by trying to aspirate/dispense with an amount of liquid that we can tell from the beginning is no good. 