### PR TITLE
feat(step-generation): add python to `aspirateInPlace`

### DIFF
--- a/step-generation/src/__tests__/aspirateInPlace.test.ts
+++ b/step-generation/src/__tests__/aspirateInPlace.test.ts
@@ -11,11 +11,10 @@ import type { AspirateInPlaceParams } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
 
 describe('aspirateInPlace', () => {
-  let invariantContext: InvariantContext
   let robotStateWithTip: RobotState
-
-  const mockId = 'mockId'
-  const mockFlowRate = 10
+  let invariantContext: InvariantContext
+  const mockId = 'p10SingleId'
+  const mockFlowRate = 20
   const mockVolume = 10
   beforeEach(() => {
     invariantContext = makeContext()
@@ -40,5 +39,12 @@ describe('aspirateInPlace', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      `
+mockPythonName.aspirate(
+    volume=10,
+    rate=20 / mockPythonName.flow_rate.aspirate,
+)`.trimStart()
+    )
   })
 })

--- a/step-generation/src/commandCreators/atomic/aspirateInPlace.ts
+++ b/step-generation/src/commandCreators/atomic/aspirateInPlace.ts
@@ -6,7 +6,7 @@ import type { CommandCreator } from '../../types'
 export const aspirateInPlace: CommandCreator<AspirateInPlaceParams> = (
   args,
   invariantContext,
-  robotState
+  prevRobotState
 ) => {
   const { pipetteId, volume, flowRate } = args
 
@@ -21,8 +21,6 @@ export const aspirateInPlace: CommandCreator<AspirateInPlaceParams> = (
       },
     },
   ]
-  console.log(pipetteId)
-  console.log(invariantContext.pipetteEntities)
 
   const pipettePythonName =
     invariantContext.pipetteEntities[pipetteId].pythonName

--- a/step-generation/src/commandCreators/atomic/aspirateInPlace.ts
+++ b/step-generation/src/commandCreators/atomic/aspirateInPlace.ts
@@ -1,4 +1,4 @@
-import { uuid } from '../../utils'
+import { indentPyLines, uuid } from '../../utils'
 
 import type { AspirateInPlaceParams } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
@@ -6,7 +6,7 @@ import type { CommandCreator } from '../../types'
 export const aspirateInPlace: CommandCreator<AspirateInPlaceParams> = (
   args,
   invariantContext,
-  prevRobotState
+  robotState
 ) => {
   const { pipetteId, volume, flowRate } = args
 
@@ -21,7 +21,23 @@ export const aspirateInPlace: CommandCreator<AspirateInPlaceParams> = (
       },
     },
   ]
+  console.log(pipetteId)
+  console.log(invariantContext.pipetteEntities)
+
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const pythonArgs = [
+    `volume=${volume}`,
+    // rate= is a ratio in the PAPI, and we have no good way to figure out what
+    // flowrate the PAPI has set the pipette to, so we just have to do a division:
+    `rate=${flowRate} / ${pipettePythonName}.flow_rate.aspirate`,
+  ]
+  const python = `${pipettePythonName}.aspirate(\n${indentPyLines(
+    pythonArgs.join(',\n')
+  )},\n)`
+
   return {
     commands,
+    python,
   }
 }


### PR DESCRIPTION
# Overview

This PR adds Python code to the `aspirateInPlace` step-generation atomic command creator. Note that there is no separate `aspirate_in_place` Python API method— rather, the in place behavior is determined by the intentional omission of a `location` param to the `aspirate` method.

## Test Plan and Hands on Testing

- review code and make sure this aligns with how we handle aspirate in place in Python API

## Changelog

- update `aspirateInPlace` command creator and test

## Review requests

--

## Risk assessment

low