### PR TITLE
fix(app): fix labware displayed on modules during LPC

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/PrepareLabware/LPCDeck.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/PrepareLabware/LPCDeck.tsx
@@ -50,14 +50,18 @@ export function LPCDeck({ runId }: EditOffsetContentProps): JSX.Element {
   const adapterLwDef = useSelector(selectSelectedLwAdapterDef(runId))
 
   const offsetLocationDetails = selectedLwInfo.offsetLocationDetails as OffsetLocationDetails
-  const { closestBeneathModuleModel, kind: offsetKind } = offsetLocationDetails
+  const {
+    closestBeneathModuleModel,
+    closestBeneathModuleId,
+    kind: offsetKind,
+  } = offsetLocationDetails
 
   const buildModulesOnDeck = (): ModuleOnDeck[] => {
     const allModulesOnDeck = protocolData.modules.map(mod => {
       return {
         moduleModel: mod.model,
         moduleLocation: mod.location,
-        nestedLabwareDef: closestBeneathModuleModel != null ? labwareDef : null,
+        nestedLabwareDef: closestBeneathModuleId === mod.id ? labwareDef : null,
         innerProps:
           closestBeneathModuleModel != null &&
           getModuleType(closestBeneathModuleModel) === THERMOCYCLER_MODULE_TYPE


### PR DESCRIPTION
Closes [RQA-4156](https://opentrons.atlassian.net/browse/RQA-4156)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When LPCing a labware in a module slot, the "Prepare deck for LPC" view's deck map currently renders the actively LPC'd labware above _all_ modules and not just the module of interest.

To fix, we only render the LPC'd labware above the module with an id that matches the location-specific module id.

### Current Behavior

<img width="1016" alt="Screenshot 2025-04-29 at 12 52 55 PM" src="https://github.com/user-attachments/assets/ef1ed354-8a45-4437-b27e-285d9b2776c0" />

### Fixed Behavior

<img width="1016" alt="Screenshot 2025-04-29 at 12 56 27 PM" src="https://github.com/user-attachments/assets/aa4010f1-1555-465b-8c53-70a6fd54d9ef" />


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed labware appearing on top of every module when calibrating an offset in LPC instead of just the module of interest.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4156]: https://opentrons.atlassian.net/browse/RQA-4156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ