### PR TITLE
fix(api): handle arbitrary stacks in move_labware

### DIFF
--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -88,6 +88,7 @@ from .exceptions import (
     OffsetLocationInvalidError,
     FlexStackerLabwarePoolNotYetDefinedError,
     FlexStackerNotLogicallyEmptyError,
+    InvalidLabwarePositionError,
 )
 
 from .error_occurrence import ErrorOccurrence, ProtocolCommandFailedError
@@ -171,6 +172,7 @@ __all__ = [
     "OffsetLocationInvalidError",
     "FlexStackerLabwarePoolNotYetDefinedError",
     "FlexStackerNotLogicallyEmptyError",
+    "InvalidLabwarePositionError",
     # error occurrence models
     "ErrorOccurrence",
     "CommandNotAllowedError",

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -1281,3 +1281,15 @@ class FlexStackerLabwarePoolNotYetDefinedError(ProtocolEngineError):
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
+
+class InvalidLabwarePositionError(ProtocolEngineError):
+    """Raised when a labware position is internally invalid."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -34,6 +34,8 @@ from ..errors import (
     LabwareNotLoadedOnModuleError,
     LabwareMovementNotAllowedError,
     OperationLocationNotInWellError,
+    InvalidLabwarePositionError,
+    LabwareNotOnDeckError,
 )
 from ..errors.exceptions import InvalidLiquidHeightFound
 from ..resources import (
@@ -368,6 +370,57 @@ class GeometryView:
                 z=on_labware_dimensions.z - stacking_overlap.z,
             )
             return labware_offset + self._get_offset_from_parent(
+                self._labware.get_definition(on_labware.id), on_labware.location
+            )
+        else:
+            raise errors.LabwareNotOnDeckError(
+                "Cannot access labware since it is not on the deck. "
+                "Either it has been loaded off-deck or its been moved off-deck."
+            )
+
+    def _get_offset_from_parent_addressable_area(
+        self, child_definition: LabwareDefinition, parent: LabwareLocation
+    ) -> LabwareOffsetVector:
+        """Gets the offset vector of a labware from its eventual parent addressable area.
+
+        This returns the sum of the offsets for any labware-on-labware pairs plus the
+        "base offset", which is (0, 0, 0) in all cases except for modules on the
+        OT-2. See
+        protocol_engine.state.modules.get_nominal_offset_to_child_from_addressable_area
+        for more.
+        """
+        if isinstance(parent, (AddressableAreaLocation, DeckSlotLocation)):
+            return LabwareOffsetVector(x=0, y=0, z=0)
+        elif isinstance(parent, ModuleLocation):
+            module_id = parent.moduleId
+            module_model = self._modules.get_connected_model(module_id)
+            stacking_overlap = self._labware.get_module_overlap_offsets(
+                child_definition, module_model
+            )
+            module_to_child = (
+                self._modules.get_nominal_offset_to_child_from_addressable_area(
+                    module_id=module_id
+                )
+            )
+            return LabwareOffsetVector(
+                x=module_to_child.x - stacking_overlap.x,
+                y=module_to_child.y - stacking_overlap.y,
+                z=module_to_child.z - stacking_overlap.z,
+            )
+        elif isinstance(parent, OnLabwareLocation):
+            on_labware = self._labware.get(parent.labwareId)
+            on_labware_dimensions = self._labware.get_dimensions(
+                labware_id=on_labware.id
+            )
+            stacking_overlap = self._labware.get_labware_overlap_offsets(
+                definition=child_definition, below_labware_name=on_labware.loadName
+            )
+            labware_offset = LabwareOffsetVector(
+                x=stacking_overlap.x,
+                y=stacking_overlap.y,
+                z=on_labware_dimensions.z - stacking_overlap.z,
+            )
+            return labware_offset + self._get_offset_from_parent_addressable_area(
                 self._labware.get_definition(on_labware.id), on_labware.location
             )
         else:
@@ -822,6 +875,32 @@ class GeometryView:
 
         return slot_name
 
+    def get_ancestor_addressable_area_name(self, labware_id: str) -> str:
+        """Get the name of the addressable area the labware is eventually on."""
+        labware = self._labware.get(labware_id)
+        original_display_name = self._labware.get_display_name(labware_id)
+        seen: Set[str] = set((labware_id,))
+        while isinstance(labware.location, OnLabwareLocation):
+            labware = self._labware.get(labware.location.labwareId)
+            if labware.id in seen:
+                raise InvalidLabwarePositionError(
+                    f"Cycle detected in labware positioning for {original_display_name}"
+                )
+            seen.add(labware.id)
+        if isinstance(labware.location, DeckSlotLocation):
+            return labware.location.slotName.id
+        elif isinstance(labware.location, AddressableAreaLocation):
+            return labware.location.addressableAreaName
+        elif isinstance(labware.location, ModuleLocation):
+            return self._modules.get_provided_addressable_area(
+                labware.location.moduleId
+            )
+        else:
+            raise LabwareNotOnDeckError(
+                f"Labware {original_display_name} is not loaded on deck",
+                details={"eventual-location": repr(labware.location)},
+            )
+
     def ensure_location_not_occupied(
         self,
         location: _LabwareLocation,
@@ -990,69 +1069,23 @@ class GeometryView:
         )
         location_name: str
         module_location: ModuleLocation | None = None
-
+        offset = self._get_offset_from_parent_addressable_area(
+            child_definition=labware_definition, parent=location
+        ) + self._get_calibrated_module_offset(location)
         if isinstance(location, DeckSlotLocation):
             location_name = location.slotName.id
-            offset = LabwareOffsetVector(x=0, y=0, z=0)
         elif isinstance(location, AddressableAreaLocation):
             location_name = location.addressableAreaName
-            if fixture_validation.is_gripper_waste_chute(location_name):
-                drop_labware_location = (
-                    self._addressable_areas.get_addressable_area_move_to_location(
-                        location_name
-                    )
-                )
-                return drop_labware_location + Point(z=grip_height_from_labware_bottom)
-            # Location should have been pre-validated so this will be a deck/staging area slot
-            else:
-                offset = LabwareOffsetVector(x=0, y=0, z=0)
-        else:
-            if isinstance(location, ModuleLocation):
-                location_name = self._modules.get_provided_addressable_area(
-                    location.moduleId
-                )
-                module_location = location
-            else:  # OnLabwareLocation
-                labware_loc = self._labware.get(location.labwareId).location
-                if isinstance(labware_loc, ModuleLocation):
-                    location_name = self._modules.get_provided_addressable_area(
-                        labware_loc.moduleId
-                    )
-                    module_location = labware_loc
-                else:
-                    location_name = self.get_ancestor_slot_name(location.labwareId).id
-            labware_offset = self._get_offset_from_parent(
-                child_definition=labware_definition, parent=location
+        elif isinstance(location, ModuleLocation):
+            location_name = self._modules.get_provided_addressable_area(
+                location.moduleId
             )
-            # Get the calibrated offset if the on labware location is on top of a module, otherwise return empty one
-            cal_offset = self._get_calibrated_module_offset(location)
-            offset = LabwareOffsetVector(
-                x=labware_offset.x + cal_offset.x,
-                y=labware_offset.y + cal_offset.y,
-                z=labware_offset.z + cal_offset.z,
-            )
+        else:  # OnLabwareLocation
+            location_name = self.get_ancestor_addressable_area_name(location.labwareId)
 
-        if module_location is not None:
-            # Location center must be determined from the cutout the Module is loaded in
-            position = deck_configuration_provider.get_cutout_position(
-                cutout_id=self._addressable_areas.get_cutout_id_by_deck_slot_name(
-                    self._modules.get_location(module_location.moduleId).slotName
-                ),
-                deck_definition=self._addressable_areas.deck_definition,
-            )
-            bounding_box = self._addressable_areas.get_addressable_area(
-                location_name
-            ).bounding_box
-            location_center = Point(
-                position.x + bounding_box.x / 2,
-                position.y + bounding_box.y / 2,
-                position.z,
-            )
-
-        else:
-            location_center = self._addressable_areas.get_addressable_area_center(
-                location_name
-            )
+        location_center = self._addressable_areas.get_addressable_area_center(
+            location_name
+        )
 
         return Point(
             location_center.x + offset.x,
@@ -1255,9 +1288,9 @@ class GeometryView:
                 pipette_mount=pipette_mount,
                 labware_slot_column=labware_slot_column,
             )
-            self._last_drop_tip_location_spot[
-                addressable_area_name
-            ] = _TipDropSection.LEFT
+            self._last_drop_tip_location_spot[addressable_area_name] = (
+                _TipDropSection.LEFT
+            )
         else:
             # Drop tip in RIGHT section
             x_offset = self._get_drop_tip_well_x_offset(
@@ -1267,9 +1300,9 @@ class GeometryView:
                 pipette_mount=pipette_mount,
                 labware_slot_column=labware_slot_column,
             )
-            self._last_drop_tip_location_spot[
-                addressable_area_name
-            ] = _TipDropSection.RIGHT
+            self._last_drop_tip_location_spot[addressable_area_name] = (
+                _TipDropSection.RIGHT
+            )
 
         return AddressableOffsetVector(x=x_offset, y=0, z=0)
 

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -388,6 +388,8 @@ class GeometryView:
         OT-2. See
         protocol_engine.state.modules.get_nominal_offset_to_child_from_addressable_area
         for more.
+
+        This does not incorporate LPC offsets or module calibration offsets.
         """
         if isinstance(parent, (AddressableAreaLocation, DeckSlotLocation)):
             return LabwareOffsetVector(x=0, y=0, z=0)

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1491,10 +1491,6 @@ class GeometryView:
     # * The "additional offset" or "user offset", e.g. the `pickUpOffset` and `dropOffset`
     #   params in the `moveLabware` command.
     #
-    # And this *does* take these extra offsets into account:
-    #
-    # * The labware's Labware Position Check offset
-    #
     # For robustness, we should combine this with `get_gripper_labware_movement_waypoints()`.
     #
     # We should also be more explicit about which offsets act to move the gripper paddles
@@ -1516,23 +1512,17 @@ class GeometryView:
                 return
 
             tip = self._pipettes.get_attached_tip(pipette.id)
-            if tip:
-                # NOTE: This call to get_labware_highest_z() uses the labware's LPC offset,
-                # which is an inconsistency between this and the actual gripper movement.
-                # See the todo comment above this function.
-                labware_top_z_when_gripped = gripper_homed_position_z + (
-                    self.get_labware_highest_z(labware_id=labware_id)
-                    - self.get_labware_grip_point(
-                        labware_definition=labware_definition, location=current_location
-                    ).z
+            if not tip:
+                continue
+            labware_top_z_when_gripped = gripper_homed_position_z + (
+                self._labware.get_dimensions(labware_definition=labware_definition).z
+                - self._labware.get_grip_height_from_labware_bottom(labware_definition)
+            )
+            # TODO(cb, 2024-01-18): Utilizing the nozzle map and labware X coordinates verify if collisions will occur on the X axis (analysis will use hard coded data to measure from the gripper critical point to the pipette mount)
+            if (_PIPETTE_HOMED_POSITION_Z - tip.length) < labware_top_z_when_gripped:
+                raise LabwareMovementNotAllowedError(
+                    f"Cannot move labware '{labware_definition.parameters.loadName}' when {int(tip.volume)} µL tips are attached."
                 )
-                # TODO(cb, 2024-01-18): Utilizing the nozzle map and labware X coordinates verify if collisions will occur on the X axis (analysis will use hard coded data to measure from the gripper critical point to the pipette mount)
-                if (
-                    _PIPETTE_HOMED_POSITION_Z - tip.length
-                ) < labware_top_z_when_gripped:
-                    raise LabwareMovementNotAllowedError(
-                        f"Cannot move labware '{labware_definition.parameters.loadName}' when {int(tip.volume)} µL tips are attached."
-                    )
         return
 
     def _nominal_gripper_offsets_for_location(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -426,7 +426,7 @@ class GeometryView:
         else:
             raise errors.LabwareNotOnDeckError(
                 "Cannot access labware since it is not on the deck. "
-                "Either it has been loaded off-deck or its been moved off-deck."
+                "Either it has been loaded off-deck or it has been moved off-deck."
             )
 
     def _normalize_module_calibration_offset(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1068,7 +1068,6 @@ class GeometryView:
             self._labware.get_grip_height_from_labware_bottom(labware_definition)
         )
         location_name: str
-        module_location: ModuleLocation | None = None
         offset = self._get_offset_from_parent_addressable_area(
             child_definition=labware_definition, parent=location
         ) + self._get_calibrated_module_offset(location)
@@ -1288,9 +1287,9 @@ class GeometryView:
                 pipette_mount=pipette_mount,
                 labware_slot_column=labware_slot_column,
             )
-            self._last_drop_tip_location_spot[addressable_area_name] = (
-                _TipDropSection.LEFT
-            )
+            self._last_drop_tip_location_spot[
+                addressable_area_name
+            ] = _TipDropSection.LEFT
         else:
             # Drop tip in RIGHT section
             x_offset = self._get_drop_tip_well_x_offset(
@@ -1300,9 +1299,9 @@ class GeometryView:
                 pipette_mount=pipette_mount,
                 labware_slot_column=labware_slot_column,
             )
-            self._last_drop_tip_location_spot[addressable_area_name] = (
-                _TipDropSection.RIGHT
-            )
+            self._last_drop_tip_location_spot[
+                addressable_area_name
+            ] = _TipDropSection.RIGHT
 
         return AddressableOffsetVector(x=x_offset, y=0, z=0)
 

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -930,10 +930,42 @@ class ModuleView:
         Includes the slot-specific transform. Does not include the child's
         Labware Position Check offset.
         """
-        if (
-            self._state.deck_type == DeckType.OT2_STANDARD
-            or self._state.deck_type == DeckType.OT2_SHORT_TRASH
-        ):
+        # todo(sf, 2025-04-29): This extra offset makes the vector be relative to the
+        # cutout in the Flex case, which is weird, and seems incorrect. If we didn't do
+        # this life would be much simpler.
+        base = self.get_nominal_offset_to_child_from_addressable_area(module_id)
+        if self.get_deck_supports_module_fixtures():
+            module_addressable_area = self.get_provided_addressable_area(module_id)
+            module_addressable_area_position = (
+                addressable_areas.get_addressable_area_offsets_from_cutout(
+                    module_addressable_area
+                )
+            )
+            return base + LabwareOffsetVector(
+                x=module_addressable_area_position.x,
+                y=module_addressable_area_position.y,
+                z=module_addressable_area_position.z,
+            )
+        else:
+            return base
+
+    def get_nominal_offset_to_child_from_addressable_area(
+        self, module_id: str
+    ) -> LabwareOffsetVector:
+        """Get the position offset for a child of this module from the nearest AA.
+
+        On the Flex, this is always (0, 0, 0); on the OT-2, since modules load on top
+        of addressable areas rather than providing addressable areas, the offset is
+        the labwareOffset from the module definition, rotated by the module's
+        slotTransform if appropriate.
+        """
+        if self.get_deck_supports_module_fixtures():
+            return LabwareOffsetVector(
+                x=0,
+                y=0,
+                z=0,
+            )
+        else:
             definition = self.get_definition(module_id)
             slot = self.get_location(module_id).slotName.id
 
@@ -967,18 +999,6 @@ class ModuleView:
                 x=xformed[0],
                 y=xformed[1],
                 z=xformed[2],
-            )
-        else:
-            module_addressable_area = self.get_provided_addressable_area(module_id)
-            module_addressable_area_position = (
-                addressable_areas.get_addressable_area_offsets_from_cutout(
-                    module_addressable_area
-                )
-            )
-            return LabwareOffsetVector(
-                x=module_addressable_area_position.x,
-                y=module_addressable_area_position.y,
-                z=module_addressable_area_position.z,
             )
 
     def get_module_calibration_offset(

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -930,9 +930,6 @@ class ModuleView:
         Includes the slot-specific transform. Does not include the child's
         Labware Position Check offset.
         """
-        # todo(sf, 2025-04-29): This extra offset makes the vector be relative to the
-        # cutout in the Flex case, which is weird, and seems incorrect. If we didn't do
-        # this life would be much simpler.
         base = self.get_nominal_offset_to_child_from_addressable_area(module_id)
         if self.get_deck_supports_module_fixtures():
             module_addressable_area = self.get_provided_addressable_area(module_id)

--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -253,6 +253,38 @@ class ModuleOffsetVector(BaseModel):
     y: float
     z: float
 
+    def __add__(self, other: Any) -> ModuleOffsetVector:
+        """Adds two vectors together."""
+        if not isinstance(other, (LabwareOffsetVector, ModuleOffsetVector)):
+            return NotImplemented
+        return ModuleOffsetVector(
+            x=self.x + other.x, y=self.y + other.y, z=self.z + other.z
+        )
+
+    def __radd__(self, other: Any) -> ModuleOffsetVector:
+        """Adds two vectors together, the other way."""
+        if not isinstance(other, (LabwareOffsetVector, ModuleOffsetVector)):
+            return NotImplemented
+        return ModuleOffsetVector(
+            x=other.x + self.x, y=other.y + self.y, z=other.z + self.z
+        )
+
+    def __sub__(self, other: Any) -> ModuleOffsetVector:
+        """Subtracts two vectors."""
+        if not isinstance(other, (LabwareOffsetVector, ModuleOffsetVector)):
+            return NotImplemented
+        return ModuleOffsetVector(
+            x=self.x - other.x, y=self.y - other.y, z=self.z - other.z
+        )
+
+    def __rsub__(self, other: Any) -> ModuleOffsetVector:
+        """Subtracts two vectors, the other way."""
+        if not isinstance(other, (LabwareOffsetVector, ModuleOffsetVector)):
+            return NotImplemented
+        return ModuleOffsetVector(
+            x=other.x - self.x, y=other.y - self.y, z=other.z - self.z
+        )
+
 
 @dataclass
 class ModuleOffsetData:

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2719,7 +2719,6 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
     subject: GeometryView,
 ) -> None:
     """It should return the grip point for labware directly on a module."""
-
     addressable_area_view = AddressableAreaView(
         state=AddressableAreaState(
             loaded_addressable_areas_by_name={},
@@ -2757,9 +2756,9 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
             sentinel.labware_definition
         )
     ).then_return(500)
-    decoy.when(mock_labware_view.get(labware_id=f"below-id-0")).then_return(
+    decoy.when(mock_labware_view.get(labware_id="below-id-0")).then_return(
         LoadedLabware(
-            id=f"below-id-0",
+            id="below-id-0",
             loadName="below-name",
             definitionUri="1234",
             location=ModuleLocation(moduleId="module-id"),

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -3226,22 +3226,13 @@ def test_check_gripper_labware_tip_collision(
     decoy.when(subject._get_highest_z_from_labware_data(labware_data)).then_return(1000)
 
     decoy.when(mock_labware_view.get_definition("labware-id")).then_return(definition)
-    decoy.when(subject.get_labware_highest_z("labware-id")).then_return(100.0)
     decoy.when(
-        mock_addressable_area_view.get_addressable_area_center(
-            addressable_area_name=DeckSlotName.SLOT_1.id
-        )
-    ).then_return(Point(x=11, y=22, z=33))
+        mock_labware_view.get_dimensions(labware_definition=definition)
+    ).then_return(Dimensions(x=1, y=2, z=67))
     decoy.when(
         mock_labware_view.get_grip_height_from_labware_bottom(definition)
     ).then_return(1.0)
     decoy.when(mock_labware_view.get_definition("labware-id")).then_return(definition)
-    decoy.when(
-        subject.get_labware_grip_point(
-            labware_definition=definition,
-            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-        )
-    ).then_return(Point(x=100.0, y=100.0, z=0.0))
 
     with pytest.raises(errors.LabwareMovementNotAllowedError):
         subject.check_gripper_labware_tip_collision(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2436,6 +2436,99 @@ def test_get_ancestor_slot_for_labware_stack_in_staging_area_slot(
     assert subject.get_ancestor_slot_name("labware-2") == StagingSlotName.SLOT_D4
 
 
+def test_get_ancestor_addressable_area_name(
+    decoy: Decoy,
+    mock_labware_view: LabwareView,
+    mock_module_view: ModuleView,
+    subject: GeometryView,
+) -> None:
+    """It should get name of ancestor AA of labware."""
+    decoy.when(mock_labware_view.get("labware-1")).then_return(
+        LoadedLabware(
+            id="labware-1",
+            loadName="load-name",
+            definitionUri="1234",
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+        )
+    )
+    assert subject.get_ancestor_addressable_area_name("labware-1") == "4"
+
+    decoy.when(mock_labware_view.get("labware-2")).then_return(
+        LoadedLabware(
+            id="labware-2",
+            loadName="load-name",
+            definitionUri="4567",
+            location=ModuleLocation(moduleId="4321"),
+        )
+    )
+    decoy.when(mock_module_view.get_provided_addressable_area("4321")).then_return(
+        "someModuleAddressableArea"
+    )
+    assert (
+        subject.get_ancestor_addressable_area_name("labware-2")
+        == "someModuleAddressableArea"
+    )
+
+
+def test_get_ancestor_addressable_area_for_labware_stack_in_staging_area_slot(
+    decoy: Decoy,
+    mock_labware_view: LabwareView,
+    subject: GeometryView,
+) -> None:
+    """It should get name of ancestor AA of a stack of labware in a staging area slot."""
+    decoy.when(mock_labware_view.get("labware-1")).then_return(
+        LoadedLabware(
+            id="labware-1",
+            loadName="load-name",
+            definitionUri="1234",
+            location=AddressableAreaLocation(
+                addressableAreaName=StagingSlotName.SLOT_D4.id
+            ),
+        )
+    )
+    decoy.when(mock_labware_view.get("labware-2")).then_return(
+        LoadedLabware(
+            id="labware-2",
+            loadName="load-name",
+            definitionUri="1234",
+            location=OnLabwareLocation(labwareId="labware-1"),
+        )
+    )
+    assert subject.get_ancestor_addressable_area_name("labware-2") == "D4"
+
+
+def test_get_ancestor_addressable_area_handles_cycles(
+    decoy: Decoy, mock_labware_view: LabwareView, subject: GeometryView
+) -> None:
+    """It should raise and not lock up if there is a location cycle."""
+    decoy.when(mock_labware_view.get("labware-1")).then_return(
+        LoadedLabware(
+            id="labware-1",
+            loadName="load-name",
+            definitionUri="1234",
+            location=OnLabwareLocation(labwareId="labware-2"),
+        )
+    )
+    decoy.when(mock_labware_view.get("labware-2")).then_return(
+        LoadedLabware(
+            id="labware-2",
+            loadName="load-name",
+            definitionUri="1234",
+            location=OnLabwareLocation(labwareId="labware-3"),
+        )
+    )
+    decoy.when(mock_labware_view.get("labware-3")).then_return(
+        LoadedLabware(
+            id="labware-3",
+            loadName="load-name",
+            definitionUri="1234",
+            location=OnLabwareLocation(labwareId="labware-1"),
+        )
+    )
+    with pytest.raises(errors.InvalidLabwarePositionError):
+        subject.get_ancestor_addressable_area_name("labware-1")
+
+
 def test_ensure_location_not_occupied_raises(
     decoy: Decoy,
     mock_labware_view: LabwareView,
@@ -2591,11 +2684,10 @@ def test_get_labware_grip_point_for_labware_on_module(
         ot3_standard_deck_def
     )
     decoy.when(
-        mock_module_view.get_nominal_offset_to_child(
+        mock_module_view.get_nominal_offset_to_child_from_addressable_area(
             module_id="module-id",
-            addressable_areas=addressable_area_view,
         )
-    ).then_return(LabwareOffsetVector(x=-291, y=52, z=303))
+    ).then_return(LabwareOffsetVector(x=-291, y=52, z=265))
     decoy.when(mock_module_view.get_connected_model("module-id")).then_return(
         ModuleModel.MAGNETIC_BLOCK_V1
     )
@@ -2617,6 +2709,125 @@ def test_get_labware_grip_point_for_labware_on_module(
         location=ModuleLocation(moduleId="module-id"),
     )
     assert result_grip_point == Point(x=191, y=382, z=1073)
+
+
+def test_get_labware_grip_point_for_labware_stack_on_module(
+    decoy: Decoy,
+    mock_labware_view: LabwareView,
+    mock_module_view: ModuleView,
+    ot3_standard_deck_def: DeckDefinitionV5,
+    subject: GeometryView,
+) -> None:
+    """It should return the grip point for labware directly on a module."""
+
+    addressable_area_view = AddressableAreaView(
+        state=AddressableAreaState(
+            loaded_addressable_areas_by_name={},
+            potential_cutout_fixtures_by_cutout_id={
+                "cutoutC3": {
+                    PotentialCutoutFixture(
+                        "cutoutC3", "magneticBlockV1", frozenset({"magneticBlockV1C3"})
+                    )
+                }
+            },
+            deck_definition=ot3_standard_deck_def,
+            deck_configuration=None,
+            robot_type=subject._config.robot_type,
+            use_simulated_deck_config=True,
+            robot_definition=RobotDefinition(
+                displayName="cool_guy",
+                robotType="OT-3 Standard",
+                models=[],
+                extents=[5000, 5000, 5000],
+                paddingOffsets=paddingOffset(rear=0, front=0, leftSide=0, rightSide=0),
+                mountOffsets=mountOffset(left=[0], right=[0], gripper=[0]),
+            ),
+        )
+    )
+    subject = GeometryView(
+        config=subject._config,
+        labware_view=subject._labware,
+        well_view=subject._wells,
+        module_view=subject._modules,
+        pipette_view=subject._pipettes,
+        addressable_area_view=addressable_area_view,
+    )
+    decoy.when(
+        mock_labware_view.get_grip_height_from_labware_bottom(
+            sentinel.labware_definition
+        )
+    ).then_return(500)
+    decoy.when(mock_labware_view.get(labware_id=f"below-id-0")).then_return(
+        LoadedLabware(
+            id=f"below-id-0",
+            loadName="below-name",
+            definitionUri="1234",
+            location=ModuleLocation(moduleId="module-id"),
+        )
+    )
+    decoy.when(mock_labware_view.get_dimensions(labware_id="below-id-0")).then_return(
+        Dimensions(x=1000, y=1001, z=11)
+    )
+    decoy.when(
+        mock_labware_view.get_labware_overlap_offsets(
+            sentinel.labware_definition, "below-name"
+        )
+    ).then_return(OverlapOffset(x=0, y=1, z=6))
+    decoy.when(mock_labware_view.get_definition("below-id-0")).then_return(
+        sentinel.labware_definition
+    )
+    for idx in range(9):
+        decoy.when(mock_labware_view.get(labware_id=f"below-id-{idx+1}")).then_return(
+            LoadedLabware(
+                id=f"below-id-{idx+1}",
+                loadName="below-name",
+                definitionUri="1234",
+                location=OnLabwareLocation(labwareId=f"below-id-{idx}"),
+            )
+        )
+        decoy.when(
+            mock_labware_view.get_dimensions(labware_id=f"below-id-{idx+1}")
+        ).then_return(Dimensions(x=1000, y=1001, z=11))
+        decoy.when(mock_labware_view.get_definition(f"below-id-{idx+1}")).then_return(
+            sentinel.labware_definition
+        )
+    decoy.when(mock_module_view.get_provided_addressable_area("module-id")).then_return(
+        "magneticBlockV1C3"
+    )
+    decoy.when(mock_module_view.get_location("module-id")).then_return(
+        DeckSlotLocation(slotName=DeckSlotName.SLOT_C3)
+    )
+    decoy.when(mock_labware_view.get_deck_definition()).then_return(
+        ot3_standard_deck_def
+    )
+    decoy.when(
+        mock_module_view.get_nominal_offset_to_child_from_addressable_area(
+            module_id="module-id",
+        )
+    ).then_return(LabwareOffsetVector(x=-291, y=52, z=265))
+    decoy.when(mock_module_view.get_connected_model("module-id")).then_return(
+        ModuleModel.MAGNETIC_BLOCK_V1
+    )
+    decoy.when(
+        mock_labware_view.get_module_overlap_offsets(
+            sentinel.labware_definition, ModuleModel.MAGNETIC_BLOCK_V1
+        )
+    ).then_return(OverlapOffset(x=10, y=20, z=30))
+
+    decoy.when(mock_module_view.get_module_calibration_offset("module-id")).then_return(
+        ModuleOffsetData(
+            moduleOffsetVector=ModuleOffsetVector(x=100, y=200, z=300),
+            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C3),
+        )
+    )
+
+    result_grip_point = subject.get_labware_grip_point(
+        labware_definition=sentinel.labware_definition,
+        location=OnLabwareLocation(labwareId="below-id-9"),
+    )
+    # we do not take into account labware stack offsets for some reason
+    # so all those 1000s go away
+    assert result_grip_point == Point(x=191, y=392, z=1073 + 50)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We altered modules to not be eventually loaded on deck slots on the
Flex, so we could better support the stacker providing two addressable
areas per module. This had an unexpected knock-on effect of making
get_ancestor_slot() not a good fallback if we ran out of depth to check
in get_labware_grip_point(), and protocols that called that
function (e.g. by calling move_labware) on a location that consisted of
a stack of more than one labware on a module (so, moving something on to
or off of a labware on an adapter on a module) would give you a deck
configuration conflict, since get_ancestor_slot would request a slot but
the module is there instead.

There is a larger fix for this - geometry needs to be more broadly
overhauled to work on location sequences throughout - but for now we can
make duals of the recursive pointer-chasing symbolic geometry resolvers
that work based on the "everything ends up on an addressable area"
assumption.

Particularly notable is modules - there was some very weird stuff in
here to make code that was intended for the OT-2 and geometry from the
module defs continue to work on Flex and geometry that is based on the
deck def addressable area coordinates, which was causing a lot of
complexity in get_labware_grip_point(). By changing the module
get_nominal_position() (or really making a new one) that returns the
offset of a child labware _from the nearest addressable area_ (i.e.
0-vec on the flex) instead of from the underlying deck slot, we can
eliminate a whole lot of logic.

Also, we can eliminate a call to one of these altered and possibly problematic
functions in the gripper tip error checking by just poking through and doing the
underlying math. I thought this was going to be more necessary when I was
looking at this first, because I thought I was going to change `get_labware_grip_point()`
more than I ended up doing, but I still think it's a good idea to not call it there.

## review requests
- does this seem safe and adequately covered for regression?

## testing
- [ ] set up a protocol that loads a labware on a labware on a module, and try and
       gripper move something to and from it. this needs a fake labware that allows
       stacking.

Closes RQA-4153

