### PR TITLE
refactor(api): fewer z raises in resin tip actions

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -834,7 +834,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-    def resin_tip_unseal(self, location: Location, well_core: WellCore) -> None:
+    def resin_tip_unseal(self, location: Location | None, well_core: WellCore) -> None:
         well_name = well_core.get_name()
         labware_id = well_core.labware_id
 
@@ -1188,9 +1188,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             cmd.GetNextTipParams(
                 pipetteId=self._pipette_id,
                 labwareIds=[tip_rack.labware_id for tip_rack in valid_tip_racks],
-                startingTipWell=starting_well.get_name()
-                if starting_well is not None
-                else None,
+                startingTipWell=(
+                    starting_well.get_name() if starting_well is not None else None
+                ),
             )
         )
         next_tip_info = result.nextTipInfo

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -206,7 +206,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
     @abstractmethod
     def resin_tip_unseal(
         self,
-        location: types.Location,
+        location: types.Location | None,
         well_core: WellCoreType,
     ) -> None:
         ...

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -332,7 +332,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
 
     def resin_tip_unseal(
         self,
-        location: types.Location,
+        location: types.Location | None,
         well_core: WellCore,
     ) -> None:
         raise APIVersionError(api_element="Unsealing resin tips.")

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -298,7 +298,7 @@ class LegacyInstrumentCoreSimulator(
 
     def resin_tip_unseal(
         self,
-        location: types.Location,
+        location: types.Location | None,
         well_core: WellCore,
     ) -> None:
         raise APIVersionError(api_element="Unsealing resin tips.")

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1624,9 +1624,9 @@ class InstrumentContext(publisher.CommandPublisher):
                     (types.Location(types.Point(), labware=rack), rack._core)
                     for rack in transfer_args.tip_racks
                 ],
-                starting_tip=self.starting_tip._core
-                if self.starting_tip is not None
-                else None,
+                starting_tip=(
+                    self.starting_tip._core if self.starting_tip is not None else None
+                ),
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
             )
@@ -1740,9 +1740,9 @@ class InstrumentContext(publisher.CommandPublisher):
                     (types.Location(types.Point(), labware=rack), rack._core)
                     for rack in transfer_args.tip_racks
                 ],
-                starting_tip=self.starting_tip._core
-                if self.starting_tip is not None
-                else None,
+                starting_tip=(
+                    self.starting_tip._core if self.starting_tip is not None else None
+                ),
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
             )
@@ -1856,9 +1856,9 @@ class InstrumentContext(publisher.CommandPublisher):
                     (types.Location(types.Point(), labware=rack), rack._core)
                     for rack in transfer_args.tip_racks
                 ],
-                starting_tip=self.starting_tip._core
-                if self.starting_tip is not None
-                else None,
+                starting_tip=(
+                    self.starting_tip._core if self.starting_tip is not None else None
+                ),
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
             )
@@ -2032,7 +2032,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 location=well,
             ),
         ):
-            self._core.resin_tip_unseal(location=well.top(), well_core=well._core)
+            self._core.resin_tip_unseal(location=None, well_core=well._core)
 
         return self
 

--- a/api/src/opentrons/protocol_engine/commands/seal_pipette_to_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/seal_pipette_to_tip.py
@@ -1,12 +1,15 @@
 """Seal tips to pipette command request, result, and implementation models."""
 
 from __future__ import annotations
-from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type, Union
+
+from typing_extensions import Literal
+from pydantic import Field, BaseModel
+
+from opentrons_shared_data.errors.exceptions import PositionUnknownError
+
 from opentrons.types import MountType
 from opentrons.protocol_engine.types import MotorAxis
-from typing_extensions import Literal
-
 from ..resources import ModelUtils, ensure_ot3_hardware
 from ..types import PickUpTipWellLocation, FluidKind, AspiratedFluid
 from .pipetting_common import (
@@ -27,7 +30,6 @@ from .command import (
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import Axis
-from ..state.update_types import StateUpdate
 
 if TYPE_CHECKING:
     from ..state.state import StateView
@@ -138,28 +140,50 @@ class SealPipetteToTipImplementation(
         """A relative press-fit pick up command using gantry moves."""
         prep_distance = tip_pick_up_params.prepDistance
         press_distance = tip_pick_up_params.pressDistance
-        retract_distance = -1 * (prep_distance + press_distance)
+        retract_distance = -1 * (press_distance) / 2
 
         mount_axis = MotorAxis.LEFT_Z if mount == MountType.LEFT else MotorAxis.RIGHT_Z
-
+        ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
         # TODO chb, 2025-01-29): Factor out the movement constants and relocate this logic into the hardware controller
-        await self._gantry_mover.move_axes(
-            axis_map={mount_axis: prep_distance}, speed=10, relative_move=True
+        try:
+            await self._gantry_mover.move_axes(
+                axis_map={mount_axis: prep_distance},
+                speed=10,
+                relative_move=True,
+                expect_stalls=True,
+            )
+        except PositionUnknownError:
+            # if this happens it's from the get position after the move and we can ignore it
+            pass
+
+        await ot3_hardware_api.update_axis_position_estimations(
+            self._gantry_mover.motor_axes_to_present_hardware_axes([mount_axis])
         )
 
         # Drive mount down for press-fit
-        await self._gantry_mover.move_axes(
-            axis_map={mount_axis: press_distance},
-            speed=10.0,
-            relative_move=True,
-            expect_stalls=True,
-        )
-        # retract cam : 11.05
-        await self._gantry_mover.move_axes(
-            axis_map={mount_axis: retract_distance}, speed=5.5, relative_move=True
+        try:
+            await self._gantry_mover.move_axes(
+                axis_map={mount_axis: press_distance},
+                speed=10.0,
+                relative_move=True,
+                expect_stalls=True,
+            )
+        except PositionUnknownError:
+            # if this happens it's from the get position after the move and we can ignore it
+            pass
+
+        await ot3_hardware_api.update_axis_position_estimations(
+            self._gantry_mover.motor_axes_to_present_hardware_axes([mount_axis])
         )
 
-        ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
+        try:
+            await self._gantry_mover.move_axes(
+                axis_map={mount_axis: retract_distance}, speed=5.5, relative_move=True
+            )
+        except PositionUnknownError:
+            # if this happens it's from the get position after the move and we can ignore it
+            pass
+
         await ot3_hardware_api.update_axis_position_estimations(
             self._gantry_mover.motor_axes_to_present_hardware_axes([mount_axis])
         )
@@ -283,13 +307,10 @@ class SealPipetteToTipImplementation(
             if hw_instr is not None:
                 hw_instr.set_current_volume(_SAFE_TOP_VOLUME)
 
-        state_update = StateUpdate()
-        state_update.update_pipette_tip_state(
+        state_update = move_result.state_update.update_pipette_tip_state(
             pipette_id=pipette_id,
             tip_geometry=tip_geometry,
-        )
-
-        state_update.set_fluid_aspirated(
+        ).set_fluid_aspirated(
             pipette_id=pipette_id,
             fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=_SAFE_TOP_VOLUME),
         )

--- a/api/src/opentrons/protocol_engine/commands/unseal_pipette_from_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/unseal_pipette_from_tip.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
-from opentrons.protocol_engine.types import MotorAxis
-from opentrons.types import MountType
 
 from ..types import DropTipWellLocation
 from .pipetting_common import (
@@ -85,6 +83,10 @@ class UnsealPipetteFromTipImplementation(
 
         well_location = params.wellLocation
 
+        tip_geometry = self._state_view.geometry.get_nominal_tip_geometry(
+            pipette_id, labware_id, well_name
+        )
+
         is_partially_configured = self._state_view.pipettes.get_is_partially_configured(
             pipette_id=pipette_id
         )
@@ -93,6 +95,7 @@ class UnsealPipetteFromTipImplementation(
             labware_id=labware_id,
             well_location=well_location,
             partially_configured=is_partially_configured,
+            override_default_offset=-(tip_geometry.length - 10),
         )
 
         move_result = await move_to_well(
@@ -105,14 +108,6 @@ class UnsealPipetteFromTipImplementation(
         )
         if isinstance(move_result, DefinedErrorData):
             return move_result
-
-        # Move to an appropriate position
-        mount = self._state_view.pipettes.get_mount(pipette_id)
-
-        mount_axis = MotorAxis.LEFT_Z if mount == MountType.LEFT else MotorAxis.RIGHT_Z
-        await self._gantry_mover.move_axes(
-            axis_map={mount_axis: -14}, speed=10, relative_move=True
-        )
 
         await self._tip_handler.drop_tip(
             pipette_id=pipette_id,

--- a/api/src/opentrons/protocol_engine/commands/unseal_pipette_from_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/unseal_pipette_from_tip.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pydantic import Field
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type, Final
 from typing_extensions import Literal
 
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
@@ -54,6 +54,8 @@ _ExecuteReturn = (
     SuccessData[UnsealPipetteFromTipResult] | DefinedErrorData[StallOrCollisionError]
 )
 
+CUSTOM_TIP_LENGTH_MARGIN: Final = 10
+
 
 class UnsealPipetteFromTipImplementation(
     AbstractCommandImpl[UnsealPipetteFromTipParams, _ExecuteReturn]
@@ -95,7 +97,7 @@ class UnsealPipetteFromTipImplementation(
             labware_id=labware_id,
             well_location=well_location,
             partially_configured=is_partially_configured,
-            override_default_offset=-(tip_geometry.length - 10),
+            override_default_offset=-(tip_geometry.length - CUSTOM_TIP_LENGTH_MARGIN),
         )
 
         move_result = await move_to_well(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -722,6 +722,7 @@ class GeometryView:
         labware_id: str,
         well_location: DropTipWellLocation,
         partially_configured: bool = False,
+        override_default_offset: float | None = None,
     ) -> WellLocation:
         """Get tip drop location given labware and hardware pipette.
 
@@ -740,8 +741,9 @@ class GeometryView:
                 origin=WellOrigin(well_location.origin.value),
                 offset=well_location.offset,
             )
-
-        if self._labware.get_definition(labware_id).parameters.isTiprack:
+        if override_default_offset is not None:
+            z_offset = override_default_offset
+        elif self._labware.get_definition(labware_id).parameters.isTiprack:
             z_offset = self._labware.get_tip_drop_z_offset(
                 labware_id=labware_id,
                 length_scale=self._pipettes.get_return_tip_scale(pipette_id),

--- a/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
@@ -135,6 +135,11 @@ async def test_success(
                 pipette_id="pipette-id",
                 fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=1000),
             ),
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="pipette-id",
+                new_location=update_types.Well(labware_id="labware-id", well_name="A3"),
+                new_deck_point=DeckPoint(x=111, y=222, z=333),
+            ),
         ),
     )
 
@@ -222,6 +227,13 @@ async def test_no_tip_physically_missing_error(
             pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
                 pipette_id="pipette-id",
                 fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=1000),
+            ),
+            pipette_location=update_types.PipetteLocationUpdate(
+                pipette_id="pipette-id",
+                new_location=update_types.Well(
+                    labware_id="labware-id", well_name="well-name"
+                ),
+                new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
@@ -7,6 +7,12 @@ from decoy import Decoy, matchers
 
 from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 
+from opentrons_shared_data.labware import load_definition
+from opentrons_shared_data.labware.labware_definition import (
+    LabwareDefinition,
+    labware_definition_type_adapter,
+)
+
 from opentrons.protocol_engine import (
     DropTipWellLocation,
     DropTipWellOrigin,
@@ -26,12 +32,7 @@ from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.execution import MovementHandler, GantryMover, TipHandler
-
-from opentrons_shared_data.labware import load_definition
-from opentrons_shared_data.labware.labware_definition import (
-    LabwareDefinition,
-    labware_definition_type_adapter,
-)
+from opentrons.protocol_engine.types import TipGeometry
 
 from opentrons.types import Point
 
@@ -125,6 +126,10 @@ async def test_drop_tip_implementation(
     )
 
     decoy.when(
+        mock_state_view.geometry.get_nominal_tip_geometry("abc", "123", "A3")
+    ).then_return(TipGeometry(length=10, diameter=20, volume=1000))
+
+    decoy.when(
         mock_state_view.pipettes.get_is_partially_configured(pipette_id="abc")
     ).then_return(False)
 
@@ -134,6 +139,7 @@ async def test_drop_tip_implementation(
             labware_id="123",
             well_location=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
             partially_configured=False,
+            override_default_offset=0,
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
 
@@ -207,6 +213,9 @@ async def test_tip_attached_error(
         wellName="A3",
         wellLocation=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
     )
+    decoy.when(
+        mock_state_view.geometry.get_nominal_tip_geometry("abc", "123", "A3")
+    ).then_return(TipGeometry(length=10, diameter=20, volume=1000))
     decoy.when(mock_state_view.labware.get_definition("123")).then_return(
         evotips_definition
     )
@@ -221,6 +230,7 @@ async def test_tip_attached_error(
             labware_id="123",
             well_location=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
             partially_configured=False,
+            override_default_offset=0,
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
 
@@ -282,6 +292,9 @@ async def test_stall_error(
     decoy.when(mock_state_view.labware.get_definition("123")).then_return(
         evotips_definition
     )
+    decoy.when(
+        mock_state_view.geometry.get_nominal_tip_geometry("abc", "123", "A3")
+    ).then_return(TipGeometry(length=10, diameter=20, volume=1000))
 
     decoy.when(
         mock_state_view.pipettes.get_is_partially_configured(pipette_id="abc")
@@ -293,6 +306,7 @@ async def test_stall_error(
             labware_id="123",
             well_location=DropTipWellLocation(offset=WellOffset(x=1, y=2, z=3)),
             partially_configured=False,
+            override_default_offset=0,
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
 


### PR DESCRIPTION
Avoid some previous uncommanded raises in Z while executing resin tip commands.

These were caused by some unnecessarily high motions and because the seal command didn't set the pipette locations tate update, so the subsequent motions would run as-if moving between labware, raising the z stage up to clear labware in between.

There was also an issue that required a slight refactor in `drop_tip`. Our drop-tip functionality tries to position the pipette such that the tip is somewhat inside the target well. This is based on multipliers that are specific to the pipette and the tips, since we don't support custom tips - we get to tune them in for ours. Well, these aren't our tips, and to the system they're not really tips at all: we forbid using tips as labware, and that's what resin tips are, so they can't be tips. This added up to making the drop-tip (or, unseal in this case) functionality drop the tips from way above the labware and they'd go everywhere.

By overriding the function that provides the default drop tip location, we can make this all work properly, and since we don't override it in any other circumstances, we won't break the non-resin-tip drop.

## review
- good enough?

## testing
- [x] on 8 channel and 96 channel make sure that a straightforward seal-dispense-unseal routine doesn't move high above the labware

Closes EXEC-1467