### PR TITLE
fix(app): fix blocking LPC on the flex when the protocol does not involve a tip pick up

### DIFF
--- a/app/src/local-resources/instruments/utils.ts
+++ b/app/src/local-resources/instruments/utils.ts
@@ -1,3 +1,16 @@
+import { getProtocolUsesGripper } from '/app/transformations/commands'
+
+import type {
+  CompletedProtocolAnalysis,
+  LoadedPipette,
+  ProtocolAnalysisOutput,
+} from '@opentrons/shared-data'
+import type {
+  GripperData,
+  Instruments,
+  PipetteData,
+} from '@opentrons/api-client'
+
 export interface IsPartialTipConfigParams {
   channel: 1 | 8 | 96
   activeNozzleCount: number
@@ -15,4 +28,54 @@ export function isPartialTipConfig({
     case 96:
       return activeNozzleCount !== 96
   }
+}
+
+export function getIncompleteInstrumentCount(
+  analysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput,
+  attachedInstruments: Instruments
+): number {
+  const speccedPipettes = analysis?.pipettes ?? []
+
+  const incompleteInstrumentCount = speccedPipettes.filter(loadedPipette => {
+    const attachedPipetteMatch = getPipetteMatch(
+      loadedPipette,
+      attachedInstruments
+    )
+    return attachedPipetteMatch?.data.calibratedOffset?.last_modified == null
+  }).length
+
+  const isExtensionMountReady = getProtocolUsesGripper(analysis)
+    ? getAttachedGripper(attachedInstruments)?.data.calibratedOffset
+        ?.last_modified != null
+    : true
+
+  return incompleteInstrumentCount + (isExtensionMountReady ? 0 : 1)
+}
+
+export function getAttachedGripper(
+  attachedInstruments: Instruments
+): GripperData | null {
+  return (
+    (attachedInstruments?.data ?? []).find(
+      (i): i is GripperData =>
+        i.instrumentType === 'gripper' &&
+        i.ok &&
+        i.data.calibratedOffset != null
+    ) ?? null
+  )
+}
+
+export function getPipetteMatch(
+  loadedPipette: LoadedPipette,
+  attachedInstruments: Instruments
+): PipetteData | null {
+  return (
+    (attachedInstruments?.data ?? []).find(
+      (i): i is PipetteData =>
+        i.instrumentType === 'pipette' &&
+        i.ok &&
+        i.mount === loadedPipette.mount &&
+        i.instrumentName === loadedPipette.pipetteName
+    ) ?? null
+  )
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -21,7 +21,10 @@ import {
   OT2_ROBOT_TYPE,
   parseAllRequiredModuleModels,
 } from '@opentrons/shared-data'
-import { useProtocolQuery } from '@opentrons/react-api-client'
+import {
+  useProtocolQuery,
+  useInstrumentsQuery,
+} from '@opentrons/react-api-client'
 
 import { Line } from '/app/atoms/structure'
 import { InfoMessage } from '/app/molecules/InfoMessage'
@@ -65,6 +68,9 @@ import { EmptySetupStep } from './EmptySetupStep'
 import { LearnAboutOffsetsLink } from './LearnAboutOffsetsLink'
 import { useLPCFlows } from '/app/organisms/LabwarePositionCheck'
 import { useUpdateClientLPC } from '/app/resources/client_data'
+// TODO(jh, 04-30-25): Relocate this util.
+// eslint-disable-next-line opentrons/no-imports-across-applications
+import { getIncompleteInstrumentCount } from '/app/organisms/ODD/ProtocolSetup'
 
 import type { RefObject } from 'react'
 import type { Dispatch, State } from '/app/redux/types'
@@ -181,6 +187,13 @@ export function ProtocolRunSetup({
 
   const isMissingModule = missingModuleIds.length > 0
 
+  const { data: attachedInstruments } = useInstrumentsQuery()
+
+  const incompleteInstrumentCount: number | null =
+    protocolAnalysis != null && attachedInstruments != null
+      ? getIncompleteInstrumentCount(protocolAnalysis, attachedInstruments)
+      : null
+
   const hasModules = protocolAnalysis != null && modules.length > 0
   // need config compatibility (including check for single slot conflicts)
   const requiredDeckConfigCompatibility = getRequiredDeckConfig(
@@ -285,6 +298,10 @@ export function ProtocolRunSetup({
             }
           }}
           offsetsConfirmed={offsetsConfirmed}
+          hasMissingModulesForFlex={isMissingModule}
+          hasMissingCalForFlex={
+            incompleteInstrumentCount != null && incompleteInstrumentCount > 0
+          }
           lpcUtils={lpcUtils}
         />
       ),

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -68,9 +68,7 @@ import { EmptySetupStep } from './EmptySetupStep'
 import { LearnAboutOffsetsLink } from './LearnAboutOffsetsLink'
 import { useLPCFlows } from '/app/organisms/LabwarePositionCheck'
 import { useUpdateClientLPC } from '/app/resources/client_data'
-// TODO(jh, 04-30-25): Relocate this util.
-// eslint-disable-next-line opentrons/no-imports-across-applications
-import { getIncompleteInstrumentCount } from '/app/organisms/ODD/ProtocolSetup'
+import { getIncompleteInstrumentCount } from '/app/local-resources/instruments'
 
 import type { RefObject } from 'react'
 import type { Dispatch, State } from '/app/redux/types'

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
@@ -34,10 +34,17 @@ export function LPCSetupFlexBtns({
   launchLPC,
   runId,
   robotName,
+  hasMissingModulesForFlex,
+  hasMissingCalForFlex,
 }: LPCSetupFlexBtnsProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
   const { makeSnackbar } = useToaster()
-  const lpcDisabledReason = useLPCDisabledReason({ robotName, runId })
+  const lpcDisabledReason = useLPCDisabledReason({
+    robotName,
+    runId,
+    hasMissingCalForFlex: hasMissingCalForFlex,
+    hasMissingModulesForFlex: hasMissingModulesForFlex,
+  })
   const isNecessaryDefaultOffsetMissing = useSelector(
     selectIsAnyNecessaryDefaultOffsetMissing(runId)
   )

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
@@ -13,6 +13,8 @@ export interface SetupLabwarePositionCheckProps {
   robotType: RobotType
   runId: string
   lpcUtils: UseLPCFlowsResult
+  hasMissingModulesForFlex: boolean
+  hasMissingCalForFlex: boolean
 }
 
 export function SetupLabwarePositionCheck(

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/utils.ts
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/utils.ts
@@ -1,43 +1,11 @@
-import type {
-  CompletedProtocolAnalysis,
-  LoadedPipette,
-  ProtocolAnalysisOutput,
-} from '@opentrons/shared-data'
-import type {
-  GripperData,
-  Instruments,
-  PipetteData,
-} from '@opentrons/api-client'
+import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+import type { Instruments } from '@opentrons/api-client'
 
 import { getProtocolUsesGripper } from '/app/transformations/commands'
-
-export function getAttachedGripper(
-  attachedInstruments: Instruments
-): GripperData | null {
-  return (
-    (attachedInstruments?.data ?? []).find(
-      (i): i is GripperData =>
-        i.instrumentType === 'gripper' &&
-        i.ok &&
-        i.data.calibratedOffset != null
-    ) ?? null
-  )
-}
-
-export function getPipetteMatch(
-  loadedPipette: LoadedPipette,
-  attachedInstruments: Instruments
-): PipetteData | null {
-  return (
-    (attachedInstruments?.data ?? []).find(
-      (i): i is PipetteData =>
-        i.instrumentType === 'pipette' &&
-        i.ok &&
-        i.mount === loadedPipette.mount &&
-        i.instrumentName === loadedPipette.pipetteName
-    ) ?? null
-  )
-}
+import {
+  getAttachedGripper,
+  getPipetteMatch,
+} from '/app/local-resources/instruments'
 
 export function getAreInstrumentsReady(
   analysis: CompletedProtocolAnalysis,
@@ -57,26 +25,4 @@ export function getAreInstrumentsReady(
     : true
 
   return allSpeccedPipettesReady && isExtensionMountReady
-}
-
-export function getIncompleteInstrumentCount(
-  analysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput,
-  attachedInstruments: Instruments
-): number {
-  const speccedPipettes = analysis?.pipettes ?? []
-
-  const incompleteInstrumentCount = speccedPipettes.filter(loadedPipette => {
-    const attachedPipetteMatch = getPipetteMatch(
-      loadedPipette,
-      attachedInstruments
-    )
-    return attachedPipetteMatch?.data.calibratedOffset?.last_modified == null
-  }).length
-
-  const isExtensionMountReady = getProtocolUsesGripper(analysis)
-    ? getAttachedGripper(attachedInstruments)?.data.calibratedOffset
-        ?.last_modified != null
-    : true
-
-  return incompleteInstrumentCount + (isExtensionMountReady ? 0 : 1)
 }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/utils.ts
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/utils.ts
@@ -1,6 +1,7 @@
 import type {
   CompletedProtocolAnalysis,
   LoadedPipette,
+  ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type {
   GripperData,
@@ -59,7 +60,7 @@ export function getAreInstrumentsReady(
 }
 
 export function getIncompleteInstrumentCount(
-  analysis: CompletedProtocolAnalysis,
+  analysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput,
   attachedInstruments: Instruments
 ): number {
   const speccedPipettes = analysis?.pipettes ?? []

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -38,7 +38,6 @@ import {
   ProtocolSetupTitleSkeleton,
   ProtocolSetupStepSkeleton,
   getUnmatchedModulesForProtocol,
-  getIncompleteInstrumentCount,
 } from '/app/organisms/ODD/ProtocolSetup'
 import { ConfirmCancelRunModal } from '/app/organisms/ODD/RunningProtocol'
 import { mockProtocolModuleInfo } from '/app/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/__fixtures__'
@@ -72,6 +71,7 @@ import {
   selectOffsetSource,
 } from '/app/redux/protocol-runs'
 import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
+import { getIncompleteInstrumentCount } from '/app/local-resources/instruments'
 
 import type { UseQueryResult } from 'react-query'
 import type * as SharedData from '@opentrons/shared-data'
@@ -125,6 +125,7 @@ vi.mock('/app/local-resources/dom-utils')
 vi.mock('/app/organisms/LabwarePositionCheck')
 vi.mock('/app/redux/protocol-runs')
 vi.mock('/app/resources/maintenance_runs')
+vi.mock('/app/local-resources/instruments')
 
 const render = (path = '/') => {
   return renderWithProviders(

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -53,7 +53,6 @@ import {
   ProtocolSetupStepSkeleton,
   ProtocolSetupTitleSkeleton,
   getUnmatchedModulesForProtocol,
-  getIncompleteInstrumentCount,
   ViewOnlyParameters,
 } from '/app/organisms/ODD/ProtocolSetup'
 import { ConfirmCancelRunModal } from '/app/organisms/ODD/RunningProtocol'
@@ -97,6 +96,7 @@ import {
 } from '/app/redux/protocol-runs'
 import { LabwareOffsetsConflictModal } from '/app/organisms/LabwareOffsetsConflictModal'
 import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
+import { getIncompleteInstrumentCount } from '/app/local-resources/instruments'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { FlattenSimpleInterpolation } from 'styled-components'

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -754,8 +754,8 @@ export function ProtocolSetup(): JSX.Element {
   const lpcDisabledReason = useLPCDisabledReason({
     runId,
     robotName,
-    hasMissingModulesForOdd: isMissingModules,
-    hasMissingCalForOdd:
+    hasMissingModulesForFlex: isMissingModules,
+    hasMissingCalForFlex:
       incompleteInstrumentCount != null && incompleteInstrumentCount > 0,
   })
   const protocolName =

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -753,6 +753,7 @@ export function ProtocolSetup(): JSX.Element {
       : null
   const lpcDisabledReason = useLPCDisabledReason({
     runId,
+    robotName,
     hasMissingModulesForOdd: isMissingModules,
     hasMissingCalForOdd:
       incompleteInstrumentCount != null && incompleteInstrumentCount > 0,

--- a/app/src/resources/runs/__tests__/useLPCDisabledReason.test.tsx
+++ b/app/src/resources/runs/__tests__/useLPCDisabledReason.test.tsx
@@ -90,8 +90,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: false,
-          hasMissingCalForOdd: false,
+          hasMissingModulesForFlex: false,
+          hasMissingCalForFlex: false,
         }),
       { wrapper }
     )
@@ -102,8 +102,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: true,
-          hasMissingCalForOdd: true,
+          hasMissingModulesForFlex: true,
+          hasMissingCalForFlex: true,
         }),
       { wrapper }
     )
@@ -130,8 +130,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: false,
-          hasMissingCalForOdd: true,
+          hasMissingModulesForFlex: false,
+          hasMissingCalForFlex: true,
         }),
       { wrapper }
     )
@@ -152,8 +152,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: true,
-          hasMissingCalForOdd: false,
+          hasMissingModulesForFlex: true,
+          hasMissingCalForFlex: false,
         }),
       { wrapper }
     )
@@ -189,8 +189,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: false,
-          hasMissingCalForOdd: false,
+          hasMissingModulesForFlex: false,
+          hasMissingCalForFlex: false,
         }),
       { wrapper }
     )
@@ -213,8 +213,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: false,
-          hasMissingCalForOdd: false,
+          hasMissingModulesForFlex: false,
+          hasMissingCalForFlex: false,
         }),
       { wrapper }
     )
@@ -239,8 +239,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: false,
-          hasMissingCalForOdd: false,
+          hasMissingModulesForFlex: false,
+          hasMissingCalForFlex: false,
         }),
       { wrapper }
     )
@@ -268,8 +268,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: false,
-          hasMissingCalForOdd: false,
+          hasMissingModulesForFlex: false,
+          hasMissingCalForFlex: false,
         }),
       { wrapper }
     )
@@ -305,8 +305,8 @@ describe('useLPCDisabledReason', () => {
       () =>
         useLPCDisabledReason({
           runId: RUN_ID_1,
-          hasMissingModulesForOdd: false,
-          hasMissingCalForOdd: false,
+          hasMissingModulesForFlex: false,
+          hasMissingCalForFlex: false,
         }),
       { wrapper }
     )

--- a/app/src/resources/runs/useLPCDisabledReason.tsx
+++ b/app/src/resources/runs/useLPCDisabledReason.tsx
@@ -20,8 +20,8 @@ import {
 interface LPCDisabledReasonProps {
   runId: string
   robotName?: string
-  hasMissingModulesForOdd?: boolean
-  hasMissingCalForOdd?: boolean
+  hasMissingModulesForFlex?: boolean
+  hasMissingCalForFlex?: boolean
 }
 export function useLPCDisabledReason(
   props: LPCDisabledReasonProps
@@ -29,8 +29,8 @@ export function useLPCDisabledReason(
   const {
     runId,
     robotName,
-    hasMissingModulesForOdd,
-    hasMissingCalForOdd,
+    hasMissingModulesForFlex,
+    hasMissingCalForFlex,
   } = props
   const { t } = useTranslation(['protocol_setup', 'shared'])
   const runHasStarted = useRunHasStarted(runId)
@@ -41,7 +41,7 @@ export function useLPCDisabledReason(
   )
 
   const isCalibrationComplete =
-    robotName != null ? complete : !hasMissingCalForOdd
+    robotName != null ? complete : !hasMissingCalForFlex
   const { missingModuleIds } = unmatchedModuleResults
   const isFlex = useIsFlex(robotName ?? '')
   const robotProtocolAnalysis = useMostRecentCompletedAnalysis(runId)
@@ -53,7 +53,7 @@ export function useLPCDisabledReason(
   )
   const isFixtureMismatch = getIsFixtureMismatch(deckConfigCompatibility)
   const hasMissingModules =
-    hasMissingModulesForOdd ?? missingModuleIds.length > 0
+    hasMissingModulesForFlex ?? missingModuleIds.length > 0
   const calibrationIncomplete = !hasMissingModules && !isCalibrationComplete
   const moduleSetupIncomplete =
     (hasMissingModules || isFixtureMismatch) && isCalibrationComplete


### PR DESCRIPTION
Closes [RQA-4159](https://opentrons.atlassian.net/browse/RQA-4159)
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

`useLPCDisabledReason` is responsible for blocking LPC due to LPC-external reasons. Some of these reasons are OT-2/Flex specific, and depend on a `robotName`, which is an optional prop. This optional prop was not passed to the hook for the ODD LPC entry point, which defaults the hook to treating Flexes as OT-2s on the ODD.

To fix (see d25ee1bbb3bf656c17a2a150a9afdfab0b9ea682), we just pass the `robotName` prop. While I did consider marking the prop as non-optional, which seems like the correct thing to do, the blast radius seems a little too great given that we render quite different copy depending on whether this name is supplied or not, and I don't think where we are in the release cycle lends itself to making a larger change. 

Upon further investigation (30481e96449438348f85805edcee9f583d97cca3), it appears that the desktop app was missing some calibration/module specific blocking reasons. The original prop names lend themselves to thinking they only apply to the ODD, but I don't see why this is the case after reviewing how the props are used. My guess is there used to be some existing discrepancies in how desktop vs. ODD setup used to occur that are no longer relevant. I think keeping the two apps consistent in their disabled reasons warrants this change, but I'm open to discussion on this point.

42c960928b50332c412859f50abe96a338c8bcc0 is just a simple refactor: relocate a util since it's not ODD specific anymore.


### Current Behavior

https://github.com/user-attachments/assets/2e021195-c401-4217-be7b-0a7cdc9a2893

### Fixed Behavior

https://github.com/user-attachments/assets/2e220058-3e41-4f4c-9d2c-2b194004a428


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Audited all our usages of `useLPCDisabledReason`, ensuring that correct props are passed in all places.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed LPC on the ODD sometimes being disabled for OT-2 reasons.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- How do we feel about 30481e96449438348f85805edcee9f583d97cca3? Does this change seem reasonable given where we are in the QA cycle? Easy to revert if we need to, but I personally think we want this.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4159]: https://opentrons.atlassian.net/browse/RQA-4159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ