### PR TITLE
refactor(api): Compare `opentrons.types.Point` with strict floating-point equality

### DIFF
--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -35,12 +35,6 @@ class Point(NamedTuple):
     y: float = 0.0
     z: float = 0.0
 
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, Point):
-            return False
-        pairs = ((self.x, other.x), (self.y, other.y), (self.z, other.z))
-        return all(isclose(s, o, rel_tol=1e-05, abs_tol=1e-08) for s, o in pairs)
-
     def __add__(self, other: Any) -> Point:
         if not isinstance(other, Point):
             return NotImplemented
@@ -74,6 +68,12 @@ class Point(NamedTuple):
         y_diff = self.y - other.y
         z_diff = self.z - other.z
         return sqrt(x_diff**2 + y_diff**2 + z_diff**2)
+
+    def elementwise_isclose(
+        self, other: Point, *, rel_tol: float = 1e-05, abs_tol: float = 1e-08
+    ) -> bool:
+        pairs = ((self.x, other.x), (self.y, other.y), (self.z, other.z))
+        return all(isclose(s, o, rel_tol=rel_tol, abs_tol=abs_tol) for s, o in pairs)
 
 
 LocationLabware = Union[

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_gripper.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_gripper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 import pytest
 from datetime import datetime
-from decoy import Decoy
+from decoy import Decoy, matchers
 from typing import TYPE_CHECKING
 
 from opentrons.hardware_control import ot3_calibration
@@ -93,6 +93,7 @@ async def test_calibrate_gripper_saves_calibration(
         status=CalibrationStatus(markedBad=False),
         last_modified=datetime(year=3000, month=1, day=1),
     )
+    saved_delta_captor = matchers.Captor()
     decoy.when(
         await ot3_calibration.calibrate_gripper_jaw(
             ot3_hardware_api, probe=GripperProbe.REAR
@@ -100,11 +101,13 @@ async def test_calibrate_gripper_saves_calibration(
     ).then_return(Point(1.1, 2.2, 3.3))
     decoy.when(
         await ot3_hardware_api.save_instrument_offset(
-            mount=OT3Mount.GRIPPER, delta=Point(x=2.75, y=3.85, z=4.95)
+            mount=OT3Mount.GRIPPER, delta=saved_delta_captor
         )
     ).then_return(expected_calibration_data)
     result = await subject.execute(params)
+    saved_delta: Point = saved_delta_captor.value
     assert result.public.jawOffset == Vec3f(x=1.1, y=2.2, z=3.3)
+    assert saved_delta.elementwise_isclose(Point(x=2.75, y=3.85, z=4.95))
     assert result.public.savedCalibration == expected_calibration_data
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -1390,10 +1390,12 @@ def test_get_well_position(
 
     result = subject.get_well_position("labware-id", "B2")
 
-    assert result == Point(
-        x=slot_pos[0] + 1 + well_def.x,
-        y=slot_pos[1] - 2 + well_def.y,
-        z=slot_pos[2] + 3 + well_def.z + well_def.depth,
+    assert result.elementwise_isclose(
+        Point(
+            x=slot_pos[0] + 1 + well_def.x,
+            y=slot_pos[1] - 2 + well_def.y,
+            z=slot_pos[2] + 3 + well_def.z + well_def.depth,
+        )
     )
 
 
@@ -1473,10 +1475,12 @@ def test_get_module_labware_well_position(
     ).then_return(OverlapOffset(x=0, y=0, z=0))
 
     result = subject.get_well_position("labware-id", "B2")
-    assert result == Point(
-        x=slot_pos[0] + 1 + well_def.x + 4,
-        y=slot_pos[1] - 2 + well_def.y + 5,
-        z=slot_pos[2] + 3 + well_def.z + well_def.depth + 6,
+    assert result.elementwise_isclose(
+        Point(
+            x=slot_pos[0] + 1 + well_def.x + 4,
+            y=slot_pos[1] - 2 + well_def.y + 5,
+            z=slot_pos[2] + 3 + well_def.z + well_def.depth + 6,
+        )
     )
 
 
@@ -1522,10 +1526,12 @@ def test_get_well_position_with_top_offset(
         ),
     )
 
-    assert result == Point(
-        x=slot_pos[0] + 1 + well_def.x + 1,
-        y=slot_pos[1] - 2 + well_def.y + 2,
-        z=slot_pos[2] + 3 + well_def.z + well_def.depth + 3,
+    assert result.elementwise_isclose(
+        Point(
+            x=slot_pos[0] + 1 + well_def.x + 1,
+            y=slot_pos[1] - 2 + well_def.y + 2,
+            z=slot_pos[2] + 3 + well_def.z + well_def.depth + 3,
+        )
     )
 
 


### PR DESCRIPTION
## Overview

For a long time, `opentrons.types.Point` has overridden its `==` operator to return `True` if the two points are *numerically approximately* equal to each other, instead of *actually* equal.

This was introduced in commit d13ed345a8990ef3478cb753e638aae05dcd2dff of PR #5583, possibly for the benefit of some calibration unit tests?

I personally find this very surprising. If I do `a == b`, I strongly expect that to mean actual equality—if I wanted approximation, I would have used `isclose()`. In other words, I expect `point_a == point_b` to behave exactly like `(point_a.x == point_b.x) and (point_a.y == point_b.y) and (point_a.z == point_b.z)`.

Also, it breaks [the rule that objects that compare equal must have the same hash value](https://docs.python.org/3/reference/datamodel.html#object.__hash__).

```python
>>> a = Point()
>>> b = Point(z=1e-20)
>>> a == b
True
>>> hash(a)
3010437511937009226
>>> hash(b)
9180445109486892018
```

So this PR restores strict equality checking. The old behavior is preserved as an explicit method, `point.elementwise_isclose(other)`, for the benefit of the few tests that were implicitly relying on it.

## Test Plan and Hands on Testing

* [x] Analysis snapshot tests pass

## Risk assessment

High. `Point` is used, uh, everywhere, and it's impossible for us to audit all the call sites of `Point.__eq__` to determine if any of them were implicitly relying on the approximation.

## Review requests

Is this actually a good idea?