### PR TITLE
fix(components): filter out loadLiquid commands without a liquid associated

### DIFF
--- a/components/src/hardware-sim/ProtocolDeck/utils/getLabwareInfoByLiquidId.ts
+++ b/components/src/hardware-sim/ProtocolDeck/utils/getLabwareInfoByLiquidId.ts
@@ -1,8 +1,8 @@
-import reduce from 'lodash/reduce'
 import type {
   LoadLiquidRunTimeCommand,
   RunTimeCommand,
 } from '@opentrons/shared-data'
+import reduce from 'lodash/reduce'
 import type { LabwareByLiquidId } from '../types'
 
 export function getLabwareInfoByLiquidId(
@@ -12,7 +12,8 @@ export function getLabwareInfoByLiquidId(
     commands.length !== 0
       ? commands.filter(
           (command): command is LoadLiquidRunTimeCommand =>
-            command.commandType === 'loadLiquid'
+            command.commandType === 'loadLiquid' &&
+            command.params.liquidId !== 'EMPTY'
         )
       : []
 


### PR DESCRIPTION
fix RQA-4157

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This is a weird bug where the python `load_empty` command results in a `loadLiquid` command with a liquidId `EMPTY` that has no associated liquid and empty wells. I'm not sure if this empty loadLiquid command is new, but the client has never handled it. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Look at protocol setup for the protocol linked in the ticket - before this PR, the labware in C2 shows that contains 1 liquid and the well fill is black, but there is actually no liquid in it
<img width="904" alt="Screenshot 2025-04-30 at 11 09 22 PM" src="https://github.com/user-attachments/assets/a47206d5-341f-4750-9b1f-738b846184f3" />
<img width="605" alt="Screenshot 2025-04-30 at 11 09 16 PM" src="https://github.com/user-attachments/assets/8d97df30-8dac-4614-97a6-0feb68cc2f97" />
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Filter out `loadLiquid` commands with liquidId `EMPTY`
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick check - not sure why the protocol engine does it this way but this will patch the UI
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
