### PR TITLE
refactor(protocol-designer): allow magneticBlock and staging to be added

### DIFF
--- a/protocol-designer/src/components/organisms/FlexHardware/util.ts
+++ b/protocol-designer/src/components/organisms/FlexHardware/util.ts
@@ -194,7 +194,7 @@ export const updateInitialDeckState = (
               value.cutoutId,
               'A1'
             )
-          : { isCompatible: true, slot: '' }
+          : null
       //  if deleting staging area where labware is in 4th column slot
       if (
         matchingStagingArea != null &&


### PR DESCRIPTION
# Overview

Noticed that you couldn't add a magnetic block and staging when editing the deck because the logic was wrong saying that there was a labware in the way incorrectly.

## Test Plan and Hands on Testing

Create a flex protocol and then click on edit hardware and add a magnetic block and staging area. see that both entities are created

## Changelog

- fix logic

## Risk assessment

low
