### PR TITLE
fix(api): Ensure labware locations list includes all labware retrieved from stacker

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -879,7 +879,9 @@ def build_retrieve_labware_move_updates(
             [OnLabwareOffsetLocationSequenceComponent(labwareUri=primary_uri)],
             primary_offset_location,
         )
-        locations_for_ids[group.lidLabwareId] = OnLabwareLocation(labwareId=group.primaryLabwareId)
+        locations_for_ids[group.lidLabwareId] = OnLabwareLocation(
+            labwareId=group.primaryLabwareId
+        )
         offset_ids_by_id[group.lidLabwareId] = _find_offset_id(
             state_view.labware.get_uri_from_definition(stacker.pool_lid_definition),
             lid_offset_location,

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -842,6 +842,9 @@ def build_retrieve_labware_move_updates(
         locations_for_ids[group.adapterLabwareId] = ModuleLocation(
             moduleId=stacker.module_id
         )
+        locations_for_ids[group.primaryLabwareId] = OnLabwareLocation(
+            labwareId=group.adapterLabwareId
+        )
         assert (
             stacker.pool_adapter_definition
         ), "Mismatched pool and labware definitions"
@@ -876,6 +879,7 @@ def build_retrieve_labware_move_updates(
             [OnLabwareOffsetLocationSequenceComponent(labwareUri=primary_uri)],
             primary_offset_location,
         )
+        locations_for_ids[group.lidLabwareId] = OnLabwareLocation(labwareId=group.primaryLabwareId)
         offset_ids_by_id[group.lidLabwareId] = _find_offset_id(
             state_view.labware.get_uri_from_definition(stacker.pool_lid_definition),
             lid_offset_location,

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
@@ -2079,6 +2079,7 @@ def test_build_ids_to_fill_builds_specified_components(
             ),
             {
                 "adapter-id": ModuleLocation(moduleId="stacker-id"),
+                "primary-id": OnLabwareLocation(labwareId="adapter-id"),
             },
             {
                 "primary-id": "primary-on-adapter-base-id",
@@ -2094,6 +2095,7 @@ def test_build_ids_to_fill_builds_specified_components(
             ),
             {
                 "primary-id": ModuleLocation(moduleId="stacker-id"),
+                "lid-id": OnLabwareLocation(labwareId="primary-id"),
             },
             {"primary-id": "primary-base-id", "lid-id": "lid-primary-base-id"},
             id="primary-and-lid",
@@ -2106,6 +2108,8 @@ def test_build_ids_to_fill_builds_specified_components(
             ),
             {
                 "adapter-id": ModuleLocation(moduleId="stacker-id"),
+                "primary-id": OnLabwareLocation(labwareId="adapter-id"),
+                "lid-id": OnLabwareLocation(labwareId="primary-id"),
             },
             {
                 "primary-id": "primary-on-adapter-base-id",

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -35,6 +35,7 @@ from opentrons.protocol_engine.commands.flex_stacker.retrieve import RetrieveImp
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     ModuleLocation,
+    OnLabwareLocation,
     ModuleModel,
     LoadedModule,
     OnModuleLocationSequenceComponent,
@@ -334,6 +335,7 @@ async def test_retrieve_primary_and_lid(
             batch_labware_location=BatchLabwareLocationUpdate(
                 new_locations_by_id={
                     "primary-id-1": ModuleLocation(moduleId=stacker_id),
+                    "lid-id-1": OnLabwareLocation(labwareId="primary-id-1"),
                 },
                 new_offset_ids_by_id={"primary-id-1": "offset-id-1", "lid-id-1": None},
             ),
@@ -454,6 +456,7 @@ async def test_retrieve_primary_and_adapter(
             batch_labware_location=BatchLabwareLocationUpdate(
                 new_locations_by_id={
                     "adapter-id-1": ModuleLocation(moduleId=stacker_id),
+                    "primary-id-1": OnLabwareLocation(labwareId="adapter-id-1"),
                 },
                 new_offset_ids_by_id={
                     "primary-id-1": "offset-id-2",
@@ -623,6 +626,8 @@ async def test_retrieve_primary_adapter_and_lid(
             batch_labware_location=BatchLabwareLocationUpdate(
                 new_locations_by_id={
                     "adapter-id-1": ModuleLocation(moduleId=stacker_id),
+                    "primary-id-1": OnLabwareLocation(labwareId="adapter-id-1"),
+                    "lid-id-1": OnLabwareLocation(labwareId="primary-id-1"),
                 },
                 new_offset_ids_by_id={
                     "primary-id-1": "offset-id-2",

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_manual_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_manual_retrieve.py
@@ -309,6 +309,7 @@ async def test_manual_retrieve_primary_and_lid(
             batch_labware_location=BatchLabwareLocationUpdate(
                 new_locations_by_id={
                     "primary-id-1": ModuleLocation(moduleId=stacker_id),
+                    "lid-id-1": OnLabwareLocation(labwareId="primary-id-1"),
                 },
                 new_offset_ids_by_id={"primary-id-1": None, "lid-id-1": None},
             ),
@@ -410,6 +411,7 @@ async def test_manual_retrieve_primary_and_adapter(
             batch_labware_location=BatchLabwareLocationUpdate(
                 new_locations_by_id={
                     "adapter-id-1": ModuleLocation(moduleId=stacker_id),
+                    "primary-id-1": OnLabwareLocation(labwareId="adapter-id-1"),
                 },
                 new_offset_ids_by_id={"primary-id-1": None, "adapter-id-1": None},
             ),
@@ -562,6 +564,8 @@ async def test_manual_retrieve_primary_adapter_and_lid(
             batch_labware_location=BatchLabwareLocationUpdate(
                 new_locations_by_id={
                     "adapter-id-1": ModuleLocation(moduleId=stacker_id),
+                    "primary-id-1": OnLabwareLocation(labwareId="adapter-id-1"),
+                    "lid-id-1": OnLabwareLocation(labwareId="primary-id-1"),
                 },
                 new_offset_ids_by_id={
                     "primary-id-1": None,


### PR DESCRIPTION
# Overview

The list of labware locations updated for each labware retrieved from a stacker as a group was incorrectly updating the locations of "all" labwares involved, leaving some labware lost.

## Test Plan and Hands on Testing

- [x] Ensure protocol that stores and unstores multiple stacked labware passes analysis
- [x] Update unit tests to reflect expected results of retrieve and manual retrieve

## Changelog


## Review requests

## Risk assessment
