### PR TITLE
fix(step-generation): add Python `-> None` type annotation to `def run()`

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -158,7 +158,7 @@ requirements = {
     "apiLevel": "2.24",
 }
 
-def run(protocol: protocol_api.ProtocolContext):
+def run(protocol: protocol_api.ProtocolContext) -> None:
     # Load Labware:
     mock_python_name_1 = protocol.load_labware_from_definition(
         CUSTOM_LABWARE["fixture/fixture_trash/1"],

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -385,7 +385,7 @@ export function pythonDefRun(
       .filter(section => section) // skip empty sections
       .join('\n\n') || 'pass'
   return (
-    `def run(${PROTOCOL_CONTEXT_NAME}: protocol_api.ProtocolContext):\n` +
+    `def run(${PROTOCOL_CONTEXT_NAME}: protocol_api.ProtocolContext) -> None:\n` +
     `${indentPyLines(functionBody)}`
   )
 }


### PR DESCRIPTION
# Overview

Some users (like us) have strict type checking for Python, which complains about the `def run()` function our generated Python code:
```
error: Function is missing a return type annotation  [no-untyped-def]
```

So this PR changes the declaration to:
```
def run(protocol: protocol_api.ProtocolContext) -> None:
```

This will be helpful for users who want to integrate our generated code into a bigger Python project.

## Test Plan and Hands on Testing

Updated unit tests.

## Risk assessment

Low.