### PR TITLE
fix(api): Correctly mark ready to aspirate whenever called

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -180,7 +180,11 @@ async def prepare_for_aspirate(
     else:
         return SuccessData(
             public=EmptyResult(),
-            state_update=StateUpdate().set_fluid_empty(pipette_id=pipette_id),
+            state_update=StateUpdate()
+            .set_fluid_empty(pipette_id=pipette_id)
+            .set_pipette_ready_to_aspirate(
+                pipette_id=pipette_id, ready_to_aspirate=True
+            ),
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -95,12 +95,7 @@ class PrepareToAspirateImplementation(
         if isinstance(prepare_result, DefinedErrorData):
             return prepare_result
         else:
-            return SuccessData(
-                public=PrepareToAspirateResult(),
-                state_update=prepare_result.state_update.set_pipette_ready_to_aspirate(
-                    pipette_id=params.pipetteId, ready_to_aspirate=True
-                ),
-            )
+            return self._transform_result(prepare_result)
 
 
 class PrepareToAspirate(

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -265,6 +265,9 @@ async def test_aspirate_implementation_with_prep(
                 pipette_id=pipette_id,
                 fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=50),
             ),
+            ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
+                pipette_id=pipette_id, ready_to_aspirate=True
+            ),
         ),
     )
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The bug was due to the fact that the state engine update only marked the pipette "ready-to-aspirate" when the protocol engine "prepare_to_aspirate" command was called and not when it automatically prepares to aspirate as part of an aspirate or other command.
This moves the state update object creation into pipetting common, so it gets updated no matter where it is called from.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
