### PR TITLE
test(step-generation): test to compare PD JSON protocols vs Python export

### DIFF
--- a/api/.flake8
+++ b/api/.flake8
@@ -63,3 +63,4 @@ per-file-ignores =
     tests/opentrons/util/test_async_helpers.py:ANN,D
     tests/opentrons/util/test_linal.py:ANN,D
     tests/opentrons/util/test_entrypoint_util.py:ANN,D
+    tests/interop/__pd_protocols__/*:D,F

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -3,6 +3,7 @@ plugins = pydantic.mypy, decoy.mypy, numpy.typing.mypy_plugin
 show_error_codes = True
 warn_unused_configs = True
 strict = True
+exclude = __pd_protocols__
 
 [pydantic-mypy]
 init_forbid_extra = True

--- a/api/tests/interop/__pd_protocols__/demo_day.json
+++ b/api/tests/interop/__pd_protocols__/demo_day.json
@@ -1,0 +1,6206 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Demo_3.27.25",
+    "author": "",
+    "description": "PD py export for Demo day",
+    "created": 1743005975337,
+    "lastModified": 1746129044545,
+    "source": "Protocol Designer",
+    "category": null,
+    "subcategory": null,
+    "tags": []
+  },
+  "designerApplication": {
+    "name": "opentrons/protocol-designer",
+    "version": "8.4.4-alpha.0",
+    "data": {
+      "_internalAppBuildDate": "Thu, 01 May 2025 19:46:48 GMT",
+      "pipetteTiprackAssignments": {
+        "3664e7f4-5090-4e29-bc2d-59b65a2a24cd": [
+          "opentrons/opentrons_flex_96_tiprack_1000ul/1"
+        ]
+      },
+      "dismissedWarnings": {
+        "form": [],
+        "timeline": []
+      },
+      "ingredients": {
+        "0": {
+          "displayName": "h20",
+          "description": "water",
+          "displayColor": "#b925ff",
+          "liquidGroupId": "0"
+        },
+        "1": {
+          "displayName": "Wash buffer",
+          "description": "to mix with",
+          "displayColor": "#ffd600",
+          "liquidGroupId": "1"
+        }
+      },
+      "ingredLocations": {
+        "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3": {
+          "A1": {
+            "0": {
+              "volume": 10
+            }
+          },
+          "B1": {
+            "0": {
+              "volume": 10
+            }
+          },
+          "C1": {
+            "0": {
+              "volume": 10
+            }
+          },
+          "D1": {
+            "0": {
+              "volume": 10
+            }
+          },
+          "E1": {
+            "0": {
+              "volume": 10
+            }
+          },
+          "F1": {
+            "0": {
+              "volume": 10
+            }
+          },
+          "G1": {
+            "0": {
+              "volume": 10
+            }
+          },
+          "H1": {
+            "0": {
+              "volume": 10
+            }
+          }
+        },
+        "df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2": {
+          "A1": {
+            "1": {
+              "volume": 10000
+            }
+          }
+        }
+      },
+      "savedStepForms": {
+        "__INITIAL_DECK_SETUP_STEP__": {
+          "labwareLocationUpdate": {
+            "325368d0-9394-4bd2-8a0b-7473b1447922:opentrons/opentrons_96_well_aluminum_block/1": "b7cad88e-0442-432e-aa0b-e674e46db433:temperatureModuleType",
+            "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3": "325368d0-9394-4bd2-8a0b-7473b1447922:opentrons/opentrons_96_well_aluminum_block/1",
+            "774f5010-9552-49a8-8eed-7dce2445d162:opentrons/opentrons_96_pcr_adapter/1": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType",
+            "df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2": "D2",
+            "c7d7d009-192b-4890-9501-67cc37d53eea:opentrons/opentrons_flex_96_tiprack_1000ul/1": "C3",
+            "61e31103-0441-44e0-bd7c-028f90eb78d3:opentrons/opentrons_flex_96_tiprack_adapter/1": "A2",
+            "d355d9c8-45e5-4344-9896-1e1a5cf6282b:opentrons/opentrons_flex_96_tiprack_1000ul/1": "61e31103-0441-44e0-bd7c-028f90eb78d3:opentrons/opentrons_flex_96_tiprack_adapter/1"
+          },
+          "moduleLocationUpdate": {
+            "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType": "B3",
+            "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType": "B1",
+            "59c015c0-0694-4f35-ac54-55162b0c0766:magneticBlockType": "A3",
+            "b7cad88e-0442-432e-aa0b-e674e46db433:temperatureModuleType": "D1",
+            "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType": "C1"
+          },
+          "pipetteLocationUpdate": {
+            "3664e7f4-5090-4e29-bc2d-59b65a2a24cd": "left"
+          },
+          "trashBinLocationUpdate": {},
+          "wasteChuteLocationUpdate": {
+            "5eb8a110-22fd-4d96-a5bc-d408289f44b3:wasteChute": "cutoutD3"
+          },
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {
+            "6d122c41-8880-446e-a810-25ee0380888b:gripper": "mounted"
+          },
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__"
+        },
+        "09a5e999-33a4-4ad7-baa4-072878b80775": {
+          "heaterShakerSetTimer": null,
+          "heaterShakerTimer": null,
+          "latchOpen": true,
+          "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType",
+          "setHeaterShakerTemperature": null,
+          "setShake": null,
+          "targetHeaterShakerTemperature": null,
+          "targetSpeed": null,
+          "id": "09a5e999-33a4-4ad7-baa4-072878b80775",
+          "stepType": "heaterShaker",
+          "stepName": "heater-shaker",
+          "stepDetails": ""
+        },
+        "eb76e6c9-1846-4539-b472-387a92053033": {
+          "blockIsActive": false,
+          "blockIsActiveHold": false,
+          "blockTargetTemp": null,
+          "blockTargetTempHold": null,
+          "lidIsActive": false,
+          "lidIsActiveHold": false,
+          "lidOpen": true,
+          "lidOpenHold": null,
+          "lidTargetTemp": null,
+          "lidTargetTempHold": null,
+          "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType",
+          "orderedProfileItems": [],
+          "profileItemsById": {},
+          "profileTargetLidTemp": null,
+          "profileVolume": null,
+          "thermocyclerFormType": "thermocyclerState",
+          "id": "eb76e6c9-1846-4539-b472-387a92053033",
+          "stepType": "thermocycler",
+          "stepName": "thermocycler",
+          "stepDetails": ""
+        },
+        "27576b03-c247-4e2e-9ab0-38e895fff6ed": {
+          "absorbanceReaderFormType": "absorbanceReaderInitialize",
+          "fileName": null,
+          "lidOpen": null,
+          "mode": "single",
+          "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType",
+          "referenceWavelength": null,
+          "referenceWavelengthActive": false,
+          "wavelengths": [
+            "450"
+          ],
+          "id": "27576b03-c247-4e2e-9ab0-38e895fff6ed",
+          "stepType": "absorbanceReader",
+          "stepName": "absorbance plate reader",
+          "stepDetails": ""
+        },
+        "a67256c4-264e-4ee4-b54d-e6067427f702": {
+          "aspirate_airGap_checkbox": false,
+          "aspirate_airGap_volume": null,
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_mmFromBottom": null,
+          "aspirate_delay_seconds": "1",
+          "aspirate_flowRate": "160",
+          "aspirate_labware": "df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2",
+          "aspirate_mix_checkbox": false,
+          "aspirate_mix_times": null,
+          "aspirate_mix_volume": null,
+          "aspirate_mmFromBottom": null,
+          "aspirate_position_reference": null,
+          "aspirate_retract_delay_seconds": null,
+          "aspirate_retract_mmFromBottom": null,
+          "aspirate_retract_speed": null,
+          "aspirate_retract_x_position": 0,
+          "aspirate_retract_y_position": 0,
+          "aspirate_retract_position_reference": null,
+          "aspirate_submerge_delay_seconds": null,
+          "aspirate_submerge_speed": null,
+          "aspirate_submerge_mmFromBottom": null,
+          "aspirate_submerge_x_position": null,
+          "aspirate_submerge_y_position": null,
+          "aspirate_submerge_position_reference": null,
+          "aspirate_touchTip_checkbox": false,
+          "aspirate_touchTip_mmFromTop": null,
+          "aspirate_touchTip_speed": null,
+          "aspirate_touchTip_mmFromEdge": 0,
+          "aspirate_wellOrder_first": "t2b",
+          "aspirate_wellOrder_second": "l2r",
+          "aspirate_wells_grouped": false,
+          "aspirate_wells": [
+            "A1"
+          ],
+          "aspirate_x_position": 0,
+          "aspirate_y_position": 0,
+          "blowout_checkbox": false,
+          "blowout_flowRate": null,
+          "blowout_location": null,
+          "blowout_z_offset": 0,
+          "changeTip": "always",
+          "conditioning_checkbox": false,
+          "conditioning_volume": null,
+          "dispense_airGap_checkbox": false,
+          "dispense_airGap_volume": null,
+          "dispense_delay_checkbox": false,
+          "dispense_delay_mmFromBottom": null,
+          "dispense_delay_seconds": "1",
+          "dispense_flowRate": null,
+          "dispense_labware": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+          "dispense_mix_checkbox": false,
+          "dispense_mix_times": null,
+          "dispense_mix_volume": null,
+          "dispense_mmFromBottom": null,
+          "dispense_position_reference": null,
+          "dispense_retract_delay_seconds": null,
+          "dispense_retract_mmFromBottom": null,
+          "dispense_retract_speed": null,
+          "dispense_retract_x_position": 0,
+          "dispense_retract_y_position": 0,
+          "dispense_retract_position_reference": null,
+          "dispense_submerge_delay_seconds": null,
+          "dispense_submerge_speed": null,
+          "dispense_submerge_mmFromBottom": null,
+          "dispense_submerge_x_position": null,
+          "dispense_submerge_y_position": null,
+          "dispense_submerge_position_reference": null,
+          "dispense_touchTip_checkbox": false,
+          "dispense_touchTip_mmFromTop": null,
+          "dispense_touchTip_speed": null,
+          "dispense_touchTip_mmFromEdge": 0,
+          "dispense_wellOrder_first": "t2b",
+          "dispense_wellOrder_second": "l2r",
+          "dispense_wells": [
+            "A1"
+          ],
+          "dispense_x_position": 0,
+          "dispense_y_position": 0,
+          "disposalVolume_checkbox": true,
+          "disposalVolume_volume": null,
+          "dropTip_location": "5eb8a110-22fd-4d96-a5bc-d408289f44b3:wasteChute",
+          "liquidClassesSupported": true,
+          "liquidClass": null,
+          "nozzles": "COLUMN",
+          "path": "single",
+          "pipette": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+          "preWetTip": false,
+          "pushOut_checkbox": true,
+          "pushOut_volume": 20,
+          "tipRack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
+          "volume": "100",
+          "stepType": "moveLiquid",
+          "stepName": "transfer",
+          "stepDetails": "",
+          "id": "a67256c4-264e-4ee4-b54d-e6067427f702",
+          "dispense_touchTip_mmfromTop": null
+        },
+        "717a98db-eb91-4858-a64c-4f9010c0fd19": {
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_seconds": "1",
+          "aspirate_flowRate": "160",
+          "blowout_checkbox": false,
+          "blowout_flowRate": null,
+          "blowout_location": null,
+          "blowout_z_offset": 0,
+          "changeTip": "always",
+          "dispense_delay_checkbox": false,
+          "dispense_delay_seconds": "1",
+          "dispense_flowRate": null,
+          "dropTip_location": "5eb8a110-22fd-4d96-a5bc-d408289f44b3:wasteChute",
+          "labware": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+          "liquidClassesSupported": true,
+          "liquidClass": "none",
+          "mix_mmFromBottom": 1,
+          "mix_touchTip_checkbox": false,
+          "mix_touchTip_mmFromTop": null,
+          "mix_wellOrder_first": "t2b",
+          "mix_wellOrder_second": "l2r",
+          "mix_position_reference": null,
+          "mix_x_position": 0,
+          "mix_y_position": 0,
+          "nozzles": "COLUMN",
+          "pipette": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+          "pushOut_checkbox": null,
+          "pushOut_volume": null,
+          "times": "2",
+          "tipRack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
+          "volume": "100",
+          "wells": [
+            "A1"
+          ],
+          "stepType": "mix",
+          "stepName": "mix",
+          "stepDetails": "",
+          "id": "717a98db-eb91-4858-a64c-4f9010c0fd19"
+        },
+        "ba365819-ed80-4ab3-a2b7-afa1e6b0169d": {
+          "labware": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+          "newLocation": "59c015c0-0694-4f35-ac54-55162b0c0766:magneticBlockType",
+          "useGripper": true,
+          "id": "ba365819-ed80-4ab3-a2b7-afa1e6b0169d",
+          "stepType": "moveLabware",
+          "stepName": "move",
+          "stepDetails": ""
+        },
+        "213ac071-714f-4484-88a2-2732153a9ea9": {
+          "moduleId": null,
+          "pauseAction": "untilTime",
+          "pauseMessage": "Pause for 5 seconds",
+          "pauseTemperature": null,
+          "pauseTime": "00:00:05",
+          "id": "213ac071-714f-4484-88a2-2732153a9ea9",
+          "stepType": "pause",
+          "stepName": "pause",
+          "stepDetails": ""
+        },
+        "07026308-39fb-442b-8df4-f821a639dc3b": {
+          "labware": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+          "newLocation": "774f5010-9552-49a8-8eed-7dce2445d162:opentrons/opentrons_96_pcr_adapter/1",
+          "useGripper": true,
+          "id": "07026308-39fb-442b-8df4-f821a639dc3b",
+          "stepType": "moveLabware",
+          "stepName": "move",
+          "stepDetails": ""
+        },
+        "124625d8-52aa-4e2b-87bd-1b8584baa2ae": {
+          "heaterShakerSetTimer": true,
+          "heaterShakerTimer": "00:05",
+          "latchOpen": false,
+          "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType",
+          "setHeaterShakerTemperature": null,
+          "setShake": true,
+          "targetHeaterShakerTemperature": null,
+          "targetSpeed": "200",
+          "id": "124625d8-52aa-4e2b-87bd-1b8584baa2ae",
+          "stepType": "heaterShaker",
+          "stepName": "heater-shaker",
+          "stepDetails": ""
+        },
+        "15d135a3-b12b-46e6-b5b7-5188249a3926": {
+          "heaterShakerSetTimer": null,
+          "heaterShakerTimer": null,
+          "latchOpen": true,
+          "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType",
+          "setHeaterShakerTemperature": null,
+          "setShake": null,
+          "targetHeaterShakerTemperature": null,
+          "targetSpeed": null,
+          "id": "15d135a3-b12b-46e6-b5b7-5188249a3926",
+          "stepType": "heaterShaker",
+          "stepName": "heater-shaker",
+          "stepDetails": ""
+        },
+        "ba37127c-38b3-4a1f-adf7-9906a973fdc7": {
+          "labware": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+          "newLocation": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType",
+          "useGripper": true,
+          "id": "ba37127c-38b3-4a1f-adf7-9906a973fdc7",
+          "stepType": "moveLabware",
+          "stepName": "move",
+          "stepDetails": ""
+        },
+        "9732f6dc-6538-49b5-80e8-b7b62b53c6a7": {
+          "absorbanceReaderFormType": "absorbanceReaderLid",
+          "fileName": null,
+          "lidOpen": true,
+          "mode": "single",
+          "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType",
+          "referenceWavelength": null,
+          "referenceWavelengthActive": false,
+          "wavelengths": [
+            "450"
+          ],
+          "id": "9732f6dc-6538-49b5-80e8-b7b62b53c6a7",
+          "stepType": "absorbanceReader",
+          "stepName": "absorbance plate reader",
+          "stepDetails": ""
+        },
+        "b12aff9e-51be-4e52-a031-4babbdd30016": {
+          "absorbanceReaderFormType": "absorbanceReaderRead",
+          "fileName": "testPlateReaderFile",
+          "lidOpen": null,
+          "mode": "single",
+          "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType",
+          "referenceWavelength": null,
+          "referenceWavelengthActive": false,
+          "wavelengths": [
+            "450"
+          ],
+          "id": "b12aff9e-51be-4e52-a031-4babbdd30016",
+          "stepType": "absorbanceReader",
+          "stepName": "absorbance plate reader",
+          "stepDetails": ""
+        },
+        "c75f3fb5-0368-4fc2-8e4e-a402ebba49a8": {
+          "absorbanceReaderFormType": "absorbanceReaderLid",
+          "fileName": null,
+          "lidOpen": true,
+          "mode": "single",
+          "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType",
+          "referenceWavelength": null,
+          "referenceWavelengthActive": false,
+          "wavelengths": [
+            "450"
+          ],
+          "id": "c75f3fb5-0368-4fc2-8e4e-a402ebba49a8",
+          "stepType": "absorbanceReader",
+          "stepName": "absorbance plate reader",
+          "stepDetails": ""
+        },
+        "ab02b3d3-b6dc-4509-b05f-8ddffb668c47": {
+          "labware": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+          "newLocation": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType",
+          "useGripper": true,
+          "id": "ab02b3d3-b6dc-4509-b05f-8ddffb668c47",
+          "stepType": "moveLabware",
+          "stepName": "move",
+          "stepDetails": ""
+        },
+        "befa85f7-e3f1-4512-a8a1-5cacf2cd7008": {
+          "blockIsActive": false,
+          "blockIsActiveHold": false,
+          "blockTargetTemp": null,
+          "blockTargetTempHold": null,
+          "lidIsActive": false,
+          "lidIsActiveHold": false,
+          "lidOpen": false,
+          "lidOpenHold": null,
+          "lidTargetTemp": null,
+          "lidTargetTempHold": null,
+          "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType",
+          "orderedProfileItems": [
+            "324fab35-8982-4d99-8e12-d19dd8945c2b"
+          ],
+          "profileItemsById": {
+            "324fab35-8982-4d99-8e12-d19dd8945c2b": {
+              "id": "324fab35-8982-4d99-8e12-d19dd8945c2b",
+              "title": "",
+              "steps": [
+                {
+                  "durationMinutes": "00",
+                  "durationSeconds": "05",
+                  "id": "5fe485c7-9e44-4ba1-94a9-1767be13969c",
+                  "temperature": "30",
+                  "title": "step 1",
+                  "type": "profileStep"
+                },
+                {
+                  "durationMinutes": "00",
+                  "durationSeconds": "05",
+                  "id": "446dad12-9789-433e-9a93-04fb0887a3d2",
+                  "temperature": "32",
+                  "title": "step 2",
+                  "type": "profileStep"
+                }
+              ],
+              "type": "profileCycle",
+              "repetitions": "2"
+            }
+          },
+          "profileTargetLidTemp": "40",
+          "profileVolume": "10",
+          "thermocyclerFormType": "thermocyclerProfile",
+          "id": "befa85f7-e3f1-4512-a8a1-5cacf2cd7008",
+          "stepType": "thermocycler",
+          "stepName": "thermocycler",
+          "stepDetails": ""
+        }
+      },
+      "orderedStepIds": [
+        "09a5e999-33a4-4ad7-baa4-072878b80775",
+        "eb76e6c9-1846-4539-b472-387a92053033",
+        "27576b03-c247-4e2e-9ab0-38e895fff6ed",
+        "a67256c4-264e-4ee4-b54d-e6067427f702",
+        "717a98db-eb91-4858-a64c-4f9010c0fd19",
+        "ba365819-ed80-4ab3-a2b7-afa1e6b0169d",
+        "213ac071-714f-4484-88a2-2732153a9ea9",
+        "07026308-39fb-442b-8df4-f821a639dc3b",
+        "124625d8-52aa-4e2b-87bd-1b8584baa2ae",
+        "15d135a3-b12b-46e6-b5b7-5188249a3926",
+        "9732f6dc-6538-49b5-80e8-b7b62b53c6a7",
+        "ba37127c-38b3-4a1f-adf7-9906a973fdc7",
+        "b12aff9e-51be-4e52-a031-4babbdd30016",
+        "c75f3fb5-0368-4fc2-8e4e-a402ebba49a8",
+        "ab02b3d3-b6dc-4509-b05f-8ddffb668c47",
+        "befa85f7-e3f1-4512-a8a1-5cacf2cd7008"
+      ],
+      "pipettes": {
+        "3664e7f4-5090-4e29-bc2d-59b65a2a24cd": {
+          "pipetteName": "p1000_96"
+        }
+      },
+      "modules": {
+        "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType": {
+          "model": "absorbanceReaderV1"
+        },
+        "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType": {
+          "model": "thermocyclerModuleV2"
+        },
+        "59c015c0-0694-4f35-ac54-55162b0c0766:magneticBlockType": {
+          "model": "magneticBlockV1"
+        },
+        "b7cad88e-0442-432e-aa0b-e674e46db433:temperatureModuleType": {
+          "model": "temperatureModuleV2"
+        },
+        "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType": {
+          "model": "heaterShakerModuleV1"
+        }
+      },
+      "labware": {
+        "325368d0-9394-4bd2-8a0b-7473b1447922:opentrons/opentrons_96_well_aluminum_block/1": {
+          "displayName": "Opentrons 96 Well Aluminum Block",
+          "labwareDefURI": "opentrons/opentrons_96_well_aluminum_block/1"
+        },
+        "774f5010-9552-49a8-8eed-7dce2445d162:opentrons/opentrons_96_pcr_adapter/1": {
+          "displayName": "Opentrons 96 PCR Heater-Shaker Adapter",
+          "labwareDefURI": "opentrons/opentrons_96_pcr_adapter/1"
+        },
+        "61e31103-0441-44e0-bd7c-028f90eb78d3:opentrons/opentrons_flex_96_tiprack_adapter/1": {
+          "displayName": "Opentrons Flex 96 Tip Rack Adapter",
+          "labwareDefURI": "opentrons/opentrons_flex_96_tiprack_adapter/1"
+        },
+        "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3": {
+          "displayName": "Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt",
+          "labwareDefURI": "opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3"
+        },
+        "df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2": {
+          "displayName": "NEST 12 Well Reservoir 15 mL",
+          "labwareDefURI": "opentrons/nest_12_reservoir_15ml/2"
+        },
+        "c7d7d009-192b-4890-9501-67cc37d53eea:opentrons/opentrons_flex_96_tiprack_1000ul/1": {
+          "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
+          "labwareDefURI": "opentrons/opentrons_flex_96_tiprack_1000ul/1"
+        },
+        "d355d9c8-45e5-4344-9896-1e1a5cf6282b:opentrons/opentrons_flex_96_tiprack_1000ul/1": {
+          "displayName": "Opentrons Flex 96 Tip Rack 1000 µL (1)",
+          "labwareDefURI": "opentrons/opentrons_flex_96_tiprack_1000ul/1"
+        }
+      }
+    }
+  },
+  "robot": {
+    "model": "OT-3 Standard",
+    "deckId": "ot3_standard"
+  },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitions": {
+    "opentrons/opentrons_flex_96_tiprack_1000ul/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": []
+      },
+      "metadata": {
+        "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.75,
+        "yDimension": 85.75,
+        "zDimension": 99
+      },
+      "gripForce": 16,
+      "gripHeightFromLabwareBottom": 23.9,
+      "wells": {
+        "A1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 14.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 14.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 14.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 14.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 14.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 14.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 14.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 14.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 23.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 23.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 23.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 23.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 23.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 23.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 23.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 23.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 32.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 32.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 32.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 32.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 32.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 32.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 32.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 32.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 41.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 41.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 41.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 41.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 41.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 41.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 41.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 41.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 50.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 50.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 50.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 50.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 50.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 50.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 50.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 50.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 59.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 59.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 59.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 59.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 59.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 59.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 59.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 59.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 68.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 68.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 68.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 68.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 68.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 68.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 68.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 68.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 77.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 77.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 77.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 77.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 77.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 77.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 77.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 77.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 86.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 86.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 86.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 86.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 86.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 86.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 86.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 86.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 95.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 95.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 95.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 95.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 95.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 95.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 95.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 95.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 104.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 104.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 104.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 104.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 104.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 104.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 104.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 104.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 113.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 113.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 113.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 113.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 113.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 113.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 113.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.47,
+          "totalLiquidVolume": 1000,
+          "x": 113.38,
+          "y": 11.38,
+          "z": 1.5
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "quirks": [],
+        "isTiprack": true,
+        "tipLength": 95.6,
+        "tipOverlap": 10.5,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_flex_96_tiprack_1000ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "stackingOffsetWithLabware": {
+        "opentrons_flex_96_tiprack_adapter": {
+          "x": 0,
+          "y": 0,
+          "z": 121
+        }
+      }
+    },
+    "opentrons/opentrons_96_well_aluminum_block/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": []
+      },
+      "metadata": {
+        "displayName": "Opentrons 96 Well Aluminum Block",
+        "displayCategory": "aluminumBlock",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 18.16
+      },
+      "wells": {
+        "A1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 3.38
+        },
+        "A12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 3.38
+        },
+        "B12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 3.38
+        },
+        "C12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 3.38
+        },
+        "D12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 3.38
+        },
+        "E12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 3.38
+        },
+        "F12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 3.38
+        },
+        "G12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 3.38
+        },
+        "H12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 0,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 3.38
+        }
+      },
+      "groups": [
+        {
+          "metadata": {
+            "wellBottomShape": "v"
+          },
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_well_aluminum_block"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "allowedRoles": [
+        "adapter"
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "gripperOffsets": {
+        "default": {
+          "pickUpOffset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dropOffset": {
+            "x": 0,
+            "y": 0,
+            "z": 1
+          }
+        }
+      }
+    },
+    "opentrons/opentrons_96_pcr_adapter/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": []
+      },
+      "metadata": {
+        "displayName": "Opentrons 96 PCR Heater-Shaker Adapter",
+        "displayCategory": "adapter",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 111,
+        "yDimension": 75,
+        "zDimension": 13.85
+      },
+      "wells": {
+        "A1": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 6,
+          "y": 69,
+          "z": 1.85
+        },
+        "B1": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 6,
+          "y": 60,
+          "z": 1.85
+        },
+        "C1": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 6,
+          "y": 51,
+          "z": 1.85
+        },
+        "D1": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 6,
+          "y": 42,
+          "z": 1.85
+        },
+        "E1": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 6,
+          "y": 33,
+          "z": 1.85
+        },
+        "F1": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 6,
+          "y": 24,
+          "z": 1.85
+        },
+        "G1": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 6,
+          "y": 15,
+          "z": 1.85
+        },
+        "H1": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 6,
+          "y": 6,
+          "z": 1.85
+        },
+        "A2": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 15,
+          "y": 69,
+          "z": 1.85
+        },
+        "B2": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 15,
+          "y": 60,
+          "z": 1.85
+        },
+        "C2": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 15,
+          "y": 51,
+          "z": 1.85
+        },
+        "D2": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 15,
+          "y": 42,
+          "z": 1.85
+        },
+        "E2": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 15,
+          "y": 33,
+          "z": 1.85
+        },
+        "F2": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 15,
+          "y": 24,
+          "z": 1.85
+        },
+        "G2": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 15,
+          "y": 15,
+          "z": 1.85
+        },
+        "H2": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 15,
+          "y": 6,
+          "z": 1.85
+        },
+        "A3": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 24,
+          "y": 69,
+          "z": 1.85
+        },
+        "B3": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 24,
+          "y": 60,
+          "z": 1.85
+        },
+        "C3": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 24,
+          "y": 51,
+          "z": 1.85
+        },
+        "D3": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 24,
+          "y": 42,
+          "z": 1.85
+        },
+        "E3": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 24,
+          "y": 33,
+          "z": 1.85
+        },
+        "F3": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 24,
+          "y": 24,
+          "z": 1.85
+        },
+        "G3": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 24,
+          "y": 15,
+          "z": 1.85
+        },
+        "H3": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 24,
+          "y": 6,
+          "z": 1.85
+        },
+        "A4": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 33,
+          "y": 69,
+          "z": 1.85
+        },
+        "B4": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 33,
+          "y": 60,
+          "z": 1.85
+        },
+        "C4": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 33,
+          "y": 51,
+          "z": 1.85
+        },
+        "D4": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 33,
+          "y": 42,
+          "z": 1.85
+        },
+        "E4": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 33,
+          "y": 33,
+          "z": 1.85
+        },
+        "F4": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 33,
+          "y": 24,
+          "z": 1.85
+        },
+        "G4": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 33,
+          "y": 15,
+          "z": 1.85
+        },
+        "H4": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 33,
+          "y": 6,
+          "z": 1.85
+        },
+        "A5": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 42,
+          "y": 69,
+          "z": 1.85
+        },
+        "B5": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 42,
+          "y": 60,
+          "z": 1.85
+        },
+        "C5": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 42,
+          "y": 51,
+          "z": 1.85
+        },
+        "D5": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 42,
+          "y": 42,
+          "z": 1.85
+        },
+        "E5": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 42,
+          "y": 33,
+          "z": 1.85
+        },
+        "F5": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 42,
+          "y": 24,
+          "z": 1.85
+        },
+        "G5": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 42,
+          "y": 15,
+          "z": 1.85
+        },
+        "H5": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 42,
+          "y": 6,
+          "z": 1.85
+        },
+        "A6": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 51,
+          "y": 69,
+          "z": 1.85
+        },
+        "B6": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 51,
+          "y": 60,
+          "z": 1.85
+        },
+        "C6": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 51,
+          "y": 51,
+          "z": 1.85
+        },
+        "D6": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 51,
+          "y": 42,
+          "z": 1.85
+        },
+        "E6": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 51,
+          "y": 33,
+          "z": 1.85
+        },
+        "F6": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 51,
+          "y": 24,
+          "z": 1.85
+        },
+        "G6": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 51,
+          "y": 15,
+          "z": 1.85
+        },
+        "H6": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 51,
+          "y": 6,
+          "z": 1.85
+        },
+        "A7": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 60,
+          "y": 69,
+          "z": 1.85
+        },
+        "B7": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 60,
+          "y": 60,
+          "z": 1.85
+        },
+        "C7": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 60,
+          "y": 51,
+          "z": 1.85
+        },
+        "D7": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 60,
+          "y": 42,
+          "z": 1.85
+        },
+        "E7": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 60,
+          "y": 33,
+          "z": 1.85
+        },
+        "F7": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 60,
+          "y": 24,
+          "z": 1.85
+        },
+        "G7": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 60,
+          "y": 15,
+          "z": 1.85
+        },
+        "H7": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 60,
+          "y": 6,
+          "z": 1.85
+        },
+        "A8": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 69,
+          "y": 69,
+          "z": 1.85
+        },
+        "B8": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 69,
+          "y": 60,
+          "z": 1.85
+        },
+        "C8": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 69,
+          "y": 51,
+          "z": 1.85
+        },
+        "D8": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 69,
+          "y": 42,
+          "z": 1.85
+        },
+        "E8": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 69,
+          "y": 33,
+          "z": 1.85
+        },
+        "F8": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 69,
+          "y": 24,
+          "z": 1.85
+        },
+        "G8": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 69,
+          "y": 15,
+          "z": 1.85
+        },
+        "H8": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 69,
+          "y": 6,
+          "z": 1.85
+        },
+        "A9": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 78,
+          "y": 69,
+          "z": 1.85
+        },
+        "B9": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 78,
+          "y": 60,
+          "z": 1.85
+        },
+        "C9": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 78,
+          "y": 51,
+          "z": 1.85
+        },
+        "D9": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 78,
+          "y": 42,
+          "z": 1.85
+        },
+        "E9": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 78,
+          "y": 33,
+          "z": 1.85
+        },
+        "F9": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 78,
+          "y": 24,
+          "z": 1.85
+        },
+        "G9": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 78,
+          "y": 15,
+          "z": 1.85
+        },
+        "H9": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 78,
+          "y": 6,
+          "z": 1.85
+        },
+        "A10": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 87,
+          "y": 69,
+          "z": 1.85
+        },
+        "B10": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 87,
+          "y": 60,
+          "z": 1.85
+        },
+        "C10": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 87,
+          "y": 51,
+          "z": 1.85
+        },
+        "D10": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 87,
+          "y": 42,
+          "z": 1.85
+        },
+        "E10": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 87,
+          "y": 33,
+          "z": 1.85
+        },
+        "F10": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 87,
+          "y": 24,
+          "z": 1.85
+        },
+        "G10": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 87,
+          "y": 15,
+          "z": 1.85
+        },
+        "H10": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 87,
+          "y": 6,
+          "z": 1.85
+        },
+        "A11": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 96,
+          "y": 69,
+          "z": 1.85
+        },
+        "B11": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 96,
+          "y": 60,
+          "z": 1.85
+        },
+        "C11": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 96,
+          "y": 51,
+          "z": 1.85
+        },
+        "D11": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 96,
+          "y": 42,
+          "z": 1.85
+        },
+        "E11": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 96,
+          "y": 33,
+          "z": 1.85
+        },
+        "F11": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 96,
+          "y": 24,
+          "z": 1.85
+        },
+        "G11": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 96,
+          "y": 15,
+          "z": 1.85
+        },
+        "H11": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 96,
+          "y": 6,
+          "z": 1.85
+        },
+        "A12": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 105,
+          "y": 69,
+          "z": 1.85
+        },
+        "B12": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 105,
+          "y": 60,
+          "z": 1.85
+        },
+        "C12": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 105,
+          "y": 51,
+          "z": 1.85
+        },
+        "D12": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 105,
+          "y": 42,
+          "z": 1.85
+        },
+        "E12": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 105,
+          "y": 33,
+          "z": 1.85
+        },
+        "F12": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 105,
+          "y": 24,
+          "z": 1.85
+        },
+        "G12": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 105,
+          "y": 15,
+          "z": 1.85
+        },
+        "H12": {
+          "depth": 12,
+          "shape": "circular",
+          "diameter": 5.64,
+          "totalLiquidVolume": 0,
+          "x": 105,
+          "y": 6,
+          "z": 1.85
+        }
+      },
+      "groups": [
+        {
+          "metadata": {
+            "wellBottomShape": "v"
+          },
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_pcr_adapter"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "allowedRoles": [
+        "adapter"
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 8.5,
+        "y": 5.5,
+        "z": 0
+      },
+      "gripperOffsets": {
+        "default": {
+          "pickUpOffset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dropOffset": {
+            "x": 0,
+            "y": 0,
+            "z": 1
+          }
+        }
+      }
+    },
+    "opentrons/opentrons_flex_96_tiprack_adapter/1": {
+      "ordering": [],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": []
+      },
+      "metadata": {
+        "displayName": "Opentrons Flex 96 Tip Rack Adapter",
+        "displayCategory": "adapter",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 156.5,
+        "yDimension": 93,
+        "zDimension": 132
+      },
+      "wells": {},
+      "groups": [
+        {
+          "metadata": {},
+          "wells": []
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "quirks": [
+          "tiprackAdapterFor96Channel"
+        ],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_flex_96_tiprack_adapter"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "allowedRoles": [
+        "adapter"
+      ],
+      "cornerOffsetFromSlot": {
+        "x": -14.25,
+        "y": -3.5,
+        "z": 0
+      }
+    },
+    "opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3": {
+      "namespace": "opentrons",
+      "version": 3,
+      "schemaVersion": 2,
+      "parameters": {
+        "loadName": "opentrons_96_wellplate_200ul_pcr_full_skirt",
+        "format": "96Standard",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": true
+      },
+      "metadata": {
+        "displayName": "Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [
+          "991-00076"
+        ],
+        "links": [
+          "https://shop.opentrons.com/tough-0.2-ml-96-well-pcr-plate-full-skirt/"
+        ]
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 16
+      },
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "stackLimit": 4,
+      "compatibleParentLabware": [
+        "opentrons_96_wellplate_200ul_pcr_full_skirt"
+      ],
+      "stackingOffsetWithLabware": {
+        "opentrons_96_pcr_adapter": {
+          "x": 0,
+          "y": 0,
+          "z": 10.95
+        },
+        "opentrons_96_well_aluminum_block": {
+          "x": 0,
+          "y": 0,
+          "z": 11.91
+        },
+        "opentrons_96_wellplate_200ul_pcr_full_skirt": {
+          "x": 0,
+          "y": 0,
+          "z": 3
+        }
+      },
+      "stackingOffsetWithModule": {
+        "magneticBlockV1": {
+          "x": 0,
+          "y": 0,
+          "z": 3.54
+        },
+        "thermocyclerModuleV2": {
+          "x": 0,
+          "y": 0,
+          "z": 10.7
+        }
+      },
+      "gripForce": 15,
+      "gripHeightFromLabwareBottom": 10,
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "wells": {
+        "A1": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B1": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C1": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D1": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E1": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F1": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G1": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H1": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A2": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B2": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C2": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D2": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E2": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F2": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G2": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H2": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A3": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B3": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C3": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D3": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E3": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F3": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G3": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H3": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A4": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B4": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C4": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D4": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E4": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F4": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G4": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H4": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A5": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B5": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C5": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D5": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E5": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F5": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G5": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H5": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A6": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B6": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C6": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D6": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E6": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F6": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G6": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H6": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A7": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B7": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C7": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D7": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E7": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F7": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G7": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H7": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A8": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B8": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C8": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D8": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E8": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F8": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G8": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H8": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A9": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B9": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C9": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D9": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E9": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F9": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G9": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H9": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A10": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B10": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C10": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D10": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E10": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F10": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G10": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H10": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A11": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B11": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C11": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D11": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E11": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F11": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G11": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H11": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A12": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B12": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C12": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D12": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E12": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F12": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G12": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H12": {
+          "depth": 14.95,
+          "totalLiquidVolume": 200,
+          "shape": "circular",
+          "diameter": 5.5,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 1.05,
+          "geometryDefinitionId": "conicalWell"
+        }
+      },
+      "groups": [
+        {
+          "metadata": {
+            "wellBottomShape": "v"
+          },
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "innerLabwareGeometry": {
+        "conicalWell": {
+          "sections": [
+            {
+              "shape": "conical",
+              "bottomDiameter": 5.5,
+              "topDiameter": 5.5,
+              "topHeight": 14.95,
+              "bottomHeight": 11.35
+            },
+            {
+              "shape": "conical",
+              "topDiameter": 5.5,
+              "bottomDiameter": 2.33,
+              "topHeight": 11.35,
+              "bottomHeight": 0.8
+            },
+            {
+              "shape": "spherical",
+              "radiusOfCurvature": 1.25,
+              "topHeight": 0.8,
+              "bottomHeight": 0
+            }
+          ]
+        }
+      }
+    },
+    "opentrons/nest_12_reservoir_15ml/2": {
+      "ordering": [
+        [
+          "A1"
+        ],
+        [
+          "A2"
+        ],
+        [
+          "A3"
+        ],
+        [
+          "A4"
+        ],
+        [
+          "A5"
+        ],
+        [
+          "A6"
+        ],
+        [
+          "A7"
+        ],
+        [
+          "A8"
+        ],
+        [
+          "A9"
+        ],
+        [
+          "A10"
+        ],
+        [
+          "A11"
+        ],
+        [
+          "A12"
+        ]
+      ],
+      "brand": {
+        "brand": "NEST",
+        "brandId": [
+          "360102"
+        ],
+        "links": [
+          "https://www.nest-biotech.com/reagent-reserviors/59178414.html"
+        ]
+      },
+      "metadata": {
+        "displayName": "NEST 12 Well Reservoir 15 mL",
+        "displayCategory": "reservoir",
+        "displayVolumeUnits": "mL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 31.4
+      },
+      "wells": {
+        "A1": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 14.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A2": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 23.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A3": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 32.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A4": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 41.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A5": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 50.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A6": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 59.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A7": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 68.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A8": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 77.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A9": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 86.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A10": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 95.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A11": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 104.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        },
+        "A12": {
+          "depth": 26.85,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 71.2,
+          "totalLiquidVolume": 15000,
+          "x": 113.38,
+          "y": 42.78,
+          "z": 4.55,
+          "geometryDefinitionId": "cuboidalWell"
+        }
+      },
+      "groups": [
+        {
+          "metadata": {
+            "wellBottomShape": "v"
+          },
+          "wells": [
+            "A1",
+            "A2",
+            "A3",
+            "A4",
+            "A5",
+            "A6",
+            "A7",
+            "A8",
+            "A9",
+            "A10",
+            "A11",
+            "A12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "trough",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "quirks": [
+          "centerMultichannelOnWells",
+          "touchTipDisabled"
+        ],
+        "loadName": "nest_12_reservoir_15ml"
+      },
+      "namespace": "opentrons",
+      "version": 2,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "innerLabwareGeometry": {
+        "cuboidalWell": {
+          "sections": [
+            {
+              "shape": "cuboidal",
+              "topXDimension": 8.35,
+              "topYDimension": 71.25,
+              "bottomXDimension": 7.95,
+              "bottomYDimension": 70.53,
+              "topHeight": 26.85,
+              "bottomHeight": 2.05
+            },
+            {
+              "shape": "cuboidal",
+              "topXDimension": 7.95,
+              "topYDimension": 70.53,
+              "bottomXDimension": 1.87,
+              "bottomYDimension": 64.45,
+              "topHeight": 2.05,
+              "bottomHeight": 0
+            }
+          ]
+        }
+      }
+    }
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {
+    "0": {
+      "displayName": "h20",
+      "description": "water",
+      "displayColor": "#b925ff"
+    },
+    "1": {
+      "displayName": "Wash buffer",
+      "description": "to mix with",
+      "displayColor": "#ffd600"
+    }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV10",
+  "commands": [
+    {
+      "key": "720e2255-8e96-4c7f-8aaf-3d60fdc9a959",
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteName": "p1000_96",
+        "mount": "left",
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd"
+      }
+    },
+    {
+      "key": "4be95bfb-08bc-4094-8d20-e4bbf8cbeb10",
+      "commandType": "loadModule",
+      "params": {
+        "model": "absorbanceReaderV1",
+        "location": {
+          "slotName": "B3"
+        },
+        "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType"
+      }
+    },
+    {
+      "key": "4c5ee4b5-a7c9-4eee-ad44-8effa628eab8",
+      "commandType": "loadModule",
+      "params": {
+        "model": "thermocyclerModuleV2",
+        "location": {
+          "slotName": "B1"
+        },
+        "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType"
+      }
+    },
+    {
+      "key": "21a3cd4a-ea82-429b-a6b5-231882ea4fd7",
+      "commandType": "loadModule",
+      "params": {
+        "model": "magneticBlockV1",
+        "location": {
+          "slotName": "A3"
+        },
+        "moduleId": "59c015c0-0694-4f35-ac54-55162b0c0766:magneticBlockType"
+      }
+    },
+    {
+      "key": "afb94206-cd2c-4875-aea1-61eb6001ed55",
+      "commandType": "loadModule",
+      "params": {
+        "model": "temperatureModuleV2",
+        "location": {
+          "slotName": "D1"
+        },
+        "moduleId": "b7cad88e-0442-432e-aa0b-e674e46db433:temperatureModuleType"
+      }
+    },
+    {
+      "key": "ae4be165-cdc9-4b40-b6f1-66a60e250ffb",
+      "commandType": "loadModule",
+      "params": {
+        "model": "heaterShakerModuleV1",
+        "location": {
+          "slotName": "C1"
+        },
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "key": "c6b02311-6a23-44c7-b7b3-782e885d5ab9",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons 96 Well Aluminum Block",
+        "labwareId": "325368d0-9394-4bd2-8a0b-7473b1447922:opentrons/opentrons_96_well_aluminum_block/1",
+        "loadName": "opentrons_96_well_aluminum_block",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "moduleId": "b7cad88e-0442-432e-aa0b-e674e46db433:temperatureModuleType"
+        }
+      }
+    },
+    {
+      "key": "04fd398f-4983-4f34-87a1-e590c1a9e3ab",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons 96 PCR Heater-Shaker Adapter",
+        "labwareId": "774f5010-9552-49a8-8eed-7dce2445d162:opentrons/opentrons_96_pcr_adapter/1",
+        "loadName": "opentrons_96_pcr_adapter",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+        }
+      }
+    },
+    {
+      "key": "d035454b-85f0-4579-8209-dbc4e80a4a9d",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Flex 96 Tip Rack Adapter",
+        "labwareId": "61e31103-0441-44e0-bd7c-028f90eb78d3:opentrons/opentrons_flex_96_tiprack_adapter/1",
+        "loadName": "opentrons_flex_96_tiprack_adapter",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "slotName": "A2"
+        }
+      }
+    },
+    {
+      "key": "8ab34ce1-feda-4e72-8c35-c043dfa0fc0f",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt",
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "loadName": "opentrons_96_wellplate_200ul_pcr_full_skirt",
+        "namespace": "opentrons",
+        "version": 3,
+        "location": {
+          "labwareId": "325368d0-9394-4bd2-8a0b-7473b1447922:opentrons/opentrons_96_well_aluminum_block/1"
+        }
+      }
+    },
+    {
+      "key": "490014ff-4087-444b-8862-e444d079d298",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "NEST 12 Well Reservoir 15 mL",
+        "labwareId": "df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2",
+        "loadName": "nest_12_reservoir_15ml",
+        "namespace": "opentrons",
+        "version": 2,
+        "location": {
+          "slotName": "D2"
+        }
+      }
+    },
+    {
+      "key": "c5c3520f-e563-4673-8ae1-380e9294ee4d",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
+        "labwareId": "c7d7d009-192b-4890-9501-67cc37d53eea:opentrons/opentrons_flex_96_tiprack_1000ul/1",
+        "loadName": "opentrons_flex_96_tiprack_1000ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "slotName": "C3"
+        }
+      }
+    },
+    {
+      "key": "fb3af120-763e-43d9-9196-3433c35ee957",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Flex 96 Tip Rack 1000 µL (1)",
+        "labwareId": "d355d9c8-45e5-4344-9896-1e1a5cf6282b:opentrons/opentrons_flex_96_tiprack_1000ul/1",
+        "loadName": "opentrons_flex_96_tiprack_1000ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "labwareId": "61e31103-0441-44e0-bd7c-028f90eb78d3:opentrons/opentrons_flex_96_tiprack_adapter/1"
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "7513142e-a630-4f28-b62f-5918048a45e3",
+      "params": {
+        "liquidId": "1",
+        "labwareId": "df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2",
+        "volumeByWell": {
+          "A1": 10000
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "d7e9f04c-6324-4872-a0ee-b4031404a919",
+      "params": {
+        "liquidId": "0",
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "volumeByWell": {
+          "A1": 10,
+          "B1": 10,
+          "C1": 10,
+          "D1": 10,
+          "E1": 10,
+          "F1": 10,
+          "G1": 10,
+          "H1": 10
+        }
+      }
+    },
+    {
+      "commandType": "heaterShaker/deactivateHeater",
+      "key": "f255b699-bae8-4617-a5f7-af216f0573ac",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "heaterShaker/openLabwareLatch",
+      "key": "476ebad2-b99d-4979-81d9-ab692af7818b",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "thermocycler/openLid",
+      "key": "75b05913-0d47-4d46-ae43-c9159c6de14f",
+      "params": {
+        "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType"
+      }
+    },
+    {
+      "commandType": "absorbanceReader/closeLid",
+      "key": "56ca0b48-583a-4272-a59f-b53986bf5ad7",
+      "params": {
+        "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType"
+      }
+    },
+    {
+      "commandType": "absorbanceReader/initialize",
+      "key": "67a7412a-473a-4c43-9a67-80b556e76a10",
+      "params": {
+        "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType",
+        "measureMode": "single",
+        "sampleWavelengths": [
+          450
+        ]
+      }
+    },
+    {
+      "commandType": "configureNozzleLayout",
+      "key": "0fa7aed5-0c07-4a45-b79a-5f526d23c2ba",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "configurationParams": {
+          "primaryNozzle": "A12",
+          "style": "COLUMN"
+        }
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "d0016a93-80da-4181-b404-bbda8577677f",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "labwareId": "c7d7d009-192b-4890-9501-67cc37d53eea:opentrons/opentrons_flex_96_tiprack_1000ul/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "8f39f468-6243-4e06-8c19-a6cec56d9318",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "volume": 100,
+        "labwareId": "df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 1,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 160
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a815c8c3-f992-4811-bdd6-2168e7ceb739",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "volume": 100,
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 1,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 160
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "11e2b26e-808c-4ca3-8153-5ea1a59a0545",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "addressableAreaName": "96ChannelWasteChute",
+        "offset": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "5bf38642-7d65-44e3-8cde-fbfdf71fa376",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "4855759c-1edd-4499-be2a-03ac9b3a4308",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "labwareId": "c7d7d009-192b-4890-9501-67cc37d53eea:opentrons/opentrons_flex_96_tiprack_1000ul/1",
+        "wellName": "A2"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "e0625a18-a967-4d4a-9381-9a64f32269e6",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "volume": 100,
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 1,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 160
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "5a42491c-bb9e-41f0-9ee4-ac34f13b1168",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "volume": 100,
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 1,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 160,
+        "pushOut": 0
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "af315c0b-922e-42a8-b104-10df9b5eeaac",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "volume": 100,
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 1,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 160
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "9613ff55-051d-4e6c-8389-a85c73bee74e",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "volume": 100,
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 1,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 160,
+        "pushOut": 0
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "83477952-7110-4b42-ac41-0f6416970219",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd",
+        "addressableAreaName": "96ChannelWasteChute",
+        "offset": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "14029459-673a-4709-9c26-ce8239c6183b",
+      "params": {
+        "pipetteId": "3664e7f4-5090-4e29-bc2d-59b65a2a24cd"
+      }
+    },
+    {
+      "commandType": "moveLabware",
+      "key": "470b97ab-fb60-41ef-8d7b-b76eccaf3f0b",
+      "params": {
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "strategy": "usingGripper",
+        "newLocation": {
+          "moduleId": "59c015c0-0694-4f35-ac54-55162b0c0766:magneticBlockType"
+        }
+      }
+    },
+    {
+      "commandType": "waitForDuration",
+      "key": "a76f4bb7-c020-4a91-aa81-947f89744724",
+      "params": {
+        "seconds": 5,
+        "message": "Pause for 5 seconds"
+      }
+    },
+    {
+      "commandType": "moveLabware",
+      "key": "131cc16d-5b32-4eb5-a406-974ba7014f62",
+      "params": {
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "strategy": "usingGripper",
+        "newLocation": {
+          "labwareId": "774f5010-9552-49a8-8eed-7dce2445d162:opentrons/opentrons_96_pcr_adapter/1"
+        }
+      }
+    },
+    {
+      "commandType": "heaterShaker/closeLabwareLatch",
+      "key": "7a32fd3e-267b-4319-96c0-daa2ed17a5b7",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "heaterShaker/deactivateHeater",
+      "key": "89783a0e-49ea-45b8-bf76-3722c9fa9a66",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "heaterShaker/setAndWaitForShakeSpeed",
+      "key": "2f680c87-ec92-4516-8ea7-51a07f68af56",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType",
+        "rpm": 200
+      }
+    },
+    {
+      "commandType": "waitForDuration",
+      "key": "a26493ca-5734-40a8-a34c-9bcb257fe88d",
+      "params": {
+        "seconds": 5
+      }
+    },
+    {
+      "commandType": "heaterShaker/deactivateShaker",
+      "key": "2ea7fc83-9561-41ae-9111-3a21c5d468a2",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "heaterShaker/deactivateHeater",
+      "key": "2cfd5566-aaa2-4b02-9c96-d0c9ac86affe",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "heaterShaker/deactivateHeater",
+      "key": "040605ee-657d-4a87-a365-a8b48768728c",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "heaterShaker/openLabwareLatch",
+      "key": "bd0adcf4-bf4f-41bb-9e05-5cd5a692174a",
+      "params": {
+        "moduleId": "ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "absorbanceReader/openLid",
+      "key": "eadac36c-0eb3-437f-9fc5-6eb3bbcdd5af",
+      "params": {
+        "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType"
+      }
+    },
+    {
+      "commandType": "moveLabware",
+      "key": "94d410bf-44e7-42e1-b925-1ef840d2b448",
+      "params": {
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "strategy": "usingGripper",
+        "newLocation": {
+          "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType"
+        }
+      }
+    },
+    {
+      "commandType": "absorbanceReader/closeLid",
+      "key": "5cae2b5d-2ec3-42cc-b94f-6f1925e4618d",
+      "params": {
+        "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType"
+      }
+    },
+    {
+      "commandType": "absorbanceReader/read",
+      "key": "bdf46892-ba13-43ee-a095-2119b6e5c341",
+      "params": {
+        "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType",
+        "fileName": "testPlateReaderFile"
+      }
+    },
+    {
+      "commandType": "absorbanceReader/openLid",
+      "key": "dea1cb58-7998-45e3-ad48-f9e804549a41",
+      "params": {
+        "moduleId": "7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType"
+      }
+    },
+    {
+      "commandType": "moveLabware",
+      "key": "e9d9c703-786f-4169-a630-fc28d79af78f",
+      "params": {
+        "labwareId": "806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3",
+        "strategy": "usingGripper",
+        "newLocation": {
+          "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType"
+        }
+      }
+    },
+    {
+      "commandType": "thermocycler/closeLid",
+      "key": "49757023-6763-4bcc-bf5b-71446f5036b8",
+      "params": {
+        "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType"
+      }
+    },
+    {
+      "commandType": "thermocycler/setTargetLidTemperature",
+      "key": "24c8d2e8-132d-445d-a5ea-eb210085fc7d",
+      "params": {
+        "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType",
+        "celsius": 40
+      }
+    },
+    {
+      "commandType": "thermocycler/waitForLidTemperature",
+      "key": "81dfb608-32bc-4ebb-b8c2-ab63042f07cd",
+      "params": {
+        "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType"
+      }
+    },
+    {
+      "commandType": "thermocycler/runProfile",
+      "key": "7d0c47bf-0cd3-4438-b8a6-d5b11304c7ea",
+      "params": {
+        "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType",
+        "profile": [
+          {
+            "holdSeconds": 5,
+            "celsius": 30
+          },
+          {
+            "holdSeconds": 5,
+            "celsius": 32
+          },
+          {
+            "holdSeconds": 5,
+            "celsius": 30
+          },
+          {
+            "holdSeconds": 5,
+            "celsius": 32
+          }
+        ],
+        "blockMaxVolumeUl": 10
+      }
+    },
+    {
+      "commandType": "thermocycler/deactivateBlock",
+      "key": "c0ecd9ea-5100-44c6-8c68-9a44eabbfd62",
+      "params": {
+        "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType"
+      }
+    },
+    {
+      "commandType": "thermocycler/deactivateLid",
+      "key": "83ee18fe-b156-4622-a2b2-f3d1821e7350",
+      "params": {
+        "moduleId": "e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType"
+      }
+    }
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": []
+}

--- a/api/tests/interop/__pd_protocols__/demo_day.py
+++ b/api/tests/interop/__pd_protocols__/demo_day.py
@@ -1,0 +1,194 @@
+import json
+from contextlib import nullcontext as pd_step
+from opentrons import protocol_api, types
+
+metadata = {
+    "protocolName": "Demo_3.27.25",
+    "description": "PD py export for Demo day",
+    "created": "2025-03-26T16:19:35.337Z",
+    "lastModified": "2025-05-01T19:52:23.926Z",
+    "protocolDesigner": "8.4.4-alpha.0",
+    "source": "Protocol Designer",
+}
+
+requirements = {
+    "robotType": "Flex",
+    "apiLevel": "2.24",
+}
+
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    # Load Modules:
+    absorbance_reader_1 = protocol.load_module("absorbanceReaderV1", "B3")
+    thermocycler_module_1 = protocol.load_module("thermocyclerModuleV2", "B1")
+    magnetic_block_1 = protocol.load_module("magneticBlockV1", "A3")
+    temperature_module_1 = protocol.load_module("temperatureModuleV2", "D1")
+    heater_shaker_module_1 = protocol.load_module("heaterShakerModuleV1", "C1")
+
+    # Load Adapters:
+    aluminum_block_1 = temperature_module_1.load_adapter(
+        "opentrons_96_well_aluminum_block",
+        namespace="opentrons",
+        version=1,
+    )
+    adapter_1 = heater_shaker_module_1.load_adapter(
+        "opentrons_96_pcr_adapter",
+        namespace="opentrons",
+        version=1,
+    )
+    adapter_2 = protocol.load_adapter(
+        "opentrons_flex_96_tiprack_adapter",
+        location="A2",
+        namespace="opentrons",
+        version=1,
+    )
+
+    # Load Labware:
+    well_plate_1 = aluminum_block_1.load_labware(
+        "opentrons_96_wellplate_200ul_pcr_full_skirt",
+        namespace="opentrons",
+        version=3,
+    )
+    reservoir_1 = protocol.load_labware(
+        "nest_12_reservoir_15ml",
+        location="D2",
+        namespace="opentrons",
+        version=2,
+    )
+    tip_rack_1 = protocol.load_labware(
+        "opentrons_flex_96_tiprack_1000ul",
+        location="C3",
+        namespace="opentrons",
+        version=1,
+    )
+    tip_rack_2 = adapter_2.load_labware(
+        "opentrons_flex_96_tiprack_1000ul",
+        label="Opentrons Flex 96 Tip Rack 1000 µL (1)",
+        namespace="opentrons",
+        version=1,
+    )
+
+    # Load Pipettes:
+    pipette = protocol.load_instrument(
+        "flex_96channel_1000", tip_racks=[tip_rack_1, tip_rack_2]
+    )
+
+    # Load Waste Chute:
+    waste_chute = protocol.load_waste_chute()
+
+    # Define Liquids:
+    liquid_1 = protocol.define_liquid(
+        "h20",
+        description="water",
+        display_color="#b925ff",
+    )
+    liquid_2 = protocol.define_liquid(
+        "Wash buffer",
+        description="to mix with",
+        display_color="#ffd600",
+    )
+
+    # Load Liquids:
+    well_plate_1["A1"].load_liquid(liquid_1, 10)
+    well_plate_1["B1"].load_liquid(liquid_1, 10)
+    well_plate_1["C1"].load_liquid(liquid_1, 10)
+    well_plate_1["D1"].load_liquid(liquid_1, 10)
+    well_plate_1["E1"].load_liquid(liquid_1, 10)
+    well_plate_1["F1"].load_liquid(liquid_1, 10)
+    well_plate_1["G1"].load_liquid(liquid_1, 10)
+    well_plate_1["H1"].load_liquid(liquid_1, 10)
+    reservoir_1["A1"].load_liquid(liquid_2, 10000)
+
+    # PROTOCOL STEPS
+
+    # Step 1:
+    heater_shaker_module_1.deactivate_heater()
+    heater_shaker_module_1.open_labware_latch()
+
+    # Step 2:
+    thermocycler_module_1.open_lid()
+
+    # Step 3:
+    absorbance_reader_1.close_lid()
+    absorbance_reader_1.initialize("single", [450])
+
+    # Step 4:
+    pipette.configure_nozzle_layout(protocol_api.COLUMN, start="A12")
+    pipette.pick_up_tip(location=tip_rack_1)
+    pipette.aspirate(
+        volume=100,
+        location=reservoir_1["A1"].bottom(z=1),
+        rate=160 / pipette.flow_rate.aspirate,
+    )
+    pipette.dispense(
+        volume=100,
+        location=well_plate_1["A1"].bottom(z=1),
+        rate=160 / pipette.flow_rate.dispense,
+    )
+    pipette.drop_tip(waste_chute)
+
+    # Step 5:
+    pipette.pick_up_tip(location=tip_rack_1)
+    pipette.flow_rate.aspirate = 160
+    pipette.flow_rate.dispense = 160
+    pipette.mix(
+        repetitions=2,
+        volume=100,
+        location=well_plate_1["A1"].bottom(z=1),
+        final_push_out=0,
+    )
+    pipette.drop_tip(waste_chute)
+
+    # Step 6:
+    protocol.move_labware(well_plate_1, magnetic_block_1, use_gripper=True)
+
+    # Step 7:
+    protocol.delay(seconds=5, msg="Pause for 5 seconds")
+
+    # Step 8:
+    protocol.move_labware(well_plate_1, adapter_1, use_gripper=True)
+
+    # Step 9:
+    heater_shaker_module_1.close_labware_latch()
+    heater_shaker_module_1.deactivate_heater()
+    heater_shaker_module_1.set_and_wait_for_shake_speed(200)
+    protocol.delay(seconds=5)
+    heater_shaker_module_1.deactivate_shaker()
+    heater_shaker_module_1.deactivate_heater()
+
+    # Step 10:
+    heater_shaker_module_1.deactivate_heater()
+    heater_shaker_module_1.open_labware_latch()
+
+    # Step 11:
+    absorbance_reader_1.open_lid()
+
+    # Step 12:
+    protocol.move_labware(well_plate_1, absorbance_reader_1, use_gripper=True)
+
+    # Step 13:
+    absorbance_reader_1.close_lid()
+    absorbance_reader_1.read(export_filename="testPlateReaderFile")
+
+    # Step 14:
+    absorbance_reader_1.open_lid()
+
+    # Step 15:
+    protocol.move_labware(well_plate_1, thermocycler_module_1, use_gripper=True)
+
+    # Step 16:
+    thermocycler_module_1.close_lid()
+    thermocycler_module_1.set_lid_temperature(40)
+    thermocycler_module_1.execute_profile(
+        [
+            {"temperature": 30, "hold_time_seconds": 5},
+            {"temperature": 32, "hold_time_seconds": 5},
+        ],
+        2,
+        block_max_volume=10,
+    )
+    thermocycler_module_1.deactivate_block()
+    thermocycler_module_1.deactivate_lid()
+
+
+DESIGNER_APPLICATION = """{"robot":{"model":"OT-3 Standard"},"designerApplication":{"name":"opentrons/protocol-designer","version":"8.5.0","data":{"pipetteTiprackAssignments":{"3664e7f4-5090-4e29-bc2d-59b65a2a24cd":["opentrons/opentrons_flex_96_tiprack_1000ul/1"]},"dismissedWarnings":{"form":[],"timeline":[]},"ingredients":{"0":{"displayName":"h20","description":"water","displayColor":"#b925ff","liquidGroupId":"0"},"1":{"displayName":"Wash buffer","description":"to mix with","displayColor":"#ffd600","liquidGroupId":"1"}},"ingredLocations":{"806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3":{"A1":{"0":{"volume":10}},"B1":{"0":{"volume":10}},"C1":{"0":{"volume":10}},"D1":{"0":{"volume":10}},"E1":{"0":{"volume":10}},"F1":{"0":{"volume":10}},"G1":{"0":{"volume":10}},"H1":{"0":{"volume":10}}},"df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2":{"A1":{"1":{"volume":10000}}}},"savedStepForms":{"__INITIAL_DECK_SETUP_STEP__":{"labwareLocationUpdate":{"325368d0-9394-4bd2-8a0b-7473b1447922:opentrons/opentrons_96_well_aluminum_block/1":"b7cad88e-0442-432e-aa0b-e674e46db433:temperatureModuleType","806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3":"325368d0-9394-4bd2-8a0b-7473b1447922:opentrons/opentrons_96_well_aluminum_block/1","774f5010-9552-49a8-8eed-7dce2445d162:opentrons/opentrons_96_pcr_adapter/1":"ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType","df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2":"D2","c7d7d009-192b-4890-9501-67cc37d53eea:opentrons/opentrons_flex_96_tiprack_1000ul/1":"C3","61e31103-0441-44e0-bd7c-028f90eb78d3:opentrons/opentrons_flex_96_tiprack_adapter/1":"A2","d355d9c8-45e5-4344-9896-1e1a5cf6282b:opentrons/opentrons_flex_96_tiprack_1000ul/1":"61e31103-0441-44e0-bd7c-028f90eb78d3:opentrons/opentrons_flex_96_tiprack_adapter/1"},"moduleLocationUpdate":{"7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType":"B3","e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType":"B1","59c015c0-0694-4f35-ac54-55162b0c0766:magneticBlockType":"A3","b7cad88e-0442-432e-aa0b-e674e46db433:temperatureModuleType":"D1","ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType":"C1"},"pipetteLocationUpdate":{"3664e7f4-5090-4e29-bc2d-59b65a2a24cd":"left"},"trashBinLocationUpdate":{},"wasteChuteLocationUpdate":{"5eb8a110-22fd-4d96-a5bc-d408289f44b3:wasteChute":"cutoutD3"},"stagingAreaLocationUpdate":{},"gripperLocationUpdate":{"6d122c41-8880-446e-a810-25ee0380888b:gripper":"mounted"},"stepType":"manualIntervention","id":"__INITIAL_DECK_SETUP_STEP__"},"09a5e999-33a4-4ad7-baa4-072878b80775":{"heaterShakerSetTimer":null,"heaterShakerTimer":null,"latchOpen":true,"moduleId":"ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType","setHeaterShakerTemperature":null,"setShake":null,"targetHeaterShakerTemperature":null,"targetSpeed":null,"id":"09a5e999-33a4-4ad7-baa4-072878b80775","stepType":"heaterShaker","stepName":"heater-shaker","stepDetails":""},"eb76e6c9-1846-4539-b472-387a92053033":{"blockIsActive":false,"blockIsActiveHold":false,"blockTargetTemp":null,"blockTargetTempHold":null,"lidIsActive":false,"lidIsActiveHold":false,"lidOpen":true,"lidOpenHold":null,"lidTargetTemp":null,"lidTargetTempHold":null,"moduleId":"e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType","orderedProfileItems":[],"profileItemsById":{},"profileTargetLidTemp":null,"profileVolume":null,"thermocyclerFormType":"thermocyclerState","id":"eb76e6c9-1846-4539-b472-387a92053033","stepType":"thermocycler","stepName":"thermocycler","stepDetails":""},"27576b03-c247-4e2e-9ab0-38e895fff6ed":{"absorbanceReaderFormType":"absorbanceReaderInitialize","fileName":null,"lidOpen":null,"mode":"single","moduleId":"7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType","referenceWavelength":null,"referenceWavelengthActive":false,"wavelengths":["450"],"id":"27576b03-c247-4e2e-9ab0-38e895fff6ed","stepType":"absorbanceReader","stepName":"absorbance plate reader","stepDetails":""},"a67256c4-264e-4ee4-b54d-e6067427f702":{"aspirate_airGap_checkbox":false,"aspirate_airGap_volume":null,"aspirate_delay_checkbox":false,"aspirate_delay_mmFromBottom":null,"aspirate_delay_seconds":"1","aspirate_flowRate":"160","aspirate_labware":"df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2","aspirate_mix_checkbox":false,"aspirate_mix_times":null,"aspirate_mix_volume":null,"aspirate_mmFromBottom":null,"aspirate_position_reference":null,"aspirate_retract_delay_seconds":null,"aspirate_retract_mmFromBottom":null,"aspirate_retract_speed":null,"aspirate_retract_x_position":0,"aspirate_retract_y_position":0,"aspirate_retract_position_reference":null,"aspirate_submerge_delay_seconds":null,"aspirate_submerge_speed":null,"aspirate_submerge_mmFromBottom":null,"aspirate_submerge_x_position":null,"aspirate_submerge_y_position":null,"aspirate_submerge_position_reference":null,"aspirate_touchTip_checkbox":false,"aspirate_touchTip_mmFromTop":null,"aspirate_touchTip_speed":null,"aspirate_touchTip_mmFromEdge":0,"aspirate_wellOrder_first":"t2b","aspirate_wellOrder_second":"l2r","aspirate_wells_grouped":false,"aspirate_wells":["A1"],"aspirate_x_position":0,"aspirate_y_position":0,"blowout_checkbox":false,"blowout_flowRate":null,"blowout_location":null,"blowout_z_offset":0,"changeTip":"always","conditioning_checkbox":false,"conditioning_volume":null,"dispense_airGap_checkbox":false,"dispense_airGap_volume":null,"dispense_delay_checkbox":false,"dispense_delay_mmFromBottom":null,"dispense_delay_seconds":"1","dispense_flowRate":null,"dispense_labware":"806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3","dispense_mix_checkbox":false,"dispense_mix_times":null,"dispense_mix_volume":null,"dispense_mmFromBottom":null,"dispense_position_reference":null,"dispense_retract_delay_seconds":null,"dispense_retract_mmFromBottom":null,"dispense_retract_speed":null,"dispense_retract_x_position":0,"dispense_retract_y_position":0,"dispense_retract_position_reference":null,"dispense_submerge_delay_seconds":null,"dispense_submerge_speed":null,"dispense_submerge_mmFromBottom":null,"dispense_submerge_x_position":null,"dispense_submerge_y_position":null,"dispense_submerge_position_reference":null,"dispense_touchTip_checkbox":false,"dispense_touchTip_mmFromTop":null,"dispense_touchTip_speed":null,"dispense_touchTip_mmFromEdge":0,"dispense_wellOrder_first":"t2b","dispense_wellOrder_second":"l2r","dispense_wells":["A1"],"dispense_x_position":0,"dispense_y_position":0,"disposalVolume_checkbox":true,"disposalVolume_volume":null,"dropTip_location":"5eb8a110-22fd-4d96-a5bc-d408289f44b3:wasteChute","liquidClassesSupported":true,"liquidClass":null,"nozzles":"COLUMN","path":"single","pipette":"3664e7f4-5090-4e29-bc2d-59b65a2a24cd","preWetTip":false,"pushOut_checkbox":true,"pushOut_volume":20,"tipRack":"opentrons/opentrons_flex_96_tiprack_1000ul/1","volume":"100","stepType":"moveLiquid","stepName":"transfer","stepDetails":"","id":"a67256c4-264e-4ee4-b54d-e6067427f702","dispense_touchTip_mmfromTop":null},"717a98db-eb91-4858-a64c-4f9010c0fd19":{"aspirate_delay_checkbox":false,"aspirate_delay_seconds":"1","aspirate_flowRate":"160","blowout_checkbox":false,"blowout_flowRate":null,"blowout_location":null,"blowout_z_offset":0,"changeTip":"always","dispense_delay_checkbox":false,"dispense_delay_seconds":"1","dispense_flowRate":null,"dropTip_location":"5eb8a110-22fd-4d96-a5bc-d408289f44b3:wasteChute","labware":"806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3","liquidClassesSupported":true,"liquidClass":"none","mix_mmFromBottom":1,"mix_touchTip_checkbox":false,"mix_touchTip_mmFromTop":null,"mix_wellOrder_first":"t2b","mix_wellOrder_second":"l2r","mix_position_reference":null,"mix_x_position":0,"mix_y_position":0,"nozzles":"COLUMN","pipette":"3664e7f4-5090-4e29-bc2d-59b65a2a24cd","pushOut_checkbox":null,"pushOut_volume":null,"times":"2","tipRack":"opentrons/opentrons_flex_96_tiprack_1000ul/1","volume":"100","wells":["A1"],"stepType":"mix","stepName":"mix","stepDetails":"","id":"717a98db-eb91-4858-a64c-4f9010c0fd19"},"ba365819-ed80-4ab3-a2b7-afa1e6b0169d":{"labware":"806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3","newLocation":"59c015c0-0694-4f35-ac54-55162b0c0766:magneticBlockType","useGripper":true,"id":"ba365819-ed80-4ab3-a2b7-afa1e6b0169d","stepType":"moveLabware","stepName":"move","stepDetails":""},"213ac071-714f-4484-88a2-2732153a9ea9":{"moduleId":null,"pauseAction":"untilTime","pauseMessage":"Pause for 5 seconds","pauseTemperature":null,"pauseTime":"00:00:05","id":"213ac071-714f-4484-88a2-2732153a9ea9","stepType":"pause","stepName":"pause","stepDetails":""},"07026308-39fb-442b-8df4-f821a639dc3b":{"labware":"806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3","newLocation":"774f5010-9552-49a8-8eed-7dce2445d162:opentrons/opentrons_96_pcr_adapter/1","useGripper":true,"id":"07026308-39fb-442b-8df4-f821a639dc3b","stepType":"moveLabware","stepName":"move","stepDetails":""},"124625d8-52aa-4e2b-87bd-1b8584baa2ae":{"heaterShakerSetTimer":true,"heaterShakerTimer":"00:05","latchOpen":false,"moduleId":"ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType","setHeaterShakerTemperature":null,"setShake":true,"targetHeaterShakerTemperature":null,"targetSpeed":"200","id":"124625d8-52aa-4e2b-87bd-1b8584baa2ae","stepType":"heaterShaker","stepName":"heater-shaker","stepDetails":""},"15d135a3-b12b-46e6-b5b7-5188249a3926":{"heaterShakerSetTimer":null,"heaterShakerTimer":null,"latchOpen":true,"moduleId":"ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType","setHeaterShakerTemperature":null,"setShake":null,"targetHeaterShakerTemperature":null,"targetSpeed":null,"id":"15d135a3-b12b-46e6-b5b7-5188249a3926","stepType":"heaterShaker","stepName":"heater-shaker","stepDetails":""},"ba37127c-38b3-4a1f-adf7-9906a973fdc7":{"labware":"806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3","newLocation":"7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType","useGripper":true,"id":"ba37127c-38b3-4a1f-adf7-9906a973fdc7","stepType":"moveLabware","stepName":"move","stepDetails":""},"9732f6dc-6538-49b5-80e8-b7b62b53c6a7":{"absorbanceReaderFormType":"absorbanceReaderLid","fileName":null,"lidOpen":true,"mode":"single","moduleId":"7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType","referenceWavelength":null,"referenceWavelengthActive":false,"wavelengths":["450"],"id":"9732f6dc-6538-49b5-80e8-b7b62b53c6a7","stepType":"absorbanceReader","stepName":"absorbance plate reader","stepDetails":""},"b12aff9e-51be-4e52-a031-4babbdd30016":{"absorbanceReaderFormType":"absorbanceReaderRead","fileName":"testPlateReaderFile","lidOpen":null,"mode":"single","moduleId":"7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType","referenceWavelength":null,"referenceWavelengthActive":false,"wavelengths":["450"],"id":"b12aff9e-51be-4e52-a031-4babbdd30016","stepType":"absorbanceReader","stepName":"absorbance plate reader","stepDetails":""},"c75f3fb5-0368-4fc2-8e4e-a402ebba49a8":{"absorbanceReaderFormType":"absorbanceReaderLid","fileName":null,"lidOpen":true,"mode":"single","moduleId":"7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType","referenceWavelength":null,"referenceWavelengthActive":false,"wavelengths":["450"],"id":"c75f3fb5-0368-4fc2-8e4e-a402ebba49a8","stepType":"absorbanceReader","stepName":"absorbance plate reader","stepDetails":""},"ab02b3d3-b6dc-4509-b05f-8ddffb668c47":{"labware":"806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3","newLocation":"e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType","useGripper":true,"id":"ab02b3d3-b6dc-4509-b05f-8ddffb668c47","stepType":"moveLabware","stepName":"move","stepDetails":""},"befa85f7-e3f1-4512-a8a1-5cacf2cd7008":{"blockIsActive":false,"blockIsActiveHold":false,"blockTargetTemp":null,"blockTargetTempHold":null,"lidIsActive":false,"lidIsActiveHold":false,"lidOpen":false,"lidOpenHold":null,"lidTargetTemp":null,"lidTargetTempHold":null,"moduleId":"e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType","orderedProfileItems":["324fab35-8982-4d99-8e12-d19dd8945c2b"],"profileItemsById":{"324fab35-8982-4d99-8e12-d19dd8945c2b":{"id":"324fab35-8982-4d99-8e12-d19dd8945c2b","title":"","steps":[{"durationMinutes":"00","durationSeconds":"05","id":"5fe485c7-9e44-4ba1-94a9-1767be13969c","temperature":"30","title":"step 1","type":"profileStep"},{"durationMinutes":"00","durationSeconds":"05","id":"446dad12-9789-433e-9a93-04fb0887a3d2","temperature":"32","title":"step 2","type":"profileStep"}],"type":"profileCycle","repetitions":"2"}},"profileTargetLidTemp":"40","profileVolume":"10","thermocyclerFormType":"thermocyclerProfile","id":"befa85f7-e3f1-4512-a8a1-5cacf2cd7008","stepType":"thermocycler","stepName":"thermocycler","stepDetails":""}},"orderedStepIds":["09a5e999-33a4-4ad7-baa4-072878b80775","eb76e6c9-1846-4539-b472-387a92053033","27576b03-c247-4e2e-9ab0-38e895fff6ed","a67256c4-264e-4ee4-b54d-e6067427f702","717a98db-eb91-4858-a64c-4f9010c0fd19","ba365819-ed80-4ab3-a2b7-afa1e6b0169d","213ac071-714f-4484-88a2-2732153a9ea9","07026308-39fb-442b-8df4-f821a639dc3b","124625d8-52aa-4e2b-87bd-1b8584baa2ae","15d135a3-b12b-46e6-b5b7-5188249a3926","9732f6dc-6538-49b5-80e8-b7b62b53c6a7","ba37127c-38b3-4a1f-adf7-9906a973fdc7","b12aff9e-51be-4e52-a031-4babbdd30016","c75f3fb5-0368-4fc2-8e4e-a402ebba49a8","ab02b3d3-b6dc-4509-b05f-8ddffb668c47","befa85f7-e3f1-4512-a8a1-5cacf2cd7008"],"pipettes":{"3664e7f4-5090-4e29-bc2d-59b65a2a24cd":{"pipetteName":"p1000_96"}},"modules":{"7f0722a7-d295-4249-bd9f-a63b865e6dc9:absorbanceReaderType":{"model":"absorbanceReaderV1"},"e1c14ad3-0715-4159-8e22-160f9189c8fb:thermocyclerModuleType":{"model":"thermocyclerModuleV2"},"59c015c0-0694-4f35-ac54-55162b0c0766:magneticBlockType":{"model":"magneticBlockV1"},"b7cad88e-0442-432e-aa0b-e674e46db433:temperatureModuleType":{"model":"temperatureModuleV2"},"ebf227c5-aa8b-47ac-97a6-28a4b3d05544:heaterShakerModuleType":{"model":"heaterShakerModuleV1"}},"labware":{"325368d0-9394-4bd2-8a0b-7473b1447922:opentrons/opentrons_96_well_aluminum_block/1":{"displayName":"Opentrons 96 Well Aluminum Block","labwareDefURI":"opentrons/opentrons_96_well_aluminum_block/1"},"774f5010-9552-49a8-8eed-7dce2445d162:opentrons/opentrons_96_pcr_adapter/1":{"displayName":"Opentrons 96 PCR Heater-Shaker Adapter","labwareDefURI":"opentrons/opentrons_96_pcr_adapter/1"},"61e31103-0441-44e0-bd7c-028f90eb78d3:opentrons/opentrons_flex_96_tiprack_adapter/1":{"displayName":"Opentrons Flex 96 Tip Rack Adapter","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_adapter/1"},"806d2d10-dc9e-42e6-bbda-92db70b5536f:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3":{"displayName":"Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt","labwareDefURI":"opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/3"},"df710585-aa6a-4cdc-9617-56e07a4c971c:opentrons/nest_12_reservoir_15ml/2":{"displayName":"NEST 12 Well Reservoir 15 mL","labwareDefURI":"opentrons/nest_12_reservoir_15ml/2"},"c7d7d009-192b-4890-9501-67cc37d53eea:opentrons/opentrons_flex_96_tiprack_1000ul/1":{"displayName":"Opentrons Flex 96 Tip Rack 1000 µL","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_1000ul/1"},"d355d9c8-45e5-4344-9896-1e1a5cf6282b:opentrons/opentrons_flex_96_tiprack_1000ul/1":{"displayName":"Opentrons Flex 96 Tip Rack 1000 µL (1)","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_1000ul/1"}}}},"metadata":{"protocolName":"Demo_3.27.25","author":"","description":"PD py export for Demo day","created":1743005975337,"lastModified":1746129143926,"source":"Protocol Designer","category":null,"subcategory":null,"tags":[]}}"""

--- a/api/tests/interop/__pd_protocols__/hypothetical_lc_transfer.py
+++ b/api/tests/interop/__pd_protocols__/hypothetical_lc_transfer.py
@@ -52,7 +52,7 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
 
     # This hypothetical transfer_with_liquid_class() call (which PD doesn't emit yet)
     # should produce the same engine commands as the PD JSON step generator.
-    liquid_class = protocol.define_liquid_class("ethanol_80")
+    liquid_class = protocol.get_liquid_class("ethanol_80")
     pipette_left.transfer_with_liquid_class(
         liquid_class=liquid_class,
         volume=99,

--- a/api/tests/interop/__pd_protocols__/hypothetical_lc_transfer.py
+++ b/api/tests/interop/__pd_protocols__/hypothetical_lc_transfer.py
@@ -1,0 +1,65 @@
+import json
+from contextlib import nullcontext as pd_step
+from opentrons import protocol_api, types
+
+metadata = {
+    "protocolName": "Hypothetical Liquid Class Transfer",
+    "created": "2025-05-01T20:38:02.936Z",
+    "lastModified": "2025-05-02T02:12:58.677Z",
+    "protocolDesigner": "8.4.4-alpha.0",
+    "source": "Protocol Designer",
+}
+
+requirements = {
+    "robotType": "Flex",
+    "apiLevel": "2.24",
+}
+
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    # Load Labware:
+    tip_rack_1 = protocol.load_labware(
+        "opentrons_flex_96_tiprack_50ul",
+        location="C2",
+        namespace="opentrons",
+        version=1,
+    )
+    well_plate_1 = protocol.load_labware(
+        "corning_96_wellplate_360ul_flat",
+        location="D1",
+        namespace="opentrons",
+        version=3,
+    )
+
+    # Load Pipettes:
+    pipette_left = protocol.load_instrument(
+        "flex_1channel_50", "left", tip_racks=[tip_rack_1]
+    )
+
+    # Load Trash Bins:
+    trash_bin_1 = protocol.load_trash_bin("A3")
+
+    # Define Liquids:
+    liquid_1 = protocol.define_liquid(
+        "Vodka",
+        display_color="#ffd600ff",
+    )
+
+    # Load Liquids:
+    well_plate_1["A1"].load_liquid(liquid_1, 350)
+
+    # PROTOCOL STEPS
+
+    # This hypothetical transfer_with_liquid_class() call (which PD doesn't emit yet)
+    # should produce the same engine commands as the PD JSON step generator.
+    liquid_class = protocol.define_liquid_class("ethanol_80")
+    pipette_left.transfer_with_liquid_class(
+        liquid_class=liquid_class,
+        volume=99,
+        source=well_plate_1["A1"],
+        dest=well_plate_1["H1"],
+        new_tip="per source",
+    )
+
+
+DESIGNER_APPLICATION = """{"robot":{"model":"OT-3 Standard"},"designerApplication":{"name":"opentrons/protocol-designer","version":"8.5.0","data":{"pipetteTiprackAssignments":{"203c0e99-386f-4742-aac6-5cf1d2bcd9a4":["opentrons/opentrons_flex_96_tiprack_50ul/1"]},"dismissedWarnings":{"form":[],"timeline":[]},"ingredients":{"0":{"displayName":"Vodka","displayColor":"#ffd600ff","liquidClass":"ethanol80V1","description":null,"liquidGroupId":"0"}},"ingredLocations":{"5cbbb6da-439e-44f6-bcd8-45c8c8e0d673:opentrons/corning_96_wellplate_360ul_flat/3":{"A1":{"0":{"volume":350}}}},"savedStepForms":{"__INITIAL_DECK_SETUP_STEP__":{"labwareLocationUpdate":{"5e9f9199-2c43-4222-9482-cae33f17504d:opentrons/opentrons_flex_96_tiprack_50ul/1":"C2","5cbbb6da-439e-44f6-bcd8-45c8c8e0d673:opentrons/corning_96_wellplate_360ul_flat/3":"D1"},"moduleLocationUpdate":{},"pipetteLocationUpdate":{"203c0e99-386f-4742-aac6-5cf1d2bcd9a4":"left"},"trashBinLocationUpdate":{"a3ad8187-1ccc-47f4-b8bf-e274a95db917:trashBin":"cutoutA3"},"wasteChuteLocationUpdate":{},"stagingAreaLocationUpdate":{},"gripperLocationUpdate":{},"stepType":"manualIntervention","id":"__INITIAL_DECK_SETUP_STEP__"},"5e372c6c-19a3-4b4a-80d9-c333462d06b1":{"id":"5e372c6c-19a3-4b4a-80d9-c333462d06b1","stepType":"moveLiquid","stepName":"transfer","stepDetails":"","aspirate_airGap_checkbox":false,"aspirate_airGap_volume":null,"aspirate_delay_checkbox":true,"aspirate_delay_mmFromBottom":null,"aspirate_delay_seconds":"0.2","aspirate_flowRate":"29.7","aspirate_labware":"5cbbb6da-439e-44f6-bcd8-45c8c8e0d673:opentrons/corning_96_wellplate_360ul_flat/3","aspirate_mix_checkbox":false,"aspirate_mix_times":"1","aspirate_mix_volume":"50","aspirate_mmFromBottom":2,"aspirate_position_reference":"well-bottom","aspirate_retract_delay_seconds":"0.5","aspirate_retract_mmFromBottom":2,"aspirate_retract_speed":"100","aspirate_retract_x_position":0,"aspirate_retract_y_position":0,"aspirate_retract_position_reference":"well-top","aspirate_submerge_delay_seconds":"0","aspirate_submerge_speed":"100","aspirate_submerge_mmFromBottom":2,"aspirate_submerge_x_position":0,"aspirate_submerge_y_position":0,"aspirate_submerge_position_reference":"well-top","aspirate_touchTip_checkbox":false,"aspirate_touchTip_mmFromTop":-1,"aspirate_touchTip_speed":"30","aspirate_touchTip_mmFromEdge":"0.5","aspirate_wellOrder_first":"t2b","aspirate_wellOrder_second":"l2r","aspirate_wells_grouped":false,"aspirate_wells":["A1"],"aspirate_x_position":0,"aspirate_y_position":0,"blowout_checkbox":false,"blowout_flowRate":null,"blowout_location":null,"blowout_z_offset":0,"changeTip":"perSource","conditioning_checkbox":true,"conditioning_volume":"5","dispense_airGap_checkbox":false,"dispense_airGap_volume":"","dispense_delay_checkbox":true,"dispense_delay_mmFromBottom":null,"dispense_delay_seconds":"0.2","dispense_flowRate":"30","dispense_labware":"5cbbb6da-439e-44f6-bcd8-45c8c8e0d673:opentrons/corning_96_wellplate_360ul_flat/3","dispense_mix_checkbox":false,"dispense_mix_times":"1","dispense_mix_volume":"50","dispense_mmFromBottom":2,"dispense_position_reference":"well-top","dispense_retract_delay_seconds":"0.5","dispense_retract_mmFromBottom":2,"dispense_retract_speed":"100","dispense_retract_x_position":0,"dispense_retract_y_position":0,"dispense_retract_position_reference":"well-top","dispense_submerge_delay_seconds":"0","dispense_submerge_speed":"100","dispense_submerge_mmFromBottom":2,"dispense_submerge_x_position":0,"dispense_submerge_y_position":0,"dispense_submerge_position_reference":"well-top","dispense_touchTip_checkbox":false,"dispense_touchTip_mmFromTop":-1,"dispense_touchTip_speed":"30","dispense_touchTip_mmFromEdge":"0.5","dispense_wellOrder_first":"t2b","dispense_wellOrder_second":"l2r","dispense_wells":["H1"],"dispense_x_position":0,"dispense_y_position":0,"disposalVolume_checkbox":true,"disposalVolume_volume":"5","dropTip_location":"a3ad8187-1ccc-47f4-b8bf-e274a95db917:trashBin","liquidClassesSupported":true,"liquidClass":"ethanol80V1","nozzles":null,"path":"single","pipette":"203c0e99-386f-4742-aac6-5cf1d2bcd9a4","preWetTip":false,"pushOut_checkbox":true,"pushOut_volume":"1","tipRack":"opentrons/opentrons_flex_96_tiprack_50ul/1","volume":"99"}},"orderedStepIds":["5e372c6c-19a3-4b4a-80d9-c333462d06b1"],"pipettes":{"203c0e99-386f-4742-aac6-5cf1d2bcd9a4":{"pipetteName":"p50_single_flex"}},"modules":{},"labware":{"5e9f9199-2c43-4222-9482-cae33f17504d:opentrons/opentrons_flex_96_tiprack_50ul/1":{"displayName":"Opentrons Flex 96 Tip Rack 50 µL","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_50ul/1"},"5cbbb6da-439e-44f6-bcd8-45c8c8e0d673:opentrons/corning_96_wellplate_360ul_flat/3":{"displayName":"Corning 96 Well Plate 360 µL Flat","labwareDefURI":"opentrons/corning_96_wellplate_360ul_flat/3"}}}},"metadata":{"protocolName":"Hypothetical Liquid Class Transfer","author":"","description":"","created":1746131882936,"lastModified":1746151978677,"source":"Protocol Designer","category":null,"subcategory":null,"tags":[]}}"""

--- a/api/tests/interop/__pd_protocols__/simple_transfer.json
+++ b/api/tests/interop/__pd_protocols__/simple_transfer.json
@@ -1,0 +1,2954 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Simple Transfer",
+    "author": "",
+    "description": "",
+    "created": 1746130262969,
+    "lastModified": 1746131272734,
+    "source": "Protocol Designer",
+    "category": null,
+    "subcategory": null,
+    "tags": []
+  },
+  "designerApplication": {
+    "name": "opentrons/protocol-designer",
+    "version": "8.4.4-alpha.0",
+    "data": {
+      "_internalAppBuildDate": "Thu, 01 May 2025 19:46:48 GMT",
+      "pipetteTiprackAssignments": {
+        "cc20dc01-30ee-41ff-807a-a5eb3208a335": [
+          "opentrons/opentrons_flex_96_tiprack_50ul/1"
+        ]
+      },
+      "dismissedWarnings": {
+        "form": [],
+        "timeline": []
+      },
+      "ingredients": {
+        "0": {
+          "displayName": "Apple juice",
+          "description": null,
+          "displayColor": "#ffd600ff",
+          "liquidGroupId": "0"
+        }
+      },
+      "ingredLocations": {
+        "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3": {
+          "A1": {
+            "0": {
+              "volume": 200
+            }
+          },
+          "A2": {
+            "0": {
+              "volume": 200
+            }
+          }
+        }
+      },
+      "savedStepForms": {
+        "__INITIAL_DECK_SETUP_STEP__": {
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__",
+          "labwareLocationUpdate": {
+            "72f476a9-0d27-446d-9f59-b15ed5a88ebe:opentrons/opentrons_flex_96_tiprack_50ul/1": "C2",
+            "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3": "D1"
+          },
+          "pipetteLocationUpdate": {
+            "cc20dc01-30ee-41ff-807a-a5eb3208a335": "left"
+          },
+          "moduleLocationUpdate": {},
+          "trashBinLocationUpdate": {
+            "447f9dee-5502-4cc2-b143-cb5935a7d8a3:trashBin": "cutoutA3"
+          },
+          "wasteChuteLocationUpdate": {},
+          "stagingAreaLocationUpdate": {},
+          "gripperLocationUpdate": {}
+        },
+        "7321c1af-2a5a-4538-acc7-1b03f439d572": {
+          "id": "7321c1af-2a5a-4538-acc7-1b03f439d572",
+          "stepType": "moveLiquid",
+          "stepName": "transfer",
+          "stepDetails": "",
+          "aspirate_airGap_checkbox": false,
+          "aspirate_airGap_volume": "5",
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_mmFromBottom": null,
+          "aspirate_delay_seconds": "1",
+          "aspirate_flowRate": "40",
+          "aspirate_labware": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+          "aspirate_mix_checkbox": true,
+          "aspirate_mix_times": "2",
+          "aspirate_mix_volume": "25",
+          "aspirate_mmFromBottom": 0.5,
+          "aspirate_position_reference": "well-bottom",
+          "aspirate_retract_delay_seconds": null,
+          "aspirate_retract_mmFromBottom": null,
+          "aspirate_retract_speed": null,
+          "aspirate_retract_x_position": 0,
+          "aspirate_retract_y_position": 0,
+          "aspirate_retract_position_reference": null,
+          "aspirate_submerge_delay_seconds": null,
+          "aspirate_submerge_speed": null,
+          "aspirate_submerge_mmFromBottom": null,
+          "aspirate_submerge_x_position": 0,
+          "aspirate_submerge_y_position": 0,
+          "aspirate_submerge_position_reference": null,
+          "aspirate_touchTip_checkbox": false,
+          "aspirate_touchTip_mmFromTop": null,
+          "aspirate_touchTip_speed": null,
+          "aspirate_touchTip_mmFromEdge": null,
+          "aspirate_wellOrder_first": "t2b",
+          "aspirate_wellOrder_second": "l2r",
+          "aspirate_wells_grouped": false,
+          "aspirate_wells": [
+            "A1",
+            "A2"
+          ],
+          "aspirate_x_position": 0,
+          "aspirate_y_position": 0,
+          "blowout_checkbox": false,
+          "blowout_flowRate": null,
+          "blowout_location": null,
+          "blowout_z_offset": 0,
+          "changeTip": "perSource",
+          "conditioning_checkbox": false,
+          "conditioning_volume": null,
+          "dispense_airGap_checkbox": false,
+          "dispense_airGap_volume": null,
+          "dispense_delay_checkbox": false,
+          "dispense_delay_mmFromBottom": null,
+          "dispense_delay_seconds": "1",
+          "dispense_flowRate": "50",
+          "dispense_labware": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+          "dispense_mix_checkbox": false,
+          "dispense_mix_times": null,
+          "dispense_mix_volume": null,
+          "dispense_mmFromBottom": null,
+          "dispense_position_reference": null,
+          "dispense_retract_delay_seconds": null,
+          "dispense_retract_mmFromBottom": null,
+          "dispense_retract_speed": null,
+          "dispense_retract_x_position": 0,
+          "dispense_retract_y_position": 0,
+          "dispense_retract_position_reference": null,
+          "dispense_submerge_delay_seconds": null,
+          "dispense_submerge_speed": null,
+          "dispense_submerge_mmFromBottom": null,
+          "dispense_submerge_x_position": 0,
+          "dispense_submerge_y_position": 0,
+          "dispense_submerge_position_reference": null,
+          "dispense_touchTip_checkbox": false,
+          "dispense_touchTip_mmFromTop": null,
+          "dispense_touchTip_speed": null,
+          "dispense_touchTip_mmFromEdge": null,
+          "dispense_wellOrder_first": "t2b",
+          "dispense_wellOrder_second": "l2r",
+          "dispense_wells": [
+            "H11",
+            "H12"
+          ],
+          "dispense_x_position": 0,
+          "dispense_y_position": 0,
+          "disposalVolume_checkbox": true,
+          "disposalVolume_volume": null,
+          "dropTip_location": "447f9dee-5502-4cc2-b143-cb5935a7d8a3:trashBin",
+          "liquidClassesSupported": true,
+          "liquidClass": "none",
+          "nozzles": null,
+          "path": "single",
+          "pipette": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+          "preWetTip": false,
+          "pushOut_checkbox": true,
+          "pushOut_volume": "3",
+          "tipRack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "volume": "45"
+        }
+      },
+      "orderedStepIds": [
+        "7321c1af-2a5a-4538-acc7-1b03f439d572"
+      ],
+      "pipettes": {
+        "cc20dc01-30ee-41ff-807a-a5eb3208a335": {
+          "pipetteName": "p50_single_flex"
+        }
+      },
+      "modules": {},
+      "labware": {
+        "72f476a9-0d27-446d-9f59-b15ed5a88ebe:opentrons/opentrons_flex_96_tiprack_50ul/1": {
+          "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
+          "labwareDefURI": "opentrons/opentrons_flex_96_tiprack_50ul/1"
+        },
+        "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3": {
+          "displayName": "NEST 96 Well Plate 200 µL Flat",
+          "labwareDefURI": "opentrons/nest_96_wellplate_200ul_flat/3"
+        }
+      }
+    }
+  },
+  "robot": {
+    "model": "OT-3 Standard",
+    "deckId": "ot3_standard"
+  },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitions": {
+    "opentrons/opentrons_flex_96_tiprack_50ul/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": []
+      },
+      "metadata": {
+        "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.75,
+        "yDimension": 85.75,
+        "zDimension": 99
+      },
+      "gripForce": 16,
+      "gripHeightFromLabwareBottom": 23.9,
+      "wells": {
+        "A1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 14.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 14.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 14.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 14.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 14.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 14.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 14.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H1": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 14.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 23.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 23.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 23.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 23.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 23.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 23.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 23.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H2": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 23.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 32.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 32.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 32.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 32.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 32.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 32.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 32.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H3": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 32.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 41.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 41.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 41.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 41.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 41.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 41.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 41.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H4": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 41.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 50.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 50.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 50.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 50.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 50.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 50.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 50.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H5": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 50.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 59.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 59.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 59.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 59.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 59.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 59.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 59.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H6": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 59.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 68.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 68.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 68.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 68.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 68.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 68.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 68.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H7": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 68.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 77.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 77.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 77.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 77.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 77.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 77.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 77.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H8": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 77.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 86.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 86.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 86.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 86.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 86.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 86.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 86.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H9": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 86.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 95.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 95.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 95.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 95.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 95.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 95.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 95.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H10": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 95.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 104.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 104.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 104.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 104.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 104.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 104.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 104.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H11": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 104.38,
+          "y": 11.38,
+          "z": 1.5
+        },
+        "A12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 113.38,
+          "y": 74.38,
+          "z": 1.5
+        },
+        "B12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 113.38,
+          "y": 65.38,
+          "z": 1.5
+        },
+        "C12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 113.38,
+          "y": 56.38,
+          "z": 1.5
+        },
+        "D12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 113.38,
+          "y": 47.38,
+          "z": 1.5
+        },
+        "E12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 113.38,
+          "y": 38.38,
+          "z": 1.5
+        },
+        "F12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 113.38,
+          "y": 29.38,
+          "z": 1.5
+        },
+        "G12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 113.38,
+          "y": 20.38,
+          "z": 1.5
+        },
+        "H12": {
+          "depth": 97.5,
+          "shape": "circular",
+          "diameter": 5.58,
+          "totalLiquidVolume": 50,
+          "x": 113.38,
+          "y": 11.38,
+          "z": 1.5
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "quirks": [],
+        "isTiprack": true,
+        "tipLength": 57.9,
+        "tipOverlap": 10.5,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_flex_96_tiprack_50ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "stackingOffsetWithLabware": {
+        "opentrons_flex_96_tiprack_adapter": {
+          "x": 0,
+          "y": 0,
+          "z": 121
+        }
+      }
+    },
+    "opentrons/nest_96_wellplate_200ul_flat/3": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "NEST",
+        "brandId": [
+          "701011"
+        ],
+        "links": [
+          "https://www.nest-biotech.com/cell-culture-plates/59415537.html"
+        ]
+      },
+      "metadata": {
+        "displayName": "NEST 96 Well Plate 200 µL Flat",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.56,
+        "yDimension": 85.36,
+        "zDimension": 14.3
+      },
+      "gripForce": 15,
+      "gripHeightFromLabwareBottom": 11.8,
+      "wells": {
+        "A1": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 14.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B1": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 14.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C1": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 14.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D1": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 14.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E1": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 14.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F1": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 14.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G1": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 14.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H1": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 14.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A2": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 23.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B2": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 23.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C2": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 23.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D2": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 23.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E2": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 23.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F2": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 23.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G2": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 23.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H2": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 23.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A3": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 32.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B3": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 32.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C3": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 32.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D3": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 32.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E3": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 32.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F3": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 32.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G3": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 32.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H3": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 32.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A4": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 41.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B4": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 41.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C4": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 41.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D4": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 41.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E4": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 41.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F4": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 41.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G4": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 41.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H4": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 41.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A5": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 50.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B5": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 50.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C5": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 50.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D5": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 50.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E5": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 50.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F5": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 50.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G5": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 50.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H5": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 50.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A6": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 59.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B6": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 59.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C6": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 59.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D6": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 59.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E6": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 59.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F6": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 59.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G6": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 59.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H6": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 59.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A7": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 68.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B7": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 68.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C7": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 68.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D7": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 68.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E7": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 68.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F7": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 68.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G7": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 68.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H7": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 68.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A8": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 77.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B8": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 77.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C8": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 77.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D8": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 77.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E8": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 77.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F8": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 77.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G8": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 77.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H8": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 77.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A9": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 86.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B9": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 86.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C9": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 86.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D9": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 86.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E9": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 86.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F9": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 86.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G9": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 86.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H9": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 86.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A10": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 95.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B10": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 95.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C10": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 95.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D10": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 95.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E10": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 95.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F10": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 95.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G10": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 95.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H10": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 95.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A11": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 104.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B11": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 104.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C11": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 104.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D11": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 104.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E11": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 104.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F11": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 104.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G11": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 104.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H11": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 104.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "A12": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 113.28,
+          "y": 74.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "B12": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 113.28,
+          "y": 65.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "C12": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 113.28,
+          "y": 56.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "D12": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 113.28,
+          "y": 47.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "E12": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 113.28,
+          "y": 38.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "F12": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 113.28,
+          "y": 29.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "G12": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 113.28,
+          "y": 20.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        },
+        "H12": {
+          "depth": 10.8,
+          "shape": "circular",
+          "diameter": 6.85,
+          "totalLiquidVolume": 200,
+          "x": 113.28,
+          "y": 11.18,
+          "z": 3.5,
+          "geometryDefinitionId": "conicalWell"
+        }
+      },
+      "groups": [
+        {
+          "metadata": {
+            "wellBottomShape": "flat"
+          },
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "nest_96_wellplate_200ul_flat"
+      },
+      "namespace": "opentrons",
+      "version": 3,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "stackingOffsetWithLabware": {
+        "opentrons_96_flat_bottom_adapter": {
+          "x": 0,
+          "y": 0,
+          "z": 6.7
+        },
+        "opentrons_aluminum_flat_bottom_plate": {
+          "x": 0,
+          "y": 0,
+          "z": 5.55
+        }
+      },
+      "innerLabwareGeometry": {
+        "conicalWell": {
+          "sections": [
+            {
+              "shape": "conical",
+              "bottomDiameter": 6.32,
+              "topDiameter": 6.85,
+              "topHeight": 10.8,
+              "bottomHeight": 0
+            }
+          ]
+        }
+      }
+    }
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {
+    "0": {
+      "displayName": "Apple juice",
+      "description": "",
+      "displayColor": "#ffd600ff"
+    }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV10",
+  "commands": [
+    {
+      "key": "6769078b-61f3-4cf9-9a28-6b9a7d0ff6c1",
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteName": "p50_single_flex",
+        "mount": "left",
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335"
+      }
+    },
+    {
+      "key": "06769361-56ed-4041-a737-db30e8b29044",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
+        "labwareId": "72f476a9-0d27-446d-9f59-b15ed5a88ebe:opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "loadName": "opentrons_flex_96_tiprack_50ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "slotName": "C2"
+        }
+      }
+    },
+    {
+      "key": "da55e40e-8458-41ce-87ee-2fe0bfc177ff",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "NEST 96 Well Plate 200 µL Flat",
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "loadName": "nest_96_wellplate_200ul_flat",
+        "namespace": "opentrons",
+        "version": 3,
+        "location": {
+          "slotName": "D1"
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "123fa870-3c55-4290-a80e-4a41139bab8f",
+      "params": {
+        "liquidId": "0",
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "volumeByWell": {
+          "A1": 200,
+          "A2": 200
+        }
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "19c92d7c-2111-4a9b-ab24-b8176c1b983a",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "labwareId": "72f476a9-0d27-446d-9f59-b15ed5a88ebe:opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "configureForVolume",
+      "key": "a51efd40-c171-464d-9623-d208daf5e767",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 45
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "76cf9eb8-d4e8-4557-ba21-8d902451e6d7",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 25,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "897bfd08-a5c8-43b0-93f6-a16c5723774c",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 25,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 50,
+        "pushOut": 0
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "fe054da6-5bbf-4c43-9e1e-fe87796960c4",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 25,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "63e84fdf-67e5-44f1-9e75-198a10c28168",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 25,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 50,
+        "pushOut": 3
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4765c992-c14a-4d06-a728-71ed1a8699d4",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 45,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "7fee12b6-fb4d-4b3a-b7c3-46ebf1752c73",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 45,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "H11",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 1,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 50
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "913da689-97f0-4051-8177-d20327beaa8d",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "addressableAreaName": "movableTrashA3",
+        "offset": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "b65e128e-0121-445c-8cbe-1db81e32e37a",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "6510e0c2-8f41-4b6b-986f-b7027097b728",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "labwareId": "72f476a9-0d27-446d-9f59-b15ed5a88ebe:opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "configureForVolume",
+      "key": "0210204e-b9d3-4174-b2b0-fb5dafe64a92",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 45
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "2df2c18b-9bca-4e65-a722-f005b3c10b1e",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 25,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A2",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "c718ef59-b037-48f3-bda6-59593fb67baf",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 25,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A2",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 50,
+        "pushOut": 0
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "0702117c-f080-40ee-bb3f-988f5187a11a",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 25,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A2",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "acdc6478-ccb6-4d7b-ac49-610903d55100",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 25,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A2",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 50,
+        "pushOut": 3
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "a17b90c3-7c1e-4e7f-9657-5dc0e51b3e95",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 45,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "A2",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 0.5,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "3dcada3b-1030-441f-b3cc-e7c2cc7c6880",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "volume": 45,
+        "labwareId": "5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3",
+        "wellName": "H12",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "z": 1,
+            "x": 0,
+            "y": 0
+          }
+        },
+        "flowRate": 50
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "2acd3ec2-d00d-4a32-86f7-d63219b0bd70",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335",
+        "addressableAreaName": "movableTrashA3",
+        "offset": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "5d1f8448-2fc9-42cf-ab32-294dd699fcf0",
+      "params": {
+        "pipetteId": "cc20dc01-30ee-41ff-807a-a5eb3208a335"
+      }
+    }
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": []
+}

--- a/api/tests/interop/__pd_protocols__/simple_transfer.py
+++ b/api/tests/interop/__pd_protocols__/simple_transfer.py
@@ -1,0 +1,99 @@
+import json
+from contextlib import nullcontext as pd_step
+from opentrons import protocol_api, types
+
+metadata = {
+    "protocolName": "Simple Transfer",
+    "created": "2025-05-01T20:11:02.969Z",
+    "lastModified": "2025-05-01T20:27:18.382Z",
+    "protocolDesigner": "8.4.4-alpha.0",
+    "source": "Protocol Designer",
+}
+
+requirements = {
+    "robotType": "Flex",
+    "apiLevel": "2.24",
+}
+
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    # Load Labware:
+    tip_rack_1 = protocol.load_labware(
+        "opentrons_flex_96_tiprack_50ul",
+        location="C2",
+        namespace="opentrons",
+        version=1,
+    )
+    well_plate_1 = protocol.load_labware(
+        "nest_96_wellplate_200ul_flat",
+        location="D1",
+        namespace="opentrons",
+        version=3,
+    )
+
+    # Load Pipettes:
+    pipette_left = protocol.load_instrument(
+        "flex_1channel_50", "left", tip_racks=[tip_rack_1]
+    )
+
+    # Load Trash Bins:
+    trash_bin_1 = protocol.load_trash_bin("A3")
+
+    # Define Liquids:
+    liquid_1 = protocol.define_liquid(
+        "Apple juice",
+        display_color="#ffd600ff",
+    )
+
+    # Load Liquids:
+    well_plate_1["A1"].load_liquid(liquid_1, 200)
+    well_plate_1["A2"].load_liquid(liquid_1, 200)
+
+    # PROTOCOL STEPS
+
+    # Step 1:
+    pipette_left.pick_up_tip(location=tip_rack_1)
+    pipette_left.configure_for_volume(45)
+    pipette_left.flow_rate.aspirate = 40
+    pipette_left.flow_rate.dispense = 50
+    pipette_left.mix(
+        repetitions=2,
+        volume=25,
+        location=well_plate_1["A1"].bottom(z=0.5),
+        final_push_out=3,
+    )
+    pipette_left.aspirate(
+        volume=45,
+        location=well_plate_1["A1"].bottom(z=0.5),
+        rate=40 / pipette_left.flow_rate.aspirate,
+    )
+    pipette_left.dispense(
+        volume=45,
+        location=well_plate_1["H11"].bottom(z=1),
+        rate=50 / pipette_left.flow_rate.dispense,
+    )
+    pipette_left.drop_tip()
+    pipette_left.pick_up_tip(location=tip_rack_1)
+    pipette_left.configure_for_volume(45)
+    pipette_left.flow_rate.aspirate = 40
+    pipette_left.flow_rate.dispense = 50
+    pipette_left.mix(
+        repetitions=2,
+        volume=25,
+        location=well_plate_1["A2"].bottom(z=0.5),
+        final_push_out=3,
+    )
+    pipette_left.aspirate(
+        volume=45,
+        location=well_plate_1["A2"].bottom(z=0.5),
+        rate=40 / pipette_left.flow_rate.aspirate,
+    )
+    pipette_left.dispense(
+        volume=45,
+        location=well_plate_1["H12"].bottom(z=1),
+        rate=50 / pipette_left.flow_rate.dispense,
+    )
+    pipette_left.drop_tip()
+
+
+DESIGNER_APPLICATION = """{"robot":{"model":"OT-3 Standard"},"designerApplication":{"name":"opentrons/protocol-designer","version":"8.5.0","data":{"pipetteTiprackAssignments":{"cc20dc01-30ee-41ff-807a-a5eb3208a335":["opentrons/opentrons_flex_96_tiprack_50ul/1"]},"dismissedWarnings":{"form":[],"timeline":[]},"ingredients":{"0":{"displayName":"Apple juice","displayColor":"#ffd600ff","description":null,"liquidGroupId":"0"}},"ingredLocations":{"5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3":{"A1":{"0":{"volume":200}},"A2":{"0":{"volume":200}}}},"savedStepForms":{"__INITIAL_DECK_SETUP_STEP__":{"stepType":"manualIntervention","id":"__INITIAL_DECK_SETUP_STEP__","labwareLocationUpdate":{"72f476a9-0d27-446d-9f59-b15ed5a88ebe:opentrons/opentrons_flex_96_tiprack_50ul/1":"C2","5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3":"D1"},"pipetteLocationUpdate":{"cc20dc01-30ee-41ff-807a-a5eb3208a335":"left"},"moduleLocationUpdate":{},"trashBinLocationUpdate":{"447f9dee-5502-4cc2-b143-cb5935a7d8a3:trashBin":"cutoutA3"},"wasteChuteLocationUpdate":{},"stagingAreaLocationUpdate":{},"gripperLocationUpdate":{}},"7321c1af-2a5a-4538-acc7-1b03f439d572":{"id":"7321c1af-2a5a-4538-acc7-1b03f439d572","stepType":"moveLiquid","stepName":"transfer","stepDetails":"","aspirate_airGap_checkbox":false,"aspirate_airGap_volume":"5","aspirate_delay_checkbox":false,"aspirate_delay_mmFromBottom":null,"aspirate_delay_seconds":"1","aspirate_flowRate":"40","aspirate_labware":"5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3","aspirate_mix_checkbox":true,"aspirate_mix_times":"2","aspirate_mix_volume":"25","aspirate_mmFromBottom":0.5,"aspirate_position_reference":"well-bottom","aspirate_retract_delay_seconds":null,"aspirate_retract_mmFromBottom":null,"aspirate_retract_speed":null,"aspirate_retract_x_position":0,"aspirate_retract_y_position":0,"aspirate_retract_position_reference":null,"aspirate_submerge_delay_seconds":null,"aspirate_submerge_speed":null,"aspirate_submerge_mmFromBottom":null,"aspirate_submerge_x_position":0,"aspirate_submerge_y_position":0,"aspirate_submerge_position_reference":null,"aspirate_touchTip_checkbox":false,"aspirate_touchTip_mmFromTop":null,"aspirate_touchTip_speed":null,"aspirate_touchTip_mmFromEdge":null,"aspirate_wellOrder_first":"t2b","aspirate_wellOrder_second":"l2r","aspirate_wells_grouped":false,"aspirate_wells":["A1","A2"],"aspirate_x_position":0,"aspirate_y_position":0,"blowout_checkbox":false,"blowout_flowRate":null,"blowout_location":null,"blowout_z_offset":0,"changeTip":"perSource","conditioning_checkbox":false,"conditioning_volume":null,"dispense_airGap_checkbox":false,"dispense_airGap_volume":null,"dispense_delay_checkbox":false,"dispense_delay_mmFromBottom":null,"dispense_delay_seconds":"1","dispense_flowRate":"50","dispense_labware":"5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3","dispense_mix_checkbox":false,"dispense_mix_times":null,"dispense_mix_volume":null,"dispense_mmFromBottom":null,"dispense_position_reference":null,"dispense_retract_delay_seconds":null,"dispense_retract_mmFromBottom":null,"dispense_retract_speed":null,"dispense_retract_x_position":0,"dispense_retract_y_position":0,"dispense_retract_position_reference":null,"dispense_submerge_delay_seconds":null,"dispense_submerge_speed":null,"dispense_submerge_mmFromBottom":null,"dispense_submerge_x_position":0,"dispense_submerge_y_position":0,"dispense_submerge_position_reference":null,"dispense_touchTip_checkbox":false,"dispense_touchTip_mmFromTop":null,"dispense_touchTip_speed":null,"dispense_touchTip_mmFromEdge":null,"dispense_wellOrder_first":"t2b","dispense_wellOrder_second":"l2r","dispense_wells":["H11","H12"],"dispense_x_position":0,"dispense_y_position":0,"disposalVolume_checkbox":true,"disposalVolume_volume":null,"dropTip_location":"447f9dee-5502-4cc2-b143-cb5935a7d8a3:trashBin","liquidClassesSupported":true,"liquidClass":"none","nozzles":null,"path":"single","pipette":"cc20dc01-30ee-41ff-807a-a5eb3208a335","preWetTip":false,"pushOut_checkbox":true,"pushOut_volume":"3","tipRack":"opentrons/opentrons_flex_96_tiprack_50ul/1","volume":"45"}},"orderedStepIds":["7321c1af-2a5a-4538-acc7-1b03f439d572"],"pipettes":{"cc20dc01-30ee-41ff-807a-a5eb3208a335":{"pipetteName":"p50_single_flex"}},"modules":{},"labware":{"72f476a9-0d27-446d-9f59-b15ed5a88ebe:opentrons/opentrons_flex_96_tiprack_50ul/1":{"displayName":"Opentrons Flex 96 Tip Rack 50 µL","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_50ul/1"},"5625912d-cda6-469d-8de6-cbb671a4d706:opentrons/nest_96_wellplate_200ul_flat/3":{"displayName":"NEST 96 Well Plate 200 µL Flat","labwareDefURI":"opentrons/nest_96_wellplate_200ul_flat/3"}}}},"metadata":{"protocolName":"Simple Transfer","author":"","description":"","source":"Protocol Designer","created":1746130262969,"lastModified":1746131238382}}"""

--- a/api/tests/interop/test_pd_python_compare.py
+++ b/api/tests/interop/test_pd_python_compare.py
@@ -1,0 +1,361 @@
+"""Test that PD Python generation produces the same engine commands as JSON.
+
+For each .json/.py pair of protocols in the __pd_protocols__ directory, run the protocols
+and compare their commands.
+"""
+
+from copy import deepcopy
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Tuple
+
+import mock
+import pytest
+
+from opentrons.protocol_api import Well
+from opentrons.protocol_api.core.engine import InstrumentCore
+from opentrons.protocol_engine import (
+    Command,
+    WellOrigin,
+)
+from opentrons.protocol_engine.state.geometry import GeometryView
+from opentrons.protocol_engine.types import WellLocationType
+from opentrons.protocol_reader import ProtocolReader
+from opentrons.protocol_runner.create_simulating_orchestrator import (
+    create_simulating_orchestrator,
+)
+from opentrons.types import Location
+
+
+async def _get_engine_commands_for_protocol(
+    protocol_path: Path,
+) -> list[dict[str, Any]]:
+    """This is the top-level function to run a protocol.
+
+    Given a path to a JSON or Python protocol, run the protocol and get the list
+    of commands from the Protocol Engine, cleaning up the commands. Returns a list of
+    JSON commands.
+    """
+    protocol_source = await ProtocolReader().read_saved(
+        files=[protocol_path],
+        directory=protocol_path.parent,
+    )
+    orchestrator = await create_simulating_orchestrator(
+        protocol_source.robot_type, protocol_source.config
+    )
+    run_result = await orchestrator.run(
+        deck_configuration=[], protocol_source=protocol_source
+    )
+    await orchestrator.finish()
+
+    commands = _commands_to_json_rename_ids(run_result.commands)
+    _sort_load_commands(commands)
+    _expand_load_liquid(commands)
+    _sort_load_liquid(commands)
+    _expand_thermocycler_profiles(commands)
+    return commands
+
+
+def _commands_to_json_rename_ids(  # noqa: C901
+    commands: list[Command],
+) -> list[dict[str, Any]]:
+    """Convert RunResult Commands into something that looks like JSON commands.
+
+    Renames the labwareIds/moduleIds/etc. in commands so that they're deterministic.
+    """
+    json_commands = [
+        command.model_dump(mode="json", exclude_none=True) for command in commands
+    ]
+
+    # JSON protocols specify the labwareId/moduleId/etc. in the load commands, whereas
+    # Python protocols let the engine assign the IDs. For consistency, always populate
+    # the ID in the commands.
+    for command in json_commands:
+        match command["commandType"]:
+            case "loadPipette":
+                command["params"].setdefault(
+                    "pipetteId", command["result"]["pipetteId"]
+                )
+            case "loadModule":
+                command["params"].setdefault("moduleId", command["result"]["moduleId"])
+            case "loadLabware":
+                command["params"].setdefault(
+                    "labwareId", command["result"]["labwareId"]
+                )
+
+    # Now we rename all the IDs to make them deterministic (instead of random UUIDs) ...
+
+    # These are maps of engine ID -> renamed ID:
+    pipette_id_map: dict[str, str] = {}  # e.g. "p1000_single_flex@left"
+    module_id_map: dict[str, str] = {}  # e.g. "temperatureModuleV2@D1"
+    labware_id_map: dict[str, str] = {}  # e.g. "opentrons_flex_96_tiprack_200ul@B2"
+
+    # Compute the mappings of engine ID -> renamed IDs:
+    for command in json_commands:
+        match command["commandType"]:
+            case "loadPipette":
+                old_id = command["params"]["pipetteId"]
+                new_id = (
+                    f"{command['params']['pipetteName']}@{command['params']['mount']}"
+                )
+                pipette_id_map[old_id] = new_id
+            case "loadModule":
+                old_id = command["params"]["moduleId"]
+                new_id = f"{command['params']['model']}@{command['params']['location']['slotName']}"
+                module_id_map[old_id] = new_id
+            case "loadLabware":
+                old_id = command["params"]["labwareId"]
+                if "slotName" in command["params"]["location"]:
+                    location = command["params"]["location"]["slotName"]
+                elif "addressableAreaName" in command["params"]["location"]:
+                    location = command["params"]["location"]["addressableAreaName"]
+                elif "moduleId" in command["params"]["location"]:
+                    location = module_id_map[command["params"]["location"]["moduleId"]]
+                elif "labwareId" in command["params"]["location"]:
+                    location = labware_id_map[
+                        command["params"]["location"]["labwareId"]
+                    ]
+                new_id = f"{command['params']['loadName']}@{location}"
+                labware_id_map[old_id] = new_id
+
+    # Rewrite all the IDs in the commands:
+    for command in json_commands:
+        if "pipetteId" in command["params"]:
+            command["params"]["pipetteId"] = pipette_id_map[
+                command["params"]["pipetteId"]
+            ]
+        if "moduleId" in command["params"]:
+            command["params"]["moduleId"] = module_id_map[command["params"]["moduleId"]]
+        if "labwareId" in command["params"]:
+            command["params"]["labwareId"] = labware_id_map[
+                command["params"]["labwareId"]
+            ]
+        for sub_param in command["params"].values():
+            if isinstance(sub_param, dict):
+                if "moduleId" in sub_param:
+                    sub_param["moduleId"] = module_id_map[sub_param["moduleId"]]
+                if "labwareId" in sub_param:
+                    sub_param["labwareId"] = labware_id_map[sub_param["labwareId"]]
+
+    # For liquidIds, there is no good way to assign consistent names to them, so just
+    # delete them.
+    for command in json_commands:
+        command["params"].pop("liquidId", None)
+
+    # Remove some default values that the PAPI adds to loadPipette commands.
+    for command in json_commands:
+        if command["commandType"] == "loadPipette":
+            if command["params"].get("liquidPresenceDetection") is False:
+                command["params"].pop("liquidPresenceDetection")
+
+    for command in json_commands:
+        command["params"].pop("tipOverlapNotAfterVersion", None)
+
+    # JSON protocols always adds a displayName to labware, whereas Python protocols omit
+    # the displayName if it's the same as the labware definition:
+    for command in json_commands:
+        if command["commandType"] == "loadLabware":
+            if (
+                command["params"].get("displayName")
+                == command["result"]["definition"]["metadata"]["displayName"]
+            ):
+                command["params"].pop("displayName")
+
+    # The RunResult commands also have a lot of fields like `createdAt` and `result` that
+    # we don't want. Keep only the `params`.
+    json_commands = [
+        {"commandType": command["commandType"], "params": command["params"]}
+        for command in json_commands
+    ]
+
+    # Also drop the `home` command that the protocol runner inserted at the beginning:
+    if json_commands[0]["commandType"] == "home":
+        json_commands = json_commands[1:]
+
+    return json_commands
+
+
+def _sort_load_commands(commands: list[dict[str, Any]]) -> None:
+    """Reorder loadPipette/loadModule/loadLabware commands to match PD Python export."""
+    sort_order = {"loadModule": 1, "loadLabware": 2, "loadPipette": 3}
+    load_cmd_start = 0
+    while (
+        load_cmd_start < len(commands)
+        and commands[load_cmd_start]["commandType"] not in sort_order
+    ):
+        load_cmd_start += 1
+    load_cmd_end = load_cmd_start + 1
+    while (
+        load_cmd_end < len(commands)
+        and commands[load_cmd_end]["commandType"] in sort_order
+    ):
+        load_cmd_end += 1
+
+    commands[load_cmd_start:load_cmd_end] = sorted(
+        commands[load_cmd_start:load_cmd_end],
+        key=lambda command: sort_order[command["commandType"]],
+    )
+
+
+def _sort_load_liquid(commands: list[dict[str, Any]]) -> None:
+    """Sort the loadLiquid commands in commands."""
+    load_liquid_start = 0
+    while (
+        load_liquid_start < len(commands)
+        and commands[load_liquid_start]["commandType"] != "loadLiquid"
+    ):
+        load_liquid_start += 1
+    load_liquid_end = load_liquid_start + 1
+    while (
+        load_liquid_end < len(commands)
+        and commands[load_liquid_end]["commandType"] == "loadLiquid"
+    ):
+        load_liquid_end += 1
+
+    commands[load_liquid_start:load_liquid_end] = sorted(
+        commands[load_liquid_start:load_liquid_end],
+        key=lambda command: (
+            command["params"]["labwareId"],
+            sorted(command["params"]["volumeByWell"].items()),
+        ),
+    )
+
+
+def _expand_load_liquid(commands: list[dict[str, Any]]) -> None:
+    """Expand any multi-well loadLiquid commands to match PD Python export."""
+    expanded_commands = []
+    for command in commands:
+        if command["commandType"] == "loadLiquid":
+            original_volume_by_well = command["params"].pop("volumeByWell")
+            for well, volume in original_volume_by_well.items():
+                load_liquid_command = deepcopy(command)
+                load_liquid_command["params"]["volumeByWell"] = {well: volume}
+                expanded_commands.append(load_liquid_command)
+        else:
+            expanded_commands.append(command)
+    commands[:] = expanded_commands
+
+
+def _expand_thermocycler_profiles(commands: list[dict[str, Any]]) -> None:
+    """Expand any repetitions in thermocycler profiles so that we can compare them."""
+    for command in commands:
+        if command["commandType"] == "thermocycler/runExtendedProfile":
+            command["commandType"] = "thermocycler/runProfile"
+            profile = []
+            profile_elements = command["params"].pop("profileElements")
+            for element in profile_elements:
+                repetitions = element.get("repetitions", 1)
+                profile.extend(element["steps"] * repetitions)
+            command["params"]["profile"] = profile
+
+
+# Ugh ... In the PAPI, if you use a Location like well.bottom(), the API turns it into a
+# Point with an absolute position, and doesn't remember that it is a position relative to
+# the bottom of the well. Then when the API generates engine commands, it takes the Point
+# and recomputes its relative position from the TOP of the well. So the offsets in the
+# engine commands that the PAPI generates are completely different from the offsets in
+# the JSON protocol.
+#
+# To hack around this limitation, this test patches Well.bottom() to add a secret
+# field `._well_bottom_z` to the Location object that it returns. Then in aspirate() and
+# dispense(), if the Location has the secret field `._well_bottom_z`, we emit offsets
+# from the bottom of the well instead of from the top.
+
+_original_well_bottom = Well.bottom
+_original_instrument_aspirate = InstrumentCore.aspirate
+_original_instrument_dispense = InstrumentCore.dispense
+_original_instrument_move_to = InstrumentCore.move_to
+_original_get_relative_liquid_handling_well_location = (
+    GeometryView._get_relative_liquid_handling_well_location
+)
+
+
+def _patched_well_bottom(self: Well, z: float = 0.0) -> Location:
+    location = _original_well_bottom(self, z)
+    location._well_bottom_z = _original_well_bottom(self, 0).point.z  # type: ignore[attr-defined]
+    return location
+
+
+def _make_patched_get_relative_liquid_handling_well_location(location: Location) -> Any:
+    # This is a nested helper function, sorry.
+    # The outer function is a factory that captures the `location` that aspirate()/etc was
+    # called with. We return this inner function that will be used to patch the call to
+    # _get_relative_liquid_handling_well_location().
+    def patched_get_relative_liquid_handling_well_location(
+        *args: Any, **kwargs: Any
+    ) -> Tuple[WellLocationType, bool]:
+        well_location, dynamic = _original_get_relative_liquid_handling_well_location(
+            *args, **kwargs
+        )
+        if hasattr(location, "_well_bottom_z"):
+            well_location.origin = WellOrigin.BOTTOM
+            well_location.offset.z = float(
+                Decimal(repr(location.point.z)) - Decimal(repr(location._well_bottom_z))
+            )
+        return well_location, dynamic
+
+    return patched_get_relative_liquid_handling_well_location
+
+
+def _patched_instrument_aspirate(
+    self: InstrumentCore, location: Location, *args: Any, **kwargs: Any
+) -> None:
+    # Patch GeometryView._get_relative_liquid_handling_well_location() only during aspirate()
+    with mock.patch.object(
+        GeometryView,
+        "_get_relative_liquid_handling_well_location",
+        _make_patched_get_relative_liquid_handling_well_location(location),
+    ):
+        _original_instrument_aspirate(self, location, *args, **kwargs)
+
+
+def _patched_instrument_dispense(
+    self: InstrumentCore, location: Location, *args: Any, **kwargs: Any
+) -> None:
+    # Patch GeometryView._get_relative_liquid_handling_well_location() only during dispense()
+    with mock.patch.object(
+        GeometryView,
+        "_get_relative_liquid_handling_well_location",
+        _make_patched_get_relative_liquid_handling_well_location(location),
+    ):
+        _original_instrument_dispense(self, location, *args, **kwargs)
+
+
+def _patched_instrument_move_to(
+    self: InstrumentCore, location: Location, *args: Any, **kwargs: Any
+) -> None:
+    # Patch GeometryView._get_relative_liquid_handling_well_location() only during move_to()
+    with mock.patch.object(
+        GeometryView,
+        "_get_relative_liquid_handling_well_location",
+        _make_patched_get_relative_liquid_handling_well_location(location),
+    ):
+        _original_instrument_move_to(self, location, *args, **kwargs)
+
+
+PROTOCOL_PATH_ROOTS = [
+    path.with_suffix("")
+    for path in (Path(__file__).parent / "__pd_protocols__").glob("*.json")
+]
+"""The filenames of the protocols in the test directory, without the .json/.py suffixes."""
+
+
+@pytest.mark.parametrize(
+    "protocol_path_root", PROTOCOL_PATH_ROOTS, ids=lambda path: path.name
+)
+@mock.patch.object(Well, "bottom", _patched_well_bottom)
+@mock.patch.object(InstrumentCore, "aspirate", _patched_instrument_aspirate)
+@mock.patch.object(InstrumentCore, "dispense", _patched_instrument_dispense)
+@mock.patch.object(InstrumentCore, "move_to", _patched_instrument_move_to)
+async def test_python_interoperability(protocol_path_root: Path) -> None:
+    """Compare the commands in the .py and .json protocol."""
+    python_protocol_path = protocol_path_root.with_suffix(".py")
+    python_commands = await _get_engine_commands_for_protocol(python_protocol_path)
+
+    json_protocol_path = protocol_path_root.with_suffix(".json")
+    json_commands = await _get_engine_commands_for_protocol(json_protocol_path)
+
+    assert python_commands == json_commands
+
+    # If you're looking at test failures in the PyCharm IDE, the `Expected` window is
+    # the JSON protocol, and the `Actual` window is the Python protocol.

--- a/api/tests/interop/test_pd_python_compare.py
+++ b/api/tests/interop/test_pd_python_compare.py
@@ -6,6 +6,7 @@ and compare their commands.
 
 from copy import deepcopy
 from decimal import Decimal
+import itertools
 from pathlib import Path
 from typing import Any, Tuple
 
@@ -52,6 +53,7 @@ async def _get_engine_commands_for_protocol(
     _sort_load_commands(commands)
     _expand_load_liquid(commands)
     _sort_load_liquid(commands)
+    _make_aspirate_in_place(commands)
     _expand_thermocycler_profiles(commands)
     return commands
 
@@ -234,6 +236,27 @@ def _expand_load_liquid(commands: list[dict[str, Any]]) -> None:
         else:
             expanded_commands.append(command)
     commands[:] = expanded_commands
+
+
+def _make_aspirate_in_place(commands: list[dict[str, Any]]) -> None:
+    """Change (moveToWell + aspirate) to aspirateInPlace."""
+    # In the API, you can call aspirate() with no location to aspirate in place. But the
+    # API still emits an `aspirate` engine command, with the location set explicitly to
+    # the last location of the pipette. This transformation changes the adjacent commands
+    # (moveToWell + aspirate) to aspirateInPlace if they have the same location.
+    for cmd1, cmd2 in itertools.pairwise(commands):
+        if (
+            cmd1["commandType"] == "moveToWell"
+            and cmd2["commandType"] == "aspirate"
+            and all(
+                cmd1["params"][param] == cmd2["params"][param]
+                for param in ["pipetteId", "labwareId", "wellName", "wellLocation"]
+            )
+        ):
+            cmd2["commandType"] = "aspirateInPlace"
+            cmd2["params"].pop("labwareId")
+            cmd2["params"].pop("wellName")
+            cmd2["params"].pop("wellLocation")
 
 
 def _expand_thermocycler_profiles(commands: list[dict[str, Any]]) -> None:


### PR DESCRIPTION
# Overview

This test compares the JSON commands that PD generates to the engine commands produced by PD Python export.

When we launch Python export, we want to be able to guarantee that if users run the Python file instead of the JSON file, the protocol will do the same thing.

This test takes pairs of JSON and Python protocols from the `__pd_protocols__/` directory. It executes the Python protocol to see what engine commands it calls. We then compare those engine commands to the commands in the JSON protocol. If PD Python export is working correctly, the commands should match exactly (after some cleanup that this test performs).

This PR includes 2 test protocols for now:

- `simple_transfer.json` and `.py`: A simple protocol with a single Transfer step. This confirms that the Python code we generate produces exactly the same engine commands as JSON step generation. (I selected the mix option for this transfer, so this test also exercises the new Python `mix()` options we just implemented this week.)
- `demo_day.json` and `.py`: The was the protocol we showed for Demo Day. This test exercises the commands for controlling the various modules.

## Future test plans

1)
I'd like to build a comprehensive test suite that exercises every option in PD (or at least the ones we care about). The plan would be: make a protocol in PD, export it as JSON, also export it as Python, save both files into `__pd_protocols__/`, then run this test to confirm that Python and JSON do the same thing. Maybe we could get help from QA for this? (@alexjoel42)

For now we'd have to do this manually, and update the files every time step generation changes. In the future, we could maybe rig up something to regenerate the JSON and Python protocols whenever we change step generation.

2)
We can also use this test to see if the upcoming PD liquid class implementation is doing the right thing. Hypothetically, if you create liquid class transfer in PD (liquid class ethanol, volume 99 uL, tip pickup per source), and don't change any of the options, PD should generate JSON commands exactly equivalent to the engine commands from:
```
liquid_class = protocol.define_liquid_class("ethanol_80")
pipette_left.transfer_with_liquid_class(
    liquid_class=liquid_class,
    volume=99,
    source=well_plate_1["A1"],
    dest=well_plate_1["H1"],
    new_tip="per source",
)
```
which is the Python protocol in `hypothetical_lc_transfer.py`.

PD's step generation doesn't do that right now, so we have our work cut out for us. But we can use this test to see what we're missing in PD. (@ncdiehl)

## Risk assessment

Low, test only.