### PR TITLE
chore: add components-devs as owners of components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,6 @@
 /api-client @Opentrons/js
 /react-api-client @Opentrons/js
 /app-shell @Opentrons/js
-/components @Opentrons/js
+/components @Opentrons/js @Opentrons/components-devs
 /api @Opentrons/py
 /shared-data/js @Opentrons/js


### PR DESCRIPTION
Add the new @Opentrons/components-devs team to autoreview changes to /components