### PR TITLE
fix(api): dont check SYSTEM lid stacks z

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -197,7 +197,7 @@ class GeometryView:
             (
                 self._get_highest_z_from_labware_data(lw_data)
                 for lw_data in self._labware.get_all()
-                if lw_data.location != OFF_DECK_LOCATION
+                if lw_data.location not in [OFF_DECK_LOCATION, SYSTEM_LOCATION]
                 and not self._labware.get_labware_by_lid_id(lw_data.id)
             ),
             default=0.0,
@@ -875,6 +875,13 @@ class GeometryView:
             raise errors.LabwareNotOnDeckError(
                 f"Labware {labware_id} does not have a slot associated with it"
                 f" since it is no longer on the deck."
+            )
+        else:
+            _LOG.error(
+                f"Unhandled location type in get_ancestor_slot_name: {labware.location}"
+            )
+            raise errors.InvalidLabwarePositionError(
+                f"Cannot get ancestor slot of {self._labware.get_display_name(labware_id)} with location {labware.location}"
             )
 
         return slot_name

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -49,6 +49,7 @@ from opentrons_shared_data.labware import load_definition as load_labware_defini
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (
     OFF_DECK_LOCATION,
+    SYSTEM_LOCATION,
     LabwareOffsetVector,
     DeckSlotLocation,
     ModuleLocation,
@@ -790,6 +791,7 @@ def test_get_all_obstacle_highest_z(
     well_plate_def: LabwareDefinition,
     reservoir_def: LabwareDefinition,
     falcon_tuberack_def: LabwareDefinition,
+    lid_stack_def: LabwareDefinition,
     mock_labware_view: LabwareView,
     mock_module_view: ModuleView,
     mock_addressable_area_view: AddressableAreaView,
@@ -817,7 +819,13 @@ def test_get_all_obstacle_highest_z(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
         offsetId="reservoir-offset-id",
     )
-
+    lid_stack_system = LoadedLabware(
+        id="lid-stack-id",
+        loadName="protocol_engine_lid_stack_object",
+        definitionUri="lid-stack-1",
+        location=SYSTEM_LOCATION,
+        offsetId=None,
+    )
     plate_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     off_deck_lw_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     reservoir_offset = LabwareOffsetVector(x=1, y=-2, z=3)
@@ -829,6 +837,7 @@ def test_get_all_obstacle_highest_z(
     decoy.when(mock_labware_view.get("plate-id")).then_return(plate)
     decoy.when(mock_labware_view.get("off-deck-plate-id")).then_return(off_deck_lw)
     decoy.when(mock_labware_view.get("reservoir-id")).then_return(reservoir)
+    decoy.when(mock_labware_view.get("lid-stack-id")).then_return(lid_stack_system)
 
     decoy.when(mock_labware_view.get_definition("plate-id")).then_return(well_plate_def)
     decoy.when(mock_labware_view.get_definition("off-deck-plate-id")).then_return(
@@ -836,6 +845,9 @@ def test_get_all_obstacle_highest_z(
     )
     decoy.when(mock_labware_view.get_definition("reservoir-id")).then_return(
         reservoir_def
+    )
+    decoy.when(mock_labware_view.get_definition("lid-stack-id")).then_return(
+        lid_stack_def
     )
 
     decoy.when(mock_labware_view.get_labware_offset_vector("plate-id")).then_return(


### PR DESCRIPTION
This avoids a problem where the protocol_engine_lid_stack object can be in SYSTEM_LOCATION and we were asking for its ancestor slot. Also avoids a problem where asking for the ancestor slot of a SYSTEM_LOCATION would give you a bad kind of exception instead of a nice kind of exception.

Closes RQA-4164

## Reviews and TODOs
This issue would also be addressed by https://github.com/Opentrons/opentrons/pull/18188 but that includes stacker stuff that isn't in the release branch, so it does just a much lighter version of that.

## testing
Check that the protocol in the ticket passes analysis