### PR TITLE
feat(monorepo): transfer command creator updates pt.2 

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
@@ -135,6 +135,7 @@ describe('quickTransferStepCommands', () => {
       aspirateRetractYOffset: 0,
       aspirateRetractZOffset: 0,
       aspirateRetractPositionReference: POSITION_REFERENCE_BOTTOM,
+      aspirateRetractDelay: null,
       dispenseSubmergeSpeed: null,
       dispenseSubmergeXOffset: 0,
       dispenseSubmergeYOffset: 0,
@@ -199,6 +200,7 @@ pipette.aspirate(
     volume=10,
     rate=56 / pipette.flow_rate.aspirate,
 )
+pipette.move_to(mock_labware_1["A1"].bottom())
 pipette.dispense(
     volume=10,
     location=mock_labware_2["B1"].bottom(z=-1),
@@ -229,6 +231,7 @@ pipette.drop_tip()`.trimStart()
       aspirateRetractYOffset: 0,
       aspirateRetractZOffset: 0,
       aspirateRetractPositionReference: POSITION_REFERENCE_BOTTOM,
+      aspirateRetractDelay: null,
       dispenseSubmergeSpeed: null,
       dispenseSubmergeXOffset: 0,
       dispenseSubmergeYOffset: 0,
@@ -327,6 +330,7 @@ pipette.drop_tip()`.trimStart()
       aspirateRetractYOffset: 0,
       aspirateRetractZOffset: 0,
       aspirateRetractPositionReference: POSITION_REFERENCE_BOTTOM,
+      aspirateRetractDelay: null,
       dispenseSubmergeSpeed: null,
       dispenseSubmergeXOffset: 0,
       dispenseSubmergeYOffset: 0,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -435,6 +435,7 @@ export function generateQuickTransferArgs(
     aspirateRetractYOffset: 0,
     aspirateRetractZOffset: 0,
     aspirateRetractPositionReference: POSITION_REFERENCE_BOTTOM,
+    aspirateRetractDelay: null,
     dispenseSubmergeSpeed: null,
     dispenseSubmergeXOffset: 0,
     dispenseSubmergeYOffset: 0,

--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Fixture",
     "description": "Test all v3 commands",
     "created": 1585930833548,
-    "lastModified": 1746124329699,
+    "lastModified": 1746209745232,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -130,7 +130,7 @@
             "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
           },
           "trashBinLocationUpdate": {
-            "408d2d12-f464-4abe-a97c-0b45b46d1de9:trashBin": "cutout12"
+            "0b4601c2-2696-444a-82a6-22c39135a514:trashBin": "cutout12"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
@@ -152,17 +152,17 @@
           "aspirate_mmFromBottom": 1,
           "aspirate_position_reference": "well-bottom",
           "aspirate_retract_delay_seconds": null,
-          "aspirate_retract_mmFromBottom": null,
+          "aspirate_retract_mmFromBottom": 0,
           "aspirate_retract_speed": null,
-          "aspirate_retract_x_position": 0,
-          "aspirate_retract_y_position": 0,
-          "aspirate_retract_position_reference": "well-bottom",
+          "aspirate_retract_x_position": null,
+          "aspirate_retract_y_position": null,
+          "aspirate_retract_position_reference": "well-top",
           "aspirate_submerge_delay_seconds": null,
           "aspirate_submerge_speed": null,
-          "aspirate_submerge_mmFromBottom": null,
+          "aspirate_submerge_mmFromBottom": 0,
           "aspirate_submerge_x_position": null,
           "aspirate_submerge_y_position": null,
-          "aspirate_submerge_position_reference": "well-bottom",
+          "aspirate_submerge_position_reference": "well-top",
           "aspirate_touchTip_checkbox": true,
           "aspirate_touchTip_mmFromTop": -2,
           "aspirate_touchTip_speed": null,
@@ -175,7 +175,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "408d2d12-f464-4abe-a97c-0b45b46d1de9:trashBin",
+          "blowout_location": "0b4601c2-2696-444a-82a6-22c39135a514:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -193,17 +193,17 @@
           "dispense_mmFromBottom": 0.5,
           "dispense_position_reference": "well-bottom",
           "dispense_retract_delay_seconds": null,
-          "dispense_retract_mmFromBottom": null,
+          "dispense_retract_mmFromBottom": 0,
           "dispense_retract_speed": null,
-          "dispense_retract_x_position": 0,
-          "dispense_retract_y_position": 0,
-          "dispense_retract_position_reference": "well-bottom",
+          "dispense_retract_x_position": null,
+          "dispense_retract_y_position": null,
+          "dispense_retract_position_reference": "well-top",
           "dispense_submerge_delay_seconds": null,
           "dispense_submerge_speed": null,
-          "dispense_submerge_mmFromBottom": null,
+          "dispense_submerge_mmFromBottom": 0,
           "dispense_submerge_x_position": null,
           "dispense_submerge_y_position": null,
-          "dispense_submerge_position_reference": "well-bottom",
+          "dispense_submerge_position_reference": "well-top",
           "dispense_touchTip_checkbox": true,
           "dispense_touchTip_mmFromTop": null,
           "dispense_touchTip_speed": null,
@@ -215,7 +215,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "20",
-          "dropTip_location": "408d2d12-f464-4abe-a97c-0b45b46d1de9:trashBin",
+          "dropTip_location": "0b4601c2-2696-444a-82a6-22c39135a514:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -260,13 +260,13 @@
           "aspirate_flowRate": 40,
           "blowout_checkbox": true,
           "blowout_flowRate": 46.43,
-          "blowout_location": "408d2d12-f464-4abe-a97c-0b45b46d1de9:trashBin",
+          "blowout_location": "0b4601c2-2696-444a-82a6-22c39135a514:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": 35,
-          "dropTip_location": "408d2d12-f464-4abe-a97c-0b45b46d1de9:trashBin",
+          "dropTip_location": "0b4601c2-2696-444a-82a6-22c39135a514:trashBin",
           "labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
           "liquidClassesSupported": false,
           "liquidClass": "none",
@@ -2675,7 +2675,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "805306fe-1913-4893-b417-ee81909e46fa",
+      "key": "aad4087e-6de3-46bc-9214-a929f9911213",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p300_single_gen2",
@@ -2684,7 +2684,7 @@
       }
     },
     {
-      "key": "a471d2a0-4a83-4595-9ab0-be8fabc66077",
+      "key": "7f100441-7aec-449d-acc6-082fc50ff63b",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Tip Rack 300 µL",
@@ -2698,7 +2698,7 @@
       }
     },
     {
-      "key": "ded76b25-a046-46f8-b340-6273732045df",
+      "key": "6dbf2118-b455-454b-8438-9ab9912883e8",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -2712,7 +2712,7 @@
       }
     },
     {
-      "key": "c49216a4-e8e7-4133-b5a1-4398849ac811",
+      "key": "654df753-a60f-43ba-9971-625a6a4b2793",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
@@ -2727,7 +2727,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "3360069e-b69b-435d-b627-631685770aae",
+      "key": "1b458301-12c6-4b2f-aab0-63eb8c3c0ef6",
       "params": {
         "liquidId": "0",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2753,7 +2753,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "29144f1e-028b-4f2c-83de-d404ad4fd44a",
+      "key": "08db99bc-5cc2-4f79-a84a-6d4fbeff79c7",
       "params": {
         "seconds": 62,
         "message": ""
@@ -2761,7 +2761,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "5dea11bb-bf9f-4afb-ae56-421b8fa08926",
+      "key": "6b2c4094-679c-4022-8541-0c7314021bb1",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2770,7 +2770,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "13b272d4-982f-48c3-992c-9c67414d3b0f",
+      "key": "9f1ccfa5-79a1-4403-9c7c-376aafe27ad0",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2789,7 +2789,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "72d31fdf-fbd8-45fc-9b5a-8e2a24c807fd",
+      "key": "b500be91-499b-4970-b124-23e3e4f1910c",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2809,7 +2809,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "95fb8949-18b9-4e4f-ac42-45229b40bb94",
+      "key": "47d2ba40-65d1-465f-a653-215a17ad094f",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2828,7 +2828,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d4b8cbe0-3c88-4434-88e4-117b44c63902",
+      "key": "5cc31bdc-49fd-4cf7-bca7-e0e90ee2c6c6",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2848,7 +2848,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f04dce25-88d1-4662-ad82-7a90d37df7f7",
+      "key": "ab39ef88-ed4d-4bc9-80a0-5207b4cc6a40",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 100,
@@ -2867,7 +2867,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "40482bfa-fbcc-4999-bfc9-3e85b878e2de",
+      "key": "043678ac-6547-4579-a072-ca3ec2d01182",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2882,7 +2882,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "b5fe2710-6766-4bb1-9d9c-b72f3c9195d0",
+      "key": "7b2835dd-ed36-4441-bbb3-92cc2037f9d2",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 40,
@@ -2901,7 +2901,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "590846a4-76cb-4df4-87a7-eaa31d0fe6ea",
+      "key": "4d085a32-ce40-486c-bf08-3917cd65dc48",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
@@ -2916,7 +2916,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "43eb7a29-5705-4aed-ad8b-eee87cde4610",
+      "key": "654c28e7-d59b-4b80-b090-16a72e2f4fb2",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 40,
@@ -2935,7 +2935,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "4bdd2448-d0eb-40de-a343-9f632967167a",
+      "key": "607592a0-c64b-47b4-ac31-d1e5326b705a",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
@@ -2950,7 +2950,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "cfc35584-fcbf-4d0a-abef-37d5f9879da6",
+      "key": "8deda0a9-c4dc-412a-aaf0-64a67a4205b5",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2963,7 +2963,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "5211d641-070e-4268-b74f-3a9dcb854308",
+      "key": "1a263e56-ab62-4577-bb7a-0995034a2a61",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -2971,7 +2971,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "2ab2268d-3f4b-4fcc-b822-dbbc0ffcd4f0",
+      "key": "48d7f53d-29ac-4fc4-865b-2a0c0c26f551",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2985,21 +2985,21 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "1c3d6cfb-2eb0-4eab-b8c9-ecc03d8ec3ef",
+      "key": "9321bcc2-b218-4c64-b470-413594d95459",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "waitForResume",
-      "key": "2b365553-21be-4890-a97e-3ecc8550c8e8",
+      "key": "ec4ce4db-5329-460b-9933-b7b38af47420",
       "params": {
         "message": "Wait until user intervention"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "cf5bea9d-acc6-47f2-9ecf-de32ab36eda2",
+      "key": "b4a52858-529f-454e-86f6-8abd7220fced",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -3008,7 +3008,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a3e09891-cf8b-4dae-bf3f-349fce18e4ff",
+      "key": "c1e1898a-5ef5-4932-a44f-8768213aa195",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3027,7 +3027,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "85305c0a-e491-40c8-acc5-afbf706aa507",
+      "key": "f2423109-0e4b-4c26-87b0-fc8e44f9f87f",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3047,7 +3047,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ea54b078-0cef-457a-ba41-ed582abb805d",
+      "key": "00826459-ff8e-4abc-a6d4-8a5974b305e5",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3066,7 +3066,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "057822dc-29a2-413c-89dd-f79c429d14a2",
+      "key": "4e1e0033-e496-43c5-8f52-e1294432e749",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3086,7 +3086,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "48b71d99-2c4f-444a-9b4d-46b5aaa0b0e2",
+      "key": "51570500-9cba-4d0f-bd2e-50ef00f90e86",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3105,7 +3105,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d29d32dc-cd65-4aa5-beb6-fe012d116548",
+      "key": "949be069-b4df-4bb4-a728-1c749b423420",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3125,7 +3125,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "2a998269-5bf8-4fd3-98ed-ce3e24ce7015",
+      "key": "497fe320-8449-415c-a853-0425556c5102",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3138,7 +3138,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "0ed5b7cd-116f-4c52-9c3f-b9efd0f6e71d",
+      "key": "feac54ab-9052-4ba8-b8be-09934c425e62",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -3146,7 +3146,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "b0f10424-f0c5-41bc-9f4d-2c18b5aa8bba",
+      "key": "66e308ac-09e6-41b4-bd27-c6ca6f284b89",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3161,7 +3161,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "353b8ac1-f43d-454a-b3b9-c2be319923e3",
+      "key": "1ca2893e-756d-4850-9ae5-48bac92e7592",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3175,14 +3175,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "61125c37-032c-4fb2-8f81-f40f5b0d2dc8",
+      "key": "e584cf9c-cbff-4718-8e52-ed00fca45b85",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "e0609884-924c-4fdd-a378-99a9ba2829da",
+      "key": "2d5dc88b-d38d-42ea-b094-08df7c757212",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -3191,7 +3191,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4b09bed5-7a67-43a9-97f5-77fd88c0a0ba",
+      "key": "e5e572ab-77c3-4f56-94d3-e9547a70107f",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3210,7 +3210,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "c2968c52-8f96-4409-b9c5-971d2e5cf33f",
+      "key": "bf26638b-62e3-4791-b560-87c03ab83bda",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3230,7 +3230,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4cdd1630-6cdc-49c9-8d6f-6d5529c7d26e",
+      "key": "632dc539-710f-4666-b03f-7c8ec616bb92",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3249,7 +3249,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e8a1fa1d-65cd-4fbc-9fe9-d25ba80f0e1a",
+      "key": "c187eef5-d85d-466e-b2bb-0c3a9cce01fc",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3269,7 +3269,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4147f54c-121f-4b73-a27c-39f109252c30",
+      "key": "e9d8c049-ae26-4d5e-bba6-6079dad7b2bd",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3288,7 +3288,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "40de7c29-b0ca-4c4a-84b9-1ae70dc8bba2",
+      "key": "1da719ed-9769-4ce0-a0a0-4c5249ce2631",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3308,7 +3308,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "aee686df-d6c3-467b-803c-11c960cfc3c3",
+      "key": "0ae8af13-c370-4d7b-ab0b-f63e149f7cd5",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3321,7 +3321,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "421ebb64-0451-45a6-8913-cdec8dec2f75",
+      "key": "a3794c3a-bcaf-4f1b-94cc-1f056ecd6793",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -3329,7 +3329,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "ed5aa32b-0ab9-47a8-9cc9-0610be70d576",
+      "key": "f8df4672-eb1b-439b-8b8a-8e02cb924efe",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3344,7 +3344,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "6e15c9e1-354d-4834-ace5-754fb2488b66",
+      "key": "28435b2c-e36b-4aa0-84ff-a3e6a9d91409",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3358,7 +3358,7 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "722f5c2e-e10f-4af3-82e2-27e9c459e5a1",
+      "key": "5716c6eb-5963-4d33-9aa2-4e537211fb6e",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Fixture",
     "description": "Test all v4 commands",
     "created": 1585930833548,
-    "lastModified": 1746124377470,
+    "lastModified": 1746209789867,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -133,7 +133,7 @@
             "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
           },
           "trashBinLocationUpdate": {
-            "fc9ec12f-6339-435f-bf10-c6eb0c794fa6:trashBin": "cutout12"
+            "6c653d13-259d-4be6-8728-2f3d8acaad64:trashBin": "cutout12"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
@@ -184,17 +184,17 @@
           "aspirate_mmFromBottom": 1,
           "aspirate_position_reference": "well-bottom",
           "aspirate_retract_delay_seconds": null,
-          "aspirate_retract_mmFromBottom": null,
+          "aspirate_retract_mmFromBottom": 0,
           "aspirate_retract_speed": null,
-          "aspirate_retract_x_position": 0,
-          "aspirate_retract_y_position": 0,
-          "aspirate_retract_position_reference": "well-bottom",
+          "aspirate_retract_x_position": null,
+          "aspirate_retract_y_position": null,
+          "aspirate_retract_position_reference": "well-top",
           "aspirate_submerge_delay_seconds": null,
           "aspirate_submerge_speed": null,
-          "aspirate_submerge_mmFromBottom": null,
+          "aspirate_submerge_mmFromBottom": 0,
           "aspirate_submerge_x_position": null,
           "aspirate_submerge_y_position": null,
-          "aspirate_submerge_position_reference": "well-bottom",
+          "aspirate_submerge_position_reference": "well-top",
           "aspirate_touchTip_checkbox": false,
           "aspirate_touchTip_mmFromTop": null,
           "aspirate_touchTip_speed": null,
@@ -207,7 +207,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "fc9ec12f-6339-435f-bf10-c6eb0c794fa6:trashBin",
+          "blowout_location": "6c653d13-259d-4be6-8728-2f3d8acaad64:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -225,17 +225,17 @@
           "dispense_mmFromBottom": 0.5,
           "dispense_position_reference": "well-bottom",
           "dispense_retract_delay_seconds": null,
-          "dispense_retract_mmFromBottom": null,
+          "dispense_retract_mmFromBottom": 0,
           "dispense_retract_speed": null,
-          "dispense_retract_x_position": 0,
-          "dispense_retract_y_position": 0,
-          "dispense_retract_position_reference": "well-bottom",
+          "dispense_retract_x_position": null,
+          "dispense_retract_y_position": null,
+          "dispense_retract_position_reference": "well-top",
           "dispense_submerge_delay_seconds": null,
           "dispense_submerge_speed": null,
-          "dispense_submerge_mmFromBottom": null,
+          "dispense_submerge_mmFromBottom": 0,
           "dispense_submerge_x_position": null,
           "dispense_submerge_y_position": null,
-          "dispense_submerge_position_reference": "well-bottom",
+          "dispense_submerge_position_reference": "well-top",
           "dispense_touchTip_checkbox": false,
           "dispense_touchTip_mmFromTop": null,
           "dispense_touchTip_speed": null,
@@ -247,7 +247,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "20",
-          "dropTip_location": "fc9ec12f-6339-435f-bf10-c6eb0c794fa6:trashBin",
+          "dropTip_location": "6c653d13-259d-4be6-8728-2f3d8acaad64:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -2699,7 +2699,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "6ea86e62-09aa-4678-a8e3-a16a3f94f56a",
+      "key": "ab1cabd3-5b77-403f-a53a-ee1d3dd404f6",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p300_single_gen2",
@@ -2708,7 +2708,7 @@
       }
     },
     {
-      "key": "8856084d-558d-4cd4-8c9d-89212254a193",
+      "key": "a1ac750f-be94-4e35-9373-592e63aef6f8",
       "commandType": "loadModule",
       "params": {
         "model": "magneticModuleV2",
@@ -2719,7 +2719,7 @@
       }
     },
     {
-      "key": "0e9af40b-a108-4e2c-85a0-a544ace3ba18",
+      "key": "62b10d3c-f54b-458d-8e02-96cf7bc65b53",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -2730,7 +2730,7 @@
       }
     },
     {
-      "key": "2bd0c57f-9d2a-49c7-a7ec-ff422e3c4514",
+      "key": "8a8b6300-4071-4108-942a-9f0900f7c86f",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Tip Rack 300 µL",
@@ -2744,7 +2744,7 @@
       }
     },
     {
-      "key": "2637acc9-046c-476c-bf58-2df9a50fdd2e",
+      "key": "7d9762d1-607e-4700-b531-50e7daa916c5",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -2758,7 +2758,7 @@
       }
     },
     {
-      "key": "74bfb814-71fd-4ff3-adb4-3c1787f1795f",
+      "key": "3ef7a6cf-28a0-4687-93ca-e0ae98dc7ad0",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
@@ -2773,7 +2773,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "f7d7eedd-c9da-4d33-8185-474f3612fb88",
+      "key": "e12c079e-74ce-43c5-9d40-89c7e2af30e6",
       "params": {
         "liquidId": "0",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2799,7 +2799,7 @@
     },
     {
       "commandType": "magneticModule/engage",
-      "key": "c11166af-6125-426a-84e4-2bb286c921f0",
+      "key": "324106dc-29be-4099-9c86-40c5a15607df",
       "params": {
         "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType",
         "height": 6
@@ -2807,7 +2807,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "e613f05c-4a13-48dc-b868-9d5c60e671b7",
+      "key": "dde98f07-c206-4dbf-aafa-00dde8fb94bb",
       "params": {
         "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
         "celsius": 25
@@ -2815,7 +2815,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "8e1e1cfd-5c61-46b5-96ba-bdef094f5f97",
+      "key": "5ed0a3d8-739e-47e6-b120-2fb801d8df6b",
       "params": {
         "seconds": 62,
         "message": ""
@@ -2823,7 +2823,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "233f0da8-7d2c-404f-a918-1fbb80d9c4ae",
+      "key": "7bd6ab97-cef1-4e62-8693-5e2f2937ce13",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2832,7 +2832,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "b32580f3-000d-4944-b550-e9b86e080be6",
+      "key": "ecece894-4d14-45c3-9b85-eae18f4b9a14",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2849,7 +2849,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "ac1c6a77-cc2d-4d7d-a835-ce769ae597a3",
+      "key": "05d33612-7b9b-4ccb-ade4-4fec09058b13",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2866,20 +2866,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "d4a48099-dc8a-456d-81d8-bef955edc1bc",
+      "key": "7a9796dc-d279-40c8-87c2-752e7e84170e",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "61f29155-1ce5-4036-9209-e7f353c859a6",
+      "key": "b3868959-44b1-47d2-a91e-7d3e0e14180e",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -2890,7 +2890,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c7ab5bc7-de11-41ca-890b-ddc5570700df",
+      "key": "df125d55-09ff-4eb6-b2db-ad25d42e2a55",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2907,7 +2907,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "551f6104-4d1a-4ba5-9271-e5186175de20",
+      "key": "f3f43cd7-b706-4d15-b034-5c65777ff75b",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2915,8 +2915,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "de4d133b-b8dc-4f39-89f9-eecf14162759",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "7994949e-4484-4169-9ca4-fa8e9667016f",
+      "key": "6e97e02a-f690-4dbe-a423-1e6cab066ccd",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2935,7 +2952,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "4ffbf312-004d-41e0-9d20-eba2e6c715f4",
+      "key": "62a4e52f-f4cb-4c88-a128-f33c507d2ef6",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2949,14 +2966,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "1acbb6cf-b45e-46e3-96e2-91fbfba38ca4",
+      "key": "2d373e17-5f19-4f3d-9fe5-32a1406c289f",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "a931694b-7fbf-4820-9ddc-88aa3bd8b1d7",
+      "key": "cda024fb-3edb-4e9a-b146-665c33ded321",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2965,7 +2982,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "fc5b2c11-c07b-4c11-a1f3-3ac9c9556b85",
+      "key": "31fd89ad-826b-49a3-9a73-b0e193a2cd37",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2982,7 +2999,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "9a5f4e7c-d490-488c-ba6a-ea6efa2db3a4",
+      "key": "f644a8b3-3719-496b-806b-ac9bc45db354",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2999,20 +3016,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "35c150c8-030c-43c9-b179-bc241228d7a1",
+      "key": "b8f8acdb-b475-41e3-af8a-4a8d7811ae0a",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "1ee4c911-ec1d-4b03-98a8-55aa65d5a536",
+      "key": "9e23758b-0bd0-41b3-892a-dd0b8817aa76",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
         "wellName": "B1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -3023,7 +3040,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e2476926-f18e-4fe4-ade4-e8018d9d18eb",
+      "key": "bc4aa529-356d-4d72-9995-b9bb1fdda8fa",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3040,7 +3057,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "dd133c9d-13df-4ed4-a425-cd3f85f8e924",
+      "key": "e37707a1-8739-4e7c-bceb-7afb63034fa6",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -3048,8 +3065,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "a6c32105-7ba2-47fa-9353-ceeb04486924",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "B1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "8c6cc2a4-eedb-4d9f-9740-3b55291742be",
+      "key": "12894316-e396-427f-abcd-bcb96848468d",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -3068,7 +3102,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "d3a83790-7776-4c02-8b28-a0b670330c10",
+      "key": "4e0a23ae-04f6-4e75-992f-7df924df584b",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3082,14 +3116,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "54bd00bd-5ef1-426b-b376-70f799fb6841",
+      "key": "2def7f5e-aa7d-4eeb-9030-2de0f9109a97",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "temperatureModule/waitForTemperature",
-      "key": "4a9ade42-c13a-4564-b918-3318d6199af1",
+      "key": "14859997-8f24-4c3c-9c92-c8bdaa213bbf",
       "params": {
         "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
         "celsius": 25
@@ -3097,21 +3131,21 @@
     },
     {
       "commandType": "magneticModule/disengage",
-      "key": "55894e51-7e09-45d4-8d4c-c257a2c53316",
+      "key": "bc3040a6-6d20-4421-8d95-dcf55806f314",
       "params": {
         "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType"
       }
     },
     {
       "commandType": "waitForResume",
-      "key": "16bc2b24-0a9a-4cbd-a88f-36c1d38addc8",
+      "key": "b045c9d2-13f0-42a5-bb6f-aca1f628a5f6",
       "params": {
         "message": "Wait until user intervention"
       }
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "23c3c12c-a140-4090-8a6c-cc2b13855ad7",
+      "key": "b48a1e53-7b4f-4966-bedf-43b2797fc721",
       "params": {
         "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType"
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1689346890165,
-    "lastModified": 1746124415866,
+    "lastModified": 1746209819810,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -114,12 +114,12 @@
             "6d1e53c3-2db3-451b-ad60-3fe13781a193": "right"
           },
           "trashBinLocationUpdate": {
-            "f7605d12-eb02-4f4e-a50d-1a342ffa3007:trashBin": "cutoutA3"
+            "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin": "cutoutA3"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
           "gripperLocationUpdate": {
-            "9129b881-1703-49fc-a8cd-e09b4a098cb2:gripper": "mounted"
+            "7c9ca5a4-a298-4d7b-a7cf-edadecc26c58:gripper": "mounted"
           },
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
@@ -202,17 +202,17 @@
           "aspirate_mmFromBottom": null,
           "aspirate_position_reference": "well-bottom",
           "aspirate_retract_delay_seconds": null,
-          "aspirate_retract_mmFromBottom": null,
+          "aspirate_retract_mmFromBottom": 0,
           "aspirate_retract_speed": null,
-          "aspirate_retract_x_position": 0,
-          "aspirate_retract_y_position": 0,
-          "aspirate_retract_position_reference": "well-bottom",
+          "aspirate_retract_x_position": null,
+          "aspirate_retract_y_position": null,
+          "aspirate_retract_position_reference": "well-top",
           "aspirate_submerge_delay_seconds": null,
           "aspirate_submerge_speed": null,
-          "aspirate_submerge_mmFromBottom": null,
+          "aspirate_submerge_mmFromBottom": 0,
           "aspirate_submerge_x_position": null,
           "aspirate_submerge_y_position": null,
-          "aspirate_submerge_position_reference": "well-bottom",
+          "aspirate_submerge_position_reference": "well-top",
           "aspirate_touchTip_checkbox": false,
           "aspirate_touchTip_mmFromTop": null,
           "aspirate_touchTip_speed": null,
@@ -225,7 +225,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "f7605d12-eb02-4f4e-a50d-1a342ffa3007:trashBin",
+          "blowout_location": "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -243,17 +243,17 @@
           "dispense_mmFromBottom": null,
           "dispense_position_reference": "well-bottom",
           "dispense_retract_delay_seconds": null,
-          "dispense_retract_mmFromBottom": null,
+          "dispense_retract_mmFromBottom": 0,
           "dispense_retract_speed": null,
-          "dispense_retract_x_position": 0,
-          "dispense_retract_y_position": 0,
-          "dispense_retract_position_reference": "well-bottom",
+          "dispense_retract_x_position": null,
+          "dispense_retract_y_position": null,
+          "dispense_retract_position_reference": "well-top",
           "dispense_submerge_delay_seconds": null,
           "dispense_submerge_speed": null,
-          "dispense_submerge_mmFromBottom": null,
+          "dispense_submerge_mmFromBottom": 0,
           "dispense_submerge_x_position": null,
           "dispense_submerge_y_position": null,
-          "dispense_submerge_position_reference": "well-bottom",
+          "dispense_submerge_position_reference": "well-top",
           "dispense_touchTip_checkbox": false,
           "dispense_touchTip_mmFromTop": null,
           "dispense_touchTip_speed": null,
@@ -265,7 +265,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "100",
-          "dropTip_location": "f7605d12-eb02-4f4e-a50d-1a342ffa3007:trashBin",
+          "dropTip_location": "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -288,13 +288,13 @@
           "aspirate_flowRate": null,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "f7605d12-eb02-4f4e-a50d-1a342ffa3007:trashBin",
+          "blowout_location": "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": null,
-          "dropTip_location": "f7605d12-eb02-4f4e-a50d-1a342ffa3007:trashBin",
+          "dropTip_location": "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin",
           "labware": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
           "liquidClassesSupported": false,
           "liquidClass": "none",
@@ -3949,7 +3949,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "3e8e6577-aa07-497c-ac53-eb27fc0eff03",
+      "key": "94a03494-de32-40ff-8703-a2fdffc940ee",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -3958,7 +3958,7 @@
       }
     },
     {
-      "key": "9c9bb9a0-47af-49d8-810e-aa95e39f0cb9",
+      "key": "b3323053-9da3-43ef-9fab-2840ed3c0a3c",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_multi_flex",
@@ -3967,7 +3967,7 @@
       }
     },
     {
-      "key": "3b76c511-2239-460b-b581-e227601c5664",
+      "key": "3e9bdf23-f219-49eb-b31d-383eafe9a62f",
       "commandType": "loadModule",
       "params": {
         "model": "magneticBlockV1",
@@ -3978,7 +3978,7 @@
       }
     },
     {
-      "key": "52d913ee-7534-4f7c-b30c-48360ce73ada",
+      "key": "d6f31246-63cd-44a6-af0b-c30491756d34",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -3989,7 +3989,7 @@
       }
     },
     {
-      "key": "f02704e1-28ab-4d80-b0d4-bd4bc46d2c51",
+      "key": "2027bb4a-7609-4621-9104-adf6fa051c0f",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -4000,7 +4000,7 @@
       }
     },
     {
-      "key": "62585888-b556-4ae4-a2e2-6b4eee80b7a1",
+      "key": "2a21a46c-4997-4859-8697-27bead7d1911",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -4011,7 +4011,7 @@
       }
     },
     {
-      "key": "d4d9a53d-a2d4-41c3-a546-72098dce0606",
+      "key": "f4935553-2eba-4dd2-be4a-1a35aaab06fc",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
@@ -4025,7 +4025,7 @@
       }
     },
     {
-      "key": "017372f1-1803-4246-a8b4-e7a377d58ff7",
+      "key": "33d678fe-a59f-44ff-bbcb-3658a8779c14",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Filter Tip Rack 50 µL",
@@ -4039,7 +4039,7 @@
       }
     },
     {
-      "key": "eb55a292-9f86-4155-b402-cf0b9f264b7d",
+      "key": "82ecdcfa-0758-4f57-a83f-4af167946b4c",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -4053,7 +4053,7 @@
       }
     },
     {
-      "key": "b2014b4e-576e-49f7-8e68-bb276ac9e0ad",
+      "key": "fe5acd0a-5ff5-4270-851f-9e34417f1221",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap",
@@ -4067,7 +4067,7 @@
       }
     },
     {
-      "key": "c23480e5-7129-4b98-86a7-8af699faaa77",
+      "key": "0f91689f-f440-4241-beaf-45b6b53fc95b",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 200 µL Flat",
@@ -4082,7 +4082,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "4119d891-b434-4b4e-8eae-92436ae337ac",
+      "key": "6f69d71d-50f2-4e17-a4cd-87dd222433fc",
       "params": {
         "liquidId": "1",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4093,7 +4093,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "4ef382b8-608f-43a1-a21a-3dac3261a3c0",
+      "key": "4b42e730-71e6-4bb8-89d2-e1adc5c8be08",
       "params": {
         "liquidId": "0",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4111,7 +4111,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "460c41d6-2abb-44f7-bd84-90644acfc1ff",
+      "key": "f452f660-9df4-4ccf-953e-fb34a259a2fc",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType",
         "celsius": 4
@@ -4119,7 +4119,7 @@
     },
     {
       "commandType": "heaterShaker/waitForTemperature",
-      "key": "70d80ef0-d325-46e0-bb5a-48c37cc33776",
+      "key": "ab22931d-663a-4379-bd12-4ddc9ed1c069",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "celsius": 4
@@ -4127,14 +4127,14 @@
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "fca34f95-4544-4151-be2f-605d18a39ad4",
+      "key": "544b940d-9adc-4783-9d8d-4e691057c986",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetLidTemperature",
-      "key": "f5749889-883b-46d6-9b4c-14ba5593a48b",
+      "key": "953d3005-04ee-4b9a-ba49-d2c91a794ee2",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "celsius": 40
@@ -4142,14 +4142,14 @@
     },
     {
       "commandType": "thermocycler/waitForLidTemperature",
-      "key": "e9f21079-909b-4796-868b-95523c33b300",
+      "key": "eea9708c-b11a-4626-8729-0ed7510d05f0",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/runProfile",
-      "key": "6903b2a5-124c-4194-8870-6cd71716d5a7",
+      "key": "0c99fe27-9490-4e59-bcd4-0f8470dc95b2",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "profile": [
@@ -4167,28 +4167,28 @@
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "a746f9d8-2600-4915-aa8b-3a81044a70f0",
+      "key": "15b959ac-0588-4dd3-9791-dbcc0a956fa7",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateLid",
-      "key": "0d41290c-758f-4e40-b12a-9809ae43af33",
+      "key": "681447ae-8fd7-4039-95d0-680ff8c54879",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "5aab3b18-8d2a-4aa1-a8d8-df00ec11dbef",
+      "key": "8a48ae62-f250-4de5-9928-b4b695859d7f",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "c6788ddb-c5f5-4d97-af3b-819ee703adf8",
+      "key": "0362e76b-1292-41cb-ad26-ea606f57bfd2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4197,7 +4197,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "982257a3-ac33-4352-9d25-acf5f123679c",
+      "key": "82921916-eb8e-4e9a-8ebd-a7122c027924",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4214,7 +4214,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "53349b41-0181-42d6-be2a-9538deff5ce6",
+      "key": "0fb1bf0a-65fc-4e95-9899-f6b5315e90bf",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4231,20 +4231,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "796ac72e-e88e-4d4e-ac6e-a25b0be2a865",
+      "key": "f8975cf6-bc23-4a0e-a1e3-efee25270d03",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "b3e1a5a8-a39c-4289-bade-bb1a6f0142f8",
+      "key": "08557306-a013-470e-b21a-72dae7643af0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4255,7 +4255,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "35e92417-b0f4-49f0-92f5-41d6abe8fb55",
+      "key": "c706bffc-e6b3-4eba-90d5-c8a34b575f31",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4272,7 +4272,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c0e70ae7-4fdc-448f-a370-153a4892f7dc",
+      "key": "1ae36dcc-85a0-40a8-bae9-ea918f1d4678",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4280,8 +4280,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "7d9130cf-80c7-4e0b-af70-cdf5c962bde4",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "6d8a9955-a09b-460a-9f7f-99c102a270b9",
+      "key": "6987fbbc-1846-4308-aef2-64e1ade87ce3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4300,7 +4317,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "145f23a3-9ce1-480c-a0ad-e2cff1037721",
+      "key": "db9fffbd-a992-4472-be5d-d3c5ca1e09ba",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4314,14 +4331,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "7960dc09-d5ed-48d1-a7d3-95d2745aa875",
+      "key": "0bea1569-e839-46f3-8284-6347bbc3d052",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "b71d7bce-f006-4e21-be60-d8c42a3d2587",
+      "key": "98b82b80-02a0-4c10-a4be-43f06a94b8c9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4330,7 +4347,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "03c2808e-8ece-4880-b132-2984b0b79a49",
+      "key": "99005145-bde7-4182-a866-b53c3db84df5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4347,20 +4364,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "0bfd5626-70ed-4375-b629-53139bbe5ca5",
+      "key": "555cd77a-e271-4870-9618-898675a77672",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "884c4619-e280-4b43-9fd5-564cbe4e8db1",
+      "key": "e1575dee-d84f-4959-936c-81643c434ed7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4371,7 +4388,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3d78610a-f8f1-429c-99df-8bd544d9ca50",
+      "key": "db3ae10d-6b06-4314-b7f0-183aa6571d60",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4388,7 +4405,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c922ca70-b9fd-4c8d-bb22-f0f3a3335b8e",
+      "key": "ad67419a-ee77-47fa-abd3-1cac7e3079a9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4396,8 +4413,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "60a93a52-85db-45e7-8c9a-f08f50f01e74",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "0f87570f-1eef-4631-a78d-8b0fa86114c5",
+      "key": "70b4b8f6-d31b-4f02-b5f3-0f3dbbc3325c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4416,7 +4450,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "568cfb91-209c-4fc9-a19f-6c62dfac0e9a",
+      "key": "182817c0-4054-4ec2-a4c6-f559c803ad06",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4430,14 +4464,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "a5604e3b-ba9f-4add-8b9c-84a21789b80f",
+      "key": "594451e3-c057-4d1b-87f1-1e60e6332637",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6d3a90fc-ca52-49d0-9b85-d0d16a32bddd",
+      "key": "3e9e39e8-1720-4907-abce-b8c014a1b119",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4446,7 +4480,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "57f05fe6-865d-4a8f-bc42-c8c94b2091e4",
+      "key": "a439b792-c267-418a-96ad-3cedac790cec",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4463,20 +4497,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "fdd1dd60-e911-4f2d-b53e-178a5798d569",
+      "key": "6152de89-0ba7-4ed0-8803-fc652000b078",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "e63414c0-9657-4548-8c1d-89fd08e95f24",
+      "key": "d1b212b9-f736-4ae5-8b40-95d7fe1833b6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4487,7 +4521,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f2115df0-6f2f-4a4d-8b68-15a7b2bfe654",
+      "key": "3d7c932f-5c09-4f4d-811d-789f8afe207b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4504,7 +4538,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "07a892db-5781-42d4-aa79-43a1b35d6ec7",
+      "key": "9ba31d58-40c2-497d-9dd3-7dfef15a485a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4512,8 +4546,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "f3aea34c-188f-48f1-909e-07f69867a808",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "eb3e1047-8883-4d03-b581-4c67251be257",
+      "key": "4054fbd5-f1ce-4c33-9659-aba46d60041b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4532,7 +4583,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "f1812bd4-81dc-4dfe-aaa8-610e4ef18c48",
+      "key": "335a5111-ee98-4e12-91eb-5f4eb44f0930",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4546,14 +4597,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "360050ab-fc86-4fe7-9cd6-56c37bd238f0",
+      "key": "d5ac17ab-0cfa-4914-84e0-48c3fcafc094",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "34e94a1c-7c8e-4b63-a826-5da3296fef76",
+      "key": "7ce9ed8d-3c1c-4923-b89d-caaa801591cb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4562,7 +4613,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "62836e93-d0e6-4b37-ac76-04e0e11e56c5",
+      "key": "1b69ef98-e86b-472a-b504-c07151dd23e2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4579,20 +4630,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "313c03d2-f37a-4a39-a01b-76fb89d4a9f7",
+      "key": "483a941d-5b2d-49e5-8730-6e1ee8171be5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "f7ef81a2-e553-4b6e-ae0c-3d345d934a2b",
+      "key": "97da8b7d-7af1-4658-8d11-75d13c4874d8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4603,7 +4654,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "32a63193-fe48-4449-ac65-b3dabb1cde95",
+      "key": "459be449-54c1-4651-a9f9-8e7bdd25755a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4620,7 +4671,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "48d3f62d-4c60-4163-9818-550fe957cccb",
+      "key": "fc207a7a-76a6-41b2-8b62-2afde51cb655",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4628,8 +4679,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "8b2fe219-dbc0-4ae5-8e9d-d731e52cd42d",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "45387986-a307-46f0-a439-b67087cf29d8",
+      "key": "9b1227b7-7967-4179-8068-6a35c2ff9ba4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4648,7 +4716,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "fc203ba1-464d-45a4-8782-4b718019179b",
+      "key": "510cc0e5-7333-4c2e-9525-68db3bbdc349",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4662,14 +4730,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "b19976d2-4b2d-471a-83c4-2eebe6e96793",
+      "key": "4abf13c0-a9e0-435c-98d6-855246dfb24b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "ada2092a-c025-4393-89e2-3e7b728fa33d",
+      "key": "2eeee9c5-c548-4a80-ac6b-a69bd6418172",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4678,7 +4746,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4ed5856d-f81c-47e7-adcb-396c9c2e3aaa",
+      "key": "5df1c768-d005-4b25-aa15-6490b1b5ffdf",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4695,20 +4763,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "ee651e1b-3c88-404b-820d-c86e6f1a658d",
+      "key": "aa703a1c-b105-4808-87d6-0591154bb38a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "ebdabba2-884f-4f62-853d-8e04396543b3",
+      "key": "f587ac58-373b-49cb-be4c-238b50881b7c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4719,7 +4787,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7ccca75e-10c2-4c55-a3fb-dd6c625ee324",
+      "key": "1cdbf57b-d28f-46af-b9c7-7bf8185663f3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4736,7 +4804,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c835cda5-9608-41fb-b7c3-c1eaad4dab7d",
+      "key": "eb8144e2-d398-459b-94f6-13783c703078",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4744,8 +4812,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "cc2841e2-6a99-4b05-8a8c-3ee7fc48c14e",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "55dbc249-d5a6-46e6-8bb4-bf28606fd3bb",
+      "key": "d61b21bd-b706-4483-a5bb-9e1753b4cc35",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4764,7 +4849,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "20aeb854-9795-45d5-adc0-3857dcf13077",
+      "key": "9d0d3adc-8492-4b43-a21e-4428de12e8c0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4778,14 +4863,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "3c12712f-83f3-4323-84fa-f4f11d2b524c",
+      "key": "4aafd22e-72f4-4d26-90d2-8dc106c834df",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "36299dda-92a0-4f13-a942-554a0aceae73",
+      "key": "2333103a-32ee-48a4-ae7d-4e692ce0f5bb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4794,7 +4879,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "aee614cc-873a-4a00-b0d7-1685f598e6ae",
+      "key": "7906388a-d331-4310-b091-edaa0fd494df",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4811,20 +4896,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "875d5ae5-b68b-45fe-87ad-5e74d0d8327c",
+      "key": "4c92f67f-b350-460e-bbf1-a3449af46e6b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "54076923-baf4-48a1-8237-4adaa4b6003f",
+      "key": "a3f0fbb0-ae00-4a6d-a5f1-d6fcce1f6bf1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4835,7 +4920,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8ce14634-5bf0-4808-9010-4e00d30148bc",
+      "key": "c8b94aa8-9f30-4642-b4ee-5cbe19c1ddec",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4852,7 +4937,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "61eb7cc8-905d-4d03-b12a-e296db1f5fb6",
+      "key": "c5bde304-da48-4475-8aa2-c4195fa70220",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4860,8 +4945,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "ce75f4c6-871a-4190-935e-17e57fbfd7bc",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "9c7d395d-6036-43c5-81b4-31ac7fbe72b2",
+      "key": "1334de84-1582-4069-a52f-65f1b8cfc38b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4880,7 +4982,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "eac2b5c8-ea7d-431c-a808-a6a2b138b6b6",
+      "key": "0d58a10c-4542-425f-b89c-eb1ac17f91e2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4894,14 +4996,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "8c6cf249-5835-40f8-9837-8bdcf872d6fd",
+      "key": "e5fc79ec-1832-4645-a97a-8e2a7a3f27f3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "7064be9e-7c4b-4ab1-a97e-af40c51dec7f",
+      "key": "ef49a1a1-5fbd-408a-b5d5-09ac4de68416",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4910,7 +5012,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3f2a43a9-fa87-4e71-b055-7bf18baffb59",
+      "key": "01b147d3-d029-47a3-a8a8-d8a7590f9950",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4927,20 +5029,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "323368e8-d9a0-4e5b-ac1c-373a73fcb62a",
+      "key": "f43bc16c-1a9f-4fe8-b216-b8db69e21912",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "90b54888-0538-4320-b2d4-233c55d2b223",
+      "key": "6b25e4f8-59ec-4ecc-b7bf-2a7d07653f6c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4951,7 +5053,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "fb78b88e-7c3b-474e-ae57-bbe78ee82ab5",
+      "key": "11496e46-bdbc-4e31-82ed-502e24bec1fe",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4968,7 +5070,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e0aab003-6b04-4563-a6ba-19f2f54d2d64",
+      "key": "30761e4d-b065-4b5b-9401-59bf16e99453",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4976,8 +5078,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "a6a351c2-d929-454f-87f7-c805a65522a4",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "294627d2-0939-4074-ba8f-a7d3a37ccd10",
+      "key": "a91a8e06-618f-4a94-b66e-b62b2daf153a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4996,7 +5115,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "83001277-33b8-4a78-ab4d-ad07c99ff0fe",
+      "key": "3f3c69fe-963a-4f4e-9673-3793169b260a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5010,14 +5129,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "e595d091-a2b1-4ff2-83b2-eaa212f69e6a",
+      "key": "c69773a2-45f4-4089-9d2d-b4ce09bd6b09",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "f797c5b6-eac5-47a0-9000-58840037f1cd",
+      "key": "7eefcd9c-16fe-4a5d-8382-a4d309089297",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5026,7 +5145,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3d10d83c-4494-4ad0-94b2-0d94c1a22dc2",
+      "key": "9c3e8f2d-84ab-45db-80b5-73d4fd1fe850",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5043,20 +5162,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "dacf2ce6-fd30-4214-b8f7-f93c7d9c2c9b",
+      "key": "da4bdf08-9ab5-44b3-ad5f-153853d3ac6d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "94fe99d3-ec4a-439f-bf90-f04f662820c0",
+      "key": "5952266e-9005-40ac-a7e4-2dcbd39872a2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5067,7 +5186,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a2df1efa-f95a-426f-bc92-74e0e4c15aa5",
+      "key": "e2e8ade8-4906-4db9-a217-b24ab2ed700b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5084,7 +5203,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "fd24b07c-89cc-4ae6-9850-b623e6ce456b",
+      "key": "e5ed8bb7-1ee8-43c4-b4a7-9b84ce02c964",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5092,8 +5211,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "8aba4ebb-15aa-4aa7-be1b-a9d33d2644da",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "0858dd29-b3a4-48e3-a024-8332025b8577",
+      "key": "4bfccb84-e4bc-4bd5-8984-64b5048a2481",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5112,7 +5248,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "c0bebb67-f0bb-4a85-9c2f-f691b85b8e24",
+      "key": "849f20a0-171f-48d7-bdf9-0bdd86427a6b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5126,14 +5262,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "9d3363a9-c194-42dc-8e66-60a62986c603",
+      "key": "1a1d7453-2dd6-4548-ac1f-2f6f89c6fa4f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "11b21264-e4e6-48f4-92f2-c80ba69f05c8",
+      "key": "9d263e15-0ef8-4597-8a72-24c3d2435fe3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5142,7 +5278,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "fd41f104-cbe7-4f5f-89d6-4b26283c747b",
+      "key": "3aa20a47-f6ca-4ef0-936e-baac37a1afe1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5159,20 +5295,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "27afa503-0ff3-4880-a9e3-4d03138ade34",
+      "key": "898e344c-8ff1-4537-b2ff-258f51f90e22",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "9401fc95-4ec7-4d2a-8c16-c131cadffb1a",
+      "key": "dbda64fb-8225-4886-9ebb-f851a97c592a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5183,7 +5319,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "122db236-0ff1-4ccb-a8d8-e1c30305d78a",
+      "key": "9d7b5e53-f6ec-445b-b097-e0836bacc689",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5200,7 +5336,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "6f9f23b8-b3ec-4458-bea0-23e713d57fb6",
+      "key": "1e87f116-b700-4252-b3b5-0b13683933cd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5208,8 +5344,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "52c3493d-8cbf-4039-a37b-6bef1784caea",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "f503d5fd-3367-4e6a-8346-0e0500edcc4f",
+      "key": "ddb01927-8f48-443e-adfc-c4b4cfd05f3b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5228,7 +5381,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "8ff4646e-f133-48d7-ab4e-5226d36c9ab5",
+      "key": "d8731329-212e-4017-9feb-89686279e124",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5242,14 +5395,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "23fa4806-a8f2-435e-9507-3ba4b937cbba",
+      "key": "60a044af-5175-4450-8d5b-f7cebaf5930b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "a34e38ee-63f0-42c0-b6d6-ece3316591cc",
+      "key": "6671f3bd-9dd3-4100-8f92-8ef92fc59ef8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5258,7 +5411,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "825c0eb7-09b6-4504-92af-a4ff82999a43",
+      "key": "698ce736-32c1-4464-8fac-f8206d582e81",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5275,20 +5428,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "fb217502-a79c-4c63-a1c2-9a8cde7583c8",
+      "key": "c12f8b93-8666-4c4b-8c8f-002132b2025f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "0de41822-4859-4bbf-a0a9-e4c59bbe4a2d",
+      "key": "5fdb291e-e0c5-405f-b61d-7bde68a86c97",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5299,7 +5452,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "97284d4c-f1c9-47ed-a8ec-0c017ba6b582",
+      "key": "c33efbeb-b893-4f28-ba29-b6e195f9d594",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5316,7 +5469,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "95ef9021-5b04-4476-baba-3e5ac3ba8f17",
+      "key": "e47d8f07-6946-4d0d-a75c-69facbcd85ef",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5324,8 +5477,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "59f1d929-5f40-4029-97de-3121746c28e3",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "b5abf11d-1b04-4386-b55e-43cd3a1a065e",
+      "key": "34d5e636-2a28-448c-b8d0-a87472a68dad",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5344,7 +5514,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "7c5b5250-7894-44e1-9c2f-27ad7fc0e814",
+      "key": "ef7703de-c8be-438a-aa60-3eaf7b60406a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5358,14 +5528,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "2e45d647-4f9a-4705-8609-1d6e10dbb1a8",
+      "key": "771948fb-2f0a-4204-91b2-330f11a2e5de",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "3314bec6-7c83-405f-b89d-b6c71c02a34b",
+      "key": "861f0030-8903-486c-8a83-1689f3429b2d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5374,7 +5544,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a2d8ee5f-9280-401e-9ad4-2dd196405c54",
+      "key": "ab176de5-d0b0-49da-a52c-cb7b9471ac16",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5391,20 +5561,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "21805371-0e7d-4a7b-9f35-5bfce0d2c7b9",
+      "key": "7d6e227f-aa97-4bdb-9abd-3d60fc523294",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "32c24538-ad73-4434-84b8-fff4baf1bfe4",
+      "key": "535619e8-0743-4060-8587-f0e10a0c0b87",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5415,7 +5585,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7df2875a-7a42-4f0d-ae13-29ca963c67bb",
+      "key": "8003f164-ddb9-4683-b749-a4f2b06501d6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5432,7 +5602,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "75b28c3c-86fd-4323-9c20-ee9ac5f967c8",
+      "key": "fe92924d-8896-4b8c-abe7-5f6d56c9f429",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5440,8 +5610,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "46bf9fc3-14c1-49e3-a48d-dbf44304c5cd",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "6dedbfef-3365-4691-8cc5-95535f4c9076",
+      "key": "60746cb1-85ad-4860-a34f-8f0a8af9ef7e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5460,7 +5647,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "b2de534a-c750-448d-9434-293b748c81a8",
+      "key": "49a9e558-7e86-422f-a2b5-22f29687e4fe",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5474,14 +5661,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "3a832d0a-fb6d-41b3-9b9e-28d8fb63efdd",
+      "key": "44d958bd-518b-45b5-bc01-e56a464e2ca4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "ff7bc500-0867-4c15-8269-1b1584873f81",
+      "key": "f2c52277-e37b-4673-a331-4937fe1ef737",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5490,7 +5677,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f02338f2-b4f9-4da8-a412-9a8e5a40d1ff",
+      "key": "f5ddb8c1-596e-43f9-a053-956cd9e72d81",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5507,20 +5694,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "8994c489-273b-4e6b-b15f-91f505b18504",
+      "key": "01333526-4125-4544-b489-85e7b9030fea",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "444635f8-1205-4d34-93c0-d0e85477454c",
+      "key": "ba8ec3fb-5251-46a6-b472-49ee22ba28cb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5531,7 +5718,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "135a3202-9691-491a-98d1-b9efec06a4c9",
+      "key": "45dd78cc-df87-4de4-972d-5133fc050bb5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5548,7 +5735,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "12dbf44d-e299-41d3-909d-93919ab66ba3",
+      "key": "3cdcb360-3225-4839-a332-47ffb6391296",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5556,8 +5743,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "9d5b68d0-c38b-4a29-9cff-21f3e9ffcadb",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "a857ccf1-b1ed-4e64-90e5-52f25b81c009",
+      "key": "48d0744d-a3b2-4b0f-a586-e4351cac5941",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5576,7 +5780,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "727ad7bf-6e20-46da-93eb-6821769f5239",
+      "key": "0a3ba7a6-42d5-4e94-bfb9-4627db0edd90",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5590,14 +5794,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "49ae540b-9f71-46b2-a1fc-8309e425c7d4",
+      "key": "261b8456-7523-4362-a9f9-dafc18cd7679",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "63a06024-a8cc-4e9c-8f91-5897df30f661",
+      "key": "cf2648e9-1ec4-4397-a79d-c3d9b3aeed67",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5606,7 +5810,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "35781500-ef7b-4ff2-930b-ab094a6429d7",
+      "key": "c6f01d11-7db4-4b8f-b6fa-8015b14b2614",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5623,20 +5827,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "620b6c5a-ae28-436d-b1df-74c29563f93e",
+      "key": "40aca2ea-ffd6-4781-b4eb-07f99bb2c04c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "6ae7ef11-fb62-472a-b8a4-f4054895ef97",
+      "key": "d0a0d482-fb85-43bf-a843-21e89a4b35cb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5647,7 +5851,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "23924109-5d6c-4d3c-83a0-7ad47d46369b",
+      "key": "c94ce12c-5da2-4f0e-9c68-7881a0c0b8bd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5664,7 +5868,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "11f86369-bce2-4fff-b9c1-76ccccd0fb12",
+      "key": "4e81fa38-a13e-47e3-ba8c-a158046253ee",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5672,8 +5876,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "dc5c21f9-52e5-4406-af7d-1f9228665810",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "673f2c63-0462-4aa7-a862-caef522c1c7c",
+      "key": "81f07f26-eeaa-4f3c-a8c4-809e0cc5bb3b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5692,7 +5913,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "859bc265-40fc-4774-a555-827e7ffa712b",
+      "key": "1fe0ef8a-52dc-4b48-8a4e-6fcb9b3cc8ab",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5706,14 +5927,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4f1fd044-4726-44ef-b82b-9abbad03ed84",
+      "key": "7e8ca479-46c3-4225-ae28-3ebef22ab441",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6493e2c4-c7bf-4318-94f5-689581c5fe92",
+      "key": "0775ee58-330d-4abc-878f-718cebebe1b3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5722,7 +5943,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5c9ca8e5-f72d-4bf1-a498-3224922f3e2b",
+      "key": "007d1a87-2e53-46a0-82fb-aca0b0ccd19d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5739,20 +5960,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "7f2b1e4a-9139-4afe-8d34-e581f5feb331",
+      "key": "7af59d1f-abd6-4c2c-aa9f-2b5493f5751d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "117b15f9-13c2-4a48-bfbe-d266f2c5b790",
+      "key": "a97634fb-043e-421e-a2fc-dd1feb3f58b0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5763,7 +5984,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "12b0cf33-0690-44f3-b85f-8de606d684cf",
+      "key": "d2de7bcf-61e2-4a02-908c-1b79b1fa0a89",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5780,7 +6001,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "6083bf14-9d10-4f3f-b13d-396cb1f8d1bf",
+      "key": "f14fa8fb-f3b3-43d5-872b-c1c17245f339",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5788,8 +6009,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "1ba0810f-411f-4e40-98fd-65bbe29e95c3",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "2dc22638-f37c-4a15-a9fe-d9b88c94db5f",
+      "key": "d64b51bd-b399-4807-9a99-a8be6944a749",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5808,7 +6046,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "3263cf1f-3fd8-4adf-8d1f-766ab116d1b1",
+      "key": "45199ceb-b44c-451e-af05-1669f1fa07ff",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5822,14 +6060,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0d263a9b-a594-44a2-9d62-af668c768c76",
+      "key": "44bc5e0d-c588-4966-a396-1b0a89849499",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "63e0f891-bdf2-4298-bb66-8a90ee7cfbbe",
+      "key": "25ab0698-e8b7-4166-9ef9-f1bc5b795723",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5838,7 +6076,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "927e5679-c94d-4625-90d5-85d28a769fd5",
+      "key": "16f60f59-6c4b-48da-9c93-f24c5e3dca5c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5855,20 +6093,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "74edfb7d-ca6e-4534-9ecd-9ab92cd15afe",
+      "key": "14876cfd-c1d0-4c5e-ad9a-7dbb1a30defe",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "0dd021cc-efdc-4207-bd25-ca3e574fd2ff",
+      "key": "92f30722-e6a9-4136-bb5e-b341108aec1e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5879,7 +6117,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "12ec2f2d-1b74-4bfe-8522-20aea7b91b9e",
+      "key": "8019a927-ae18-4e9d-9868-ac472051738a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5896,7 +6134,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "183c5672-f904-4b76-bf76-d3f4a9299f74",
+      "key": "62368d98-5514-4dd3-9c05-10d027e90aac",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5904,8 +6142,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "9becff2f-c25f-4004-90e8-5712bed27a9c",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "f52ce4c3-b0aa-4708-8881-87b25b741d0d",
+      "key": "61caf86b-3e6e-4110-b125-f08e46ab161a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5924,7 +6179,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "2b79618e-a16a-4027-87bb-7cfc0351eebf",
+      "key": "ca0516cf-3d06-4a55-9c66-b2ce6114094f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5938,14 +6193,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "1effffb9-4460-4d9d-9654-df4b55c422f2",
+      "key": "76edec38-499d-45e4-b734-aca57b277b55",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "1874c173-2d06-48e8-a2c0-5694e06a89bd",
+      "key": "07d9c5d1-6ee8-44b9-bfcf-fd3d0233bd2f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5954,7 +6209,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9610138b-1c2b-4de8-9ab2-376d8dee6666",
+      "key": "c5fcf843-aa72-4bec-900a-570d631029b4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5971,20 +6226,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "64c540cf-454d-427b-877b-e4b467e94ff8",
+      "key": "b9ca76fa-d14b-4247-a839-3f0a85d3fde2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "98c4a0f5-8b60-4556-8e8f-c2c582ddd91f",
+      "key": "f819f8a1-5d5b-46a0-8b13-f6824583d3e6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5995,7 +6250,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9d9f1e32-360d-4b71-a804-0868a6262281",
+      "key": "52611872-d570-4962-a91f-031568af3cda",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6012,7 +6267,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "27dc5cc8-7973-4d8b-99ec-2ecd7c02893f",
+      "key": "9364d182-ec6d-4ec3-b01b-e472e33eabe2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6020,8 +6275,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "0c95a8e1-993f-4cd6-9907-a6502ba36a7e",
+      "params": {
+        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
+        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "5e58742f-3a25-4471-b9c9-b3e520f61db2",
+      "key": "41a82386-65db-4cc0-b856-0b7c9a644584",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6040,7 +6312,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "fce1bc6c-13bd-402d-93b6-d8207ba1ca93",
+      "key": "a12e2fa4-7aa1-4a8c-a86e-dddeb12e47c4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6054,14 +6326,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "b35ebff4-dde8-491e-b59c-2051edebfd4b",
+      "key": "3edb2789-cd6d-4ae1-8def-bdc60fbf3adf",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "525ccd42-b4a3-4b8f-8e57-cb5b7763c52a",
+      "key": "9f284063-4225-4c4e-a671-82440ff6d762",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6070,7 +6342,7 @@
     },
     {
       "commandType": "configureForVolume",
-      "key": "2022b1e6-8485-4daa-b121-cad569c40c75",
+      "key": "7887c06f-d10f-4f91-a146-c8788c0b393f",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10
@@ -6078,7 +6350,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d6f8470c-a547-46b9-bc13-650c910e1926",
+      "key": "c22773f3-e2e7-47d8-ae69-c4c58c626d36",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -6097,7 +6369,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6be87884-3fbb-4d59-8921-f9f1bdf08979",
+      "key": "e0447b54-7e81-49a5-8d97-587e37e0960e",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -6117,7 +6389,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "154012c3-2753-427d-a95c-658120e3479c",
+      "key": "ccd1fb49-e477-456a-9ba4-7ae4b6d3b631",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -6136,7 +6408,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1f846ebc-ecf8-40f8-96f8-f082d65479a6",
+      "key": "9339d5f5-cb2d-4e0c-96d4-c072b6a86cde",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -6156,7 +6428,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "a69100e6-c2a7-4162-92da-295c72c54c5a",
+      "key": "ef969b1b-5665-4e6f-97a1-29dd28a2aa07",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "addressableAreaName": "movableTrashA3",
@@ -6170,14 +6442,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "26755048-b827-4c04-8620-d54b1a80e5a2",
+      "key": "99ac4ab2-96ad-46a6-8728-907fd037c3c2",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "38a877a2-0982-4725-b8af-8b9b944804e8",
+      "key": "31334841-33c1-407e-8fe7-f205bc1f9d39",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -6188,7 +6460,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "deca7004-4aad-44c5-8f58-b77b8ee0a407",
+      "key": "32c789ce-c511-4f78-b3b6-331299d61c4a",
       "params": {
         "seconds": 60,
         "message": ""
@@ -6196,7 +6468,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "c7cb978f-6893-4eaf-ae3f-df8fe319156a",
+      "key": "ab7b158f-87c9-41f1-ba59-835752dd052f",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -6207,21 +6479,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "3c0afe47-cea2-422c-9810-d2fbd9e1a1c9",
+      "key": "fd7ff030-c536-41fb-947c-876251c32a09",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "31ac8336-6911-4f93-9d6b-0909b1c11647",
+      "key": "59b0e96c-fdcb-4b47-9c86-7e6292834985",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "43b502fa-c3ce-480c-ae0e-f88511e0094c",
+      "key": "094b64bf-f609-4576-9a94-64857807346b",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "rpm": 500
@@ -6229,28 +6501,28 @@
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "2288119c-fa88-4daa-a489-2b126c539935",
+      "key": "ab693690-5091-4200-b234-0d7ef62f84ec",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "45c1efad-60cf-4c88-a657-6cc441643bd5",
+      "key": "bac58d5d-50fa-403e-9f76-1099da577887",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "9f86c06a-5947-4922-a379-cc74bfd2f69d",
+      "key": "26409823-b7ec-4d43-b413-24bff2b8307d",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "8630050f-843b-4c03-b70f-2d625058e13e",
+      "key": "ce85735d-5dd2-4a7b-8709-d3b313863873",
       "params": {
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "strategy": "manualMoveWithPause",
@@ -6259,14 +6531,14 @@
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "14568079-89e7-4847-be8a-18338bd13171",
+      "key": "c5256eea-fc5a-4905-aa4a-fe070a17eabd",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "1783509e-4e84-40b1-8a41-ec5ed040d2cc",
+      "key": "12ee6a26-0a6a-4bf0-8ca9-56b3af11f698",
       "params": {
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
         "strategy": "manualMoveWithPause",

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1701659107408,
-    "lastModified": 1746124471760,
+    "lastModified": 1746209876922,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -3599,7 +3599,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "1c51d339-bbe5-4369-a43d-d046f5ce61fb",
+      "key": "213f9fd4-33fa-40a1-9930-cac0ee2e71ba",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -3608,7 +3608,7 @@
       }
     },
     {
-      "key": "a7378cdf-809b-4163-8271-5200ef1f7800",
+      "key": "eea7f013-dd47-4d1f-92cc-afdd170a48ac",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -3619,7 +3619,7 @@
       }
     },
     {
-      "key": "e98aefb5-a80b-471c-9859-6a54b0c4b6cb",
+      "key": "bb04b7ff-4e87-4cd7-b918-e187f5992281",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -3630,7 +3630,7 @@
       }
     },
     {
-      "key": "f92cf967-d3a7-4d5b-a172-a83b9e1a1a5c",
+      "key": "6603a5b6-e0f7-4923-9079-d9702c713d25",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 PCR Heater-Shaker Adapter",
@@ -3644,7 +3644,7 @@
       }
     },
     {
-      "key": "21f685e6-a0b8-40f5-9c34-5e4be7386bf6",
+      "key": "199735b6-d254-450a-8717-2e42247fd5b9",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
@@ -3658,7 +3658,7 @@
       }
     },
     {
-      "key": "027ff186-1fc3-4b3d-8f64-8c0590f144b4",
+      "key": "b2a6e4e5-ae97-479a-803c-b8735b38c0fc",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt",
@@ -3672,7 +3672,7 @@
       }
     },
     {
-      "key": "26ad3474-bca6-4729-8d04-fd64efa4105f",
+      "key": "dcfcead5-5643-4641-92fc-1d652f7c4d28",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Axygen 1 Well Reservoir 90 mL",
@@ -3687,7 +3687,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "710aecd9-7f2d-4ef6-ac1c-a8cb7e878013",
+      "key": "384f0736-6b3b-45a1-97be-149c342a736d",
       "params": {
         "liquidId": "1",
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
@@ -3705,7 +3705,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "f9f22d73-9d16-4219-a6f5-5796d3cb17fb",
+      "key": "31136a20-5542-4595-9b31-d4b802f841ca",
       "params": {
         "liquidId": "0",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3716,14 +3716,14 @@
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "b477104a-f66f-4253-8325-05dceeb780f5",
+      "key": "8cc93bc3-df96-4df7-bef4-6ad132769195",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "e3ce93b3-5821-4c15-b619-df52a8f28c6d",
+      "key": "32f861a7-4091-43ad-adec-1173f965f1bc",
       "params": {
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "strategy": "usingGripper",
@@ -3734,7 +3734,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "ad9f8629-0f13-42de-adcf-48484945736a",
+      "key": "58545623-3a5b-4f17-b2c1-5895c9a04459",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3743,7 +3743,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "58a242f7-16b6-4c65-9728-fa65d594fd8c",
+      "key": "f193633a-b37c-4b43-8222-17ba10094153",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3760,7 +3760,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "88f17d55-c991-43d8-bcac-d72e2fc12117",
+      "key": "561b1889-c4eb-45a5-b33a-95ca0d5a67c7",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3777,14 +3777,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "c7f775f9-b18f-44a0-b5ad-ba0f03d12f7a",
+      "key": "8570f0b0-3d64-414b-a746-dc031ad6263b",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "82777961-0ed6-4160-9d24-e4b4cfa3e2b4",
+      "key": "6922309f-8d3a-450d-9f25-130f04fa63a8",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3800,7 +3800,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4548802b-41e4-4c36-9816-c6bea4f21ce0",
+      "key": "848a830c-9b5d-4d38-9d0e-021ad129769c",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3816,7 +3816,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "82438223-f20a-449e-862a-67757966f1f6",
+      "key": "9b23cb60-af48-4de9-9665-9b6356663382",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3824,8 +3824,24 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "4ec11542-f7bc-4344-b5af-86fdb839f09a",
+      "params": {
+        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
+        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "fb96392c-989f-41b1-a52f-581db3bc9e2a",
+      "key": "0d758884-c982-4252-8011-2f36b976bc45",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3844,7 +3860,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "29b765d3-f11b-485f-8f25-3628add0e1f0",
+      "key": "cada7816-5980-495d-afd6-63df5ca99891",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3857,14 +3873,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0781305f-f8ab-45c0-8c69-02920a72aac4",
+      "key": "7f794f0c-9bfd-4a1f-b244-3ef9d35e9118",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "ff76dc1a-135b-4bdc-9a54-c088b32ec9bb",
+      "key": "d8ca7dbc-4235-4b2e-b91c-f04ff449f1b4",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3873,7 +3889,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3abf84f1-1285-42ed-93de-2c00aeba1b8b",
+      "key": "d4ffe2a0-d8eb-4e40-8916-8153deb4272a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3890,14 +3906,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "3ca84a01-c6ee-4bac-b304-661bf0ada0bd",
+      "key": "ec1a198e-4a21-4016-80e6-640c885e5f31",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "fb56945c-345a-4211-9740-8f9c9c8caea8",
+      "key": "c9f5e564-4505-410e-bdc8-3894c392104e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3913,7 +3929,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "132718d0-ef6e-4bd9-838f-0c151f194650",
+      "key": "32740c48-ecf0-4b83-8de4-357a1f0d9d80",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -3929,7 +3945,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "d7561aed-2482-424d-b39f-cf193469bada",
+      "key": "2a71afb0-67a6-4aaf-993c-ef77bf051264",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3937,8 +3953,24 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "b8e6d9f9-2065-4698-9255-2b3bd71d31ea",
+      "params": {
+        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
+        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "5e7cabed-bd34-46d6-be7a-d973c69ba289",
+      "key": "4985da49-d7db-4b34-9f8b-6e750a64e099",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -3957,7 +3989,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "f280773f-6261-4512-a76b-6f190dd5dfaa",
+      "key": "0681e124-5837-4c28-87f7-f5c49d7f0bec",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -3970,14 +4002,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "712cbb86-55a6-4eb3-8d47-0e6bb97b22a7",
+      "key": "eef1eaaa-2858-43e7-aebf-02ab33ca95b8",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "7b2ba60b-f0fa-45b5-81d1-4d954195b4aa",
+      "key": "5be053c8-5101-4193-a853-429f8be901fb",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -3986,7 +4018,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "cdafd966-c8f5-4091-bbd6-604ffcb82b24",
+      "key": "c31064b2-852d-4c29-9bc7-0d365d7b5ec8",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4003,14 +4035,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "7f863025-aa93-4de8-90ac-73a80602d978",
+      "key": "b3e58d81-fcaf-483a-ba04-b3c4300c4603",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "965c9604-298a-4fbd-8241-f4339b65b022",
+      "key": "e13060e2-2baf-4fc8-b6cf-0c9759a385b3",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4026,7 +4058,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "6e88a737-3fa6-477f-b1ed-5bcb2e7f1029",
+      "key": "29254a61-6c8f-4d2a-95b0-ee5af456782e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4042,7 +4074,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "2d4fcb77-c1ef-474e-8c06-9223fff918d5",
+      "key": "94ae6467-181b-4da2-b55f-14d69d14f000",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4050,8 +4082,24 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "2f0020e0-1e54-45db-8cb1-1ca01b98fa93",
+      "params": {
+        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
+        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "b82943ef-cdf3-4230-bc48-0d5ab5089827",
+      "key": "94388040-30b0-4560-8140-21ceffe55b01",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4070,7 +4118,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "562f1e80-7b1a-4fa2-83d1-c608eceb8226",
+      "key": "b8a2e28b-5fab-4c05-af76-4857a7c0dc26",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4083,14 +4131,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "bcc1012a-6169-4bbc-80a7-668bc8adaa84",
+      "key": "f47e499e-d252-4795-8047-269c8648a15e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "7c3f6f93-1bda-4e17-b917-fc96a837d135",
+      "key": "da42dcd6-1c97-4710-a446-661706cec94b",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4099,7 +4147,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "806603c0-2baa-48cd-8db8-3dc9f167250e",
+      "key": "bc67ab51-682b-4698-9223-d5f36ae86390",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4116,14 +4164,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "76fa3d2f-63cf-4abd-9de2-9af6cb39218a",
+      "key": "54d3ea14-4510-468d-814a-39969d886f25",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "a4e63d50-57da-40d0-9afb-cc38fbf40a76",
+      "key": "77a0e9a6-abbc-4f6b-8225-e801063427dd",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4139,7 +4187,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c92b48b2-a06d-4707-b025-8e9dd6210895",
+      "key": "916fcb59-cd10-4f5c-9b33-ec9916a717ef",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4155,7 +4203,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "233228ac-4cbc-4592-b223-5c9a5a97f876",
+      "key": "b2b40e96-7ed1-410b-b96c-7ee1c4c2ff74",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4163,8 +4211,24 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "90584501-9cd6-439b-9943-b2d630e4bd90",
+      "params": {
+        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
+        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "a5c4e28c-3c50-4e56-a133-0c944f648ae1",
+      "key": "be3efec8-0d4a-461e-b87f-1c05de83ce13",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4183,7 +4247,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "af409e1d-5dbb-4e11-9a9b-6d25ddd85c60",
+      "key": "8cef6a47-c50b-489c-81be-f646e77586d3",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4196,14 +4260,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4a458d99-899e-4d5b-9894-b46f11bb6aea",
+      "key": "81c106c7-9e32-4749-afcb-8ed861d92252",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "2d7ad380-2ee5-4be1-9cf7-d2e0e25d7aa2",
+      "key": "065ed461-bdbb-493e-b3bb-6207a3c4ba2b",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4212,7 +4276,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "2a527552-9f69-44ed-b9ce-e1523215f152",
+      "key": "601a5242-4042-4677-9b03-d4bfae6a5143",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4229,14 +4293,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "84ff9e6f-ff2d-4327-82d1-67252de275db",
+      "key": "6906d1d6-c8db-4dd1-9a52-70c6ab42acda",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "9e245fe0-66e4-4cf8-9148-5b4abfc1106e",
+      "key": "f822226f-ab8d-4ec0-9748-a391e91ac3a6",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4252,7 +4316,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "59e123d7-ba83-426c-a731-fc729f955418",
+      "key": "8faec9b6-5308-448e-9292-f6eb9a831e5e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4268,7 +4332,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "a7b7202e-8137-48ea-a94d-b116f894d65f",
+      "key": "e8800b38-94b4-4881-ad31-08fd0bd31ffe",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4276,8 +4340,24 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "530c3648-9463-4d77-aa59-dfecfc9ecdb0",
+      "params": {
+        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
+        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "60644c2f-d812-4466-b293-aab124edcc89",
+      "key": "f65cfb56-7966-42a7-805c-9f10527edea4",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4296,7 +4376,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "af30db51-9051-4563-8e1d-174d73268173",
+      "key": "2c1d87ea-25da-431c-aa3d-5a4753dce673",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4309,14 +4389,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "d16cba52-5fb4-424d-b753-a39b66f664dc",
+      "key": "3ecec850-8d75-4395-860d-3b1f3b250db8",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "09cc949f-1f26-4b98-9d33-badacd9ba1cd",
+      "key": "d645d5c1-6d56-4929-aaab-45feebb51301",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4325,7 +4405,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "667f3f3d-c9df-441d-abe4-842213134a83",
+      "key": "d2fb069c-c82b-4583-8281-4b91dfb245cb",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4342,14 +4422,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "d4645e88-0c69-4efc-91e4-0ec7bc51f183",
+      "key": "b3c0fe2a-a567-4dbf-8643-63790cb771eb",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "6e3d2913-d0d5-4f0a-8d6b-9d45cfc4f550",
+      "key": "687fcc44-a1e3-4120-8a45-5314a6cc3faf",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4365,7 +4445,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7e6411eb-b245-4326-abe2-f499678a391f",
+      "key": "283684d7-75ad-49c9-b6d3-22cf2c993383",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4381,7 +4461,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "534c0b36-13c6-42a0-a8dd-8b2832b9f586",
+      "key": "7726e281-50e5-4581-ab8b-05dd9c25126a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4389,8 +4469,24 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "7ae5b2d2-bd05-4b70-842c-c89afd76378f",
+      "params": {
+        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
+        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "b94d8b78-9939-4163-a154-10b9a83ba055",
+      "key": "f9e74264-692e-4e20-8d28-74f1f11536af",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4409,7 +4505,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "fda9e312-3e07-4557-8165-066c237119d6",
+      "key": "735ed011-29ab-4657-9284-ec8e28fb5db3",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4422,14 +4518,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "d2d7d9bf-61b8-47e3-9f7c-40f8dd50b234",
+      "key": "9d52fbf3-d253-4d80-aee8-68f773c4c908",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "f704b9a4-f11d-4aa7-a6ab-870d2abcaa79",
+      "key": "419a4464-9b5f-4c51-94af-ddaa899a5f9a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4438,7 +4534,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "b6db54fb-4e9f-46ab-bbba-de4eb107f6ad",
+      "key": "46eab659-7f10-47a3-8fe9-386472ab7049",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4455,14 +4551,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "adf7db79-9f0b-4b55-a531-f8f58ddb03d6",
+      "key": "1f65b23b-139d-4740-ab4f-ab71bc14ed54",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "0ab4cb29-8d51-438c-a55e-a52dd710d10e",
+      "key": "9af7dd29-ebd1-43bb-9db6-e4c5ab774795",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4478,7 +4574,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ce637cc0-0e92-4646-a3b1-c846524458d1",
+      "key": "3b2080dd-2389-4c17-8596-d9a11601438a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4494,7 +4590,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c4ffb239-2ffe-42de-84a0-d91c441a42d5",
+      "key": "a736d521-b33f-49d3-bbbe-02a3719cfb93",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4502,8 +4598,24 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "e06ebf6a-97fc-4f08-ad79-487627ebb253",
+      "params": {
+        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
+        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "b17434d4-b6a1-414a-a4e0-4c2185f40e21",
+      "key": "5485e107-29ea-40d0-ab70-5cf48a5c250a",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4522,7 +4634,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "0ba9e287-9877-4b46-827b-eb3a657f0841",
+      "key": "7cf396c2-cda2-4dba-9590-58386face4d5",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4535,14 +4647,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "8533ca3b-0708-4fe6-9768-04f0043719d9",
+      "key": "234884c0-f778-416a-be1d-bf2e3a0915c1",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "39943494-2d83-4ae1-b5eb-66191fcb2cae",
+      "key": "e3b51732-93da-4906-8e10-ffa33c9566db",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
@@ -4551,7 +4663,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5b35ec29-d2e4-467b-b006-b123c1d17edb",
+      "key": "1d2dbc24-66fb-42b0-bdf5-10cef0a90b27",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4568,14 +4680,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "e466d896-0acf-4f51-8612-bd40d60e5fc0",
+      "key": "af4e6a34-fe80-40bb-bc3c-7fd91a4f2c0e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "9928f7f0-f8ea-436e-82e2-1055ba653eb3",
+      "key": "94b34c1c-39ec-4a7b-b3e2-cc1a9ca31688",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4591,7 +4703,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5f0a8de6-ddd9-45c3-9edd-611af590836f",
+      "key": "5cae42aa-3f30-453c-b413-b4325cabdaec",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
@@ -4607,7 +4719,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "61151fa6-c2ca-4f24-8077-a67b46b7ea29",
+      "key": "88f0f152-ffad-4802-8b7b-2aa8f2c80530",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4615,8 +4727,24 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "abae1ae8-2fe9-430a-bc8f-aa5f729abb3f",
+      "params": {
+        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
+        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "e132d8ee-60cf-45eb-ae9f-04d6049567f0",
+      "key": "5b637b97-72bf-49da-9df7-59d90c56318d",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "volume": 100,
@@ -4635,7 +4763,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "31a0e0a8-dcca-4da2-b10b-705b45fcd754",
+      "key": "e446b09c-bea8-4f83-89cf-e3f80854210e",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
         "addressableAreaName": "1ChannelWasteChute",
@@ -4648,21 +4776,21 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "91e32fe2-f3f5-4f01-92a6-a57979471230",
+      "key": "4268ecbe-e80b-4d66-abb6-fb8ef15cf1c5",
       "params": {
         "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc"
       }
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "a8be76ae-db20-480a-8cda-388d73dc69d6",
+      "key": "75744361-568f-413a-b3ff-928057be4a42",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetBlockTemperature",
-      "key": "51293e5e-8c3c-4c2f-8d36-361b96e289ed",
+      "key": "a0e3f787-330c-48e1-8d4e-80d330f216de",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType",
         "celsius": 40
@@ -4670,14 +4798,14 @@
     },
     {
       "commandType": "thermocycler/waitForBlockTemperature",
-      "key": "22091eff-c4b1-4e4e-b1d1-2f42162419af",
+      "key": "ed5feeb3-874e-455d-a9f3-efb3fb11ffcb",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "waitForDuration",
-      "key": "e57f2294-9893-43bd-ae82-7b61b151c400",
+      "key": "f8582a3d-5bf4-404c-b545-b01793807877",
       "params": {
         "seconds": 60,
         "message": ""
@@ -4685,35 +4813,35 @@
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "27586ec8-834e-4976-8aca-79cacf043f73",
+      "key": "10614e03-f768-4ec0-b256-a4b9a76f3c58",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "23cde8aa-fb1f-4b25-a865-132d6af45846",
+      "key": "b0e2a763-a52d-4fb5-9879-cbbb25b84ada",
       "params": {
         "moduleId": "fd6da9f1-d63b-414b-929e-c646b64790e9:thermocyclerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "a642d669-307b-4439-a8fe-1cf24aa370d3",
+      "key": "fe2a5a61-7e03-49ad-a402-0d6d88487ca0",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "1eead2a8-9578-4157-b72d-56b0e68ff4ca",
+      "key": "5617f72f-0cc3-402d-b726-80b537881047",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "a076dfc3-658c-4762-9e81-4cda4870b3d6",
+      "key": "4a232eb9-16a3-4e25-a2b2-403a1e56a2dd",
       "params": {
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4724,21 +4852,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "2a41c1d6-e559-4655-9acd-aee8467b0db5",
+      "key": "aa4604e6-6324-4315-ae98-95c8bbc1cc88",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "d9b603c1-8908-40a4-a27a-32a35bf460a2",
+      "key": "6a2fe4b8-4317-4244-ba38-429e3baf6c3a",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "cbcfee6c-07be-4474-93aa-8cd12951f902",
+      "key": "8be1cf9d-f787-4ea1-90a7-32295954784d",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType",
         "rpm": 200
@@ -4746,42 +4874,42 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "0bcbd566-c440-4b7e-bfbe-3e4a571dde0b",
+      "key": "52526c73-8ba3-4ae1-8290-41ddca1e55db",
       "params": {
         "seconds": 60
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "e77e7bab-2c7a-4390-98ee-d2259661d718",
+      "key": "b23749dd-cdf8-48aa-9cf7-2b313bfe8bd5",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "b49ce96b-2c73-4db2-ae2a-3b0142b44f00",
+      "key": "403d6b3c-0643-4155-a087-3794f9dc10b9",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "c307ab5c-365e-41a1-ac8b-dd50742c173a",
+      "key": "b669f7b3-3c8a-49da-9f6a-533a18ad930c",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "581f6cf8-7903-4a2e-a4d1-cbb644799245",
+      "key": "78d762bd-29c0-434f-9cd6-17427312e6a6",
       "params": {
         "moduleId": "23347241-80bb-4a7e-9c91-5d9727a9e483:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "b0082d04-0532-4b28-8833-763c95e1bf35",
+      "key": "04bf052a-0ba0-4817-aeff-5057f1bfdb10",
       "params": {
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4792,7 +4920,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "bdcd5945-6274-4003-b619-05d298439e05",
+      "key": "e103415e-5ad6-4f81-b282-8a008609da0f",
       "params": {
         "labwareId": "f2d371ea-5146-4c89-8200-9c056a7f321a:opentrons/opentrons_flex_96_tiprack_1000ul/1",
         "strategy": "usingGripper",

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Author name",
     "description": "Description here",
     "created": 1560957631666,
-    "lastModified": 1746124173343,
+    "lastModified": 1746209689325,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -100,7 +100,7 @@
             "c6f47740-92a5-11e9-ac62-1b173f839d9e": "right"
           },
           "trashBinLocationUpdate": {
-            "45def806-3700-4f7f-a3e3-8867c8714f76:trashBin": "cutout12"
+            "b2f39c5e-4179-4ee2-9a5d-b8b7e9adabf5:trashBin": "cutout12"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
@@ -122,17 +122,17 @@
           "aspirate_mmFromBottom": 1,
           "aspirate_position_reference": "well-bottom",
           "aspirate_retract_delay_seconds": null,
-          "aspirate_retract_mmFromBottom": null,
+          "aspirate_retract_mmFromBottom": 0,
           "aspirate_retract_speed": null,
-          "aspirate_retract_x_position": 0,
-          "aspirate_retract_y_position": 0,
-          "aspirate_retract_position_reference": "well-bottom",
+          "aspirate_retract_x_position": null,
+          "aspirate_retract_y_position": null,
+          "aspirate_retract_position_reference": "well-top",
           "aspirate_submerge_delay_seconds": null,
           "aspirate_submerge_speed": null,
-          "aspirate_submerge_mmFromBottom": null,
+          "aspirate_submerge_mmFromBottom": 0,
           "aspirate_submerge_x_position": null,
           "aspirate_submerge_y_position": null,
-          "aspirate_submerge_position_reference": "well-bottom",
+          "aspirate_submerge_position_reference": "well-top",
           "aspirate_touchTip_checkbox": true,
           "aspirate_touchTip_mmFromTop": -12.8,
           "aspirate_touchTip_speed": null,
@@ -145,7 +145,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": true,
           "blowout_flowRate": 1000,
-          "blowout_location": "45def806-3700-4f7f-a3e3-8867c8714f76:trashBin",
+          "blowout_location": "b2f39c5e-4179-4ee2-9a5d-b8b7e9adabf5:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -163,17 +163,17 @@
           "dispense_mmFromBottom": 2.5,
           "dispense_position_reference": "well-bottom",
           "dispense_retract_delay_seconds": null,
-          "dispense_retract_mmFromBottom": null,
+          "dispense_retract_mmFromBottom": 0,
           "dispense_retract_speed": null,
-          "dispense_retract_x_position": 0,
-          "dispense_retract_y_position": 0,
-          "dispense_retract_position_reference": "well-bottom",
+          "dispense_retract_x_position": null,
+          "dispense_retract_y_position": null,
+          "dispense_retract_position_reference": "well-top",
           "dispense_submerge_delay_seconds": null,
           "dispense_submerge_speed": null,
-          "dispense_submerge_mmFromBottom": null,
+          "dispense_submerge_mmFromBottom": 0,
           "dispense_submerge_x_position": null,
           "dispense_submerge_y_position": null,
-          "dispense_submerge_position_reference": "well-bottom",
+          "dispense_submerge_position_reference": "well-top",
           "dispense_touchTip_checkbox": true,
           "dispense_touchTip_mmFromTop": null,
           "dispense_touchTip_speed": null,
@@ -195,7 +195,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "1",
-          "dropTip_location": "45def806-3700-4f7f-a3e3-8867c8714f76:trashBin",
+          "dropTip_location": "b2f39c5e-4179-4ee2-9a5d-b8b7e9adabf5:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -224,7 +224,7 @@
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": 7,
-          "dropTip_location": "45def806-3700-4f7f-a3e3-8867c8714f76:trashBin",
+          "dropTip_location": "b2f39c5e-4179-4ee2-9a5d-b8b7e9adabf5:trashBin",
           "labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
           "liquidClassesSupported": false,
           "liquidClass": "none",
@@ -3586,7 +3586,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "8bed0ff0-863f-49ff-b445-e1e5c50a6781",
+      "key": "c9446388-d550-4ff4-ae24-db1a22b0b4ba",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p10_single",
@@ -3595,7 +3595,7 @@
       }
     },
     {
-      "key": "4886b773-ab55-4130-b484-732b317a4da1",
+      "key": "37a2306b-3b13-4e0c-9d9f-9e215e3995d9",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_single",
@@ -3604,7 +3604,7 @@
       }
     },
     {
-      "key": "ecf287ab-dd8b-4c9c-a15d-8ddcafd468d7",
+      "key": "f2fee7fa-2517-4a5b-b0f6-32b4eded2e7d",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 10ul (1)",
@@ -3618,7 +3618,7 @@
       }
     },
     {
-      "key": "aa0404dc-3114-4b85-947d-431ca5188a86",
+      "key": "e98ef825-3e20-4e0d-b8b4-f5c890ac6600",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 200ul (1)",
@@ -3632,7 +3632,7 @@
       }
     },
     {
-      "key": "249673f1-8c8f-4df3-a36e-368675c138c2",
+      "key": "ddae6c3b-17f3-4284-ae8f-d83277f8d236",
       "commandType": "loadLabware",
       "params": {
         "displayName": "96 deep well (1)",
@@ -3647,7 +3647,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "2a9450a4-32da-4300-bb5e-4e9e915fec21",
+      "key": "94d94b5d-52cb-4c92-a382-111f606cd463",
       "params": {
         "liquidId": "1",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3660,7 +3660,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "13c445ab-7f4b-474f-8007-7b51afaf611b",
+      "key": "fb8a3332-bcea-48c2-baf8-e250e11e0a0c",
       "params": {
         "liquidId": "0",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3675,7 +3675,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "d217df42-e254-45ec-8ecc-d9b66829dffb",
+      "key": "2117ba97-5864-4bbc-8f11-dcbac955e6d0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -3684,7 +3684,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "da989327-fc87-422a-8074-eff2918cf5a4",
+      "key": "ffefd5cc-8aeb-4e59-b247-38df4aa48eb0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3701,7 +3701,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "c8977758-685f-4122-98d3-4f2b45dd29fb",
+      "key": "a3b5b26d-8a91-4f97-8a23-e93ec45c4245",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3718,20 +3718,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "985a5e76-21f2-4452-b982-e173d7eebf01",
+      "key": "ad686823-1509-46aa-98e3-b565d5df1446",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "2f968a51-2bc2-4c6a-b8e4-9b51b4fc6f0a",
+      "key": "547722c8-40cb-4a49-b0e6-3295fbb686b9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -3742,7 +3742,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "24c9f6a2-ac4d-4f51-b755-7caae9b0d865",
+      "key": "3446f234-eb42-4d06-af20-e378df6177cc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3759,7 +3759,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "fca926bb-b170-4cc8-90d6-c20c9bb99ab3",
+      "key": "1741085b-d1b3-4268-8386-88d1680a87c3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3768,7 +3768,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "0586c128-be53-4703-9446-9b5cf2c461f7",
+      "key": "7ffccda9-75e2-4811-8cc4-d58076f95a98",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3778,7 +3778,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "4ddf3d22-01c9-4460-b239-91da1485f2ee",
+      "key": "3da4a475-aec8-42bd-9ce2-2be855211b94",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3787,7 +3787,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "1054967a-b1ae-4ff4-908e-1dad0f91e05b",
+      "key": "f8bcd5fc-703f-4d3a-bb29-dd647fbe206f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3797,7 +3797,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "d6a7103d-f47d-4c90-b81e-f49fcf8bf3d6",
+      "key": "b3f0e5b9-2373-4fab-8fb2-fe56041a1cdc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3806,7 +3806,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "f08e645f-20e4-45ae-9deb-6312b58d76b1",
+      "key": "04b27887-a6c5-4f20-be15-c89a23f53844",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3816,7 +3816,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "bc5aea86-699d-48af-ab21-b0f71a1ab1f4",
+      "key": "ab5419f4-cad2-4c24-aab0-37aaedfeb162",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3824,8 +3824,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "e3016444-c104-41f7-b4e0-e1a04670843f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "90a94cf6-187d-4d9d-a938-2fb57ddb3cdf",
+      "key": "7ef71441-339b-40fd-87c2-a8252a3422c2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3842,7 +3859,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6e4ec27c-68b8-4c03-bd39-ddbfa3383ca2",
+      "key": "f903c5ac-3e87-4eec-aa0d-816aea5fcd7b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3861,7 +3878,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1084ca08-6c20-4d08-aa7e-5dd51de3e5cb",
+      "key": "c856b063-ad06-482b-a797-e497fd8a4499",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3880,7 +3897,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "38a20156-245c-4307-b0a9-22ba4a7185cf",
+      "key": "966bf876-9f1a-4568-b784-ddad08b020a2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3900,7 +3917,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "79e4218d-1ba2-436d-bfc5-fe4ae4439a6a",
+      "key": "1e57e02d-5690-4f7e-9acf-4acaa7b2ab1d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3919,7 +3936,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "df490812-4200-4afc-8954-d6914bb6b657",
+      "key": "d3abded8-23ff-44ed-bc4d-5b131621c0b3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3939,7 +3956,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "b5baa36f-886b-43f0-9a9d-74e4d734cef4",
+      "key": "9280b483-1fad-443e-8d42-173a95a6c550",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3952,7 +3969,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "79e5a43b-9af1-4f15-93b7-d5b587518847",
+      "key": "e5bf8e4a-c05c-459a-a671-9a55ca03d3ff",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -3960,7 +3977,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "9ec0175e-5e2f-4b61-8c93-0f9a5487a9fc",
+      "key": "82db913c-4ac2-487a-bbf2-664d78b26206",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3976,7 +3993,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "ad526810-4746-4907-a61a-9e0e9a4d4690",
+      "key": "4ec3fa08-cabe-4bdc-b6cb-226b9475049e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3990,14 +4007,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "dc05d8ac-f5d3-4339-90d0-f595e4a21e25",
+      "key": "01f39597-a7f6-42fa-886c-6347eb1f5fc3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "010464b2-0b6d-4395-b4bd-3c56a5650b96",
+      "key": "d09a67c8-cd70-4513-bc23-c992d59ab46d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4006,7 +4023,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "bdadcad7-e4fc-4ca6-9891-52f70306c901",
+      "key": "49e1c57f-e39c-44b8-b696-acf418344951",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4023,20 +4040,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "b2cf3457-7281-4031-a4a5-85c493e853ea",
+      "key": "a357cac5-5d3d-4543-a754-46dce7007989",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "fe04fc68-d6ee-41c0-8030-c1f38664cf02",
+      "key": "bad48231-320a-4f3b-802d-c9769d7e7c3a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4047,7 +4064,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "91f62ae8-805c-4821-a145-b4a2e5835abb",
+      "key": "73f20741-3649-4bb9-bb98-10a1659e03c7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4064,7 +4081,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "f56565e6-739b-4eaa-a338-f6fac9c9204b",
+      "key": "e1ff1614-08df-421c-b1d4-f02fb6d79dda",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4073,7 +4090,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "400cbebe-07fc-4464-91c8-6b3760750749",
+      "key": "48c778d8-08c9-4454-a51c-b3d945b4f950",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4083,7 +4100,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "684c80b0-5560-48ea-ab8b-e94bcb7e828f",
+      "key": "371a85c0-2022-48fb-b74f-aad07e803390",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4092,7 +4109,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "3a576457-f498-4c93-828f-75bf524f135c",
+      "key": "e451d88a-d1fa-447f-8588-84e45ae84936",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4102,7 +4119,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "25c27060-e499-4af2-a049-4278d595f2eb",
+      "key": "944feff5-fce0-4f76-8bb4-e52309579c77",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4111,7 +4128,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "320ec25a-7bce-41e1-862b-bc9be734c1e7",
+      "key": "9416202e-dddd-4d1d-9b0c-643ed6e06b92",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4121,7 +4138,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "aa7c1f82-a966-44b2-abd9-6df4d1413958",
+      "key": "f51bdda6-a45a-4eac-b7c3-d41697374948",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4129,8 +4146,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "2b5cae3f-e322-4f55-a38e-e69dca26a6f5",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "f9dd0b60-4395-414e-802e-3538e63c435a",
+      "key": "1aba6342-25b5-4583-9299-9a8d984651a9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4147,7 +4181,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4abc949d-a85d-4999-9e99-898c1b724afa",
+      "key": "12176d87-93fe-4bd6-b9df-da3f3c98a9ee",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4166,7 +4200,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2c69e6ec-68ef-4635-a8b2-d9cf9ebb1737",
+      "key": "d6a7882d-c311-4be1-a7b8-8cd0a2637132",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4185,7 +4219,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "304a5763-02a6-46a9-a6f2-1a0818f50e38",
+      "key": "32d5b3e1-33f7-4f1a-8615-5da648dcc652",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4205,7 +4239,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a88b2141-2867-4a43-9e0f-c6d1cc3c0731",
+      "key": "bcce9a3d-e4ff-4b2c-9d15-e773cdfcbda6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4224,7 +4258,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e9967b0c-3d89-43c2-a413-ee64118eb4b7",
+      "key": "cdc0ce36-ca24-44a6-ab99-e6da05ada97f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4244,7 +4278,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "0f307b67-9d23-4db8-b94c-2e9fac2946de",
+      "key": "cc1ce3c1-74f9-46b3-973e-af3ca4bf111b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4257,7 +4291,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "81df6bd4-2bcc-4eba-8a0f-3887fef121ad",
+      "key": "bf6f0ce3-8c6f-4301-8615-1195976b4c4a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4265,7 +4299,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "213e7c67-cabf-4429-b58e-6c43bbdebd89",
+      "key": "0bcaf341-1239-48fb-96a2-6a59c07e7348",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4281,7 +4315,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "55a3a692-0b9c-4bb0-9fcc-45e0ddfa2098",
+      "key": "b0787e68-1286-402c-ba90-fd75ba8aa999",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4295,14 +4329,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0e83cadd-e8e1-4c8c-ace4-09ba0014aa8c",
+      "key": "494ad915-a568-4dab-ade3-0081f3a9972f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6c595cde-f0a2-4ace-a56f-cb5b4a3c7e2f",
+      "key": "92da2f7d-ecd5-4ea8-969d-ebfb67e90adf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4311,7 +4345,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "83089717-9177-46b2-aab0-7b2406a2415a",
+      "key": "0634e1e4-d70d-4f12-8d55-bb2c89478b34",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4328,20 +4362,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "0ccb9a88-00c6-47e3-87c9-f72941a3b446",
+      "key": "85d4c45e-8810-49e6-a05a-b8d99cc80377",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "62c19bf1-b649-4953-b6ca-8fd688081c96",
+      "key": "2a87a03c-42e3-4803-a138-354e059c5e25",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4352,7 +4386,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f5f6d97c-a8a4-42d6-bbf9-348554ce9577",
+      "key": "e2d30330-f65d-43ae-a38d-c315ee451b7c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4369,7 +4403,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "8f3c1f01-d7b3-4cf5-8962-d498fbb77ac0",
+      "key": "74166c10-e9cd-49fd-8a94-f682bfce22a2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4378,7 +4412,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "b55ede00-6bf1-4d4d-95e7-88693a333c93",
+      "key": "ec63c38b-bdc5-4907-bc49-1f8f66815405",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4388,7 +4422,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "831f5d89-22fd-4a53-8eba-f218b865b438",
+      "key": "8fd07a77-72d5-4917-a38b-47e62bcdd309",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4397,7 +4431,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "00ed5148-4960-4758-a6e3-da22e40501b7",
+      "key": "ced9ac12-ff67-40d3-b945-ee6a0161ee69",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4407,7 +4441,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "54894155-645b-4131-a58d-f7c0338868ff",
+      "key": "1b182404-43a7-496c-826b-091db90deec4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4416,7 +4450,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "42664326-c4ab-420a-8f3d-61521562d62b",
+      "key": "1120f33a-fa9c-4fb6-8577-6b5074e1b441",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4426,7 +4460,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "03e7c61b-802a-4b8e-8dae-f41e892316da",
+      "key": "85bfcdf2-6d8c-4d8d-8d88-d2dcf3207a22",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4434,8 +4468,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "a98f71fa-4c2f-427b-bcd3-8f927f0b12a2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "ac7f9fe2-5174-4750-aba2-9d69e81222a8",
+      "key": "614c26c6-7259-439c-9402-6c8a2e9c9cb9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4452,7 +4503,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "8d4a4486-5977-481a-bb1a-c5ec3ade1f02",
+      "key": "78df1353-54ba-4ca4-b90c-698c23f42563",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4471,7 +4522,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "bd995d08-5671-48b7-be36-b67da009f9fa",
+      "key": "db443dc4-1388-4ad8-8785-f94e387def1b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4490,7 +4541,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "87f53304-e810-4df1-b7af-eb7548090a9b",
+      "key": "289c272e-bc3a-4f81-9c26-8b8db67aa1f4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4510,7 +4561,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "40e2f10f-dbe1-45ef-8140-1c9dd33e3bdd",
+      "key": "99d1d496-32d9-44ab-a16f-d9d79115a2ba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4529,7 +4580,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1763ae0d-2241-4c86-88bb-e4808af76da3",
+      "key": "f1a7dc98-b0de-47f0-955e-638ac934bb78",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4549,7 +4600,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "7e6124d7-5286-4ad3-8c77-e143c005b160",
+      "key": "9ff5fc91-e978-47f3-ac3e-e8e86a793269",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4562,7 +4613,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "0976beb5-1770-428a-b0f8-9e95865447e8",
+      "key": "81075a4d-5175-438f-971c-75d550f7aedb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4570,7 +4621,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "919518de-8094-4eb8-a9ba-0d967a4249bd",
+      "key": "82e05636-e5f4-4a25-a91d-129d8718de08",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4586,7 +4637,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "08a6f0e7-8893-4d6c-8911-8d65586a579b",
+      "key": "e9adb1c4-418d-407f-82e3-1d05f4f0c295",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4600,14 +4651,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "d7fe1f99-e70b-4e11-bdee-bf2f40ed74d7",
+      "key": "eac6e444-2b22-43cb-b597-01f0ba52d505",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "576d3233-0ea0-4c14-bec1-e4365c78e040",
+      "key": "78b3a664-389b-44d1-a461-9e92b12b9855",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4616,7 +4667,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1cd7c8d1-c527-4878-b408-3d0282f94950",
+      "key": "ff95363a-453c-4ebe-9d63-99b2f8cbab75",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4633,20 +4684,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "436e13fc-f8ed-4120-9c2d-4de9ec3a6cf2",
+      "key": "040d1d78-2778-4861-a867-fa13ef2747ba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "8d557dfd-fda6-4f2c-8520-7262556cc3a0",
+      "key": "03792021-acd8-4022-8392-33d68e011cb5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4657,7 +4708,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f5f03e03-6675-4cf9-8669-5cac707c4eed",
+      "key": "52d8ad43-b859-44f3-82ee-0c355090dbad",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4674,7 +4725,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "df46ba6f-bcff-49f8-b23a-38a31a668c99",
+      "key": "f5c9af56-137d-4bf5-ae6a-d6b2947158ec",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4683,7 +4734,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "d95732f2-3743-424a-b1f5-3a95134b1901",
+      "key": "82f87702-5c67-482d-b986-3cb464d0d18f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4693,7 +4744,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "4891fa7d-8e17-4e75-8845-dd184898c4c6",
+      "key": "298bfe90-a217-46ee-887e-2648398f99a8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4702,7 +4753,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "9c66415f-7518-4cbe-ab2e-d9e3ed57b132",
+      "key": "64cf5414-d068-462c-ba1c-a3699bf6c6f1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4712,7 +4763,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "27b4bfff-b972-495c-b03e-41edd7597e3d",
+      "key": "68187826-13b9-4c62-8be1-cce4d10ec1dc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4721,7 +4772,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "bcba6033-7b52-466c-850c-af9400208649",
+      "key": "2ba0fa5d-4ef6-435e-9e05-16760d3411ce",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4731,7 +4782,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "3e4b03ba-063f-4e88-88ef-08809994c0bc",
+      "key": "3d1c7ffc-85d6-4c2f-919d-18696fdb4cec",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4739,8 +4790,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "8dac5970-7f3d-42eb-914e-b98f35313435",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "75111b46-71a4-4adf-b36e-55bf0f855eed",
+      "key": "f85989ac-4126-4835-9c1a-d1f4e6c5e17d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4757,7 +4825,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "3abc6134-b6a2-4972-9c6c-b4887c5aa880",
+      "key": "9c9b3f48-ad43-418e-b5a1-6d397e94e305",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4776,7 +4844,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "77090b86-c87c-493b-9ff7-8891b7e2af50",
+      "key": "0657883c-59c0-49f8-b772-e4d31b007075",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4795,7 +4863,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "84fd33fc-bd46-4cee-a46f-8bc9fe853e94",
+      "key": "e2247ba9-de51-45bd-8c52-d9561215dabb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4815,7 +4883,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "42800465-b367-435b-9a49-e632f0353b88",
+      "key": "25ce796d-b8dc-4f56-a79e-16167a16a167",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4834,7 +4902,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "afd30138-3a36-4804-98ee-d2e03e16c7be",
+      "key": "da753746-e1ba-402d-b540-fcc42892d544",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4854,7 +4922,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "34236160-e6db-4409-b409-d132503f9d45",
+      "key": "bd00a7dd-fbeb-4198-8c17-6bcc6b157cd5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4867,7 +4935,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "a4fea306-b683-486e-a862-5413e89eef6f",
+      "key": "997aee96-9524-4ee9-bea0-d398e6dad83d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4875,7 +4943,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "f9bfe186-1876-4eec-9b81-d37b932fbc68",
+      "key": "65f9b34e-36e9-4382-bc78-43c9cff85dd2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4891,7 +4959,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "bad10329-08e5-4748-8e98-5aa774d14fb5",
+      "key": "6f6dc5dd-29d0-431c-84ce-4ea4d61c6ec2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4905,14 +4973,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "751cf311-20fc-48e7-a45f-c83e40ca83a9",
+      "key": "ae9f6cb0-f491-4e1d-a0ac-4f7a95a9ab7f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "af4fcf3d-d704-472a-9a55-86f7c3afcc9f",
+      "key": "2b262ce1-b543-44a8-88e3-bcb7840d9c1b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4921,7 +4989,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "16cde92f-9b04-4d48-92a6-6b2456dabf35",
+      "key": "458fd3cb-37e3-4e59-b995-2785abd0bfcf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4938,20 +5006,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "afe11e88-36d8-4614-b9a5-b6fbcd1f586b",
+      "key": "d01cc40c-93bb-45d1-845d-3a0a8859c324",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "5bfdf520-120f-4d38-b267-cfad41364137",
+      "key": "985e9b96-24bb-47ba-9dcb-46cccfe9b1e3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -4962,7 +5030,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "307f3051-167e-4611-b32d-f2e48a18d214",
+      "key": "523fffdd-370d-4ce4-841f-6733bcbfc9f7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4979,7 +5047,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "047c4150-cb3f-4c22-8266-14b549de8699",
+      "key": "fe9c9142-dca5-4525-863c-408ca351ac93",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4988,7 +5056,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "b39a29b7-3ba5-48b1-a633-13a5f0ed3fe5",
+      "key": "73d9ca1e-dff4-4799-8a7b-ffc35e9cd89a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4998,7 +5066,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "546d62f2-b8b0-4406-82a1-b3428dbb394a",
+      "key": "07d2e419-96d7-439b-b0d8-cd638973da38",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5007,7 +5075,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "a3bdd307-dd1e-47e4-8150-668085f06ec2",
+      "key": "00a4cc47-db23-4d08-b566-45296c9963f3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5017,7 +5085,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "5a9edcbc-42e6-4243-9b31-03c61c28cff1",
+      "key": "1ed4df67-693a-434e-a9bf-495b4e04d627",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5026,7 +5094,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "4ee56c4a-d6f6-4649-b77a-61c83b5c7d37",
+      "key": "0a90b5cb-54d6-4b8c-b4ba-adc599a79279",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5036,7 +5104,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "a8ed2b55-01c8-4e78-8c7e-f0ca504e5f7f",
+      "key": "416effd5-c3f7-47a3-9016-5ab8cf00ab4e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5044,8 +5112,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "8cb6451c-6bfb-443e-b24c-c1c6e12c5a99",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "357944b6-4cce-45b5-81c0-12f437493a4f",
+      "key": "603f9f4c-bd55-4e88-86fb-89dac07ef1d1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5062,7 +5147,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "fd0953d0-a320-4533-b298-406dcb8f77cc",
+      "key": "297f5ecc-f9b6-4d77-ac0f-2284a1cf81f6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5081,7 +5166,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "84cf943f-a879-4919-b260-eae8eaaf6957",
+      "key": "52d757ce-995d-4dde-ae5a-10be7460b5b8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5100,7 +5185,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "181761c0-1c58-4980-83eb-71f58817e3a7",
+      "key": "a95f64c6-be93-43fb-950e-f001041ccd05",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5120,7 +5205,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "50dbd02a-d1f4-47e3-9342-320c55313f18",
+      "key": "ae80c674-a52c-41c1-be85-f9cf234591f0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5139,7 +5224,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "612dcd1b-a9fa-4562-9b91-3a9be1318499",
+      "key": "3eb55461-bda1-4c79-981a-38982bbfc114",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5159,7 +5244,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "c631446d-196f-47ca-8187-92b1e8c1408f",
+      "key": "2b36c5b6-28fb-4ea5-877c-2cff3e45c1e3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5172,7 +5257,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "5010b656-d8cc-4eed-9ea2-bd79bee07efd",
+      "key": "cd093aba-8a37-4963-8325-52d04a1068c7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5180,7 +5265,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "ff1da433-3aca-480e-9165-bace45be57f7",
+      "key": "612f0ad0-d175-45d2-ac63-72885204b20f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5196,7 +5281,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "670f94e2-5973-40ee-9143-a8bb6e9719bd",
+      "key": "44e0cb1e-1849-48b9-9f39-8a80a6e6408c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5210,14 +5295,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "22df14ae-1068-4c57-8e4c-95aa118159a1",
+      "key": "bb18431d-ae35-43a2-9d8c-2604857d8e58",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "af759636-cb81-47bd-a634-fe958ada4417",
+      "key": "6d42a3af-3aee-4e55-9ae1-fd5df9bbb3d7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5226,7 +5311,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "01740b17-ead1-490c-b417-de7e8a091983",
+      "key": "0424ae40-30fa-4a8a-b970-79e62719f98f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5243,20 +5328,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "ff065a8e-74a9-42b0-b25a-7ea2665f449b",
+      "key": "7e2622d2-b1a1-4211-84df-c30cd54b3be0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "f9d50b4e-149c-490e-884e-9cb16d7b2380",
+      "key": "7fe53f69-48f3-411d-b8ea-730e9208e99b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5267,7 +5352,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4ca5166b-1711-480f-82e3-0c57a1939645",
+      "key": "0d6ecaa5-6f86-45c7-b857-209ce0c81215",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5284,7 +5369,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c783ccda-b3fc-4cc4-8ae2-d6056c54f77f",
+      "key": "b37e8d38-3212-4973-992e-52a805853ea7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5293,7 +5378,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "ed9b626f-e8ce-436f-90d2-acd57a12c932",
+      "key": "5e7bf70c-d08f-40be-a468-203fd9c4bf43",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5303,7 +5388,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "51c782a4-66d3-49fd-843c-763b4f8a730a",
+      "key": "3b2ec3dc-98b6-4dc1-8210-35903ad1a01d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5312,7 +5397,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "1c6211e2-47b6-4073-9d0d-c30b32d7049a",
+      "key": "4cc654dc-65e7-46ab-9798-53049fee45e9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5322,7 +5407,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "9200dc53-f916-454c-a8b8-afa7ae024a69",
+      "key": "ec5d2273-ae81-48e2-b526-25d8020f678e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5331,7 +5416,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "3a22197a-c969-49b5-b39c-98a4c91f9e80",
+      "key": "77a5c166-7cb7-4304-a20e-6aa6fdea085d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5341,7 +5426,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "9e91d6ab-fc70-4391-9bd1-762b95afed29",
+      "key": "9b44bbf3-73ce-425e-8fb1-9a70485f085f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5349,8 +5434,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "9440a2cb-eff0-40d4-ad67-d1a31c836dd8",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "97cc1403-3f01-43bc-a849-82fbb4ea0bfe",
+      "key": "59860c67-0b96-4269-917e-7fdf64f69a0f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5367,7 +5469,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2e5b5ea4-b984-4017-8caa-0b01add3706b",
+      "key": "4a30e4f6-28f9-45e2-a298-a649ac5bdbab",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5386,7 +5488,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "318e4713-55b0-4742-906b-7864cfa3a457",
+      "key": "be00229c-8715-44ab-a0ef-3e5b0631dcc0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5405,7 +5507,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "06464858-70ba-44da-b87d-cd9251cb8bed",
+      "key": "483df83d-b32e-4663-aa59-c6faa5a8c7b0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5425,7 +5527,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a265e9aa-09d1-4cee-b5f4-298cc065be51",
+      "key": "37b7bde4-7682-4759-9ad1-bb91630c7201",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5444,7 +5546,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "ade37e61-8e43-4620-9de2-ce432e9546f9",
+      "key": "79bbe37d-d1ca-44c1-9b70-82e8c26cb7eb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5464,7 +5566,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "084a769c-6268-478a-ad6b-f89b83fef725",
+      "key": "14da5df8-6cd6-4ab6-989c-3c31dc0c9529",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5477,7 +5579,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "08b2da68-dcef-4983-a54f-5fd1235b5d06",
+      "key": "f4c832e3-4745-4b57-8cfe-b37e5bc1653b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5485,7 +5587,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "c12e0313-d271-4de7-a2e0-792da04c3ddc",
+      "key": "3053a465-d319-4b09-9934-38c50885587c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5501,7 +5603,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "2056bc4d-d34e-41c4-88d8-9421d6711311",
+      "key": "0fa5848c-7b69-4924-beaf-d8b907eeb46d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5515,14 +5617,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "49a1f1b5-e27b-4dc4-b512-62b3cabae7ce",
+      "key": "be13c775-9dcf-4dc7-bd3d-b51b36f025e2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "de9a7864-50bd-4386-a4d3-067fc949662d",
+      "key": "350a45d9-0086-4c14-b3f5-dc1309f333a8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5531,7 +5633,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "efb8c025-dec1-4409-9407-931a7825f065",
+      "key": "c375b93f-57bf-474f-ae46-763ecfb6b644",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5548,20 +5650,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "de562d2c-9096-42cb-8504-619129c49d8a",
+      "key": "389c8561-ea2f-4590-8823-89dc8ca77d1e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "f1a41051-5518-449a-8a74-72bbea1060be",
+      "key": "79b12839-4c49-4718-824b-6a3a5da7988d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5572,7 +5674,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0fe29a20-eb08-4311-8800-6fbd4fdf00fd",
+      "key": "3bb8537a-cf43-4613-a602-b4f39c3384e8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5589,7 +5691,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "a79ef348-86a7-42af-8a8d-c356337665e9",
+      "key": "53cfd382-6f1a-4ab1-b613-c529c15e1a00",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5598,7 +5700,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "fb56baea-68a9-40c2-85cc-e586ad35482f",
+      "key": "6758112e-4f91-443d-91b2-acc09e0aa446",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5608,7 +5710,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "831cd3d6-2cee-47b1-9089-373b2c94dd9d",
+      "key": "95c51014-c760-4744-9da2-f840a34e62b2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5617,7 +5719,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "fe6dc798-5594-4136-8474-1c6ada5296ee",
+      "key": "8e95b709-b4d9-45ad-85f4-6e2770751bf7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5627,7 +5729,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c2841430-ac47-4cfd-b260-f8d262c50691",
+      "key": "cdfb7df0-95cb-4c4a-9d8d-14e023859281",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5636,7 +5738,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "fa5c20e9-168f-4d59-9db1-84de81fde6ae",
+      "key": "1e4f4b10-997a-45f8-82a7-192c22fde2fd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5646,7 +5748,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "293156df-6db4-4cdd-bc9e-0e14bfa0ac41",
+      "key": "15b2358c-9283-48da-a5d4-1bd4e993519d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5654,8 +5756,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "30c3b561-c062-4fc6-9d79-74e24ed83a28",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "144b3dc0-f8ec-4bb2-b693-28d1cadc3f2c",
+      "key": "4c04e1c4-c60a-4ed7-8c54-073c1e90bbab",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5672,7 +5791,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5903aba8-65e5-4f6b-8d5e-0d9fa9be4f89",
+      "key": "72ac7a1f-868a-495b-b67b-6e19b93dd717",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5691,7 +5810,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9f44ac38-7ee2-4d64-899c-c983900d5404",
+      "key": "e464835c-354e-4733-8df0-3d803a14cc7e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5710,7 +5829,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "b935cde9-9f37-44d4-88fd-ffc3f452612a",
+      "key": "803826f7-92be-4fa7-8fd5-03bb258a5a67",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5730,7 +5849,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ce522e93-8e3e-48a0-8164-e2a9131631d4",
+      "key": "c16b5878-565b-43bb-9670-34c164cfddd0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5749,7 +5868,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "dfeefff1-20d8-4c80-94f8-368c6bc1716b",
+      "key": "9a41ecec-4cc1-4a56-983c-380f626f1f68",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5769,7 +5888,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "5a0e1ff1-23eb-431c-9a81-55e5ccc1f76e",
+      "key": "35349a37-50ab-43a1-8bdb-21b102b4cd91",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5782,7 +5901,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "0a39d0a2-9379-41a8-981f-d15cae822ca6",
+      "key": "0f1a7889-bd4c-4e92-b6f0-d4107997167e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5790,7 +5909,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "604213a9-1c60-4d5e-879b-61534b6dd2ef",
+      "key": "fa355dfb-8b7b-4719-a3c3-ec943ad88198",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5806,7 +5925,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "fbc85ee7-57e3-45e2-bfc4-196a77ef307d",
+      "key": "d2854eae-1df1-44d9-b178-7278ccd47db4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5820,14 +5939,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "fe60c91f-1f86-4e90-80d9-153cb0321622",
+      "key": "d3147ad8-2989-4730-81d8-593437654f6f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "61e0ab44-a4c9-4376-b36c-f8698cb3b995",
+      "key": "d5284cbb-7553-425e-af78-ae3a76c5a640",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5836,7 +5955,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1ae708ad-80ba-417a-972e-ab5731076b5d",
+      "key": "5bcf00ac-d8cc-427b-aa77-952470a660c5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5853,20 +5972,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "7c3d0fae-c88e-420e-8e38-b32a996b1239",
+      "key": "e5f08c11-87a6-453c-9f25-27449448cccf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "d02865cf-e83f-4c1d-8fb9-1f6168f580cf",
+      "key": "6b9bc909-0395-4d1c-bcd1-5017d39e139a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -5877,7 +5996,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c5a66465-dbb1-489d-a29f-94d73cffb244",
+      "key": "559eac9d-9b12-40bc-a04e-caf38c073931",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5894,7 +6013,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e6b60b0c-2b72-4f44-acab-d161e3346575",
+      "key": "1f737705-d6db-406d-9331-cb2579d1c4bd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5903,7 +6022,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "c528ec4a-50dd-429c-a044-fea1ea7b8ac9",
+      "key": "301686e7-b97c-4038-ab55-a8eadf29b533",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5913,7 +6032,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "a33086bb-edfd-481e-a22f-7059ebb0e4f5",
+      "key": "fd43684e-1e4e-4a9e-abf6-04cafad97fdd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5922,7 +6041,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "3345c175-10e5-47cc-9fb0-bff3ba5fa50b",
+      "key": "cecc2112-5581-4b9f-8503-4906f38d4b8b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5932,7 +6051,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "fd860250-f15d-4eae-a737-c7f604f7be18",
+      "key": "aeeb1a92-aa68-4b8b-bee3-f78680dd7846",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5941,7 +6060,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "3fd3e1e4-bcce-4444-b1dd-429ab6ea56b9",
+      "key": "4e0afc9a-14b8-4c4b-87cc-73109986b18f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5951,7 +6070,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "f9634ae9-a28a-4f51-8934-b1318c457231",
+      "key": "e8a686e4-4903-4803-a452-26b3e52451e5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5959,8 +6078,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "2e7eac5e-24b3-4d32-bb81-7169e59f0250",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "7a616caa-b92e-4dce-873f-1cb7590426b6",
+      "key": "4e330b42-7bb3-4234-b11c-a2a10652c601",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5977,7 +6113,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2b844304-b1bb-428c-8dd3-d79cffbce4a6",
+      "key": "330ba968-39b9-40d2-873e-6102cf0e751f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5996,7 +6132,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c8333c9b-af99-4d10-ac27-4533ae8a6425",
+      "key": "37cbc799-2cbc-4b9d-a60f-64324afe7a9c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6015,7 +6151,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "9b90af74-c2fd-422e-bbc9-6e91b0a45026",
+      "key": "e95a651c-6fd6-41a0-a3fb-410540630600",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6035,7 +6171,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a5ee8523-8db5-455f-949c-a890bb496044",
+      "key": "234ecaf0-59f6-4eb4-a659-5498e8c77ad9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6054,7 +6190,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5e62f427-f412-46f0-ae03-84610fd65b11",
+      "key": "2a99d48d-9580-4630-a7a0-868c4cddcb09",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6074,7 +6210,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "87cc5380-004a-4709-856c-35444a40e31e",
+      "key": "c35b6b6f-a9be-4cae-b472-c7eb7e532480",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6087,7 +6223,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "9a251083-c1cd-493c-a0b8-f9c894a07eca",
+      "key": "32961300-446c-4c99-a981-96cada7f3c11",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -6095,7 +6231,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "fdbd93e8-ee75-4e44-9b64-60ccdcc8d380",
+      "key": "d80f0452-7d54-463c-b52d-94b461187f86",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6111,7 +6247,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "e0f4f38a-7b63-4a30-870e-2ed8f0127a2b",
+      "key": "26484db7-1618-4e9c-9397-b3c78141faf8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6125,14 +6261,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "beb5f70d-bb86-454e-934d-d8fe9adc6a79",
+      "key": "8146a5f4-a6bd-4ff0-9818-3c96b3b680de",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d34491c1-0aae-4d67-8dda-18bc2e78befa",
+      "key": "f8b1100f-cd3e-468d-904d-463a2dd7ac3a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -6141,7 +6277,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "708f87b8-2ae2-422b-87d6-acb72737b2d4",
+      "key": "2ead0a27-15f9-4d30-8f52-61345c4a5401",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6158,20 +6294,20 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "0bcbc009-7b67-4f84-8c71-0e8adbaab0d5",
+      "key": "2732e3d7-193d-41e6-bdc1-702cbce05baa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "662a88f4-c0ef-4ccb-90ae-a208719e6806",
+      "key": "ff183cda-1fdc-4d6d-b0ce-8aececd7933b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
         "wellName": "A1",
         "wellLocation": {
-          "origin": "bottom",
+          "origin": "top",
           "offset": {
             "x": 0,
             "y": 0,
@@ -6182,7 +6318,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "01c7da1a-35f8-44a8-a756-eea8d1f5b3c2",
+      "key": "ae247b0d-3bea-4d75-b8f3-d411aa786299",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6199,7 +6335,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "daed8189-be9c-4e0e-a071-b2ea43521b8b",
+      "key": "1daa028c-2894-4f2c-9acc-c67f70943971",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6208,7 +6344,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "e8eb9ba9-efab-403f-9ac4-0a6c22e60c59",
+      "key": "1668ecda-122b-4c4f-b900-896a1fee5340",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6218,7 +6354,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "024e02a3-b013-46fb-80c5-5fc63f2b9fbf",
+      "key": "d19d690c-5d0d-4f8b-9505-1036a1adbacf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6227,7 +6363,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "f694c379-9ac7-4dd7-af66-0d41115070ff",
+      "key": "373d0d65-6d1c-4058-8269-a9fbb62e20b4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6237,7 +6373,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "daeb4d99-e45c-428c-ba81-52ba057b5b41",
+      "key": "8d5fde08-1435-4195-b2b0-8c100a1e44bf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6246,7 +6382,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "f3787e72-8d66-48cc-a3e3-608605d8b1f7",
+      "key": "added96b-f5a0-413e-9e70-cdb7ecca8a35",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6256,7 +6392,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "d63ae54a-8759-448e-a432-b55f02a2d205",
+      "key": "48672754-6568-4b2f-be27-3f6121e2649d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -6264,8 +6400,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "e9b39145-7e98-4c0b-b0e2-808c9ae4a2da",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "touchTip",
-      "key": "3ea8faab-2b39-40a2-b18e-115b0435dc4f",
+      "key": "828c0d97-937e-45d2-b58c-c48539cb6be6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6282,7 +6435,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "01584d32-5623-45c5-b4dc-e57afc91b5bb",
+      "key": "df4b2a2e-331c-4c49-8781-6985a00bc42a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -6301,7 +6454,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b983ea29-030f-4f82-afd4-0b707fcf6f01",
+      "key": "f7eb7dc9-dcec-4182-98e2-95dbc747276e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6320,7 +6473,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "692962c8-fc2b-43ba-af03-12d206352f54",
+      "key": "562a881e-795d-469f-8e19-5c379d24e2b8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6340,7 +6493,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a2c7e74c-61f5-4c23-b7f4-ae3f7fabf585",
+      "key": "40a28ea7-e248-40e3-ad17-e817e65a8d05",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6359,7 +6512,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "c52e12f6-9909-4199-b238-6f7906d5dad4",
+      "key": "4abc37c0-d162-4679-9028-a457f7383f8b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6379,7 +6532,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "04b3e46a-e505-4b38-a698-77e4316f4ad0",
+      "key": "def6a61a-d961-491a-b6de-dcab18f9961b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6392,7 +6545,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "c6cfb1a5-1c6b-4dda-9970-5ebca424408c",
+      "key": "04736e53-c1bf-43ec-b792-bf59de57d878",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -6400,7 +6553,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "46e058e8-7e28-4fd2-98a5-3a6035beb3fa",
+      "key": "1ccdeb08-82e6-4b51-8f6a-13fda988aa87",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6416,7 +6569,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "9dd49da6-92d3-4da3-83fb-acea2ab8870f",
+      "key": "b5ffdeda-34c9-4ced-8308-7689948e9315",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6430,14 +6583,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "06d15fb1-8612-4523-8bfd-37a4af20d523",
+      "key": "ae28198b-5489-436e-99d0-24141c33eb66",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "2e646493-a6fd-4c7c-9326-fee898ceeb14",
+      "key": "089a6052-1c9a-447a-9050-192f6786bcdb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -6446,7 +6599,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f8d9ea5b-a698-46aa-873f-9e067eee93ac",
+      "key": "95db2086-efcf-418a-b062-6212ee108091",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6465,7 +6618,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5b2a9937-5059-4ee5-b708-a253258391dc",
+      "key": "f576ee29-b704-43b6-8577-da2d7e0e8c7e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6485,7 +6638,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e1ddb5a9-4675-4dd0-b71d-1f1e95541f23",
+      "key": "c37b75d0-e749-4535-85ee-b04029bb14f3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6504,7 +6657,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "cfb0be14-85a0-4cd0-9e72-fbdcc24aa22e",
+      "key": "2ed51c6e-f3fe-46a0-a76d-b274a570e710",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6524,7 +6677,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "66e0c559-9e23-4337-bb73-49120265a6d9",
+      "key": "b70e1440-620b-4f62-865a-bbb24a24b56e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6543,7 +6696,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "ab090c75-2712-4f01-97b2-878933bf1d55",
+      "key": "416917d7-54ca-47a8-83cf-6ad65661e26b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6563,7 +6716,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "3ddc49dd-f61a-44ef-92f5-04feaccaed8f",
+      "key": "53283687-1327-4e9a-a664-edc49b567278",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6576,7 +6729,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "e91864a2-c0ff-424c-9197-14114f150520",
+      "key": "2aacffe1-4edd-46d8-8539-1d1e1f46434f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -6584,7 +6737,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "3eac72ba-5d77-4148-9b65-bf9adaa8cb01",
+      "key": "0e7b2710-a0b6-4e71-a373-57ca7f1cea2a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6599,7 +6752,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "b67465b2-3919-4f22-85f2-582f5e06d9a1",
+      "key": "30a9b224-ce6c-459a-8967-3c97d38162c4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6613,14 +6766,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "b8e76758-e6d2-4d2c-845a-28854d3772c7",
+      "key": "5f14498a-ccd8-46d2-83e8-bf4eb3751277",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "waitForDuration",
-      "key": "0fed1553-9c04-4962-9041-d474b27654d0",
+      "key": "94009c5d-5bab-4c5d-bbc2-af8f9d057c59",
       "params": {
         "seconds": 3723,
         "message": "Delay plz"

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1714565695341,
-    "lastModified": 1746124497025,
+    "lastModified": 1746209898791,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -3655,7 +3655,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "5bc7f710-bccf-40e3-a299-70067bc75df3",
+      "key": "3ad65f2f-bc7f-429c-a268-abf0b9f156fb",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_single_flex",
@@ -3664,7 +3664,7 @@
       }
     },
     {
-      "key": "268427fa-4db9-46b9-8a8f-6e815d9e0528",
+      "key": "d140fb1f-c487-4159-ac0f-894a2524f25c",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -3675,7 +3675,7 @@
       }
     },
     {
-      "key": "037888c2-a9b3-446f-ba4c-2e1858a96256",
+      "key": "dc9ba141-4cf3-44e7-8348-7380f5ad3979",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -3686,7 +3686,7 @@
       }
     },
     {
-      "key": "25d2f271-09cd-4d5f-81c7-148f14d39d6b",
+      "key": "af3f6311-af4e-437e-b1cc-b1da424f1f09",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Well Aluminum Block",
@@ -3700,7 +3700,7 @@
       }
     },
     {
-      "key": "b37bbb53-0df1-45f8-9a4a-eff7cecdce04",
+      "key": "98a75caa-cd67-4908-879d-c855f8addce2",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
@@ -3714,7 +3714,7 @@
       }
     },
     {
-      "key": "b4dcb908-ef02-4daf-8d88-c8939196daef",
+      "key": "04231724-a677-494e-a511-019a29c2e89e",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap",
@@ -3728,7 +3728,7 @@
       }
     },
     {
-      "key": "253bd3d6-5bfe-4364-8f3a-8013181141af",
+      "key": "fe08fac1-a664-46d9-b631-af3ae41c7bcf",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -3743,7 +3743,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "3e610c0b-57b7-4d92-9d8a-b59a1208e745",
+      "key": "fc0ab606-f9b3-41dc-a037-dbde8a36e681",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "labwareId": "0d39213c-49c2-4170-bf19-4c09e1b72aca:opentrons/opentrons_flex_96_tiprack_50ul/1",
@@ -3752,7 +3752,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8da9b5c6-a083-4582-986e-a8f49b581b81",
+      "key": "e1160399-0976-4a26-a109-9f49bac6fd43",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "labwareId": "c0093e5f-3f7d-4cbf-aa17-d88394108501:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -3769,7 +3769,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "abbb6515-c53f-41af-8152-8b9931780b85",
+      "key": "cefa87f0-f1de-4c65-ad92-e3ca860da8e6",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "labwareId": "c0093e5f-3f7d-4cbf-aa17-d88394108501:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -3786,7 +3786,7 @@
     },
     {
       "commandType": "configureForVolume",
-      "key": "68cb8430-778c-465c-8bc9-12e1e8d43cf7",
+      "key": "22036463-eda2-4e32-9f62-d64e11fc86c6",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "volume": 10
@@ -3794,14 +3794,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "ecfbaee5-850e-4e26-a866-07f1d1580fe5",
+      "key": "516b3378-6f87-45b2-bef4-d64c8cf66b62",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "001cb404-a7e0-4181-beeb-b700e8c1d7df",
+      "key": "d51f299f-e7bb-4ce3-a6c3-51aaca6a0299",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "labwareId": "c0093e5f-3f7d-4cbf-aa17-d88394108501:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -3818,7 +3818,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "b405a761-329a-4aba-8ee2-13ccec60317b",
+      "key": "b8fbc51d-8ff8-45d0-b778-a748fe3fd889",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "labwareId": "c0093e5f-3f7d-4cbf-aa17-d88394108501:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -3835,7 +3835,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "7a149435-15c8-417e-8f43-29e5ae4d304e",
+      "key": "d0365218-caeb-469d-9a07-5cf7f0abf258",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "volume": 10,
@@ -3843,8 +3843,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "6ccef1ed-b913-4de7-8e88-d1b9d3d1f180",
+      "params": {
+        "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
+        "labwareId": "c0093e5f-3f7d-4cbf-aa17-d88394108501:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+        "wellName": "C1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "dispense",
-      "key": "57df80ca-bf6b-44b4-b770-cf7e9f051418",
+      "key": "1bdaf2f6-fd02-406c-b8c8-fabba64eb0ef",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "volume": 10,
@@ -3863,7 +3880,7 @@
     },
     {
       "commandType": "blowout",
-      "key": "b3df6637-b435-4ef3-aff9-685def6416fa",
+      "key": "23e8bf4e-49cb-438a-8eda-d72a756060c5",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "labwareId": "c0093e5f-3f7d-4cbf-aa17-d88394108501:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -3879,7 +3896,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "be0f0aab-521d-446a-b9a1-62bfaad20c26",
+      "key": "efbe09c4-9f09-44d2-8786-c16ad7b2884d",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
         "addressableAreaName": "movableTrashA3",
@@ -3893,14 +3910,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "dbd0059c-80be-4e1d-b742-e3c161f44fa0",
+      "key": "eef29454-4720-44c6-9a3a-daa8d69f6c26",
       "params": {
         "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0"
       }
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "557b52ec-5e73-4656-b4cb-975c1e9d6759",
+      "key": "fe3aebfa-1a8f-408f-a31c-be3cd15d8e88",
       "params": {
         "moduleId": "d6966555-6c0e-45e0-8056-428d7c486401:temperatureModuleType",
         "celsius": 40
@@ -3908,7 +3925,7 @@
     },
     {
       "commandType": "temperatureModule/waitForTemperature",
-      "key": "8cce14de-32f2-463f-94b9-126542cccd7b",
+      "key": "a42417fc-00e1-4032-801c-807c4a21078f",
       "params": {
         "moduleId": "d6966555-6c0e-45e0-8056-428d7c486401:temperatureModuleType",
         "celsius": 40
@@ -3916,7 +3933,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "2c4fe4ec-b3a9-41c1-9f6d-221d5a07240d",
+      "key": "d58ac7af-2b65-4b18-8f5c-6102609bbc44",
       "params": {
         "moduleId": "b9c56153-9026-42d1-8113-949e15254571:temperatureModuleType",
         "celsius": 4
@@ -3924,7 +3941,7 @@
     },
     {
       "commandType": "temperatureModule/waitForTemperature",
-      "key": "d46844d5-069a-4c18-a97e-6b38bb3e75ca",
+      "key": "a028a3b8-b3a7-470b-8cba-1507a73b66e6",
       "params": {
         "moduleId": "b9c56153-9026-42d1-8113-949e15254571:temperatureModuleType",
         "celsius": 4
@@ -3932,14 +3949,14 @@
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "9c2b3702-ec60-462a-b08a-a806fd04b4b6",
+      "key": "17f56d23-ea1a-403e-8a8e-371157b082a3",
       "params": {
         "moduleId": "d6966555-6c0e-45e0-8056-428d7c486401:temperatureModuleType"
       }
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "5b365c63-847d-4bd6-a09b-8f5b9a462b03",
+      "key": "e894a3e5-89f0-4aaa-9cfb-f746b2a28ae3",
       "params": {
         "moduleId": "b9c56153-9026-42d1-8113-949e15254571:temperatureModuleType"
       }

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1701805621086,
-    "lastModified": 1746124443783,
+    "lastModified": 1746209849790,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -2395,7 +2395,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "63c71a4a-5ca9-4c25-9290-11337d34e125",
+      "key": "936cc3f6-dee0-4262-9bec-1e11f14a884b",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_96",
@@ -2404,7 +2404,7 @@
       }
     },
     {
-      "key": "3cff9141-419f-41ca-a00a-ef5af0e56cc0",
+      "key": "7a62a2de-504c-46df-8a66-9dbc89e64761",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack Adapter",
@@ -2418,7 +2418,7 @@
       }
     },
     {
-      "key": "f90e2114-64e1-4ede-8137-01fbab55e746",
+      "key": "5f25dc48-b697-411f-a974-3b9d4d4d7547",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
@@ -2432,7 +2432,7 @@
       }
     },
     {
-      "key": "b5514d4e-ec9e-4e4b-98de-1aa49e126b49",
+      "key": "3c0c104b-c6ed-4ff3-a59e-c9af4240fabd",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Bio-Rad 96 Well Plate 200 µL PCR",
@@ -2446,7 +2446,7 @@
       }
     },
     {
-      "key": "058c0468-1ce4-4371-9e59-242144f76729",
+      "key": "98f9b259-25d7-4049-8679-f14ffa6e95d1",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Tip Rack 50 µL",
@@ -2461,7 +2461,7 @@
     },
     {
       "commandType": "configureNozzleLayout",
-      "key": "fb20cbae-f010-41e2-9c56-6d528dd0ce9b",
+      "key": "90fc5ca7-544f-40ce-b733-3c110be6c03b",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "configurationParams": {
@@ -2471,7 +2471,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "5bc92675-ede0-4d5d-8ca8-74214aa10d89",
+      "key": "624030e9-9871-43f4-9990-9333efbc3b06",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "75aa666f-98d8-4af9-908e-963ced428580:opentrons/opentrons_flex_96_tiprack_50ul/1",
@@ -2480,7 +2480,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7495c922-ad0a-4956-a3cc-286555becf73",
+      "key": "f389dec9-39b0-4ab3-8d11-67ea9d996c01",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
@@ -2497,7 +2497,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "9ffd230b-17f6-4652-bb1b-d498700f78f2",
+      "key": "3e7b64e8-2d89-4013-9878-79bc41350858",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
@@ -2514,14 +2514,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "14f1cee6-1f49-4efa-9189-d63db1e65b2c",
+      "key": "3259208a-900b-4f6a-a378-0fb2dc3b0107",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "544dc00a-acc9-48fb-9d99-876ba991812c",
+      "key": "a072e728-88d0-44f4-9ce4-2d6d8337bd2f",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
@@ -2538,7 +2538,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "004cbee3-e5f3-45e2-9133-cc63f088994f",
+      "key": "714880eb-b59c-428b-bc7a-11fd5944387b",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
@@ -2555,7 +2555,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "f5753ef5-d53d-4b10-9aa2-4fa0676a725e",
+      "key": "88fe9f07-f6e1-4e0c-bdd9-0a846cf74cd0",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
@@ -2563,8 +2563,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "74543fe5-5117-45bb-bfca-fabbd1b8ac03",
+      "params": {
+        "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
+        "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "moveToAddressableArea",
-      "key": "9ef77010-1a49-45d6-9377-b3129609e578",
+      "key": "a8c2e3df-363b-49b1-a83f-58ad536f3ed2",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "addressableAreaName": "movableTrashA3",
@@ -2577,7 +2594,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "fc566c08-7244-4545-8156-1dc613bb0252",
+      "key": "a3edef9f-286b-4250-9f08-827de89e4887",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
@@ -2586,7 +2603,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "02786fef-1f66-4827-8763-4792d14e5a93",
+      "key": "5da8d144-44fa-486c-90f0-0ab45210089f",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "addressableAreaName": "movableTrashA3",
@@ -2600,14 +2617,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "60ef9764-e1b8-4d39-99d5-6fb02bf0fdb9",
+      "key": "52bf39b6-190b-49e1-afb2-c55131137d2b",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9"
       }
     },
     {
       "commandType": "configureNozzleLayout",
-      "key": "fc01473b-3b5f-4df7-a7dd-77c983084249",
+      "key": "0c5707c0-0b8e-4133-9d5a-ec8f4768fea7",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "configurationParams": {
@@ -2618,7 +2635,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "fe15987f-804b-4cf6-b68a-09aa487ead2a",
+      "key": "275c6049-aafa-4779-afa7-9cee8fcb3a01",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "9bd16b50-4ae9-4cfd-8583-3378087e6a6c:opentrons/opentrons_flex_96_tiprack_50ul/1",
@@ -2627,7 +2644,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "18933d23-7f47-46c3-8c97-0d851c79ca21",
+      "key": "48427bab-36b1-4585-bfef-ff85c4a52e40",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
@@ -2644,7 +2661,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "4b362c7c-dd8f-4ea6-8862-66d05618b8f7",
+      "key": "8ceb15d5-d164-44e1-a633-11d6987b2d70",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
@@ -2661,14 +2678,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "1da52d2d-1480-44b2-ab51-5a95c23ae8a1",
+      "key": "74937ba4-d09c-4448-b826-fe0e1e8b4719",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "dd9d4929-f67b-4045-92a0-3eb50b255a3b",
+      "key": "46e0612d-7fee-4e06-bd79-9a048114f6a0",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
@@ -2685,7 +2702,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "09b6e06e-da46-45ff-9c2a-673c131e99b2",
+      "key": "68a1b768-81cc-402a-b274-d7a443487241",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
@@ -2702,7 +2719,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "d3a63980-870c-454a-a084-6daa84912a1b",
+      "key": "57001afe-fb4d-4a88-9554-697399aadfcf",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
@@ -2710,8 +2727,25 @@
       }
     },
     {
+      "commandType": "moveToWell",
+      "key": "1ebc1a90-5f44-4f3b-a32a-ac5a8109f758",
+      "params": {
+        "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
+        "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
+        "wellName": "A7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      }
+    },
+    {
       "commandType": "moveToAddressableArea",
-      "key": "75ac54fd-cd01-47ff-abef-0c7e668df7d8",
+      "key": "2db1bb74-9cde-40f6-902b-2f2dd55b36fd",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "addressableAreaName": "movableTrashA3",
@@ -2724,7 +2758,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "66de58ce-f97e-40b3-bf4d-17621d16dfbf",
+      "key": "cddf00a3-fc5c-4b2f-b910-26aa17674821",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
@@ -2733,7 +2767,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "e80ae82b-9ac3-45f7-b7b7-5fb52c8c94cf",
+      "key": "0d0c3fe8-a23a-46c7-9394-0a44913d8db2",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "addressableAreaName": "movableTrashA3",
@@ -2747,7 +2781,7 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "d2c8602e-6faa-4240-8183-ef7fcb3a9a32",
+      "key": "7c655560-9aaf-475c-8092-0fa28d173c91",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9"
       }

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -3,6 +3,7 @@ import floor from 'lodash/floor'
 import {
   getPipetteSpecsV2,
   POSITION_REFERENCE_BOTTOM,
+  POSITION_REFERENCE_TOP,
 } from '@opentrons/shared-data'
 
 import {
@@ -114,17 +115,23 @@ export const migrateFile = (
           aspirate_touchTip_mmFromEdge: DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_EDGE, // this field and the following were previously not configurable and defaulted to 0mm
           dispense_touchTip_mmFromEdge: DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_EDGE,
           aspirate_position_reference: POSITION_REFERENCE_BOTTOM,
-          aspirate_retract_position_reference: POSITION_REFERENCE_BOTTOM,
-          aspirate_submerge_mmFromBottom: null,
+          aspirate_retract_position_reference: POSITION_REFERENCE_TOP,
+          aspirate_retract_mmFromBottom: 0,
+          aspirate_retract_x_position: null,
+          aspirate_retract_y_position: null,
+          aspirate_submerge_mmFromBottom: 0,
           aspirate_submerge_x_position: null,
           aspirate_submerge_y_position: null,
-          aspirate_submerge_position_reference: POSITION_REFERENCE_BOTTOM,
+          aspirate_submerge_position_reference: POSITION_REFERENCE_TOP,
           dispense_position_reference: POSITION_REFERENCE_BOTTOM,
-          dispense_retract_position_reference: POSITION_REFERENCE_BOTTOM,
-          dispense_submerge_mmFromBottom: null,
+          dispense_retract_position_reference: POSITION_REFERENCE_TOP,
+          dispense_retract_mmFromBottom: 0,
+          dispense_retract_x_position: null,
+          dispense_retract_y_position: null,
+          dispense_submerge_position_reference: POSITION_REFERENCE_TOP,
+          dispense_submerge_mmFromBottom: 0,
           dispense_submerge_x_position: null,
           dispense_submerge_y_position: null,
-          dispense_submerge_position_reference: POSITION_REFERENCE_BOTTOM,
           liquidClassesSupported: liquidClassesSupported ?? false,
           liquidClass: 'none',
           pushOut_checkbox:

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -281,7 +281,7 @@ export const moveLiquidFormToArgs = (
     aspirateRetractYOffset: hydratedFormData.aspirate_retract_y_position ?? 0,
     aspirateRetractZOffset: hydratedFormData.aspirate_retract_mmFromBottom ?? 0,
     aspirateRetractPositionReference:
-      hydratedFormData.aspirate_position_reference,
+      hydratedFormData.aspirate_retract_position_reference,
     dispenseSubmergeSpeed: hydratedFormData.dispense_submerge_speed ?? null,
     dispenseSubmergeXOffset: hydratedFormData.dispense_submerge_x_position ?? 0,
     dispenseSubmergeYOffset: hydratedFormData.dispense_submerge_y_position ?? 0,

--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -47,6 +47,7 @@ describe('generateRobotStateTimeline', () => {
           aspirateRetractYOffset: 0,
           aspirateRetractZOffset: 0,
           aspirateRetractPositionReference: POSITION_REFERENCE_BOTTOM,
+          aspirateRetractDelay: null,
           dispenseSubmergeSpeed: null,
           dispenseSubmergeXOffset: 0,
           dispenseSubmergeYOffset: 0,
@@ -149,6 +150,7 @@ describe('generateRobotStateTimeline', () => {
           aspirateRetractYOffset: 0,
           aspirateRetractZOffset: 0,
           aspirateRetractPositionReference: POSITION_REFERENCE_BOTTOM,
+          aspirateRetractDelay: null,
           dispenseSubmergeSpeed: null,
           dispenseSubmergeXOffset: 0,
           dispenseSubmergeYOffset: 0,
@@ -219,12 +221,14 @@ describe('generateRobotStateTimeline', () => {
           "moveToWell",
           "moveToWell",
           "aspirateInPlace",
+          "moveToWell",
           "dispense",
           "moveToWell",
           "prepareToAspirate",
           "moveToWell",
           "moveToWell",
           "aspirateInPlace",
+          "moveToWell",
           "dispense",
           "moveToAddressableAreaForDropTip",
           "dropTipInPlace",
@@ -237,6 +241,7 @@ describe('generateRobotStateTimeline', () => {
           "moveToWell",
           "moveToWell",
           "aspirateInPlace",
+          "moveToWell",
           "dispense",
           "moveToAddressableAreaForDropTip",
           "dropTipInPlace",
@@ -273,12 +278,14 @@ mockPythonName.prepare_to_aspirate()
 mockPythonName.move_to(mockPythonName["A1"].bottom())
 mockPythonName.move_to(mockPythonName["A1"].bottom())
 mockPythonName.aspirate(...)
+mockPythonName.move_to(mockPythonName["A1"].bottom())
 mockPythonName.dispense(...)
 mockPythonName.move_to(mockPythonName["A2"].top(z=2))
 mockPythonName.prepare_to_aspirate()
 mockPythonName.move_to(mockPythonName["A2"].bottom())
 mockPythonName.move_to(mockPythonName["A2"].bottom())
 mockPythonName.aspirate(...)
+mockPythonName.move_to(mockPythonName["A2"].bottom())
 mockPythonName.dispense(...)
 mockPythonName.drop_tip()
 `.trim(),
@@ -290,6 +297,7 @@ mockPythonName.prepare_to_aspirate()
 mockPythonName.move_to(mockPythonName["A1"].bottom())
 mockPythonName.move_to(mockPythonName["A1"].bottom())
 mockPythonName.aspirate(...)
+mockPythonName.move_to(mockPythonName["A1"].bottom())
 mockPythonName.dispense(...)
 mockPythonName.drop_tip()
 `.trim(),

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -5,8 +5,10 @@ import {
   getLabwareDefURI,
   ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   POSITION_REFERENCE_BOTTOM,
+  POSITION_REFERENCE_TOP,
   WASTE_CHUTE_CUTOUT,
   WELL_ORIGIN_BOTTOM,
+  WELL_ORIGIN_TOP,
 } from '@opentrons/shared-data'
 
 import { transfer } from '../commandCreators/compound/transfer'
@@ -23,7 +25,6 @@ import {
   getFlowRateAndOffsetParamsTransferLike,
   getRobotStateWithTipStandard,
   getSuccessResult,
-  makeAirGapAfterAspirateHelper,
   makeAirGapHelper,
   makeAspirateHelper,
   makeContext,
@@ -83,6 +84,11 @@ beforeEach(() => {
     aspirateSubmergeYOffset: 0,
     aspirateSubmergeZOffset: 5,
     aspirateSubmergePositionReference: POSITION_REFERENCE_BOTTOM,
+    aspirateRetractSpeed: 51,
+    aspirateRetractXOffset: 2,
+    aspirateRetractYOffset: -1,
+    aspirateRetractZOffset: -4,
+    aspirateRetractPositionReference: POSITION_REFERENCE_TOP,
     aspirateFlowRateUlSec: 10,
   }
 
@@ -172,7 +178,8 @@ describe('pick up tip if no tip on pipette', () => {
       ...submergeWithAspirateHelper({
         volume: 30,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -182,6 +189,14 @@ describe('pick up tip if no tip on pipette', () => {
             x: 1,
             y: 0,
             z: 5,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         aspirateLocation: {
@@ -260,7 +275,8 @@ it('single transfer: 1 source & 1 dest', () => {
     ...submergeWithAspirateHelper({
       volume: 30,
       aspirateFlowRate: 10,
-      speed: 50,
+      submergeSpeed: 50,
+      retractSpeed: 51,
       pipetteId: 'p300SingleId',
       wellName: 'A1',
       labwareId: SOURCE_LABWARE,
@@ -270,6 +286,14 @@ it('single transfer: 1 source & 1 dest', () => {
           x: 1,
           y: 0,
           z: 5,
+        },
+      },
+      retractLocation: {
+        origin: WELL_ORIGIN_TOP,
+        offset: {
+          x: 2,
+          y: -1,
+          z: -4,
         },
       },
       aspirateLocation: {
@@ -326,7 +350,8 @@ test('single transfer: 1 source & 1 dest with waste chute', () => {
     ...submergeWithAspirateHelper({
       volume: 30,
       aspirateFlowRate: 10,
-      speed: 50,
+      submergeSpeed: 50,
+      retractSpeed: 51,
       pipetteId: 'p300SingleId',
       wellName: 'A1',
       labwareId: SOURCE_LABWARE,
@@ -344,6 +369,14 @@ test('single transfer: 1 source & 1 dest with waste chute', () => {
           x: 0,
           y: 0,
           z: 2,
+        },
+      },
+      retractLocation: {
+        origin: WELL_ORIGIN_TOP,
+        offset: {
+          x: 2,
+          y: -1,
+          z: -4,
         },
       },
       shouldProbe: false,
@@ -387,7 +420,8 @@ test('transfer with multiple sets of wells', () => {
     ...submergeWithAspirateHelper({
       volume: 30,
       aspirateFlowRate: 10,
-      speed: 50,
+      submergeSpeed: 50,
+      retractSpeed: 51,
       pipetteId: 'p300SingleId',
       wellName: 'A1',
       labwareId: SOURCE_LABWARE,
@@ -407,6 +441,14 @@ test('transfer with multiple sets of wells', () => {
           z: 2,
         },
       },
+      retractLocation: {
+        origin: WELL_ORIGIN_TOP,
+        offset: {
+          x: 2,
+          y: -1,
+          z: -4,
+        },
+      },
       shouldProbe: false,
     }),
     dispenseHelper('B2', 30),
@@ -414,7 +456,8 @@ test('transfer with multiple sets of wells', () => {
     ...submergeWithAspirateHelper({
       volume: 30,
       aspirateFlowRate: 10,
-      speed: 50,
+      submergeSpeed: 50,
+      retractSpeed: 51,
       pipetteId: 'p300SingleId',
       wellName: 'A2',
       labwareId: SOURCE_LABWARE,
@@ -432,6 +475,14 @@ test('transfer with multiple sets of wells', () => {
           x: 0,
           y: 0,
           z: 2,
+        },
+      },
+      retractLocation: {
+        origin: WELL_ORIGIN_TOP,
+        offset: {
+          x: 2,
+          y: -1,
+          z: -4,
         },
       },
       shouldProbe: false,
@@ -524,7 +575,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -542,6 +594,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
       }),
@@ -549,7 +609,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -567,6 +628,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -575,7 +644,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -593,6 +663,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -601,7 +679,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -619,6 +698,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -643,7 +730,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -653,6 +741,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 1,
             y: 0,
             z: 5,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         aspirateLocation: {
@@ -674,7 +770,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -684,6 +781,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 1,
             y: 0,
             z: 5,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         aspirateLocation: {
@@ -706,7 +811,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -724,6 +830,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
       }),
@@ -737,7 +851,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -755,6 +870,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -780,7 +903,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -798,6 +922,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
       }),
@@ -807,7 +939,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -825,6 +958,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -836,7 +977,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -854,6 +996,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -864,7 +1014,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -882,6 +1033,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -895,7 +1054,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A2',
         labwareId: SOURCE_LABWARE,
@@ -913,6 +1073,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
       }),
@@ -921,7 +1089,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A2',
         labwareId: SOURCE_LABWARE,
@@ -939,6 +1108,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -964,7 +1141,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -982,6 +1160,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
       }),
@@ -990,7 +1176,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -1008,6 +1195,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1021,7 +1216,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -1039,6 +1235,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1048,7 +1252,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -1066,6 +1271,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1077,7 +1290,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A2',
         labwareId: SOURCE_LABWARE,
@@ -1095,6 +1309,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1104,7 +1326,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A2',
         labwareId: SOURCE_LABWARE,
@@ -1122,6 +1345,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1145,7 +1376,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -1163,6 +1395,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1172,7 +1412,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -1190,6 +1431,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1200,7 +1449,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -1218,6 +1468,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1227,7 +1485,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 50,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -1245,6 +1504,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1269,7 +1536,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -1287,6 +1555,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1296,7 +1572,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 164.5,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -1314,6 +1591,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1322,7 +1607,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 164.5,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'A1',
         labwareId: SOURCE_LABWARE,
@@ -1340,6 +1626,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1349,7 +1643,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 300,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -1367,6 +1662,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1376,7 +1679,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 164.5,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -1394,6 +1698,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1402,7 +1714,8 @@ describe('single transfer exceeding pipette max', () => {
       ...submergeWithAspirateHelper({
         volume: 164.5,
         aspirateFlowRate: 10,
-        speed: 50,
+        submergeSpeed: 50,
+        retractSpeed: 51,
         pipetteId: 'p300SingleId',
         wellName: 'B1',
         labwareId: SOURCE_LABWARE,
@@ -1420,6 +1733,14 @@ describe('single transfer exceeding pipette max', () => {
             x: 0,
             y: 0,
             z: 2,
+          },
+        },
+        retractLocation: {
+          origin: WELL_ORIGIN_TOP,
+          offset: {
+            x: 2,
+            y: -1,
+            z: -4,
           },
         },
         shouldProbe: false,
@@ -1455,7 +1776,8 @@ describe('advanced options', () => {
           volume: 300,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1475,15 +1797,24 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
-          preWet: true,
+          shouldPreWet: true,
         }),
         dispenseHelper('B1', 300),
 
         ...submergeWithAspirateHelper({
           volume: 50,
           aspirateFlowRate: 10,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1501,6 +1832,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -1526,7 +1865,8 @@ describe('advanced options', () => {
           volume: 300,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1546,9 +1886,17 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           aspirateDelay: 12,
           shouldProbe: false,
-          preWet: true,
+          shouldPreWet: true,
         }),
         dispenseHelper('B1', 300),
 
@@ -1556,7 +1904,8 @@ describe('advanced options', () => {
           volume: 50,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1574,6 +1923,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           aspirateDelay: 12,
@@ -1598,7 +1955,8 @@ describe('advanced options', () => {
           volume: 300,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1618,9 +1976,17 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           dispenseDelay: 12,
           shouldProbe: false,
-          preWet: true,
+          shouldPreWet: true,
         }),
         dispenseHelper('B1', 300),
         ...delayWithOffset('B1', DEST_LABWARE),
@@ -1629,7 +1995,8 @@ describe('advanced options', () => {
           volume: 50,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1647,6 +2014,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -1669,7 +2044,8 @@ describe('advanced options', () => {
         ...submergeWithAspirateHelper({
           volume: 300,
           aspirateFlowRate: 10,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1687,6 +2063,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -1697,7 +2081,8 @@ describe('advanced options', () => {
         ...submergeWithAspirateHelper({
           volume: 50,
           aspirateFlowRate: 10,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1715,6 +2100,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -1737,7 +2130,8 @@ describe('advanced options', () => {
         ...submergeWithAspirateHelper({
           volume: 300,
           aspirateFlowRate: 10,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1755,6 +2149,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -1765,7 +2167,8 @@ describe('advanced options', () => {
         ...submergeWithAspirateHelper({
           volume: 50,
           aspirateFlowRate: 10,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1783,6 +2186,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -1810,7 +2221,8 @@ describe('advanced options', () => {
           volume: 300,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1828,6 +2240,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -1840,7 +2260,8 @@ describe('advanced options', () => {
           volume: 50,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1858,6 +2279,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -1886,7 +2315,8 @@ describe('advanced options', () => {
           volume: 300,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1904,6 +2334,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           aspirateDelay: 12,
@@ -1917,7 +2355,8 @@ describe('advanced options', () => {
           volume: 50,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1935,6 +2374,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           aspirateDelay: 12,
@@ -1960,7 +2407,8 @@ describe('advanced options', () => {
           volume: 300,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -1978,6 +2426,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           aspirateDelay: 12,
@@ -1989,7 +2445,8 @@ describe('advanced options', () => {
           volume: 50,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2007,6 +2464,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           aspirateDelay: 12,
@@ -2030,10 +2495,12 @@ describe('advanced options', () => {
           volume: 295,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
+          aspirateAirGap: 5,
           submergeLocation: {
             origin: WELL_ORIGIN_BOTTOM,
             offset: {
@@ -2050,17 +2517,25 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
-        makeMoveToWellHelper('A1'),
-        makeAirGapAfterAspirateHelper(5, 10),
         makeDispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 295),
         ...submergeWithAspirateHelper({
           volume: 55,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
+          aspirateAirGap: 5,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2080,10 +2555,16 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
-        makeMoveToWellHelper('A1'),
-        makeAirGapAfterAspirateHelper(5, 10),
         makeDispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 55),
       ])
@@ -2102,7 +2583,9 @@ describe('advanced options', () => {
           volume: 150,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
+          aspirateAirGap: 5,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2122,10 +2605,16 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
-        makeMoveToWellHelper('A1'),
-        makeAirGapAfterAspirateHelper(5, 10),
         makeDispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 150),
 
@@ -2133,7 +2622,9 @@ describe('advanced options', () => {
           volume: 150,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
+          aspirateAirGap: 5,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2153,10 +2644,16 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
-        makeMoveToWellHelper('A1'),
-        makeAirGapAfterAspirateHelper(5, 10),
         makeDispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 150),
       ])
@@ -2174,10 +2671,12 @@ describe('advanced options', () => {
       expect(res.commands).toEqual([
         ...submergeWithAspirateHelper({
           volume: 295,
+          aspirateAirGap: 5,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           aspirateDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2197,12 +2696,16 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
-        makeMoveToWellHelper('A1'),
-        makeAirGapAfterAspirateHelper(5, 10),
-        delayCommand(12),
-
         makeDispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 295),
 
@@ -2211,7 +2714,9 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           aspirateDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
+          aspirateAirGap: 5,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2231,11 +2736,16 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
-        makeMoveToWellHelper('A1'),
-        makeAirGapAfterAspirateHelper(5, 10),
-        delayCommand(12),
 
         makeDispenseAirGapHelper('B1', 5),
         dispenseHelper('B1', 55),
@@ -2257,7 +2767,9 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
+          aspirateAirGap: 5,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2277,10 +2789,16 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
-        makeMoveToWellHelper('A1'),
-        makeAirGapAfterAspirateHelper(5, 10),
 
         makeDispenseAirGapHelper('B1', 5),
         delayCommand(12),
@@ -2293,7 +2811,9 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
+          aspirateAirGap: 5,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2313,10 +2833,16 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
-        makeMoveToWellHelper('A1'),
-        makeAirGapAfterAspirateHelper(5, 10),
 
         makeDispenseAirGapHelper('B1', 5),
         delayCommand(12),
@@ -2377,7 +2903,8 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2395,6 +2922,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -2407,7 +2942,8 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2425,6 +2961,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -2499,7 +3043,8 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2519,6 +3064,14 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           shouldProbe: false,
         }),
         dispenseHelper('B1', 300),
@@ -2531,7 +3084,8 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2541,6 +3095,14 @@ describe('advanced options', () => {
               x: 1,
               y: 0,
               z: 5,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           aspirateLocation: {
@@ -2575,7 +3137,8 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2593,6 +3156,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -2605,7 +3176,8 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2623,6 +3195,14 @@ describe('advanced options', () => {
               x: 0,
               y: 0,
               z: 2,
+            },
+          },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
             },
           },
           shouldProbe: false,
@@ -2679,7 +3259,8 @@ describe('advanced options', () => {
           dispenseFlowRate: 2.2,
           aspirateDelay: 11,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2699,62 +3280,22 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           mixTimes: 1,
           mixVolume: 35,
-          preWet: true,
+          shouldPreWet: true,
           shouldProbe: false,
+          shouldTouchTip: true,
+          touchTipMmFromTop: -14.5,
+          aspirateAirGap: 31,
         }),
-
-        // touch tip (asp)
-        {
-          commandType: 'touchTip',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                z: -14.5,
-              },
-            },
-          },
-        },
-        // aspirate > air gap
-        {
-          commandType: 'moveToWell',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 1,
-              },
-            },
-          },
-        },
-        {
-          commandType: 'airGapInPlace',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            flowRate: 10,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 11,
-          },
-        },
         // dispense the aspirate > air gap
         {
           commandType: 'dispense',
@@ -2925,7 +3466,8 @@ describe('advanced options', () => {
           dispenseFlowRate: 2.2,
           aspirateDelay: 11,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -2945,62 +3487,23 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           mixTimes: 1,
           mixVolume: 35,
           shouldProbe: false,
           dispenseAirGap: 3,
+          shouldTouchTip: true,
+          touchTipMmFromTop: -14.5,
+          aspirateAirGap: 31,
         }),
 
-        // touch tip (asp)
-        {
-          commandType: 'touchTip',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                z: -14.5,
-              },
-            },
-          },
-        },
-        // aspirate > air gap
-        {
-          commandType: 'moveToWell',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 1,
-              },
-            },
-          },
-        },
-        {
-          commandType: 'airGapInPlace',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            flowRate: 10,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 11,
-          },
-        },
         // dispense aspirate > air gap then liquid
         {
           commandType: 'dispense',
@@ -3220,7 +3723,8 @@ describe('advanced options', () => {
           dispenseFlowRate: 2.2,
           aspirateDelay: 11,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -3240,61 +3744,23 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           mixTimes: 1,
           mixVolume: 35,
-          preWet: true,
+          shouldPreWet: true,
           shouldProbe: false,
+          shouldTouchTip: true,
+          touchTipMmFromTop: -14.5,
+          aspirateAirGap: 31,
         }),
-        // touch tip (asp)
-        {
-          commandType: 'touchTip',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                z: -14.5,
-              },
-            },
-          },
-        },
-        // aspirate > air gap
-        {
-          commandType: 'moveToWell',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 1,
-              },
-            },
-          },
-        },
-        {
-          commandType: 'airGapInPlace',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            flowRate: 10,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 11,
-          },
-        },
+
         // dispense the aspirate > air gap
         {
           commandType: 'dispense',
@@ -3463,7 +3929,8 @@ describe('advanced options', () => {
           dispenseFlowRate: 2.2,
           aspirateDelay: 11,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -3483,61 +3950,22 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           mixTimes: 1,
           mixVolume: 35,
           shouldProbe: false,
           dispenseAirGap: 3,
+          shouldTouchTip: true,
+          touchTipMmFromTop: -14.5,
+          aspirateAirGap: 31,
         }),
-        // touch tip (asp)
-        {
-          commandType: 'touchTip',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                z: -14.5,
-              },
-            },
-          },
-        },
-        // aspirate > air gap
-        {
-          commandType: 'moveToWell',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 1,
-              },
-            },
-          },
-        },
-        {
-          commandType: 'airGapInPlace',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            flowRate: 10,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 11,
-          },
-        },
         {
           commandType: 'dispense',
           meta: AIR_GAP_META,
@@ -3786,7 +4214,8 @@ describe('advanced options', () => {
           dispenseFlowRate: 2.2,
           aspirateDelay: 11,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -3806,60 +4235,21 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           mixTimes: 1,
           mixVolume: 35,
-          preWet: true,
+          shouldPreWet: true,
+          shouldTouchTip: true,
+          touchTipMmFromTop: -14.5,
+          aspirateAirGap: 31,
         }),
-        // touch tip (asp)
-        {
-          commandType: 'touchTip',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                z: -14.5,
-              },
-            },
-          },
-        },
-        // aspirate > air gap
-        {
-          commandType: 'moveToWell',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 1,
-              },
-            },
-          },
-        },
-        {
-          commandType: 'airGapInPlace',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            flowRate: 10,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 11,
-          },
-        },
         // dispense
         {
           commandType: 'dispense',
@@ -4028,7 +4418,9 @@ describe('advanced options', () => {
           dispenseFlowRate: 2.2,
           aspirateDelay: 11,
           dispenseDelay: 12,
-          speed: 50,
+          dispenseAirGap: 3,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -4048,62 +4440,22 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           mixTimes: 1,
           mixVolume: 35,
+          shouldTouchTip: true,
           shouldProbe: false,
-          dispenseAirGap: 3,
+          touchTipMmFromTop: -14.5,
+          aspirateAirGap: 31,
         }),
 
-        // touch tip (asp)
-        {
-          commandType: 'touchTip',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                z: -14.5,
-              },
-            },
-          },
-        },
-        // aspirate > air gap
-        {
-          commandType: 'moveToWell',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 1,
-              },
-            },
-          },
-        },
-        {
-          commandType: 'airGapInPlace',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            flowRate: 10,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 11,
-          },
-        },
         // dispense "aspirate > air gap" then dispense liquid
         {
           commandType: 'dispense',
@@ -4308,7 +4660,7 @@ describe('advanced options', () => {
       ])
     })
 
-    it('should create commands in the expected order with expected params (blowout in source well, change tip each aspirate)', () => {
+    it.only('should create commands in the expected order with expected params (blowout in source well, change tip each aspirate)', () => {
       const args = {
         ...allArgs,
         changeTip: 'always',
@@ -4345,14 +4697,14 @@ describe('advanced options', () => {
             wellName: 'A1',
           },
         },
-        // Pre-wet
         ...submergeWithAspirateHelper({
           volume: 269,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
           aspirateDelay: 11,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -4372,61 +4724,21 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           mixTimes: 1,
           mixVolume: 35,
-          preWet: true,
+          shouldTouchTip: true,
+          shouldPreWet: true,
+          touchTipMmFromTop: -14.5,
+          aspirateAirGap: 31,
         }),
-
-        // touch tip (asp)
-        {
-          commandType: 'touchTip',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                z: -14.5,
-              },
-            },
-          },
-        },
-        // aspirate > air gap
-        {
-          commandType: 'moveToWell',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 1,
-              },
-            },
-          },
-        },
-        {
-          commandType: 'airGapInPlace',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            flowRate: 10,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 11,
-          },
-        },
         // dispense
         {
           commandType: 'dispense',
@@ -4659,7 +4971,8 @@ describe('advanced options', () => {
           dispenseFlowRate: 2.2,
           aspirateDelay: 11,
           dispenseDelay: 12,
-          speed: 50,
+          submergeSpeed: 50,
+          retractSpeed: 51,
           pipetteId: 'p300SingleId',
           wellName: 'A1',
           labwareId: SOURCE_LABWARE,
@@ -4679,60 +4992,22 @@ describe('advanced options', () => {
               z: 2,
             },
           },
+          retractLocation: {
+            origin: WELL_ORIGIN_TOP,
+            offset: {
+              x: 2,
+              y: -1,
+              z: -4,
+            },
+          },
           mixTimes: 1,
           mixVolume: 35,
           shouldProbe: false,
+          shouldTouchTip: true,
+          shouldPreWet: true,
+          touchTipMmFromTop: -14.5,
+          aspirateAirGap: 31,
         }),
-        // touch tip (asp)
-        {
-          commandType: 'touchTip',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                z: -14.5,
-              },
-            },
-          },
-        },
-        // aspirate > air gap
-        {
-          commandType: 'moveToWell',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            labwareId: 'sourcePlateId',
-            wellName: 'A1',
-            wellLocation: {
-              origin: 'top',
-              offset: {
-                x: 0,
-                y: 0,
-                z: 1,
-              },
-            },
-          },
-        },
-        {
-          commandType: 'airGapInPlace',
-          key: expect.any(String),
-          params: {
-            pipetteId: 'p300SingleId',
-            volume: 31,
-            flowRate: 10,
-          },
-        },
-        {
-          commandType: 'waitForDuration',
-          key: expect.any(String),
-          params: {
-            seconds: 11,
-          },
-        },
         // dispense "aspirate > air gap" then dispense liquid
         {
           commandType: 'dispense',

--- a/step-generation/src/commandCreators/atomic/touchTip.ts
+++ b/step-generation/src/commandCreators/atomic/touchTip.ts
@@ -1,3 +1,5 @@
+import { WELL_ORIGIN_TOP } from '@opentrons/shared-data'
+
 import { noTipOnPipette, pipetteDoesNotExist } from '../../errorCreators'
 import { formatPyStr, uuid } from '../../utils'
 
@@ -74,7 +76,7 @@ export const touchTip: CommandCreator<TouchTipAtomicParams> = (
         labwareId,
         wellName,
         wellLocation: {
-          origin: 'top',
+          origin: WELL_ORIGIN_TOP,
           offset: {
             z: zOffsetFromTop,
           },

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -23,6 +23,7 @@ import {
   reduceCommandCreators,
 } from '../../utils'
 import {
+  airGapInPlace,
   aspirateInPlace,
   configureForVolume,
   delay,
@@ -34,7 +35,6 @@ import {
   prepareToAspirate,
   touchTip,
 } from '../atomic'
-import { airGapInWell } from './airGapInWell'
 import { dropTipInTrash } from './dropTipInTrash'
 import { dropTipInWasteChute } from './dropTipInWasteChute'
 import { mixInPlaceUtil, mixUtil } from './mix'
@@ -108,6 +108,11 @@ export const transfer: CommandCreator<TransferArgs> = (
     aspirateSubmergeZOffset,
     aspirateSubmergePositionReference,
     aspirateSubmergeDelay,
+    aspirateRetractXOffset,
+    aspirateRetractYOffset,
+    aspirateRetractZOffset,
+    aspirateRetractPositionReference,
+    aspirateRetractDelay,
   } = args
 
   const trashOrLabware = getTrashOrLabware(
@@ -232,6 +237,17 @@ export const transfer: CommandCreator<TransferArgs> = (
       z: aspirateSubmergeZOffset,
     },
   }
+  const aspirateRetractLocation: WellLocation = {
+    origin:
+      POSITION_REFERENCE_MAPPED_TO_WELL_ORIGIN[
+        aspirateRetractPositionReference
+      ],
+    offset: {
+      x: aspirateRetractXOffset,
+      y: aspirateRetractYOffset,
+      z: aspirateRetractZOffset,
+    },
+  }
   // @ts-expect-error(SA, 2021-05-05): zip can return undefined so this really should be Array<[string | undefined, string | undefined]>
   const sourceDestPairs: Array<[string, string | null]> = zip(
     args.sourceWells,
@@ -305,12 +321,24 @@ export const transfer: CommandCreator<TransferArgs> = (
             aspirateSubmergePositionReference,
             wellDepth
           )
+          const aspirateRetractMmFromBottom = getMmFromBottom(
+            aspirateRetractZOffset,
+            aspirateRetractPositionReference,
+            wellDepth
+          )
           if (
             aspirateMmFromBottom != null &&
             aspirateSubmergeMmFromBottom != null &&
             aspirateMmFromBottom >= aspirateSubmergeMmFromBottom
           ) {
             errors.push(errorCreators.submergeBelowAspirate())
+          }
+          if (
+            aspirateMmFromBottom != null &&
+            aspirateRetractMmFromBottom != null &&
+            aspirateMmFromBottom >= aspirateRetractMmFromBottom
+          ) {
+            errors.push(errorCreators.retractBelowAspirate())
           }
 
           const moveToSourceWellTopCommand = [
@@ -392,20 +420,20 @@ export const transfer: CommandCreator<TransferArgs> = (
               },
             }),
           ]
-          const preWetTipCommands =
-            args.preWetTip && chunkIdx === 0
-              ? mixInPlaceUtil({
-                  pipette: args.pipette,
-                  volume: subTransferVol,
-                  times: 1,
-                  aspirateFlowRateUlSec,
-                  dispenseFlowRateUlSec,
-                  aspirateDelaySeconds: aspirateDelay?.seconds ?? 0,
-                  dispenseDelaySeconds: dispenseDelay?.seconds ?? 0,
-                  finalPushOut: 0, // according to transfer_components_executor, don't push out here
-                  invariantContext,
-                })
-              : []
+          // prewet before each aspirate if enabled
+          const preWetTipCommands = args.preWetTip
+            ? mixInPlaceUtil({
+                pipette: args.pipette,
+                volume: subTransferVol,
+                times: 1,
+                aspirateFlowRateUlSec,
+                dispenseFlowRateUlSec,
+                aspirateDelaySeconds: aspirateDelay?.seconds ?? 0,
+                dispenseDelaySeconds: dispenseDelay?.seconds ?? 0,
+                finalPushOut: 0, // according to transfer_components_executor, don't push out here
+                invariantContext,
+              })
+            : []
           const mixBeforeAspirateCommands =
             args.mixBeforeAspirate != null
               ? mixInPlaceUtil({
@@ -428,7 +456,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   }),
                 ]
               : []
-          const touchTipAfterAspirateCommands = args.touchTipAfterAspirate
+          const touchTipAfterRetractCommands = args.touchTipAfterAspirate
             ? [
                 curryCommandCreator(touchTip, {
                   pipetteId: args.pipette,
@@ -442,8 +470,30 @@ export const transfer: CommandCreator<TransferArgs> = (
                     ? { speed: args.touchTipAfterAspirateSpeed }
                     : {}),
                 }),
+                // move back to retract position after touch tip if air gap needed
+                ...(aspirateAirGapVolume > 0
+                  ? [
+                      curryCommandCreator(moveToWell, {
+                        pipetteId: args.pipette,
+                        labwareId: args.sourceLabware,
+                        wellName: sourceWell,
+                        wellLocation: aspirateRetractLocation,
+                      }),
+                    ]
+                  : []),
               ]
             : []
+          const airGapAfterRetractCommands =
+            aspirateAirGapVolume > 0
+              ? [
+                  curryCommandCreator(airGapInPlace, {
+                    pipetteId: args.pipette,
+                    volume: aspirateAirGapVolume,
+                    flowRate: aspirateFlowRateUlSec,
+                  }),
+                  ...(aspirateDelay != null ? delayAfterAspirateCommands : []),
+                ]
+              : []
           //  can not touch tip in a waste chute
           const touchTipAfterDispenseCommands =
             args.touchTipAfterDispense && destinationWell != null
@@ -482,24 +532,9 @@ export const transfer: CommandCreator<TransferArgs> = (
                 })
               : []
 
-          const airGapAfterAspirateCommands =
+          const dispenseAspirateAirGapCommands =
             aspirateAirGapVolume && destinationWell != null
               ? [
-                  curryCommandCreator(airGapInWell, {
-                    pipetteId: args.pipette,
-                    labwareId: args.sourceLabware,
-                    wellName: sourceWell,
-                    volume: aspirateAirGapVolume,
-                    flowRate: aspirateFlowRateUlSec,
-                    type: 'aspirate',
-                  }),
-                  ...(aspirateDelay != null
-                    ? [
-                        curryCommandCreator(delay, {
-                          seconds: aspirateDelay.seconds,
-                        }),
-                      ]
-                    : []),
                   curryCommandCreator(dispense, {
                     pipetteId: args.pipette,
                     volume: aspirateAirGapVolume,
@@ -545,12 +580,32 @@ export const transfer: CommandCreator<TransferArgs> = (
             willReuseTip = nextDestWell === destinationWell
           }
 
-          const aspirateCommand = [
+          const aspirateCommands = [
             curryCommandCreator(aspirateInPlace, {
               pipetteId: args.pipette,
               volume: subTransferVol,
               flowRate: aspirateFlowRateUlSec,
             }),
+            ...delayAfterAspirateCommands,
+          ]
+          const postAspirateRetractCommands = [
+            curryCommandCreator(moveToWell, {
+              pipetteId: args.pipette,
+              labwareId: args.sourceLabware,
+              ...(args.aspirateRetractSpeed != null
+                ? { speed: args.aspirateRetractSpeed }
+                : {}),
+              wellName: sourceWell,
+              wellLocation: aspirateRetractLocation,
+            }),
+            ...(aspirateRetractDelay != null &&
+            aspirateRetractDelay?.seconds > 0
+              ? [
+                  curryCommandCreator(delay, {
+                    seconds: aspirateRetractDelay.seconds,
+                  }),
+                ]
+              : []),
           ]
           const dispenseCommand = [
             curryCommandCreator(dispenseLocationHelper, {
@@ -654,10 +709,11 @@ export const transfer: CommandCreator<TransferArgs> = (
             ...aspirateSubmergeCommands,
             ...mixBeforeAspirateCommands,
             ...preWetTipCommands,
-            ...aspirateCommand,
-            ...delayAfterAspirateCommands,
-            ...touchTipAfterAspirateCommands,
-            ...airGapAfterAspirateCommands,
+            ...aspirateCommands,
+            ...postAspirateRetractCommands,
+            ...touchTipAfterRetractCommands,
+            ...airGapAfterRetractCommands,
+            ...dispenseAspirateAirGapCommands,
             ...dispenseCommand,
             ...delayAfterDispenseCommands,
             ...mixInDestinationCommands,

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -306,3 +306,10 @@ export const submergeBelowAspirate = (): CommandCreatorError => {
     message: 'The submerge position must be above the aspirate position',
   }
 }
+
+export const retractBelowAspirate = (): CommandCreatorError => {
+  return {
+    type: 'RETRACT_BELOW_ASPIRATE',
+    message: 'The retract position must be above the aspirate position',
+  }
+}

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -144,36 +144,54 @@ export const submergeWithAspirateHelper = (submergeParams: {
   labwareId: string
   wellName: string
   volume: number
-  speed: number
+  submergeSpeed: number
+  retractSpeed: number
   aspirateFlowRate: number
   submergeLocation: WellLocation
   aspirateLocation: WellLocation
+  retractLocation: WellLocation
+  aspirateAirGap?: number
   dispenseAirGap?: number
   dispenseFlowRate?: number
   shouldProbe?: boolean
-  preWet?: boolean
+  shouldPreWet?: boolean
+  shouldTouchTip?: boolean
+  submergeDelay?: number
   aspirateDelay?: number
+  retractDelay?: number
   dispenseDelay?: number
   mixTimes?: number
   mixVolume?: number
+  touchTipMmFromTop?: number
+  touchTipMmFromEdge?: number
+  touchTipSpeed?: number
 }) => {
   const {
     volume,
     aspirateFlowRate,
     dispenseFlowRate,
-    speed,
+    submergeSpeed,
+    retractSpeed,
     pipetteId,
     labwareId,
     wellName,
     submergeLocation,
     aspirateLocation,
+    retractLocation,
     shouldProbe = true,
-    preWet = false,
+    shouldPreWet = false,
+    shouldTouchTip = false,
+    submergeDelay = 0,
     aspirateDelay = 0,
+    retractDelay = 0,
     dispenseDelay = 0,
     mixTimes = 0,
     mixVolume = 0,
+    aspirateAirGap = 0,
     dispenseAirGap = 0,
+    touchTipMmFromTop,
+    touchTipMmFromEdge,
+    touchTipSpeed,
   } = submergeParams
   const mixCommands = []
   for (let i = 0; i < mixTimes; i++) {
@@ -294,13 +312,23 @@ export const submergeWithAspirateHelper = (submergeParams: {
       params: {
         pipetteId: 'p300SingleId',
         labwareId: SOURCE_LABWARE,
-        speed,
+        speed: submergeSpeed,
         wellName,
         wellLocation: aspirateLocation,
       },
     },
+    ...(submergeDelay > 0
+      ? [
+          {
+            commandType: 'waitForDuration',
+            key: expect.any(String),
+            params: { seconds: submergeDelay },
+          },
+        ]
+      : []),
+
     ...(mixTimes > 0 ? mixCommands : []),
-    ...(preWet
+    ...(shouldPreWet
       ? [
           {
             commandType: 'aspirateInPlace',
@@ -357,6 +385,80 @@ export const submergeWithAspirateHelper = (submergeParams: {
             key: expect.any(String),
             params: { seconds: aspirateDelay },
           },
+        ]
+      : []),
+
+    {
+      commandType: 'moveToWell',
+      key: expect.any(String),
+      params: {
+        pipetteId: 'p300SingleId',
+        labwareId: SOURCE_LABWARE,
+        speed: retractSpeed,
+        wellName,
+        wellLocation: retractLocation,
+      },
+    },
+    ...(retractDelay > 0
+      ? [
+          {
+            commandType: 'waitForDuration',
+            key: expect.any(String),
+            params: { seconds: retractDelay },
+          },
+        ]
+      : []),
+    ...(shouldTouchTip
+      ? [
+          {
+            commandType: 'touchTip',
+            key: expect.any(String),
+            params: {
+              pipetteId: 'p300SingleId',
+              labwareId: SOURCE_LABWARE,
+              wellName,
+              wellLocation: {
+                origin: WELL_ORIGIN_TOP,
+                offset: {
+                  z: touchTipMmFromTop,
+                },
+              },
+              mmFromEdge: touchTipMmFromEdge,
+              speed: touchTipSpeed,
+            },
+          },
+          {
+            commandType: 'moveToWell',
+            key: expect.any(String),
+            params: {
+              pipetteId: 'p300SingleId',
+              labwareId: SOURCE_LABWARE,
+              wellName,
+              wellLocation: retractLocation,
+            },
+          },
+        ]
+      : []),
+    ...(aspirateAirGap > 0
+      ? [
+          {
+            commandType: 'airGapInPlace',
+            key: expect.any(String),
+            params: {
+              pipetteId,
+              volume: aspirateAirGap,
+              flowRate: aspirateFlowRate,
+            },
+          },
+          ...(aspirateDelay > 0
+            ? [
+                {
+                  commandType: 'waitForDuration',
+                  key: expect.any(String),
+                  params: { seconds: aspirateDelay },
+                },
+              ]
+            : []),
         ]
       : []),
   ]

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -308,6 +308,7 @@ export type SharedTransferLikeArgs = CommonArgs & {
   aspirateRetractYOffset: number
   aspirateRetractZOffset: number
   aspirateRetractPositionReference: PositionReference
+  aspirateRetractDelay: InnerDelayArgs | null
   dispenseSubmergeSpeed: number | null
   dispenseSubmergeXOffset: number
   dispenseSubmergeYOffset: number
@@ -693,6 +694,7 @@ export type ErrorType =
   | 'PIPETTING_INTO_COLUMN_4'
   | 'POSSIBLE_PIPETTE_COLLISION'
   | 'REMOVE_96_CHANNEL_TIPRACK_ADAPTER'
+  | 'RETRACT_BELOW_ASPIRATE'
   | 'SUBMERGE_BELOW_ASPIRATE'
   | 'TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER'
   | 'THERMOCYCLER_LID_CLOSED'


### PR DESCRIPTION
# Overview

This PR adds the second part of the transfer compound command creator updates, relating to post-aspiration (plunger movement) retract behavior. The implementation is scoped to post-aspiration moves, touch tip, and air gap behavior

## Test Plan and Hands on Testing

Due to the scope of this PR, I recommend walking through this live with me so I can explain some of the changes made. Please reference the [step generation execution doc](https://opentrons.atlassian.net/wiki/x/cYDbIgE) for correctness as well.

## Changelog

- add aspirate retract behavior to transfer compound command creator
- update command fixture utility to create expected retract behavior 
- update 8.5 migration to correctly populate submerge and retract positions/references to safe position (well top)

## Review requests

see test plan

## Risk assessment

medium - high. touches foundational step generation command creator logic