### PR TITLE
fix(app): Actually reset run history when that option is selected

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/DeviceResetSlideout.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/DeviceResetSlideout.tsx
@@ -388,9 +388,6 @@ export function DeviceResetSlideout({
 }
 
 // Keys in this object do not need to map to the server's HTTP API.
-//
-// This is `{ot2Only: ..., flexOnly: ...}`` instead of `OT2Only | FlexOnly`` to be
-// defensive against the robot type changing
 interface DisplayedResetOptionState {
   common: {
     runsHistory: boolean

--- a/app/src/organisms/ODD/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/DeviceReset.tsx
@@ -51,10 +51,10 @@ const OptionLabel = styled.label<LabelProps>`
  * - deckConfiguration
  */
 interface DisplayedResetOptionState extends Record<string, boolean> {
-  pipetteOffsetCalibrations: boolean
   gripperOffsetCalibrations: boolean
-  moduleCalibration: boolean
   labwareOffsets: boolean
+  moduleCalibration: boolean
+  pipetteOffsetCalibrations: boolean
   runsHistory: boolean
 }
 
@@ -78,6 +78,7 @@ function isAnyOptionSelected(
   return Object.values(displayedState).some(value => value)
 }
 
+/** Convert the options selected in the UI to the options we want to send to the server. */
 function buildResetRequest(
   displayedState: DisplayedResetOptionState
 ): ResetConfigRequest {
@@ -85,10 +86,12 @@ function buildResetRequest(
     resetLabwareOffsets: displayedState.labwareOffsets,
 
     settingsResets: {
-      // These keys need to follow the server's HTTP API.
-      pipetteOffsetCalibrations: displayedState.pipetteOffsetCalibrations,
+      // Note: keys inside `settingsResets` need to follow the server's HTTP API.
       gripperOffsetCalibrations: displayedState.gripperOffsetCalibrations,
       moduleCalibration: displayedState.moduleCalibration,
+      pipetteOffsetCalibrations: displayedState.pipetteOffsetCalibrations,
+      runsHistory: displayedState.runsHistory,
+
       // If the user selected every visible option, implicitly select certain additional options.
       ...(isEveryOptionSelected(displayedState)
         ? {

--- a/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
@@ -11,7 +11,6 @@ import { DeviceReset } from '../DeviceReset'
 import type { ComponentProps } from 'react'
 import type { DispatchApiRequestType } from '/app/redux/robot-api'
 
-vi.mock('/app/redux/robot-admin')
 vi.mock('/app/redux/robot-api')
 
 const render = (props: ComponentProps<typeof DeviceReset>) => {
@@ -65,6 +64,7 @@ describe('DeviceReset', () => {
     const clearMockResetOptions = {
       resetLabwareOffsets: false,
       settingsResets: {
+        gripperOffsetCalibrations: false,
         pipetteOffsetCalibrations: true,
         moduleCalibration: true,
         runsHistory: true,
@@ -145,9 +145,6 @@ describe('DeviceReset', () => {
         moduleCalibration: true,
         runsHistory: true,
         gripperOffsetCalibrations: true,
-        authorizedKeys: false,
-        onDeviceDisplay: false,
-        deckConfiguration: false,
       },
     }
 


### PR DESCRIPTION
## Overview

Fixes RQA-4161.

In PR #17921, I apparently wrote a stupid bug where I just outright forgot to send `runsHistory: true` when that option was selected in the UI.

## Test Plan and Hands on Testing

* [x] Push it to a Flex and test manually.
* [x] Manually review the reset code (both ODD and desktop app) for other similar bugs

[This exact case *was* already unit tested.](https://github.com/Opentrons/opentrons/blob/00b83c9c5102041e5a22fb615f1fd660ca44c796/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx#L72) However, there appears to be some kind of bug in the test causing that assertion to always pass, no matter how wrong the value is. ~~I suspect this has to do with a misconfigured mock somewhere, but I haven't figured it out yet.~~ See [comment below](https://github.com/Opentrons/opentrons/pull/18244#issuecomment-2848022487).

## Review requests

Any ideas for making the `buildResetRequest()` code inherently safer?

See [comment below](https://github.com/Opentrons/opentrons/pull/18244#issuecomment-2848022487) for the test bug. Does this fix make sense?

## Risk assessment

The fix is low-risk. I need therapy for the test bug, though.
