### PR TITLE
feat(step-generation): generate Python for blowOutInPlace command

### DIFF
--- a/step-generation/src/__tests__/blowOutInPlace.test.ts
+++ b/step-generation/src/__tests__/blowOutInPlace.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { blowOutInPlace } from '../commandCreators/atomic/blowOutInPlace'
 import {
+  DEFAULT_PIPETTE,
   getRobotStateWithTipStandard,
   getSuccessResult,
   makeContext,
@@ -14,7 +15,6 @@ describe('blowOutInPlace', () => {
   let invariantContext: InvariantContext
   let robotStateWithTip: RobotState
 
-  const mockId = 'mockId'
   const mockFlowRate = 10
   beforeEach(() => {
     invariantContext = makeContext()
@@ -22,7 +22,7 @@ describe('blowOutInPlace', () => {
   })
   it('blowOut in place', () => {
     const params: BlowoutInPlaceParams = {
-      pipetteId: mockId,
+      pipetteId: DEFAULT_PIPETTE,
       flowRate: mockFlowRate,
     }
     const result = blowOutInPlace(params, invariantContext, robotStateWithTip)
@@ -32,10 +32,16 @@ describe('blowOutInPlace', () => {
         commandType: 'blowOutInPlace',
         key: expect.any(String),
         params: {
-          pipetteId: mockId,
+          pipetteId: DEFAULT_PIPETTE,
           flowRate: mockFlowRate,
         },
       },
     ])
+    expect(res.python).toBe(
+      `
+mockPythonName.flow_rate.blow_out = 10
+mockPythonName.blow_out()
+`.trim()
+    )
   })
 })

--- a/step-generation/src/commandCreators/atomic/blowOutInPlace.ts
+++ b/step-generation/src/commandCreators/atomic/blowOutInPlace.ts
@@ -9,6 +9,9 @@ export const blowOutInPlace: CommandCreator<BlowoutInPlaceParams> = (
   prevRobotState
 ) => {
   const { pipetteId, flowRate } = args
+  const { pipetteEntities } = invariantContext
+  const pipette = pipetteEntities[pipetteId]
+  const pipettePythonName = pipette.pythonName
   const commands = [
     {
       commandType: 'blowOutInPlace' as const,
@@ -21,5 +24,9 @@ export const blowOutInPlace: CommandCreator<BlowoutInPlaceParams> = (
   ]
   return {
     commands,
+    python:
+      // blow_out() blows out in place if no location= is specified
+      `${pipettePythonName}.flow_rate.blow_out = ${flowRate}\n` +
+      `${pipettePythonName}.blow_out()`,
   }
 }


### PR DESCRIPTION
# Overview

Emit Python for the `blowOutInPlace` CommandCreator. AUTH-1584

I'm not sure if @ncdiehl11 will need this for liquid class transfers, but since this was easy to do, I might as well add this for consistency with `aspirateInPlace` and `dispenseInPlace` that Nick already implemented.

## Test Plan and Hands on Testing

Added unit test.

## Risk assessment

Low.