### PR TITLE
feat(api): add rate and flow_rate args to air_gap

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -844,7 +844,10 @@ class InstrumentContext(publisher.CommandPublisher):
     @publisher.publish(command=cmds.air_gap)
     @requires_version(2, 0)
     def air_gap(
-        self, volume: Optional[float] = None, height: Optional[float] = None
+        self,
+        volume: Optional[float] = None,
+        height: Optional[float] = None,
+        rate: Optional[float] = None,
     ) -> InstrumentContext:
         """
         Draw air into the pipette's tip at the current well.
@@ -858,6 +861,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :param height: The height, in mm, to move above the current well before creating
                        the air gap. The default is 5 mm above the current well.
         :type height: float
+
+        :param rate: A multiplier for the default flow rate of the pipette. Calculated
+                     as ``rate`` multiplied by :py:attr:`flow_rate.aspirate
+                     <flow_rate>`. If not specified, defaults to 1.0. See
+                     :ref:`new-plunger-flow-rates`.
+        :type rate: float
 
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
 
@@ -882,9 +891,19 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. versionchanged:: 2.22
             No longer implemented as an aspirate.
+
+        .. versionchanged:: 2.24
+            Adds the ``rate`` parameter.
         """
         if not self._core.has_tip():
             raise UnexpectedTipRemovalError("air_gap", self.name, self.mount)
+
+        if rate and self.api_version < APIVersion(2, 24):
+            raise APIVersionError(
+                api_element="rate",
+                until_version="2.24",
+                current_version=f"{self._api_version}",
+            )
 
         if height is None:
             height = 5
@@ -896,7 +915,9 @@ class InstrumentContext(publisher.CommandPublisher):
         if self.api_version >= _AIR_GAP_TRACKING_ADDED_IN:
             self._core.prepare_to_aspirate()
             c_vol = self._core.get_available_volume() if volume is None else volume
-            flow_rate = self._core.get_aspirate_flow_rate()
+            flow_rate = (
+                rate if rate is not None else self._core.get_aspirate_flow_rate()
+            )
             self._core.air_gap_in_place(c_vol, flow_rate)
         else:
             self.aspirate(volume)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -865,7 +865,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :param rate: A multiplier for the default flow rate of the pipette. Calculated
                      as ``rate`` multiplied by :py:attr:`flow_rate.aspirate
-                     <flow_rate>`. If not specified, defaults to 1.0. See
+                     <flow_rate>`. If neither rate nor flow_rate is specified, the pipette
+                     will aspirate at a rate of 1.0 * InstrumentContext.flow_rate.aspirate. See
                      :ref:`new-plunger-flow-rates`.
         :type rate: float
 
@@ -897,26 +898,27 @@ class InstrumentContext(publisher.CommandPublisher):
             No longer implemented as an aspirate.
 
         .. versionchanged:: 2.24
-            Adds the ``rate`` and ``flow_rate`` parameter. You can only define one or the other.
+            Adds the ``rate`` and ``flow_rate`` parameter. You can only define one or the other. If
+            both are unspecified then ``rate`` is by default set to 1.0.
         """
         if not self._core.has_tip():
             raise UnexpectedTipRemovalError("air_gap", self.name, self.mount)
 
-        if rate and self.api_version < APIVersion(2, 24):
+        if rate is not None and self.api_version < APIVersion(2, 24):
             raise APIVersionError(
                 api_element="rate",
                 until_version="2.24",
                 current_version=f"{self._api_version}",
             )
 
-        if flow_rate and self.api_version < APIVersion(2, 24):
+        if flow_rate is not None and self.api_version < APIVersion(2, 24):
             raise APIVersionError(
                 api_element="flow_rate",
                 until_version="2.24",
                 current_version=f"{self._api_version}",
             )
 
-        if flow_rate and rate:
+        if flow_rate is not None and rate is not None:
             raise ValueError("Cannot define both flow_rate and rate.")
 
         if height is None:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -843,7 +843,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
     @publisher.publish(command=cmds.air_gap)
     @requires_version(2, 0)
-    def air_gap(
+    def air_gap(  # noqa: C901
         self,
         volume: Optional[float] = None,
         height: Optional[float] = None,
@@ -897,7 +897,7 @@ class InstrumentContext(publisher.CommandPublisher):
             No longer implemented as an aspirate.
 
         .. versionchanged:: 2.24
-            Adds the ``rate`` and ``flow_rate`` parameter. You only need to define one or the other.
+            Adds the ``rate`` and ``flow_rate`` parameter. You can only define one or the other.
         """
         if not self._core.has_tip():
             raise UnexpectedTipRemovalError("air_gap", self.name, self.mount)
@@ -916,6 +916,9 @@ class InstrumentContext(publisher.CommandPublisher):
                 current_version=f"{self._api_version}",
             )
 
+        if flow_rate and rate:
+            raise UnsupportedAPIError(message="Cannot define both flow_rate and rate.")
+
         if height is None:
             height = 5
         loc = self._protocol_core.get_last_location()
@@ -926,14 +929,13 @@ class InstrumentContext(publisher.CommandPublisher):
         if self.api_version >= _AIR_GAP_TRACKING_ADDED_IN:
             self._core.prepare_to_aspirate()
             c_vol = self._core.get_available_volume() if volume is None else volume
+            if flow_rate is not None:
+                calculated_rate = flow_rate
+            elif rate is not None:
+                calculated_rate = rate * self._core.get_aspirate_flow_rate()
+            else:
+                calculated_rate = self._core.get_aspirate_flow_rate()
 
-            calculated_rate = (
-                flow_rate / self._core.get_aspirate_flow_rate()
-                if flow_rate is not None
-                else rate
-                if rate is not None
-                else self._core.get_aspirate_flow_rate()
-            )
             self._core.air_gap_in_place(c_vol, calculated_rate)
         else:
             self.aspirate(volume)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -869,7 +869,7 @@ class InstrumentContext(publisher.CommandPublisher):
                      :ref:`new-plunger-flow-rates`.
         :type rate: float
 
-        :param flow_rate: Raw flow_rate value that has not been calculated.
+        :param flow_rate: The speed, in µL/s, at which the pipette will draw in air.
         :type flow_rate: float
 
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -848,6 +848,7 @@ class InstrumentContext(publisher.CommandPublisher):
         volume: Optional[float] = None,
         height: Optional[float] = None,
         rate: Optional[float] = None,
+        flow_rate: Optional[float] = None,
     ) -> InstrumentContext:
         """
         Draw air into the pipette's tip at the current well.
@@ -867,6 +868,9 @@ class InstrumentContext(publisher.CommandPublisher):
                      <flow_rate>`. If not specified, defaults to 1.0. See
                      :ref:`new-plunger-flow-rates`.
         :type rate: float
+
+        :param flow_rate: Raw flow_rate value that has not been calculated.
+        :type flow_rate: float
 
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
 
@@ -893,7 +897,7 @@ class InstrumentContext(publisher.CommandPublisher):
             No longer implemented as an aspirate.
 
         .. versionchanged:: 2.24
-            Adds the ``rate`` parameter.
+            Adds the ``rate`` and ``flow_rate`` parameter. You only need to define one or the other.
         """
         if not self._core.has_tip():
             raise UnexpectedTipRemovalError("air_gap", self.name, self.mount)
@@ -901,6 +905,13 @@ class InstrumentContext(publisher.CommandPublisher):
         if rate and self.api_version < APIVersion(2, 24):
             raise APIVersionError(
                 api_element="rate",
+                until_version="2.24",
+                current_version=f"{self._api_version}",
+            )
+
+        if flow_rate and self.api_version < APIVersion(2, 24):
+            raise APIVersionError(
+                api_element="flow_rate",
                 until_version="2.24",
                 current_version=f"{self._api_version}",
             )
@@ -915,10 +926,15 @@ class InstrumentContext(publisher.CommandPublisher):
         if self.api_version >= _AIR_GAP_TRACKING_ADDED_IN:
             self._core.prepare_to_aspirate()
             c_vol = self._core.get_available_volume() if volume is None else volume
-            flow_rate = (
-                rate if rate is not None else self._core.get_aspirate_flow_rate()
+
+            calculated_rate = (
+                flow_rate / self._core.get_aspirate_flow_rate()
+                if flow_rate is not None
+                else rate
+                if rate is not None
+                else self._core.get_aspirate_flow_rate()
             )
-            self._core.air_gap_in_place(c_vol, flow_rate)
+            self._core.air_gap_in_place(c_vol, calculated_rate)
         else:
             self.aspirate(volume)
         return self

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -917,7 +917,7 @@ class InstrumentContext(publisher.CommandPublisher):
             )
 
         if flow_rate and rate:
-            raise UnsupportedAPIError(message="Cannot define both flow_rate and rate.")
+            raise ValueError("Cannot define both flow_rate and rate.")
 
         if height is None:
             height = 5

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -870,7 +870,7 @@ class InstrumentContext(publisher.CommandPublisher):
                      :ref:`new-plunger-flow-rates`.
         :type rate: float
 
-        :param flow_rate: The speed, in µL/s, at which the pipette will draw in air.
+        :param flow_rate: The rate, in µL/s, at which the pipette will draw in air.
         :type flow_rate: float
 
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1863,14 +1863,15 @@ def test_air_gap_has_rate(
     decoy.when(mock_instrument_core.has_tip()).then_return(True)
     decoy.when(mock_protocol_core.get_last_location()).then_return(last_location)
     decoy.when(mock_well.top(z=5.0)).then_return(top_location)
+    decoy.when(mock_instrument_core.get_aspirate_flow_rate()).then_return(100)
 
-    subject.air_gap(volume=10, height=5, rate=12)
+    subject.air_gap(volume=10, height=5, rate=1.2)
 
     decoy.verify(mock_move_to(top_location, publish=False))
     decoy.verify(mock_instrument_core.prepare_to_aspirate())
     decoy.verify(
-        mock_instrument_core.air_gap_in_place(10, 12)
-    )  # 12 is from the rate param
+        mock_instrument_core.air_gap_in_place(10, 120)
+    )  # 120 is from the flow_rate calculated from the rate * aspirate_flow_rate param
 
 
 @pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 24)))
@@ -1891,15 +1892,14 @@ def test_air_gap_has_flow_rate(
     decoy.when(mock_instrument_core.has_tip()).then_return(True)
     decoy.when(mock_protocol_core.get_last_location()).then_return(last_location)
     decoy.when(mock_well.top(z=5.0)).then_return(top_location)
-    decoy.when(mock_instrument_core.get_aspirate_flow_rate()).then_return(12)
 
-    subject.air_gap(volume=10, height=5, flow_rate=144)
+    subject.air_gap(volume=10, height=5, flow_rate=100)
 
     decoy.verify(mock_move_to(top_location, publish=False))
     decoy.verify(mock_instrument_core.prepare_to_aspirate())
     decoy.verify(
-        mock_instrument_core.air_gap_in_place(10, 12)
-    )  # 12 is the rate calculated from the flow_rate param
+        mock_instrument_core.air_gap_in_place(10, 100)
+    )  # 100 is the flow_rate param
 
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1873,6 +1873,35 @@ def test_air_gap_has_rate(
     )  # 12 is from the rate param
 
 
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 24)))
+def test_air_gap_has_flow_rate(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """It should use its own flow_rate param."""
+    mock_well = decoy.mock(cls=Well)
+    top_location = Location(point=Point(9, 9, 14), labware=mock_well)
+    last_location = Location(point=Point(9, 9, 9), labware=mock_well)
+    mock_move_to = decoy.mock(func=subject.move_to)
+    monkeypatch.setattr(subject, "move_to", mock_move_to)
+
+    decoy.when(mock_instrument_core.has_tip()).then_return(True)
+    decoy.when(mock_protocol_core.get_last_location()).then_return(last_location)
+    decoy.when(mock_well.top(z=5.0)).then_return(top_location)
+    decoy.when(mock_instrument_core.get_aspirate_flow_rate()).then_return(12)
+
+    subject.air_gap(volume=10, height=5, flow_rate=144)
+
+    decoy.verify(mock_move_to(top_location, publish=False))
+    decoy.verify(mock_instrument_core.prepare_to_aspirate())
+    decoy.verify(
+        mock_instrument_core.air_gap_in_place(10, 12)
+    )  # 12 is the rate calculated from the flow_rate param
+
+
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
 def test_transfer_liquid_raises_for_invalid_locations(
     decoy: Decoy,

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1844,6 +1844,31 @@ def test_air_gap_uses_air_gap(
     decoy.verify(mock_instrument_core.prepare_to_aspirate())
     decoy.verify(mock_instrument_core.air_gap_in_place(10, 11))
 
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 24)))
+def test_air_gap_has_rate(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """It should use its own rate param"""
+    mock_well = decoy.mock(cls=Well)
+    top_location = Location(point=Point(9, 9, 14), labware=mock_well)
+    last_location = Location(point=Point(9, 9, 9), labware=mock_well)
+    mock_move_to = decoy.mock(func=subject.move_to)
+    monkeypatch.setattr(subject, "move_to", mock_move_to)
+
+    decoy.when(mock_instrument_core.has_tip()).then_return(True)
+    decoy.when(mock_protocol_core.get_last_location()).then_return(last_location)
+    decoy.when(mock_well.top(z=5.0)).then_return(top_location)
+
+    subject.air_gap(volume=10, height=5, rate=12)
+
+    decoy.verify(mock_move_to(top_location, publish=False))
+    decoy.verify(mock_instrument_core.prepare_to_aspirate())
+    decoy.verify(mock_instrument_core.air_gap_in_place(10, 12)) # 12 is from the rate param
+
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
 def test_transfer_liquid_raises_for_invalid_locations(

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1844,6 +1844,7 @@ def test_air_gap_uses_air_gap(
     decoy.verify(mock_instrument_core.prepare_to_aspirate())
     decoy.verify(mock_instrument_core.air_gap_in_place(10, 11))
 
+
 @pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 24)))
 def test_air_gap_has_rate(
     decoy: Decoy,
@@ -1852,7 +1853,7 @@ def test_air_gap_has_rate(
     subject: InstrumentContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """It should use its own rate param"""
+    """It should use its own rate param."""
     mock_well = decoy.mock(cls=Well)
     top_location = Location(point=Point(9, 9, 14), labware=mock_well)
     last_location = Location(point=Point(9, 9, 9), labware=mock_well)
@@ -1867,7 +1868,9 @@ def test_air_gap_has_rate(
 
     decoy.verify(mock_move_to(top_location, publish=False))
     decoy.verify(mock_instrument_core.prepare_to_aspirate())
-    decoy.verify(mock_instrument_core.air_gap_in_place(10, 12)) # 12 is from the rate param
+    decoy.verify(
+        mock_instrument_core.air_gap_in_place(10, 12)
+    )  # 12 is from the rate param
 
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1902,6 +1902,27 @@ def test_air_gap_has_flow_rate(
     )  # 100 is the flow_rate param
 
 
+def test_air_gap_has_flow_rate_and_rate(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    mock_protocol_core: ProtocolCore,
+    subject: InstrumentContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """It raise an error when rate and flow_rate are specified."""
+    mock_well = decoy.mock(cls=Well)
+    top_location = Location(point=Point(9, 9, 14), labware=mock_well)
+    last_location = Location(point=Point(9, 9, 9), labware=mock_well)
+    mock_move_to = decoy.mock(func=subject.move_to)
+    monkeypatch.setattr(subject, "move_to", mock_move_to)
+
+    decoy.when(mock_instrument_core.has_tip()).then_return(True)
+    decoy.when(mock_protocol_core.get_last_location()).then_return(last_location)
+    decoy.when(mock_well.top(z=5.0)).then_return(top_location)
+    with pytest.raises(ValueError, match="Cannot define both flow_rate and rate."):
+        subject.air_gap(volume=10, height=5, flow_rate=100, rate=5.0)
+
+
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
 def test_transfer_liquid_raises_for_invalid_locations(
     decoy: Decoy,


### PR DESCRIPTION
closes AUTH-1628

# Overview

This PR introduces `rate` and `flow_rate` arg for `air_gap` starting in api version 2.24

## Test Plan and Hands on Testing

Review the code and py tests.

## Changelog

- add optional `rate` arg and `flow_rate` arg to `air_gap`
- add py tests to test both

## Risk assessment

low
