### PR TITLE
fix (app): Corrected module mixpanel hook to get module id and temperature

### DIFF
--- a/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
+++ b/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
@@ -22,13 +22,11 @@ import type {
   TemperatureParams,
   TemperatureModuleAwaitTemperatureParams,
   ThermocyclerSetTargetBlockTemperatureParams,
-  TCSetTargetLidTemperatureRunTimeCommand,
   RunTimeCommand,
   CompletedProtocolAnalysis,
 } from '@opentrons/shared-data'
 import type { CommandData } from '@opentrons/api-client'
-import { Temperature } from '@opentrons/components/src/hardware-sim/Module/Temperature'
-import { Thermocycler } from '@opentrons/components'
+
 
 const ANALYTIC_COMMAND_TYPES: Array<RunTimeCommand['commandType']> = [
   'thermocycler/closeLid',
@@ -169,25 +167,26 @@ export function useModuleCommandAnalytics(): UseModuleCommandAnalyticsResult {
 function isModuleOnlyParams(params: unknown): params is ModuleOnlyParams {
   return typeof params === 'object' && params !== null && 'moduleId' in params
 }
-type AllTemperatureParams = 
+
+type AllTemperatureParams =
   TemperatureModuleAwaitTemperatureParams |
   TemperatureParams |
-  ThermocyclerSetTargetBlockTemperatureParams 
+  ThermocyclerSetTargetBlockTemperatureParams
 
-function isTemperatureParams(params: unknown): params is AllTemperatureParams{
+function isTemperatureParams(params: unknown): params is AllTemperatureParams {
   return typeof params === 'object' && params !== null && 'celsius' in params
 }
 
 /* Checks param type and returns variables found */
 function isParamType(params: unknown): { moduleId: string; celsius: string } {
-  if (isModuleOnlyParams(params)) {
-    return { moduleId: String(params.moduleId), celsius: '' }
-  }
   if (isTemperatureParams(params)) {
     return {
       moduleId: String(params.moduleId),
       celsius: String(params.celsius),
     }
+  }
+  if (isModuleOnlyParams(params)) {
+    return { moduleId: String(params.moduleId), celsius: '' }
   }
   return { moduleId: '', celsius: '' }
 }

--- a/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
+++ b/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
@@ -84,7 +84,6 @@ export interface UseModuleCommandAnalyticsResult {
 
 export function useModuleCommandAnalytics(): UseModuleCommandAnalyticsResult {
   const doTrackEvent = useTrackEvent()
-  const { data: deckConfig = [] } = useNotifyDeckConfigurationQuery()
   const moduleQuery = useModulesQuery()
 
   const reportModuleCommand = ({
@@ -99,23 +98,12 @@ export function useModuleCommandAnalytics(): UseModuleCommandAnalyticsResult {
 
     const attachedModules = moduleQuery?.data?.data ?? []
 
-    const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
-
-    const protocolModulesInfo =
-      analysis != null ? getProtocolModulesInfo(analysis, deckDef) : []
-
-    const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
-      attachedModules,
-      protocolModulesInfo,
-      deckConfig
-    )
-
-    const matchedModules = attachedProtocolModuleMatches.map(module => ({
-      moduleType: module.attachedModuleMatch?.moduleType,
-      moduleId: module.attachedModuleMatch?.id,
-      serialNumber: module.attachedModuleMatch?.serialNumber,
-      firmwareVersion: module.attachedModuleMatch?.firmwareVersion,
-    }))
+    const matchedModules = attachedModules.map(module => ({
+      moduleType: module.moduleType,
+      moduleId: module.id,
+      serialNumber: module.serialNumber,
+      firmwareVersion: module.firmwareVersion,
+    }));
 
     const { moduleId, celsius } = isParamType(
       'params' in rest ? rest.params : null

--- a/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
+++ b/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
@@ -20,10 +20,15 @@ import type {
   ModuleOnlyParams,
   ModuleType,
   TemperatureParams,
+  TemperatureModuleAwaitTemperatureParams,
+  ThermocyclerSetTargetBlockTemperatureParams,
+  TCSetTargetLidTemperatureRunTimeCommand,
   RunTimeCommand,
   CompletedProtocolAnalysis,
 } from '@opentrons/shared-data'
 import type { CommandData } from '@opentrons/api-client'
+import { Temperature } from '@opentrons/components/src/hardware-sim/Module/Temperature'
+import { Thermocycler } from '@opentrons/components'
 
 const ANALYTIC_COMMAND_TYPES: Array<RunTimeCommand['commandType']> = [
   'thermocycler/closeLid',
@@ -164,8 +169,13 @@ export function useModuleCommandAnalytics(): UseModuleCommandAnalyticsResult {
 function isModuleOnlyParams(params: unknown): params is ModuleOnlyParams {
   return typeof params === 'object' && params !== null && 'moduleId' in params
 }
+type AllTemperatureParams = 
+  TemperatureModuleAwaitTemperatureParams |
+  TemperatureParams |
+  ThermocyclerSetTargetBlockTemperatureParams |
+  TCSetTargetLidTemperatureRunTimeCommand 
 
-function isTemperatureParams(params: unknown): params is TemperatureParams {
+function isTemperatureParams(params: unknown): params is AllTemperatureParams{
   return typeof params === 'object' && params !== null && 'celsius' in params
 }
 

--- a/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
+++ b/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
@@ -172,8 +172,7 @@ function isModuleOnlyParams(params: unknown): params is ModuleOnlyParams {
 type AllTemperatureParams = 
   TemperatureModuleAwaitTemperatureParams |
   TemperatureParams |
-  ThermocyclerSetTargetBlockTemperatureParams |
-  TCSetTargetLidTemperatureRunTimeCommand 
+  ThermocyclerSetTargetBlockTemperatureParams 
 
 function isTemperatureParams(params: unknown): params is AllTemperatureParams{
   return typeof params === 'object' && params !== null && 'celsius' in params

--- a/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
+++ b/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
@@ -1,19 +1,10 @@
 import { useModulesQuery } from '@opentrons/react-api-client'
-import {
-  FLEX_ROBOT_TYPE,
-  getDeckDefFromRobotType,
-} from '@opentrons/shared-data'
 
 import {
   useTrackEvent,
   ANALYTICS_MODULE_COMMAND_ERROR,
   ANALYTICS_MODULE_COMMAND_COMPLETED,
 } from '/app/redux/analytics'
-import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
-import {
-  getAttachedProtocolModuleMatches,
-  getProtocolModulesInfo,
-} from '/app/transformations/analysis'
 
 import type {
   CommandStatus,
@@ -26,7 +17,6 @@ import type {
   CompletedProtocolAnalysis,
 } from '@opentrons/shared-data'
 import type { CommandData } from '@opentrons/api-client'
-
 
 const ANALYTIC_COMMAND_TYPES: Array<RunTimeCommand['commandType']> = [
   'thermocycler/closeLid',
@@ -103,7 +93,7 @@ export function useModuleCommandAnalytics(): UseModuleCommandAnalyticsResult {
       moduleId: module.id,
       serialNumber: module.serialNumber,
       firmwareVersion: module.firmwareVersion,
-    }));
+    }))
 
     const { moduleId, celsius } = isParamType(
       'params' in rest ? rest.params : null
@@ -157,9 +147,9 @@ function isModuleOnlyParams(params: unknown): params is ModuleOnlyParams {
 }
 
 type AllTemperatureParams =
-  TemperatureModuleAwaitTemperatureParams |
-  TemperatureParams |
-  ThermocyclerSetTargetBlockTemperatureParams
+  | TemperatureModuleAwaitTemperatureParams
+  | TemperatureParams
+  | ThermocyclerSetTargetBlockTemperatureParams
 
 function isTemperatureParams(params: unknown): params is AllTemperatureParams {
   return typeof params === 'object' && params !== null && 'celsius' in params


### PR DESCRIPTION
Corrected the module mixpanel hook by checking if the params passed are temperatureParams before module params. 
The matchedModules array is now derived directly from attachedModules, bypassing protocol analysis and match verification logic