### PR TITLE
fix(app): Fix ODD intermittent indefinite "canceling run" modal state

### DIFF
--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -1,32 +1,29 @@
-import { useState, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
-import { useSelector } from 'react-redux'
-
 import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import {
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
-  SPACING,
   LegacyStyledText,
+  SPACING,
 } from '@opentrons/components'
 import {
-  useStopRunMutation,
   useDeleteRunMutation,
   useDismissCurrentRunMutation,
+  useStopRunMutation,
 } from '@opentrons/react-api-client'
-
 import { SmallButton } from '/app/atoms/buttons'
 import { OddModal } from '/app/molecules/OddModal'
+import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
-import { useRunStatus } from '/app/resources/runs'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '/app/redux/analytics'
 import { getLocalRobot } from '/app/redux/discovery'
+import { useNotifyRunQuery } from '/app/resources/runs'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
 import { CancelingRunModal } from './CancelingRunModal'
-
-import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
 
 interface ConfirmCancelRunModalProps {
   runId: string
@@ -61,8 +58,9 @@ export function ConfirmCancelRunModal({
       }
     },
   })
-  const runStatus = useRunStatus(runId)
   const localRobot = useSelector(getLocalRobot)
+  const { data, isError: isRunFetchError } = useNotifyRunQuery(runId)
+  const runStatus = data?.data.status
   const robotName = localRobot?.name ?? ''
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const navigate = useNavigate()
@@ -85,7 +83,7 @@ export function ConfirmCancelRunModal({
   }
 
   useEffect(() => {
-    if (runStatus === RUN_STATUS_STOPPED) {
+    if (runStatus === RUN_STATUS_STOPPED || isRunFetchError) {
       trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
       if (!isActiveRun) {
         dismissCurrentRun(runId)

--- a/app/src/organisms/ODD/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
@@ -1,27 +1,24 @@
-import { when } from 'vitest-when'
-import { MemoryRouter } from 'react-router-dom'
-import { fireEvent, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
 import { RUN_STATUS_IDLE, RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import {
-  useStopRunMutation,
   useDeleteRunMutation,
   useDismissCurrentRunMutation,
+  useStopRunMutation,
 } from '@opentrons/react-api-client'
-
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
-import { useRunStatus } from '/app/resources/runs'
 import { useTrackEvent } from '/app/redux/analytics'
 import { getLocalRobot } from '/app/redux/discovery'
 import { mockConnectedRobot } from '/app/redux/discovery/__fixtures__'
-import { ConfirmCancelRunModal } from '../ConfirmCancelRunModal'
-import { CancelingRunModal } from '../CancelingRunModal'
-
+import { useNotifyRunQuery } from '/app/resources/runs'
 import type { ComponentProps } from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import type { NavigateFunction } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { when } from 'vitest-when'
+import { CancelingRunModal } from '../CancelingRunModal'
+import { ConfirmCancelRunModal } from '../ConfirmCancelRunModal'
 
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/runs')
@@ -95,7 +92,14 @@ describe('ConfirmCancelRunModal', () => {
       ...mockConnectedRobot,
       name: ROBOT_NAME,
     })
-    when(useRunStatus).calledWith(RUN_ID).thenReturn(RUN_STATUS_IDLE)
+
+    vi.mocked(useNotifyRunQuery).mockReturnValue({
+      data: {
+        data: {
+          status: RUN_STATUS_IDLE,
+        },
+      },
+    } as any)
   })
 
   afterEach(() => {
@@ -142,20 +146,36 @@ describe('ConfirmCancelRunModal', () => {
       ...props,
       isActiveRun: false,
     }
-    when(useRunStatus).calledWith(RUN_ID).thenReturn(RUN_STATUS_STOPPED)
+
+    vi.mocked(useNotifyRunQuery).mockReturnValue({
+      data: {
+        data: {
+          status: RUN_STATUS_STOPPED,
+        },
+      },
+    } as any)
+
     render(props)
 
     expect(mockDismissCurrentRun).toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
   })
 
-  it('when quick transfer run is stopped, the run is dismissed and the modal closes if the run is not yet active', () => {
+  it('when quick transfer run is stopped, the run is dismissed and navigates to quick transfer', () => {
     props = {
       ...props,
       isActiveRun: false,
       isQuickTransfer: true,
     }
-    when(useRunStatus).calledWith(RUN_ID).thenReturn(RUN_STATUS_STOPPED)
+
+    vi.mocked(useNotifyRunQuery).mockReturnValue({
+      data: {
+        data: {
+          status: RUN_STATUS_STOPPED,
+        },
+      },
+    } as any)
+
     render(props)
 
     expect(mockDismissCurrentRun).toHaveBeenCalled()
@@ -163,11 +183,78 @@ describe('ConfirmCancelRunModal', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/quick-transfer')
   })
 
+  it('when quick transfer run with protocolId is stopped, it navigates to protocol-specific quick transfer', () => {
+    props = {
+      ...props,
+      isActiveRun: false,
+      isQuickTransfer: true,
+      protocolId: 'test-protocol-id',
+    }
+
+    vi.mocked(useNotifyRunQuery).mockReturnValue({
+      data: {
+        data: {
+          status: RUN_STATUS_STOPPED,
+        },
+      },
+    } as any)
+
+    render(props)
+
+    expect(mockDismissCurrentRun).toHaveBeenCalled()
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/quick-transfer/test-protocol-id'
+    )
+  })
+
+  it('when run with protocolId is stopped, it navigates to protocol page', () => {
+    props = {
+      ...props,
+      isActiveRun: false,
+      protocolId: 'test-protocol-id',
+    }
+
+    vi.mocked(useNotifyRunQuery).mockReturnValue({
+      data: {
+        data: {
+          status: RUN_STATUS_STOPPED,
+        },
+      },
+    } as any)
+
+    render(props)
+
+    expect(mockDismissCurrentRun).toHaveBeenCalled()
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith('/protocols/test-protocol-id')
+  })
+
   it('when run is stopped, the run is not dismissed if the run is active', () => {
-    when(useRunStatus).calledWith(RUN_ID).thenReturn(RUN_STATUS_STOPPED)
+    vi.mocked(useNotifyRunQuery).mockReturnValue({
+      data: {
+        data: {
+          status: RUN_STATUS_STOPPED,
+        },
+      },
+    } as any)
+
     render(props)
 
     expect(mockDismissCurrentRun).not.toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+  })
+
+  it('when tapping cancel run with error, should reset isCanceling', () => {
+    mockStopRun.mockImplementation((id, options) => {
+      options.onError()
+    })
+
+    render(props)
+    const button = screen.getByText('Cancel run')
+    fireEvent.click(button)
+
+    const cancelButton = screen.getByText('Cancel run')
+    expect(cancelButton).toBeInTheDocument()
   })
 })

--- a/app/src/resources/runs/useRunStatus.ts
+++ b/app/src/resources/runs/useRunStatus.ts
@@ -9,6 +9,10 @@ import { DEFAULT_STATUS_REFETCH_INTERVAL } from './constants'
 import type { UseQueryOptions } from 'react-query'
 import type { RunStatus, RunAction, Run } from '@opentrons/api-client'
 
+/**
+ * @deprecated TODO(jh, 05-05-24): Confirming MM's observation, this hook is no longer necessary
+ *  and appears bug-prone. Let's remove it and replace with useNotifyRunQuery.
+ */
 export function useRunStatus(
   runId: string | null,
   options?: UseQueryOptions<Run>


### PR DESCRIPTION
Closes [RQA-4112](https://opentrons.atlassian.net/browse/RQA-4112)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The `useRunStatus` hook has proven to be bug prone in the past (with the desktop app's running protocol page tab transitions), and no longer provides any necessary functionality now that the run status does not transition to "idle" between protocol commands during a run.

Most likely, this hook was causing intermittent issues. There's also a chance we'll need to address [EXEC-1450](https://opentrons.atlassian.net/browse/EXEC-1450) to solve this entirely, but it's hard to say because it's so intermittent. If the run fetch happens to fail, let's try routing. Let's see if these changes solve the issue.

Given 8.4 release constraints, I've decided not to refactor out all the usages of `useRunStatus`, but I have created a sustaining ticket for that work [here](https://opentrons.atlassian.net/browse/EXEC-1478). In the meantime, the hook has been marked as deprecated.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

- Tested remotely, the ODD run setup page seems to cancel the run and redirect as expected. Would be great if someone could test in office though!
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the ODD intermittently rendering the "Canceling run" modal indefinitely.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Does this fix seem low enough risk given release constraints?
- Could someone test this on a physical robot in the office? To test, just go to run setup on the ODD and cancel a run, confirming the run cancels and the redirect occurs.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4112]: https://opentrons.atlassian.net/browse/RQA-4112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EXEC-1450]: https://opentrons.atlassian.net/browse/EXEC-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ