### PR TITLE
fix(api): try to open thermocycler lid before throwing an error

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -61,6 +61,7 @@ class LabwareMovementHandler:
         """Initialize a LabwareMovementHandler instance."""
         self._hardware_api = hardware_api
         self._state_store = state_store
+        self._equipment = equipment
         self._thermocycler_plate_lifter = (
             thermocycler_plate_lifter
             or ThermocyclerPlateLifter(
@@ -72,7 +73,13 @@ class LabwareMovementHandler:
         self._tc_movement_flagger = (
             thermocycler_movement_flagger
             or ThermocyclerMovementFlagger(
-                state_store=self._state_store, hardware_api=self._hardware_api
+                state_store=self._state_store,
+                hardware_api=self._hardware_api,
+                equipment=self._equipment
+                or EquipmentHandler(
+                    hardware_api=self._hardware_api,
+                    state_store=self._state_store,
+                ),
             )
         )
         self._hs_movement_flagger = (
@@ -264,7 +271,7 @@ class LabwareMovementHandler:
             )
         for parent in (current_parent, new_location):
             try:
-                await self._tc_movement_flagger.raise_if_labware_in_non_open_thermocycler(
+                await self._tc_movement_flagger.ensure_labware_in_open_thermocycler(
                     labware_parent=parent
                 )
                 await self._hs_movement_flagger.raise_if_labware_latched_on_heater_shaker(

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -47,8 +47,6 @@ class MovementHandler:
         equipment: Optional[EquipmentHandler] = None,
     ) -> None:
         """Initialize a MovementHandler instance."""
-        if thermocycler_movement_flagger:
-            assert equipment is not None, "no module handler received."
         self._state_store = state_store
         self._model_utils = model_utils or ModelUtils()
         self._tc_movement_flagger = (

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -24,6 +24,7 @@ from .thermocycler_movement_flagger import ThermocyclerMovementFlagger
 from .heater_shaker_movement_flagger import HeaterShakerMovementFlagger
 
 from .gantry_mover import GantryMover
+from .equipment import EquipmentHandler
 
 
 log = logging.getLogger(__name__)
@@ -43,14 +44,25 @@ class MovementHandler:
         model_utils: Optional[ModelUtils] = None,
         thermocycler_movement_flagger: Optional[ThermocyclerMovementFlagger] = None,
         heater_shaker_movement_flagger: Optional[HeaterShakerMovementFlagger] = None,
+        equipment: Optional[
+            EquipmentHandler
+        ] = None,
     ) -> None:
         """Initialize a MovementHandler instance."""
+        if thermocycler_movement_flagger:
+            assert equipment is not None, "no module handler received."
         self._state_store = state_store
         self._model_utils = model_utils or ModelUtils()
         self._tc_movement_flagger = (
             thermocycler_movement_flagger
             or ThermocyclerMovementFlagger(
-                state_store=self._state_store, hardware_api=hardware_api
+                state_store=self._state_store,
+                hardware_api=hardware_api,
+                equipment=equipment
+                or EquipmentHandler(
+                    hardware_api=hardware_api,
+                    state_store=state_store,
+                ),
             )
         )
         self._hs_movement_flagger = (
@@ -83,8 +95,7 @@ class MovementHandler:
         self._state_store.labware.raise_if_labware_has_labware_on_top(
             labware_id=labware_id
         )
-
-        await self._tc_movement_flagger.raise_if_labware_in_non_open_thermocycler(
+        await self._tc_movement_flagger.ensure_labware_in_open_thermocycler(
             labware_parent=self._state_store.labware.get_location(labware_id=labware_id)
         )
 

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -44,9 +44,7 @@ class MovementHandler:
         model_utils: Optional[ModelUtils] = None,
         thermocycler_movement_flagger: Optional[ThermocyclerMovementFlagger] = None,
         heater_shaker_movement_flagger: Optional[HeaterShakerMovementFlagger] = None,
-        equipment: Optional[
-            EquipmentHandler
-        ] = None,
+        equipment: Optional[EquipmentHandler] = None,
     ) -> None:
         """Initialize a MovementHandler instance."""
         if thermocycler_movement_flagger:

--- a/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
@@ -55,7 +55,10 @@ class ThermocyclerMovementFlagger:
                 " but can't confirm Thermocycler's current status."
             ) from e
 
-        if hw_tc_lid_status == ThermocyclerLidStatus.IN_BETWEEN:
+        if (
+            hw_tc_lid_status == ThermocyclerLidStatus.IN_BETWEEN
+            or hw_tc_lid_status == ThermocyclerLidStatus.UNKNOWN
+        ):
             await self.open_tc_lid(module_id=module_id)
         if hw_tc_lid_status != ThermocyclerLidStatus.OPEN:
             raise ThermocyclerNotOpenError(

--- a/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
@@ -1,14 +1,19 @@
 """Helpers for flagging unsafe movements to a Thermocycler Module."""
-
 from typing import Optional
 
 from opentrons.drivers.types import ThermocyclerLidStatus
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import Thermocycler as HardwareThermocycler
 
+
+from opentrons.protocol_engine.state.module_substates import ThermocyclerModuleId
 from ..types import ModuleLocation, LabwareLocation
 from ..state.state import StateStore
 from ..errors import ThermocyclerNotOpenError, WrongModuleTypeError
+
+# if TYPE_CHECKING:
+#     from opentrons.protocol_engine.execution import EquipmentHandler
+from .equipment import EquipmentHandler
 
 
 class ThermocyclerMovementFlagger:
@@ -19,7 +24,10 @@ class ThermocyclerMovementFlagger:
     """
 
     def __init__(
-        self, state_store: StateStore, hardware_api: HardwareControlAPI
+        self,
+        state_store: StateStore,
+        hardware_api: HardwareControlAPI,
+        equipment: EquipmentHandler,
     ) -> None:
         """Initialize the ThermocyclerMovementFlagger.
 
@@ -28,18 +36,50 @@ class ThermocyclerMovementFlagger:
                          which Thermocycler a labware is in, if any.
             hardware_api: The underlying hardware interface. Used to query
                           Thermocyclers' current lid states.
+            equipment: The protocol engine interface to move a present thermocycler to an
+                            operable state if need be.
         """
         self._state_store = state_store
         self._hardware_api = hardware_api
+        self._equipment = equipment
 
-    async def raise_if_labware_in_non_open_thermocycler(
+    async def verify_tc_lid_status(self, module_id: str) -> None:
+        """Ensure the thermocycler's lid state is correct or raise an error."""
+        try:
+            hw_tc_lid_status = await self._get_hardware_thermocycler_lid_status(
+                module_id=module_id
+            )
+        except self._HardwareThermocyclerMissingError as e:
+            raise ThermocyclerNotOpenError(
+                "Thermocycler must be open when moving to labware inside it,"
+                " but can't confirm Thermocycler's current status."
+            ) from e
+
+        if hw_tc_lid_status == ThermocyclerLidStatus.IN_BETWEEN:
+            await self.open_tc_lid(module_id=module_id)
+        if hw_tc_lid_status != ThermocyclerLidStatus.OPEN:
+            raise ThermocyclerNotOpenError(
+                f"Thermocycler must be open when moving to labware inside it,"
+                f' but Thermocycler is currently "{hw_tc_lid_status}".'
+            )
+
+    async def open_tc_lid(self, module_id: str) -> None:
+        """Try to open the thermocycler lid."""
+        tc_hardware = self._equipment.get_module_hardware_api(
+            ThermocyclerModuleId(module_id)
+        )
+        if tc_hardware:
+            await tc_hardware.open()
+
+    async def ensure_labware_in_open_thermocycler(
         self, labware_parent: LabwareLocation
     ) -> None:
         """Flag unsafe movements to a Thermocycler.
 
         If the given labware is in a Thermocycler, and that Thermocycler's lid isn't
         currently open according the engine's thermocycler state as well as
-        the hardware API (for non-virtual modules), raises ThermocyclerNotOpenError.
+        the hardware API (for non-virtual modules), tries to open the thermocycler lid.
+        If this is unsuccessful, raises ThermocyclerNotOpenError.
         If it is a virtual module, checks only for thermocycler lid state in engine.
 
         Otherwise, no-ops.
@@ -81,21 +121,7 @@ class ThermocyclerMovementFlagger:
         # There is a chance that the engine might not have the latest lid status;
         # do a hardware state check just to be sure that the lid is truly open.
         if not self._state_store.config.use_virtual_modules:
-            try:
-                hw_tc_lid_status = await self._get_hardware_thermocycler_lid_status(
-                    module_id=tc_substate.module_id
-                )
-            except self._HardwareThermocyclerMissingError as e:
-                raise ThermocyclerNotOpenError(
-                    "Thermocycler must be open when moving to labware inside it,"
-                    " but can't confirm Thermocycler's current status."
-                ) from e
-
-            if hw_tc_lid_status != ThermocyclerLidStatus.OPEN:
-                raise ThermocyclerNotOpenError(
-                    f"Thermocycler must be open when moving to labware inside it,"
-                    f' but Thermocycler is currently "{hw_tc_lid_status}".'
-                )
+            await self.verify_tc_lid_status(module_id=module_id)
 
     async def _get_hardware_thermocycler_lid_status(
         self,

--- a/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
@@ -11,8 +11,6 @@ from ..types import ModuleLocation, LabwareLocation
 from ..state.state import StateStore
 from ..errors import ThermocyclerNotOpenError, WrongModuleTypeError
 
-# if TYPE_CHECKING:
-#     from opentrons.protocol_engine.execution import EquipmentHandler
 from .equipment import EquipmentHandler
 
 

--- a/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
@@ -41,7 +41,7 @@ class ThermocyclerMovementFlagger:
         self._hardware_api = hardware_api
         self._equipment = equipment
 
-    async def verify_tc_lid_status(self, module_id: str) -> None:
+    async def _verify_tc_lid_status(self, module_id: str) -> None:
         """Ensure the thermocycler's lid state is correct or raise an error."""
         try:
             hw_tc_lid_status = await self._get_hardware_thermocycler_lid_status(
@@ -57,14 +57,20 @@ class ThermocyclerMovementFlagger:
             hw_tc_lid_status == ThermocyclerLidStatus.IN_BETWEEN
             or hw_tc_lid_status == ThermocyclerLidStatus.UNKNOWN
         ):
-            await self.open_tc_lid(module_id=module_id)
+            # NOTE(cm): due to a potential hardware bug, the thermocycler might lose its position
+            # status when idling in an open position and default to UNKNOWN or IN_BETWEEN.
+            # This tries to recover only from an unexpected known position.
+            await self._open_tc_lid(module_id=module_id)
+            hw_tc_lid_status = await self._get_hardware_thermocycler_lid_status(
+                module_id=module_id
+            )
         if hw_tc_lid_status != ThermocyclerLidStatus.OPEN:
             raise ThermocyclerNotOpenError(
                 f"Thermocycler must be open when moving to labware inside it,"
                 f' but Thermocycler is currently "{hw_tc_lid_status}".'
             )
 
-    async def open_tc_lid(self, module_id: str) -> None:
+    async def _open_tc_lid(self, module_id: str) -> None:
         """Try to open the thermocycler lid."""
         tc_hardware = self._equipment.get_module_hardware_api(
             ThermocyclerModuleId(module_id)
@@ -122,7 +128,7 @@ class ThermocyclerMovementFlagger:
         # There is a chance that the engine might not have the latest lid status;
         # do a hardware state check just to be sure that the lid is truly open.
         if not self._state_store.config.use_virtual_modules:
-            await self.verify_tc_lid_status(module_id=module_id)
+            await self._verify_tc_lid_status(module_id=module_id)
 
     async def _get_hardware_thermocycler_lid_status(
         self,

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -563,7 +563,7 @@ async def test_ensure_movement_obstructed_by_thermocycler_raises(
         state_store.labware.get_parent_location(labware_id="labware-id")
     ).then_return(from_loc)
     decoy.when(
-        await thermocycler_movement_flagger.raise_if_labware_in_non_open_thermocycler(
+        await thermocycler_movement_flagger.ensure_labware_in_open_thermocycler(
             labware_parent=ModuleLocation(moduleId="a-thermocycler-id")
         )
     ).then_raise(ThermocyclerNotOpenError("Thou shall not pass!"))

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -64,6 +64,7 @@ def mock_gantry_mover(decoy: Decoy) -> GantryMover:
     """Get a mock in the shape of a GantryMover."""
     return decoy.mock(cls=GantryMover)
 
+
 @pytest.fixture
 def mock_equipment_handler(decoy: Decoy) -> EquipmentHandler:
     """Get a mock in the shape of an EquipmentHandler."""

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -24,6 +24,7 @@ from opentrons.protocol_engine.state.state import (
 )
 from opentrons.protocol_engine.state.motion import PipetteLocationData
 from opentrons.protocol_engine.execution.movement import MovementHandler
+from opentrons.protocol_engine.execution.equipment import EquipmentHandler
 from opentrons.protocol_engine.execution.thermocycler_movement_flagger import (
     ThermocyclerMovementFlagger,
 )
@@ -63,6 +64,11 @@ def mock_gantry_mover(decoy: Decoy) -> GantryMover:
     """Get a mock in the shape of a GantryMover."""
     return decoy.mock(cls=GantryMover)
 
+@pytest.fixture
+def mock_equipment_handler(decoy: Decoy) -> EquipmentHandler:
+    """Get a mock in the shape of an EquipmentHandler."""
+    return decoy.mock(cls=EquipmentHandler)
+
 
 @pytest.fixture
 def subject(
@@ -71,6 +77,7 @@ def subject(
     thermocycler_movement_flagger: ThermocyclerMovementFlagger,
     heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
     mock_gantry_mover: GantryMover,
+    mock_equipment_handler: EquipmentHandler,
 ) -> MovementHandler:
     """Create a MovementHandler with its dependencies mocked out."""
     return MovementHandler(
@@ -79,6 +86,7 @@ def subject(
         thermocycler_movement_flagger=thermocycler_movement_flagger,
         heater_shaker_movement_flagger=heater_shaker_movement_flagger,
         gantry_mover=mock_gantry_mover,
+        equipment=mock_equipment_handler,
     )
 
 
@@ -179,7 +187,7 @@ async def test_move_to_well(
     assert result == Point(x=4, y=5, z=6)
 
     decoy.verify(
-        await thermocycler_movement_flagger.raise_if_labware_in_non_open_thermocycler(
+        await thermocycler_movement_flagger.ensure_labware_in_open_thermocycler(
             labware_parent=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
         ),
         heater_shaker_movement_flagger.raise_if_movement_restricted(
@@ -287,7 +295,7 @@ async def test_move_to_well_from_starting_location(
     assert result == Point(4, 5, 6)
 
     decoy.verify(
-        await thermocycler_movement_flagger.raise_if_labware_in_non_open_thermocycler(
+        await thermocycler_movement_flagger.ensure_labware_in_open_thermocycler(
             labware_parent=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
         ),
         heater_shaker_movement_flagger.raise_if_movement_restricted(

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
@@ -28,6 +28,7 @@ from opentrons.drivers.types import ThermocyclerLidStatus
 from opentrons.protocol_engine.execution.thermocycler_movement_flagger import (
     ThermocyclerMovementFlagger,
 )
+from opentrons.protocol_engine.execution.equipment import EquipmentHandler
 
 
 @pytest.fixture
@@ -43,14 +44,20 @@ def state_store(decoy: Decoy) -> StateStore:
 
 
 @pytest.fixture
+def equipment_handler(decoy: Decoy) -> EquipmentHandler:
+    """Get a mock in the shape of an EquipmentHandler."""
+    return decoy.mock(cls=EquipmentHandler)
+
+
+@pytest.fixture
 def subject(
     state_store: StateStore,
     hardware_api: HardwareAPI,
+    equipment_handler: EquipmentHandler,
 ) -> ThermocyclerMovementFlagger:
     """Return a movement flagger initialized with mocked-out dependencies."""
     return ThermocyclerMovementFlagger(
-        state_store=state_store,
-        hardware_api=hardware_api,
+        state_store=state_store, hardware_api=hardware_api, equipment=equipment_handler
     )
 
 
@@ -72,7 +79,7 @@ async def test_raises_depending_on_thermocycler_substate_lid_status(
     )
 
     with pytest.raises(ThermocyclerNotOpenError):
-        await subject.raise_if_labware_in_non_open_thermocycler(
+        await subject.ensure_labware_in_open_thermocycler(
             labware_parent=ModuleLocation(moduleId="module-id"),
         )
 
@@ -117,6 +124,7 @@ async def test_raises_depending_on_thermocycler_hardware_lid_status(
     subject: ThermocyclerMovementFlagger,
     state_store: StateStore,
     hardware_api: HardwareAPI,
+    # equipment_handler: EquipmentHandler,
     decoy: Decoy,
 ) -> None:
     """When on a Thermocycler, it should raise if the lid isn't open."""
@@ -140,9 +148,11 @@ async def test_raises_depending_on_thermocycler_hardware_lid_status(
     decoy.when(thermocycler.device_info).then_return({"serial": "module-serial"})
     decoy.when(thermocycler.lid_status).then_return(lid_status)
     decoy.when(hardware_api.attached_modules).then_return([thermocycler])
-
+    decoy.when(
+        subject._equipment.get_module_hardware_api(ThermocyclerModuleId("module-id"))
+    ).then_return(thermocycler)
     with expected_raise_cm:
-        await subject.raise_if_labware_in_non_open_thermocycler(
+        await subject.ensure_labware_in_open_thermocycler(
             labware_parent=ModuleLocation(moduleId="module-id"),
         )
 
@@ -172,7 +182,7 @@ async def test_raises_if_hardware_module_has_gone_missing(
     decoy.when(hardware_api.attached_modules).then_return([])
 
     with pytest.raises(ThermocyclerNotOpenError):
-        await subject.raise_if_labware_in_non_open_thermocycler(
+        await subject.ensure_labware_in_open_thermocycler(
             labware_parent=ModuleLocation(moduleId="module-id"),
         )
 
@@ -194,7 +204,7 @@ async def test_passes_if_virtual_module_lid_open(
         ),
     )
     decoy.when(state_store.config.use_virtual_modules).then_return(True)
-    await subject.raise_if_labware_in_non_open_thermocycler(
+    await subject.ensure_labware_in_open_thermocycler(
         labware_parent=ModuleLocation(moduleId="module-id")
     )
 
@@ -209,7 +219,7 @@ async def test_passes_if_labware_on_non_thermocycler_module(
     decoy.when(
         state_store.modules.get_thermocycler_module_substate(module_id="module-id")
     ).then_raise(WrongModuleTypeError("Woops"))
-    await subject.raise_if_labware_in_non_open_thermocycler(
+    await subject.ensure_labware_in_open_thermocycler(
         ModuleLocation(moduleId="module-id")
     )
 
@@ -221,6 +231,6 @@ async def test_passes_if_labware_not_on_any_module(
     decoy: Decoy,
 ) -> None:
     """It shouldn't raise if the labware isn't on a module."""
-    await subject.raise_if_labware_in_non_open_thermocycler(
+    await subject.ensure_labware_in_open_thermocycler(
         DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
     )

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
@@ -124,7 +124,6 @@ async def test_raises_depending_on_thermocycler_hardware_lid_status(
     subject: ThermocyclerMovementFlagger,
     state_store: StateStore,
     hardware_api: HardwareAPI,
-    # equipment_handler: EquipmentHandler,
     decoy: Decoy,
 ) -> None:
     """When on a Thermocycler, it should raise if the lid isn't open."""


### PR DESCRIPTION
## Overview
Sometimes, in response to a lack of error-handling from the thermocyler firmware, and rarely from reasons yet unknown, it's possible for the thermocycler to lose track of its lid's position status. Most of the time this happens, the lid is already all the way open, and just barely backed off the limit switch. However, because it's backed off the limit switch, the robot server doesn't know the lid's position and throws a `ThermocyclerLidNotOpenError`. It's possible to fix this issue most if not all of the time by attempting to open the lid until we find the lid-open limit switch.

This code changes the robot-server protocol for this to check if the thermocycler lid is open. If the position is `IN_BETWEEN` or `UNKNOWN`, try to open the lid and check the status again. If the status at this point is still anything besides `OPEN`, throw a `ThermocyclerLidNotOpenError`.

## Changelog
- make `ThermocyclerMovementFlagger` take in an `EquipmentHandler`, so it can command the tc lid to move
- change `ThermocyclerMovementFlagger::raise_if_labware_in_non_open_thermocycler` to `ThermocyclerMovementFlagger::ensure_labware_in_open_thermocycler`, and have it try to open the tc lid before throwing an error

Also closes [RABR-736](https://opentrons.atlassian.net/browse/RABR-736)

[RABR-736]: https://opentrons.atlassian.net/browse/RABR-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ