### PR TITLE
feat(protocol-designer): update migration for speed-related fields

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Fixture",
     "description": "Test all v3 commands",
     "created": 1585930833548,
-    "lastModified": 1746209745232,
+    "lastModified": 1746468231434,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -130,7 +130,7 @@
             "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
           },
           "trashBinLocationUpdate": {
-            "0b4601c2-2696-444a-82a6-22c39135a514:trashBin": "cutout12"
+            "7c075cfe-8c16-4a09-91c8-c93d361d26b2:trashBin": "cutout12"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
@@ -153,19 +153,19 @@
           "aspirate_position_reference": "well-bottom",
           "aspirate_retract_delay_seconds": null,
           "aspirate_retract_mmFromBottom": 0,
-          "aspirate_retract_speed": null,
+          "aspirate_retract_speed": 125,
           "aspirate_retract_x_position": null,
           "aspirate_retract_y_position": null,
           "aspirate_retract_position_reference": "well-top",
           "aspirate_submerge_delay_seconds": null,
-          "aspirate_submerge_speed": null,
+          "aspirate_submerge_speed": 125,
           "aspirate_submerge_mmFromBottom": 0,
           "aspirate_submerge_x_position": null,
           "aspirate_submerge_y_position": null,
           "aspirate_submerge_position_reference": "well-top",
           "aspirate_touchTip_checkbox": true,
           "aspirate_touchTip_mmFromTop": -2,
-          "aspirate_touchTip_speed": null,
+          "aspirate_touchTip_speed": 400,
           "aspirate_touchTip_mmFromEdge": 0,
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -175,7 +175,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "0b4601c2-2696-444a-82a6-22c39135a514:trashBin",
+          "blowout_location": "7c075cfe-8c16-4a09-91c8-c93d361d26b2:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -194,19 +194,19 @@
           "dispense_position_reference": "well-bottom",
           "dispense_retract_delay_seconds": null,
           "dispense_retract_mmFromBottom": 0,
-          "dispense_retract_speed": null,
+          "dispense_retract_speed": 125,
           "dispense_retract_x_position": null,
           "dispense_retract_y_position": null,
           "dispense_retract_position_reference": "well-top",
           "dispense_submerge_delay_seconds": null,
-          "dispense_submerge_speed": null,
+          "dispense_submerge_speed": 125,
           "dispense_submerge_mmFromBottom": 0,
           "dispense_submerge_x_position": null,
           "dispense_submerge_y_position": null,
           "dispense_submerge_position_reference": "well-top",
           "dispense_touchTip_checkbox": true,
           "dispense_touchTip_mmFromTop": null,
-          "dispense_touchTip_speed": null,
+          "dispense_touchTip_speed": 400,
           "dispense_touchTip_mmFromEdge": 0,
           "dispense_wellOrder_first": "t2b",
           "dispense_wellOrder_second": "l2r",
@@ -215,7 +215,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "20",
-          "dropTip_location": "0b4601c2-2696-444a-82a6-22c39135a514:trashBin",
+          "dropTip_location": "7c075cfe-8c16-4a09-91c8-c93d361d26b2:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -260,13 +260,13 @@
           "aspirate_flowRate": 40,
           "blowout_checkbox": true,
           "blowout_flowRate": 46.43,
-          "blowout_location": "0b4601c2-2696-444a-82a6-22c39135a514:trashBin",
+          "blowout_location": "7c075cfe-8c16-4a09-91c8-c93d361d26b2:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": 35,
-          "dropTip_location": "0b4601c2-2696-444a-82a6-22c39135a514:trashBin",
+          "dropTip_location": "7c075cfe-8c16-4a09-91c8-c93d361d26b2:trashBin",
           "labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
           "liquidClassesSupported": false,
           "liquidClass": "none",
@@ -2675,7 +2675,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "aad4087e-6de3-46bc-9214-a929f9911213",
+      "key": "4682b30a-0d08-4785-b3ae-b973f865788d",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p300_single_gen2",
@@ -2684,7 +2684,7 @@
       }
     },
     {
-      "key": "7f100441-7aec-449d-acc6-082fc50ff63b",
+      "key": "227d775e-da68-494c-9fb4-f70863b0b688",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Tip Rack 300 µL",
@@ -2698,7 +2698,7 @@
       }
     },
     {
-      "key": "6dbf2118-b455-454b-8438-9ab9912883e8",
+      "key": "6fdb3222-159e-491e-9559-004c24500e73",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -2712,7 +2712,7 @@
       }
     },
     {
-      "key": "654df753-a60f-43ba-9971-625a6a4b2793",
+      "key": "4c5a0c64-8584-4480-a118-ded70e51059e",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
@@ -2727,7 +2727,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "1b458301-12c6-4b2f-aab0-63eb8c3c0ef6",
+      "key": "71c4de07-fd12-4cec-8370-5d505e29f04c",
       "params": {
         "liquidId": "0",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2753,7 +2753,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "08db99bc-5cc2-4f79-a84a-6d4fbeff79c7",
+      "key": "e91057de-b596-4716-b831-b0efbcd77595",
       "params": {
         "seconds": 62,
         "message": ""
@@ -2761,7 +2761,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "6b2c4094-679c-4022-8541-0c7314021bb1",
+      "key": "d4afdfee-fe9f-4537-8c46-07d5229fca1a",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2770,7 +2770,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9f1ccfa5-79a1-4403-9c7c-376aafe27ad0",
+      "key": "2953d0fe-fbc3-40b8-a6d6-fdb5ed3bbb6d",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2789,7 +2789,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "b500be91-499b-4970-b124-23e3e4f1910c",
+      "key": "bf88c2c3-7bf9-4f07-aa0e-dfd9f81b6957",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2809,7 +2809,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "47d2ba40-65d1-465f-a653-215a17ad094f",
+      "key": "014cdfbf-e6c1-4d07-b56b-dbee4410a186",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2828,7 +2828,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5cc31bdc-49fd-4cf7-bca7-e0e90ee2c6c6",
+      "key": "24b97a6b-7ff8-4647-a334-2be824dd41b2",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2848,7 +2848,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ab39ef88-ed4d-4bc9-80a0-5207b4cc6a40",
+      "key": "dfa0e829-63e8-4015-8642-df61d88565b3",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 100,
@@ -2867,7 +2867,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "043678ac-6547-4579-a072-ca3ec2d01182",
+      "key": "ff79e599-e605-43f1-b5c6-061f206adf08",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2882,7 +2882,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "7b2835dd-ed36-4441-bbb3-92cc2037f9d2",
+      "key": "be27b4f1-bd31-4952-be13-3f29a042ef55",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 40,
@@ -2901,7 +2901,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "4d085a32-ce40-486c-bf08-3917cd65dc48",
+      "key": "d3f074ef-02ec-4afa-a0d0-6646c2b37249",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
@@ -2916,7 +2916,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "654c28e7-d59b-4b80-b090-16a72e2f4fb2",
+      "key": "945ac5ab-c970-4cbb-ae5a-32ae5c9aeaf7",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 40,
@@ -2935,7 +2935,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "607592a0-c64b-47b4-ac31-d1e5326b705a",
+      "key": "ec118d95-0408-46f9-99e3-284d05cdda49",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
@@ -2950,7 +2950,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "8deda0a9-c4dc-412a-aaf0-64a67a4205b5",
+      "key": "e6fbd072-6e67-4d3d-a06b-aafc7b43de70",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2963,7 +2963,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "1a263e56-ab62-4577-bb7a-0995034a2a61",
+      "key": "7a480adb-a97b-4fff-b174-f287618895ab",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -2971,7 +2971,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "48d7f53d-29ac-4fc4-865b-2a0c0c26f551",
+      "key": "40689b7b-e8d3-421d-9f14-32fc7a770e3b",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2985,21 +2985,21 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "9321bcc2-b218-4c64-b470-413594d95459",
+      "key": "84e2b7e8-f1e8-4112-87ad-3cb56836feee",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "waitForResume",
-      "key": "ec4ce4db-5329-460b-9933-b7b38af47420",
+      "key": "d1bd251d-a8ce-4fc2-9012-90b3ed81379f",
       "params": {
         "message": "Wait until user intervention"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "b4a52858-529f-454e-86f6-8abd7220fced",
+      "key": "b431c1f5-9971-4552-838e-66c497791fcc",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -3008,7 +3008,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c1e1898a-5ef5-4932-a44f-8768213aa195",
+      "key": "f8b40c2e-d568-4c8a-818b-6ff4ee08109d",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3027,7 +3027,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f2423109-0e4b-4c26-87b0-fc8e44f9f87f",
+      "key": "cd9a838e-9147-47da-898b-64fbda3ca968",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3047,7 +3047,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "00826459-ff8e-4abc-a6d4-8a5974b305e5",
+      "key": "2f6ea6ea-9851-4b5a-958e-1d6c318f3d17",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3066,7 +3066,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4e1e0033-e496-43c5-8f52-e1294432e749",
+      "key": "1ba036ef-9876-40e1-abbe-35932782d021",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3086,7 +3086,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "51570500-9cba-4d0f-bd2e-50ef00f90e86",
+      "key": "fba79a54-aecf-4fe8-82ff-8a5fd914665b",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3105,7 +3105,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "949be069-b4df-4bb4-a728-1c749b423420",
+      "key": "0e7c1659-73ff-4728-b0c9-839f8964214c",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3125,7 +3125,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "497fe320-8449-415c-a853-0425556c5102",
+      "key": "36ea16ce-57af-4a6d-a686-792abc2192bf",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3138,7 +3138,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "feac54ab-9052-4ba8-b8be-09934c425e62",
+      "key": "659c4b4a-28e7-4f2d-8ad5-387211695fd9",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -3146,7 +3146,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "66e308ac-09e6-41b4-bd27-c6ca6f284b89",
+      "key": "26f0dd85-b1ab-4591-a7ef-ecc4ee1ad911",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3161,7 +3161,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "1ca2893e-756d-4850-9ae5-48bac92e7592",
+      "key": "3e2c46af-9ffc-4aa6-8f80-f9f44934a932",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3175,14 +3175,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "e584cf9c-cbff-4718-8e52-ed00fca45b85",
+      "key": "436e9c44-25ae-4c88-8268-8ac292c95822",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "2d5dc88b-d38d-42ea-b094-08df7c757212",
+      "key": "7752c7f9-c0de-43a2-b9e4-7f9fbbd50e06",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -3191,7 +3191,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e5e572ab-77c3-4f56-94d3-e9547a70107f",
+      "key": "5de268a2-5b8c-4e64-a20b-a7909e696f67",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3210,7 +3210,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "bf26638b-62e3-4791-b560-87c03ab83bda",
+      "key": "60a9726b-c835-4c8b-8480-74b091efa941",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3230,7 +3230,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "632dc539-710f-4666-b03f-7c8ec616bb92",
+      "key": "29fea0c2-8620-49b9-9a2c-d856dc93b067",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3249,7 +3249,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "c187eef5-d85d-466e-b2bb-0c3a9cce01fc",
+      "key": "220cbceb-2047-4ae5-bad0-a6b3b8ce9088",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3269,7 +3269,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e9d8c049-ae26-4d5e-bba6-6079dad7b2bd",
+      "key": "80292bc3-2d37-4835-8591-4010a5d2a726",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3288,7 +3288,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1da719ed-9769-4ce0-a0a0-4c5249ce2631",
+      "key": "9d9d410d-11e1-4f47-8109-5bc1e23e7bbe",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 35,
@@ -3308,7 +3308,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "0ae8af13-c370-4d7b-ab0b-f63e149f7cd5",
+      "key": "a641b52b-0351-4dc2-9093-b9e4e20cc32c",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3321,7 +3321,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "a3794c3a-bcaf-4f1b-94cc-1f056ecd6793",
+      "key": "7469f660-d445-457d-bcf4-addc6ecc0f3c",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "flowRate": 46.43
@@ -3329,7 +3329,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "f8df4672-eb1b-439b-8b8a-8e02cb924efe",
+      "key": "3dc97012-90b6-44b4-a6b1-4d6813ead66c",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3344,7 +3344,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "28435b2c-e36b-4aa0-84ff-a3e6a9d91409",
+      "key": "073ce229-dbe9-4aa4-8827-a392d4bf1538",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3358,7 +3358,7 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "5716c6eb-5963-4d33-9aa2-4e537211fb6e",
+      "key": "96cd9fde-5f48-4179-9427-2e06e9cee774",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Fixture",
     "description": "Test all v4 commands",
     "created": 1585930833548,
-    "lastModified": 1746209789867,
+    "lastModified": 1746468249856,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -133,7 +133,7 @@
             "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
           },
           "trashBinLocationUpdate": {
-            "6c653d13-259d-4be6-8728-2f3d8acaad64:trashBin": "cutout12"
+            "97f7cf4f-c3ce-4660-8740-7aab4263d366:trashBin": "cutout12"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
@@ -185,19 +185,19 @@
           "aspirate_position_reference": "well-bottom",
           "aspirate_retract_delay_seconds": null,
           "aspirate_retract_mmFromBottom": 0,
-          "aspirate_retract_speed": null,
+          "aspirate_retract_speed": 125,
           "aspirate_retract_x_position": null,
           "aspirate_retract_y_position": null,
           "aspirate_retract_position_reference": "well-top",
           "aspirate_submerge_delay_seconds": null,
-          "aspirate_submerge_speed": null,
+          "aspirate_submerge_speed": 125,
           "aspirate_submerge_mmFromBottom": 0,
           "aspirate_submerge_x_position": null,
           "aspirate_submerge_y_position": null,
           "aspirate_submerge_position_reference": "well-top",
           "aspirate_touchTip_checkbox": false,
           "aspirate_touchTip_mmFromTop": null,
-          "aspirate_touchTip_speed": null,
+          "aspirate_touchTip_speed": 400,
           "aspirate_touchTip_mmFromEdge": 0,
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -207,7 +207,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "6c653d13-259d-4be6-8728-2f3d8acaad64:trashBin",
+          "blowout_location": "97f7cf4f-c3ce-4660-8740-7aab4263d366:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -226,19 +226,19 @@
           "dispense_position_reference": "well-bottom",
           "dispense_retract_delay_seconds": null,
           "dispense_retract_mmFromBottom": 0,
-          "dispense_retract_speed": null,
+          "dispense_retract_speed": 125,
           "dispense_retract_x_position": null,
           "dispense_retract_y_position": null,
           "dispense_retract_position_reference": "well-top",
           "dispense_submerge_delay_seconds": null,
-          "dispense_submerge_speed": null,
+          "dispense_submerge_speed": 125,
           "dispense_submerge_mmFromBottom": 0,
           "dispense_submerge_x_position": null,
           "dispense_submerge_y_position": null,
           "dispense_submerge_position_reference": "well-top",
           "dispense_touchTip_checkbox": false,
           "dispense_touchTip_mmFromTop": null,
-          "dispense_touchTip_speed": null,
+          "dispense_touchTip_speed": 400,
           "dispense_touchTip_mmFromEdge": 0,
           "dispense_wellOrder_first": "t2b",
           "dispense_wellOrder_second": "l2r",
@@ -247,7 +247,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "20",
-          "dropTip_location": "6c653d13-259d-4be6-8728-2f3d8acaad64:trashBin",
+          "dropTip_location": "97f7cf4f-c3ce-4660-8740-7aab4263d366:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -2699,7 +2699,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "ab1cabd3-5b77-403f-a53a-ee1d3dd404f6",
+      "key": "489bc658-4c5d-4730-880a-00a268a5c3e4",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p300_single_gen2",
@@ -2708,7 +2708,7 @@
       }
     },
     {
-      "key": "a1ac750f-be94-4e35-9373-592e63aef6f8",
+      "key": "56ebbfab-1705-48e8-8a8b-2e4f4c3aa04c",
       "commandType": "loadModule",
       "params": {
         "model": "magneticModuleV2",
@@ -2719,7 +2719,7 @@
       }
     },
     {
-      "key": "62b10d3c-f54b-458d-8e02-96cf7bc65b53",
+      "key": "f41e7434-3187-4df8-a34b-ab1342509245",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -2730,7 +2730,7 @@
       }
     },
     {
-      "key": "8a8b6300-4071-4108-942a-9f0900f7c86f",
+      "key": "b5713fe4-7bf1-44f4-b4cc-ff2d0d1c5793",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Tip Rack 300 µL",
@@ -2744,7 +2744,7 @@
       }
     },
     {
-      "key": "7d9762d1-607e-4700-b531-50e7daa916c5",
+      "key": "06bd196d-9e0d-467b-bf07-12966e7d4aae",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -2758,7 +2758,7 @@
       }
     },
     {
-      "key": "3ef7a6cf-28a0-4687-93ca-e0ae98dc7ad0",
+      "key": "50080067-f879-4f0e-b822-f9d9c4ee5d12",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
@@ -2773,7 +2773,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "e12c079e-74ce-43c5-9d40-89c7e2af30e6",
+      "key": "ff480cc1-9598-4386-b03e-ef3823352c93",
       "params": {
         "liquidId": "0",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2799,7 +2799,7 @@
     },
     {
       "commandType": "magneticModule/engage",
-      "key": "324106dc-29be-4099-9c86-40c5a15607df",
+      "key": "59fbef1a-05be-47a7-83dd-79ec67ee2910",
       "params": {
         "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType",
         "height": 6
@@ -2807,7 +2807,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "dde98f07-c206-4dbf-aafa-00dde8fb94bb",
+      "key": "d9fe7bab-778e-4b3b-9fb3-782d99b880c1",
       "params": {
         "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
         "celsius": 25
@@ -2815,7 +2815,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "5ed0a3d8-739e-47e6-b120-2fb801d8df6b",
+      "key": "893d7a50-778f-456e-946e-ae4b7d31a7e8",
       "params": {
         "seconds": 62,
         "message": ""
@@ -2823,7 +2823,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "7bd6ab97-cef1-4e62-8693-5e2f2937ce13",
+      "key": "81af6711-5027-4ca3-85a0-77785ecbc45a",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2832,7 +2832,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ecece894-4d14-45c3-9b85-eae18f4b9a14",
+      "key": "2df21247-e8d2-4c71-8ddd-c662915d9026",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2849,7 +2849,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "05d33612-7b9b-4ccb-ade4-4fec09058b13",
+      "key": "dad9d19a-0602-4723-855e-876ebb90370d",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2866,14 +2866,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "7a9796dc-d279-40c8-87c2-752e7e84170e",
+      "key": "7dfe7ff9-ca51-428d-9aeb-3b8f6dbeffe5",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "b3868959-44b1-47d2-a91e-7d3e0e14180e",
+      "key": "59a3d1b7-0e61-460e-9974-814c271b4284",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2890,7 +2890,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "df125d55-09ff-4eb6-b2db-ad25d42e2a55",
+      "key": "d7e7ca2a-f594-49d0-93b7-05db85f47550",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2902,12 +2902,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "f3f43cd7-b706-4d15-b034-5c65777ff75b",
+      "key": "caad486b-ac83-45d5-825e-1bc6f0845587",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2916,7 +2917,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "de4d133b-b8dc-4f39-89f9-eecf14162759",
+      "key": "43e50b7a-dc03-43e5-aeb9-7158cc0476c4",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2928,12 +2929,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "dispense",
-      "key": "6e97e02a-f690-4dbe-a423-1e6cab066ccd",
+      "key": "de64ac7a-0c83-42ce-9733-1c6710e37840",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -2952,7 +2954,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "62a4e52f-f4cb-4c88-a128-f33c507d2ef6",
+      "key": "adc4eda6-de56-420a-a009-e5dc06868642",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -2966,14 +2968,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "2d373e17-5f19-4f3d-9fe5-32a1406c289f",
+      "key": "987d4a30-8f35-484d-94a5-803dbbaec8b5",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "cda024fb-3edb-4e9a-b146-665c33ded321",
+      "key": "071622bd-ee1b-4270-80d6-3e84edaeef8f",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
@@ -2982,7 +2984,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "31fd89ad-826b-49a3-9a73-b0e193a2cd37",
+      "key": "4d31f960-9361-45ce-b159-603571d086b0",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -2999,7 +3001,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "f644a8b3-3719-496b-806b-ac9bc45db354",
+      "key": "9f81a3ee-b291-4b93-8088-8efb6b04ebd9",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3016,14 +3018,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "b8f8acdb-b475-41e3-af8a-4a8d7811ae0a",
+      "key": "c5e6e409-31cc-4de7-9a4d-5770edfc5206",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "9e23758b-0bd0-41b3-892a-dd0b8817aa76",
+      "key": "666f2029-cc7d-42fc-b380-20df188b1eb3",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3040,7 +3042,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "bc4aa529-356d-4d72-9995-b9bb1fdda8fa",
+      "key": "cbf87307-0344-4091-9749-98e0e18d3ee3",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3052,12 +3054,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e37707a1-8739-4e7c-bceb-7afb63034fa6",
+      "key": "38cc8377-68dd-48c4-8a66-fdc49168573a",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -3066,7 +3069,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a6c32105-7ba2-47fa-9353-ceeb04486924",
+      "key": "408a0633-d726-4a39-b0d7-e3d2b95b5acd",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -3078,12 +3081,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "dispense",
-      "key": "12894316-e396-427f-abcd-bcb96848468d",
+      "key": "719bb357-e92b-4e3d-8909-4e4c288031ba",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "volume": 30,
@@ -3102,7 +3106,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "4e0a23ae-04f6-4e75-992f-7df924df584b",
+      "key": "b618a1eb-1d86-44f9-b13e-7d2b7f7870d0",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "addressableAreaName": "fixedTrash",
@@ -3116,14 +3120,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "2def7f5e-aa7d-4eeb-9030-2de0f9109a97",
+      "key": "7e6a1522-6640-4d01-b18d-d0f0c1adbef7",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
     {
       "commandType": "temperatureModule/waitForTemperature",
-      "key": "14859997-8f24-4c3c-9c92-c8bdaa213bbf",
+      "key": "35c2e3e7-4076-4c3a-b956-b6f6cd4669a9",
       "params": {
         "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
         "celsius": 25
@@ -3131,21 +3135,21 @@
     },
     {
       "commandType": "magneticModule/disengage",
-      "key": "bc3040a6-6d20-4421-8d95-dcf55806f314",
+      "key": "6ea9d453-2413-4f1a-9d9a-b7fcd4dc9552",
       "params": {
         "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType"
       }
     },
     {
       "commandType": "waitForResume",
-      "key": "b045c9d2-13f0-42a5-bb6f-aca1f628a5f6",
+      "key": "765e59a9-646a-47b6-952b-6fba92db7536",
       "params": {
         "message": "Wait until user intervention"
       }
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "b48a1e53-7b4f-4966-bedf-43b2797fc721",
+      "key": "b2a863de-4975-4b87-855d-01e0dd093582",
       "params": {
         "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType"
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1689346890165,
-    "lastModified": 1746209819810,
+    "lastModified": 1746468408046,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -114,12 +114,12 @@
             "6d1e53c3-2db3-451b-ad60-3fe13781a193": "right"
           },
           "trashBinLocationUpdate": {
-            "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin": "cutoutA3"
+            "6c864e47-6a2e-4f29-9330-2a8dc427902a:trashBin": "cutoutA3"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
           "gripperLocationUpdate": {
-            "7c9ca5a4-a298-4d7b-a7cf-edadecc26c58:gripper": "mounted"
+            "bffb7e68-e0a1-4662-9a8a-b729c8d24941:gripper": "mounted"
           },
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
@@ -203,19 +203,19 @@
           "aspirate_position_reference": "well-bottom",
           "aspirate_retract_delay_seconds": null,
           "aspirate_retract_mmFromBottom": 0,
-          "aspirate_retract_speed": null,
+          "aspirate_retract_speed": 100,
           "aspirate_retract_x_position": null,
           "aspirate_retract_y_position": null,
           "aspirate_retract_position_reference": "well-top",
           "aspirate_submerge_delay_seconds": null,
-          "aspirate_submerge_speed": null,
+          "aspirate_submerge_speed": 100,
           "aspirate_submerge_mmFromBottom": 0,
           "aspirate_submerge_x_position": null,
           "aspirate_submerge_y_position": null,
           "aspirate_submerge_position_reference": "well-top",
           "aspirate_touchTip_checkbox": false,
           "aspirate_touchTip_mmFromTop": null,
-          "aspirate_touchTip_speed": null,
+          "aspirate_touchTip_speed": 300,
           "aspirate_touchTip_mmFromEdge": 0,
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -225,7 +225,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin",
+          "blowout_location": "6c864e47-6a2e-4f29-9330-2a8dc427902a:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -244,19 +244,19 @@
           "dispense_position_reference": "well-bottom",
           "dispense_retract_delay_seconds": null,
           "dispense_retract_mmFromBottom": 0,
-          "dispense_retract_speed": null,
+          "dispense_retract_speed": 100,
           "dispense_retract_x_position": null,
           "dispense_retract_y_position": null,
           "dispense_retract_position_reference": "well-top",
           "dispense_submerge_delay_seconds": null,
-          "dispense_submerge_speed": null,
+          "dispense_submerge_speed": 100,
           "dispense_submerge_mmFromBottom": 0,
           "dispense_submerge_x_position": null,
           "dispense_submerge_y_position": null,
           "dispense_submerge_position_reference": "well-top",
           "dispense_touchTip_checkbox": false,
           "dispense_touchTip_mmFromTop": null,
-          "dispense_touchTip_speed": null,
+          "dispense_touchTip_speed": 300,
           "dispense_touchTip_mmFromEdge": 0,
           "dispense_wellOrder_first": "t2b",
           "dispense_wellOrder_second": "l2r",
@@ -265,7 +265,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "100",
-          "dropTip_location": "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin",
+          "dropTip_location": "6c864e47-6a2e-4f29-9330-2a8dc427902a:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -288,13 +288,13 @@
           "aspirate_flowRate": null,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin",
+          "blowout_location": "6c864e47-6a2e-4f29-9330-2a8dc427902a:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": null,
-          "dropTip_location": "da3df12f-de29-4d7f-862f-b345b9d383d8:trashBin",
+          "dropTip_location": "6c864e47-6a2e-4f29-9330-2a8dc427902a:trashBin",
           "labware": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
           "liquidClassesSupported": false,
           "liquidClass": "none",
@@ -3949,7 +3949,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "94a03494-de32-40ff-8703-a2fdffc940ee",
+      "key": "9bb70e9f-1a3d-4ef4-9acd-76c1a2d4b87a",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -3958,7 +3958,7 @@
       }
     },
     {
-      "key": "b3323053-9da3-43ef-9fab-2840ed3c0a3c",
+      "key": "cbee921c-78b2-4116-8a0c-30b02d63bb69",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_multi_flex",
@@ -3967,7 +3967,7 @@
       }
     },
     {
-      "key": "3e9bdf23-f219-49eb-b31d-383eafe9a62f",
+      "key": "f6ce0022-022c-452e-9c8a-aa62ac9080df",
       "commandType": "loadModule",
       "params": {
         "model": "magneticBlockV1",
@@ -3978,7 +3978,7 @@
       }
     },
     {
-      "key": "d6f31246-63cd-44a6-af0b-c30491756d34",
+      "key": "91593fa6-2798-4d34-bce5-34ef7f1fb983",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -3989,7 +3989,7 @@
       }
     },
     {
-      "key": "2027bb4a-7609-4621-9104-adf6fa051c0f",
+      "key": "534669ce-b412-443d-8178-7d33e325e99a",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -4000,7 +4000,7 @@
       }
     },
     {
-      "key": "2a21a46c-4997-4859-8697-27bead7d1911",
+      "key": "f8396ee9-e3d9-4a4d-9a40-efdbdffd47e3",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -4011,7 +4011,7 @@
       }
     },
     {
-      "key": "f4935553-2eba-4dd2-be4a-1a35aaab06fc",
+      "key": "a3384918-338a-47be-819e-66cc801a5698",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
@@ -4025,7 +4025,7 @@
       }
     },
     {
-      "key": "33d678fe-a59f-44ff-bbcb-3658a8779c14",
+      "key": "c7bc68a4-c524-429a-b8fa-e96d749cf113",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Filter Tip Rack 50 µL",
@@ -4039,7 +4039,7 @@
       }
     },
     {
-      "key": "82ecdcfa-0758-4f57-a83f-4af167946b4c",
+      "key": "a784ae58-87a0-4a9c-a1d7-0e9a1e95de27",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -4053,7 +4053,7 @@
       }
     },
     {
-      "key": "fe5acd0a-5ff5-4270-851f-9e34417f1221",
+      "key": "f6824802-86f8-4a22-af1d-a29e568980cc",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap",
@@ -4067,7 +4067,7 @@
       }
     },
     {
-      "key": "0f91689f-f440-4241-beaf-45b6b53fc95b",
+      "key": "4680cd3f-1159-4d23-bd35-c89d15e2069a",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 200 µL Flat",
@@ -4082,7 +4082,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "6f69d71d-50f2-4e17-a4cd-87dd222433fc",
+      "key": "3126b5d0-d1fa-41c1-9dea-b23d7ac1e81f",
       "params": {
         "liquidId": "1",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4093,7 +4093,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "4b42e730-71e6-4bb8-89d2-e1adc5c8be08",
+      "key": "64949227-53d0-49d3-8b5b-84d242666bd9",
       "params": {
         "liquidId": "0",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4111,7 +4111,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "f452f660-9df4-4ccf-953e-fb34a259a2fc",
+      "key": "ac048c3a-36dd-4903-a8dd-fdc81c6ea11e",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType",
         "celsius": 4
@@ -4119,7 +4119,7 @@
     },
     {
       "commandType": "heaterShaker/waitForTemperature",
-      "key": "ab22931d-663a-4379-bd12-4ddc9ed1c069",
+      "key": "40573e60-4ea7-4ff7-9d3c-ad81a081665e",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "celsius": 4
@@ -4127,14 +4127,14 @@
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "544b940d-9adc-4783-9d8d-4e691057c986",
+      "key": "20d68857-f1ea-4538-8a29-ff1eec21febe",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetLidTemperature",
-      "key": "953d3005-04ee-4b9a-ba49-d2c91a794ee2",
+      "key": "c634d75c-8e28-4d5a-9591-a578ea3428e8",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "celsius": 40
@@ -4142,14 +4142,14 @@
     },
     {
       "commandType": "thermocycler/waitForLidTemperature",
-      "key": "eea9708c-b11a-4626-8729-0ed7510d05f0",
+      "key": "21efd529-2130-4262-abf0-ac5479dfd9b7",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/runProfile",
-      "key": "0c99fe27-9490-4e59-bcd4-0f8470dc95b2",
+      "key": "e3902a91-af57-4fe5-b5a4-2404a7ca1d1d",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "profile": [
@@ -4167,28 +4167,28 @@
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "15b959ac-0588-4dd3-9791-dbcc0a956fa7",
+      "key": "fddab970-6bed-42fb-b1cb-57a466feaa49",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateLid",
-      "key": "681447ae-8fd7-4039-95d0-680ff8c54879",
+      "key": "f463d1a2-4ede-4049-be20-6580fd68b4d2",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "8a48ae62-f250-4de5-9928-b4b695859d7f",
+      "key": "efdbee0e-b48e-49fa-b777-d7d09fac88aa",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "0362e76b-1292-41cb-ad26-ea606f57bfd2",
+      "key": "d86583b6-4181-44d2-bd81-32f64ee7d144",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4197,7 +4197,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "82921916-eb8e-4e9a-8ebd-a7122c027924",
+      "key": "834f4830-fad1-423c-86bc-df83f1713fbf",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4214,7 +4214,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "0fb1bf0a-65fc-4e95-9899-f6b5315e90bf",
+      "key": "c8a61132-10f9-4f12-a6c7-77103e92bee1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4231,14 +4231,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "f8975cf6-bc23-4a0e-a1e3-efee25270d03",
+      "key": "2330d295-06f4-4a2c-8449-e924ec2305f5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "08557306-a013-470e-b21a-72dae7643af0",
+      "key": "d13520cb-d3fc-47bf-8b74-67e2a59dbe1e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4255,7 +4255,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c706bffc-e6b3-4eba-90d5-c8a34b575f31",
+      "key": "17384786-418e-4ce7-9886-3835fbbb0251",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4267,12 +4267,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1ae36dcc-85a0-40a8-bae9-ea918f1d4678",
+      "key": "eb94a004-d36a-4ee4-9e93-2a60df9b4d6b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4281,7 +4282,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7d9130cf-80c7-4e0b-af70-cdf5c962bde4",
+      "key": "84ad890c-af03-4435-80eb-218aea3b2aa8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4293,12 +4294,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "6987fbbc-1846-4308-aef2-64e1ade87ce3",
+      "key": "acf8afe5-78ba-4a12-bb4f-4e117c5b2994",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4317,7 +4319,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "db9fffbd-a992-4472-be5d-d3c5ca1e09ba",
+      "key": "a5d9e22a-8119-4714-8cb4-f9669051e177",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4331,14 +4333,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0bea1569-e839-46f3-8284-6347bbc3d052",
+      "key": "e6c2c9cc-55cb-4229-b1b8-9d106f659a08",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "98b82b80-02a0-4c10-a4be-43f06a94b8c9",
+      "key": "3bc64236-4277-48e7-b3b6-fe3637103bea",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4347,7 +4349,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "99005145-bde7-4182-a866-b53c3db84df5",
+      "key": "5fa2050b-560f-49fc-95e0-d7353ea77b31",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4364,14 +4366,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "555cd77a-e271-4870-9618-898675a77672",
+      "key": "5fbfed0e-b889-4b8c-aece-efa534142897",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "e1575dee-d84f-4959-936c-81643c434ed7",
+      "key": "e3ed10de-a738-4d4c-ba1d-507ad473e37b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4388,7 +4390,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "db3ae10d-6b06-4314-b7f0-183aa6571d60",
+      "key": "309fa792-45a5-4fcd-ae26-bf2a591110fd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4400,12 +4402,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "ad67419a-ee77-47fa-abd3-1cac7e3079a9",
+      "key": "febb714a-7e41-4ef6-8560-b2b31cd07714",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4414,7 +4417,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "60a93a52-85db-45e7-8c9a-f08f50f01e74",
+      "key": "7b55c922-f083-4c7c-8cbd-c59131d24fa8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4426,12 +4429,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "70b4b8f6-d31b-4f02-b5f3-0f3dbbc3325c",
+      "key": "aac835ee-8fc7-4ed2-81c3-7fccf6fab42d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4450,7 +4454,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "182817c0-4054-4ec2-a4c6-f559c803ad06",
+      "key": "3b5495b1-37e9-4292-8bdf-08a9ac44eed3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4464,14 +4468,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "594451e3-c057-4d1b-87f1-1e60e6332637",
+      "key": "e5e37f8a-dd8c-4b47-8c8e-718967b0a5b2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "3e9e39e8-1720-4907-abce-b8c014a1b119",
+      "key": "7da046f8-5888-4ad3-ac9d-a6d8a41ea60a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4480,7 +4484,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a439b792-c267-418a-96ad-3cedac790cec",
+      "key": "538aab99-960d-4811-8335-333bba891fb8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4497,14 +4501,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "6152de89-0ba7-4ed0-8803-fc652000b078",
+      "key": "b9dabb4f-ea5a-436a-a222-889c28d8ad73",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "d1b212b9-f736-4ae5-8b40-95d7fe1833b6",
+      "key": "49cae333-6e68-47f5-8222-3e4fc970a66e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4521,7 +4525,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3d7c932f-5c09-4f4d-811d-789f8afe207b",
+      "key": "097602a5-8b7f-4faa-b12e-2ee9f186550c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4533,12 +4537,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "9ba31d58-40c2-497d-9dd3-7dfef15a485a",
+      "key": "9267ea38-9b1f-4417-abaa-25339084ad1e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4547,7 +4552,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f3aea34c-188f-48f1-909e-07f69867a808",
+      "key": "b7c238be-8137-48fe-8a89-d508b14cdce6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4559,12 +4564,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "4054fbd5-f1ce-4c33-9659-aba46d60041b",
+      "key": "da20a40f-7962-46ad-9c75-3362de887a03",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4583,7 +4589,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "335a5111-ee98-4e12-91eb-5f4eb44f0930",
+      "key": "8d81a2df-ee2f-4b88-9134-3e1e6d37c5f9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4597,14 +4603,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "d5ac17ab-0cfa-4914-84e0-48c3fcafc094",
+      "key": "d43c1207-d08b-40f1-91de-73df8286defb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "7ce9ed8d-3c1c-4923-b89d-caaa801591cb",
+      "key": "c66327ba-2bf3-4c7c-8187-c79a6b2c7112",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4613,7 +4619,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1b69ef98-e86b-472a-b504-c07151dd23e2",
+      "key": "7bd87c9e-77c7-4f88-9f95-e0fe4d5288ca",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4630,14 +4636,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "483a941d-5b2d-49e5-8730-6e1ee8171be5",
+      "key": "7bfe1b71-361d-43e1-a997-de169efc6ee4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "97da8b7d-7af1-4658-8d11-75d13c4874d8",
+      "key": "7ff6954a-8b9a-4032-a369-6076280e4b8d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4654,7 +4660,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "459be449-54c1-4651-a9f9-8e7bdd25755a",
+      "key": "14dd2ac2-a4d7-4f8e-a565-b661b37d97a9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4666,12 +4672,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "fc207a7a-76a6-41b2-8b62-2afde51cb655",
+      "key": "d8f6cce1-3c2a-4f14-acea-55db1c02b951",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4680,7 +4687,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8b2fe219-dbc0-4ae5-8e9d-d731e52cd42d",
+      "key": "2be5c5c4-9280-4b9e-ba59-d7b89d9560ea",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4692,12 +4699,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "9b1227b7-7967-4179-8068-6a35c2ff9ba4",
+      "key": "67a45c1c-5b98-4af5-927a-e74e3dd7115e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4716,7 +4724,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "510cc0e5-7333-4c2e-9525-68db3bbdc349",
+      "key": "1440dfaf-2aa7-4c4b-9438-646164d8528c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4730,14 +4738,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4abf13c0-a9e0-435c-98d6-855246dfb24b",
+      "key": "000ace6a-e43b-4ca3-a697-320316a1f0a8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "2eeee9c5-c548-4a80-ac6b-a69bd6418172",
+      "key": "c870bcc5-1ee6-4954-87b2-661624797102",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4746,7 +4754,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5df1c768-d005-4b25-aa15-6490b1b5ffdf",
+      "key": "3a6324b9-bd88-4ad9-991a-b9c5d9f1ce45",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4763,14 +4771,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "aa703a1c-b105-4808-87d6-0591154bb38a",
+      "key": "66d50544-d690-4f21-ae36-bccaccd903d2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "f587ac58-373b-49cb-be4c-238b50881b7c",
+      "key": "7ead17f5-6d24-4a83-ab08-ec6ead6f1fa9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4787,7 +4795,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1cdbf57b-d28f-46af-b9c7-7bf8185663f3",
+      "key": "c960c563-c587-4517-a843-f9c4d4f509a4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4799,12 +4807,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "eb8144e2-d398-459b-94f6-13783c703078",
+      "key": "796c27a4-60dc-4c31-a1a6-0412d626623c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4813,7 +4822,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "cc2841e2-6a99-4b05-8a8c-3ee7fc48c14e",
+      "key": "e63715a9-4edf-40bd-a9f2-c0d37cedf9ce",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4825,12 +4834,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "d61b21bd-b706-4483-a5bb-9e1753b4cc35",
+      "key": "5abfba5e-5ec1-46c3-aa01-000c1071de90",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4849,7 +4859,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "9d0d3adc-8492-4b43-a21e-4428de12e8c0",
+      "key": "baec1d30-ab28-4bbd-94c9-4ff158140f89",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4863,14 +4873,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4aafd22e-72f4-4d26-90d2-8dc106c834df",
+      "key": "93e5c613-3b4d-46f7-8cf6-4c7cd29a3cbb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "2333103a-32ee-48a4-ae7d-4e692ce0f5bb",
+      "key": "3257d06d-2cf8-48d5-80e8-4dd7e3cac280",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4879,7 +4889,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7906388a-d331-4310-b091-edaa0fd494df",
+      "key": "124016fc-9c2d-49b8-b101-18099e927813",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4896,14 +4906,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "4c92f67f-b350-460e-bbf1-a3449af46e6b",
+      "key": "67700ad3-908a-438f-a2e8-8c052f1ea243",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "a3f0fbb0-ae00-4a6d-a5f1-d6fcce1f6bf1",
+      "key": "c681a578-3f41-47ca-9a6b-a267fac3b594",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4920,7 +4930,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c8b94aa8-9f30-4642-b4ee-5cbe19c1ddec",
+      "key": "3e9ead0c-c4fd-4c19-a0aa-e5b08ade2bfd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4932,12 +4942,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c5bde304-da48-4475-8aa2-c4195fa70220",
+      "key": "ed2d9df5-f94e-4ef2-9c2f-b02636848db3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4946,7 +4957,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ce75f4c6-871a-4190-935e-17e57fbfd7bc",
+      "key": "dd100d3a-a343-4f51-8757-6f129a33a8f4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4958,12 +4969,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "1334de84-1582-4069-a52f-65f1b8cfc38b",
+      "key": "a2353955-0fdf-4d9e-a8f4-4b57db2e4f2a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4982,7 +4994,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "0d58a10c-4542-425f-b89c-eb1ac17f91e2",
+      "key": "c79f4043-9d8d-4b08-8856-11c313da8e97",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4996,14 +5008,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "e5fc79ec-1832-4645-a97a-8e2a7a3f27f3",
+      "key": "198d170f-21aa-4d2c-9772-d08783c36eb2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "ef49a1a1-5fbd-408a-b5d5-09ac4de68416",
+      "key": "d239ae97-19ef-4ee5-a42a-f3da8b516e4c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5012,7 +5024,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "01b147d3-d029-47a3-a8a8-d8a7590f9950",
+      "key": "afb154b4-d40a-41cc-8e38-c262df329dc1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5029,14 +5041,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "f43bc16c-1a9f-4fe8-b216-b8db69e21912",
+      "key": "677a6bf5-0a21-40c6-a993-39fb2dffd9d5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "6b25e4f8-59ec-4ecc-b7bf-2a7d07653f6c",
+      "key": "18469447-dfcf-42a9-b526-7a2c4a174aa0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5053,7 +5065,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "11496e46-bdbc-4e31-82ed-502e24bec1fe",
+      "key": "e2699b4b-22d5-4955-91ee-c3b89b8e5bee",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5065,12 +5077,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "30761e4d-b065-4b5b-9401-59bf16e99453",
+      "key": "501b29e8-b111-433e-ad54-88f8d2739072",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5079,7 +5092,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a6a351c2-d929-454f-87f7-c805a65522a4",
+      "key": "3a7a0ffa-a486-4a29-9c81-4779ca6cfcf7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5091,12 +5104,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "a91a8e06-618f-4a94-b66e-b62b2daf153a",
+      "key": "32a6008e-842d-485c-9027-f2fb0086f73c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5115,7 +5129,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "3f3c69fe-963a-4f4e-9673-3793169b260a",
+      "key": "4e89f963-47c2-4455-9711-e968dd8fcc17",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5129,14 +5143,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "c69773a2-45f4-4089-9d2d-b4ce09bd6b09",
+      "key": "2b1776ea-4a10-4715-8e88-27e81a4e6197",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "7eefcd9c-16fe-4a5d-8382-a4d309089297",
+      "key": "738f28d6-6ebd-4bfa-9491-026fe7aa2440",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5145,7 +5159,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9c3e8f2d-84ab-45db-80b5-73d4fd1fe850",
+      "key": "c2db5e4a-238e-4c32-a84a-f3c368f62123",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5162,14 +5176,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "da4bdf08-9ab5-44b3-ad5f-153853d3ac6d",
+      "key": "fb02857a-6b75-49a3-9617-59bb9eae906e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "5952266e-9005-40ac-a7e4-2dcbd39872a2",
+      "key": "34b2f173-d496-4f51-8d1c-109fb9ee2420",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5186,7 +5200,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e2e8ade8-4906-4db9-a217-b24ab2ed700b",
+      "key": "306f4755-0f79-48e8-beb5-87159f509aaa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5198,12 +5212,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e5ed8bb7-1ee8-43c4-b4a7-9b84ce02c964",
+      "key": "ab768bbe-225a-46ae-9eac-97fe5a8fa600",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5212,7 +5227,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8aba4ebb-15aa-4aa7-be1b-a9d33d2644da",
+      "key": "78a53388-4f62-40e1-aea7-5970201649d5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5224,12 +5239,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "4bfccb84-e4bc-4bd5-8984-64b5048a2481",
+      "key": "3e039bf0-1be0-4d8a-8505-42e938711c95",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5248,7 +5264,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "849f20a0-171f-48d7-bdf9-0bdd86427a6b",
+      "key": "d0d0f699-e9d8-47e7-a740-7c50aa6c8ea5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5262,14 +5278,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "1a1d7453-2dd6-4548-ac1f-2f6f89c6fa4f",
+      "key": "c287230a-4e3d-48d5-afdd-a27eb41b1814",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "9d263e15-0ef8-4597-8a72-24c3d2435fe3",
+      "key": "10e4102e-28f8-4da5-9f8a-d34fd3fdbe4c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5278,7 +5294,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3aa20a47-f6ca-4ef0-936e-baac37a1afe1",
+      "key": "d9c1f6ea-e94a-466a-b2d2-43d9af3fda52",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5295,14 +5311,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "898e344c-8ff1-4537-b2ff-258f51f90e22",
+      "key": "eb2d9e88-2d54-4697-bc26-53ec7ff38a2e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "dbda64fb-8225-4886-9ebb-f851a97c592a",
+      "key": "8a5bbac5-439b-4e8e-b013-204557e710db",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5319,7 +5335,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9d7b5e53-f6ec-445b-b097-e0836bacc689",
+      "key": "7bee86f8-9156-4e12-8322-fd6287d2372b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5331,12 +5347,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1e87f116-b700-4252-b3b5-0b13683933cd",
+      "key": "66c96353-8872-4d7d-8f6e-d3c133863698",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5345,7 +5362,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "52c3493d-8cbf-4039-a37b-6bef1784caea",
+      "key": "90aa8ad9-9136-4c43-bac7-efd598cc730a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5357,12 +5374,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "ddb01927-8f48-443e-adfc-c4b4cfd05f3b",
+      "key": "9224ee17-b841-4f2e-bfc7-e221a2d9c460",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5381,7 +5399,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "d8731329-212e-4017-9feb-89686279e124",
+      "key": "b4327195-3db5-42f2-80bc-f1fd7d2e70a2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5395,14 +5413,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "60a044af-5175-4450-8d5b-f7cebaf5930b",
+      "key": "b7f1abf1-f34e-48e8-9f67-7955a32343e1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6671f3bd-9dd3-4100-8f92-8ef92fc59ef8",
+      "key": "3eeb36c4-6218-461e-9116-84f1d2704aee",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5411,7 +5429,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "698ce736-32c1-4464-8fac-f8206d582e81",
+      "key": "aeaa7ccb-2692-40d9-a896-4e19b9f4faa5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5428,14 +5446,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "c12f8b93-8666-4c4b-8c8f-002132b2025f",
+      "key": "9ef2f6e3-d51b-49b9-948c-746103d087c4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "5fdb291e-e0c5-405f-b61d-7bde68a86c97",
+      "key": "6dffbb99-b48b-4a2c-a27d-cba85c9c6afd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5452,7 +5470,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c33efbeb-b893-4f28-ba29-b6e195f9d594",
+      "key": "11920671-5ea1-4839-9708-3136579a6547",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5464,12 +5482,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e47d8f07-6946-4d0d-a75c-69facbcd85ef",
+      "key": "042acfee-880c-46cb-bb12-933305eb2b79",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5478,7 +5497,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "59f1d929-5f40-4029-97de-3121746c28e3",
+      "key": "a62c8da9-28a2-4f25-9ca0-37567bceb945",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5490,12 +5509,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "34d5e636-2a28-448c-b8d0-a87472a68dad",
+      "key": "425750b1-27fa-47cb-9bb3-95d999a8887b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5514,7 +5534,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "ef7703de-c8be-438a-aa60-3eaf7b60406a",
+      "key": "3e49ba3b-9856-43d1-9e83-6a6805f5014f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5528,14 +5548,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "771948fb-2f0a-4204-91b2-330f11a2e5de",
+      "key": "9150c744-076a-4aa2-9b45-914347cda23c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "861f0030-8903-486c-8a83-1689f3429b2d",
+      "key": "a5ee4972-170a-48a7-afa7-d1e3a1410199",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5544,7 +5564,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ab176de5-d0b0-49da-a52c-cb7b9471ac16",
+      "key": "5bca1ac7-3dc3-4dc0-8827-9368ca76c059",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5561,14 +5581,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "7d6e227f-aa97-4bdb-9abd-3d60fc523294",
+      "key": "321dbe78-1602-4fcb-b289-9299a52d549c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "535619e8-0743-4060-8587-f0e10a0c0b87",
+      "key": "b6769563-a83d-4292-8997-b0125509044b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5585,7 +5605,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8003f164-ddb9-4683-b749-a4f2b06501d6",
+      "key": "65b6128e-5509-4817-8a37-2ed370602afc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5597,12 +5617,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "fe92924d-8896-4b8c-abe7-5f6d56c9f429",
+      "key": "68d2353d-7de3-44d1-b488-0eb1a93d6c5b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5611,7 +5632,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "46bf9fc3-14c1-49e3-a48d-dbf44304c5cd",
+      "key": "e443780a-3fef-4ca6-9f32-591c32a7984e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5623,12 +5644,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "60746cb1-85ad-4860-a34f-8f0a8af9ef7e",
+      "key": "90dc03c0-b0ad-408b-b3cf-8adb60009ff8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5647,7 +5669,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "49a9e558-7e86-422f-a2b5-22f29687e4fe",
+      "key": "f48d9459-e50f-4d68-9bc8-5433acd63440",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5661,14 +5683,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "44d958bd-518b-45b5-bc01-e56a464e2ca4",
+      "key": "1364c836-bc1a-4173-b2c0-2d5d290f92cf",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "f2c52277-e37b-4673-a331-4937fe1ef737",
+      "key": "c6a1ff60-29a2-4562-8d7f-01d8125e7bf3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5677,7 +5699,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f5ddb8c1-596e-43f9-a053-956cd9e72d81",
+      "key": "98387e49-7c95-4514-885b-b5f5cd79a537",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5694,14 +5716,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "01333526-4125-4544-b489-85e7b9030fea",
+      "key": "eb754638-e6fc-4e4c-b9e7-5892c951028d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "ba8ec3fb-5251-46a6-b472-49ee22ba28cb",
+      "key": "ddeeddf5-c2f1-4c5a-ab08-7c02b4a3a2ca",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5718,7 +5740,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "45dd78cc-df87-4de4-972d-5133fc050bb5",
+      "key": "e25dd6a6-7335-4179-a009-0587923b8c2b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5730,12 +5752,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "3cdcb360-3225-4839-a332-47ffb6391296",
+      "key": "2965a392-220c-4109-bc05-13de36556881",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5744,7 +5767,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9d5b68d0-c38b-4a29-9cff-21f3e9ffcadb",
+      "key": "03c602dd-b812-41b5-aab3-5788b845aa2a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5756,12 +5779,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "48d0744d-a3b2-4b0f-a586-e4351cac5941",
+      "key": "59b80474-076a-414f-850f-0eea58a44e52",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5780,7 +5804,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "0a3ba7a6-42d5-4e94-bfb9-4627db0edd90",
+      "key": "f395dc3b-e361-4baa-a4a9-46039929cc02",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5794,14 +5818,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "261b8456-7523-4362-a9f9-dafc18cd7679",
+      "key": "1517d00a-f65f-4fd0-8b18-f6cc9002f451",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "cf2648e9-1ec4-4397-a79d-c3d9b3aeed67",
+      "key": "149efc29-0117-4f79-a903-db6400e95a74",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5810,7 +5834,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c6f01d11-7db4-4b8f-b6fa-8015b14b2614",
+      "key": "fbee53e0-cf2d-46c7-8b64-18ae8dbf4cb4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5827,14 +5851,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "40aca2ea-ffd6-4781-b4eb-07f99bb2c04c",
+      "key": "752450d1-b3c7-4205-8291-06599c5a338d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "d0a0d482-fb85-43bf-a843-21e89a4b35cb",
+      "key": "7f0477e5-f7d8-460c-9801-8d3a8c4f9ed1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5851,7 +5875,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c94ce12c-5da2-4f0e-9c68-7881a0c0b8bd",
+      "key": "70e78ac0-7a71-477b-b926-102188f1a331",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5863,12 +5887,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "4e81fa38-a13e-47e3-ba8c-a158046253ee",
+      "key": "83330687-99cf-46bb-9c6c-4687edd25646",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5877,7 +5902,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "dc5c21f9-52e5-4406-af7d-1f9228665810",
+      "key": "79e976af-5434-45ca-a492-c5422048ba4d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5889,12 +5914,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "81f07f26-eeaa-4f3c-a8c4-809e0cc5bb3b",
+      "key": "3352a538-67b1-4ad0-9aae-6d71bda42a4c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5913,7 +5939,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "1fe0ef8a-52dc-4b48-8a4e-6fcb9b3cc8ab",
+      "key": "a756b377-2be6-446c-826c-81bcbc062395",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5927,14 +5953,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "7e8ca479-46c3-4225-ae28-3ebef22ab441",
+      "key": "6e07c00c-70da-4b33-89f5-362b1f5ad851",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "0775ee58-330d-4abc-878f-718cebebe1b3",
+      "key": "bc63e7aa-323e-4f23-8177-089047f8a45c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5943,7 +5969,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "007d1a87-2e53-46a0-82fb-aca0b0ccd19d",
+      "key": "92043840-fdba-4117-98c2-cdea8efd6e85",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5960,14 +5986,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "7af59d1f-abd6-4c2c-aa9f-2b5493f5751d",
+      "key": "13f1bc06-aa3f-47bf-b22f-de584d7c3d2c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "a97634fb-043e-421e-a2fc-dd1feb3f58b0",
+      "key": "8e54484d-a11d-403e-8648-24577d061afa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5984,7 +6010,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "d2de7bcf-61e2-4a02-908c-1b79b1fa0a89",
+      "key": "ef423660-a8fe-4620-8cc6-d9a9bf0ceb8b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5996,12 +6022,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "f14fa8fb-f3b3-43d5-872b-c1c17245f339",
+      "key": "c7a1f8b3-0a2f-465e-8b80-6555f9a74970",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6010,7 +6037,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1ba0810f-411f-4e40-98fd-65bbe29e95c3",
+      "key": "aa9e12a8-99cb-49bd-a3d5-db3941f3637f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6022,12 +6049,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "d64b51bd-b399-4807-9a99-a8be6944a749",
+      "key": "e3ddb31c-bf85-432f-b9f2-7e38845deb23",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6046,7 +6074,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "45199ceb-b44c-451e-af05-1669f1fa07ff",
+      "key": "61dd1420-2543-4f97-ad62-0fce99da0266",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6060,14 +6088,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "44bc5e0d-c588-4966-a396-1b0a89849499",
+      "key": "8803c2c2-0bb8-4639-a7e1-e381f7c119e3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "25ab0698-e8b7-4166-9ef9-f1bc5b795723",
+      "key": "315f9e02-e7d1-4a56-af29-56b287840c47",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6076,7 +6104,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "16f60f59-6c4b-48da-9c93-f24c5e3dca5c",
+      "key": "b38c791e-a762-4c9f-ac4b-a1d74e672d61",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6093,14 +6121,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "14876cfd-c1d0-4c5e-ad9a-7dbb1a30defe",
+      "key": "e4648560-d670-4b8a-8c7d-b350a7e41f34",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "92f30722-e6a9-4136-bb5e-b341108aec1e",
+      "key": "79cb2b0a-36cd-4ae7-96e5-7fba6560f14f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6117,7 +6145,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8019a927-ae18-4e9d-9868-ac472051738a",
+      "key": "6a5377b7-09da-49bc-bf3b-914194f66027",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6129,12 +6157,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "62368d98-5514-4dd3-9c05-10d027e90aac",
+      "key": "ce763a52-e973-4f61-bd18-6d88e8328942",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6143,7 +6172,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9becff2f-c25f-4004-90e8-5712bed27a9c",
+      "key": "dc6824fe-2628-4688-97cd-77f4e6f7b5ce",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6155,12 +6184,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "61caf86b-3e6e-4110-b125-f08e46ab161a",
+      "key": "8dabe726-e9d9-4cda-b008-35052b60fd2f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6179,7 +6209,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "ca0516cf-3d06-4a55-9c66-b2ce6114094f",
+      "key": "7f623a4d-5071-4c5b-a426-0100c6a18dc0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6193,14 +6223,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "76edec38-499d-45e4-b734-aca57b277b55",
+      "key": "cf75a5fd-659e-4715-aea9-4a2cd0975aba",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "07d9c5d1-6ee8-44b9-bfcf-fd3d0233bd2f",
+      "key": "b67d690d-06d9-4516-a79e-857edefe84ba",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6209,7 +6239,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c5fcf843-aa72-4bec-900a-570d631029b4",
+      "key": "d36cd330-401e-47e9-96c4-b3317e381185",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6226,14 +6256,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "b9ca76fa-d14b-4247-a839-3f0a85d3fde2",
+      "key": "86125e87-7ffe-4f84-9c37-64b2ebfe96ea",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "f819f8a1-5d5b-46a0-8b13-f6824583d3e6",
+      "key": "4a79fab0-26a3-4d72-bbcb-e5a9d19929da",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6250,7 +6280,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "52611872-d570-4962-a91f-031568af3cda",
+      "key": "c008734e-ca1d-4e48-b82c-74b7a25aa86a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6262,12 +6292,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "9364d182-ec6d-4ec3-b01b-e472e33eabe2",
+      "key": "15b12ffb-14df-476d-8063-2fd1dea1b53b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6276,7 +6307,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0c95a8e1-993f-4cd6-9907-a6502ba36a7e",
+      "key": "dd4618b4-5339-40b3-9e64-3973092082de",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6288,12 +6319,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 100
       }
     },
     {
       "commandType": "dispense",
-      "key": "41a82386-65db-4cc0-b856-0b7c9a644584",
+      "key": "80fae9ab-fab8-4114-83ea-21027d297007",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6312,7 +6344,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "a12e2fa4-7aa1-4a8c-a86e-dddeb12e47c4",
+      "key": "89ac605d-bab7-4319-ac44-e620633b6d88",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6326,14 +6358,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "3edb2789-cd6d-4ae1-8def-bdc60fbf3adf",
+      "key": "13c6d6b6-2dc5-4da2-8cce-07231135d734",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "9f284063-4225-4c4e-a671-82440ff6d762",
+      "key": "e102da5b-6415-4b0d-8586-3c716a5b3d4f",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6342,7 +6374,7 @@
     },
     {
       "commandType": "configureForVolume",
-      "key": "7887c06f-d10f-4f91-a146-c8788c0b393f",
+      "key": "bef0b0da-de4c-4fa8-80c9-c383dc4e6bd8",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10
@@ -6350,7 +6382,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c22773f3-e2e7-47d8-ae69-c4c58c626d36",
+      "key": "44f84bdf-57a7-4e0a-a698-e65b72dbe1ef",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -6369,7 +6401,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e0447b54-7e81-49a5-8d97-587e37e0960e",
+      "key": "9d6f5b04-b6e6-4e87-8f31-8785e3ed1d47",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -6389,7 +6421,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ccd1fb49-e477-456a-9ba4-7ae4b6d3b631",
+      "key": "cd36c398-42a6-40c2-a4ec-6a32bb63781a",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -6408,7 +6440,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "9339d5f5-cb2d-4e0c-96d4-c072b6a86cde",
+      "key": "903d37f8-80f0-43bb-bc03-c453e3a81692",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -6428,7 +6460,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "ef969b1b-5665-4e6f-97a1-29dd28a2aa07",
+      "key": "221a10ab-f9a1-4fe2-8550-c1ccf70ec16c",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "addressableAreaName": "movableTrashA3",
@@ -6442,14 +6474,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "99ac4ab2-96ad-46a6-8728-907fd037c3c2",
+      "key": "13fc3ec4-c735-476d-89ec-3a04b56f31c6",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "31334841-33c1-407e-8fe7-f205bc1f9d39",
+      "key": "801438e3-2f8d-495a-89a8-46d5ee3838fa",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -6460,7 +6492,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "32c789ce-c511-4f78-b3b6-331299d61c4a",
+      "key": "b5e92644-c4f3-4c09-8e35-a6195d4946d4",
       "params": {
         "seconds": 60,
         "message": ""
@@ -6468,7 +6500,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "ab7b158f-87c9-41f1-ba59-835752dd052f",
+      "key": "e3627ceb-759a-4bf6-8270-b303a988cdfe",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -6479,21 +6511,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "fd7ff030-c536-41fb-947c-876251c32a09",
+      "key": "7001fa33-2cb6-4fe8-a178-2f9769105d0d",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "59b0e96c-fdcb-4b47-9c86-7e6292834985",
+      "key": "36091c0c-b6c0-4c48-a42b-6d66b85b1d81",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "094b64bf-f609-4576-9a94-64857807346b",
+      "key": "dff3f344-ca22-4240-89cc-dd97b8c0fa55",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "rpm": 500
@@ -6501,28 +6533,28 @@
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "ab693690-5091-4200-b234-0d7ef62f84ec",
+      "key": "03136dca-cbc3-4b1d-90d3-db0e6b66705f",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "bac58d5d-50fa-403e-9f76-1099da577887",
+      "key": "06274a7e-c0f9-42dc-b9f4-b1fdc79e5217",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "26409823-b7ec-4d43-b413-24bff2b8307d",
+      "key": "32b4247d-ff27-4949-9ab8-df42aad08784",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "ce85735d-5dd2-4a7b-8709-d3b313863873",
+      "key": "05725b71-b1b8-41b1-a253-09ce8d24eaa2",
       "params": {
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "strategy": "manualMoveWithPause",
@@ -6531,14 +6563,14 @@
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "c5256eea-fc5a-4905-aa4a-fe070a17eabd",
+      "key": "ccf95519-5626-4cc4-81ac-d1abde9f9002",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "12ee6a26-0a6a-4bf0-8ca9-56b3af11f698",
+      "key": "8df1445c-2d81-4e80-af5c-55cbffc1064f",
       "params": {
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
         "strategy": "manualMoveWithPause",

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Author name",
     "description": "Description here",
     "created": 1560957631666,
-    "lastModified": 1746209689325,
+    "lastModified": 1746467889525,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -100,7 +100,7 @@
             "c6f47740-92a5-11e9-ac62-1b173f839d9e": "right"
           },
           "trashBinLocationUpdate": {
-            "b2f39c5e-4179-4ee2-9a5d-b8b7e9adabf5:trashBin": "cutout12"
+            "7010f369-f511-4c3d-bf6e-5aafabba9354:trashBin": "cutout12"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
@@ -123,19 +123,19 @@
           "aspirate_position_reference": "well-bottom",
           "aspirate_retract_delay_seconds": null,
           "aspirate_retract_mmFromBottom": 0,
-          "aspirate_retract_speed": null,
+          "aspirate_retract_speed": 125,
           "aspirate_retract_x_position": null,
           "aspirate_retract_y_position": null,
           "aspirate_retract_position_reference": "well-top",
           "aspirate_submerge_delay_seconds": null,
-          "aspirate_submerge_speed": null,
+          "aspirate_submerge_speed": 125,
           "aspirate_submerge_mmFromBottom": 0,
           "aspirate_submerge_x_position": null,
           "aspirate_submerge_y_position": null,
           "aspirate_submerge_position_reference": "well-top",
           "aspirate_touchTip_checkbox": true,
           "aspirate_touchTip_mmFromTop": -12.8,
-          "aspirate_touchTip_speed": null,
+          "aspirate_touchTip_speed": 400,
           "aspirate_touchTip_mmFromEdge": 0,
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -145,7 +145,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": true,
           "blowout_flowRate": 1000,
-          "blowout_location": "b2f39c5e-4179-4ee2-9a5d-b8b7e9adabf5:trashBin",
+          "blowout_location": "7010f369-f511-4c3d-bf6e-5aafabba9354:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -164,19 +164,19 @@
           "dispense_position_reference": "well-bottom",
           "dispense_retract_delay_seconds": null,
           "dispense_retract_mmFromBottom": 0,
-          "dispense_retract_speed": null,
+          "dispense_retract_speed": 125,
           "dispense_retract_x_position": null,
           "dispense_retract_y_position": null,
           "dispense_retract_position_reference": "well-top",
           "dispense_submerge_delay_seconds": null,
-          "dispense_submerge_speed": null,
+          "dispense_submerge_speed": 125,
           "dispense_submerge_mmFromBottom": 0,
           "dispense_submerge_x_position": null,
           "dispense_submerge_y_position": null,
           "dispense_submerge_position_reference": "well-top",
           "dispense_touchTip_checkbox": true,
           "dispense_touchTip_mmFromTop": null,
-          "dispense_touchTip_speed": null,
+          "dispense_touchTip_speed": 400,
           "dispense_touchTip_mmFromEdge": 0,
           "dispense_wellOrder_first": "b2t",
           "dispense_wellOrder_second": "r2l",
@@ -195,7 +195,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "1",
-          "dropTip_location": "b2f39c5e-4179-4ee2-9a5d-b8b7e9adabf5:trashBin",
+          "dropTip_location": "7010f369-f511-4c3d-bf6e-5aafabba9354:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -224,7 +224,7 @@
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": 7,
-          "dropTip_location": "b2f39c5e-4179-4ee2-9a5d-b8b7e9adabf5:trashBin",
+          "dropTip_location": "7010f369-f511-4c3d-bf6e-5aafabba9354:trashBin",
           "labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
           "liquidClassesSupported": false,
           "liquidClass": "none",
@@ -3586,7 +3586,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "c9446388-d550-4ff4-ae24-db1a22b0b4ba",
+      "key": "aa1bc722-c52b-4afa-95bc-5c26dec4a3f6",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p10_single",
@@ -3595,7 +3595,7 @@
       }
     },
     {
-      "key": "37a2306b-3b13-4e0c-9d9f-9e215e3995d9",
+      "key": "fe502f69-ea2a-4456-a73d-ee9410d15d4c",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_single",
@@ -3604,7 +3604,7 @@
       }
     },
     {
-      "key": "f2fee7fa-2517-4a5b-b0f6-32b4eded2e7d",
+      "key": "f0d53ef5-99d4-4d80-85ef-6acef1651793",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 10ul (1)",
@@ -3618,7 +3618,7 @@
       }
     },
     {
-      "key": "e98ef825-3e20-4e0d-b8b4-f5c890ac6600",
+      "key": "a5ebc2f2-169e-4b58-92e8-94d3636f7e71",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 200ul (1)",
@@ -3632,7 +3632,7 @@
       }
     },
     {
-      "key": "ddae6c3b-17f3-4284-ae8f-d83277f8d236",
+      "key": "9bec171c-43cc-4e34-8102-56d541d52de0",
       "commandType": "loadLabware",
       "params": {
         "displayName": "96 deep well (1)",
@@ -3647,7 +3647,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "94d94b5d-52cb-4c92-a382-111f606cd463",
+      "key": "d4aa673c-7c09-4c4f-ae66-ebd10ee775d1",
       "params": {
         "liquidId": "1",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3660,7 +3660,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "fb8a3332-bcea-48c2-baf8-e250e11e0a0c",
+      "key": "b4c7ce3f-e369-4213-8f67-0eaa2ba9bd63",
       "params": {
         "liquidId": "0",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3675,7 +3675,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "2117ba97-5864-4bbc-8f11-dcbac955e6d0",
+      "key": "0ee9fff0-0325-4147-90c8-2099216f1551",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -3684,7 +3684,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ffefd5cc-8aeb-4e59-b247-38df4aa48eb0",
+      "key": "5b8e2e79-709e-429f-9db7-719c6b5429a6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3701,7 +3701,7 @@
     },
     {
       "commandType": "liquidProbe",
-      "key": "a3b5b26d-8a91-4f97-8a23-e93ec45c4245",
+      "key": "e4128e02-bcc5-4ba5-956b-497c23769e43",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3718,14 +3718,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "ad686823-1509-46aa-98e3-b565d5df1446",
+      "key": "7cd332a8-60e1-454a-880c-99ef2ccac82c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "547722c8-40cb-4a49-b0e6-3295fbb686b9",
+      "key": "d64413c0-86b9-4bf0-8cd6-02679108e23a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3742,7 +3742,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3446f234-eb42-4d06-af20-e378df6177cc",
+      "key": "046646f3-01b8-474d-b6f6-5ccc8e4b6f90",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3754,12 +3754,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1741085b-d1b3-4268-8386-88d1680a87c3",
+      "key": "eb1518ac-c578-4bda-b02d-1d433ea210df",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3768,7 +3769,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "7ffccda9-75e2-4811-8cc4-d58076f95a98",
+      "key": "3d272088-fb92-4706-93d6-04baeac87600",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3778,7 +3779,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "3da4a475-aec8-42bd-9ce2-2be855211b94",
+      "key": "1d4d016c-cb8a-40db-9e37-d45b98c42dfa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3787,7 +3788,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "f8bcd5fc-703f-4d3a-bb29-dd647fbe206f",
+      "key": "9b4b18e8-c191-426e-baab-bd16d7be6f3c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3797,7 +3798,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "b3f0e5b9-2373-4fab-8fb2-fe56041a1cdc",
+      "key": "6d6c6713-1422-4094-93af-e8e7c538b767",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3806,7 +3807,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "04b27887-a6c5-4f20-be15-c89a23f53844",
+      "key": "90480e84-d463-4958-9129-aeff19492716",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3816,7 +3817,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "ab5419f4-cad2-4c24-aab0-37aaedfeb162",
+      "key": "9d16ea0d-2a09-4580-9986-af8a4eb2aa39",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3825,7 +3826,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e3016444-c104-41f7-b4e0-e1a04670843f",
+      "key": "7ff957ef-ce92-4bcb-abee-5dc33f4f2d1d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3837,12 +3838,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "7ef71441-339b-40fd-87c2-a8252a3422c2",
+      "key": "90ddbfab-028b-49fd-b2c7-d23932698e16",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3853,13 +3855,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "f903c5ac-3e87-4eec-aa0d-816aea5fcd7b",
+      "key": "71b74904-e47f-4b22-aedd-945763345dd7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3878,7 +3880,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c856b063-ad06-482b-a797-e497fd8a4499",
+      "key": "54029a18-b94a-4655-9cb3-c1d2ac39029e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3897,7 +3899,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "966bf876-9f1a-4568-b784-ddad08b020a2",
+      "key": "f72c16f7-2995-40bc-bc23-0252b7e35656",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3917,7 +3919,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1e57e02d-5690-4f7e-9acf-4acaa7b2ab1d",
+      "key": "8adf8e12-4b74-445d-a553-e0b092474a6a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3936,7 +3938,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d3abded8-23ff-44ed-bc4d-5b131621c0b3",
+      "key": "1b8fed29-c3b2-4904-bb93-e02a6b25365f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3956,7 +3958,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "9280b483-1fad-443e-8d42-173a95a6c550",
+      "key": "ebf89b16-9adf-4a9b-9653-fc8673ef5028",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3969,7 +3971,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "e5bf8e4a-c05c-459a-a671-9a55ca03d3ff",
+      "key": "7c4e0e79-0eee-4511-a5aa-e7c198e424ac",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -3977,7 +3979,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "82db913c-4ac2-487a-bbf2-664d78b26206",
+      "key": "5119f258-6d6d-4e34-aaf5-f01f145d85ae",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -3988,12 +3990,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "4ec3fa08-cabe-4bdc-b6cb-226b9475049e",
+      "key": "0337265c-2b0a-4a09-87a9-aed7a389efdb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4007,14 +4009,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "01f39597-a7f6-42fa-886c-6347eb1f5fc3",
+      "key": "b455d27e-47fe-4405-b1ad-8d100aa7aa24",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d09a67c8-cd70-4513-bc23-c992d59ab46d",
+      "key": "8f14f69b-c8f9-4fb5-9107-2869c6b1d405",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4023,7 +4025,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "49e1c57f-e39c-44b8-b696-acf418344951",
+      "key": "4b6ec547-aec8-440c-9a54-a55362b2ee03",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4040,14 +4042,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "a357cac5-5d3d-4543-a754-46dce7007989",
+      "key": "7e093efb-de1f-4c0d-93b1-ddb51f1ea61f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "bad48231-320a-4f3b-802d-c9769d7e7c3a",
+      "key": "00d80352-9440-4943-9ba5-dec1adb4e63a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4064,7 +4066,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "73f20741-3649-4bb9-bb98-10a1659e03c7",
+      "key": "0c865b38-81e1-4d49-bd92-0ff8ab214b68",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4076,12 +4078,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e1ff1614-08df-421c-b1d4-f02fb6d79dda",
+      "key": "16d761ff-3891-496b-ba78-8eb809699711",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4090,7 +4093,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "48c778d8-08c9-4454-a51c-b3d945b4f950",
+      "key": "822905c2-3d37-4d3b-ba9b-59d61b7afa78",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4100,7 +4103,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "371a85c0-2022-48fb-b74f-aad07e803390",
+      "key": "7901b312-8951-40c5-a8c9-055eb1609552",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4109,7 +4112,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "e451d88a-d1fa-447f-8588-84e45ae84936",
+      "key": "77dec89d-1b37-4483-8e91-ea137fc9d58f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4119,7 +4122,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "944feff5-fce0-4f76-8bb4-e52309579c77",
+      "key": "15537096-248e-4758-b5f6-ac50443cc3f8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4128,7 +4131,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "9416202e-dddd-4d1d-9b0c-643ed6e06b92",
+      "key": "3eec0687-98a3-4b90-a446-51104c12ca89",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4138,7 +4141,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "f51bdda6-a45a-4eac-b7c3-d41697374948",
+      "key": "f66abef3-4f85-45f5-a13b-e8c590a332fd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4147,7 +4150,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "2b5cae3f-e322-4f55-a38e-e69dca26a6f5",
+      "key": "e176ab99-1ab1-4111-9e65-9e7ef8db2b06",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4159,12 +4162,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "1aba6342-25b5-4583-9299-9a8d984651a9",
+      "key": "da8504cf-c0db-4f93-acb8-1a3fa5ee4e84",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4175,13 +4179,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "12176d87-93fe-4bd6-b9df-da3f3c98a9ee",
+      "key": "df18b6ea-60c6-4453-988f-7b10aab0e9e2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4200,7 +4204,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d6a7882d-c311-4be1-a7b8-8cd0a2637132",
+      "key": "90b78546-2cc2-4c91-8e20-0ae40bf82368",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4219,7 +4223,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "32d5b3e1-33f7-4f1a-8615-5da648dcc652",
+      "key": "e8e89663-18e5-458c-a879-9df40f29d4ab",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4239,7 +4243,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "bcce9a3d-e4ff-4b2c-9d15-e773cdfcbda6",
+      "key": "b5e542eb-ebf2-4eea-8f9e-a5fd03793058",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4258,7 +4262,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "cdc0ce36-ca24-44a6-ab99-e6da05ada97f",
+      "key": "53f5fa17-5b33-48ec-8b6a-8558b7078d04",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4278,7 +4282,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "cc1ce3c1-74f9-46b3-973e-af3ca4bf111b",
+      "key": "51721c60-8498-412c-b036-38e69bed2c59",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4291,7 +4295,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "bf6f0ce3-8c6f-4301-8615-1195976b4c4a",
+      "key": "dd27478c-7a0f-4bd7-9d22-dd72a375c9b0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4299,7 +4303,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "0bcaf341-1239-48fb-96a2-6a59c07e7348",
+      "key": "3d9d7823-b943-45e8-80db-0471a5c4b321",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4310,12 +4314,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "b0787e68-1286-402c-ba90-fd75ba8aa999",
+      "key": "53eaaa90-9bfb-4542-b552-52e2f719a039",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4329,14 +4333,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "494ad915-a568-4dab-ade3-0081f3a9972f",
+      "key": "4d959013-48be-4025-8e09-8599e5e912e2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "92da2f7d-ecd5-4ea8-969d-ebfb67e90adf",
+      "key": "7e6b49fe-3802-4530-b7d9-8d1d92b8f636",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4345,7 +4349,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0634e1e4-d70d-4f12-8d55-bb2c89478b34",
+      "key": "b0a8c5dd-ef92-47fd-a015-190023feb0b2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4362,14 +4366,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "85d4c45e-8810-49e6-a05a-b8d99cc80377",
+      "key": "35fb10b0-2656-49f6-840d-cd19b0011988",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "2a87a03c-42e3-4803-a138-354e059c5e25",
+      "key": "82ba6c57-70da-4f51-83c2-eca534f70fb1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4386,7 +4390,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e2d30330-f65d-43ae-a38d-c315ee451b7c",
+      "key": "ca07aea8-9190-4679-8f42-fff51fe89a68",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4398,12 +4402,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "74166c10-e9cd-49fd-8a94-f682bfce22a2",
+      "key": "bc9ca6a3-5b22-4d1f-b5d6-4b8f7026ad84",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4412,7 +4417,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "ec63c38b-bdc5-4907-bc49-1f8f66815405",
+      "key": "3b4e1856-3ee3-4b98-9199-75ce669ed0f9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4422,7 +4427,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "8fd07a77-72d5-4917-a38b-47e62bcdd309",
+      "key": "c77335b2-02bb-44aa-a555-f92c06bc9b44",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4431,7 +4436,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "ced9ac12-ff67-40d3-b945-ee6a0161ee69",
+      "key": "5bd67f87-2e95-4c69-a944-f8288ee67bd2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4441,7 +4446,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1b182404-43a7-496c-826b-091db90deec4",
+      "key": "83808a85-fba5-4abc-b672-b4d68481b073",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4450,7 +4455,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "1120f33a-fa9c-4fb6-8577-6b5074e1b441",
+      "key": "69fa0df3-6610-4a21-aca6-59fb9b65949f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4460,7 +4465,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "85bfcdf2-6d8c-4d8d-8d88-d2dcf3207a22",
+      "key": "10dbe31f-a2d8-4ab5-a77c-425dacf6240e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4469,7 +4474,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a98f71fa-4c2f-427b-bcd3-8f927f0b12a2",
+      "key": "3007c1a7-042d-4494-a367-9676e4fa3abe",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4481,12 +4486,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "614c26c6-7259-439c-9402-6c8a2e9c9cb9",
+      "key": "98ae369c-b69c-40a4-bc90-106758fd0319",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4497,13 +4503,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "78df1353-54ba-4ca4-b90c-698c23f42563",
+      "key": "0e20f78a-a251-4fb9-9675-8aaf2ab91651",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4522,7 +4528,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "db443dc4-1388-4ad8-8785-f94e387def1b",
+      "key": "29e27c51-68d6-45c5-a4c0-daab82b18d9d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4541,7 +4547,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "289c272e-bc3a-4f81-9c26-8b8db67aa1f4",
+      "key": "099a538c-445d-4541-a512-6e5898ab5f4a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4561,7 +4567,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "99d1d496-32d9-44ab-a16f-d9d79115a2ba",
+      "key": "6b6ade38-dbe9-4fab-8974-44cdcab8e381",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4580,7 +4586,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f1a7dc98-b0de-47f0-955e-638ac934bb78",
+      "key": "0db94b12-393b-42f8-a280-d9445e97534b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4600,7 +4606,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "9ff5fc91-e978-47f3-ac3e-e8e86a793269",
+      "key": "9fbd3304-d345-4566-beb4-e4421786ccc8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4613,7 +4619,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "81075a4d-5175-438f-971c-75d550f7aedb",
+      "key": "24a36f12-4ab7-40b2-9669-f52bc6469185",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4621,7 +4627,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "82e05636-e5f4-4a25-a91d-129d8718de08",
+      "key": "6a9363c9-def9-41cc-83d9-0bee0e489b91",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4632,12 +4638,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "e9adb1c4-418d-407f-82e3-1d05f4f0c295",
+      "key": "924a31d9-6380-4f60-8a13-b96d8ed93d0f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4651,14 +4657,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "eac6e444-2b22-43cb-b597-01f0ba52d505",
+      "key": "26ec1932-7733-46de-bdfe-074e2a188133",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "78b3a664-389b-44d1-a461-9e92b12b9855",
+      "key": "4f7312a4-d548-40b8-a6bb-9aa847ba6836",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4667,7 +4673,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ff95363a-453c-4ebe-9d63-99b2f8cbab75",
+      "key": "f40db681-71fd-43fc-b41c-b6cc42488980",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4684,14 +4690,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "040d1d78-2778-4861-a867-fa13ef2747ba",
+      "key": "1a53d820-d516-44cc-926a-8e182e4187ac",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "03792021-acd8-4022-8392-33d68e011cb5",
+      "key": "df50f3df-34ba-4638-a906-7d06b5b0bafa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4708,7 +4714,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "52d8ad43-b859-44f3-82ee-0c355090dbad",
+      "key": "55f244c0-8c23-4a13-8e44-33f4faa62e0f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4720,12 +4726,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "f5c9af56-137d-4bf5-ae6a-d6b2947158ec",
+      "key": "be9377c7-77a4-48e5-b029-a3e0580dbacd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4734,7 +4741,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "82f87702-5c67-482d-b986-3cb464d0d18f",
+      "key": "32cbabad-61c0-4bf3-8970-1fcf0dacd6d7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4744,7 +4751,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "298bfe90-a217-46ee-887e-2648398f99a8",
+      "key": "6accf2c4-7c42-46c8-ac91-33aac0dab823",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4753,7 +4760,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "64cf5414-d068-462c-ba1c-a3699bf6c6f1",
+      "key": "b7254fd2-ec1f-46de-bdf8-dc6f6bc448f0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4763,7 +4770,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "68187826-13b9-4c62-8be1-cce4d10ec1dc",
+      "key": "d55fc1e0-b73c-467d-86a7-314434e9af5a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4772,7 +4779,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "2ba0fa5d-4ef6-435e-9e05-16760d3411ce",
+      "key": "35414712-3755-4510-be2e-529dcbcd9bdd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4782,7 +4789,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "3d1c7ffc-85d6-4c2f-919d-18696fdb4cec",
+      "key": "249b6033-cdef-4ff6-89c7-9449b483e416",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4791,7 +4798,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8dac5970-7f3d-42eb-914e-b98f35313435",
+      "key": "59a83493-6b2d-444b-a441-24dc594c7d9c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4803,12 +4810,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "f85989ac-4126-4835-9c1a-d1f4e6c5e17d",
+      "key": "df48edbd-b987-4091-8338-80a2147d1051",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4819,13 +4827,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "9c9b3f48-ad43-418e-b5a1-6d397e94e305",
+      "key": "e806071d-1620-4f8c-928a-0f15d3af2b3b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4844,7 +4852,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "0657883c-59c0-49f8-b772-e4d31b007075",
+      "key": "498de59e-511b-4ebf-b147-0d22ff74e6bc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4863,7 +4871,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e2247ba9-de51-45bd-8c52-d9561215dabb",
+      "key": "181bf27d-23c8-4cac-98de-a9933cb1c761",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4883,7 +4891,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "25ce796d-b8dc-4f56-a79e-16167a16a167",
+      "key": "b0e88a3f-7ec0-41ce-b970-2ad7c7a65781",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4902,7 +4910,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "da753746-e1ba-402d-b540-fcc42892d544",
+      "key": "3c5a21cf-1105-47d8-b920-8ed622740025",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4922,7 +4930,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "bd00a7dd-fbeb-4198-8c17-6bcc6b157cd5",
+      "key": "b92fda29-ed74-4f5e-85a7-e9b4787c9e06",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4935,7 +4943,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "997aee96-9524-4ee9-bea0-d398e6dad83d",
+      "key": "8d48038b-05db-4500-96ae-33e0fd4513f9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4943,7 +4951,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "65f9b34e-36e9-4382-bc78-43c9cff85dd2",
+      "key": "ad08ec5b-5d5f-49e8-913e-4f7b10f5ca3a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -4954,12 +4962,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "6f6dc5dd-29d0-431c-84ce-4ea4d61c6ec2",
+      "key": "4b23624a-c43f-47bb-9fd3-b1b6b3fddc8f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4973,14 +4981,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "ae9f6cb0-f491-4e1d-a0ac-4f7a95a9ab7f",
+      "key": "ac6664e2-126a-4293-80fb-fcb2d72af350",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "2b262ce1-b543-44a8-88e3-bcb7840d9c1b",
+      "key": "04d405f5-6a1e-4865-bebf-67005fb56d34",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4989,7 +4997,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "458fd3cb-37e3-4e59-b995-2785abd0bfcf",
+      "key": "62648d30-0d97-4b77-a1ad-188d02b2a2c1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5006,14 +5014,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "d01cc40c-93bb-45d1-845d-3a0a8859c324",
+      "key": "039cf9c9-848d-4467-91c1-32f9600aa267",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "985e9b96-24bb-47ba-9dcb-46cccfe9b1e3",
+      "key": "6a020775-f327-4c86-89df-ee2da3cea05f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5030,7 +5038,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "523fffdd-370d-4ce4-841f-6733bcbfc9f7",
+      "key": "52db9a1f-f909-4154-a5af-c725793869d9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5042,12 +5050,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "fe9c9142-dca5-4525-863c-408ca351ac93",
+      "key": "1832e164-f9e9-49c8-a56e-a14325541abe",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5056,7 +5065,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "73d9ca1e-dff4-4799-8a7b-ffc35e9cd89a",
+      "key": "9c266740-2056-4554-a875-6e4cb3a899b7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5066,7 +5075,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "07d2e419-96d7-439b-b0d8-cd638973da38",
+      "key": "7253442f-e66b-4846-b556-a084eac7d803",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5075,7 +5084,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "00a4cc47-db23-4d08-b566-45296c9963f3",
+      "key": "a64db7ae-b0bb-427a-9973-fc17dcabc04f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5085,7 +5094,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1ed4df67-693a-434e-a9bf-495b4e04d627",
+      "key": "d6f585c0-401e-41ec-887d-a2c58e2689ac",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5094,7 +5103,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "0a90b5cb-54d6-4b8c-b4ba-adc599a79279",
+      "key": "6ca3ddc5-23e5-418d-aa9f-d5d699b53b98",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5104,7 +5113,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "416effd5-c3f7-47a3-9016-5ab8cf00ab4e",
+      "key": "49a25279-b95c-47fd-bdd9-beb7eccfba62",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5113,7 +5122,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8cb6451c-6bfb-443e-b24c-c1c6e12c5a99",
+      "key": "6144ab52-a6f0-4b42-9ee1-35c055337d68",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5125,12 +5134,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "603f9f4c-bd55-4e88-86fb-89dac07ef1d1",
+      "key": "ee4e4f56-5218-4796-bc48-5e6b711b089e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5141,13 +5151,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "297f5ecc-f9b6-4d77-ac0f-2284a1cf81f6",
+      "key": "1dcf3144-f671-4525-a4a1-ac88bc2c5432",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5166,7 +5176,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "52d757ce-995d-4dde-ae5a-10be7460b5b8",
+      "key": "d8abed3b-300f-4f62-afcc-44d8ee639bf6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5185,7 +5195,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a95f64c6-be93-43fb-950e-f001041ccd05",
+      "key": "956adfea-fd5e-4acd-86dc-722b794fa31c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5205,7 +5215,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ae80c674-a52c-41c1-be85-f9cf234591f0",
+      "key": "ef9c8b47-0e97-46ed-8c5e-640a80be80be",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5224,7 +5234,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "3eb55461-bda1-4c79-981a-38982bbfc114",
+      "key": "278acecd-d4be-473d-af39-0dabb014e8ce",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5244,7 +5254,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "2b36c5b6-28fb-4ea5-877c-2cff3e45c1e3",
+      "key": "110b4e01-d9b2-4bd0-9440-09f564ab064c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5257,7 +5267,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "cd093aba-8a37-4963-8325-52d04a1068c7",
+      "key": "3a6f9e40-a5ec-43bd-bd45-2c8c3ed6b67b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5265,7 +5275,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "612f0ad0-d175-45d2-ac63-72885204b20f",
+      "key": "dd1d3ec2-dd05-4f7c-9e34-9ffe46108ccf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5276,12 +5286,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "44e0cb1e-1849-48b9-9f39-8a80a6e6408c",
+      "key": "897975e3-5218-4c59-bf21-a9b73f523832",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5295,14 +5305,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "bb18431d-ae35-43a2-9d8c-2604857d8e58",
+      "key": "3c83109b-ab8e-42bf-a40e-8a1fb6223110",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6d42a3af-3aee-4e55-9ae1-fd5df9bbb3d7",
+      "key": "82e77104-5d1e-41fd-8962-c608b7f4ccc5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5311,7 +5321,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0424ae40-30fa-4a8a-b970-79e62719f98f",
+      "key": "4a6e172c-1690-44e1-b503-c1f876ef9eaa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5328,14 +5338,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "7e2622d2-b1a1-4211-84df-c30cd54b3be0",
+      "key": "5eb16f62-a3b9-4da2-818a-0c909cfd3402",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "7fe53f69-48f3-411d-b8ea-730e9208e99b",
+      "key": "b4a19885-0a36-46ea-85f1-f961e14a2d41",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5352,7 +5362,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0d6ecaa5-6f86-45c7-b857-209ce0c81215",
+      "key": "ae69a6ae-af56-49cf-9d97-d6d02ed5c921",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5364,12 +5374,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "b37e8d38-3212-4973-992e-52a805853ea7",
+      "key": "8b7a5c4b-5bd4-46b5-9b87-243f46fd5545",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5378,7 +5389,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "5e7bf70c-d08f-40be-a468-203fd9c4bf43",
+      "key": "bea5f2c9-57d3-4bec-9459-fe521f8f7eee",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5388,7 +5399,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "3b2ec3dc-98b6-4dc1-8210-35903ad1a01d",
+      "key": "b3cb3473-28c2-496a-bed0-6d27817577d1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5397,7 +5408,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "4cc654dc-65e7-46ab-9798-53049fee45e9",
+      "key": "e6490c7e-c21e-4d19-9843-3fdeac39e9ad",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5407,7 +5418,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "ec5d2273-ae81-48e2-b526-25d8020f678e",
+      "key": "9c4063c3-fc88-4e31-94ed-0c48dea79fb1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5416,7 +5427,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "77a5c166-7cb7-4304-a20e-6aa6fdea085d",
+      "key": "457f7ee0-9d3c-48f7-aeea-7d32c24bf0a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5426,7 +5437,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "9b44bbf3-73ce-425e-8fb1-9a70485f085f",
+      "key": "2f92650f-5a9c-4c91-b18f-e734f809ef3f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5435,7 +5446,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9440a2cb-eff0-40d4-ad67-d1a31c836dd8",
+      "key": "df8a59cd-2e29-4230-b737-e89cd3697dad",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5447,12 +5458,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "59860c67-0b96-4269-917e-7fdf64f69a0f",
+      "key": "ff784f97-ad02-4e9d-8b9e-f0e24736c2e6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5463,13 +5475,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "4a30e4f6-28f9-45e2-a298-a649ac5bdbab",
+      "key": "d7c39126-eff9-478b-bd67-c6b35a1ec980",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5488,7 +5500,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "be00229c-8715-44ab-a0ef-3e5b0631dcc0",
+      "key": "15d62d6a-0570-4356-a076-c4964ecea1d8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5507,7 +5519,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "483df83d-b32e-4663-aa59-c6faa5a8c7b0",
+      "key": "746bc774-fbcb-4be4-8217-b991d2b68f44",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5527,7 +5539,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "37b7bde4-7682-4759-9ad1-bb91630c7201",
+      "key": "adf57333-bdb5-4a65-afc3-c86c6fe48da4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5546,7 +5558,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "79bbe37d-d1ca-44c1-9b70-82e8c26cb7eb",
+      "key": "dc9c036d-de93-43e3-b8ee-65ddfe5cc03b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5566,7 +5578,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "14da5df8-6cd6-4ab6-989c-3c31dc0c9529",
+      "key": "64ae34cc-5515-4ca5-88b5-978c74212d95",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5579,7 +5591,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "f4c832e3-4745-4b57-8cfe-b37e5bc1653b",
+      "key": "651bdb34-fa3b-476a-9e56-7d17bbb511ee",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5587,7 +5599,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "3053a465-d319-4b09-9934-38c50885587c",
+      "key": "a6d17cb4-1dab-4339-8b40-91360a854103",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5598,12 +5610,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "0fa5848c-7b69-4924-beaf-d8b907eeb46d",
+      "key": "c8537f7c-2ba1-4918-a4fb-473539cdb343",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5617,14 +5629,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "be13c775-9dcf-4dc7-bd3d-b51b36f025e2",
+      "key": "2f28de6f-a7ce-47a4-8088-94dd5c52d9c3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "350a45d9-0086-4c14-b3f5-dc1309f333a8",
+      "key": "f91f4759-148e-4b22-8755-cc50439d2017",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5633,7 +5645,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c375b93f-57bf-474f-ae46-763ecfb6b644",
+      "key": "1454e241-8d47-43a3-b198-c1e79a70cef4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5650,14 +5662,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "389c8561-ea2f-4590-8823-89dc8ca77d1e",
+      "key": "20616916-8cd7-4c31-acf8-eae8521d18eb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "79b12839-4c49-4718-824b-6a3a5da7988d",
+      "key": "a1b94463-207e-408b-8ef0-dbbca9998913",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5674,7 +5686,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3bb8537a-cf43-4613-a602-b4f39c3384e8",
+      "key": "dec91d43-7795-486a-8004-1290a57ed655",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5686,12 +5698,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "53cfd382-6f1a-4ab1-b613-c529c15e1a00",
+      "key": "736c6199-625f-46a3-9305-a315bb611307",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5700,7 +5713,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "6758112e-4f91-443d-91b2-acc09e0aa446",
+      "key": "855ea62a-e2ca-4e61-bc2d-8488cbb46d03",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5710,7 +5723,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "95c51014-c760-4744-9da2-f840a34e62b2",
+      "key": "3fabaac6-5d57-49e7-826c-b2322d834a01",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5719,7 +5732,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "8e95b709-b4d9-45ad-85f4-6e2770751bf7",
+      "key": "7118be2e-9d7b-4e91-9438-02bcf1e980cb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5729,7 +5742,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "cdfb7df0-95cb-4c4a-9d8d-14e023859281",
+      "key": "c06f3888-807a-40dc-a5e2-80d5c6106a75",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5738,7 +5751,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "1e4f4b10-997a-45f8-82a7-192c22fde2fd",
+      "key": "979ca04b-7cff-4ab0-b96c-0b57ca956eb6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5748,7 +5761,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "15b2358c-9283-48da-a5d4-1bd4e993519d",
+      "key": "0e245515-62ed-49d0-b834-ff1c2d17eded",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5757,7 +5770,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "30c3b561-c062-4fc6-9d79-74e24ed83a28",
+      "key": "03c95dcd-0bd2-4c4d-9fb7-1f6f41e8b955",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5769,12 +5782,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "4c04e1c4-c60a-4ed7-8c54-073c1e90bbab",
+      "key": "b059240f-f8fc-4db8-b422-77470584d4bd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5785,13 +5799,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "72ac7a1f-868a-495b-b67b-6e19b93dd717",
+      "key": "9508542b-a173-4c5d-9cd6-b6ff4dc4f183",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5810,7 +5824,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e464835c-354e-4733-8df0-3d803a14cc7e",
+      "key": "3f76e871-2ef2-4977-9eb9-b5eef7eecc0d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5829,7 +5843,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "803826f7-92be-4fa7-8fd5-03bb258a5a67",
+      "key": "8d180d68-2720-4a6b-a251-c2d674b502a8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5849,7 +5863,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c16b5878-565b-43bb-9670-34c164cfddd0",
+      "key": "e7732225-7746-4b24-814c-f44c45ccbb35",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5868,7 +5882,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "9a41ecec-4cc1-4a56-983c-380f626f1f68",
+      "key": "b23a204d-78d0-4f4c-b44c-91f6ad3d4174",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5888,7 +5902,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "35349a37-50ab-43a1-8bdb-21b102b4cd91",
+      "key": "ca1e3ad7-299b-4e0e-b064-0effbcf64aae",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5901,7 +5915,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "0f1a7889-bd4c-4e92-b6f0-d4107997167e",
+      "key": "a11fb196-f82c-4582-a095-6ace6bbaf2b1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5909,7 +5923,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "fa355dfb-8b7b-4719-a3c3-ec943ad88198",
+      "key": "a41e108b-82f2-421c-8d38-e23cc29e1640",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5920,12 +5934,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "d2854eae-1df1-44d9-b178-7278ccd47db4",
+      "key": "19b852fd-ebfd-47a1-a179-6a6920f4abad",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5939,14 +5953,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "d3147ad8-2989-4730-81d8-593437654f6f",
+      "key": "91187cc0-39fe-4a9a-ab27-cdfd0f31982a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d5284cbb-7553-425e-af78-ae3a76c5a640",
+      "key": "339e5257-ac68-467a-9050-f9cef1e88c0a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5955,7 +5969,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5bcf00ac-d8cc-427b-aa77-952470a660c5",
+      "key": "bbb9b6d8-4f4f-4f83-b8a3-2b9e0e493b86",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5972,14 +5986,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "e5f08c11-87a6-453c-9f25-27449448cccf",
+      "key": "91a090d0-cc6c-42e6-8271-de246c55267b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "6b9bc909-0395-4d1c-bcd1-5017d39e139a",
+      "key": "11cb1087-bdc3-4090-a309-cdbc881e76b1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -5996,7 +6010,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "559eac9d-9b12-40bc-a04e-caf38c073931",
+      "key": "0ae887b5-9be0-4836-8dd2-83befa949257",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6008,12 +6022,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1f737705-d6db-406d-9331-cb2579d1c4bd",
+      "key": "618c881f-4944-4627-a736-7d3f559f9c78",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6022,7 +6037,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "301686e7-b97c-4038-ab55-a8eadf29b533",
+      "key": "84b7ee02-95c0-4ca4-8e42-99b7c036fdac",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6032,7 +6047,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "fd43684e-1e4e-4a9e-abf6-04cafad97fdd",
+      "key": "911a7674-e98d-4956-a856-f3580626dd54",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6041,7 +6056,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "cecc2112-5581-4b9f-8503-4906f38d4b8b",
+      "key": "427ae722-95e9-4fd4-846c-32492d63da3a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6051,7 +6066,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "aeeb1a92-aa68-4b8b-bee3-f78680dd7846",
+      "key": "ea6cb6ff-0344-4c43-8e96-d5d494269984",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6060,7 +6075,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "4e0afc9a-14b8-4c4b-87cc-73109986b18f",
+      "key": "39ec2d12-5f43-4da9-8b85-60ef6eefbe02",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6070,7 +6085,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e8a686e4-4903-4803-a452-26b3e52451e5",
+      "key": "61ff0906-11b6-47f3-9fbe-9939f35ff7c6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -6079,7 +6094,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "2e7eac5e-24b3-4d32-bb81-7169e59f0250",
+      "key": "a0ff4a34-2f13-47ca-913e-936acb14ee25",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6091,12 +6106,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "4e330b42-7bb3-4234-b11c-a2a10652c601",
+      "key": "24364787-0402-43ff-8262-62d17b298cd8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6107,13 +6123,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "330ba968-39b9-40d2-873e-6102cf0e751f",
+      "key": "9d6ffe6d-b042-48f2-a3d5-b6382cc04167",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -6132,7 +6148,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "37cbc799-2cbc-4b9d-a60f-64324afe7a9c",
+      "key": "91097472-ce6f-48fd-9d9b-37d9302def4b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6151,7 +6167,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e95a651c-6fd6-41a0-a3fb-410540630600",
+      "key": "43f671e9-c42b-4ba2-8c6f-ad1c366db8d8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6171,7 +6187,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "234ecaf0-59f6-4eb4-a659-5498e8c77ad9",
+      "key": "93523721-9251-48ae-91ab-d493b8f4ada2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6190,7 +6206,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2a99d48d-9580-4630-a7a0-868c4cddcb09",
+      "key": "da663ef6-d097-4486-aa4a-b2e33d37210a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6210,7 +6226,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "c35b6b6f-a9be-4cae-b472-c7eb7e532480",
+      "key": "e7bff057-88b7-441c-a715-557ef6d0bf29",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6223,7 +6239,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "32961300-446c-4c99-a981-96cada7f3c11",
+      "key": "2cc000e7-49a2-4f10-a1b4-daf04fbd5b9f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -6231,7 +6247,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "d80f0452-7d54-463c-b52d-94b461187f86",
+      "key": "25dc9cc9-cc42-46e1-99b2-3b1972e1e325",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6242,12 +6258,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "26484db7-1618-4e9c-9397-b3c78141faf8",
+      "key": "db0b03e3-4c65-4c3f-96fa-ffca1f93e18e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6261,14 +6277,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "8146a5f4-a6bd-4ff0-9818-3c96b3b680de",
+      "key": "ae9799f4-f938-497a-8793-c3847890528b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "f8b1100f-cd3e-468d-904d-463a2dd7ac3a",
+      "key": "6da2579d-2a57-47a3-96ab-0a37a357c4d8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -6277,7 +6293,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "2ead0a27-15f9-4d30-8f52-61345c4a5401",
+      "key": "26ca0b6a-5d79-4748-903e-d6294e87a7ae",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6294,14 +6310,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "2732e3d7-193d-41e6-bdc1-702cbce05baa",
+      "key": "f444f205-25a6-4ea2-b5fc-7b0730b4c139",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "ff183cda-1fdc-4d6d-b0ce-8aececd7933b",
+      "key": "203bef4f-9802-4216-921c-638b613636df",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6318,7 +6334,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ae247b0d-3bea-4d75-b8f3-d411aa786299",
+      "key": "554f23e1-3f3a-489e-87c9-6e197c298c10",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6330,12 +6346,13 @@
             "y": 0,
             "z": 1
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1daa028c-2894-4f2c-9acc-c67f70943971",
+      "key": "38ea2707-ac81-4e10-af1c-9d743f154dab",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6344,7 +6361,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "1668ecda-122b-4c4f-b900-896a1fee5340",
+      "key": "6d63111f-a162-42b0-a172-04fea608c1f6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6354,7 +6371,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "d19d690c-5d0d-4f8b-9505-1036a1adbacf",
+      "key": "662671b2-173c-4e14-b44a-48c1ad587099",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6363,7 +6380,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "373d0d65-6d1c-4058-8269-a9fbb62e20b4",
+      "key": "cd6916eb-2dba-425c-8ac3-20c9f7f0a7d7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6373,7 +6390,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "8d5fde08-1435-4195-b2b0-8c100a1e44bf",
+      "key": "6bc99321-ef0f-4874-9ea0-6090bae6edba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6382,7 +6399,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "added96b-f5a0-413e-9e70-cdb7ecca8a35",
+      "key": "fc3c7601-7f3b-42e4-aa69-db726c491e10",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -6392,7 +6409,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "48672754-6568-4b2f-be27-3f6121e2649d",
+      "key": "34aefc7c-a9ad-4499-9972-ca5321d242a2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -6401,7 +6418,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e9b39145-7e98-4c0b-b0e2-808c9ae4a2da",
+      "key": "1f3c138a-f303-4549-8ef0-9365b9772ef1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6413,12 +6430,13 @@
             "y": 0,
             "z": 0
           }
-        }
+        },
+        "speed": 125
       }
     },
     {
       "commandType": "touchTip",
-      "key": "828c0d97-937e-45d2-b58c-c48539cb6be6",
+      "key": "0964de04-2fe4-42cc-b1c9-521464366d2d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6429,13 +6447,13 @@
             "z": -12.8
           }
         },
-        "speed": 0,
+        "speed": 400,
         "mmFromEdge": 0
       }
     },
     {
       "commandType": "dispense",
-      "key": "df4b2a2e-331c-4c49-8781-6985a00bc42a",
+      "key": "b4c1fe29-4e9d-45a3-ae90-0ba671dff5ba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -6454,7 +6472,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f7eb7dc9-dcec-4182-98e2-95dbc747276e",
+      "key": "961f8939-c084-40de-a551-9e84c11f47c6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6473,7 +6491,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "562a881e-795d-469f-8e19-5c379d24e2b8",
+      "key": "3ef6f5e6-9088-4005-9fc2-7ced744b2f32",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6493,7 +6511,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "40a28ea7-e248-40e3-ad17-e817e65a8d05",
+      "key": "0a2ab4ee-2121-4a8f-86d7-4698f5b621b4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6512,7 +6530,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4abc37c0-d162-4679-9028-a457f7383f8b",
+      "key": "739f6c76-cda2-4697-b76c-ba6cec7acbba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -6532,7 +6550,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "def6a61a-d961-491a-b6de-dcab18f9961b",
+      "key": "f6f657f3-830b-45f5-8cf4-13eb4242d731",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6545,7 +6563,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "04736e53-c1bf-43ec-b792-bf59de57d878",
+      "key": "0da48b2d-8d2a-460e-a8db-670da9b0c004",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -6553,7 +6571,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "1ccdeb08-82e6-4b51-8f6a-13fda988aa87",
+      "key": "c3a65b9e-8323-461b-a5e1-2aedeeb8f88a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6564,12 +6582,12 @@
             "z": -1
           }
         },
-        "speed": 0
+        "speed": 400
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "b5ffdeda-34c9-4ced-8308-7689948e9315",
+      "key": "5f595c73-94da-4ef2-b4f7-1ed54eab0f79",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6583,14 +6601,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "ae28198b-5489-436e-99d0-24141c33eb66",
+      "key": "6faa6c31-098f-47ae-9b8e-1d8f14d9694d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "089a6052-1c9a-447a-9050-192f6786bcdb",
+      "key": "1a2e1989-2b5a-4c36-82ca-db201fd891a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -6599,7 +6617,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "95db2086-efcf-418a-b062-6212ee108091",
+      "key": "3da571f7-f56f-490d-93e6-6290db50967e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6618,7 +6636,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f576ee29-b704-43b6-8577-da2d7e0e8c7e",
+      "key": "10759a5d-8f44-44a2-9944-b311f0cda929",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6638,7 +6656,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c37b75d0-e749-4535-85ee-b04029bb14f3",
+      "key": "43f93d2d-f9c6-4e3e-ba06-3a1a5d968a72",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6657,7 +6675,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2ed51c6e-f3fe-46a0-a76d-b274a570e710",
+      "key": "cfc562ce-3a52-4381-a8ba-4c6dc71cc2f5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6677,7 +6695,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b70e1440-620b-4f62-865a-bbb24a24b56e",
+      "key": "c057a033-2d84-4e68-8b82-ec77f50e0aae",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6696,7 +6714,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "416917d7-54ca-47a8-83cf-6ad65661e26b",
+      "key": "9bc874dd-5e09-4960-b845-a466000b50f1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -6716,7 +6734,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "53283687-1327-4e9a-a664-edc49b567278",
+      "key": "651b6eba-388b-4898-ac19-bf060a037973",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6729,7 +6747,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "2aacffe1-4edd-46d8-8539-1d1e1f46434f",
+      "key": "f48d9b96-21af-4aaa-b40f-4df0938622db",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -6737,7 +6755,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "0e7b2710-a0b6-4e71-a373-57ca7f1cea2a",
+      "key": "747edc52-b508-4a1d-9400-462241170a69",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
@@ -6752,7 +6770,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "30a9b224-ce6c-459a-8967-3c97d38162c4",
+      "key": "6f2a2377-0c86-4219-b33a-ff3c49d5592e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -6766,14 +6784,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "5f14498a-ccd8-46d2-83e8-bf4eb3751277",
+      "key": "b92eb02f-c351-405d-bafa-c1bb21e48c06",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
       }
     },
     {
       "commandType": "waitForDuration",
-      "key": "94009c5d-5bab-4c5d-bbc2-af8f9d057c59",
+      "key": "4ca4d7ee-42b3-4f0b-a3cd-e1ff863a816f",
       "params": {
         "seconds": 3723,
         "message": "Delay plz"

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -3,6 +3,7 @@ import mapValues from 'lodash/mapValues'
 import {
   ABSORBANCE_READER_TYPE,
   ABSORBANCE_READER_V1,
+  FLEX_ROBOT_TYPE,
   HEATERSHAKER_MODULE_TYPE,
   HEATERSHAKER_MODULE_V1,
   MAGNETIC_BLOCK_TYPE,
@@ -10,6 +11,7 @@ import {
   MAGNETIC_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
   MAGNETIC_MODULE_V2,
+  OT2_ROBOT_TYPE,
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V1,
   TEMPERATURE_MODULE_V2,
@@ -24,6 +26,7 @@ import type {
   LabwareDefinition2,
   ModuleModel,
   ModuleType,
+  RobotType,
 } from '@opentrons/shared-data'
 import type { DeckSlot, WellVolumes } from './types'
 
@@ -202,3 +205,44 @@ export const OFFDECK: 'offDeck' = 'offDeck'
 export const PROTOCOL_DESIGNER_SOURCE: 'Protocol Designer' = 'Protocol Designer' // protocolSource for tracking analytics in the app
 
 export const DECK_SETUP_TOOLS_WIDTH_REM = 21.875
+
+// Copied from opentrons/api/src/opentrons/config/defaults_ot[2/3].py
+export const CHANNELS_MAPPED_TO_MAX_SPEED: Record<
+  RobotType,
+  Record<number, { plunger: number; x: number; y: number; z: number }>
+> = {
+  [FLEX_ROBOT_TYPE]: {
+    1: {
+      plunger: 70,
+      x: 300,
+      y: 300,
+      z: 100,
+    },
+    8: {
+      plunger: 70,
+      x: 300,
+      y: 300,
+      z: 100,
+    },
+    96: {
+      plunger: 15,
+      x: 300,
+      y: 300,
+      z: 35,
+    },
+  },
+  [OT2_ROBOT_TYPE]: {
+    1: {
+      plunger: 40,
+      x: 600,
+      y: 400,
+      z: 125,
+    },
+    8: {
+      plunger: 40,
+      x: 600,
+      y: 400,
+      z: 125,
+    },
+  },
+}

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -206,43 +206,53 @@ export const PROTOCOL_DESIGNER_SOURCE: 'Protocol Designer' = 'Protocol Designer'
 
 export const DECK_SETUP_TOOLS_WIDTH_REM = 21.875
 
-// Copied from opentrons/api/src/opentrons/config/defaults_ot[2/3].py
+// Below values copied from opentrons/api/src/opentrons/config/defaults_ot[2/3].py
+export const FLEX_X_Y_MAX_SPEED = 300
+export const FLEX_LOW_THROUGHPUT_Z_MAX_SPEED = 100
+export const FLEX_HIGH_THROUGHPUT_Z_MAX_SPEED = 35
+export const FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED = 70
+export const FLEX_HIGH_THROUGHPUT_PLUNGER_MAX_SPEED = 15
+export const OT2_X_MAX_SPEED = 600
+export const OT2_Y_MAX_SPEED = 400
+export const OT2_Z_MAX_SPEED = 125
+export const OT2_PLUNGER_MAX_SPEED = 40
+
 export const CHANNELS_MAPPED_TO_MAX_SPEED: Record<
   RobotType,
   Record<number, { plunger: number; x: number; y: number; z: number }>
 > = {
   [FLEX_ROBOT_TYPE]: {
     1: {
-      plunger: 70,
-      x: 300,
-      y: 300,
-      z: 100,
+      plunger: FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED,
+      x: FLEX_X_Y_MAX_SPEED,
+      y: FLEX_X_Y_MAX_SPEED,
+      z: FLEX_LOW_THROUGHPUT_Z_MAX_SPEED,
     },
     8: {
-      plunger: 70,
-      x: 300,
-      y: 300,
-      z: 100,
+      plunger: FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED,
+      x: FLEX_X_Y_MAX_SPEED,
+      y: FLEX_X_Y_MAX_SPEED,
+      z: FLEX_LOW_THROUGHPUT_Z_MAX_SPEED,
     },
     96: {
-      plunger: 15,
-      x: 300,
-      y: 300,
-      z: 35,
+      plunger: FLEX_HIGH_THROUGHPUT_PLUNGER_MAX_SPEED,
+      x: FLEX_X_Y_MAX_SPEED,
+      y: FLEX_X_Y_MAX_SPEED,
+      z: FLEX_HIGH_THROUGHPUT_Z_MAX_SPEED,
     },
   },
   [OT2_ROBOT_TYPE]: {
     1: {
-      plunger: 40,
-      x: 600,
-      y: 400,
-      z: 125,
+      plunger: OT2_PLUNGER_MAX_SPEED,
+      x: OT2_X_MAX_SPEED,
+      y: OT2_Y_MAX_SPEED,
+      z: OT2_Z_MAX_SPEED,
     },
     8: {
-      plunger: 40,
-      x: 600,
-      y: 400,
-      z: 125,
+      plunger: OT2_PLUNGER_MAX_SPEED,
+      x: OT2_X_MAX_SPEED,
+      y: OT2_Y_MAX_SPEED,
+      z: OT2_Z_MAX_SPEED,
     },
   },
 }

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -1,12 +1,15 @@
 import floor from 'lodash/floor'
+import min from 'lodash/min'
 
 import {
+  FLEX_ROBOT_TYPE,
   getPipetteSpecsV2,
   POSITION_REFERENCE_BOTTOM,
   POSITION_REFERENCE_TOP,
 } from '@opentrons/shared-data'
 
 import {
+  CHANNELS_MAPPED_TO_MAX_SPEED,
   DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_EDGE,
   PROTOCOL_DESIGNER_SOURCE,
 } from '../../constants'
@@ -23,12 +26,12 @@ import type { PDMetadata } from '../../file-types'
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>
 ): ProtocolFile<PDMetadata> => {
-  const { designerApplication, commands, labwareDefinitions } = appData
+  const { designerApplication, commands, labwareDefinitions, robot } = appData
   if (designerApplication == null || designerApplication?.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
   }
   const { savedStepForms } = designerApplication.data
-
+  const { model: robotType } = robot
   const loadLabwareCommands = commands.filter(
     (command): command is LoadLabwareCreateCommand =>
       command.commandType === 'loadLabware'
@@ -79,6 +82,15 @@ export const migrateFile = (
               tipRackDef
             )
 
+      const channelsForSpeed =
+        pipetteSpecs?.channels ?? (robotType === FLEX_ROBOT_TYPE ? 96 : 8)
+      const maxZSpeed =
+        CHANNELS_MAPPED_TO_MAX_SPEED[robotType][channelsForSpeed].z
+      const maxXYSpeed = min([
+        CHANNELS_MAPPED_TO_MAX_SPEED[robotType][channelsForSpeed].x,
+        CHANNELS_MAPPED_TO_MAX_SPEED[robotType][channelsForSpeed].y,
+      ])
+
       return {
         ...acc,
         [id]: {
@@ -104,14 +116,14 @@ export const migrateFile = (
                 ),
           aspirate_retract_delay_seconds: null,
           dispense_retract_delay_seconds: null,
-          aspirate_retract_speed: null,
-          dispense_retract_speed: null,
+          aspirate_retract_speed: maxZSpeed,
+          dispense_retract_speed: maxZSpeed,
           aspirate_submerge_delay_seconds: null,
           dispense_submerge_delay_seconds: null,
-          aspirate_submerge_speed: null,
-          dispense_submerge_speed: null,
-          aspirate_touchTip_speed: null,
-          dispense_touchTip_speed: null,
+          aspirate_submerge_speed: maxZSpeed,
+          dispense_submerge_speed: maxZSpeed,
+          aspirate_touchTip_speed: maxXYSpeed,
+          dispense_touchTip_speed: maxXYSpeed,
           aspirate_touchTip_mmFromEdge: DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_EDGE, // this field and the following were previously not configurable and defaulted to 0mm
           dispense_touchTip_mmFromEdge: DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_EDGE,
           aspirate_position_reference: POSITION_REFERENCE_BOTTOM,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
@@ -1,7 +1,6 @@
 import round from 'lodash/round'
 
-import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
-
+import { CHANNELS_MAPPED_TO_MAX_SPEED } from '../../../../../constants'
 import { getPipetteCapacity } from '../../../../../pipettes/pipetteData'
 import {
   volumeInCapacityForMultiAspirate,
@@ -188,21 +187,6 @@ export function getDisabledPathMap(
   return disabledPathMap
 }
 
-// Copied from opentrons/api/src/opentrons/config/defaults_ot3.py
-export const MAX_PLUNGER_SPEED_FLEX_HIGH_THROUGHPUT_MM_PER_S = 15
-export const MAX_PLUNGER_SPEED_FLEX_LOW_THROUGHPUT_MM_PER_S = 70
-// Copied from opentrons/api/src/opentrons/config/defaults_ot2.py
-export const MAX_PLUNGER_SPEED_OT2 = 125
-
-export const CHANNELS_MAPPED_TO_MAX_PLUNGER_SPEED: Record<
-  PipetteChannels,
-  number
-> = {
-  1: MAX_PLUNGER_SPEED_FLEX_LOW_THROUGHPUT_MM_PER_S,
-  8: MAX_PLUNGER_SPEED_FLEX_LOW_THROUGHPUT_MM_PER_S,
-  96: MAX_PLUNGER_SPEED_FLEX_HIGH_THROUGHPUT_MM_PER_S,
-}
-
 const _getPipetteAccuracyUlPerMm = (
   targetVolume: number,
   tipLiquidSpecs: SupportedTip,
@@ -245,9 +229,7 @@ export const getMaxUiFlowRate = (args: {
     flowRateType
   )
   const maxPlungerSpeed =
-    robotType === OT2_ROBOT_TYPE
-      ? MAX_PLUNGER_SPEED_OT2
-      : CHANNELS_MAPPED_TO_MAX_PLUNGER_SPEED[channels]
+    CHANNELS_MAPPED_TO_MAX_SPEED[robotType][channels].plunger
   const correctionMultiplier = 1.0 + correctionVolume / targetVolume
   const travelMm = targetVolume / pipetteAccuracyUlPerMm
   const travelMmCorrected = travelMm * correctionMultiplier

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/__tests__/utils.test.ts
@@ -7,12 +7,7 @@ import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
 
-import {
-  getMaxUiFlowRate,
-  MAX_PLUNGER_SPEED_FLEX_HIGH_THROUGHPUT_MM_PER_S,
-  MAX_PLUNGER_SPEED_FLEX_LOW_THROUGHPUT_MM_PER_S,
-  MAX_PLUNGER_SPEED_OT2,
-} from '../PipetteFields/utils'
+import { getMaxUiFlowRate } from '../PipetteFields/utils'
 import {
   capitalizeFirstLetter,
   getBlowoutLocationOptionsForForm,
@@ -184,9 +179,7 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.05 * 50 + 1
     const expectedTravelMm = 50 / expectedAccuracy
-    const expectedMaxFlowRate = round(
-      50 / (expectedTravelMm / MAX_PLUNGER_SPEED_OT2)
-    )
+    const expectedMaxFlowRate = round(50 / (expectedTravelMm / 40))
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
@@ -201,9 +194,7 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.06 * 20 + 1.2
     const expectedTravelMm = 20 / expectedAccuracy
-    const expectedMaxFlowRate = round(
-      20 / (expectedTravelMm / MAX_PLUNGER_SPEED_FLEX_LOW_THROUGHPUT_MM_PER_S)
-    )
+    const expectedMaxFlowRate = round(20 / (expectedTravelMm / 70))
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
@@ -218,9 +209,7 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.06 * 80 + 1.2
     const expectedTravelMm = 80 / expectedAccuracy
-    const expectedMaxFlowRate = round(
-      80 / (expectedTravelMm / MAX_PLUNGER_SPEED_FLEX_LOW_THROUGHPUT_MM_PER_S)
-    )
+    const expectedMaxFlowRate = round(80 / (expectedTravelMm / 70))
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
@@ -235,9 +224,7 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.1 * 5 + 0.5
     const expectedTravelMm = 5 / expectedAccuracy
-    const expectedMaxFlowRate = round(
-      5 / (expectedTravelMm / MAX_PLUNGER_SPEED_FLEX_HIGH_THROUGHPUT_MM_PER_S)
-    )
+    const expectedMaxFlowRate = round(5 / (expectedTravelMm / 15))
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
@@ -254,9 +241,7 @@ describe('getMaxUiFlowRate', () => {
     const expectedTravelMm = 50 / expectedAccuracy
     const correctionMultiplier = 1 + 10 / 50
     const expectedTravelMmCorrected = expectedTravelMm * correctionMultiplier
-    const expectedMaxFlowRate = round(
-      50 / (expectedTravelMmCorrected / MAX_PLUNGER_SPEED_OT2)
-    )
+    const expectedMaxFlowRate = round(50 / (expectedTravelMmCorrected / 40))
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
@@ -271,8 +256,7 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.05 * 150 + 1 // Using the last entry [100, 0.05, 1]
     const expectedTravelMm = 150 / expectedAccuracy
-    const expectedMaxFlowRate =
-      150 / (expectedTravelMm / MAX_PLUNGER_SPEED_FLEX_LOW_THROUGHPUT_MM_PER_S)
+    const expectedMaxFlowRate = 150 / (expectedTravelMm / 70)
     expect(getMaxUiFlowRate(largeVolumeArgs)).toEqual(expectedMaxFlowRate)
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/__tests__/utils.test.ts
@@ -7,6 +7,11 @@ import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
 
+import {
+  FLEX_HIGH_THROUGHPUT_PLUNGER_MAX_SPEED,
+  FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED,
+  OT2_PLUNGER_MAX_SPEED,
+} from '../../../../../constants'
 import { getMaxUiFlowRate } from '../PipetteFields/utils'
 import {
   capitalizeFirstLetter,
@@ -179,11 +184,13 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.05 * 50 + 1
     const expectedTravelMm = 50 / expectedAccuracy
-    const expectedMaxFlowRate = round(50 / (expectedTravelMm / 40))
+    const expectedMaxFlowRate = round(
+      50 / (expectedTravelMm / OT2_PLUNGER_MAX_SPEED)
+    )
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
-  it('should calculate max flow rate for OT-3 single channel', () => {
+  it('should calculate max flow rate for Flex single channel', () => {
     const args = {
       targetVolume: 20,
       channels: 1,
@@ -194,11 +201,13 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.06 * 20 + 1.2
     const expectedTravelMm = 20 / expectedAccuracy
-    const expectedMaxFlowRate = round(20 / (expectedTravelMm / 70))
+    const expectedMaxFlowRate = round(
+      20 / (expectedTravelMm / FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED)
+    )
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
-  it('should calculate max flow rate for OT-3 8-channel', () => {
+  it('should calculate max flow rate for Flex 8-channel', () => {
     const args = {
       targetVolume: 80,
       channels: 8,
@@ -209,11 +218,13 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.06 * 80 + 1.2
     const expectedTravelMm = 80 / expectedAccuracy
-    const expectedMaxFlowRate = round(80 / (expectedTravelMm / 70))
+    const expectedMaxFlowRate = round(
+      80 / (expectedTravelMm / FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED)
+    )
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
-  it('should calculate max flow rate for OT-3 96-channel', () => {
+  it('should calculate max flow rate for Flex 96-channel', () => {
     const args = {
       targetVolume: 5,
       channels: 96,
@@ -224,7 +235,9 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.1 * 5 + 0.5
     const expectedTravelMm = 5 / expectedAccuracy
-    const expectedMaxFlowRate = round(5 / (expectedTravelMm / 15))
+    const expectedMaxFlowRate = round(
+      5 / (expectedTravelMm / FLEX_HIGH_THROUGHPUT_PLUNGER_MAX_SPEED)
+    )
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
@@ -241,7 +254,9 @@ describe('getMaxUiFlowRate', () => {
     const expectedTravelMm = 50 / expectedAccuracy
     const correctionMultiplier = 1 + 10 / 50
     const expectedTravelMmCorrected = expectedTravelMm * correctionMultiplier
-    const expectedMaxFlowRate = round(50 / (expectedTravelMmCorrected / 40))
+    const expectedMaxFlowRate = round(
+      50 / (expectedTravelMmCorrected / OT2_PLUNGER_MAX_SPEED)
+    )
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })
 
@@ -256,7 +271,8 @@ describe('getMaxUiFlowRate', () => {
     } as any
     const expectedAccuracy = 0.05 * 150 + 1 // Using the last entry [100, 0.05, 1]
     const expectedTravelMm = 150 / expectedAccuracy
-    const expectedMaxFlowRate = 150 / (expectedTravelMm / 70)
+    const expectedMaxFlowRate =
+      150 / (expectedTravelMm / FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED)
     expect(getMaxUiFlowRate(largeVolumeArgs)).toEqual(expectedMaxFlowRate)
   })
 })


### PR DESCRIPTION
# Overview

Add migrations for aspirate/dispense submerge/retract and touch tip speeds based on the robot default speeds. Refactors all axis speed constants into a by-robot, by-nozzle mapping.

## Test Plan and Hands on Testing

- review applied max speeds in migration 
- check that I correctly grabbed the max speeds values from `opentrons/api/src/opentrons/config/defaults_ot[2/3].py`

## Changelog

- refactor max speed constants into by-robot, by-nozzle mapping
- use constants in tests
- apply max speeds in migration for submerge/aspirate speeds and touch tip speeds

## Review requests

- see test plan

## Risk assessment

low