### PR TITLE
fix(app): fix protocol run header action button copy when implictly closing a run

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -83,7 +83,7 @@ export function useActionButtonProperties({
     buttonText = t('analyzing_on_robot')
   } else if (isClosingCurrentRun) {
     buttonIconName = 'ot-spinner'
-    buttonText = t('canceling_run')
+    buttonText = t('shared:robot_is_busy')
   } else if (runStatus === RUN_STATUS_RUNNING || isRecoveryStatus(runStatus)) {
     buttonIconName = 'pause'
     buttonText = t('pause_run')

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
@@ -127,7 +127,10 @@ export function ActionButton(props: ActionButtonProps): JSX.Element {
         boxShadow="none"
         display={DISPLAY_FLEX}
         padding={`${SPACING.spacing12} ${SPACING.spacing16}`}
-        disabled={isDisabled && !validRunAgainButRequiresSetup}
+        // TODO(jh, 05-05-25): These boolean checks should live in useActionBtnDisabledUtils as a part of the singular disabled check.
+        disabled={
+          isDisabled && (!validRunAgainButRequiresSetup || isClosingCurrentRun)
+        }
         onClick={handleButtonClick}
         id="ProtocolRunHeader_runControlButton"
         {...targetProps}


### PR DESCRIPTION
Closes [RQA-4170](https://opentrons.atlassian.net/browse/RQA-4170)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In https://github.com/Opentrons/opentrons/pull/18130, we had to touch the very fun Protocol Run Header's "run action" button logic, but the copy wasn't updated.

Only when a run is explictly cancelled (which doesn't uncurrent the run immediately), should we show "cancelling run". There are instances when we implictly uncurrent the run, and in these spots, we want to show "robot is busy".

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- @TamarZanzouri was kind enough to run through a few protocols on the OT-2 flex and confirm appropriate behavior.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the desktop run action button sometimes display "canceling run" instead of "robot is busy" 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
none, just copy
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4170]: https://opentrons.atlassian.net/browse/RQA-4170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ