### PR TITLE
chore: pin virtualenv 20.30.0 in outer py env

### DIFF
--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -33,4 +33,6 @@ runs:
     - shell: bash
       run: $OT_PYTHON -m pip install --user pipenv==2023.12.1
     - shell: bash
+      run: $OT_PYTHON -m pip install --user virtualenv==20.30.0
+    - shell: bash
       run: 'make -C ${{ inputs.project }} setup || make -C ${{ inputs.project }} setup'

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ setup: setup-js setup-py
 .PHONY: setup-py-toolchain
 setup-py-toolchain:
 	$(OT_PYTHON) -m pip install --upgrade pip
+	$(OT_PYTHON) -m pip install virtualenv==20.30.0
 	$(OT_PYTHON) -m pip install pipenv==2023.12.1
 
 # front-end dependecies handled by yarn

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,9 @@ setup: setup-js setup-py
 .PHONY: setup-py-toolchain
 setup-py-toolchain:
 	$(OT_PYTHON) -m pip install --upgrade pip
-	$(OT_PYTHON) -m pip install virtualenv==20.30.0
 	$(OT_PYTHON) -m pip install pipenv==2023.12.1
+    # this needs to be installed AFTER pipenv or pipenv will update this to the bad version
+	$(OT_PYTHON) -m pip install virtualenv==20.30.0
 
 # front-end dependecies handled by yarn
 .PHONY: setup-js


### PR DESCRIPTION
virtualenv is what pipenv uses to make virtualenvs. pipenv doesn't pin this but sets a min version dependency. virtualenv 20.31.0 interns pip 25.1 which interns a version of setuptools recent enough that it doesnt support old-style static developer installs, which are still a problem for static analysis tools [3 years after somebody noticed it](https://github.com/pypa/setuptools/issues/3518) which I think is pretty cool!

## testing
- [x] can you run `make teardown-py` and then `pip install --upgrade virtualenv` and then `make setup-py` and then `make lint-py`
- [x] can ci also do this 
