### PR TITLE
feat(step-generation) generate Python for `dispenseInPlace` CommandCreator

### DIFF
--- a/step-generation/src/__tests__/dispenseInPlace.test.ts
+++ b/step-generation/src/__tests__/dispenseInPlace.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { dispenseInPlace } from '../commandCreators/atomic'
 import {
+  DEFAULT_PIPETTE,
   getRobotStateWithTipStandard,
   getSuccessResult,
   makeContext,
@@ -14,7 +15,7 @@ describe('dispenseInPlace', () => {
   let invariantContext: InvariantContext
   let robotStateWithTip: RobotState
 
-  const mockId = 'mockId'
+  const mockId = DEFAULT_PIPETTE
   const mockFlowRate = 10
   const mockVolume = 10
   beforeEach(() => {
@@ -40,5 +41,12 @@ describe('dispenseInPlace', () => {
         },
       },
     ])
+    expect(res.python).toBe(
+      `
+mock_pipette.dispense(
+    volume=10,
+    rate=10 / mock_pipette.flow_rate.dispense,
+)`.trimStart()
+    )
   })
 })

--- a/step-generation/src/commandCreators/atomic/dispenseInPlace.ts
+++ b/step-generation/src/commandCreators/atomic/dispenseInPlace.ts
@@ -1,4 +1,4 @@
-import { uuid } from '../../utils'
+import { indentPyLines, uuid } from '../../utils'
 
 import type { DispenseInPlaceParams } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
@@ -22,7 +22,22 @@ export const dispenseInPlace: CommandCreator<DispenseInPlaceParams> = (
       },
     },
   ]
+
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const pythonArgs = [
+    `volume=${volume}`,
+    // rate= is a ratio in the PAPI, and we have no good way to figure out what
+    // flowrate the PAPI has set the pipette to, so we just have to emit a division:
+    `rate=${flowRate} / ${pipettePythonName}.flow_rate.dispense`,
+    ...(pushOut != null ? [`push_out=${pushOut}`] : []),
+  ]
+  const python = `${pipettePythonName}.dispense(\n${indentPyLines(
+    pythonArgs.join(',\n')
+  )},\n)`
+
   return {
     commands,
+    python,
   }
 }


### PR DESCRIPTION
# Overview

I noticed that we didn't generate Python for `dispenseInPlace`. We will very likely need it for the new PD transfer step generator, and it's easy enough to implement it, so this PR emits the Python code for `dispenseInPlace`. AUTH-1094

## Test Plan and Hands on Testing

Updated unit test.

## Risk assessment

Low.