### PR TITLE
test(protocol-designer): don't print the DOM tree in SlotInformation.test.tsx

### DIFF
--- a/protocol-designer/src/components/organisms/SlotInformation/__tests__/SlotInformation.test.tsx
+++ b/protocol-designer/src/components/organisms/SlotInformation/__tests__/SlotInformation.test.tsx
@@ -68,7 +68,6 @@ describe('SlotInformation', () => {
       modules: mockModules,
     }
     render(props)
-    screen.debug()
 
     expect(screen.getAllByText('Liquid').length).toBe(1)
     expect(screen.getAllByText('Labware').length).toBe(


### PR DESCRIPTION
# Overview

SlotInformation.test.tsx was calling `screen.debug()` to print the whole DOM tree to the console, which was cluttering up the vitest output.

@ncdiehl11 You don't need this anymore, right? 

## Test Plan and Hands on Testing

Ran tests after change.

## Risk assessment

Low. Test-only change.