### PR TITLE
fix(opentrons-ai-client): Match Module button designs with Figma [AUTH-1699] 

### DIFF
--- a/opentrons-ai-client/src/molecules/ControlledEmptySelectorButtonGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ControlledEmptySelectorButtonGroup/index.tsx
@@ -7,12 +7,6 @@ import { MODULES_FIELD_NAME } from '../../organisms/ModulesSection'
 
 import type { DisplayModules } from '../../organisms/ModulesSection'
 
-const ButtonWrapper = styled.div`
-  display: inline-block;
-  flex-grow: 0;
-  flex-shrink: 1;
-`
-
 export function ControlledEmptySelectorButtonGroup({
   modules,
 }: {
@@ -54,3 +48,9 @@ export function ControlledEmptySelectorButtonGroup({
     />
   )
 }
+
+const ButtonWrapper = styled.div`
+  display: inline-block;
+  flex-grow: 0;
+  flex-shrink: 1;
+`

--- a/opentrons-ai-client/src/molecules/ControlledEmptySelectorButtonGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ControlledEmptySelectorButtonGroup/index.tsx
@@ -1,10 +1,17 @@
 import { Controller, useFormContext } from 'react-hook-form'
+import styled from 'styled-components'
 
 import { EmptySelectorButton, Flex, SPACING, WRAP } from '@opentrons/components'
 
 import { MODULES_FIELD_NAME } from '../../organisms/ModulesSection'
 
 import type { DisplayModules } from '../../organisms/ModulesSection'
+
+const ButtonWrapper = styled.div`
+  display: inline-block;
+  flex-grow: 0;
+  flex-shrink: 1;
+`
 
 export function ControlledEmptySelectorButtonGroup({
   modules,
@@ -20,20 +27,26 @@ export function ControlledEmptySelectorButtonGroup({
       name={MODULES_FIELD_NAME}
       render={({ field }) => {
         return (
-          <Flex flexWrap={WRAP} gap={SPACING.spacing8}>
+          <Flex
+            flexWrap={WRAP}
+            gap={SPACING.spacing8}
+            justifyContent="flex-start"
+          >
             {modules.map(module => (
-              <EmptySelectorButton
-                key={module.type}
-                iconName="plus"
-                onClick={() => {
-                  if (modulesWatch.some(m => m.type === module.type)) {
-                    return
-                  }
-                  field.onChange([...modulesWatch, module])
-                }}
-                text={module.name}
-                textAlignment="left"
-              />
+              <ButtonWrapper key={module.type}>
+                <EmptySelectorButton
+                  key={module.type}
+                  iconName="plus"
+                  onClick={() => {
+                    if (modulesWatch.some(m => m.type === module.type)) {
+                      return
+                    }
+                    field.onChange([...modulesWatch, module])
+                  }}
+                  text={module.name}
+                  textAlignment="left"
+                />
+              </ButtonWrapper>
             ))}
           </Flex>
         )


### PR DESCRIPTION
# Overview
UI module selection buttons match with Figma

**This PR:**
<img width="828" alt="image" src="https://github.com/user-attachments/assets/607f6fd6-7ab6-42c1-b992-a8d588ae2951" />

**Previous:**
<img width="890" alt="image" src="https://github.com/user-attachments/assets/2da19988-812a-42f6-9f73-a5b92124671b" />




Closes AUTH-1699


## Changelog

Only UI change

## Review requests
- Run it and check if modules are properly shown.


## Risk assessment
Low
