### PR TITLE
test(step-generation): fix blowOutInPlace.test.ts after test broke due to merge order

### DIFF
--- a/step-generation/src/__tests__/blowOutInPlace.test.ts
+++ b/step-generation/src/__tests__/blowOutInPlace.test.ts
@@ -39,8 +39,8 @@ describe('blowOutInPlace', () => {
     ])
     expect(res.python).toBe(
       `
-mockPythonName.flow_rate.blow_out = 10
-mockPythonName.blow_out()
+mock_pipette.flow_rate.blow_out = 10
+mock_pipette.blow_out()
 `.trim()
     )
   })


### PR DESCRIPTION
# Overview

I had 2 simultaneous PRs (#18247 and #18245) that each individually passed all the tests at the time the PRs were written, but that caused `blowOutInPlace.test.ts` to fail after both PRs were merged in. This fixes the test.

## Test Plan and Hands on Testing

All the tests in `protocol-designer` and `step-generation` pass now after this fix.

## Risk assessment

Low, test only.