### PR TITLE
fix(api): Ensure validate pipette movement safety for liquid probe

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -2283,6 +2283,13 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         well_location = WellLocation(
             origin=WellOrigin.TOP, offset=WellOffset(x=offset.x, y=offset.y, z=offset.z)
         )
+        pipette_movement_conflict.check_safe_for_pipette_movement(
+            engine_state=self._engine_client.state,
+            pipette_id=self._pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+        )
         self._engine_client.execute_command(
             cmd.LiquidProbeParams(
                 labwareId=labware_id,
@@ -2302,6 +2309,13 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         well_name = well_core.get_name()
         well_location = WellLocation(
             origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
+        )
+        pipette_movement_conflict.check_safe_for_pipette_movement(
+            engine_state=self._engine_client.state,
+            pipette_id=self._pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
         )
         result = self._engine_client.execute_command_without_recovery(
             cmd.LiquidProbeParams(

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -1776,6 +1776,53 @@ def test_liquid_probe_without_recovery(
         subject.liquid_probe_without_recovery(well_core=well_core, loc=loc)
 
 
+def test_liquid_probe_without_recovery_unsafe(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: InstrumentCore,
+) -> None:
+    """It should raise an exception on when attempting to liquid probe out of bounds when the pipette is in partial tip."""
+    well_core = WellCore(
+        name="my cool well", labware_id="123abc", engine_client=mock_engine_client
+    )
+    decoy.when(
+        pipette_movement_conflict.check_safe_for_pipette_movement(
+            engine_state=mock_engine_client.state,
+            pipette_id=subject.pipette_id,
+            labware_id=well_core.labware_id,
+            well_name=well_core.get_name(),
+            well_location=WellLocation(
+                origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
+            ),
+        )
+    ).then_raise(
+        pipette_movement_conflict.PartialTipMovementNotAllowedError(
+            "Requested motion with the A1 nozzle partial configuration is outside of robot bounds for the pipette."
+        )
+    )
+
+    decoy.when(
+        mock_engine_client.execute_command_without_recovery(
+            cmd.LiquidProbeParams(
+                pipetteId=subject.pipette_id,
+                wellLocation=WellLocation(
+                    origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
+                ),
+                wellName=well_core.get_name(),
+                labwareId=well_core.labware_id,
+            )
+        )
+    ).then_return(
+        cmd.LiquidProbeResult(position=DeckPoint(x=0, y=0, z=0), z_position=0)
+    )
+    loc = Location(Point(0, 0, 0), None)
+    with pytest.raises(
+        pipette_movement_conflict.PartialTipMovementNotAllowedError,
+        match="Requested motion with the A1 nozzle partial configuration is outside of robot bounds for the pipette.",
+    ):
+        subject.liquid_probe_without_recovery(well_core=well_core, loc=loc)
+
+
 def test_liquid_probe_with_recovery(
     decoy: Decoy,
     mock_engine_client: EngineClient,
@@ -1799,6 +1846,53 @@ def test_liquid_probe_with_recovery(
             )
         )
     )
+
+
+def test_liquid_probe_with_recovery_unsafe(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: InstrumentCore,
+) -> None:
+    """It should raise an exception on when attempting to liquid probe out of bounds when the pipette is in partial tip."""
+    well_core = WellCore(
+        name="my cool well", labware_id="123abc", engine_client=mock_engine_client
+    )
+    decoy.when(
+        pipette_movement_conflict.check_safe_for_pipette_movement(
+            engine_state=mock_engine_client.state,
+            pipette_id=subject.pipette_id,
+            labware_id=well_core.labware_id,
+            well_name=well_core.get_name(),
+            well_location=WellLocation(
+                origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
+            ),
+        )
+    ).then_raise(
+        pipette_movement_conflict.PartialTipMovementNotAllowedError(
+            "Requested motion with the A1 nozzle partial configuration is outside of robot bounds for the pipette."
+        )
+    )
+
+    decoy.when(
+        mock_engine_client.execute_command(
+            cmd.LiquidProbeParams(
+                pipetteId=subject.pipette_id,
+                wellLocation=WellLocation(
+                    origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2.0)
+                ),
+                wellName=well_core.get_name(),
+                labwareId=well_core.labware_id,
+            )
+        )
+    ).then_return(
+        cmd.LiquidProbeResult(position=DeckPoint(x=0, y=0, z=0), z_position=0)
+    )
+    loc = Location(Point(0, 0, 0), None)
+    with pytest.raises(
+        pipette_movement_conflict.PartialTipMovementNotAllowedError,
+        match="Requested motion with the A1 nozzle partial configuration is outside of robot bounds for the pipette.",
+    ):
+        subject.liquid_probe_with_recovery(well_core=well_core, loc=loc)
 
 
 @pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 23)))


### PR DESCRIPTION
# Overview
Covers RQA-4174

Liquid probe calls were not checking the ensure that a given pipette movement was within the deck bounds and avoiding certain collisions, this PR adds that in.

## Test Plan and Hands on Testing
- [x] Protocol that attempts to liquid probe at an out of bounds position for partial tip should fail analysis
- [x] Unit tests enforcing this

## Changelog
Added `check_safe_for_pipette_movement` to liquid probe core methods.

## Review requests


## Risk assessment
Low - fixes missed analysis raises on new behavior