### PR TITLE
fix(step-generation): allow multiple labware to be in the waste chute

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -34,6 +34,7 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 - Choose a new tip drop location from the dropdown menu when an uploaded protocol is missing a drop tip location.
 - Protocol Designer correctly updates adapter and labware combination definitions when you upload a protocol designed in Protocol Designer v7.0.0 or earlier.
 - When adding a disposal volume, a blowout location is now required.
+- If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, a timeline error is now raised.
 
 Running a protocol created in Protocol Designer now requires Opentrons App version 8.4.0 or newer.
 

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -109,7 +109,9 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
     })
   )
   const hasMultipleObjectsInSameSlot =
-    largestStackLoadnames?.length > 0 && !isStackingAllowed
+    largestStackLoadnames?.length > 0 &&
+    !isStackingAllowed &&
+    !newLocationInWasteChute
 
   if (!labwareId || !prevRobotState.labware[labwareId]) {
     errors.push(


### PR DESCRIPTION
closes AUTH-1802

# Overview

In production, if you end up with 2 labware in the same slot from editing the timeline, a timeline error DOES NOT raise to let you know - essentially leading to a silent fail in PD until you upload to the app. We totally fixed this bug in the passed but when i was working on adding stacking, i fixed it again, but not fully. 

So this pr fixes the bug completely by raising an error if multiple labware are in the same slot but not raising the error if the same slot has the waste chute.

## Test Plan and Hands on Testing

Upload the protocol attached to the ticket and see that there is a timeline error. move the labware to the waste chute and see that there are no errors.

## Changelog

- allow multiple labware in waste chute

## Risk assessment

low
