### PR TITLE
fix(protocol-designer): disallow touch_tip from reseviors again

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -34,6 +34,7 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 - Choose a new tip drop location from the dropdown menu when an uploaded protocol is missing a drop tip location.
 - Protocol Designer correctly updates adapter and labware combination definitions when you upload a protocol designed in Protocol Designer v7.0.0 or earlier.
 - When adding a disposal volume, a blowout location is now required.
+- No longer allow touch tip with incompatible labware. This results in a change in behavior from imported protocols that had touch tip on incompatible labware.
 
 Running a protocol created in Protocol Designer now requires Opentrons App version 8.4.0 or newer.
 

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -54,11 +54,15 @@ export const migrateFile = (
         dispense_touchTip_checkbox,
         ...rest
       } = form
+      const aspirateLabwareUri =
+        equipmentLoadInfoFromCommands.labware[aspirate_labware].labwareDefURI
       const isAspirateLabwareTouchtipDisabled = labwareDefinitions[
-        aspirate_labware
+        aspirateLabwareUri
       ].parameters.quirks?.includes('touchTipDisabled')
+      const dispenseLabwareUri =
+        equipmentLoadInfoFromCommands.labware[dispense_labware].labwareDefURI
       const isDispenseLabwareTouchtipDisabled = labwareDefinitions[
-        dispense_labware
+        dispenseLabwareUri
       ].parameters.quirks?.includes('touchTipDisabled')
       const matchingAspirateLabwareWellDepth = getMigratedPositionFromTop(
         labwareDefinitions,
@@ -173,8 +177,10 @@ export const migrateFile = (
           ...rest
         } = form
         const tipRackDef = labwareDefinitions[form.tipRack]
+        const mixLabwareUri =
+          equipmentLoadInfoFromCommands.labware[labware].labwareDefURI
         const isLabwareTouchtipDisabled = labwareDefinitions[
-          labware
+          mixLabwareUri
         ].parameters.quirks?.includes('touchTipDisabled')
         const pipetteName =
           equipmentLoadInfoFromCommands.pipettes?.[form.pipette]?.pipetteName ??

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -50,8 +50,16 @@ export const migrateFile = (
         dispense_labware,
         liquidClassesSupported,
         liquidClass,
+        aspirate_touchTip_checkbox,
+        dispense_touchTip_checkbox,
         ...rest
       } = form
+      const isAspirateLabwareTouchtipDisabled = labwareDefinitions[
+        aspirate_labware
+      ].parameters.quirks?.includes('touchTipDisabled')
+      const isDispenseLabwareTouchtipDisabled = labwareDefinitions[
+        dispense_labware
+      ].parameters.quirks?.includes('touchTipDisabled')
       const matchingAspirateLabwareWellDepth = getMigratedPositionFromTop(
         labwareDefinitions,
         loadLabwareCommands,
@@ -86,16 +94,24 @@ export const migrateFile = (
           id,
           aspirate_labware,
           dispense_labware,
+          aspirate_touchTip_checkbox: isAspirateLabwareTouchtipDisabled
+            ? false
+            : aspirate_touchTip_checkbox,
           aspirate_touchTip_mmFromTop:
-            aspirate_touchTip_mmFromBottom == null
+            aspirate_touchTip_mmFromBottom == null ||
+            isAspirateLabwareTouchtipDisabled
               ? null
               : floor(
                   aspirate_touchTip_mmFromBottom -
                     matchingAspirateLabwareWellDepth,
                   1
                 ),
+          dispense_touchTip_checkbox: isDispenseLabwareTouchtipDisabled
+            ? false
+            : dispense_touchTip_checkbox,
           dispense_touchTip_mmfromTop:
-            dispense_touchTip_mmFromBottom == null
+            dispense_touchTip_mmFromBottom == null ||
+            isDispenseLabwareTouchtipDisabled
               ? null
               : floor(
                   dispense_touchTip_mmFromBottom -
@@ -153,9 +169,13 @@ export const migrateFile = (
           mix_touchTip_mmFromBottom,
           labware,
           liquidClassesSupported,
+          mix_touchTip_checkbox,
           ...rest
         } = form
         const tipRackDef = labwareDefinitions[form.tipRack]
+        const isLabwareTouchtipDisabled = labwareDefinitions[
+          labware
+        ].parameters.quirks?.includes('touchTipDisabled')
         const pipetteName =
           equipmentLoadInfoFromCommands.pipettes?.[form.pipette]?.pipetteName ??
           null
@@ -182,8 +202,11 @@ export const migrateFile = (
             ...rest,
             id,
             labware,
+            mix_touchTip_checkbox: isLabwareTouchtipDisabled
+              ? false
+              : mix_touchTip_checkbox,
             mix_touchTip_mmFromTop:
-              mix_touchTip_mmFromBottom == null
+              mix_touchTip_mmFromBottom == null || isLabwareTouchtipDisabled
                 ? null
                 : floor(
                     mix_touchTip_mmFromBottom - matchingLabwareWellDepth,


### PR DESCRIPTION
closes AUTH-1796

# Overview

In prod for awhile, we have allowed touch tip to be specified on reservoirs which is not supported and will error when you upload to the app.

We don't allow it in the UI already again but there are protocols in the wild that have this setting. So this adds to the migration to uncheck the box and migrate the field if it was previously added to an unsupported labware (aka reservoirs)

## Test Plan and Hands on Testing

Upload attached protocol and see that touch tip is disabled in the UI but when you export, the field for aspirate labware is false for the checkbox and null for the value.

[Touchtip on reservoir.json](https://github.com/user-attachments/files/20089319/Touchtip.on.reservoir.json)

## Changelog

- add logic to move liquid and mix forms in the migration

## Risk assessment

low