### PR TITLE
feat(step-generation): update airGapInWell CommandCreator to emit flow_rate

### DIFF
--- a/step-generation/src/__tests__/airGapInWell.test.ts
+++ b/step-generation/src/__tests__/airGapInWell.test.ts
@@ -68,7 +68,9 @@ describe('airGapInWell', () => {
         },
       },
     ])
-    expect(res.python).toBe('mock_pipette_p10.air_gap(volume=10, height=1)')
+    expect(res.python).toBe(
+      'mock_pipette_p10.air_gap(volume=10, height=1, flow_rate=10)'
+    )
   })
   it('air gap for multi wells for consolidate dispense', () => {
     const args = {
@@ -117,7 +119,9 @@ describe('airGapInWell', () => {
         },
       },
     ])
-    expect(res.python).toBe('mock_pipette_p10.air_gap(volume=10, height=1)')
+    expect(res.python).toBe(
+      'mock_pipette_p10.air_gap(volume=10, height=1, flow_rate=10)'
+    )
   })
   it('air gap after aspirate', () => {
     const args = {
@@ -159,6 +163,8 @@ describe('airGapInWell', () => {
         },
       },
     ])
-    expect(res.python).toBe('mock_pipette_p10.air_gap(volume=10, height=1)')
+    expect(res.python).toBe(
+      'mock_pipette_p10.air_gap(volume=10, height=1, flow_rate=10)'
+    )
   })
 })

--- a/step-generation/src/commandCreators/compound/airGapInWell.ts
+++ b/step-generation/src/commandCreators/compound/airGapInWell.ts
@@ -35,7 +35,13 @@ export const airGapInWell: CommandCreator<AirGapInWellArgs> = (
 
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
-    python: `${pipettePythonName}.air_gap(volume=${volume}, height=${AIR_GAP_OFFSET_FROM_TOP})`,
+    python: `${pipettePythonName}.air_gap(${[
+      `volume=${volume}`,
+      `height=${AIR_GAP_OFFSET_FROM_TOP}`,
+      `flow_rate=${flowRate}`,
+    ].join(', ')})`,
+    // Python air_gap() does not have a way to specify the labwareId+wellName.
+    // We expect the previous command to have already moved the pipette to the well.
   })
 
   const commandCreators = [


### PR DESCRIPTION
# Overview

The Python `air_gap()` function now accepts a `flow_rate` argument after PR 18252.

This PR updates the `airGapInWell` CommandCreator to set the `flow_rate` when generating Python.

## Test Plan and Hands on Testing

Updated unit tests.

## Risk assessment

Low.