### PR TITLE
refactor(api): silently recover from invalid liquid heights after aspirating/dispensing

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -197,12 +197,14 @@ class WellCore(AbstractWellCore):
             raise PipetteNotAttachedError(f"No pipette present on mount {mount}")
         pipette_id = pipette_from_mount.id
         starting_liquid_height = self.current_liquid_height()
-        projected_final_height = self._engine_client.state.geometry.get_well_height_after_liquid_handling_no_error(
-            labware_id=labware_id,
-            well_name=well_name,
-            pipette_id=pipette_id,
-            initial_height=starting_liquid_height,
-            volume=operation_volume,
+        projected_final_height = (
+            self._engine_client.state.geometry.get_well_height_after_liquid_handling(
+                labware_id=labware_id,
+                well_name=well_name,
+                pipette_id=pipette_id,
+                initial_height=starting_liquid_height,
+                volume=operation_volume,
+            )
         )
         return projected_final_height
 

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -423,7 +423,8 @@ def _find_height_in_partial_frustum(
     # if we finish looping through the whole well, bottom_section will be the well's volume
     total_well_volume = bottom_section_volume
     # if we've looked through all sections and can't find the target volume, raise an error
-    # also this code should never be reached bc an error should be raised by find_height_at_well_volume
+    # also this code should never be reached bc an invalid target volume should be changed
+    # by find_height_at_well_volume
     raise InvalidLiquidHeightFound(
         f"Target volume {target_volume} uL exceeds the well volume {total_well_volume} uL."
     )
@@ -443,12 +444,10 @@ def find_height_at_well_volume(
     volumetric_capacity = get_well_volumetric_capacity(well_geometry)
     max_volume = sum(row[1] for row in volumetric_capacity)
 
-    if raise_error_if_result_invalid:
-        if target_volume < 0 or target_volume > max_volume:
-            raise InvalidLiquidHeightFound(
-                f"Invalid target volume {target_volume} uL; max volume is {max_volume} uL"
-            )
-
+    if target_volume < 0:
+        target_volume = 0
+    elif target_volume > max_volume:
+        target_volume = max_volume
     sorted_well = sorted(well_geometry.sections, key=lambda section: section.topHeight)
     # find the section the target volume is in and compute the height
     return _find_height_in_partial_frustum(

--- a/api/src/opentrons/protocol_engine/state/frustum_helpers.py
+++ b/api/src/opentrons/protocol_engine/state/frustum_helpers.py
@@ -433,7 +433,6 @@ def _find_height_in_partial_frustum(
 def find_height_at_well_volume(
     target_volume: LiquidTrackingType,
     well_geometry: InnerWellGeometry,
-    raise_error_if_result_invalid: bool = True,
 ) -> LiquidTrackingType:
     """Find the height within a well, at a known volume."""
     # comparisons with SimulatedProbeResult objects aren't meaningful, just

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -7,7 +7,6 @@ from numpy.typing import NDArray
 from typing import Optional, List, Tuple, Union, cast, TypeVar, Dict, Set
 from dataclasses import dataclass
 from functools import cached_property
-from math import isclose
 
 from opentrons.types import (
     Point,
@@ -33,7 +32,6 @@ from ..errors import (
     LabwareNotLoadedOnLabwareError,
     LabwareNotLoadedOnModuleError,
     LabwareMovementNotAllowedError,
-    OperationLocationNotInWellError,
     InvalidLabwarePositionError,
     LabwareNotOnDeckError,
 )
@@ -522,39 +520,23 @@ class GeometryView:
             z=origin_pos.z + cal_offset.z,
         )
 
-    def validate_well_position(
+    def _validate_well_position(
         self,
-        well_location: WellLocationType,
-        z_offset: float,
-        pipette_id: Optional[str] = None,
-    ) -> None:
-        """Raise exception if operation location is not within well.
-
-        Primarily this checks if there is not enough liquid in a well to do meniscus-relative static aspiration.
-        """
-        if well_location.origin == WellOrigin.MENISCUS:
-            assert pipette_id is not None, "pipette id is None"
-            lld_min_height = self._pipettes.get_current_tip_lld_settings(
-                pipette_id=pipette_id
-            )
-            if z_offset < lld_min_height:
-                if isinstance(well_location, LiquidHandlingWellLocation):
-                    raise OperationLocationNotInWellError(
-                        f"Specifying {well_location.origin} with a height offset of {well_location.offset.z} results in a height of {z_offset} mm; the minimum allowed height for liquid tracking is {lld_min_height} mm"
-                    )
-                else:
-                    raise OperationLocationNotInWellError(
-                        f"Specifying {well_location.origin} with an offset of {well_location.offset} results in an operation location that could be below the bottom of the well"
-                    )
-        elif z_offset < 0 and not isclose(z_offset, 0, abs_tol=0.0000001):
-            if isinstance(well_location, LiquidHandlingWellLocation):
-                raise OperationLocationNotInWellError(
-                    f"Specifying {well_location.origin} with an offset of {well_location.offset} and a volume offset of {well_location.volumeOffset} results in an operation location below the bottom of the well"
-                )
-            else:
-                raise OperationLocationNotInWellError(
-                    f"Specifying {well_location.origin} with an offset of {well_location.offset} results in an operation location below the bottom of the well"
-                )
+        target_height: LiquidTrackingType,  # height in mm inside a well relative to the bottom
+        well_max_height: float,
+        pipette_id: str,
+    ) -> LiquidTrackingType:
+        """If well offset would be outside the bounds of a well, silently bring it back to the boundary."""
+        if isinstance(target_height, SimulatedProbeResult):
+            return target_height
+        lld_min_height = self._pipettes.get_current_tip_lld_settings(
+            pipette_id=pipette_id
+        )
+        if target_height < lld_min_height:
+            target_height = lld_min_height
+        elif target_height > well_max_height:
+            target_height = well_max_height
+        return target_height
 
     def validate_probed_height(
         self,
@@ -595,7 +577,7 @@ class GeometryView:
 
         offset = WellOffset(x=0, y=0, z=well_depth)
         if well_location is not None:
-            offset = well_location.offset
+            offset = well_location.offset  # location of the bottom of the well
             offset_adjustment = self.get_well_offset_adjustment(
                 labware_id=labware_id,
                 well_name=well_name,
@@ -606,11 +588,6 @@ class GeometryView:
             )
             if not isinstance(offset_adjustment, SimulatedProbeResult):
                 offset = offset.model_copy(update={"z": offset.z + offset_adjustment})
-                self.validate_well_position(
-                    well_location=well_location,
-                    z_offset=offset.z,
-                    pipette_id=pipette_id,
-                )
         return Point(
             x=labware_pos.x + offset.x + well_def.x,
             y=labware_pos.y + offset.y + well_def.y,
@@ -2107,6 +2084,8 @@ class GeometryView:
 
         This is given an initial handling height, with reference to the well bottom.
         """
+        well_def = self._labware.get_well_definition(labware_id, well_name)
+        well_depth = well_def.depth
         well_geometry = self._labware.get_well_geometry(
             labware_id=labware_id, well_name=well_name
         )
@@ -2122,8 +2101,16 @@ class GeometryView:
                     pipette_id=pipette_id,
                 )
             )
-            return find_height_at_well_volume(
+            # NOTE(cm): if final_volume is outside the bounds of the well, it will get
+            # adjusted inside find_height_at_well_volume to accomodate well the height
+            # calculation.
+            height_inside_well = find_height_at_well_volume(
                 target_volume=final_volume, well_geometry=well_geometry
+            )
+            return self._validate_well_position(
+                target_height=height_inside_well,
+                well_max_height=well_depth,
+                pipette_id=pipette_id,
             )
         except InvalidLiquidHeightFound as _exception:
             raise InvalidLiquidHeightFound(
@@ -2131,6 +2118,7 @@ class GeometryView:
                 + f"for well {well_name} of {self._labware.get_display_name(labware_id)} on slot {self.get_ancestor_slot_name(labware_id)}"
             )
 
+    # maybe dont need this anymore ???
     def get_well_height_after_liquid_handling_no_error(
         self,
         labware_id: str,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -2118,47 +2118,6 @@ class GeometryView:
                 + f"for well {well_name} of {self._labware.get_display_name(labware_id)} on slot {self.get_ancestor_slot_name(labware_id)}"
             )
 
-    # maybe dont need this anymore ???
-    def get_well_height_after_liquid_handling_no_error(
-        self,
-        labware_id: str,
-        well_name: str,
-        pipette_id: str,
-        initial_height: LiquidTrackingType,
-        volume: float,
-    ) -> LiquidTrackingType:
-        """Return what the height of liquid in a labware well after liquid handling will be.
-
-        This raises no error if the value returned is an invalid physical location, so it should never be
-        used for navigation, only for a pre-emptive estimate.
-        """
-        well_geometry = self._labware.get_well_geometry(
-            labware_id=labware_id, well_name=well_name
-        )
-        try:
-            initial_volume = find_volume_at_well_height(
-                target_height=initial_height, well_geometry=well_geometry
-            )
-            final_volume = initial_volume + (
-                volume
-                * self.get_nozzles_per_well(
-                    labware_id=labware_id,
-                    target_well_name=well_name,
-                    pipette_id=pipette_id,
-                )
-            )
-            well_volume = find_height_at_well_volume(
-                target_volume=final_volume,
-                well_geometry=well_geometry,
-                raise_error_if_result_invalid=False,
-            )
-            return well_volume
-        except InvalidLiquidHeightFound as _exception:
-            raise InvalidLiquidHeightFound(
-                message=_exception.message
-                + f"for well {well_name} of {self._labware.get_display_name(labware_id)} on slot {self.get_ancestor_slot_name(labware_id)}"
-            )
-
     def get_well_height_at_volume(
         self, labware_id: str, well_name: str, volume: LiquidTrackingType
     ) -> LiquidTrackingType:

--- a/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_well_core.py
@@ -360,7 +360,7 @@ def test_estimate_liquid_height_after_pipetting(
     fake_final_height = 10000000
     decoy.when(subject.current_liquid_height()).then_return(initial_liquid_height)
     decoy.when(
-        mock_engine_client.state.geometry.get_well_height_after_liquid_handling_no_error(
+        mock_engine_client.state.geometry.get_well_height_after_liquid_handling(
             labware_id="labware-id",
             well_name="well-name",
             pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -4520,7 +4520,7 @@ def test_get_height_of_labware_stack(
 
 
 @pytest.mark.parametrize("initial_liquid_height", [5.6, SimulatedProbeResult()])
-def test_virtual_get_well_height_after_liquid_handling_no_error(
+def test_virtual_get_well_height_after_liquid_handling(
     decoy: Decoy,
     subject: GeometryView,
     mock_labware_view: LabwareView,
@@ -4551,7 +4551,7 @@ def test_virtual_get_well_height_after_liquid_handling_no_error(
         _TEST_INNER_WELL_GEOMETRY
     )
     operation_volume = 1000.0
-    result_estimate = subject.get_well_height_after_liquid_handling_no_error(
+    result_estimate = subject.get_well_height_after_liquid_handling(
         labware_id="labware-id",
         well_name="B2",
         pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -38,7 +38,6 @@ from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition2,
     Dimensions as LabwareDimensions,
     Parameters2 as LabwareDefinition2Parameters,
-    RectangularWellDefinition3,
     SphericalSegment,
     Vector as LabwareDefinitionVector,
     ConicalFrustum,
@@ -1694,8 +1693,10 @@ def test_get_well_position_with_meniscus_offset(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
         offsetId="offset-id",
     )
+    meniscus_offset = WellOffset(x=2, y=3, z=4)
     calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
+    probed_liquid_height = 5.53
     well_def = well_plate_def.wells["B2"]
 
     decoy.when(mock_labware_view.get("labware-id")).then_return(labware_data)
@@ -1718,7 +1719,9 @@ def test_get_well_position_with_meniscus_offset(
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "B2")).then_return(
         WellLiquidInfo(
             probed_volume=None,
-            probed_height=ProbedHeightInfo(height=70.5, last_probed=probe_time),
+            probed_height=ProbedHeightInfo(
+                height=probed_liquid_height, last_probed=probe_time
+            ),
             loaded_volume=None,
         )
     )
@@ -1731,15 +1734,19 @@ def test_get_well_position_with_meniscus_offset(
         well_name="B2",
         well_location=WellLocation(
             origin=WellOrigin.MENISCUS,
-            offset=WellOffset(x=2, y=3, z=4),
+            offset=meniscus_offset,
         ),
         pipette_id="pipette-id",
     )
-
+    # slot_pos + calibration_offset + well_def + meniscus_offset + meniscus height(for z)
     assert result == Point(
-        x=slot_pos[0] + 1 + well_def.x + 2,
-        y=slot_pos[1] - 2 + well_def.y + 3,
-        z=slot_pos[2] + 3 + well_def.z + 4 + 70.5,
+        x=slot_pos[0] + calibration_offset.x + well_def.x + meniscus_offset.x,
+        y=slot_pos[1] + calibration_offset.y + well_def.y + meniscus_offset.y,
+        z=slot_pos[2]
+        + calibration_offset.z
+        + well_def.z
+        + meniscus_offset.z
+        + probed_liquid_height,
     )
 
 
@@ -1829,6 +1836,8 @@ def test_get_well_position_with_meniscus_and_literal_volume_offset(
     calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
     well_def = well_plate_def.wells["B2"]
+    meniscus_well_offset = WellOffset(x=2, y=3, z=4)
+    probed_height = 5.53
 
     pip_type = PipetteNameType.P300_SINGLE
     decoy.when(mock_pipette_view.get_nozzle_configuration("pipette-id")).then_return(
@@ -1854,7 +1863,9 @@ def test_get_well_position_with_meniscus_and_literal_volume_offset(
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "B2")).then_return(
         WellLiquidInfo(
             loaded_volume=None,
-            probed_height=ProbedHeightInfo(height=45.0, last_probed=probe_time),
+            probed_height=ProbedHeightInfo(
+                height=probed_height, last_probed=probe_time
+            ),
             probed_volume=None,
         )
     )
@@ -1870,18 +1881,23 @@ def test_get_well_position_with_meniscus_and_literal_volume_offset(
         well_name="B2",
         well_location=LiquidHandlingWellLocation(
             origin=WellOrigin.MENISCUS,
-            offset=WellOffset(x=2, y=3, z=4),
+            offset=meniscus_well_offset,
             volumeOffset="operationVolume",
         ),
-        operation_volume=-1245.833,
+        operation_volume=-124.58,
         pipette_id="pipette-id",
     )
-
-    assert result == Point(
-        x=slot_pos[0] + 1 + well_def.x + 2,
-        y=slot_pos[1] - 2 + well_def.y + 3,
-        z=slot_pos[2] + 3 + well_def.z + 4 + 20.0,
+    volume_adjustment = 4.3909
+    expected = Point(
+        x=slot_pos[0] + calibration_offset.x + well_def.x + meniscus_well_offset.x,
+        y=slot_pos[1] + calibration_offset.y + well_def.y + meniscus_well_offset.y,
+        z=slot_pos[2]
+        + calibration_offset.z
+        + well_def.z
+        + meniscus_well_offset.z
+        + volume_adjustment,
     )
+    assert all([isclose(i[0], i[1], abs_tol=0.0001) for i in zip(result, expected)])
 
 
 def test_get_well_position_with_meniscus_and_float_volume_offset(
@@ -1903,6 +1919,8 @@ def test_get_well_position_with_meniscus_and_float_volume_offset(
     )
     calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
+    probed_height = 5.35
+    meniscus_well_offset = WellOffset(x=2, y=3, z=4)
     well_def = well_plate_def.wells["B2"]
     pip_type = PipetteNameType.P300_SINGLE
     decoy.when(mock_pipette_view.get_nozzle_configuration("pipette-id")).then_return(
@@ -1918,6 +1936,7 @@ def test_get_well_position_with_meniscus_and_float_volume_offset(
     decoy.when(
         mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_4.id)
     ).then_return(slot_pos)
+    well_def = well_def.model_copy(update={"depth": 45.0})
     decoy.when(mock_labware_view.get_well_definition("labware-id", "B2")).then_return(
         well_def
     )
@@ -1928,7 +1947,9 @@ def test_get_well_position_with_meniscus_and_float_volume_offset(
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "B2")).then_return(
         WellLiquidInfo(
             loaded_volume=None,
-            probed_height=ProbedHeightInfo(height=45.0, last_probed=probe_time),
+            probed_height=ProbedHeightInfo(
+                height=probed_height, last_probed=probe_time
+            ),
             probed_volume=None,
         )
     )
@@ -1938,26 +1959,44 @@ def test_get_well_position_with_meniscus_and_float_volume_offset(
     decoy.when(
         mock_pipette_view.get_current_tip_lld_settings(pipette_id="pipette-id")
     ).then_return(0.5)
-
+    operation_volume = -124.58
+    well_loc = LiquidHandlingWellLocation(
+        origin=WellOrigin.MENISCUS,
+        offset=meniscus_well_offset,
+        volumeOffset=operation_volume,
+    )
     result = subject.get_well_position(
         labware_id="labware-id",
         well_name="B2",
-        well_location=LiquidHandlingWellLocation(
-            origin=WellOrigin.MENISCUS,
-            offset=WellOffset(x=2, y=3, z=4),
-            volumeOffset=-1245.833,
-        ),
+        well_location=well_loc,
         pipette_id="pipette-id",
     )
-
-    assert result == Point(
-        x=slot_pos[0] + 1 + well_def.x + 2,
-        y=slot_pos[1] - 2 + well_def.y + 3,
-        z=slot_pos[2] + 3 + well_def.z + 4 + 20.0,
+    expected_vol_offset = subject.get_well_offset_adjustment(
+        labware_id="labware-id",
+        well_name="B2",
+        well_location=well_loc,
+        well_depth=well_def.depth,
+        pipette_id="pipette-id",
+        operation_volume=operation_volume,
     )
+    assert isinstance(expected_vol_offset, float)
+    expected = Point(
+        x=slot_pos[0] + calibration_offset.x + well_def.x + meniscus_well_offset.x,
+        y=slot_pos[1] + calibration_offset.y + well_def.y + meniscus_well_offset.y,
+        z=slot_pos[2]
+        + calibration_offset.z
+        + well_def.z
+        + meniscus_well_offset.z
+        + expected_vol_offset,
+    )
+    assert all([isclose(i[0], i[1], abs_tol=0.0001) for i in zip(result, expected)])
 
 
-def test_get_well_position_raises_validation_error(
+@pytest.mark.parametrize(
+    "operation_volume",
+    [199.0, -10000.0, 10000.0],
+)
+def test_get_well_position_adjusts_well_position_to_boundaries(
     decoy: Decoy,
     well_plate_def: LabwareDefinition,
     mock_labware_view: LabwareView,
@@ -1965,8 +2004,9 @@ def test_get_well_position_raises_validation_error(
     mock_addressable_area_view: AddressableAreaView,
     mock_pipette_view: PipetteView,
     subject: GeometryView,
+    operation_volume: float,
 ) -> None:
-    """It should raise a validation error when a volume offset is too large (ie location is below the well bottom)."""
+    """If a volume offset is too large or too small, geometry should constrain the volume offset to the well bounds ."""
     labware_data = LoadedLabware(
         id="labware-id",
         loadName="load-name",
@@ -1976,7 +2016,10 @@ def test_get_well_position_raises_validation_error(
     )
     calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
+    # should not constraint user-specified offsets
+    meniscus_well_offset = WellOffset(x=2, y=3, z=-40)
     well_def = well_plate_def.wells["B2"]
+    lld_min_height = 0.5
 
     decoy.when(mock_labware_view.get("labware-id")).then_return(labware_data)
     decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
@@ -1988,6 +2031,7 @@ def test_get_well_position_raises_validation_error(
     decoy.when(
         mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_4.id)
     ).then_return(slot_pos)
+    well_def = well_def.model_copy(update={"depth": 45.0})
     decoy.when(mock_labware_view.get_well_definition("labware-id", "B2")).then_return(
         well_def
     )
@@ -2011,20 +2055,43 @@ def test_get_well_position_raises_validation_error(
     )
     decoy.when(
         mock_pipette_view.get_current_tip_lld_settings(pipette_id="pipette-id")
-    ).then_return(0.5)
+    ).then_return(lld_min_height)
 
-    with pytest.raises(errors.OperationLocationNotInWellError):
-        subject.get_well_position(
-            labware_id="labware-id",
-            well_name="B2",
-            well_location=LiquidHandlingWellLocation(
-                origin=WellOrigin.MENISCUS,
-                offset=WellOffset(x=2, y=3, z=-40),
-                volumeOffset="operationVolume",
-            ),
-            operation_volume=-100.0,
-            pipette_id="pipette-id",
-        )
+    # make sure that just the volume offset has been adjusted to the correct well boundary
+    # but the well offset overall can still end up outside the well
+    well_loc = LiquidHandlingWellLocation(
+        origin=WellOrigin.MENISCUS,
+        offset=meniscus_well_offset,
+        volumeOffset="operationVolume",
+    )
+    expected_vol_offset = subject.get_well_offset_adjustment(
+        labware_id="labware-id",
+        well_name="B2",
+        well_location=well_loc,
+        well_depth=well_def.depth,
+        pipette_id="pipette-id",
+        operation_volume=operation_volume,
+    )
+    assert isinstance(expected_vol_offset, float) or isinstance(
+        expected_vol_offset, int
+    )
+    result = subject.get_well_position(
+        labware_id="labware-id",
+        well_name="B2",
+        well_location=well_loc,
+        operation_volume=operation_volume,
+        pipette_id="pipette-id",
+    )
+    expected = Point(
+        x=slot_pos[0] + calibration_offset.x + well_def.x + meniscus_well_offset.x,
+        y=slot_pos[1] + calibration_offset.y + well_def.y + meniscus_well_offset.y,
+        z=slot_pos[2]
+        + calibration_offset.z
+        + well_def.z
+        + meniscus_well_offset.z
+        + expected_vol_offset,
+    )
+    assert all([isclose(i[0], i[1], abs_tol=0.0001) for i in zip(result, expected)])
 
 
 def test_get_meniscus_height(
@@ -3803,10 +3870,14 @@ def test_validate_dispense_volume_into_well_meniscus(
     mock_labware_view: LabwareView,
     mock_well_view: WellView,
     subject: GeometryView,
+    well_plate_def: LabwareDefinition,
 ) -> None:
     """It should raise an InvalidDispenseVolumeError if too much volume is specified."""
+    well_def = well_plate_def.wells["A1"]
+    # make the depth match the phoney baloney innerwellgeoemtry
+    well_def = well_def.model_copy(update={"depth": 45.0})
     decoy.when(mock_labware_view.get_well_definition("labware-id", "A1")).then_return(
-        RectangularWellDefinition3.model_construct(totalLiquidVolume=1100000)  # type: ignore[call-arg]
+        well_def
     )
     decoy.when(mock_labware_view.get_well_geometry("labware-id", "A1")).then_return(
         _TEST_INNER_WELL_GEOMETRY
@@ -4514,6 +4585,10 @@ def test_virtual_find_height_and_volume(
         assert height_estimate == volume_estimate == target_height_volume
 
 
+@pytest.mark.parametrize(
+    ["operation_volume", "expected_change"],
+    [(199.0, 1.9117), (-10000.0, -2.944), (10000.0, 41.556)],
+)
 def test_get_liquid_handling_z_change(
     decoy: Decoy,
     subject: GeometryView,
@@ -4521,15 +4596,23 @@ def test_get_liquid_handling_z_change(
     mock_labware_view: LabwareView,
     mock_pipette_view: PipetteView,
     mock_well_view: WellView,
+    operation_volume: float,
+    expected_change: float,
 ) -> None:
     """Test for get_liquid_handling_z_change math."""
     pip_type = PipetteNameType.P300_SINGLE
     decoy.when(mock_pipette_view.get_nozzle_configuration("pipette-id")).then_return(
         get_default_nozzle_map(pip_type)
     )
-
+    fake_min_height = 0.5
+    decoy.when(
+        mock_pipette_view.get_current_tip_lld_settings(pipette_id="pipette-id")
+    ).then_return(fake_min_height)
+    well_def = well_plate_def.wells["A1"]
+    # make the depth match the phoney baloney innerwellgeoemtry
+    well_def = well_def.model_copy(update={"depth": 45.0})
     decoy.when(mock_labware_view.get_well_definition("labware-id", "A1")).then_return(
-        RectangularWellDefinition3.model_construct(totalLiquidVolume=1100000)  # type: ignore[call-arg]
+        well_def
     )
     decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
         well_plate_def
@@ -4541,10 +4624,13 @@ def test_get_liquid_handling_z_change(
     decoy.when(mock_well_view.get_last_liquid_update("labware-id", "A1")).then_return(
         probe_time
     )
+    probed_height = 3.444
     decoy.when(mock_well_view.get_well_liquid_info("labware-id", "A1")).then_return(
         WellLiquidInfo(
             loaded_volume=None,
-            probed_height=ProbedHeightInfo(height=40.0, last_probed=probe_time),
+            probed_height=ProbedHeightInfo(
+                height=probed_height, last_probed=probe_time
+            ),
             probed_volume=None,
         )
     )
@@ -4553,7 +4639,6 @@ def test_get_liquid_handling_z_change(
         labware_id="labware-id",
         well_name="A1",
         pipette_id="pipette-id",
-        operation_volume=199.0,
+        operation_volume=operation_volume,
     )
-    expected_change = 3.2968
-    assert isclose(change, expected_change)
+    assert isclose(change, expected_change, abs_tol=0.0001)

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2016,7 +2016,7 @@ def test_get_well_position_adjusts_well_position_to_boundaries(
     )
     calibration_offset = LabwareOffsetVector(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
-    # should not constraint user-specified offsets
+    # should not constrain user-specified offsets
     meniscus_well_offset = WellOffset(x=2, y=3, z=-40)
     well_def = well_plate_def.wells["B2"]
     lld_min_height = 0.5

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -4462,8 +4462,18 @@ def test_virtual_get_well_height_after_liquid_handling_no_error(
     decoy.when(mock_pipette_view.get_nozzle_configuration("pipette-id")).then_return(
         get_default_nozzle_map(pip_type)
     )
+    fake_min_height = 0.5
+    decoy.when(
+        mock_pipette_view.get_current_tip_lld_settings(pipette_id="pipette-id")
+    ).then_return(fake_min_height)
     decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
         well_plate_def
+    )
+    well_def = well_plate_def.wells["B2"]
+    # make the depth match the phoney baloney innerwellgeoemtry
+    well_def = well_def.model_copy(update={"depth": 45.0})
+    decoy.when(mock_labware_view.get_well_definition("labware-id", "B2")).then_return(
+        well_def
     )
 
     decoy.when(mock_labware_view.get_well_geometry("labware-id", "B2")).then_return(


### PR DESCRIPTION
## Overview
The current state of liquid tracking lends itself to a weird kind of predicament for users: 

Let's say you write a protocol that aspirates at `.meniscus()`, and somewhere in the middle of the protocol, you'll run out of liquid in one of the wells you're using, and then continue to try to aspirate out of it afterward. If you've called `liquid_probe()` at any point in this protocol, then during your run, liquid tracking will notice the fact that you're trying to aspirate at a meniscus height below the bottom of the well, and raise an  `OperationLocationNotInWellError`, which at this point in time is not recoverable.

If the liquid is added into the protocol using `load_liquid`, analysis will catch this before it happens and allow you to adjust your volumes before anything starts on the robot. However, if you use `liquid_probe`, this feature of analysis no longer applies, since we now accept that the protocol won't know where the liquid will start off within the well. 

These two things together create a situation where it's easy for users to write a protocol that will fail somewhere in the middle with a new, non-recoverable error, and additionally analysis won't be able to warn them beforehand.

This pr fixes that issue by foregoing the `OperationLocationNotInWellError`. Now, if you start out with a valid amount of liquid, and aspirate/dispense enough in that well such that the projected meniscus height will be outside of the well, the protocol engine will silently constrain its target volume to whichever well boundary would have been crossed, either the minimum allowed lld height, or the well depth. 

This means that it's still on the user to avoid aspirating out of an empty well or over-filling a well, but at least now there is no protocol-ending error.

## Changelog

- don't raise `OperationLocationNotInWellError` in `geometry.py`
- constrain the `target_volume` in `frustum_helpers.py::find_height_at_well_volume`
- constrain the resulting liquid height in `geometry.py::estimate_liquid_height_after_pipetting` using `_validate_liquid_height`
- get rid of `geometry.py::get_well_height_after_liquid_handling_no_error`, now that we're not raising an error we'd want to conditionally avoid

## Review Requests
- The two constraining checks are technically redundant. Should we just do one or is it better to double make sure
- any problem with getting rid of `get_well_height_after_liquid_handling_no_error` ?