### PR TITLE
feat(app): add module setup toast when an a new unconfigured module is attached.

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -1,7 +1,13 @@
 import { useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { useDispatch, useSelector } from 'react-redux'
-import { Navigate, Route, Routes, useNavigate, useLocation } from 'react-router-dom'
+import {
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom'
 import NiceModal from '@ebay/nice-modal-react'
 import { css } from 'styled-components'
 
@@ -54,8 +60,8 @@ import { updateBrightness } from '/app/redux/shell'
 import { LocalizationProvider } from '../LocalizationProvider'
 import { hackWindowNavigatorOnLine } from './hacks'
 import {
-  useProtocolReceiptToast,
   useModuleAttachedToast,
+  useProtocolReceiptToast,
   useScrollRef,
   useSoftwareUpdatePoll,
 } from './hooks'
@@ -295,7 +301,7 @@ function ProtocolReceiptToasts(): null {
 
 function ModuleAttachedToasts(): null {
   const navigate = useNavigate()
-  useModuleAttachedToast(()=>{
+  useModuleAttachedToast(() => {
     // TODO(ba, 2025-05-02): Navigate to module setup once the route is added.
     navigate('/protocols')
   })

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { useDispatch, useSelector } from 'react-redux'
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { Navigate, Route, Routes, useNavigate, useLocation } from 'react-router-dom'
 import NiceModal from '@ebay/nice-modal-react'
 import { css } from 'styled-components'
 
@@ -55,6 +55,7 @@ import { LocalizationProvider } from '../LocalizationProvider'
 import { hackWindowNavigatorOnLine } from './hacks'
 import {
   useProtocolReceiptToast,
+  useModuleAttachedToast,
   useScrollRef,
   useSoftwareUpdatePoll,
 } from './hooks'
@@ -202,6 +203,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                     <NiceModal.Provider>
                       <ToasterOven>
                         <ProtocolReceiptToasts />
+                        <ModuleAttachedToasts />
                         <SharedScrollRefProvider>
                           <OnDeviceDisplayAppRoutes />
                         </SharedScrollRefProvider>
@@ -288,5 +290,14 @@ export function OnDeviceDisplayAppRoutes(): JSX.Element {
 
 function ProtocolReceiptToasts(): null {
   useProtocolReceiptToast()
+  return null
+}
+
+function ModuleAttachedToasts(): null {
+  const navigate = useNavigate()
+  useModuleAttachedToast(()=>{
+    // TODO(ba, 2025-05-02): Navigate to module setup once the route is added.
+    navigate('/protocols')
+  })
   return null
 }

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -125,7 +125,9 @@ export function useProtocolReceiptToast(): void {
   }, [protocolIds])
 }
 
-export function useModuleAttachedToast(launchModuleSetupCallback: () => void) {
+export function useModuleAttachedToast(
+  launchModuleSetupCallback: () => void
+): void {
   const { t, i18n } = useTranslation(['module_wizard_flows', 'shared'])
   const { makeToast } = useToaster()
   const attachedModules =
@@ -156,9 +158,9 @@ export function useModuleAttachedToast(launchModuleSetupCallback: () => void) {
         modulesInDeckConfig
       )
       const hasPipette =
-        attachedPipettes.left !== null || attachedPipettes.right !== null
+        attachedPipettes.left != null || attachedPipettes.right != null
       if (hasPipette && newUnconfiguredModules.length > 0) {
-        makeToast(t('module_added'), 'info', {
+        makeToast(t('module_added') as string, 'info', {
           buttonText: i18n.format(t('shared:close'), 'capitalize'),
           linkText: t('module_added_link'),
           onLinkClick: launchModuleSetupCallback,

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -29,7 +29,8 @@ import type { Dispatch } from '/app/redux/types'
 
 const UPDATE_RECHECK_INTERVAL_MS = 60000
 const PROTOCOL_IDS_RECHECK_INTERVAL_MS = 3000
-const ATTACHED_MODULE_POLL_MS = 3000
+const ATTACHED_MODULE_POLL_MS = 5000
+const DECK_CONFIG_POLL_MS = 5000
 
 export function useSoftwareUpdatePoll(): void {
   const dispatch = useDispatch<Dispatch>()
@@ -134,6 +135,7 @@ export function useModuleAttachedToast(launchModuleSetupCallback: () => void) {
   const attachedPipettes = useAttachedPipettes(attachedModules.length > 0)
   const deckConfig = useNotifyDeckConfigurationQuery({
     enabled: attachedModules.length > 0,
+    refetchInterval: DECK_CONFIG_POLL_MS,
   }).data
   const moduleSerials = attachedModules
     .filter(m => m.moduleOffset === undefined)

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -19,6 +19,9 @@ import {
 import { useToaster } from '/app/organisms/ToasterOven'
 import { checkShellUpdate } from '/app/redux/shell'
 
+import { useNotifyDeckConfigurationQuery } from '../resources/deck_configuration'
+import { useAttachedPipettes } from '../resources/instruments'
+import { useAttachedModules } from '../resources/modules'
 import { SharedScrollRefContext } from './ODDProviders/ScrollRefProvider'
 
 import type { SetStatusBarCreateCommand } from '@opentrons/shared-data'
@@ -118,6 +121,46 @@ export function useProtocolReceiptToast(): void {
     // dont want this hook to rerun when other deps change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [protocolIds])
+}
+
+export function useModuleAttachedToast(launchModuleSetupCallback: () => void) {
+  const { t, i18n } = useTranslation(['module_wizard_flows', 'shared'])
+  const { makeToast } = useToaster()
+  const attachedModules = useAttachedModules()
+  const attachedPipettes = useAttachedPipettes()
+  const deckConfig = useNotifyDeckConfigurationQuery({
+    enabled: attachedModules.length > 0,
+  }).data
+  const moduleSerials = attachedModules
+    .filter(m => m.moduleOffset === undefined)
+    .map(m => m.serialNumber)
+  const moduleSerialsRef = useRef(moduleSerials)
+
+  useEffect(() => {
+    if (deckConfig === undefined) return
+    const modulesInDeckConfig = deckConfig
+      ?.filter(c => c.opentronsModuleSerialNumber)
+      .map(m => m.opentronsModuleSerialNumber)
+    const newModuleSerials = difference(moduleSerials, moduleSerialsRef.current)
+    const newUnconfiguredModules = difference(
+      newModuleSerials,
+      modulesInDeckConfig
+    )
+    const hasPipette =
+      attachedPipettes.left !== null || attachedPipettes.right !== null
+    if (hasPipette && newUnconfiguredModules.length > 0) {
+      makeToast(t('module_added'), 'info', {
+        buttonText: i18n.format(t('shared:close'), 'capitalize'),
+        linkText: t('module_added_link'),
+        onLinkClick: launchModuleSetupCallback,
+        disableTimeout: true,
+        displayType: 'odd',
+      })
+    }
+    moduleSerialsRef.current = moduleSerials
+    // dont want this hook to rerun when other deps change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [moduleSerials])
 }
 
 export function useScrollRef(): {

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -29,6 +29,7 @@ import type { Dispatch } from '/app/redux/types'
 
 const UPDATE_RECHECK_INTERVAL_MS = 60000
 const PROTOCOL_IDS_RECHECK_INTERVAL_MS = 3000
+const ATTACHED_MODULE_POLL_MS = 3000
 
 export function useSoftwareUpdatePoll(): void {
   const dispatch = useDispatch<Dispatch>()
@@ -126,8 +127,11 @@ export function useProtocolReceiptToast(): void {
 export function useModuleAttachedToast(launchModuleSetupCallback: () => void) {
   const { t, i18n } = useTranslation(['module_wizard_flows', 'shared'])
   const { makeToast } = useToaster()
-  const attachedModules = useAttachedModules()
-  const attachedPipettes = useAttachedPipettes()
+  const attachedModules =
+    useAttachedModules({
+      refetchInterval: ATTACHED_MODULE_POLL_MS,
+    }) ?? []
+  const attachedPipettes = useAttachedPipettes(attachedModules.length > 0)
   const deckConfig = useNotifyDeckConfigurationQuery({
     enabled: attachedModules.length > 0,
   }).data
@@ -137,29 +141,33 @@ export function useModuleAttachedToast(launchModuleSetupCallback: () => void) {
   const moduleSerialsRef = useRef(moduleSerials)
 
   useEffect(() => {
-    if (deckConfig === undefined) return
-    const modulesInDeckConfig = deckConfig
-      ?.filter(c => c.opentronsModuleSerialNumber)
-      .map(m => m.opentronsModuleSerialNumber)
-    const newModuleSerials = difference(moduleSerials, moduleSerialsRef.current)
-    const newUnconfiguredModules = difference(
-      newModuleSerials,
-      modulesInDeckConfig
-    )
-    const hasPipette =
-      attachedPipettes.left !== null || attachedPipettes.right !== null
-    if (hasPipette && newUnconfiguredModules.length > 0) {
-      makeToast(t('module_added'), 'info', {
-        buttonText: i18n.format(t('shared:close'), 'capitalize'),
-        linkText: t('module_added_link'),
-        onLinkClick: launchModuleSetupCallback,
-        disableTimeout: true,
-        displayType: 'odd',
-      })
+    if (deckConfig != null) {
+      const modulesInDeckConfig = deckConfig
+        ?.filter(c => c.opentronsModuleSerialNumber)
+        .map(m => m.opentronsModuleSerialNumber)
+      const newModuleSerials = difference(
+        moduleSerials,
+        moduleSerialsRef.current
+      )
+      const newUnconfiguredModules = difference(
+        newModuleSerials,
+        modulesInDeckConfig
+      )
+      const hasPipette =
+        attachedPipettes.left !== null || attachedPipettes.right !== null
+      if (hasPipette && newUnconfiguredModules.length > 0) {
+        makeToast(t('module_added'), 'info', {
+          buttonText: i18n.format(t('shared:close'), 'capitalize'),
+          linkText: t('module_added_link'),
+          onLinkClick: launchModuleSetupCallback,
+          disableTimeout: true,
+          displayType: 'odd',
+        })
+      }
+      moduleSerialsRef.current = moduleSerials
+      // dont want this hook to rerun when other deps change
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }
-    moduleSerialsRef.current = moduleSerials
-    // dont want this hook to rerun when other deps change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [moduleSerials])
 }
 

--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -24,6 +24,8 @@
   "install_adapter": "Place calibration adapter in {{module}}",
   "install_calibration_adapter": "Install calibration adapter",
   "location_occupied": "A {{fixture}} is currently specified here on the deck configuration",
+  "module_added": "New module detected. Setup the module for use.",
+  "module_added_link": "Launch Setup",
   "module_calibrating": "Stand back, {{moduleName}} is calibrating",
   "module_calibration": "Module calibration",
   "module_heating_or_cooling": "Module calibration cannot proceed while heating or cooling",


### PR DESCRIPTION
# Overview

Show a toast when a new unconfigured module is attached to the Flex, don't show the modal if the module is in deck config OR has been calibrated.

Closes: [EXEC-1144](https://opentrons.atlassian.net/browse/EXEC-1144)

## Test Plan and Hands on Testing

- [x] Verify the toast is shown when attaching a module that is not in the deck config and has not been calibrated.
- [x] Verify the toast is NOT shown when attaching a module that is either in deck config or has been calibrated.
- [x] Verify the toast is NOT shown when there are no pipettes attached.
- [x] Attach multiple stackers to a flex and make sure only one toast is shown
- [x] Power on the Flex with unconfigured modules attached and make sure the toast is shown

## Changelog

- Add a new `useModuleAttachedToast` hook that checks when new modules are attached, and shows a toast with CTA to Module Setup if the following criteria are met
   - A pipette is attached
   - The module is not in deck config
   -  The module has not been calibrated

## Review requests

Does the logic make sense?
Anything else to consider?

## Risk assessment

Low


[EXEC-1144]: https://opentrons.atlassian.net/browse/EXEC-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ