### PR TITLE
fix(app): move to initial calibration position after cancelling detach probe during desktop lpc

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useHandleConfirmLwModulePlacement.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/__tests__/useHandleConfirmLwModulePlacement.test.ts
@@ -142,6 +142,34 @@ describe('useHandleConfirmLwModulePlacement', () => {
     expect(position).toEqual(mockPosition)
   })
 
+  it('should chain commands in the correct order when handleMoveToInitialOffsetPosition is called', async () => {
+    const { result } = renderHook(() =>
+      useHandleConfirmLwModulePlacement(mockProps)
+    )
+
+    const position = await result.current.handleMoveToInitialOffsetPosition(
+      mockOffsetLocationDetails,
+      mockPipetteId,
+      mockInitialVectorOffset
+    )
+
+    expect(moveToWellCommands).toHaveBeenCalledWith(
+      mockOffsetLocationDetails,
+      mockPipetteId,
+      mockInitialVectorOffset
+    )
+    expect(savePositionCommands).toHaveBeenCalledWith(mockPipetteId)
+
+    expect(mockChainLPCCommands).toHaveBeenCalled()
+    const commandsArg = mockChainLPCCommands.mock.calls[0][0]
+
+    expect(commandsArg.length).toBe(2)
+    expect(commandsArg[0].commandType).toBe('moveToWell')
+    expect(commandsArg[1].commandType).toBe('savePosition')
+
+    expect(position).toEqual(mockPosition)
+  })
+
   it('should handle labware placement on deck when no module or labware beneath', async () => {
     const mockOffsetLocationDetailsNoPriorItem = {
       ...mockOffsetLocationDetails,
@@ -173,7 +201,7 @@ describe('useHandleConfirmLwModulePlacement', () => {
     })
   })
 
-  it('should reject with error when final command response is incorrect', async () => {
+  it('should reject with error when final command response is incorrect for handleConfirmLwModulePlacement', async () => {
     mockChainLPCCommands.mockResolvedValueOnce([
       { data: { commandType: 'moveLabware' } },
       { data: { commandType: 'moduleInitDuringLPC' } },
@@ -194,6 +222,36 @@ describe('useHandleConfirmLwModulePlacement', () => {
       result.current.handleConfirmLwModulePlacement(
         mockOffsetLocationDetails,
         mockPipetteId
+      )
+    ).rejects.toThrow(
+      'CheckItem failed to save position for initial placement.'
+    )
+
+    expect(mockSetErrorMessage).toHaveBeenCalledWith(
+      'CheckItem failed to save position for initial placement.'
+    )
+  })
+
+  it('should reject with error when final command response is incorrect for handleMoveToInitialOffsetPosition', async () => {
+    mockChainLPCCommands.mockResolvedValueOnce([
+      { data: { commandType: 'moveToWell' } },
+      {
+        data: {
+          commandType: 'unknownCommand',
+          result: null,
+        },
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useHandleConfirmLwModulePlacement(mockProps)
+    )
+
+    await expect(
+      result.current.handleMoveToInitialOffsetPosition(
+        mockOffsetLocationDetails,
+        mockPipetteId,
+        mockInitialVectorOffset
       )
     ).rejects.toThrow(
       'CheckItem failed to save position for initial placement.'

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleConfirmLwModulePlacement.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleConfirmLwModulePlacement.ts
@@ -27,6 +27,11 @@ export interface UseHandleConfirmPlacementResult {
     pipetteId: string,
     initialVectorOffset?: VectorOffset | null
   ) => Promise<Coordinates>
+  handleMoveToInitialOffsetPosition: (
+    offsetLocationDetails: OffsetLocationDetails,
+    pipetteId: string,
+    initialVectorOffset: VectorOffset | null
+  ) => Promise<Coordinates>
 }
 
 export function useHandleConfirmLwModulePlacement({
@@ -70,7 +75,41 @@ export function useHandleConfirmLwModulePlacement({
     })
   }
 
-  return { handleConfirmLwModulePlacement }
+  const handleMoveToInitialOffsetPosition = (
+    offsetLocationDetails: OffsetLocationDetails,
+    pipetteId: string,
+    initialVectorOffset: VectorOffset | null
+  ): Promise<Coordinates> => {
+    const moveCommands: CreateCommand[] = [
+      ...moveToWellCommands(
+        offsetLocationDetails,
+        pipetteId,
+        initialVectorOffset
+      ),
+      ...savePositionCommands(pipetteId),
+    ]
+
+    return chainLPCCommands(moveCommands, false).then(responses => {
+      const finalResponse = responses[responses.length - 1]
+      if (
+        finalResponse.data.commandType === 'savePosition' &&
+        finalResponse.data.result != null
+      ) {
+        const { position } = finalResponse.data.result
+
+        return Promise.resolve(position)
+      } else {
+        setErrorMessage(
+          'CheckItem failed to save position for initial placement.'
+        )
+        return Promise.reject(
+          new Error('CheckItem failed to save position for initial placement.')
+        )
+      }
+    })
+  }
+
+  return { handleConfirmLwModulePlacement, handleMoveToInitialOffsetPosition }
 }
 
 function buildMoveLabwareCommand(

--- a/app/src/organisms/LabwarePositionCheck/steps/DetachProbe.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/DetachProbe.tsx
@@ -5,9 +5,20 @@ import { useSelector } from 'react-redux'
 import { LegacyStyledText, StyledText } from '@opentrons/components'
 
 import { LPCContentContainer } from '/app/organisms/LabwarePositionCheck/LPCContentContainer'
-import { selectActivePipetteChannelCount } from '/app/redux/protocol-runs'
+import {
+  selectActivePipette,
+  selectActivePipetteChannelCount,
+  selectCurrentSubstep,
+  selectSelectedLwOverview,
+  selectSelectedLwWithOffsetDetailsMostRecentVectorOffset,
+} from '/app/redux/protocol-runs'
 import { DescriptionContent, TwoColumn } from '/app/molecules/InterventionModal'
 
+import type { LoadedPipette } from '@opentrons/shared-data'
+import type {
+  OffsetLocationDetails,
+  SelectedLwOverview,
+} from '/app/redux/protocol-runs'
 import type { LPCWizardContentProps } from '/app/organisms/LabwarePositionCheck/types'
 
 import detachProbe1 from '/app/assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_1.webm'
@@ -15,17 +26,48 @@ import detachProbe8 from '/app/assets/videos/pipette-wizard-flows/Pipette_Detach
 import detachProbe96 from '/app/assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_96.webm'
 
 export function DetachProbe(props: LPCWizardContentProps): JSX.Element {
-  const { proceedStep, goBackLastStep, commandUtils } = props
+  const { proceedStep, goBackLastStep, commandUtils, runId } = props
   const { t } = useTranslation('labware_position_check')
+  const {
+    toggleRobotMoving,
+    handleMoveToInitialOffsetPosition,
+    home,
+  } = commandUtils
+
+  const currentSubstep = useSelector(selectCurrentSubstep(runId))
+  const pipette = useSelector(selectActivePipette(runId)) as LoadedPipette
+  const pipetteId = pipette.id
+  const selectedLwInfo = useSelector(
+    selectSelectedLwOverview(runId)
+  ) as SelectedLwOverview
+  const mostRecentVectorOffset = useSelector(
+    selectSelectedLwWithOffsetDetailsMostRecentVectorOffset(runId)
+  )
+  const offsetLocationDetails = selectedLwInfo.offsetLocationDetails as OffsetLocationDetails
 
   const handleGoBack = (): void => {
-    void commandUtils
-      .toggleRobotMoving(true)
-      .then(() => commandUtils.home())
+    void toggleRobotMoving(true)
+      .then(() => {
+        // On the desktop app, ensure the robot returns to the initial offset position instead of the home position
+        // when actively calibrating an offset.
+        if (currentSubstep === 'handle-lw/edit-offset/check-labware') {
+          return home()
+            .then(() =>
+              handleMoveToInitialOffsetPosition(
+                offsetLocationDetails,
+                pipetteId,
+                mostRecentVectorOffset
+              )
+            )
+            .then(() => Promise.resolve())
+        } else {
+          return home()
+        }
+      })
       .then(() => {
         goBackLastStep()
       })
-      .then(() => commandUtils.toggleRobotMoving(false))
+      .then(() => toggleRobotMoving(false))
   }
 
   const channelCount = useSelector(selectActivePipetteChannelCount(props.runId))

--- a/app/src/organisms/LabwarePositionCheck/steps/__tests__/DetachProbe.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/__tests__/DetachProbe.test.tsx
@@ -9,6 +9,10 @@ import { DetachProbe } from '/app/organisms/LabwarePositionCheck/steps'
 import {
   selectStepInfo,
   selectActivePipetteChannelCount,
+  selectActivePipette,
+  selectCurrentSubstep,
+  selectSelectedLwOverview,
+  selectSelectedLwWithOffsetDetailsMostRecentVectorOffset,
 } from '/app/redux/protocol-runs'
 
 import detachProbe1 from '/app/assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_1.webm'
@@ -26,7 +30,8 @@ vi.mock('/app/redux/protocol-runs')
 
 const render = (
   props: ComponentProps<typeof DetachProbe>,
-  channelCount = 1
+  channelCount = 1,
+  currentSubstep = 'default-substep'
 ) => {
   const mockState = {
     [props.runId]: {
@@ -36,7 +41,20 @@ const render = (
         protocolName: 'MOCK_PROTOCOL',
       },
       activePipette: {
+        id: 'mock-pipette-id',
         channelCount: channelCount,
+      },
+      currentSubstep: currentSubstep,
+      selectedLwOverview: {
+        offsetLocationDetails: {
+          labwareId: 'mock-labware-id',
+          well: 'A1',
+        },
+      },
+      selectedLwWithOffsetDetailsMostRecentVectorOffset: {
+        x: 1,
+        y: 2,
+        z: 3,
       },
     },
   }
@@ -50,9 +68,17 @@ const render = (
 describe('DetachProbe', () => {
   let props: ComponentProps<typeof DetachProbe>
   let mockHandleProceed: Mock
+  let mockToggleRobotMoving: Mock
+  let mockHome: Mock
+  let mockHandleMoveToInitialOffsetPosition: Mock
+  let mockGoBackLastStep: Mock
 
   beforeEach(() => {
     mockHandleProceed = vi.fn()
+    mockToggleRobotMoving = vi.fn().mockResolvedValue(undefined)
+    mockHome = vi.fn().mockResolvedValue(undefined)
+    mockHandleMoveToInitialOffsetPosition = vi.fn().mockResolvedValue(undefined)
+    mockGoBackLastStep = vi.fn()
 
     vi.mocked(
       selectStepInfo
@@ -61,6 +87,26 @@ describe('DetachProbe', () => {
       selectActivePipetteChannelCount
     ).mockImplementation((runId: string) => (state: any) =>
       state[runId]?.activePipette?.channelCount || 1
+    )
+    vi.mocked(
+      selectActivePipette
+    ).mockImplementation((runId: string) => (state: any) =>
+      state[runId]?.activePipette
+    )
+    vi.mocked(
+      selectCurrentSubstep
+    ).mockImplementation((runId: string) => (state: any) =>
+      state[runId]?.currentSubstep
+    )
+    vi.mocked(
+      selectSelectedLwOverview
+    ).mockImplementation((runId: string) => (state: any) =>
+      state[runId]?.selectedLwOverview
+    )
+    vi.mocked(
+      selectSelectedLwWithOffsetDetailsMostRecentVectorOffset
+    ).mockImplementation((runId: string) => (state: any) =>
+      state[runId]?.selectedLwWithOffsetDetailsMostRecentVectorOffset
     )
 
     props = {
@@ -71,7 +117,11 @@ describe('DetachProbe', () => {
           ...mockLPCContentProps.commandUtils.headerCommands,
           handleProceed: mockHandleProceed,
         },
+        toggleRobotMoving: mockToggleRobotMoving,
+        home: mockHome,
+        handleMoveToInitialOffsetPosition: mockHandleMoveToInitialOffsetPosition,
       },
+      goBackLastStep: mockGoBackLastStep,
     }
   })
 


### PR DESCRIPTION
Closes [RQA-4177](https://opentrons.atlassian.net/browse/RQA-4177)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

On specifically the desktop app, it's possible to exit LPC on any view. During the detach view, we move the pipette to a maintenance position. If a user decides to cancel the detachment, we home the gantry and then return to whatever view the user previously visited.

This is all well and good except in one particular case: while actively calibrating an offset. We should move the pipette back to the initial position instead of the home position. This isn't currently a breaking bug, because we have the "start over" button on the desktop app as a workaround, but doing the correct movement implicitly is much nicer UX.

Although this seems like a decent amount of code, it's pretty straightforward: on specifically this calibrate offset view, we do the special homing behavior. We need a new command for this as well, because we don't want to reuse the existing command for moving to the initial position, since that one also does some labware loading.

### Current Behavior

https://github.com/user-attachments/assets/3e63d613-470f-48c0-ad21-e7a1b3a2680a


### Fixed Behavior

https://github.com/user-attachments/assets/5940f4f9-d0dd-41b8-91ec-aa412be2fa86


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
- Verified that other "exit" behavior is not impacted by these changes.

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- When actively calibrating an offset on the desktop app, after cancelling a "remove probe", the robot moves to the correct position.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low - the code is quite targeted to only this one substep and therefore easy to verify correct behavior
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4177]: https://opentrons.atlassian.net/browse/RQA-4177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ