### PR TITLE
fix(app): check "apply offsets" automatically on the OT-2 on the "send to robot" slideout

### DIFF
--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -71,7 +71,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   const navigate = useNavigate()
   const isFlex =
     useRobotType(selectedRobot?.displayName ?? '') === FLEX_ROBOT_TYPE
-  const [shouldApplyOffsets, setShouldApplyOffsets] = useState<boolean>(isFlex)
+  const [shouldApplyOffsets, setShouldApplyOffsets] = useState<boolean>(true)
   const {
     protocolKey,
     srcFileNames,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We should initially check the "apply offsets" checkbox on the OT-2 on the "send to robot" slideout. This is the expected behavior, and it mirrors the behavior in our `ChooseProtocolSlideout`. There was simply an unintentional discrepancy between the two slideouts.

### Current Behavior

https://github.com/user-attachments/assets/f9c98f44-8131-4308-aecc-9a44d17e56ef

### Fixed Behavior

https://github.com/user-attachments/assets/b5f290a5-5159-43f3-a42d-0c25526326bf

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the "apply offsets" check box not being automatically checked on the "send protocol to robot" slideout for OT-2s.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very very low - this variable is only used to render this checkbox and apply offsets to the run record when we start a run (the behavior of the checking the box).
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
