### PR TITLE
fix(opentrons-ai-client): change design of Fixture buttons

### DIFF
--- a/opentrons-ai-client/src/molecules/FixturesButtonGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/FixturesButtonGroup/index.tsx
@@ -1,7 +1,12 @@
 import { Controller, useFormContext } from 'react-hook-form'
-import styled from 'styled-components'
 
-import { EmptySelectorButton, Flex, SPACING, WRAP } from '@opentrons/components'
+import {
+  EmptySelectorButton,
+  Flex,
+  FLEX_MAX_CONTENT,
+  SPACING,
+  WRAP,
+} from '@opentrons/components'
 
 import { FIXTURES_FIELD_NAME } from '../../organisms/ModulesAndFixturesSection'
 
@@ -23,7 +28,7 @@ export function FixturesButtonGroup({
         return (
           <Flex flexWrap={WRAP} gap={SPACING.spacing8}>
             {fixtures.map(fixture => (
-              <ButtonWrapper key={fixture.type}>
+              <Flex width={FLEX_MAX_CONTENT} key={fixture.type}>
                 <EmptySelectorButton
                   key={fixture.type}
                   iconName="plus"
@@ -36,7 +41,7 @@ export function FixturesButtonGroup({
                   text={fixture.name}
                   textAlignment="left"
                 />
-              </ButtonWrapper>
+              </Flex>
             ))}
           </Flex>
         )
@@ -44,9 +49,3 @@ export function FixturesButtonGroup({
     />
   )
 }
-
-const ButtonWrapper = styled.div`
-  display: inline-block;
-  flex-grow: 0;
-  flex-shrink: 1;
-`

--- a/opentrons-ai-client/src/molecules/FixturesButtonGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/FixturesButtonGroup/index.tsx
@@ -1,4 +1,5 @@
 import { Controller, useFormContext } from 'react-hook-form'
+import styled from 'styled-components'
 
 import { EmptySelectorButton, Flex, SPACING, WRAP } from '@opentrons/components'
 
@@ -22,18 +23,20 @@ export function FixturesButtonGroup({
         return (
           <Flex flexWrap={WRAP} gap={SPACING.spacing8}>
             {fixtures.map(fixture => (
-              <EmptySelectorButton
-                key={fixture.type}
-                iconName="plus"
-                onClick={() => {
-                  if (fixturesWatch.some(m => m.type === fixture.type)) {
-                    return
-                  }
-                  field.onChange([...fixturesWatch, fixture])
-                }}
-                text={fixture.name}
-                textAlignment="left"
-              />
+              <ButtonWrapper key={fixture.type}>
+                <EmptySelectorButton
+                  key={fixture.type}
+                  iconName="plus"
+                  onClick={() => {
+                    if (fixturesWatch.some(m => m.type === fixture.type)) {
+                      return
+                    }
+                    field.onChange([...fixturesWatch, fixture])
+                  }}
+                  text={fixture.name}
+                  textAlignment="left"
+                />
+              </ButtonWrapper>
             ))}
           </Flex>
         )
@@ -41,3 +44,9 @@ export function FixturesButtonGroup({
     />
   )
 }
+
+const ButtonWrapper = styled.div`
+  display: inline-block;
+  flex-grow: 0;
+  flex-shrink: 1;
+`

--- a/opentrons-ai-client/src/molecules/FixturesButtonGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/FixturesButtonGroup/index.tsx
@@ -30,7 +30,6 @@ export function FixturesButtonGroup({
             {fixtures.map(fixture => (
               <Flex width={FLEX_MAX_CONTENT} key={fixture.type}>
                 <EmptySelectorButton
-                  key={fixture.type}
                   iconName="plus"
                   onClick={() => {
                     if (fixturesWatch.some(m => m.type === fixture.type)) {


### PR DESCRIPTION
# Overview
Closes AUTH-1807
UI module selection buttons match with Figma


**New**
<img width="846" alt="image" src="https://github.com/user-attachments/assets/17983168-d6f1-44de-a65f-9dddde33f6c2" />



**Old**
<img width="877" alt="image" src="https://github.com/user-attachments/assets/e6893639-aec3-4bfe-8fb9-00c5cc0dd8fe" />


## Test Plan and Hands on Testing
Automatic



## Review requests
Look at Fixture section


## Risk assessment

Low