### PR TITLE
feat(step-generation): emit Python for `airGapInPlace` CommandCreator

### DIFF
--- a/step-generation/src/__tests__/airGapInTrash.test.ts
+++ b/step-generation/src/__tests__/airGapInTrash.test.ts
@@ -69,7 +69,6 @@ describe('airGapInTrash', () => {
     expect(getSuccessResult(result).python).toBe(
       `
 mock_pipette.move_to(mock_trash_bin_1)
-mock_pipette.prepare_to_aspirate()
 mock_pipette.air_gap(volume=10, in_place=True, flow_rate=10)
 `.trim()
     )

--- a/step-generation/src/__tests__/airGapInTrash.test.ts
+++ b/step-generation/src/__tests__/airGapInTrash.test.ts
@@ -66,5 +66,12 @@ describe('airGapInTrash', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      `
+mock_pipette.move_to(mock_trash_bin_1)
+mock_pipette.prepare_to_aspirate()
+mock_pipette.air_gap(volume=10, in_place=True, flow_rate=10)
+`.trim()
+    )
   })
 })

--- a/step-generation/src/__tests__/airGapInWasteChute.test.ts
+++ b/step-generation/src/__tests__/airGapInWasteChute.test.ts
@@ -69,7 +69,6 @@ describe('airGapInWasteChute', () => {
     expect(getSuccessResult(result).python).toBe(
       `
 mock_pipette.move_to(mock_waste_chute_1)
-mock_pipette.prepare_to_aspirate()
 mock_pipette.air_gap(volume=10, in_place=True, flow_rate=10)
 `.trim()
     )

--- a/step-generation/src/__tests__/airGapInWasteChute.test.ts
+++ b/step-generation/src/__tests__/airGapInWasteChute.test.ts
@@ -66,5 +66,12 @@ describe('airGapInWasteChute', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      `
+mock_pipette.move_to(mock_waste_chute_1)
+mock_pipette.prepare_to_aspirate()
+mock_pipette.air_gap(volume=10, in_place=True, flow_rate=10)
+`.trim()
+    )
   })
 })

--- a/step-generation/src/commandCreators/atomic/airGapInPlace.ts
+++ b/step-generation/src/commandCreators/atomic/airGapInPlace.ts
@@ -12,7 +12,6 @@ export const airGapInPlace: CommandCreator<AirGapInPlaceParams> = (
   const { flowRate, pipetteId, volume } = args
   const errors: CommandCreatorError[] = []
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId]?.spec
-
   if (!pipetteSpec) {
     errors.push(
       pipetteDoesNotExist({
@@ -20,6 +19,8 @@ export const airGapInPlace: CommandCreator<AirGapInPlaceParams> = (
       })
     )
   }
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
 
   const commands = [
     {
@@ -34,5 +35,10 @@ export const airGapInPlace: CommandCreator<AirGapInPlaceParams> = (
   ]
   return {
     commands,
+    python: `${pipettePythonName}.air_gap(${[
+      `volume=${volume}`,
+      `in_place=True`,
+      `flow_rate=${flowRate}`,
+    ].join(', ')})`,
   }
 }

--- a/step-generation/src/commandCreators/compound/airGapInTrash.ts
+++ b/step-generation/src/commandCreators/compound/airGapInTrash.ts
@@ -1,5 +1,9 @@
 import { ZERO_OFFSET } from '../../constants'
-import { curryCommandCreator, reduceCommandCreators } from '../../utils'
+import {
+  curryCommandCreator,
+  curryWithoutPython,
+  reduceCommandCreators,
+} from '../../utils'
 import {
   airGapInPlace,
   moveToAddressableArea,
@@ -26,7 +30,8 @@ export const airGapInTrash: CommandCreator<AirGapInTrashParams> = (
       fixtureId: trashId,
       offset: ZERO_OFFSET,
     }),
-    curryCommandCreator(prepareToAspirate, {
+    curryWithoutPython(prepareToAspirate, {
+      // PAPI air_gap() includes prepare_to_aspirate() so don't emit Python
       pipetteId,
     }),
     curryCommandCreator(airGapInPlace, {

--- a/step-generation/src/commandCreators/compound/airGapInWasteChute.ts
+++ b/step-generation/src/commandCreators/compound/airGapInWasteChute.ts
@@ -1,5 +1,9 @@
 import { ZERO_OFFSET } from '../../constants'
-import { curryCommandCreator, reduceCommandCreators } from '../../utils'
+import {
+  curryCommandCreator,
+  curryWithoutPython,
+  reduceCommandCreators,
+} from '../../utils'
 import {
   airGapInPlace,
   moveToAddressableArea,
@@ -28,7 +32,8 @@ export const airGapInWasteChute: CommandCreator<AirGapInWasteChuteArgs> = (
       fixtureId: wasteChuteId,
       offset: ZERO_OFFSET,
     }),
-    curryCommandCreator(prepareToAspirate, {
+    curryWithoutPython(prepareToAspirate, {
+      // PAPI air_gap() includes prepare_to_aspirate() so don't emit Python
       pipetteId,
     }),
     curryCommandCreator(airGapInPlace, {


### PR DESCRIPTION
# Overview

After the recent PAPI changes to support `air_gap()` in-place, we can now generate Python for the `airGapInPlace` CommandCreator.

This in turn completes the support for the `airGapInTrash` and `airGapInWasteChute` compound commands.

Note that in the `airGapInTrash` and `airGapInWasteChute` CommandCreators, we suppress the Python for `prepareToAspirate`, because the Python `air_gap()` command automatically issues `prepare_to_aspirate()` (PR #17919).

## Test Plan and Hands on Testing

Added unit tests.

I also tried PD Python export for a protocol that used air gaps, and confirmed that it passed analysis.

## Risk assessment

Low.