### PR TITLE
feat(step-generation): emit Python for moveToWell special options

### DIFF
--- a/step-generation/src/__tests__/moveToWell.test.ts
+++ b/step-generation/src/__tests__/moveToWell.test.ts
@@ -116,6 +116,9 @@ describe('moveToWell', () => {
         },
       },
     ])
+    expect(getSuccessResult(result).python).toBe(
+      'mock_pipette.move_to(mock_source_plate["A1"].bottom(z=3).move(types.Point(x=1, y=2)), force_direct=True, minimum_z_height=5)'
+    )
   })
   it('should return an error if pipette does not exist', () => {
     const result = moveToWell(

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -196,11 +196,16 @@ export const moveToWell: CommandCreator<MoveToWellParams> = (
       },
     },
   ]
-  //  NOTE: forceDirect and minimumZHeight were never wired up in the form or stepArgs
+  const pythonArgs = [
+    `${labwarePythonName}[${formatPyStr(wellName)}]${formatPyWellLocation(
+      wellLocation
+    )}`,
+    ...(forceDirect ? [`force_direct=True`] : []),
+    ...(minimumZHeight ? [`minimum_z_height=${minimumZHeight}`] : []),
+    ...(speed ? [`speed=${speed}`] : []),
+  ]
   return {
     commands,
-    python: `${pipettePythonName}.move_to(${labwarePythonName}[${formatPyStr(
-      wellName
-    )}]${formatPyWellLocation(wellLocation)})`,
+    python: `${pipettePythonName}.move_to(${pythonArgs.join(', ')})`,
   }
 }


### PR DESCRIPTION
# Overview

In PR #18217, @ncdiehl11 added support for the `moveToWell` parameters `forceDirect`, `minimumZHeight`, `speed`. The Python `move_to()` function has the same parameters, and we need to emit those parameters when generating Python.

Nick will probably need the `forceDirect` option when implementing liquid class transfers, because our Python `transfer_with_liquid_class()` implementation uses `forceDirect=true` when moving the pipette vertically into and out of the well.

## Test Plan and Hands on Testing

Added unit test.

## Risk assessment

Low.