### PR TITLE
feat(step-generation): emit Python for liquidProbe CommandCreator

### DIFF
--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -274,6 +274,7 @@ describe('generateRobotStateTimeline', () => {
       `
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
 mock_pipette.move_to(mock_source_plate["A1"].top(z=2))
+mock_pipette.measure_liquid_height(mock_source_plate["A1"])
 mock_pipette.prepare_to_aspirate()
 mock_pipette.move_to(mock_source_plate["A1"].bottom())
 mock_pipette.move_to(mock_source_plate["A1"].bottom())
@@ -293,6 +294,7 @@ mock_pipette.drop_tip()
       `
 mock_pipette_p300_multi.pick_up_tip(location=mock_tip_rack_1)
 mock_pipette_p300_multi.move_to(mock_source_plate["A1"].top(z=2))
+mock_pipette_p300_multi.measure_liquid_height(mock_source_plate["A1"])
 mock_pipette_p300_multi.prepare_to_aspirate()
 mock_pipette_p300_multi.move_to(mock_source_plate["A1"].bottom())
 mock_pipette_p300_multi.move_to(mock_source_plate["A1"].bottom())

--- a/step-generation/src/__tests__/liquidProbe.test.ts
+++ b/step-generation/src/__tests__/liquidProbe.test.ts
@@ -7,6 +7,7 @@ import {
   getRobotStateWithTipStandard,
   getSuccessResult,
   makeContext,
+  SOURCE_LABWARE,
 } from '../fixtures'
 
 import type { LiquidProbeParams } from '@opentrons/shared-data'
@@ -30,7 +31,7 @@ describe('liquidProbe', () => {
     }
     const params: LiquidProbeParams = {
       pipetteId: DEFAULT_PIPETTE,
-      labwareId: 'mockLabwareId',
+      labwareId: SOURCE_LABWARE,
       wellName: 'mockWellName',
       wellLocation: {
         origin: 'top',
@@ -45,7 +46,7 @@ describe('liquidProbe', () => {
         key: expect.any(String),
         params: {
           pipetteId: DEFAULT_PIPETTE,
-          labwareId: 'mockLabwareId',
+          labwareId: SOURCE_LABWARE,
           wellName: 'mockWellName',
           wellLocation: {
             origin: 'top',
@@ -54,6 +55,9 @@ describe('liquidProbe', () => {
         },
       },
     ])
+    expect(res.python).toBe(
+      'mock_pipette.measure_liquid_height(mock_source_plate["mockWellName"])'
+    )
   })
   it('does not create liquidProbe command if pipette does not have tips', () => {
     robotStateWithTip.tipState.pipettes = {

--- a/step-generation/src/commandCreators/atomic/liquidProbe.ts
+++ b/step-generation/src/commandCreators/atomic/liquidProbe.ts
@@ -1,4 +1,4 @@
-import { uuid } from '../../utils'
+import { formatPyStr, uuid } from '../../utils'
 
 import type { LiquidProbeParams } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
@@ -17,6 +17,11 @@ export const liquidProbe: CommandCreator<LiquidProbeParams> = (
     }
   }
 
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const labwarePythonName =
+    invariantContext.labwareEntities[labwareId].pythonName
+
   const commands = [
     {
       commandType: 'liquidProbe' as const,
@@ -31,5 +36,11 @@ export const liquidProbe: CommandCreator<LiquidProbeParams> = (
   ]
   return {
     commands,
+    // Note: The Python API doesn't let you specify a starting wellLocation.
+    // measure_liquid_height() probes from LIQUID_PROBE_START_OFFSET_FROM_WELL_TOP,
+    // which is the same as our SAFE_MOVE_TO_WELL_LOCATION.
+    python: `${pipettePythonName}.measure_liquid_height(${labwarePythonName}[${formatPyStr(
+      wellName
+    )}])`,
   }
 }


### PR DESCRIPTION
# Overview

We should emit Python for the `liquidProbe` CommandCreator to match the behavior of JSON step generation. This is a follow-up to PR #18132.

I chose the Python `measure_liquid_height()` by trial-and-error. There are 4 ways we can generate liquid probes in Python:
- `load_instrument(liquid_presence_detection=True)`
- `require_liquid_presence()`
- `detect_liquid_presence()`
- `measure_liquid_height()`

(1) `load_instrument(liquid_presence_detection=True)` adds `liquidProbe` commands automatically for us before each `aspirate`. But that doesn't match the command sequence of liquid class transfers, which adds `liquidProbe` before `prepareToAspirate`.

(2) `require_liquid_presence()`, like its name implies, makes the protocol fail if no liquid is present. That is not the behavior of our JSON protocol, so we can't use that.

(3) `detect_liquid_presence()` inserts a `tryLiquidProbe` engine command instead of `liquidProbe`. And for some reason, it probes from `z=0` instead of from the `z=2` that we use in JSON step generation, so we can't use that.

(4) So by process of elimination, that leaves `measure_liquid_height()` as the only Python function that matches the JSON command.

I'm still not sure why we have so many different functions in Python, and I'm not totally sure that we're doing the right thing with my choice of `measure_liquid_height()`.

Stepping back, I'm also not sure if unconditionally adding `liquidProbe`s to liquid class transfers is the right thing to do. But this PR just focuses on generating Python code to match the JSON commands.

## Test Plan and Hands on Testing

Added unit tests.
Looked at generated Python code manually.
Made sure generated Python protocols pass analysis.

## Risk assessment

Low.