### PR TITLE
fix(api): use same well offset between liquid measuring functions

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d2c818bf00][Flex_S_v2_20_P50_LPD].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d2c818bf00][Flex_S_v2_20_P50_LPD].json
@@ -4739,7 +4739,7 @@
           "offset": {
             "x": 0.0,
             "y": 0.0,
-            "z": 0.0
+            "z": 2.0
           },
           "origin": "top",
           "volumeOffset": 0.0
@@ -4750,7 +4750,7 @@
         "position": {
           "x": 391.88,
           "y": 42.74,
-          "z": 44.4
+          "z": 46.4
         },
         "z_position": "SimulatedProbeResult"
       },
@@ -5031,7 +5031,7 @@
           "offset": {
             "x": 0.0,
             "y": 0.0,
-            "z": 0.0
+            "z": 2.0
           },
           "origin": "top",
           "volumeOffset": 0.0
@@ -5042,7 +5042,7 @@
         "position": {
           "x": 391.88,
           "y": 42.74,
-          "z": 44.4
+          "z": 46.4
         },
         "z_position": "SimulatedProbeResult"
       },
@@ -5063,7 +5063,7 @@
           "offset": {
             "x": 0.0,
             "y": 0.0,
-            "z": 0.0
+            "z": 2.0
           },
           "origin": "top",
           "volumeOffset": 0.0
@@ -5074,7 +5074,7 @@
         "position": {
           "x": 391.88,
           "y": 42.74,
-          "z": 44.4
+          "z": 46.4
         },
         "z_position": "SimulatedProbeResult"
       },

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -2294,8 +2294,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def detect_liquid_presence(self, well_core: WellCore, loc: Location) -> bool:
         labware_id = well_core.labware_id
         well_name = well_core.get_name()
+        offset = LIQUID_PROBE_START_OFFSET_FROM_WELL_TOP
         well_location = WellLocation(
-            origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=0)
+            origin=WellOrigin.TOP, offset=WellOffset(x=offset.x, y=offset.y, z=offset.z)
         )
 
         # The error handling here is a bit nuanced and also a bit broken:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -2376,14 +2376,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         self._protocol_core.set_last_location(location=loc, mount=self.get_mount())
 
-    # TODO(cm, 3.4.25): decide whether to allow users to try and do math on a potential SimulatedProbeResult
     def liquid_probe_without_recovery(
         self, well_core: WellCore, loc: Location
     ) -> LiquidTrackingType:
         labware_id = well_core.labware_id
         well_name = well_core.get_name()
+        offset = LIQUID_PROBE_START_OFFSET_FROM_WELL_TOP
         well_location = WellLocation(
-            origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
+            origin=WellOrigin.TOP, offset=WellOffset(x=offset.x, y=offset.y, z=offset.z)
         )
         pipette_movement_conflict.check_safe_for_pipette_movement(
             engine_state=self._engine_client.state,

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -1886,7 +1886,7 @@ def test_detect_liquid_presence(
             cmd.TryLiquidProbeParams(
                 pipetteId=subject.pipette_id,
                 wellLocation=WellLocation(
-                    origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=0)
+                    origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
                 ),
                 wellName=well_core.get_name(),
                 labwareId=well_core.labware_id,


### PR DESCRIPTION
## Overview
When using either `liquid_probe_with_recovery`, `liquid_probe_without_recovery`, or `detect_liquid_presence` in the engine layer, use the same well offset to begin the liquid probe from, which is 2mm above the top of the well.