### PR TITLE
feat(protocol-designer): show liquid details modal for multiple liqui…

### DIFF
--- a/protocol-designer/src/components/organisms/SlotDetailModal/LiquidCardList.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/LiquidCardList.tsx
@@ -6,26 +6,27 @@ import { DIRECTION_COLUMN, Flex, SPACING } from '@opentrons/components'
 import { LiquidDetailCard } from './LiquidDetailCard'
 
 import type { Dispatch, SetStateAction } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { AllIngredGroupFields } from '../../../labware-ingred/types'
+import type { LabwareOnDeck } from '../../../step-forms'
+import type { WellContentsByNumber } from './index'
 
 interface LiquidCardListProps {
-  selectedLabwareDefinition: LabwareDefinition2
+  selectedLabware: LabwareOnDeck
   selectedLiquidId: string | undefined
   setSelectedLiquidId: Dispatch<SetStateAction<string | undefined>>
   allIngredGroupFields: AllIngredGroupFields
   individualIds: string[]
-  volumeByWell: { [wellName: string]: number }
+  volumesPerLiquid: Record<string, WellContentsByNumber>
 }
 
 export const LiquidCardList = (props: LiquidCardListProps): JSX.Element => {
   const {
-    selectedLabwareDefinition,
+    selectedLabware,
     selectedLiquidId,
     setSelectedLiquidId,
     allIngredGroupFields,
     individualIds,
-    volumeByWell,
+    volumesPerLiquid,
   } = props
   const currentLiquidRef = useRef<HTMLDivElement>(null)
 
@@ -35,7 +36,6 @@ export const LiquidCardList = (props: LiquidCardListProps): JSX.Element => {
   useEffect(() => {
     scrollToCurrentItem()
   }, [])
-
   const liquidCardList = individualIds.map(id => {
     const liquidInfo = allIngredGroupFields[id]
     return (
@@ -46,10 +46,10 @@ export const LiquidCardList = (props: LiquidCardListProps): JSX.Element => {
         <LiquidDetailCard
           liquidInfo={liquidInfo}
           liquidId={id}
-          labwareWellOrdering={selectedLabwareDefinition.ordering}
+          labwareWellOrdering={selectedLabware.def.ordering}
           setSelectedValue={setSelectedLiquidId}
           selectedValue={selectedLiquidId}
-          volumeByWell={volumeByWell}
+          volumesPerLiquid={volumesPerLiquid}
         />
       </Flex>
     )

--- a/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx
@@ -1,4 +1,3 @@
-import { useSelector } from 'react-redux'
 import sum from 'lodash/sum'
 import { css } from 'styled-components'
 
@@ -23,16 +22,15 @@ import {
   MICRO_LITERS,
 } from '@opentrons/shared-data'
 
-import { selectors as labwareIngredSelectors } from '../../../labware-ingred/selectors'
-
 import type { Dispatch, SetStateAction } from 'react'
 import type { IngredInputs } from '../../../labware-ingred/types'
+import type { WellContentsByNumber } from './index'
 
 interface LiquidDetailCardProps {
   liquidInfo: IngredInputs
   liquidId: string
   labwareWellOrdering: string[][]
-  volumeByWell: { [wellName: string]: number }
+  volumesPerLiquid: Record<string, WellContentsByNumber>
   setSelectedValue: Dispatch<SetStateAction<string | undefined>>
   selectedValue?: string
 }
@@ -44,7 +42,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     setSelectedValue,
     selectedValue,
     labwareWellOrdering,
-    volumeByWell,
+    volumesPerLiquid,
   } = props
   const { displayName, displayColor, description } = liquidInfo
   const ACTIVE_STYLE = css`
@@ -52,10 +50,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     border: 1px solid ${COLORS.blue50};
     border-radius: ${BORDERS.borderRadius8};
   `
-  const allLabwareWellContents = useSelector(
-    labwareIngredSelectors.getLiquidsByLabwareId
-  )
-
+  const volumeByWell = volumesPerLiquid[parseInt(selectedValue ?? '0')]
   const volumePerWellRange = getWellRangeForLiquidLabwarePair(
     volumeByWell,
     labwareWellOrdering
@@ -64,14 +59,8 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
   const handleSelectedValue = (): void => {
     setSelectedValue(liquidId)
   }
-  const volumePerWell = Object.values(
-    allLabwareWellContents
-  ).flatMap(labwareWithIngred =>
-    Object.values(labwareWithIngred).map(
-      ingred => ingred[liquidId]?.volume ?? 0
-    )
-  )
-  const totalVolume = sum(volumePerWell)
+
+  const totalVolume = sum(Object.values(volumesPerLiquid[parseInt(liquidId)]))
 
   return (
     <Box
@@ -147,7 +136,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
                   {well.wellName}
                 </StyledText>
                 <StyledText desktopStyle="captionRegular">
-                  {well.volume} {MICRO_LITERS}
+                  {well.volume.toFixed(1)} {MICRO_LITERS}
                 </StyledText>
               </Flex>
             )

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -85,12 +85,13 @@ export const SlotDetailModal = (
   const individualIds = Array.from(new Set(allLiquidIdsOnLabware))
 
   const volumesPerLiquid = getVolumesPerLiquid(wellContents, individualIds)
+  const ingedInputs = Object.values(allIngredientGroupFields)
+  const wellFill = Object.values(allWellFill)
+
   const [selectedLiquidId, setSelectedLiquidId] = useState<string | undefined>(
-    Object.values(allWellFill).length > 0
-      ? Object.values(allIngredientGroupFields).find(ingred =>
-          Object.values(allWellFill).includes(ingred.displayColor)
-        )?.liquidGroupId ??
-          Object.values(allIngredientGroupFields)[0].liquidGroupId
+    wellFill.length > 0
+      ? ingedInputs.find(ingred => wellFill.includes(ingred.displayColor))
+          ?.liquidGroupId ?? ingedInputs[0].liquidGroupId
       : undefined
   )
   const wellContentsWithLiquidId: WellGroup =

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -28,8 +28,10 @@ import { selectors } from '../../../labware-ingred/selectors'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import * as wellContentsSelectors from '../../../top-selectors/well-contents'
 import { getLabwareNicknamesById } from '../../../ui/labware/selectors'
+import { WellTooltip } from '../Labware/WellTooltip'
 import { wellFillFromWellContents } from '../LabwareOnDeck/utils'
 import { getMainPagePortalEl } from '../Portal'
+import { getVolumesPerLiquid } from '../utils'
 import { LiquidCardList } from './LiquidCardList'
 
 import type { WellGroup } from '@opentrons/components'
@@ -54,6 +56,7 @@ export const SlotDetailModal = (
   const allWellContentsForActiveItem = useSelector(
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
+  const ingredNames = useSelector(selectors.getLiquidNamesById)
   const liquidDisplayColors = useSelector(selectors.getLiquidDisplayColors)
   const allIngredientGroupFields = useSelector(
     selectors.allIngredientGroupFields
@@ -69,7 +72,6 @@ export const SlotDetailModal = (
     allWellContentsForActiveItem != null
       ? allWellContentsForActiveItem[labwareId]
       : null
-
   const allWellFill = wellFillFromWellContents(
     wellContents,
     liquidDisplayColors
@@ -82,28 +84,20 @@ export const SlotDetailModal = (
       : []
   const individualIds = Array.from(new Set(allLiquidIdsOnLabware))
 
+  const volumesPerLiquid = getVolumesPerLiquid(wellContents, individualIds)
   const [selectedLiquidId, setSelectedLiquidId] = useState<string | undefined>(
     Object.values(allWellFill).length > 0
-      ? Object.values(allIngredientGroupFields).find(
-          ingred => ingred.displayColor === Object.values(allWellFill)[0]
-        )?.liquidGroupId
+      ? Object.values(allIngredientGroupFields).find(ingred =>
+          Object.values(allWellFill).includes(ingred.displayColor)
+        )?.liquidGroupId ??
+          Object.values(allIngredientGroupFields)[0].liquidGroupId
       : undefined
   )
   const wellContentsWithLiquidId: WellGroup =
     wellContents != null && selectedLiquidId != null
       ? Object.values(wellContents).reduce((acc: WellGroup, wellContents) => {
-          if (wellContents.groupIds[0] === selectedLiquidId) {
+          if (wellContents.groupIds.includes(selectedLiquidId)) {
             acc[wellContents.wellName ?? 'A1'] = null
-          }
-          return acc
-        }, {})
-      : {}
-
-  const volumeByWell: WellContentsByNumber =
-    wellContents != null && selectedLiquidId != null
-      ? Object.values(wellContents).reduce((acc: WellContentsByNumber, wc) => {
-          if (wc.groupIds[0] === selectedLiquidId) {
-            acc[wc.wellName ?? 'A1'] = Object.values(wc.ingreds)[0].volume
           }
           return acc
         }, {})
@@ -120,7 +114,6 @@ export const SlotDetailModal = (
       />
     </Flex>
   )
-
   return createPortal(
     <Modal
       title={modalTitle}
@@ -155,24 +148,40 @@ export const SlotDetailModal = (
               viewBox={`0 0 ${labwareOnDeck.def.dimensions.xDimension} ${labwareOnDeck.def.dimensions.yDimension}`}
             >
               {() => (
-                <g>
-                  <LabwareRender
-                    definition={labwareOnDeck.def}
-                    wellFill={allWellFill}
-                    highlightedWells={wellContentsWithLiquidId}
-                  />
-                </g>
+                <WellTooltip ingredNames={ingredNames}>
+                  {({ makeHandleMouseEnterWell, handleMouseLeaveWell }) => (
+                    <g>
+                      <LabwareRender
+                        onMouseLeaveWell={mouseEventArgs => {
+                          handleMouseLeaveWell(mouseEventArgs)
+                          handleMouseLeaveWell(mouseEventArgs.event)
+                        }}
+                        onMouseEnterWell={({ wellName, event }) => {
+                          if (wellContents !== null) {
+                            makeHandleMouseEnterWell(
+                              wellName,
+                              wellContents[wellName]?.ingreds
+                            )(event)
+                          }
+                        }}
+                        definition={labwareOnDeck.def}
+                        wellFill={allWellFill}
+                        highlightedWells={wellContentsWithLiquidId}
+                      />
+                    </g>
+                  )}
+                </WellTooltip>
               )}
             </RobotWorkSpace>
           </Flex>
           {selectedLiquidId != null ? (
             <LiquidCardList
-              selectedLabwareDefinition={labwareOnDeck.def}
+              selectedLabware={labwareOnDeck}
               selectedLiquidId={selectedLiquidId ?? ''}
               setSelectedLiquidId={setSelectedLiquidId}
               allIngredGroupFields={allIngredientGroupFields}
               individualIds={individualIds}
-              volumeByWell={volumeByWell}
+              volumesPerLiquid={volumesPerLiquid}
             />
           ) : null}
         </Flex>

--- a/protocol-designer/src/components/organisms/utils.ts
+++ b/protocol-designer/src/components/organisms/utils.ts
@@ -17,10 +17,13 @@ import type {
   ModuleModel,
   ModuleType,
 } from '@opentrons/shared-data'
+import type { ContentsByWell } from '../../labware-ingred/types'
 import type {
   AllTemporalPropertiesForTimelineFrame,
   ModuleOnDeck,
 } from '../../step-forms'
+import type * as wellContentsSelectors from '../../top-selectors/well-contents'
+import type { WellContentsByNumber } from './SlotDetailModal'
 
 export const getSlotsWithCollisions = (
   deckDef: DeckDefinition,
@@ -105,4 +108,47 @@ export const getNextAvailableModuleSlot = (
   } else {
     return null
   }
+}
+
+export const getIsWellContentsEmpty = (
+  allWellContentsForActiveItem: wellContentsSelectors.WellContentsByLabware | null,
+  labwareId: string
+): boolean => {
+  const wellContents =
+    allWellContentsForActiveItem != null
+      ? allWellContentsForActiveItem[labwareId]
+      : {}
+  return wellContents != null
+    ? Object.values(wellContents).every(
+        well => Object.keys(well.ingreds).length === 0
+      )
+    : true
+}
+
+export const getVolumesPerLiquid = (
+  wellContents: ContentsByWell,
+  individualIds: string[]
+): Record<string, WellContentsByNumber> => {
+  const volumesPerLiquid: Record<string, WellContentsByNumber> = {}
+  individualIds.forEach(id => {
+    const volumeByWell: WellContentsByNumber =
+      wellContents != null
+        ? Object.values(wellContents).reduce(
+            (acc: WellContentsByNumber, contents) => {
+              const groupIndex = contents.groupIds.indexOf(id)
+              if (groupIndex !== -1) {
+                const ingred = contents.ingreds[id]
+                if (ingred?.volume != null) {
+                  acc[contents.wellName ?? 'A1'] = ingred.volume
+                }
+              }
+              return acc
+            },
+            {}
+          )
+        : {}
+
+    volumesPerLiquid[id] = volumeByWell
+  })
+  return volumesPerLiquid
 }

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -305,6 +305,14 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
                       isSelected={selectedZoomInSlot != null}
                     />
                   )}
+                  <ActiveLabwareControls
+                    slotPosition={[0, 0, 0]}
+                    slotBoundingBox={labwareInterfaceBoundingBox}
+                    itemId={slotId}
+                    terminalItemId={terminalItemId}
+                    hover={hover}
+                    setHover={setHover}
+                  />
                 </>
               ) : null}
 
@@ -326,15 +334,6 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
                   stagingAreaAddressableAreas={[]}
                 />
               ) : null}
-
-              <ActiveLabwareControls
-                slotPosition={[0, 0, 0]}
-                slotBoundingBox={labwareInterfaceBoundingBox}
-                itemId={slotId}
-                terminalItemId={terminalItemId}
-                hover={hover}
-                setHover={setHover}
-              />
             </Module>
           </Fragment>
         ) : null

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 
 import {
   ALIGN_CENTER,
@@ -9,9 +10,13 @@ import {
   RobotCoordsForeignDiv,
   StyledText,
 } from '@opentrons/components'
+import { getFullStackFromLabwares } from '@opentrons/step-generation'
 
+import { getIsWellContentsEmpty } from '../../../../components/organisms'
 import { SlotDetailModal } from '../../../../components/organisms/SlotDetailModal'
 import { END_TERMINAL_ITEM_ID } from '../../../../steplist'
+import { getDeckSetupForActiveItem } from '../../../../top-selectors/labware-locations'
+import * as wellContentsSelectors from '../../../../top-selectors/well-contents'
 import { DECK_CONTROLS_STYLE } from '../constants'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -39,8 +44,19 @@ export function ActiveLabwareControls(
   } = props
   const { t } = useTranslation('starting_deck_state')
   const [showSlotDetailModal, setShowSlotDetailModal] = useState<boolean>(false)
+  const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
+  const fullStack = getFullStackFromLabwares(activeDeckSetup.labware, itemId)
+  const allWellContentsForActiveItem = useSelector(
+    wellContentsSelectors.getAllWellContentsForActiveItem
+  )
+  const noContents = getIsWellContentsEmpty(
+    allWellContentsForActiveItem,
+    fullStack[0]
+  )
+
   if (
     (terminalItemId != null && terminalItemId !== END_TERMINAL_ITEM_ID) ||
+    noContents ||
     slotPosition == null
   ) {
     return null

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -45,10 +45,10 @@ export function ActiveLabwareControls(
   const { t } = useTranslation('starting_deck_state')
   const [showSlotDetailModal, setShowSlotDetailModal] = useState<boolean>(false)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
-  const fullStack = getFullStackFromLabwares(activeDeckSetup.labware, itemId)
   const allWellContentsForActiveItem = useSelector(
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
+  const fullStack = getFullStackFromLabwares(activeDeckSetup.labware, itemId)
   const noContents = getIsWellContentsEmpty(
     allWellContentsForActiveItem,
     fullStack[0]

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -49,14 +49,14 @@ export function ActiveLabwareControls(
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
   const fullStack = getFullStackFromLabwares(activeDeckSetup.labware, itemId)
-  const noContents = getIsWellContentsEmpty(
+  const hasNoContents = getIsWellContentsEmpty(
     allWellContentsForActiveItem,
     fullStack[0]
   )
 
   if (
     (terminalItemId != null && terminalItemId !== END_TERMINAL_ITEM_ID) ||
-    noContents ||
+    hasNoContents ||
     slotPosition == null
   ) {
     return null

--- a/protocol-designer/src/pages/Designer/OffDeck/OffDeckControls.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/OffDeckControls.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { css } from 'styled-components'
 
 import {
@@ -10,8 +11,10 @@ import {
   StyledText,
 } from '@opentrons/components'
 
+import { getIsWellContentsEmpty } from '../../../components/organisms'
 import { SlotDetailModal } from '../../../components/organisms/SlotDetailModal'
 import { START_TERMINAL_ITEM_ID } from '../../../steplist'
+import * as wellContentsSelectors from '../../../top-selectors/well-contents'
 import { DECK_CONTROLS_STYLE } from '../DeckSetup/constants'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -49,9 +52,22 @@ export function OffDeckControls(
   } = props
   const { t } = useTranslation('starting_deck_state')
   const [showSlotDetailModal, setShowSlotDetailModal] = useState<boolean>(false)
+  const allWellContentsForActiveItem = useSelector(
+    wellContentsSelectors.getAllWellContentsForActiveItem
+  )
+  const noContents = getIsWellContentsEmpty(
+    allWellContentsForActiveItem,
+    labwareId
+  )
 
-  if (slotPosition === null || isSelected) return null
-
+  if (
+    slotPosition === null ||
+    isSelected ||
+    ((terminalItemId == null || terminalItemId !== START_TERMINAL_ITEM_ID) &&
+      noContents)
+  ) {
+    return null
+  }
   const hoverOpacity =
     (hover != null && hover === labwareId) || menuListId === labwareId
       ? '1'

--- a/protocol-designer/src/pages/Designer/OffDeck/OffDeckControls.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/OffDeckControls.tsx
@@ -55,7 +55,7 @@ export function OffDeckControls(
   const allWellContentsForActiveItem = useSelector(
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
-  const noContents = getIsWellContentsEmpty(
+  const hasNoContents = getIsWellContentsEmpty(
     allWellContentsForActiveItem,
     labwareId
   )
@@ -64,7 +64,7 @@ export function OffDeckControls(
     slotPosition === null ||
     isSelected ||
     ((terminalItemId == null || terminalItemId !== START_TERMINAL_ITEM_ID) &&
-      noContents)
+      hasNoContents)
   ) {
     return null
   }


### PR DESCRIPTION
…ds in a well

closes AUTH-1805

# Overview

Show liquids modal only when there are liquids in the labware and even show liquid information when there are multiple liquids in 1 well

## Test Plan and Hands on Testing

Upload the attached protocol and click on the different steps and click on the labware to view the modal. See that it accurately depicts the liquid information and that each well has a tooltip

[testMovingLiquids.json](https://github.com/user-attachments/files/20190616/testMovingLiquids.json)

## Changelog

- edit the SlotDetailsModal to account for multiple liquids in 1 well
- create a few utils for getting the specific liquid info
- only show the liquids modal if the labware has liquids for on and off deck

## Risk assessment

low, pretty contained
