### PR TITLE
feat(api): take into account air gap and other volume modifying properties when splitting volume for transfer

### DIFF
--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -29,6 +29,7 @@ from . import validation
 
 class LiquidHandlingPropertyByVolume:
     def __init__(self, by_volume_property: Sequence[Tuple[float, float]]) -> None:
+        self._initial_properties_by_volume = by_volume_property
         self._properties_by_volume: Dict[float, float] = {
             float(volume): value for volume, value in by_volume_property
         }
@@ -73,6 +74,17 @@ class LiquidHandlingPropertyByVolume:
             del self._properties_by_volume[volume]
         except KeyError:
             raise KeyError(f"No value set for volume {volume} uL")
+        self._sort_volume_and_values()
+
+    def clear_values(self) -> None:
+        """Removes all existing volume and value pairs from the curve."""
+        self._properties_by_volume = {}
+
+    def reset_values(self) -> None:
+        """Resets volumes and values to the default."""
+        self._properties_by_volume = {
+            float(volume): value for volume, value in self._initial_properties_by_volume
+        }
         self._sort_volume_and_values()
 
     def _sort_volume_and_values(self) -> None:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1883,7 +1883,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 try:
                     next_step_volume, next_source = next(source_per_volume_step)
                     air_gap = aspirate_air_gap_by_volume.get_for_volume(
-                        max(next_step_volume + total_dispense_volume, max_volume)
+                        next_step_volume + total_dispense_volume
                     )
                 except StopIteration:
                     is_last_step = True

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1875,12 +1875,16 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         while not is_last_step:
             total_dispense_volume = 0.0
             vol_aspirate_combo = []
+            air_gap = aspirate_air_gap_by_volume.get_for_volume(next_step_volume)
             # Take air gap into account because there will be a final air gap before the dispense
-            while total_dispense_volume + next_step_volume <= max_volume:
+            while total_dispense_volume + next_step_volume <= max_volume - air_gap:
                 total_dispense_volume += next_step_volume
                 vol_aspirate_combo.append((next_step_volume, next_source))
                 try:
                     next_step_volume, next_source = next(source_per_volume_step)
+                    air_gap = aspirate_air_gap_by_volume.get_for_volume(
+                        max(next_step_volume + total_dispense_volume, max_volume)
+                    )
                 except StopIteration:
                     is_last_step = True
                     break
@@ -1894,6 +1898,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             else:
                 enable_lpd = False
 
+            total_aspirated_volume = 0.0
             for step_num, (step_volume, step_source) in enumerate(vol_aspirate_combo):
                 with self.lpd_for_transfer(enable=enable_lpd):
                     tip_contents = self.aspirate_liquid_class(
@@ -1905,7 +1910,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         volume_for_pipette_mode_configuration=(
                             total_dispense_volume if step_num == 0 else None
                         ),
+                        current_volume=total_aspirated_volume,
                     )
+                total_aspirated_volume += step_volume
                 is_first_step = False
                 enable_lpd = False
             tip_contents = self.dispense_liquid_class(
@@ -1954,6 +1961,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         tip_contents: List[tx_comps_executor.LiquidAndAirGapPair],
         volume_for_pipette_mode_configuration: Optional[float],
         conditioning_volume: Optional[float] = None,
+        current_volume: float = 0.0,
     ) -> List[tx_comps_executor.LiquidAndAirGapPair]:
         """Execute aspiration steps.
 
@@ -1967,15 +1975,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         Return: List of liquid and air gap pairs in tip.
         """
         aspirate_props = transfer_properties.aspirate
+        volume_for_air_gap = aspirate_props.retract.air_gap_by_volume.get_for_volume(
+            volume + current_volume
+        )
         tx_commons.check_valid_liquid_class_volume_parameters(
             aspirate_volume=volume,
-            air_gap=(
-                aspirate_props.retract.air_gap_by_volume.get_for_volume(volume)
-                if conditioning_volume is None
-                else 0
-            ),
-            disposal_volume=0,  # Disposal volume is accounted for in aspirate vol
+            air_gap=volume_for_air_gap if conditioning_volume is None else 0,
             max_volume=self.get_working_volume(),
+            current_volume=current_volume,
         )
         source_loc, source_well = source
         last_liquid_and_airgap_in_tip = (

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1252,18 +1252,23 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             target_destinations = [dest] * len(source)
         else:
             target_destinations = dest
+
+        max_volume = min(
+            self.get_max_volume(),
+            self._engine_client.state.geometry.get_nominal_tip_geometry(
+                pipette_id=self.pipette_id,
+                labware_id=tip_racks[0][1].labware_id,
+                well_name=None,
+            ).volume,
+        )
+
+        aspirate_air_gap_by_volume = transfer_props.aspirate.retract.air_gap_by_volume
         source_dest_per_volume_step = (
             tx_commons.expand_for_volume_constraints_for_liquid_classes(
                 volumes=[volume for _ in range(len(source))],
                 targets=zip(source, target_destinations),
-                max_volume=min(
-                    self.get_max_volume(),
-                    self._engine_client.state.geometry.get_nominal_tip_geometry(
-                        pipette_id=self.pipette_id,
-                        labware_id=tip_racks[0][1].labware_id,
-                        well_name=None,
-                    ).volume,
-                ),
+                max_volume=max_volume,
+                air_gap=aspirate_air_gap_by_volume,
             )
         )
 
@@ -1515,6 +1520,11 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             tiprack_uri=tiprack_uri_for_transfer_props,
         )
 
+        aspirate_air_gap_by_volume = transfer_props.aspirate.retract.air_gap_by_volume
+        disposal_vol_by_volume = transfer_props.multi_dispense.disposal_by_volume
+        conditioning_vol_by_volume = (
+            transfer_props.multi_dispense.conditioning_by_volume
+        )
         # This will return a generator that provides pairs of destination well and
         # the volume to dispense into it
         dest_per_volume_step = (
@@ -1522,6 +1532,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 volumes=[volume for _ in range(len(dest))],
                 targets=dest,
                 max_volume=working_volume,
+                air_gap=aspirate_air_gap_by_volume,
+                disposal_vol=disposal_vol_by_volume,
+                conditioning_vol=conditioning_vol_by_volume,
             )
         )
 
@@ -1784,11 +1797,13 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             ).volume,
         )
 
+        aspirate_air_gap_by_volume = transfer_props.aspirate.retract.air_gap_by_volume
         source_per_volume_step = (
             tx_commons.expand_for_volume_constraints_for_liquid_classes(
                 volumes=[volume for _ in range(len(source))],
                 targets=source,
                 max_volume=max_volume,
+                air_gap=aspirate_air_gap_by_volume,
             )
         )
 

--- a/api/src/opentrons/protocols/advanced_control/transfers/common.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/common.py
@@ -1,7 +1,9 @@
 """Common functions between v1 transfer and liquid-class-based transfer."""
 import enum
 import math
-from typing import Iterable, Generator, Tuple, TypeVar, Literal, List
+from typing import Iterable, Generator, Tuple, TypeVar, Literal, List, Union
+
+from opentrons.protocol_api._liquid_properties import LiquidHandlingPropertyByVolume
 
 
 class NoLiquidClassPropertyError(ValueError):
@@ -98,9 +100,32 @@ def expand_for_volume_constraints_for_liquid_classes(
     volumes: Iterable[float],
     targets: Iterable[Target],
     max_volume: float,
+    air_gap: Union[LiquidHandlingPropertyByVolume, float],
+    disposal_vol: Union[LiquidHandlingPropertyByVolume, float] = 0.0,
+    conditioning_vol: Union[LiquidHandlingPropertyByVolume, float] = 0.0,
 ) -> Generator[Tuple[float, "Target"], None, None]:
     """Split a sequence of proposed transfers to keep each under the max volume, splitting larger ones equally."""
     assert max_volume > 0
     for volume, target in zip(volumes, targets):
-        for split_volume in _split_volume_equally(volume, max_volume):
+        air_gap_volume = (
+            air_gap if isinstance(air_gap, float) else air_gap.get_for_volume(volume)
+        )
+        disposal_volume = (
+            disposal_vol
+            if isinstance(disposal_vol, float)
+            else disposal_vol.get_for_volume(volume)
+        )
+        conditioning_volume = (
+            conditioning_vol
+            if isinstance(conditioning_vol, float)
+            else conditioning_vol.get_for_volume(volume)
+        )
+        # If there is conditioning volume in a multi-aspirate, it will negate the air gap
+        if conditioning_volume > 0:
+            air_gap_volume = 0
+        adjusted_max_volume = (
+            max_volume - air_gap_volume - disposal_volume - conditioning_volume
+        )
+        assert adjusted_max_volume > 0
+        for split_volume in _split_volume_equally(volume, adjusted_max_volume):
             yield split_volume, target

--- a/api/src/opentrons/protocols/advanced_control/transfers/common.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/common.py
@@ -44,18 +44,24 @@ def check_valid_volume_parameters(
 
 
 def check_valid_liquid_class_volume_parameters(
-    aspirate_volume: float, air_gap: float, disposal_volume: float, max_volume: float
+    aspirate_volume: float,
+    air_gap: float,
+    max_volume: float,
+    current_volume: float,
 ) -> None:
-    if air_gap + aspirate_volume > max_volume:
+    if (
+        current_volume != 0.0
+        and air_gap + aspirate_volume + current_volume > max_volume
+    ):
+        raise ValueError(
+            f"Cannot have an air gap of {air_gap} µL for an aspiration of {aspirate_volume} µL with"
+            f" a max volume of {max_volume} µL when {current_volume} µL has already been aspirated."
+            f" Please adjust the retract air gap to fit within the bounds of the tip."
+        )
+    elif air_gap + aspirate_volume > max_volume:
         raise ValueError(
             f"Cannot have an air gap of {air_gap} µL for an aspiration of {aspirate_volume} µL"
             f" with a max volume of {max_volume} µL. Please adjust the retract air gap to fit within"
-            f" the bounds of the tip."
-        )
-    elif disposal_volume + aspirate_volume > max_volume:
-        raise ValueError(
-            f"Cannot have a dispense volume of {disposal_volume} µL for an aspiration of {aspirate_volume} µL"
-            f" with a max volume of {max_volume} µL. Please adjust the dispense volume to fit within"
             f" the bounds of the tip."
         )
 
@@ -107,13 +113,15 @@ def expand_for_volume_constraints_for_liquid_classes(
     """Split a sequence of proposed transfers to keep each under the max volume, splitting larger ones equally."""
     assert max_volume > 0
     for volume, target in zip(volumes, targets):
-        air_gap_volume = (
-            air_gap if isinstance(air_gap, float) else air_gap.get_for_volume(volume)
-        )
         disposal_volume = (
             disposal_vol
             if isinstance(disposal_vol, float)
             else disposal_vol.get_for_volume(volume)
+        )
+        air_gap_volume = (
+            air_gap
+            if isinstance(air_gap, float)
+            else air_gap.get_for_volume(volume + disposal_volume)
         )
         conditioning_volume = (
             conditioning_vol
@@ -126,6 +134,13 @@ def expand_for_volume_constraints_for_liquid_classes(
         adjusted_max_volume = (
             max_volume - air_gap_volume - disposal_volume - conditioning_volume
         )
-        assert adjusted_max_volume > 0
+        if adjusted_max_volume <= 0:
+            error_text = f"Pipette cannot aspirate {volume} µL when pipette will need {air_gap_volume} µL for air gap"
+            if disposal_volume:
+                error_text += f", {disposal_volume} for disposal volume"
+            if conditioning_volume:
+                error_text += f", {conditioning_volume} for conditioning volume"
+            error_text += f" with a max volume of {max_volume} µL."
+            raise ValueError(error_text)
         for split_volume in _split_volume_equally(volume, adjusted_max_volume):
             yield split_volume, target

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -2558,11 +2558,11 @@ def test_aspirate_liquid_class_raises_for_more_than_max_volume(
     decoy.when(
         tx_commons.check_valid_liquid_class_volume_parameters(
             aspirate_volume=123,
-            disposal_volume=0,
             air_gap=test_transfer_properties.aspirate.retract.air_gap_by_volume.get_for_volume(
                 123
             ),
             max_volume=100,
+            current_volume=4.56,
         )
     ).then_raise(ValueError("Oh oh!"))
     with pytest.raises(ValueError, match="Oh oh!"):
@@ -2573,6 +2573,7 @@ def test_aspirate_liquid_class_raises_for_more_than_max_volume(
             transfer_type=TransferType.ONE_TO_ONE,
             tip_contents=[],
             volume_for_pipette_mode_configuration=None,
+            current_volume=4.56,
         )
 
 

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -733,6 +733,7 @@ def test_order_of_water_consolidate_steps(
                 transfer_type=TransferType.MANY_TO_ONE,
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 volume_for_pipette_mode_configuration=50,
+                current_volume=0.0,
             ),
             mock.call.aspirate_liquid_class(
                 mock.ANY,
@@ -742,6 +743,7 @@ def test_order_of_water_consolidate_steps(
                 transfer_type=TransferType.MANY_TO_ONE,
                 tip_contents=[LiquidAndAirGapPair(liquid=25, air_gap=0.1)],
                 volume_for_pipette_mode_configuration=None,
+                current_volume=25.0,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,
@@ -861,6 +863,7 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip(
                 transfer_type=TransferType.MANY_TO_ONE,
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 volume_for_pipette_mode_configuration=30,
+                current_volume=0.0,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,
@@ -881,6 +884,7 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip(
                 transfer_type=TransferType.MANY_TO_ONE,
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0.1)],
                 volume_for_pipette_mode_configuration=30,
+                current_volume=0.0,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,
@@ -994,6 +998,7 @@ def test_order_of_water_consolidate_steps_with_no_new_tips(
                 transfer_type=TransferType.MANY_TO_ONE,
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 volume_for_pipette_mode_configuration=50,
+                current_volume=0.0,
             ),
             mock.call.aspirate_liquid_class(
                 mock.ANY,
@@ -1003,6 +1008,7 @@ def test_order_of_water_consolidate_steps_with_no_new_tips(
                 transfer_type=TransferType.MANY_TO_ONE,
                 tip_contents=[LiquidAndAirGapPair(liquid=25, air_gap=0.1)],
                 volume_for_pipette_mode_configuration=None,
+                current_volume=25.0,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,
@@ -1117,6 +1123,7 @@ def test_order_of_water_consolidate_steps_with_return_tip(
                 transfer_type=TransferType.MANY_TO_ONE,
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 volume_for_pipette_mode_configuration=50,
+                current_volume=0.0,
             ),
             mock.call.aspirate_liquid_class(
                 mock.ANY,
@@ -1126,6 +1133,7 @@ def test_order_of_water_consolidate_steps_with_return_tip(
                 transfer_type=TransferType.MANY_TO_ONE,
                 tip_contents=[LiquidAndAirGapPair(liquid=25, air_gap=0.1)],
                 volume_for_pipette_mode_configuration=None,
+                current_volume=25.0,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_common_functions.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_common_functions.py
@@ -92,36 +92,62 @@ def test_expand_for_volume_constraints(
 
 
 @pytest.mark.parametrize(
-    argnames=["volumes", "targets", "max_volume", "expanded_list_result"],
+    argnames=["volumes", "targets", "max_volume", "air_gap", "expanded_list_result"],
     argvalues=[
         (
             [25, 25],
             ["dest1", "dest2"],
             50,
+            24.0,
             [(25, "dest1"), (25, "dest2")],
         ),
         (
             [50, 50],
             ["dest1", "dest2"],
             50,
+            0.0,
             [(50, "dest1"), (50, "dest2")],
+        ),
+        (
+            [50, 50],
+            ["dest1", "dest2"],
+            50,
+            5.0,
+            [(25, "dest1"), (25, "dest1"), (25, "dest2"), (25, "dest2")],
         ),
         (
             [75, 75],
             ["dest1", "dest2"],
             50,
+            5.0,
             [(37.5, "dest1"), (37.5, "dest1"), (37.5, "dest2"), (37.5, "dest2")],
         ),
         (
             [100, 100],
             ["dest1", "dest2"],
             50,
+            0.0,
             [(50, "dest1"), (50, "dest1"), (50, "dest2"), (50, "dest2")],
+        ),
+        (
+            [100, 100],
+            ["dest1", "dest2"],
+            50,
+            5.0,
+            [
+                (100 / 3, "dest1"),
+                (100 / 3, "dest1"),
+                (100 / 3, "dest1"),
+                (100 / 3, "dest2"),
+                (100 / 3, "dest2"),
+                (100 / 3, "dest2"),
+            ],
         ),
         (
             [103, 103],
             ["dest1", "dest2"],
             50,
+            0.0,
             [
                 (103 / 3, "dest1"),
                 (103 / 3, "dest1"),
@@ -137,6 +163,7 @@ def test_expand_for_volume_constraints_for_liquid_classes(
     volumes: Iterable[float],
     targets: Iterable[Target],
     max_volume: float,
+    air_gap: float,
     expanded_list_result: List[Tuple[float, Target]],
 ) -> None:
     """It should create a list of volume and target transfers, splitting volumes equally if required."""
@@ -144,5 +171,6 @@ def test_expand_for_volume_constraints_for_liquid_classes(
         volumes=volumes,
         targets=targets,
         max_volume=max_volume,
+        air_gap=air_gap,
     )
     assert list(result) == expanded_list_result


### PR DESCRIPTION
# Overview

Addresses AUTH-1794.

This PR modifies volume splitting (done with `expand_for_volume_constraints_for_liquid_classes`) to take into account the air gap volume (and conditioning and disposal volume for multi-dispense distribute, more on that later) for the _**initial**_ volume splitting. This allows one to pipette the max volume for a tip even if that volume has a non-zero air gap.

For example, if one has a 50 µL pipette (or a 50 µL tip with a P1000), and they try to aspirate 50 µL with a liquid class that has an air gap of 5 µL, it will now split that volume into two 25 µL transfers. The same thing would happen if a larger value was used that would previously be split into 50 µL, a 100 µL transfer that has 5 µL air gap for the maximum would be split into three of 33.3 repeating µL instead of two 50 µL.

What will **_not_** happen is dealing with too-large air gaps _after_ we split the volume. In other words, if for some reason you have a 30 µL air gap for both 50 and 25 µL, it'll try to split into 25 µL chunks, and then fail when trying to add the air gap. While it could be possible to try and solve for a combination of volumes that would fit, this would only further complicate the liquid class transfer functions and this will cover all default and sensible cases.

For `distribute_with_liquid_class`, we are already checking if the conditioning + disposal volume + transfer volume will fit into the pipette's working volume, but the check is still included to provide an additional level of checks, the fact that a conditioning volume of non-zero negates the aspirate air gap, and to ensure that the air gap plus a disposal volume does not go over the limit either.

This PR also adds two new methods to the `LiquidHandlingPropertyByVolume` class,  a `clear_values()` the deletes all points from the curve, and a `reset_values()` that sets it back to the defaults. This was used for testing but are also useful functions to allow users to use when modifying these `byVolume` properties.

## Test Plan and Hands on Testing

Unit tests, integration tests, and snapshot tests should capture if anything in the default cases are breaking, and ensured the following protocol passes analysis and splits volume as we'd expect.

```
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.24"
}

metadata = {
    "protocolName":'Liquid Class Transfer Air Gap Splitting Test',
}

def run(protocol_context):
    tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
    trash = protocol_context.load_trash_bin('A3')
    pipette = protocol_context.load_instrument("flex_1channel_50", "left", tip_racks=[tiprack])
    nest_plate = protocol_context.load_labware("nest_96_wellplate_2ml_deep", "D1")
    arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "D3")

    water_class = protocol_context.define_liquid_class("water")

    transfer_props = water_class.get_for(pipette, tiprack)

    transfer_props.aspirate.retract.air_gap_by_volume.clear_values()
    # This sets a flat curve of 5 regardless of volume
    transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(0.1, 5)

    pipette.transfer_with_liquid_class(
        liquid_class=water_class,
        volume=50,
        source=arma_plate.columns()[0][:2],
        dest=nest_plate.columns()[0][:2],
        new_tip="always",
        trash_location=trash,
    )

    pipette.distribute_with_liquid_class(
        liquid_class=water_class,
        volume=24,
        source=arma_plate['A1'],
        dest=nest_plate.columns()[0][:2],
        new_tip="once",
        trash_location=trash,
    )

    pipette.consolidate_with_liquid_class(
        liquid_class=water_class,
        volume=100,
        source=arma_plate.columns()[0][:2],
        dest=nest_plate['A1'],
        new_tip="once",
        trash_location=trash,
    )
```

## Changelog

- modified `expand_for_volume_constraints_for_liquid_classes` to take into account for air gap, conditioning and disposal volume
- added a `clear_values()` and a `reset_values()` function to `LiquidHandlingPropertyByVolume`

## Review requests

I'm pretty confident this covers all default cases and all sensible cases, and that any errors that we don't account for will have appropriate errors be raised, but the distribute case is especially complicated so any extra eyes/thoughts on that could be useful.

## Risk assessment

Low-medium, the default liquid classes as we have them shouldn't have any change in behavior but this does affect all three liquid class methods.