### PR TITLE
refactor(step-generation): add trashBin/wasteChute to pipette robotState

### DIFF
--- a/step-generation/src/__tests__/dispenseUpdateLiquidState.test.ts
+++ b/step-generation/src/__tests__/dispenseUpdateLiquidState.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
     pipetteId: DEFAULT_PIPETTE,
     volume: 150,
     useFullVolume: false,
-    labwareId: SOURCE_LABWARE,
+    entityId: SOURCE_LABWARE,
     wellName: 'A1',
     robotStateAndWarnings: {
       robotState: getInitialRobotStateStandard(invariantContext),
@@ -401,7 +401,7 @@ describe('...8-channel pipette', () => {
         const result = getUpdatedLiquidState(
           {
             invariantContext: customInvariantContext,
-            labwareId: SOURCE_LABWARE,
+            entityId: SOURCE_LABWARE,
             pipetteId: 'p300MultiId',
             useFullVolume: false,
             volume: 150,

--- a/step-generation/src/__tests__/dropTipInWasteChute.test.ts
+++ b/step-generation/src/__tests__/dropTipInWasteChute.test.ts
@@ -23,6 +23,7 @@ const invariantContext: InvariantContext = {
 }
 const prevRobotState: RobotState = {
   tipState: { pipettes: { [DEFAULT_PIPETTE]: true } } as any,
+  pipettes: { [DEFAULT_PIPETTE]: { entityId: mockWasteChuteId } },
 } as any
 
 describe('dropTipInWasteChute', () => {

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -170,9 +170,11 @@ export const transfer: CommandCreator<TransferArgs> = (
     )
   }
 
-  const initialDestLabwareSlot = getSlotInLocationStack(
-    prevRobotState.labware[destLabware]?.stack
-  )
+  const initialDestLabwareSlot =
+    prevRobotState.labware[destLabware] != null
+      ? getSlotInLocationStack(prevRobotState.labware[destLabware]?.stack)
+      : ''
+
   const initialSourceLabwareSlot = getSlotInLocationStack(
     prevRobotState.labware[sourceLabware]?.stack
   )

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -172,7 +172,7 @@ export const transfer: CommandCreator<TransferArgs> = (
 
   const initialDestLabwareSlot =
     prevRobotState.labware[destLabware] != null
-      ? getSlotInLocationStack(prevRobotState.labware[destLabware]?.stack)
+      ? getSlotInLocationStack(prevRobotState.labware[destLabware].stack)
       : ''
 
   const initialSourceLabwareSlot = getSlotInLocationStack(

--- a/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
@@ -7,7 +7,6 @@ import {
   getLocationTotalVolume,
   getWellsForTips,
   mergeLiquid,
-  mergeLiquidForTrash,
   splitLiquid,
 } from '../utils/misc'
 
@@ -80,7 +79,6 @@ export function dispenseUpdateLiquidState(
       ? prevLiquidState.labware[entityId]
       : null
 
-  console.log('prevLiquidState', JSON.parse(JSON.stringify(prevLiquidState)))
   let liquidTrash: LocationLiquidState | null = null
   if (prevLiquidState.trashBins[entityId] != null) {
     liquidTrash = prevLiquidState.trashBins[entityId]
@@ -96,7 +94,6 @@ export function dispenseUpdateLiquidState(
     (prevTipLiquidState: LocationLiquidState): SourceAndDest => {
       if (useFullVolume) {
         const totalTipVolume = getLocationTotalVolume(prevTipLiquidState)
-        console.log('totalTipVolume', totalTipVolume)
         return totalTipVolume > 0
           ? splitLiquid(totalTipVolume, prevTipLiquidState)
           : {
@@ -107,10 +104,6 @@ export function dispenseUpdateLiquidState(
 
       return splitLiquid(volume || 0, prevTipLiquidState)
     }
-  )
-  console.log(
-    '   prevLiquidState.pipettes[pipetteId]',
-    JSON.parse(JSON.stringify(prevLiquidState.pipettes[pipetteId]))
   )
   let mergeLiquidtoSingleWell = null
   //  a labware will always have a well
@@ -128,45 +121,16 @@ export function dispenseUpdateLiquidState(
         liquidLabware[well]
       ),
     }
-  }
-  // const test =
-  //   prevLiquidState.pipettes[pipetteId] != null
-  //     ? getLocationTotalVolume(prevLiquidState.pipettes[pipetteId])
-  //     : {}
-  // console.log(test)
-
-  const pipetteRobotState = prevLiquidState.pipettes[pipetteId]
-  console.log(
-    'pipetteRobotState',
-    JSON.parse(JSON.stringify(pipetteRobotState))
-  )
-  //  waste chute and trash bin don't have wells
-  if (well == null && liquidTrash != null && pipetteRobotState != null) {
-    mergeLiquidtoSingleWell = reduce(
-      pipetteRobotState,
-      (acc: LocationLiquidState, liquid) => {
-        const totalVolume = getLocationTotalVolume(liquid)
-        console.log(
-          'totalVolume',
-          JSON.parse(JSON.stringify(liquid)),
-          totalVolume
-        )
-        acc[0] = { volume: totalVolume }
-
-        return acc
-      },
-      {}
-    )
+  } else if (liquidTrash != null) {
+    const totalVolume = Object.values(
+      prevLiquidState.pipettes[pipetteId]
+    ).reduce((acc: number, val) => {
+      return acc + (val[0]?.volume ?? 0)
+    }, 0)
+    liquidTrash[0] = { volume: totalVolume }
   }
 
-  console.log(
-    'mergeLiquidtoSingleWell',
-    JSON.parse(JSON.stringify(liquidTrash)),
-    JSON.parse(JSON.stringify(splitLiquidStates)),
-
-    JSON.parse(JSON.stringify(mergeLiquidtoSingleWell))
-  )
-  if (mergeLiquidtoSingleWell == null) {
+  if (mergeLiquidtoSingleWell == null && liquidTrash == null) {
     console.assert(
       `expected to merge liquid to a single well with sourceId ${entityId}`
     )
@@ -190,13 +154,13 @@ export function dispenseUpdateLiquidState(
     ? mergeLiquidtoSingleWell
     : mergeTipLiquidToOwnWell
   prevLiquidState.pipettes[pipetteId] = mapValues(splitLiquidStates, 'source')
-  if (liquidTrash != null && labwareLiquidState != null) {
-    console.log(
-      'hit here',
-
-      JSON.parse(JSON.stringify(labwareLiquidState))
-    )
-    liquidTrash = Object.assign(labwareLiquidState)
+  if (prevLiquidState.trashBins[entityId] != null && liquidTrash != null) {
+    Object.assign(prevLiquidState.trashBins[entityId], liquidTrash)
+  } else if (
+    prevLiquidState.wasteChute[entityId] != null &&
+    liquidTrash != null
+  ) {
+    Object.assign(prevLiquidState.wasteChute[entityId], liquidTrash)
   } else if (
     prevLiquidState.labware[entityId] != null &&
     labwareLiquidState != null

--- a/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
@@ -7,6 +7,7 @@ import {
   getLocationTotalVolume,
   getWellsForTips,
   mergeLiquid,
+  mergeLiquidForTrash,
   splitLiquid,
 } from '../utils/misc'
 
@@ -26,8 +27,8 @@ export interface DispenseUpdateLiquidStateArgs {
   // volume value is required when useFullVolume is false
   useFullVolume: boolean
   robotStateAndWarnings: RobotStateAndWarnings
+  entityId: string
   wellName?: string
-  labwareId?: string
   volume?: number
 }
 
@@ -38,7 +39,7 @@ export function dispenseUpdateLiquidState(
   const {
     robotStateAndWarnings,
     invariantContext,
-    labwareId,
+    entityId,
     pipetteId,
     prevLiquidState,
     useFullVolume,
@@ -53,28 +54,13 @@ export function dispenseUpdateLiquidState(
   } else if (nozzles === SINGLE) {
     channels = 1
   }
-  //  TODO: fix this bug, i guess if both entities exist, we default to updating liquid state
-  //  into the first one listed which is wrong if the user is using the 2nd one listed
-  const trashId =
-    Object.keys(invariantContext.wasteChuteEntities).length > 0
-      ? Object.keys(invariantContext.wasteChuteEntities)[0]
-      : Object.keys(invariantContext.trashBinEntities)[0]
-
-  const sourceId =
-    labwareId != null
-      ? invariantContext.labwareEntities[labwareId].id
-      : trashId ?? ''
-
-  if (sourceId === '') {
-    console.error(
-      `expected to find a trash entity id but could not, with trash id ${trashId}`
-    )
-  }
 
   const well = wellName ?? null
 
   const labwareDef =
-    labwareId != null ? invariantContext.labwareEntities[labwareId].def : null
+    invariantContext.labwareEntities[entityId] != null
+      ? invariantContext.labwareEntities[entityId].def
+      : null
 
   console.assert(
     !(useFullVolume && typeof volume === 'number'),
@@ -90,15 +76,16 @@ export function dispenseUpdateLiquidState(
       : { wellsForTips: null, allWellsShared: true }
 
   const liquidLabware =
-    prevLiquidState.labware[sourceId] != null
-      ? prevLiquidState.labware[sourceId]
+    prevLiquidState.labware[entityId] != null
+      ? prevLiquidState.labware[entityId]
       : null
 
+  console.log('prevLiquidState', JSON.parse(JSON.stringify(prevLiquidState)))
   let liquidTrash: LocationLiquidState | null = null
-  if (prevLiquidState.trashBins[sourceId] != null) {
-    liquidTrash = prevLiquidState.trashBins[sourceId]
-  } else if (prevLiquidState.wasteChute[sourceId] != null) {
-    liquidTrash = prevLiquidState.wasteChute[sourceId]
+  if (prevLiquidState.trashBins[entityId] != null) {
+    liquidTrash = prevLiquidState.trashBins[entityId]
+  } else if (prevLiquidState.wasteChute[entityId] != null) {
+    liquidTrash = prevLiquidState.wasteChute[entityId]
   }
 
   // remove liquid from pipette tips,
@@ -109,6 +96,7 @@ export function dispenseUpdateLiquidState(
     (prevTipLiquidState: LocationLiquidState): SourceAndDest => {
       if (useFullVolume) {
         const totalTipVolume = getLocationTotalVolume(prevTipLiquidState)
+        console.log('totalTipVolume', totalTipVolume)
         return totalTipVolume > 0
           ? splitLiquid(totalTipVolume, prevTipLiquidState)
           : {
@@ -120,7 +108,10 @@ export function dispenseUpdateLiquidState(
       return splitLiquid(volume || 0, prevTipLiquidState)
     }
   )
-
+  console.log(
+    '   prevLiquidState.pipettes[pipetteId]',
+    JSON.parse(JSON.stringify(prevLiquidState.pipettes[pipetteId]))
+  )
   let mergeLiquidtoSingleWell = null
   //  a labware will always have a well
   if (well != null && liquidLabware != null) {
@@ -138,21 +129,46 @@ export function dispenseUpdateLiquidState(
       ),
     }
   }
+  // const test =
+  //   prevLiquidState.pipettes[pipetteId] != null
+  //     ? getLocationTotalVolume(prevLiquidState.pipettes[pipetteId])
+  //     : {}
+  // console.log(test)
+
+  const pipetteRobotState = prevLiquidState.pipettes[pipetteId]
+  console.log(
+    'pipetteRobotState',
+    JSON.parse(JSON.stringify(pipetteRobotState))
+  )
   //  waste chute and trash bin don't have wells
-  if (well == null && liquidTrash != null) {
+  if (well == null && liquidTrash != null && pipetteRobotState != null) {
     mergeLiquidtoSingleWell = reduce(
-      splitLiquidStates,
-      (wellLiquidStateAcc, splitLiquidStateForTip: SourceAndDest) => {
-        const res = mergeLiquid(wellLiquidStateAcc, splitLiquidStateForTip.dest)
-        return res
+      pipetteRobotState,
+      (acc: LocationLiquidState, liquid) => {
+        const totalVolume = getLocationTotalVolume(liquid)
+        console.log(
+          'totalVolume',
+          JSON.parse(JSON.stringify(liquid)),
+          totalVolume
+        )
+        acc[0] = { volume: totalVolume }
+
+        return acc
       },
-      liquidTrash
+      {}
     )
   }
 
+  console.log(
+    'mergeLiquidtoSingleWell',
+    JSON.parse(JSON.stringify(liquidTrash)),
+    JSON.parse(JSON.stringify(splitLiquidStates)),
+
+    JSON.parse(JSON.stringify(mergeLiquidtoSingleWell))
+  )
   if (mergeLiquidtoSingleWell == null) {
     console.assert(
-      `expected to merge liquid to a single well with sourceId ${sourceId}`
+      `expected to merge liquid to a single well with sourceId ${entityId}`
     )
   }
 
@@ -175,12 +191,17 @@ export function dispenseUpdateLiquidState(
     : mergeTipLiquidToOwnWell
   prevLiquidState.pipettes[pipetteId] = mapValues(splitLiquidStates, 'source')
   if (liquidTrash != null && labwareLiquidState != null) {
+    console.log(
+      'hit here',
+
+      JSON.parse(JSON.stringify(labwareLiquidState))
+    )
     liquidTrash = Object.assign(labwareLiquidState)
   } else if (
-    prevLiquidState.labware[sourceId] != null &&
+    prevLiquidState.labware[entityId] != null &&
     labwareLiquidState != null
   ) {
-    prevLiquidState.labware[sourceId] = Object.assign(
+    prevLiquidState.labware[entityId] = Object.assign(
       liquidLabware ?? {},
       labwareLiquidState
     )

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -29,7 +29,7 @@ export function forAspirate(
   const labwareId =
     'labwareId' in params
       ? params.labwareId
-      : robotState.pipettes[pipetteId].labwareId ?? ''
+      : robotState.pipettes[pipetteId].entityId ?? ''
   const wellName =
     'wellName' in params
       ? params.wellName

--- a/step-generation/src/getNextRobotStateAndWarnings/forBlowout.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forBlowout.ts
@@ -12,7 +12,7 @@ export function forBlowout(
   const { robotState } = robotStateAndWarnings
   dispenseUpdateLiquidState({
     pipetteId,
-    labwareId,
+    entityId: labwareId,
     useFullVolume: true,
     wellName,
     prevLiquidState: robotState.liquidState,

--- a/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
@@ -22,7 +22,6 @@ export function forDispense(
       ? params.wellName
       : robotState.pipettes[pipetteId].wellName ?? ''
 
-  console.log('forDispense entitityId', entityId)
   dispenseUpdateLiquidState({
     invariantContext,
     entityId,

--- a/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
@@ -13,17 +13,19 @@ export function forDispense(
 ): void {
   const { pipetteId, volume } = params
   const { robotState } = robotStateAndWarnings
-  const labwareId =
+  const entityId =
     'labwareId' in params
       ? params.labwareId
-      : robotState.pipettes[pipetteId].labwareId ?? ''
+      : robotState.pipettes[pipetteId].entityId ?? ''
   const wellName =
     'wellName' in params
       ? params.wellName
       : robotState.pipettes[pipetteId].wellName ?? ''
+
+  console.log('forDispense entitityId', entityId)
   dispenseUpdateLiquidState({
     invariantContext,
-    labwareId,
+    entityId,
     pipetteId,
     prevLiquidState: robotState.liquidState,
     useFullVolume: false,

--- a/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
@@ -18,7 +18,7 @@ export function forDropTip(
     invariantContext,
     prevLiquidState: robotState.liquidState,
     pipetteId,
-    labwareId,
+    entityId: labwareId,
     useFullVolume: true,
     wellName,
     robotStateAndWarnings,

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveToAddressableArea.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveToAddressableArea.ts
@@ -1,0 +1,36 @@
+import { WASTE_CHUTE_ADDRESSABLE_AREAS } from '@opentrons/shared-data'
+
+import { getTrashLocationFromAddressableAreaName } from '../utils'
+
+import type {
+  MoveToAddressableAreaForDropTipParams,
+  MoveToAddressableAreaParams,
+} from '@opentrons/shared-data'
+import type { InvariantContext, RobotStateAndWarnings } from '../types'
+
+export function forMoveToAddressableArea(
+  params: MoveToAddressableAreaParams | MoveToAddressableAreaForDropTipParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void {
+  const { pipetteId, addressableAreaName } = params
+  const { wasteChuteEntities, trashBinEntities } = invariantContext
+  const addressableAreaInWasteChute = WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
+    addressableAreaName
+  )
+  const trashBinId = Object.values(trashBinEntities).find(
+    trash =>
+      trash.location ===
+      getTrashLocationFromAddressableAreaName(addressableAreaName)
+  )?.id
+
+  const entityId = addressableAreaInWasteChute
+    ? Object.values(wasteChuteEntities)[0].id
+    : trashBinId
+  console.log('entityId', entityId)
+  const { robotState } = robotStateAndWarnings
+  robotState.pipettes[pipetteId] = {
+    ...robotState.pipettes[pipetteId],
+    entityId,
+  }
+}

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveToAddressableArea.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveToAddressableArea.ts
@@ -27,7 +27,6 @@ export function forMoveToAddressableArea(
   const entityId = addressableAreaInWasteChute
     ? Object.values(wasteChuteEntities)[0].id
     : trashBinId
-  console.log('entityId', entityId)
   const { robotState } = robotStateAndWarnings
   robotState.pipettes[pipetteId] = {
     ...robotState.pipettes[pipetteId],

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveToWell.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveToWell.ts
@@ -10,7 +10,7 @@ export function forMoveToWell(
   const { robotState } = robotStateAndWarnings
   robotState.pipettes[pipetteId] = {
     ...robotState.pipettes[pipetteId],
-    labwareId: labwareId,
+    entityId: labwareId,
     wellName: wellName,
   }
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
@@ -13,12 +13,15 @@ export const forBlowOutInPlace = (
 ): void => {
   const { pipetteId } = params
   const { robotState } = robotStateAndWarnings
+  const entityId = robotState.pipettes[pipetteId].entityId ?? ''
+
   dispenseUpdateLiquidState({
     invariantContext,
     pipetteId,
     prevLiquidState: robotState.liquidState,
     useFullVolume: true,
     robotStateAndWarnings,
+    entityId,
   })
 }
 
@@ -29,6 +32,7 @@ export const forDropTipInPlace = (
 ): void => {
   const { pipetteId } = params
   const { robotState } = robotStateAndWarnings
+  const entityId = robotState.pipettes[pipetteId].entityId ?? ''
   robotState.tipState.pipettes[pipetteId] = false
 
   dispenseUpdateLiquidState({
@@ -37,5 +41,6 @@ export const forDropTipInPlace = (
     pipetteId,
     useFullVolume: true,
     robotStateAndWarnings,
+    entityId,
   })
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -14,6 +14,7 @@ import { forDispense } from './forDispense'
 import { forDropTip } from './forDropTip'
 import { forLoadLiquid } from './forLoadLiquid'
 import { forMoveLabware } from './forMoveLabware'
+import { forMoveToAddressableArea } from './forMoveToAddressableArea'
 import { forMoveToWell } from './forMoveToWell'
 import { forPickUpTip } from './forPickUpTip'
 import {
@@ -113,8 +114,6 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'loadModule':
     case 'home': // gantry VVV
     case 'moveRelative':
-    case 'moveToAddressableArea':
-    case 'moveToAddressableAreaForDropTip':
     case 'moveToSlot':
     case 'moveToCoordinates':
     case 'savePosition':
@@ -127,6 +126,15 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'airGapInPlace':
     case 'prepareToAspirate':
     case 'liquidProbe':
+      break
+
+    case 'moveToAddressableArea':
+    case 'moveToAddressableAreaForDropTip':
+      forMoveToAddressableArea(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
       break
 
     case 'moveToWell':

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -35,8 +35,9 @@ export interface LabwareTemporalProperties {
 
 export interface PipetteTemporalProperties {
   mount: Mount
-  labwareId?: string
-  //  primary nozzle's wellName
+  //  entityId is either a labwareId or a trashBin/wasteChute id
+  entityId?: string
+  //  primary nozzle's wellName if over a labware
   wellName?: string
   nozzles?: NozzleConfigurationStyle
 }

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -148,6 +148,36 @@ export function getTrashBinAddressableAreaName(
   return cutouts != null ? cutouts[trashLocation]?.[0] : 'fixedTrash'
 }
 
+export function getTrashLocationFromAddressableAreaName(
+  addressableAreaName: AddressableAreaName
+): CutoutId | null {
+  if (addressableAreaName === 'fixedTrash') {
+    return 'cutout12' as CutoutId
+  }
+
+  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+  const cutouts =
+    deckDef.cutoutFixtures.find(
+      cutoutFixture => cutoutFixture.id === 'trashBinAdapter'
+    )?.providesAddressableAreas ?? null
+
+  if (cutouts == null) {
+    console.error('Could not find trashBinAdapter cutouts for Flex')
+    return null
+  }
+
+  for (const [cutoutId, areas] of Object.entries(cutouts)) {
+    if (areas.includes(addressableAreaName)) {
+      return cutoutId as CutoutId
+    }
+  }
+
+  console.error(
+    `Could not find trashLocation for addressableAreaName ${addressableAreaName}`
+  )
+  return null
+}
+
 export function getTrashOrLabware(
   labwareEntities: LabwareEntities,
   wasteChuteEntities: WasteChuteEntities,
@@ -281,6 +311,7 @@ export function mergeLiquid(
     ),
   }
 }
+
 // TODO: Ian 2019-04-19 move to shared-data helpers?
 export function getWellsForTips(
   channels: 1 | 8 | 96,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -312,29 +312,6 @@ export function mergeLiquid(
   }
 }
 
-export function mergeLiquidForTrash(
-  source: LocationLiquidState,
-  dest: LocationLiquidState
-): LocationLiquidState {
-  return reduce<LocationLiquidState, LocationLiquidState>(
-    source,
-    (acc, ingredState, ingredId) => {
-      const isCommonIngred = ingredId in dest
-      const ingredVolume = isCommonIngred
-        ? ingredState.volume + dest[ingredId].volume
-        : ingredState.volume
-      return {
-        ...acc,
-        [ingredId]: {
-          volume: ingredVolume,
-        },
-      }
-    },
-    // start with a shallow copy of dest so we retain any exclusive ingredients
-    { ...dest }
-  )
-}
-
 // TODO: Ian 2019-04-19 move to shared-data helpers?
 export function getWellsForTips(
   channels: 1 | 8 | 96,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -148,36 +148,6 @@ export function getTrashBinAddressableAreaName(
   return cutouts != null ? cutouts[trashLocation]?.[0] : 'fixedTrash'
 }
 
-export function getTrashLocationFromAddressableAreaName(
-  addressableAreaName: AddressableAreaName
-): CutoutId | null {
-  if (addressableAreaName === 'fixedTrash') {
-    return 'cutout12' as CutoutId
-  }
-
-  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
-  const cutouts =
-    deckDef.cutoutFixtures.find(
-      cutoutFixture => cutoutFixture.id === 'trashBinAdapter'
-    )?.providesAddressableAreas ?? null
-
-  if (cutouts == null) {
-    console.error('Could not find trashBinAdapter cutouts for Flex')
-    return null
-  }
-
-  for (const [cutoutId, areas] of Object.entries(cutouts)) {
-    if (areas.includes(addressableAreaName)) {
-      return cutoutId as CutoutId
-    }
-  }
-
-  console.error(
-    `Could not find trashLocation for addressableAreaName ${addressableAreaName}`
-  )
-  return null
-}
-
 export function getTrashOrLabware(
   labwareEntities: LabwareEntities,
   wasteChuteEntities: WasteChuteEntities,
@@ -311,7 +281,6 @@ export function mergeLiquid(
     ),
   }
 }
-
 // TODO: Ian 2019-04-19 move to shared-data helpers?
 export function getWellsForTips(
   channels: 1 | 8 | 96,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -148,6 +148,36 @@ export function getTrashBinAddressableAreaName(
   return cutouts != null ? cutouts[trashLocation]?.[0] : 'fixedTrash'
 }
 
+export function getTrashLocationFromAddressableAreaName(
+  addressableAreaName: AddressableAreaName
+): CutoutId | null {
+  if (addressableAreaName === 'fixedTrash') {
+    return 'cutout12' as CutoutId
+  }
+
+  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+  const cutouts =
+    deckDef.cutoutFixtures.find(
+      cutoutFixture => cutoutFixture.id === 'trashBinAdapter'
+    )?.providesAddressableAreas ?? null
+
+  if (cutouts == null) {
+    console.error('Could not find trashBinAdapter cutouts for Flex')
+    return null
+  }
+
+  for (const [cutoutId, areas] of Object.entries(cutouts)) {
+    if (areas.includes(addressableAreaName)) {
+      return cutoutId as CutoutId
+    }
+  }
+
+  console.error(
+    `Could not find trashLocation for addressableAreaName ${addressableAreaName}`
+  )
+  return null
+}
+
 export function getTrashOrLabware(
   labwareEntities: LabwareEntities,
   wasteChuteEntities: WasteChuteEntities,
@@ -281,6 +311,30 @@ export function mergeLiquid(
     ),
   }
 }
+
+export function mergeLiquidForTrash(
+  source: LocationLiquidState,
+  dest: LocationLiquidState
+): LocationLiquidState {
+  return reduce<LocationLiquidState, LocationLiquidState>(
+    source,
+    (acc, ingredState, ingredId) => {
+      const isCommonIngred = ingredId in dest
+      const ingredVolume = isCommonIngred
+        ? ingredState.volume + dest[ingredId].volume
+        : ingredState.volume
+      return {
+        ...acc,
+        [ingredId]: {
+          volume: ingredVolume,
+        },
+      }
+    },
+    // start with a shallow copy of dest so we retain any exclusive ingredients
+    { ...dest }
+  )
+}
+
 // TODO: Ian 2019-04-19 move to shared-data helpers?
 export function getWellsForTips(
   channels: 1 | 8 | 96,


### PR DESCRIPTION
# Overview

Update `robotState.pipettes` to include the location if its a trash bin or waste chute and refactor `dispense` state update to account for that

## Test Plan and Hands on Testing

review the code and test it, seems to work as expected

## Changelog

- change the pipette robot state to include `entityId` that is either a labwareId or trashBinId or wasteChuteId
- update robot state for `moveToAddressableArea` and `moveToAddressableAreaForDropTip`
- clean up logic for updating dispense liquid state

## Risk assessment

low
