### PR TITLE
build(opentrons-ai): allow extra settings parameters

### DIFF
--- a/opentrons-ai-server/api/settings.py
+++ b/opentrons-ai-server/api/settings.py
@@ -19,7 +19,10 @@ class Settings(BaseSettings):
     If the variable is not set in the OS the default value is used (this is just for creating the .env file with default values)
     """
 
-    model_config = SettingsConfigDict(env_file=ENV_PATH, env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=ENV_PATH, env_file_encoding="utf-8", extra="allow")  # Allows extra fields
+    # Delete the extra=allow above
+    # nce we figure out why aws secret manager has a variable called protocol_designer_app_version
+    # see https://github.com/Opentrons/opentrons/actions/runs/15007084098/job/42168255050
     environment: str = "local"
     huggingface_simulate_endpoint: str = "https://Opentrons-simulator.hf.space/protocol"
     log_level: str = "info"
@@ -48,12 +51,6 @@ class Settings(BaseSettings):
     datadog_api_key: SecretStr = SecretStr("default_datadog_api_key")
     anthropic_api_key: SecretStr = SecretStr("default_anthropic_api_key")
     wandb_api_key: SecretStr = SecretStr("default_wandb_api_key")
-
-    class Config:
-        extra = "allow"  # Allows extra fields without raising an error
-        # Delete the line above once we figure out why aws secret manager has a
-        # variable called protocol_designer_app_version
-        # see https://github.com/Opentrons/opentrons/actions/runs/15007084098/job/42168255050
 
     @property
     def json_logging(self) -> bool:

--- a/opentrons-ai-server/api/settings.py
+++ b/opentrons-ai-server/api/settings.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=ENV_PATH, env_file_encoding="utf-8", extra="allow")  # Allows extra fields
     # Delete the extra=allow above
-    # nce we figure out why aws secret manager has a variable called protocol_designer_app_version
+    # once we figure out why aws secret manager has a variable called protocol_designer_app_version
     # see https://github.com/Opentrons/opentrons/actions/runs/15007084098/job/42168255050
     environment: str = "local"
     huggingface_simulate_endpoint: str = "https://Opentrons-simulator.hf.space/protocol"

--- a/opentrons-ai-server/api/settings.py
+++ b/opentrons-ai-server/api/settings.py
@@ -49,6 +49,12 @@ class Settings(BaseSettings):
     anthropic_api_key: SecretStr = SecretStr("default_anthropic_api_key")
     wandb_api_key: SecretStr = SecretStr("default_wandb_api_key")
 
+    class Config:
+        extra = "allow"  # Allows extra fields without raising an error
+        # Delete the line above once we figure out why aws secret manager has a
+        # variable called protocol_designer_app_version
+        # see https://github.com/Opentrons/opentrons/actions/runs/15007084098/job/42168255050
+
     @property
     def json_logging(self) -> bool:
         if self.environment == "local" and not is_running_in_docker():


### PR DESCRIPTION

# Overview
Temporarily allow extra settings params to be passed while we figure out why there is an aws secret key called `protocol_designer_app_version`. See https://github.com/Opentrons/opentrons/actions/runs/15007084098/job/42168255050