### PR TITLE
feat(step-generation): remove liquidProbe command from transfer command creator

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -2848,23 +2848,6 @@
       }
     },
     {
-      "commandType": "liquidProbe",
-      "key": "cc748078-15ce-456b-9858-7bda9f421ffc",
-      "params": {
-        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "top",
-          "offset": {
-            "x": 0,
-            "y": 0,
-            "z": 2
-          }
-        }
-      }
-    },
-    {
       "commandType": "prepareToAspirate",
       "key": "650d4828-375c-4981-9688-997aa298bec0",
       "params": {
@@ -3029,23 +3012,6 @@
     {
       "commandType": "moveToWell",
       "key": "814c584a-6206-40d5-8531-4aed50289fc6",
-      "params": {
-        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-        "wellName": "B1",
-        "wellLocation": {
-          "origin": "top",
-          "offset": {
-            "x": 0,
-            "y": 0,
-            "z": 2
-          }
-        }
-      }
-    },
-    {
-      "commandType": "liquidProbe",
-      "key": "5a9e771c-903c-4a2a-be60-d9139896e571",
       "params": {
         "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
         "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -4213,23 +4213,6 @@
       }
     },
     {
-      "commandType": "liquidProbe",
-      "key": "d44f69c8-2bfa-49a5-81bf-e9c645951611",
-      "params": {
-        "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "top",
-          "offset": {
-            "x": 0,
-            "y": 0,
-            "z": 2
-          }
-        }
-      }
-    },
-    {
       "commandType": "prepareToAspirate",
       "key": "5ed988c6-15af-4dae-994a-4e00762df979",
       "params": {

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -3759,23 +3759,6 @@
       }
     },
     {
-      "commandType": "liquidProbe",
-      "key": "4319b680-0f25-4416-aec5-3b93ed63f812",
-      "params": {
-        "pipetteId": "9fcd50d9-92b2-45ac-acf1-e2cf773feffc",
-        "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "top",
-          "offset": {
-            "x": 0,
-            "y": 0,
-            "z": 2
-          }
-        }
-      }
-    },
-    {
       "commandType": "prepareToAspirate",
       "key": "9ade8b83-b06f-4374-bfe9-710c1781bdf9",
       "params": {

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -3700,23 +3700,6 @@
       }
     },
     {
-      "commandType": "liquidProbe",
-      "key": "84ab8f85-26a2-4681-abf7-4b3cc693a6c7",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/2",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "top",
-          "offset": {
-            "x": 0,
-            "y": 0,
-            "z": 2
-          }
-        }
-      }
-    },
-    {
       "commandType": "prepareToAspirate",
       "key": "599a94f0-2fb6-43eb-8b49-6349ffe129a5",
       "params": {

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -3768,23 +3768,6 @@
       }
     },
     {
-      "commandType": "liquidProbe",
-      "key": "b991202d-6568-478b-b5c9-0a3e8b9733cb",
-      "params": {
-        "pipetteId": "21087f15-4c03-4587-8a2b-1ba0b5a501a0",
-        "labwareId": "c0093e5f-3f7d-4cbf-aa17-d88394108501:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
-        "wellName": "C1",
-        "wellLocation": {
-          "origin": "top",
-          "offset": {
-            "x": 0,
-            "y": 0,
-            "z": 2
-          }
-        }
-      }
-    },
-    {
       "commandType": "configureForVolume",
       "key": "1042c3fb-77a5-491b-a184-876b7be980c6",
       "params": {

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -2496,23 +2496,6 @@
       }
     },
     {
-      "commandType": "liquidProbe",
-      "key": "cf4e1a4e-dd73-4f44-9f8b-90622e2b7a85",
-      "params": {
-        "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
-        "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "top",
-          "offset": {
-            "x": 0,
-            "y": 0,
-            "z": 2
-          }
-        }
-      }
-    },
-    {
       "commandType": "prepareToAspirate",
       "key": "a4ba5bdd-6123-4e28-8fa6-278ad60c975b",
       "params": {
@@ -2646,23 +2629,6 @@
     {
       "commandType": "moveToWell",
       "key": "5d04c7cc-7395-4251-ae8d-3bf71ee02974",
-      "params": {
-        "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
-        "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
-        "wellName": "A7",
-        "wellLocation": {
-          "origin": "top",
-          "offset": {
-            "x": 0,
-            "y": 0,
-            "z": 2
-          }
-        }
-      }
-    },
-    {
-      "commandType": "liquidProbe",
-      "key": "f4cfbf8b-d62c-49cd-9750-92006840d640",
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",

--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -291,7 +291,6 @@ describe('generateRobotStateTimeline', () => {
       `
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
 mock_pipette.move_to(mock_source_plate["A1"].top(z=2))
-mock_pipette.measure_liquid_height(mock_source_plate["A1"])
 mock_pipette.prepare_to_aspirate()
 mock_pipette.move_to(mock_source_plate["A1"].bottom())
 mock_pipette.move_to(mock_source_plate["A1"].bottom())
@@ -317,7 +316,6 @@ mock_pipette.drop_tip()
       `
 mock_pipette_p300_multi.pick_up_tip(location=mock_tip_rack_1)
 mock_pipette_p300_multi.move_to(mock_source_plate["A1"].top(z=2))
-mock_pipette_p300_multi.measure_liquid_height(mock_source_plate["A1"])
 mock_pipette_p300_multi.prepare_to_aspirate()
 mock_pipette_p300_multi.move_to(mock_source_plate["A1"].bottom())
 mock_pipette_p300_multi.move_to(mock_source_plate["A1"].bottom())

--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -226,7 +226,6 @@ describe('generateRobotStateTimeline', () => {
         [
           "pickUpTip",
           "moveToWell",
-          "liquidProbe",
           "prepareToAspirate",
           "moveToWell",
           "moveToWell",
@@ -252,7 +251,6 @@ describe('generateRobotStateTimeline', () => {
         [
           "pickUpTip",
           "moveToWell",
-          "liquidProbe",
           "prepareToAspirate",
           "moveToWell",
           "moveToWell",

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -16,6 +16,7 @@ import {
 import { transfer } from '../commandCreators/compound/transfer'
 import { FIXED_TRASH_ID } from '../constants'
 import {
+  aspirateHelperLiquidClass,
   blowoutInTrashCommands,
   DEFAULT_PIPETTE,
   DEST_LABWARE,
@@ -28,7 +29,6 @@ import {
   makeContext,
   pickUpTipHelper,
   SOURCE_LABWARE,
-  submergeWithAspirateHelper,
 } from '../fixtures'
 import {
   DEST_WELL_BLOWOUT_DESTINATION,
@@ -178,7 +178,7 @@ describe('pick up tip if no tip on pipette', () => {
         },
       },
       pickUpTipHelper('A1'),
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 30,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -285,7 +285,7 @@ it('single transfer: 1 source & 1 dest', () => {
   )
   const res = getSuccessResult(result)
   expect(res.commands).toEqual([
-    ...submergeWithAspirateHelper({
+    ...aspirateHelperLiquidClass({
       volume: 30,
       aspirateFlowRate: 10,
       submergeSpeed: 50,
@@ -393,7 +393,7 @@ test('single transfer: 1 source & 1 dest with waste chute', () => {
   )
   const res = getSuccessResult(result)
   expect(res.commands).toEqual([
-    ...submergeWithAspirateHelper({
+    ...aspirateHelperLiquidClass({
       volume: 30,
       aspirateFlowRate: 10,
       submergeSpeed: 50,
@@ -463,7 +463,7 @@ test('transfer with multiple sets of wells', () => {
   )
   const res = getSuccessResult(result)
   expect(res.commands).toEqual([
-    ...submergeWithAspirateHelper({
+    ...aspirateHelperLiquidClass({
       volume: 30,
       aspirateFlowRate: 10,
       submergeSpeed: 50,
@@ -532,7 +532,7 @@ test('transfer with multiple sets of wells', () => {
       },
     }),
 
-    ...submergeWithAspirateHelper({
+    ...aspirateHelperLiquidClass({
       volume: 30,
       aspirateFlowRate: 10,
       submergeSpeed: 50,
@@ -684,7 +684,7 @@ describe('single transfer exceeding pipette max', () => {
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
       pickUpTipHelper('A1'),
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -751,7 +751,7 @@ describe('single transfer exceeding pipette max', () => {
           },
         },
       }),
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -819,7 +819,7 @@ describe('single transfer exceeding pipette max', () => {
           },
         },
       }),
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -887,7 +887,7 @@ describe('single transfer exceeding pipette max', () => {
           },
         },
       }),
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -971,7 +971,7 @@ describe('single transfer exceeding pipette max', () => {
     expect(res.commands).toEqual([
       pickUpTipHelper('A1'),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1044,7 +1044,7 @@ describe('single transfer exceeding pipette max', () => {
       ...dropTipHelper(),
       pickUpTipHelper('B1'),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1118,7 +1118,7 @@ describe('single transfer exceeding pipette max', () => {
       ...dropTipHelper(),
       pickUpTipHelper('C1'),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1191,7 +1191,7 @@ describe('single transfer exceeding pipette max', () => {
       ...dropTipHelper(),
       pickUpTipHelper('D1'),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1276,7 +1276,7 @@ describe('single transfer exceeding pipette max', () => {
     expect(res.commands).toEqual([
       pickUpTipHelper('A1'),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1345,7 +1345,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1416,7 +1416,7 @@ describe('single transfer exceeding pipette max', () => {
       }),
 
       // same source, different dest: no change
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1486,7 +1486,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1559,7 +1559,7 @@ describe('single transfer exceeding pipette max', () => {
       ...dropTipHelper(),
       pickUpTipHelper('B1'),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1627,7 +1627,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1712,7 +1712,7 @@ describe('single transfer exceeding pipette max', () => {
     expect(res.commands).toEqual([
       pickUpTipHelper('A1'),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1780,7 +1780,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1853,7 +1853,7 @@ describe('single transfer exceeding pipette max', () => {
       ...dropTipHelper(),
       pickUpTipHelper('B1'),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1922,7 +1922,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -1993,7 +1993,7 @@ describe('single transfer exceeding pipette max', () => {
 
       // different source, same dest: no change
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2062,7 +2062,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2145,7 +2145,7 @@ describe('single transfer exceeding pipette max', () => {
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
       // no pick up tip
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2214,7 +2214,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2284,7 +2284,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2353,7 +2353,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
 
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 175,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2437,7 +2437,7 @@ describe('single transfer exceeding pipette max', () => {
     const result = transfer(transferArgs, invariantContext, robotStateWithTip)
     const res = getSuccessResult(result)
     expect(res.commands).toEqual([
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 629 / 3,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2506,7 +2506,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
       // last 2 chunks split evenly
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 629 / 3,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2574,7 +2574,7 @@ describe('single transfer exceeding pipette max', () => {
           },
         },
       }),
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 629 / 3,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2642,7 +2642,7 @@ describe('single transfer exceeding pipette max', () => {
           },
         },
       }),
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 629 / 3,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2711,7 +2711,7 @@ describe('single transfer exceeding pipette max', () => {
         },
       }),
       // last 2 chunks split evenly
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 629 / 3,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2779,7 +2779,7 @@ describe('single transfer exceeding pipette max', () => {
           },
         },
       }),
-      ...submergeWithAspirateHelper({
+      ...aspirateHelperLiquidClass({
         volume: 629 / 3,
         aspirateFlowRate: 10,
         submergeSpeed: 50,
@@ -2873,7 +2873,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -2943,7 +2943,7 @@ describe('advanced options', () => {
             },
           },
         }),
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3029,7 +3029,7 @@ describe('advanced options', () => {
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
         // pre-wet aspirate/dispense
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3100,7 +3100,7 @@ describe('advanced options', () => {
             },
           },
         }),
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3185,7 +3185,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3258,7 +3258,7 @@ describe('advanced options', () => {
           },
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3345,7 +3345,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           submergeSpeed: 50,
@@ -3417,7 +3417,7 @@ describe('advanced options', () => {
             },
           },
         }),
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           submergeSpeed: 50,
@@ -3505,7 +3505,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           submergeSpeed: 50,
@@ -3578,7 +3578,7 @@ describe('advanced options', () => {
           touchTipSpeed: 60,
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           submergeSpeed: 50,
@@ -3667,7 +3667,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3739,7 +3739,7 @@ describe('advanced options', () => {
           },
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3827,7 +3827,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3900,7 +3900,7 @@ describe('advanced options', () => {
           },
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -3985,7 +3985,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4056,7 +4056,7 @@ describe('advanced options', () => {
           },
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4139,7 +4139,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4210,7 +4210,7 @@ describe('advanced options', () => {
           },
           aspirateAirGap: 5,
         }),
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4293,7 +4293,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 150,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4365,7 +4365,7 @@ describe('advanced options', () => {
           aspirateAirGap: 5,
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 150,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4449,7 +4449,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateAirGap: 5,
           aspirateFlowRate: 10,
@@ -4522,7 +4522,7 @@ describe('advanced options', () => {
           aspirateAirGap: 5,
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4608,7 +4608,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4683,7 +4683,7 @@ describe('advanced options', () => {
           dispenseDelay: 12,
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4774,7 +4774,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4845,7 +4845,7 @@ describe('advanced options', () => {
           mixTimes: 2,
           mixVolume: 250,
         }),
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -4933,7 +4933,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -5007,7 +5007,7 @@ describe('advanced options', () => {
           dispenseDelay: 12,
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -5093,7 +5093,7 @@ describe('advanced options', () => {
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -5165,7 +5165,7 @@ describe('advanced options', () => {
           },
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 2.2,
@@ -5280,7 +5280,7 @@ describe('advanced options', () => {
       const result = transfer(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -5375,7 +5375,7 @@ describe('advanced options', () => {
           aspirateFlowRate: 10,
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -5481,7 +5481,7 @@ describe('advanced options', () => {
       const result = transfer(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -5569,7 +5569,7 @@ describe('advanced options', () => {
           blowoutFlowRate: 2.3,
         }),
 
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -5697,7 +5697,7 @@ describe('advanced options', () => {
             wellName: 'A1',
           },
         },
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -5783,7 +5783,7 @@ describe('advanced options', () => {
           shouldBlowoutInDestination: true,
           blowoutFlowRate: 2.3,
         }),
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -5912,7 +5912,7 @@ describe('advanced options', () => {
             wellName: 'A1',
           },
         },
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,
@@ -6087,7 +6087,7 @@ describe('advanced options', () => {
         // next chunk from A1: remaining volume
         // do not pre-wet
         // mix (asp)
-        ...submergeWithAspirateHelper({
+        ...aspirateHelperLiquidClass({
           volume: 175,
           aspirateFlowRate: 10,
           dispenseFlowRate: 12,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -27,7 +27,6 @@ import {
   configureForVolume,
   delay,
   dispenseInPlace,
-  liquidProbe,
   moveToAddressableArea,
   moveToWell,
   prepareToAspirate,
@@ -275,7 +274,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   )
   let prevSourceWell: string | null = null
   let prevDestWell: string | null = null
-  const probedWells: Set<string> = new Set()
+  // const probedWells: Set<string> = new Set()
   const commandCreators = sourceDestPairs.reduce(
     (
       outerAcc: CurriedCommandCreator[],
@@ -370,18 +369,19 @@ export const transfer: CommandCreator<TransferArgs> = (
               wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
             }),
           ]
-          let liquidProbeCommand: CurriedCommandCreator[] = []
-          if (changeTipNow && !probedWells.has(sourceWell)) {
-            liquidProbeCommand = [
-              curryCommandCreator(liquidProbe, {
-                pipetteId: args.pipette,
-                labwareId: args.sourceLabware,
-                wellName: sourceWell,
-                wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
-              }),
-            ]
-            probedWells.add(sourceWell)
-          }
+          // TODO (nd, 05/13/2025): uncomment and refine below logic once meniscus-relative pipetting is supported in PD
+          // let liquidProbeCommand: CurriedCommandCreator[] = []
+          // if (changeTipNow && !probedWells.has(sourceWell)) {
+          //   liquidProbeCommand = [
+          //     curryCommandCreator(liquidProbe, {
+          //       pipetteId: args.pipette,
+          //       labwareId: args.sourceLabware,
+          //       wellName: sourceWell,
+          //       wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
+          //     }),
+          //   ]
+          //   probedWells.add(sourceWell)
+          // }
           const prepareToAspirateCommand = [
             curryCommandCreator(prepareToAspirate, {
               pipetteId: args.pipette,
@@ -402,7 +402,7 @@ export const transfer: CommandCreator<TransferArgs> = (
           const preAspirateSubmergeCommands = [
             ...moveToSourceWellTopCommand,
             ...voidDispenseAirGapCommand,
-            ...liquidProbeCommand,
+            // ...liquidProbeCommand,
             ...configureForVolumeCommand,
             ...prepareToAspirateCommand,
           ]

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -139,7 +139,7 @@ export const makeAspirateHelper: MakeAspDispHelper<AspDispAirgapParams> = bakedP
     ...params,
   },
 })
-export const submergeWithAspirateHelper = (submergeParams: {
+export const aspirateHelperLiquidClass = (submergeParams: {
   pipetteId: string
   labwareId: string
   wellName: string
@@ -178,7 +178,7 @@ export const submergeWithAspirateHelper = (submergeParams: {
     submergeLocation,
     aspirateLocation,
     retractLocation,
-    shouldProbe = true,
+    // shouldProbe = true,
     shouldPreWet = false,
     shouldTouchTip = false,
     submergeDelay = 0,
@@ -268,27 +268,27 @@ export const submergeWithAspirateHelper = (submergeParams: {
           },
         ]
       : []),
-    ...(shouldProbe
-      ? [
-          {
-            commandType: 'liquidProbe',
-            key: expect.any(String),
-            params: {
-              pipetteId,
-              labwareId,
-              wellName,
-              wellLocation: {
-                origin: WELL_ORIGIN_TOP,
-                offset: {
-                  x: 0,
-                  y: 0,
-                  z: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
-                },
-              },
-            },
-          },
-        ]
-      : []),
+    // ...(shouldProbe
+    //   ? [
+    //       {
+    //         commandType: 'liquidProbe',
+    //         key: expect.any(String),
+    //         params: {
+    //           pipetteId,
+    //           labwareId,
+    //           wellName,
+    //           wellLocation: {
+    //             origin: WELL_ORIGIN_TOP,
+    //             offset: {
+    //               x: 0,
+    //               y: 0,
+    //               z: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
+    //             },
+    //           },
+    //         },
+    //       },
+    //     ]
+    //   : []),
     {
       commandType: 'prepareToAspirate',
       key: expect.any(String),


### PR DESCRIPTION
# Overview

Since the next version of PD will ship at a time when no liquid class definitions will contain references to liquid meniscus for pipetting, we can safely remove liquid probing from step generation. We will implement more sophisticated logic for determining when to probe in the following release.

cc @sanni-t 

## Test Plan and Hands on Testing

not much to test here, just review code

## Changelog

- remove liquid probe command from transfer command creator and command fixtures (temporarily)
- update migrations 

## Review requests

- see test plan

## Risk assessment

low