### PR TITLE
feat(api): Stacker LED substate representation

### DIFF
--- a/api/src/opentrons/drivers/flex_stacker/abstract.py
+++ b/api/src/opentrons/drivers/flex_stacker/abstract.py
@@ -199,8 +199,8 @@ class AbstractFlexStackerDriver(Protocol):
         color: Optional[LEDColor] = None,
         external: Optional[bool] = None,
         pattern: Optional[LEDPattern] = None,
-        duration: Optional[int] = None,
-        reps: Optional[int] = None,
+        duration: Optional[int] = None,  # Default firmware duration is 500ms
+        reps: Optional[int] = None,  # Default firmware reps is 0
     ) -> None:
         """Set LED Status bar color and pattern."""
         ...

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -594,36 +594,48 @@ class FlexStacker(mod_abc.AbstractModule):
                 case StatusBarState.RUNNING:
                     await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.STATIC)
                 case StatusBarState.PAUSED:
-                    if self.hopper_door_state == HopperDoorState.OPENED:
-                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
-                    elif self.should_identify:
-                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
+                    if (
+                        self.hopper_door_state == HopperDoorState.OPENED
+                        or self.should_identify
+                    ):
+                        await self._stacker_bar_pause()
                     else:
-                        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
+                        await self._stacker_bar_idle()
                 case StatusBarState.IDLE:
                     if self.hopper_door_state == HopperDoorState.OPENED:
-                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
-                    await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
+                        await self._stacker_bar_pause()
+                    else:
+                        await self._stacker_bar_idle()
                 case StatusBarState.HARDWARE_ERROR:
                     if self.should_identify:
-                        await self.set_led_state(0.5, LEDColor.RED, LEDPattern.FLASH)
+                        await self.set_led_state(
+                            0.5, LEDColor.RED, LEDPattern.FLASH, duration=300
+                        )
                     else:
-                        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
+                        await self._stacker_bar_idle()
                 case StatusBarState.SOFTWARE_ERROR:
                     await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.STATIC)
                 case StatusBarState.ERROR_RECOVERY:
                     if self.hopper_door_state == HopperDoorState.OPENED:
-                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
+                        await self._stacker_bar_pause()
                     elif self.should_identify:
-                        await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.PULSE)
+                        await self.set_led_state(
+                            0.5, LEDColor.YELLOW, LEDPattern.PULSE, duration=2000
+                        )
                     else:
-                        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
+                        await self._stacker_bar_idle()
                 case StatusBarState.RUN_COMPLETED:
                     await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.PULSE)
                 case StatusBarState.UPDATING:
                     await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.PULSE)
                 case _:
-                    await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
+                    await self._stacker_bar_idle()
+
+    async def _stacker_bar_pause(self) -> None:
+        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE, duration=2000)
+
+    async def _stacker_bar_idle(self) -> None:
+        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
 
     async def identify(self) -> None:
         """Identify the module."""

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -592,24 +592,49 @@ class FlexStacker(mod_abc.AbstractModule):
         if event.enabled and self.initialized:
             match event.state:
                 case StatusBarState.RUNNING:
+                    if self.should_identify:
+                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.STATIC)
                 case StatusBarState.PAUSED:
                     if self.should_identify:
-                        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.PULSE)
+                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
                         self.set_stacker_identify(False)
                     else:
-                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
+                        if self.hopper_door_state == HopperDoorState.OPENED:
+                            await self.set_led_state(
+                                0.5, LEDColor.BLUE, LEDPattern.PULSE
+                            )
+                        else:
+                            await self.set_led_state(
+                                0.5, LEDColor.WHITE, LEDPattern.STATIC
+                            )
                 case StatusBarState.IDLE:
+                    if self.should_identify:
+                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
                 case StatusBarState.HARDWARE_ERROR:
-                    await self.set_led_state(0.5, LEDColor.RED, LEDPattern.FLASH)
+                    if self.should_identify:
+                        await self.set_led_state(0.5, LEDColor.RED, LEDPattern.FLASH)
+                        self.set_stacker_identify(False)
+                    else:
+                        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
                 case StatusBarState.SOFTWARE_ERROR:
+                    if self.should_identify:
+                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.STATIC)
                 case StatusBarState.ERROR_RECOVERY:
-                    await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.PULSE)
+                    if self.should_identify:
+                        await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.PULSE)
+                        self.set_stacker_identify(False)
+                    else:
+                        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
                 case StatusBarState.RUN_COMPLETED:
+                    if self.should_identify:
+                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.PULSE)
                 case StatusBarState.UPDATING:
+                    if self.should_identify:
+                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.PULSE)
                 case _:
                     await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -592,56 +592,42 @@ class FlexStacker(mod_abc.AbstractModule):
         if event.enabled and self.initialized:
             match event.state:
                 case StatusBarState.RUNNING:
-                    if self.should_identify:
-                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.STATIC)
                 case StatusBarState.PAUSED:
-                    if self.should_identify:
+                    if self.hopper_door_state == HopperDoorState.OPENED:
                         await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
-                        self.set_stacker_identify(False)
+                    elif self.should_identify:
+                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
                     else:
-                        if self.hopper_door_state == HopperDoorState.OPENED:
-                            await self.set_led_state(
-                                0.5, LEDColor.BLUE, LEDPattern.PULSE
-                            )
-                        else:
-                            await self.set_led_state(
-                                0.5, LEDColor.WHITE, LEDPattern.STATIC
-                            )
+                        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
                 case StatusBarState.IDLE:
-                    if self.should_identify:
-                        self.set_stacker_identify(False)
+                    if self.hopper_door_state == HopperDoorState.OPENED:
+                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
                     await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
                 case StatusBarState.HARDWARE_ERROR:
                     if self.should_identify:
                         await self.set_led_state(0.5, LEDColor.RED, LEDPattern.FLASH)
-                        self.set_stacker_identify(False)
                     else:
                         await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
                 case StatusBarState.SOFTWARE_ERROR:
-                    if self.should_identify:
-                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.STATIC)
                 case StatusBarState.ERROR_RECOVERY:
-                    if self.should_identify:
+                    if self.hopper_door_state == HopperDoorState.OPENED:
+                        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE)
+                    elif self.should_identify:
                         await self.set_led_state(0.5, LEDColor.YELLOW, LEDPattern.PULSE)
-                        self.set_stacker_identify(False)
                     else:
                         await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
                 case StatusBarState.RUN_COMPLETED:
-                    if self.should_identify:
-                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.GREEN, LEDPattern.PULSE)
                 case StatusBarState.UPDATING:
-                    if self.should_identify:
-                        self.set_stacker_identify(False)
                     await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.PULSE)
                 case _:
                     await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.STATIC)
 
     async def identify(self) -> None:
         """Identify the module."""
-        await self.set_led_state(0.5, LEDColor.WHITE, LEDPattern.PULSE, reps=10)
+        await self.set_led_state(0.5, LEDColor.BLUE, LEDPattern.PULSE, reps=10)
         if self._last_status_bar_event:
             await self._handle_status_bar_event(self._last_status_bar_event)
 
@@ -718,7 +704,10 @@ class FlexStackerReader(Reader):
 
     async def get_door_closed(self) -> None:
         """Check if the hopper door is closed."""
+        old_door_state = self.hopper_door_closed
         self.hopper_door_closed = await self._driver.get_hopper_door_closed()
+        if old_door_state != self.hopper_door_closed and self._initialized_callback:
+            await self._initialized_callback()
 
     def on_error(self, exception: Exception) -> None:
         self._driver.reset_serial_buffers()

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/empty.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/empty.py
@@ -147,7 +147,9 @@ class EmptyImpl(AbstractCommandImpl[EmptyParams, SuccessData[EmptyResult]]):
         self._run_control = run_control
         self._equipment = equipment
 
-    async def execute(self, params: EmptyParams) -> SuccessData[EmptyResult]:
+    async def execute(  # noqa: C901
+        self, params: EmptyParams
+    ) -> SuccessData[EmptyResult]:
         """Execute the stacker empty command."""
         stacker_state = self._state_view.modules.get_flex_stacker_substate(
             params.moduleId
@@ -208,6 +210,9 @@ class EmptyImpl(AbstractCommandImpl[EmptyParams, SuccessData[EmptyResult]]):
 
         if params.strategy == StackerFillEmptyStrategy.MANUAL_WITH_PAUSE:
             await self._run_control.wait_for_resume()
+
+        if stacker_hw:
+            stacker_hw.set_stacker_identify(False)
 
         if stacker_state.pool_primary_definition is None:
             raise FlexStackerLabwarePoolNotYetDefinedError(

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/fill.py
@@ -222,6 +222,9 @@ class FillImpl(AbstractCommandImpl[FillParams, SuccessData[FillResult]]):
         if params.strategy == StackerFillEmptyStrategy.MANUAL_WITH_PAUSE:
             await self._run_control.wait_for_resume()
 
+        if stacker_hw:
+            stacker_hw.set_stacker_identify(False)
+
         return SuccessData(
             public=FillResult.model_construct(
                 count=len(new_contained_labware),

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
@@ -270,6 +270,7 @@ class RetrieveImpl(AbstractCommandImpl[RetrieveParams, _ExecuteReturn]):
         stacker_hw = self._equipment.get_module_hardware_api(stacker_state.module_id)
         if stacker_hw is not None:
             try:
+                stacker_hw.set_stacker_identify(True)
                 await stacker_hw.dispense_labware(labware_height=labware_height)
             except (
                 FlexStackerStallError,

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
@@ -282,6 +282,9 @@ class RetrieveImpl(AbstractCommandImpl[RetrieveParams, _ExecuteReturn]):
                     e, to_retrieve.primaryLabwareId, state_update
                 )
 
+        if stacker_hw is not None:
+            stacker_hw.set_stacker_identify(False)
+
         return SuccessData(
             public=RetrieveResult.model_construct(
                 labwareId=to_retrieve.primaryLabwareId,

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -275,6 +275,9 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
             ),
         )
 
+        if stacker_hw is not None:
+            stacker_hw.set_stacker_identify(False)
+
         return SuccessData(
             public=StoreResult.model_construct(
                 eventualDestinationLocationSequence=[

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -207,6 +207,7 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
         state_update = update_types.StateUpdate()
         try:
             if stacker_hw is not None:
+                stacker_hw.set_stacker_identify(True)
                 await stacker_hw.store_labware(labware_height=stack_height)
         except FlexStackerStallError as e:
             return DefinedErrorData(

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_stacker_manual_retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_stacker_manual_retrieve.py
@@ -175,13 +175,12 @@ class UnsafeFlexStackerManualRetrieveImpl(
         stacker_hw = self._equipment.get_module_hardware_api(stacker_state.module_id)
 
         # Validate that the stacker is fully in the gripper position
-        if (
-            stacker_hw is not None
-            and stacker_hw.platform_state != PlatformState.EXTENDED
-        ):
-            raise CannotPerformModuleAction(
-                f"Cannot manually retrieve a labware from Flex Stacker in {location} if the carriage is not in gripper position."
-            )
+        if stacker_hw:
+            stacker_hw.set_stacker_identify(True)
+            if stacker_hw.platform_state != PlatformState.EXTENDED:
+                raise CannotPerformModuleAction(
+                    f"Cannot manually retrieve a labware from Flex Stacker in {location} if the carriage is not in gripper position."
+                )
 
         try:
             # In theory given this is an unsafe manual retrieve this should never raise

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_stacker_manual_retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_stacker_manual_retrieve.py
@@ -223,6 +223,9 @@ class UnsafeFlexStackerManualRetrieveImpl(
             ),
         )
 
+        if stacker_hw is not None:
+            stacker_hw.set_stacker_identify(False)
+
         return SuccessData(
             public=UnsafeFlexStackerManualRetrieveResult(
                 labwareId=to_retrieve.primaryLabwareId,

--- a/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
@@ -148,52 +148,91 @@ async def test_set_run_hold_current(
 
 
 @pytest.mark.parametrize(
-    ("door_intervention", "event", "params"),
+    ("should_identify", "hopper_door", "event", "result_params"),
     [
-        (
+        (  # running
             False,
+            True,
             StatusBarUpdateEvent(state=StatusBarState.RUNNING, enabled=True),
-            (0.5, LEDColor.GREEN, LEDPattern.STATIC),
+            (0.5, LEDColor.GREEN, LEDPattern.STATIC, None),
         ),
-        (
+        (  # paused - door open
+            False,
+            False,
+            StatusBarUpdateEvent(state=StatusBarState.PAUSED, enabled=True),
+            (0.5, LEDColor.BLUE, LEDPattern.PULSE, 2000),
+        ),
+        (  # paused - should identify
+            True,
             True,
             StatusBarUpdateEvent(state=StatusBarState.PAUSED, enabled=True),
-            (0.5, LEDColor.WHITE, LEDPattern.PULSE),
+            (0.5, LEDColor.BLUE, LEDPattern.PULSE, 2000),
         ),
-        (
+        (  # paused - door closed not identified
             False,
+            True,
             StatusBarUpdateEvent(state=StatusBarState.PAUSED, enabled=True),
-            (0.5, LEDColor.BLUE, LEDPattern.PULSE),
+            (0.5, LEDColor.WHITE, LEDPattern.STATIC, None),
         ),
-        (
+        (  # idle - door open
+            False,
             False,
             StatusBarUpdateEvent(state=StatusBarState.IDLE, enabled=True),
-            (0.5, LEDColor.WHITE, LEDPattern.STATIC),
+            (0.5, LEDColor.BLUE, LEDPattern.PULSE, 2000),
         ),
-        (
+        (  # idle - door closed
             False,
+            True,
+            StatusBarUpdateEvent(state=StatusBarState.IDLE, enabled=True),
+            (0.5, LEDColor.WHITE, LEDPattern.STATIC, None),
+        ),
+        (  # hardware error - identified
+            True,
+            True,
             StatusBarUpdateEvent(state=StatusBarState.HARDWARE_ERROR, enabled=True),
-            (0.5, LEDColor.RED, LEDPattern.FLASH),
+            (0.5, LEDColor.RED, LEDPattern.FLASH, 300),
         ),
-        (
+        (  # hardware error - not identified
             False,
-            StatusBarUpdateEvent(state=StatusBarState.SOFTWARE_ERROR, enabled=True),
-            (0.5, LEDColor.YELLOW, LEDPattern.STATIC),
+            True,
+            StatusBarUpdateEvent(state=StatusBarState.HARDWARE_ERROR, enabled=True),
+            (0.5, LEDColor.WHITE, LEDPattern.STATIC, None),
         ),
-        (
+        (  # software error
+            False,
+            True,
+            StatusBarUpdateEvent(state=StatusBarState.SOFTWARE_ERROR, enabled=True),
+            (0.5, LEDColor.YELLOW, LEDPattern.STATIC, None),
+        ),
+        (  # error recovery - door open
+            False,
             False,
             StatusBarUpdateEvent(state=StatusBarState.ERROR_RECOVERY, enabled=True),
-            (0.5, LEDColor.YELLOW, LEDPattern.PULSE),
+            (0.5, LEDColor.BLUE, LEDPattern.PULSE, 2000),
         ),
-        (
+        (  # error recovery - should identify
+            True,
+            True,
+            StatusBarUpdateEvent(state=StatusBarState.ERROR_RECOVERY, enabled=True),
+            (0.5, LEDColor.YELLOW, LEDPattern.PULSE, 2000),
+        ),
+        (  # error recovery - door closed
             False,
+            True,
+            StatusBarUpdateEvent(state=StatusBarState.ERROR_RECOVERY, enabled=True),
+            (0.5, LEDColor.WHITE, LEDPattern.STATIC, None),
+        ),
+        (  # run complete
+            False,
+            True,
             StatusBarUpdateEvent(state=StatusBarState.RUN_COMPLETED, enabled=True),
-            (0.5, LEDColor.GREEN, LEDPattern.PULSE),
+            (0.5, LEDColor.GREEN, LEDPattern.PULSE, None),
         ),
-        (
+        (  # updating
             False,
+            True,
             StatusBarUpdateEvent(state=StatusBarState.UPDATING, enabled=True),
-            (0.5, LEDColor.WHITE, LEDPattern.PULSE),
+            (0.5, LEDColor.WHITE, LEDPattern.PULSE, None),
         ),
     ],
 )
@@ -201,12 +240,19 @@ async def test_stacker_status_bar_event_handler(
     decoy: Decoy,
     subject: modules.FlexStacker,
     mock_driver: mock.AsyncMock,
-    door_intervention: bool,
+    should_identify: bool,
+    hopper_door: bool,
     event: StatusBarUpdateEvent,
-    params: tuple[float, LEDColor, LEDPattern],
+    result_params: tuple[float, LEDColor, LEDPattern, int | None],
 ) -> None:
-    subject.set_stacker_identify(door_intervention)
+    mock_driver.get_hopper_door_closed.return_value = hopper_door
+    subject.set_stacker_identify(should_identify)
+    await subject._reader.get_door_closed()
     await subject._handle_status_bar_event(event)
     mock_driver.set_led.assert_called_with(
-        params[0], color=params[1], pattern=params[2], duration=None, reps=None
+        result_params[0],
+        color=result_params[1],
+        pattern=result_params[2],
+        duration=result_params[3],
+        reps=None,
     )


### PR DESCRIPTION
# Overview
Covers EXEC-1484 and RABR-770

As outlined in EXEC 1484 each stacker must individually light with a given relevant state either relative to the status bar or a substate of the overall status.
Example: While in error recovery for a stacker, the stacker in question should flash yellow, all others should be static white. If the door is opened on that stacker during error recovery, its light must flash blue. Upon closing, it must transition back to the yellow flashing state until error recovery has ended.

## Test Plan and Hands on Testing

- [x] Verify each outlined state for the LED transitions as expected and is the correct color during a live run
- [x] Update stacker LED unit test to represent new color expectations, and substate expectations

## Changelog
- Updated and expanded the stacker local lighting states.
- Updated when should_identify is used by the stacker engine commands so if/when we transition into error-recovery the each stacker knows when it needs to change lighting states.

## Review requests
Anything sticking out as problematic here? Ran it through on a Flex to ensure the different states all were represented as expected.

## Risk assessment
Low - new behavior on a new module