### PR TITLE
feat(components): introduce tiprack background colors

### DIFF
--- a/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.tsx
@@ -1,6 +1,7 @@
 import { SLOT_RENDER_HEIGHT, SLOT_RENDER_WIDTH } from '@opentrons/shared-data'
 
 import { COLORS } from '../../../helix-design-system'
+import { getTiprackBackgroundColor } from './getTiprackBackgroundColor'
 
 import type { CSSProperties } from 'styled-components'
 import type { SVGProps } from 'react'
@@ -40,7 +41,7 @@ export function LabwareOutline(props: LabwareOutlineProps): JSX.Element {
     showRadius = true,
   } = props
   const {
-    parameters = { isTiprack },
+    parameters = { isTiprack, loadName: '' },
     dimensions = { xDimension: width, yDimension: height },
   } = definition ?? {}
 
@@ -48,8 +49,11 @@ export function LabwareOutline(props: LabwareOutlineProps): JSX.Element {
   if (fill != null) {
     backgroundFill = fill
   } else {
-    backgroundFill = parameters.isTiprack ? '#CCCCCC' : COLORS.white
+    backgroundFill = parameters.isTiprack
+      ? getTiprackBackgroundColor(parameters.loadName)
+      : COLORS.white
   }
+
   return (
     <>
       {highlight ? (

--- a/components/src/hardware-sim/Labware/labwareInternals/getTiprackBackgroundColor.ts
+++ b/components/src/hardware-sim/Labware/labwareInternals/getTiprackBackgroundColor.ts
@@ -1,0 +1,32 @@
+import {
+  flex40,
+  green40,
+  purple40,
+  yellow40,
+} from '../../../helix-design-system/colors'
+
+export const getTiprackBackgroundColor = (loadName: string): string => {
+  let tiprackColor = '#CCCCCC'
+  if (
+    loadName === 'opentrons_flex_96_tiprack_50ul' ||
+    loadName === 'opentrons_flex_96_filtertiprack_50ul'
+  ) {
+    tiprackColor = purple40
+  } else if (
+    loadName === 'opentrons_flex_96_tiprack_1000ul' ||
+    loadName === 'opentrons_flex_96_filtertiprack_1000ul'
+  ) {
+    tiprackColor = flex40
+  } else if (
+    loadName === 'opentrons_flex_96_tiprack_200ul' ||
+    loadName === 'opentrons_flex_96_filtertiprack_200ul'
+  ) {
+    tiprackColor = yellow40
+  } else if (
+    loadName === 'opentrons_flex_96_tiprack_20ul' ||
+    loadName === 'opentrons_flex_96_filtertiprack_20ul'
+  ) {
+    tiprackColor = green40
+  }
+  return tiprackColor
+}

--- a/components/src/helix-design-system/colors.ts
+++ b/components/src/helix-design-system/colors.ts
@@ -86,6 +86,7 @@ export const transparentBlack80 = `${black90}80`
 /**
  * flex
  */
+export const flex40 = '#aae3fc'
 export const flex55 = '#0297CC'
 export const flex50 = '#00BDFF'
 


### PR DESCRIPTION
closes AUTH-1489

# Overview

Add background colors to the Flex tipracks (note: PD doesn't support 20uL tipracks but i added a green background to that)

<img width="622" alt="Screenshot 2025-05-14 at 08 36 12" src="https://github.com/user-attachments/assets/0bee9355-bda7-43be-99f7-708c01abf255" />

## Test Plan and Hands on Testing

test for yourself! should work across anything that uses the `LabwareOutline` component which is used across the whole stack.

## Changelog

- add background colors to Flex tipracks
- add a new color

## Risk assessment

low