### PR TITLE
fix(hardware-testing): handle non-Location locs

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -1,4 +1,5 @@
 """Opentrons helper methods."""
+
 import asyncio
 from random import random, randint
 from types import MethodType
@@ -369,7 +370,7 @@ def _drop_tip(
         pipette.drop_tip(home_after=False)
     if minimum_z_height > 0:
         cur_location = pipette._get_last_location_by_api_version()
-        if cur_location is not None:
+        if isinstance(cur_location, Location):
             pipette.move_to(cur_location.move(Point(0, 0, minimum_z_height)))
 
 


### PR DESCRIPTION
This wasn't handling the return values of this method properly, now it is.
