### PR TITLE
fix(app): Hide the option to reset labware offsets on OT-2s

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/DeviceResetSlideout.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/DeviceResetSlideout.tsx
@@ -332,16 +332,18 @@ export function DeviceResetSlideout({
                   value={displayedOptions.common.runsHistory}
                   label={t('clear_option_runs_history')}
                 />
-                <CheckboxField
-                  onChange={() => {
-                    const options = cloneDeep(displayedOptions)
-                    options.common.labwareOffsets = !options.common
-                      .labwareOffsets
-                    setDisplayedOptions(options)
-                  }}
-                  value={displayedOptions.common.labwareOffsets}
-                  label={t('clear_option_labware_offsets')}
-                />
+                {isFlex && (
+                  <CheckboxField
+                    onChange={() => {
+                      const options = cloneDeep(displayedOptions)
+                      options.flexOnly.labwareOffsets = !options.flexOnly
+                        .labwareOffsets
+                      setDisplayedOptions(options)
+                    }}
+                    value={displayedOptions.flexOnly.labwareOffsets}
+                    label={t('clear_option_labware_offsets')}
+                  />
+                )}
               </Flex>
             </Box>
             <Box>
@@ -394,13 +396,17 @@ interface DisplayedResetOptionState {
     bootScripts: boolean
     authorizedKeys: boolean
     pipetteOffsetCalibrations: boolean
-    labwareOffsets: boolean
   }
   ot2Only: {
     deckCalibration: boolean
     tipLengthCalibrations: boolean
   }
   flexOnly: {
+    // labwareOffsets, corresponding to the server's /labwareOffsets endpoints, is also
+    // resettable on OT-2, but in practice, there's no data to reset there. On OT-2s,
+    // Labware Position Check never stores offsets into the /labwareOffsets endpoints;
+    // instead it only reuses offsets from prior runs, via the /runs endpoints.
+    labwareOffsets: boolean
     gripperCalibrations: boolean
     moduleCalibrations: boolean
   }
@@ -412,13 +418,13 @@ const ALL_DESELECTED: DisplayedResetOptionState = {
     bootScripts: false,
     authorizedKeys: false,
     pipetteOffsetCalibrations: false,
-    labwareOffsets: false,
   },
   ot2Only: {
     deckCalibration: false,
     tipLengthCalibrations: false,
   },
   flexOnly: {
+    labwareOffsets: false,
     gripperCalibrations: false,
     moduleCalibrations: false,
   },
@@ -430,13 +436,13 @@ const ALL_SELECTED: DisplayedResetOptionState = {
     bootScripts: true,
     authorizedKeys: true,
     pipetteOffsetCalibrations: true,
-    labwareOffsets: true,
   },
   ot2Only: {
     deckCalibration: true,
     tipLengthCalibrations: true,
   },
   flexOnly: {
+    labwareOffsets: true,
     gripperCalibrations: true,
     moduleCalibrations: true,
   },
@@ -470,7 +476,7 @@ function buildResetRequest(
   isFlex: boolean
 ): ResetConfigRequest {
   let requestToReturn: ResetConfigRequest = {
-    resetLabwareOffsets: displayedState.common.labwareOffsets,
+    resetLabwareOffsets: displayedState.flexOnly.labwareOffsets,
 
     settingsResets: {
       // Keys in this object need to follow the server's HTTP API.

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/DeviceResetSlideout.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/DeviceResetSlideout.test.tsx
@@ -94,8 +94,8 @@ describe('RobotSettings DeviceResetSlideout', () => {
     screen.getByText('Clear pipette offset calibrations')
     screen.getByText('Clear tip length calibrations')
     screen.getByText('Protocol run data')
+    expect(screen.queryByText('labware offset')).toBe(null)
     screen.getByText('Clear protocol run history')
-    screen.getByText('Clear labware offset data')
     screen.getByText('Boot scripts')
     screen.getByText('Clear custom boot scripts')
     screen.getByText('Clear SSH public keys')
@@ -131,6 +131,7 @@ describe('RobotSettings DeviceResetSlideout', () => {
     expect(
       screen.queryByRole('checkbox', { name: 'Clear tip length calibrations' })
     ).toBeNull()
+    screen.getByRole('checkbox', { name: 'Clear labware offset data' })
   })
 
   it('should enable Clear data and restart robot button when checked one checkbox', () => {


### PR DESCRIPTION
## Overview

Closes RQA-4183.

In the device reset slideout, the "Clear labware offset data" option is misleading on an OT-2. Although it does work in a technical sense—it sends a `DELETE /labwareOffsets` request and the server obeys it—it does not do anything meaningful in a user-facing sense. On OT-2s, the frontend does not use the `/labwareOffsets` endpoints to support Labware Position Check; it instead only reuses offsets from prior runs, via the `/runs` endpoints. So this option didn't actually clear anything, in practice.

The solution is to just hide the option on OT-2s.

## Test Plan and Hands on Testing

In the desktop app:

* On an OT-2:
    * [x] The option is no longer present in the desktop app.
    * [x] Submitting the reset does not send a `DELETE /labwareOffsets` HTTP request.
* On a Flex:
    * [x] The option is still present in the desktop app.
    * [x] Submitting the reset with the option selected actually resets labware offsets.

## Review requests

None in particular, but [I've definitely made stupid mistakes here before](https://github.com/Opentrons/opentrons/pull/18244), so double-check my logic.

## Risk assessment

Low.
