### PR TITLE
fix(api): do not check shuttle missing in move labware command

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -161,11 +161,7 @@ class GripperMovementError(ErrorOccurrence):
     errorInfo: ErrorDetails
 
 
-_ExecuteReturn = (
-    SuccessData[MoveLabwareResult]
-    | DefinedErrorData[GripperMovementError]
-    | DefinedErrorData[FlexStackerShuttleError]
-)
+_ExecuteReturn = SuccessData[MoveLabwareResult] | DefinedErrorData[GripperMovementError]
 
 
 class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteReturn]):
@@ -185,31 +181,6 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
         self._equipment = equipment
         self._labware_movement = labware_movement
         self._run_control = run_control
-
-    async def _labware_movement_stacker_validation(
-        self, module_id: str, labware_to_move: str
-    ) -> FlexStackerShuttleError | None:
-        # Validate that a Flex Stacker is in position to receive labware
-        stacker_sub = self._state_view.modules.get_flex_stacker_substate(module_id)
-        stacker_hw = self._equipment.get_module_hardware_api(stacker_sub.module_id)
-        if stacker_hw is not None:
-            try:
-                await stacker_hw.verify_shuttle_location(PlatformState.EXTENDED)
-            except FlexStackerShuttleMissingError as e:
-                return FlexStackerShuttleError(
-                    id=self._model_utils.generate_id(),
-                    createdAt=self._model_utils.get_timestamp(),
-                    wrappedErrors=[
-                        ErrorOccurrence.from_failed(
-                            id=self._model_utils.generate_id(),
-                            createdAt=self._model_utils.get_timestamp(),
-                            error=e,
-                        )
-                    ],
-                    errorInfo={"labwareId": labware_to_move},
-                )
-
-        return None
 
     async def execute(self, params: MoveLabwareParams) -> _ExecuteReturn:  # noqa: C901
         """Move a loaded labware to a new location."""
@@ -344,13 +315,6 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
             if module is not None and module.model == ModuleModel.ABSORBANCE_READER_V1:
                 self._state_view.labware.raise_if_labware_incompatible_with_plate_reader(
                     current_labware_definition
-                )
-            if (
-                module is not None
-                and module.model == ModuleModel.FLEX_STACKER_MODULE_V1
-            ):
-                module_location_error = await self._labware_movement_stacker_validation(
-                    module.id, params.labwareId
                 )
 
         # Allow propagation of ModuleNotLoadedError.
@@ -552,7 +516,7 @@ class MoveLabware(
     BaseCommand[
         MoveLabwareParams,
         MoveLabwareResult,
-        GripperMovementError | FlexStackerShuttleError,
+        GripperMovementError,
     ]
 ):
     """A ``moveLabware`` command."""

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -20,10 +20,6 @@ from opentrons_shared_data.errors.exceptions import (
     FailedGripperPickupError,
     LabwareDroppedError,
     StallOrCollisionDetectedError,
-    FlexStackerShuttleMissingError,
-)
-from opentrons.protocol_engine.commands.flex_stacker.common import (
-    FlexStackerShuttleError,
 )
 from opentrons_shared_data.gripper.constants import GRIPPER_PADDLE_WIDTH
 
@@ -59,9 +55,6 @@ from .command import (
 )
 from ..errors.error_occurrence import ErrorOccurrence
 from ..state.update_types import StateUpdate
-
-
-from opentrons.hardware_control.modules.types import PlatformState
 
 if TYPE_CHECKING:
     from ..execution import EquipmentHandler, RunControlHandler, LabwareMovementHandler

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -57,9 +57,6 @@ from opentrons.protocol_engine.execution import (
     RunControlHandler,
     LabwareMovementHandler,
 )
-from opentrons.protocol_engine.commands.flex_stacker.common import (
-    FlexStackerShuttleError,
-)
 from opentrons_shared_data.errors.exceptions import FlexStackerShuttleMissingError
 from opentrons.protocol_engine.state.module_substates import (
     FlexStackerSubState,
@@ -721,121 +718,6 @@ async def test_move_labware_raises_for_labware_or_module_not_found(
 
     with pytest.raises(errors.ModuleNotLoadedError):
         await subject.execute(move_labware_from_questionable_module_params)
-
-
-async def test_move_labware_raises_for_missing_stacker_shuttle(
-    decoy: Decoy,
-    subject: MoveLabwareImplementation,
-    equipment: EquipmentHandler,
-    model_utils: ModelUtils,
-    state_view: StateView,
-) -> None:
-    """It should raise an error when the destination is a Stacker and the shuttle is missing."""
-    new_location = ModuleLocation(moduleId="the-coolest-stacker-ever")
-    from_location = DeckSlotLocation(slotName=DeckSlotName("D2"))
-    move_labware_shuttle_params = MoveLabwareParams(
-        labwareId="my-cool-labware-id",
-        newLocation=new_location,
-        strategy=LabwareMovementStrategy.USING_GRIPPER,
-    )
-    labware_def = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
-        namespace="my-cool-namespace",
-        dimensions=Dimensions(yDimension=1, zDimension=2, xDimension=3),
-    )
-    decoy.when(
-        state_view.labware.get_definition(labware_id="my-cool-labware-id")
-    ).then_return(labware_def)
-    from_loc_sequence: LabwareLocationSequence = [
-        OnAddressableAreaLocationSequenceComponent(addressableAreaName="1")
-    ]
-    decoy.when(
-        state_view.geometry.get_location_sequence("my-cool-labware-id")
-    ).then_return(from_loc_sequence)
-
-    decoy.when(state_view.labware.get(labware_id="my-cool-labware-id")).then_return(
-        LoadedLabware(
-            id="my-cool-labware-id",
-            loadName="load-name",
-            definitionUri="opentrons-test/load-name/1",
-            location=from_location,
-            offsetId=None,
-        )
-    )
-
-    decoy.when(
-        state_view.geometry.ensure_location_not_occupied(
-            location=new_location,
-        )
-    ).then_return(new_location)
-    decoy.when(
-        equipment.find_applicable_labware_offset_id(
-            labware_definition_uri="opentrons-test/load-name/1",
-            labware_location=new_location,
-        )
-    ).then_return("wowzers-a-new-offset-id")
-
-    decoy.when(
-        state_view.geometry.ensure_valid_gripper_location(from_location)
-    ).then_return(from_location)
-    decoy.when(
-        state_view.geometry.ensure_valid_gripper_location(new_location)
-    ).then_return(new_location)
-    decoy.when(labware_validation.validate_gripper_compatible(labware_def)).then_return(
-        True
-    )
-    stacker_module_hw = decoy.mock(cls=FlexStacker)
-    stacker_module = LoadedModule(
-        id="the-coolest-stacker-ever",
-        model=ModuleModel.FLEX_STACKER_MODULE_V1,
-        location=DeckSlotLocation(slotName=DeckSlotName("D3")),
-        serialNumber="cookiecrisp",
-    )
-
-    decoy.when(
-        state_view.modules.get(module_id="the-coolest-stacker-ever")
-    ).then_return(stacker_module)
-
-    decoy.when(
-        state_view.modules.get_flex_stacker_substate(
-            module_id="the-coolest-stacker-ever"
-        )
-    ).then_return(
-        FlexStackerSubState(
-            module_id=FlexStackerId("abc"),
-            pool_primary_definition=None,
-            pool_adapter_definition=None,
-            pool_lid_definition=None,
-            contained_labware_bottom_first=[],
-            max_pool_count=0,
-            pool_overlap=0,
-        )
-    )
-    decoy.when(
-        equipment.get_module_hardware_api(module_id=FlexStackerId("abc"))
-    ).then_return(stacker_module_hw)
-    decoy.when(
-        await stacker_module_hw.verify_shuttle_location(PlatformState.EXTENDED)
-    ).then_raise(
-        FlexStackerShuttleMissingError(
-            "cookiecrisp", PlatformState.EXTENDED, PlatformState.RETRACTED
-        )
-    )
-
-    decoy.when(model_utils.generate_id()).then_return("my_err")
-    decoy.when(model_utils.get_timestamp()).then_return(
-        datetime(year=2020, month=1, day=2)
-    )
-
-    result = await subject.execute(move_labware_shuttle_params)
-
-    assert result == DefinedErrorData(
-        public=FlexStackerShuttleError.model_construct(
-            id="my_err",
-            createdAt=datetime(year=2020, month=1, day=2),
-            wrappedErrors=[matchers.Anything()],
-            errorInfo={"labwareId": "my-cool-labware-id"},
-        )
-    )
 
 
 async def test_move_labware_raises_if_movement_obstructed(

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -31,7 +31,6 @@ from opentrons.protocol_engine.types import (
     ModuleLocation,
     OnLabwareLocation,
     LoadedLabware,
-    LoadedModule,
     LabwareMovementStrategy,
     LabwareOffsetVector,
     LabwareMovementOffsetData,
@@ -42,7 +41,6 @@ from opentrons.protocol_engine.types import (
     NotOnDeckLocationSequenceComponent,
     OFF_DECK_LOCATION,
     LabwareLocationSequence,
-    ModuleModel,
 )
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
@@ -57,13 +55,6 @@ from opentrons.protocol_engine.execution import (
     RunControlHandler,
     LabwareMovementHandler,
 )
-from opentrons_shared_data.errors.exceptions import FlexStackerShuttleMissingError
-from opentrons.protocol_engine.state.module_substates import (
-    FlexStackerSubState,
-    FlexStackerId,
-)
-from opentrons.hardware_control.modules import FlexStacker
-from opentrons.hardware_control.modules.types import PlatformState
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Overview
With the new logic preventing protocols from starting on a Flex Stacker without a shuttle present, raising a recoverable ShuttleMissingError in move_labware is no longer necessary. Since we can’t enter that state, emitting this error only complicates our standard module error-recovery pattern. 