### PR TITLE
feat(api,robot-server,app): add installDetected live data for the Stacker and remove unused ones.

### DIFF
--- a/api-client/src/modules/api-types.ts
+++ b/api-client/src/modules/api-types.ts
@@ -87,8 +87,7 @@ export interface FlexStackerData {
   latchState: 'opened' | 'closed' | 'unknown'
   platformState: 'extended' | 'retracted' | 'unknown' | 'missing'
   hopperDoorState: 'opened' | 'closed' | 'unknown'
-  axisStateX: 'extended' | 'retracted' | 'unknown'
-  axisStateZ: 'extended' | 'retracted' | 'unknown'
+  installDetected: boolean
   status: FlexStackerStatus
 }
 

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -232,6 +232,11 @@ class FlexStacker(mod_abc.AbstractModule):
         return self._reader.limit_switch_status
 
     @property
+    def install_detected(self) -> bool:
+        """Whether the stacker is installed on Flex."""
+        return self._reader.installation_detected
+
+    @property
     def device_info(self) -> Mapping[str, str]:
         return self._device_info
 
@@ -258,8 +263,7 @@ class FlexStacker(mod_abc.AbstractModule):
             "latchState": self.latch_state.value,
             "platformState": self._get_platform_live_data().value,
             "hopperDoorState": self.hopper_door_state.value,
-            "axisStateX": self.limit_switch_status[StackerAxis.X].value,
-            "axisStateZ": self.limit_switch_status[StackerAxis.Z].value,
+            "installDetected": self.install_detected,
             "errorDetails": self._reader.error,
         }
         return {"status": self.status.value, "data": data}
@@ -512,6 +516,7 @@ class FlexStacker(mod_abc.AbstractModule):
         is useful when we want the shuttle to be out of the way for error
         recovery (e.g. when the latch is stuck open).
         """
+        await self._reader.get_installation_detected()
         await self._reader.get_limit_switch_status()
         # we should always be able to home the X axis first
         await self.home_axis(StackerAxis.X, Direction.RETRACT)
@@ -677,6 +682,7 @@ class FlexStackerReader(Reader):
         self.platform_state = PlatformState.UNKNOWN
         self.hopper_door_closed = False
         self.initialized = False
+        self.installation_detected = False
         self._initialized_callback: Optional[Callable[[], Awaitable[None]]] = None
 
     def set_initialized_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
@@ -688,6 +694,7 @@ class FlexStackerReader(Reader):
         await self.get_platform_sensor_state()
         if not self.initialized:
             initialized = True
+            await self.get_installation_detected()
             await self.get_limit_switch_status()
             await self.get_motion_parameters()
             for sensor, status in self.tof_sensor_status.items():
@@ -729,6 +736,11 @@ class FlexStackerReader(Reader):
         self.hopper_door_closed = await self._driver.get_hopper_door_closed()
         if old_door_state != self.hopper_door_closed and self._initialized_callback:
             await self._initialized_callback()
+
+    async def get_installation_detected(self) -> None:
+        """Check if the stacker install detect is set."""
+        detected = await self._driver.get_installation_detected()
+        self.installation_detected = detected
 
     def on_error(self, exception: Exception) -> None:
         self._driver.reset_serial_buffers()

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -107,8 +107,7 @@ class FlexStackerData(TypedDict):
     latchState: str
     platformState: str
     hopperDoorState: str
-    axisStateX: str
-    axisStateZ: str
+    installDetected: bool
     errorDetails: str | None
 
 

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/ModuleTable.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/ModuleTable.test.tsx
@@ -56,8 +56,7 @@ const mockFlexStackerModule: FlexStackerModule = {
     latchState: 'closed',
     platformState: 'extended',
     hopperDoorState: 'opened',
-    axisStateX: 'extended',
-    axisStateZ: 'extended',
+    installDetected: true,
     status: 'idle',
   },
   usbPort: {

--- a/app/src/redux/modules/api-types.ts
+++ b/app/src/redux/modules/api-types.ts
@@ -89,8 +89,7 @@ export interface FlexStackerData {
   latchState: 'opened' | 'closed' | 'unknown'
   platformState: 'extended' | 'retracted' | 'unknown' | 'missing'
   hopperDoorState: 'opened' | 'closed' | 'unknown'
-  axisStateX: 'extended' | 'retracted' | 'unknown'
-  axisStateZ: 'extended' | 'retracted' | 'unknown'
+  installDetected: boolean
   status: FlexStackerStatus
 }
 

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -14,7 +14,6 @@ from opentrons.hardware_control.modules import (
     SpeedStatus,
     AbsorbanceReaderStatus,
     PlatformState,
-    StackerAxisState,
     FlexStackerStatus,
 )
 from opentrons.hardware_control.modules.magdeck import OFFSET_TO_LABWARE_BOTTOM
@@ -178,8 +177,7 @@ class ModuleDataMapper:
                 hopperDoorState=cast(
                     HopperDoorState, live_data["data"].get("hopperDoorState")
                 ),
-                axisStateX=cast(StackerAxisState, live_data["data"].get("axisStateX")),
-                axisStateZ=cast(StackerAxisState, live_data["data"].get("axisStateZ")),
+                installDetected=cast(bool, live_data["data"].get("installDetected")),
             )
         else:
             assert False, f"Invalid module type {module_type}"

--- a/robot-server/robot_server/modules/module_models.py
+++ b/robot-server/robot_server/modules/module_models.py
@@ -13,7 +13,6 @@ from opentrons.hardware_control.modules import (
     SpeedStatus,
     AbsorbanceReaderStatus,
     PlatformState,
-    StackerAxisState,
 )
 from opentrons.drivers.types import (
     ThermocyclerLidStatus,
@@ -365,11 +364,8 @@ class FlexStackerModuleData(BaseModel):
     hopperDoorState: HopperDoorState = Field(
         ..., description="The state of the hopper door."
     )
-    axisStateX: StackerAxisState = Field(
-        ..., description="The state of the X axis limit switches."
-    )
-    axisStateZ: StackerAxisState = Field(
-        ..., description="The state of the Z axis limit switches."
+    installDetected: bool = Field(
+        ..., description="The install state of the Stacker on the Flex."
     )
 
 

--- a/robot-server/tests/integration/test_modules.tavern.yaml
+++ b/robot-server/tests/integration/test_modules.tavern.yaml
@@ -277,8 +277,7 @@ stages:
               latchState: !anystr
               platformState: !anystr
               hopperDoorState: !anystr
-              axisStateX: !anystr
-              axisStateZ: !anystr
+              installDetected: !anybool
           - id: !anystr
             serialNumber: !anystr
             firmwareVersion: !anystr
@@ -297,8 +296,7 @@ stages:
               latchState: !anystr
               platformState: !anystr
               hopperDoorState: !anystr
-              axisStateX: !anystr
-              axisStateZ: !anystr
+              installDetected: !anybool
           - id: !anystr
             serialNumber: !anystr
             firmwareVersion: !anystr


### PR DESCRIPTION
# Overview

This lets us check if the stacker was physically installed properly on the Flex.

Closes: [EXEC-1481](https://opentrons.atlassian.net/browse/EXEC-1481)

## Test Plan and Hands on Testing

- [x] Plug in the stacker to Flex but don't physically connect it to the side door, and make sure the InstallDetected is False
- [x] Plug in the stacker to Flex and physically connect it to the side door, and make sure the InstallDetected is True

## Changelog

- add `installDetected` Flex stacker status to the LiveData to be used during module setup flows.
- remove unused `axisStateX` and `axisStateX` livedata properties

## Review requests

Makes sense?

## Risk assessment

low, unreleased

[EXEC-1481]: https://opentrons.atlassian.net/browse/EXEC-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ