### PR TITLE
feat(protocol-designer): 8.5.0 announcement modal & release notes

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -12,7 +12,7 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 **Welcome to Protocol Designer v8.5.0!**
 
-This release adds support for liquid classes in Protocol Designer protocols for the Flex, exporting python, and includes feature improvements and bug fixes.
+This release adds support for liquid classes in Flex protocols, exports Python protocols for Flex and OT-2, and includes feature improvements and bug fixes.
 
 Use Opentrons-verified liquid classes to automatically define transfer settings and optimize liquid handling behavior based on liquid properties like viscosity. When adding liquids to your protocol, select an Opentrons-verified liquid class from the dropdown menu. You can choose whether or not to apply liquid class settings to protocol steps that use compatible Opentrons labware and pipettes.
 
@@ -31,13 +31,13 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 
 - Transfer step details show correct aspirate and dispense volumes when distributing liquid (a single aspirate and multiple dispenses).
 - During a mix, push out is set to 0 by default for all mixes except for the last, to avoid multiple push out actions. You can choose your own push out volume in a mix step menu.
-- Choose a new tip drop location from the dropdown menu when an uploaded protocol is missing a drop tip location.
+- Choose a new tip drop location from the dropdown menu when an uploaded protocol is missing a tip drop location.
 - Protocol Designer correctly updates adapter and labware combination definitions when you upload a protocol designed in Protocol Designer v7.0.0 or earlier.
 - When adding a disposal volume, a blowout location is now required.
-- No longer allow touch tip with incompatible labware. This results in a change in behavior from imported protocols that had touch tip on incompatible labware.
-- If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, a timeline error is now raised.
+- No longer allow touch tip with incompatible labware. This changes the behavior of imported protocols that had touch tip on incompatible labware.
+- If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.
 
-Running a protocol created in Protocol Designer now requires Opentrons App version 8.4.0 or newer.
+Running a protocol created in Protocol Designer now requires Opentrons App version 8.5.0 or newer.
 
 ## Opentrons Protocol Designer Changes in 8.4.4
 

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -8,11 +8,11 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ---
 
-## Opentrons Protocol Designer Changes in 8.5
+## Opentrons Protocol Designer Changes in 8.5.0
 
-**Welcome to Protocol Designer v8.5!**
+**Welcome to Protocol Designer v8.5.0!**
 
-This release adds support for liquid classes in Protocol Designer protocols for the Flex, and includes feature improvements and bug fixes.
+This release adds support for liquid classes in Protocol Designer protocols for the Flex, exporting python, and includes feature improvements and bug fixes.
 
 Use Opentrons-verified liquid classes to automatically define transfer settings and optimize liquid handling behavior based on liquid properties like viscosity. When adding liquids to your protocol, select an Opentrons-verified liquid class from the dropdown menu. You can choose whether or not to apply liquid class settings to protocol steps that use compatible Opentrons labware and pipettes.
 
@@ -24,7 +24,7 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 
 ### Improved Features
 
-- Protocol Designer includes a warning when you clear a slot with labware, a module, or a fixture used in a protocol step.
+- Protocol Designer includes a warning when you clear a labware, a module, or a fixture used in a protocol step.
 - Protocol Designer takes extra steps to validate any custom labware you upload.
 
 ### Bug Fixes

--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -80,6 +80,21 @@
       "body8": "Removing quantity dropdown from all modules during the Flex setup flow to reduce deck setup conflicts",
       "body9": "All protocols now require Opentrons App version 8.3.0+ to run.",
       "body10": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
+    },
+    "liquidClassAndPythonExport": {
+      "heading": "{{version}} Release Notes",
+      "body1": "Welcome to Protocol Designer {{version}}!",
+      "body2": "We're excited to introduce liquid classes support and exporting python!",
+      "body3": "Additionally, improvements for the following:",
+      "body4": "Transfer step details show correct aspirate and dispense volumes when distributing liquid (a single aspirate and multiple dispenses).",
+      "body5": "During a mix, push out is set to 0 by default for all mixes except for the last, to avoid multiple push out actions. You can choose your own push out volume in a mix step menu.",
+      "body6": "Choose a new tip drop location from the dropdown menu when an uploaded protocol is missing a drop tip location.",
+      "body7": "Protocol Designer correctly updates adapter and labware combination definitions when you upload a protocol designed in Protocol Designer v7.0.0 or earlier.",
+      "body8": "When adding a disposal volume, a blowout location is now required.",
+      "body9": "No longer allow touch tip with incompatible labware. This results in a change in behavior from imported protocols that had touch tip on incompatible labware.",
+      "body10": "If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, a timeline error is now raised.",
+      "body11": "All protocols now require Opentrons App version 8.4.0+ to run.",
+      "body12": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
     }
   },
   "labware_selection": {

--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -84,16 +84,16 @@
     "liquidClassAndPythonExport": {
       "heading": "{{version}} Release Notes",
       "body1": "Welcome to Protocol Designer {{version}}!",
-      "body2": "We're excited to introduce liquid classes support and exporting python!",
+      "body2": "We're excited to introduce support for liquid classes and exporting Python!",
       "body3": "Additionally, improvements for the following:",
       "body4": "Transfer step details show correct aspirate and dispense volumes when distributing liquid (a single aspirate and multiple dispenses).",
       "body5": "During a mix, push out is set to 0 by default for all mixes except for the last, to avoid multiple push out actions. You can choose your own push out volume in a mix step menu.",
-      "body6": "Choose a new tip drop location from the dropdown menu when an uploaded protocol is missing a drop tip location.",
+      "body6": "Choose a new tip drop location from the dropdown menu when an uploaded protocol is missing a tip drop location.",
       "body7": "Protocol Designer correctly updates adapter and labware combination definitions when you upload a protocol designed in Protocol Designer v7.0.0 or earlier.",
       "body8": "When adding a disposal volume, a blowout location is now required.",
-      "body9": "No longer allow touch tip with incompatible labware. This results in a change in behavior from imported protocols that had touch tip on incompatible labware.",
-      "body10": "If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, a timeline error is now raised.",
-      "body11": "All protocols now require Opentrons App version 8.4.0+ to run.",
+      "body9": "No longer allow touch tip with incompatible labware. This changes the behavior of imported protocols that had touch tip on incompatible labware.",
+      "body10": "If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.",
+      "body11": "All protocols now require Opentrons App version 8.5.0+ to run.",
       "body12": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
     }
   },

--- a/protocol-designer/src/components/organisms/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/organisms/AnnouncementModal/announcements.tsx
@@ -61,6 +61,15 @@ const APP = 'Opentrons App'
 const OPENTRONS_PD = 'Opentrons Protocol Designer'
 const OPENTRONS_ABSORBANCE_READER_URL =
   'https://opentrons.com/products/opentrons-flex-absorbance-plate-reader-module-gen1'
+const EIGHT_FIVE_ZERO_RELEASE_BULLET_POINTS = [
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+]
 
 export const useAnnouncements = (): Announcement[] => {
   const { t } = useTranslation('modal')
@@ -564,6 +573,62 @@ export const useAnnouncements = (): Announcement[] => {
               i18nKey="announcements.dragDropAndHotFix.body10"
             />
           </StyledText>
+        </Flex>
+      ),
+    },
+    {
+      announcementKey: 'liquidClassAndPythonExport',
+      image: <Flex />,
+      heading: t('announcements.liquidClassAndPythonExport.heading', {
+        version: pdVersion,
+      }),
+      message: (
+        <Flex gridGap={SPACING.spacing8} flexDirection={DIRECTION_COLUMN}>
+          <StyledText desktopStyle="bodyDefaultSemiBold">
+            {t('announcements.liquidClassAndPythonExport.body1', {
+              version: pdVersion,
+            })}
+          </StyledText>
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {t('announcements.liquidClassAndPythonExport.body2')}
+          </StyledText>
+          <Flex flexDirection={DIRECTION_COLUMN}>
+            <StyledText desktopStyle="bodyDefaultRegular">
+              {t('announcements.liquidClassAndPythonExport.body3')}
+            </StyledText>
+            <Flex marginLeft={SPACING.spacing16}>
+              <ul>
+                {EIGHT_FIVE_ZERO_RELEASE_BULLET_POINTS.map(num => (
+                  <li key={num}>
+                    <StyledText desktopStyle="bodyDefaultRegular">
+                      {t(`announcements.liquidClassAndPythonExport.body${num}`)}
+                    </StyledText>
+                  </li>
+                ))}
+              </ul>
+            </Flex>
+          </Flex>
+          <Flex gridGap={SPACING.spacing4} flexDirection={DIRECTION_COLUMN}>
+            <StyledText desktopStyle="bodyDefaultRegular">
+              {t('announcements.liquidClassAndPythonExport.body11')}
+            </StyledText>
+            <StyledText desktopStyle="bodyDefaultRegular">
+              <Trans
+                t={t}
+                components={{
+                  link1: (
+                    <LinkComponent
+                      external
+                      href={DOC_URL}
+                      textDecoration={TEXT_DECORATION_UNDERLINE}
+                      color={COLORS.black90}
+                    />
+                  ),
+                }}
+                i18nKey="announcements.liquidClassAndPythonExport.body12"
+              />
+            </StyledText>
+          </Flex>
         </Flex>
       ),
     },


### PR DESCRIPTION
closes AUTH-1604

# Overview

NOTE: the release number matches the release tag so it'll say 8.4.4 for now
<img width="537" alt="Screenshot 2025-05-15 at 15 04 41" src="https://github.com/user-attachments/assets/4b2f380f-4085-4b69-8398-7ea595fc3122" />

This PR updates the announcement modal and release notes

## Test Plan and Hands on Testing

Review copy @ecormany @emilyburghardt no rush in reviewing this! Just wanted to open a PR so we don't forget about updating the announcement modal. 

## Changelog

update announcement modal and release-notes

## Risk assessment

low