### PR TITLE
fix(components): include step-generation in component bundle for publish

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -210,6 +210,7 @@ jobs:
           VERSION_STRING=$(echo ${{ github.ref }} | sed 's/refs\/tags\/components@//')
           json -I -f ./components/package.json -e "this.version=\"$VERSION_STRING\""
           json -I -f ./components/package.json -e "this.dependencies['@opentrons/shared-data']=\"$VERSION_STRING\""
+          json -I -f ./components/package.json -e "delete this.dependencies['@opentrons/step-generation']"
       - uses: 'actions/setup-node@v4'
         with:
           node-version: '22.11.0'

--- a/components/vite.config.mts
+++ b/components/vite.config.mts
@@ -12,11 +12,15 @@ export default defineConfig({
     // Relative to the root
     ssr: 'src/index.ts',
     outDir: 'lib',
-    // do not delete the outdir, typescript types might live there and we dont want to delete them
+    // Do not delete the outdir, typescript types might live there and we don't want to delete them
     emptyOutDir: false,
     commonjsOptions: {
       transformMixedEsModules: true,
       esmExternals: true,
+    },
+    rollupOptions: {
+      // Only @opentrons/shared-data is external; step-generation will be bundled!
+      external: ['@opentrons/shared-data'],
     },
   },
   plugins: [


### PR DESCRIPTION
When I built and published `components@0.1.7-alpha.0` I found when I tried to install it that I get error
```bash
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "link:": link:../step-generation
```

So I think I need to:

- [x] remove step-generation from the dependencies in package.json
- [x] and make sure Vite bundles it by not including it in the rollupOptions -> external [ ] 

> when I inspect the .tgz from `npm pack` I see the step-generation functions in the `package/lib`
