### PR TITLE
fix(step-generation): emit waitForTemperature when checkbox is checked

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -36,6 +36,7 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 - When adding a disposal volume, a blowout location is now required.
 - No longer allow touch tip with incompatible labware. This changes the behavior of imported protocols that had touch tip on incompatible labware.
 - If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.
+- If a Heater-Shaker step is created with a a heater set and a timer, the protocol will now wait until the temperature is reached before counting down the timer.
 
 Running a protocol created in Protocol Designer now requires Opentrons App version 8.5.0 or newer.
 

--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -93,8 +93,9 @@
       "body8": "When adding a disposal volume, a blowout location is now required.",
       "body9": "No longer allow touch tip with incompatible labware. This changes the behavior of imported protocols that had touch tip on incompatible labware.",
       "body10": "If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.",
-      "body11": "All protocols now require Opentrons App version 8.5.0+ to run.",
-      "body12": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
+      "body11": "If a Heater-Shaker step is created with a a heater set and a timer, the protocol will now wait until the temperature is reached before counting down the timer.",
+      "body12": "All protocols now require Opentrons App version 8.5.0+ to run.",
+      "body13": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
     }
   },
   "labware_selection": {

--- a/protocol-designer/src/components/organisms/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/organisms/AnnouncementModal/announcements.tsx
@@ -69,6 +69,7 @@ const EIGHT_FIVE_ZERO_RELEASE_BULLET_POINTS = [
   '8',
   '9',
   '10',
+  '11',
 ]
 
 export const useAnnouncements = (): Announcement[] => {
@@ -610,7 +611,7 @@ export const useAnnouncements = (): Announcement[] => {
           </Flex>
           <Flex gridGap={SPACING.spacing4} flexDirection={DIRECTION_COLUMN}>
             <StyledText desktopStyle="bodyDefaultRegular">
-              {t('announcements.liquidClassAndPythonExport.body11')}
+              {t('announcements.liquidClassAndPythonExport.body12')}
             </StyledText>
             <StyledText desktopStyle="bodyDefaultRegular">
               <Trans
@@ -625,7 +626,7 @@ export const useAnnouncements = (): Announcement[] => {
                     />
                   ),
                 }}
-                i18nKey="announcements.liquidClassAndPythonExport.body12"
+                i18nKey="announcements.liquidClassAndPythonExport.body13"
               />
             </StyledText>
           </Flex>

--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -109,6 +109,14 @@ describe('heaterShaker compound command creator', () => {
         },
       },
       {
+        commandType: 'heaterShaker/waitForTemperature',
+        key: expect.any(String),
+        params: {
+          celsius: 80,
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
         commandType: 'waitForDuration',
         key: expect.any(String),
         params: {
@@ -131,7 +139,14 @@ describe('heaterShaker compound command creator', () => {
       },
     ])
     expect(getSuccessResult(result).python).toBe(
-      'mock_heater_shaker_1.close_labware_latch()\nmock_heater_shaker_1.set_target_temperature(80)\nmock_heater_shaker_1.set_and_wait_for_shake_speed(444)\nprotocol.delay(seconds=30)\nmock_heater_shaker_1.deactivate_shaker()\nmock_heater_shaker_1.deactivate_heater()'
+      `
+mock_heater_shaker_1.close_labware_latch()
+mock_heater_shaker_1.set_target_temperature(80)
+mock_heater_shaker_1.set_and_wait_for_shake_speed(444)
+mock_heater_shaker_1.wait_for_temperature()
+protocol.delay(seconds=30)
+mock_heater_shaker_1.deactivate_shaker()
+mock_heater_shaker_1.deactivate_heater()`.trim()
     )
   })
   it('should NOT delay and deactivate the heater shaker when a user specificies a timer that is 0 seconds', () => {
@@ -213,6 +228,14 @@ describe('heaterShaker compound command creator', () => {
         },
       },
       {
+        commandType: 'heaterShaker/waitForTemperature',
+        key: expect.any(String),
+        params: {
+          celsius: 80,
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
         commandType: 'waitForDuration',
         key: expect.any(String),
         params: {
@@ -242,7 +265,14 @@ describe('heaterShaker compound command creator', () => {
       },
     ])
     expect(getSuccessResult(result).python).toBe(
-      'mock_heater_shaker_1.set_target_temperature(80)\nmock_heater_shaker_1.set_and_wait_for_shake_speed(444)\nprotocol.delay(seconds=20)\nmock_heater_shaker_1.deactivate_shaker()\nmock_heater_shaker_1.deactivate_heater()\nmock_heater_shaker_1.open_labware_latch()'
+      `
+mock_heater_shaker_1.set_target_temperature(80)
+mock_heater_shaker_1.set_and_wait_for_shake_speed(444)
+mock_heater_shaker_1.wait_for_temperature()
+protocol.delay(seconds=20)
+mock_heater_shaker_1.deactivate_shaker()
+mock_heater_shaker_1.deactivate_heater()
+mock_heater_shaker_1.open_labware_latch()`.trim()
     )
   })
   it('should not call deactivateShaker when it is not shaking but call activate temperature when setting target temp', () => {

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -1,6 +1,7 @@
 import * as errorCreators from '../../errorCreators'
 import { getModuleState } from '../../robotStateSelectors'
 import { curryCommandCreator, reduceCommandCreators } from '../../utils'
+import { waitForTemperature } from '../atomic'
 import { delay } from '../atomic/delay'
 import { heaterShakerCloseLatch } from '../atomic/heaterShakerCloseLatch'
 import { heaterShakerDeactivateHeater } from '../atomic/heaterShakerDeactivateHeater'
@@ -83,6 +84,15 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
     (args.timerMinutes != null && args.timerMinutes !== 0) ||
     (args.timerSeconds != null && args.timerSeconds !== 0)
   ) {
+    if (args.targetTemperature !== null) {
+      commandCreators.push(
+        curryCommandCreator(waitForTemperature, {
+          moduleId,
+          celsius: args.targetTemperature,
+        })
+      )
+    }
+
     const totalSeconds =
       (args.timerSeconds ?? 0) + (args.timerMinutes ?? 0) * 60
     commandCreators.push(


### PR DESCRIPTION
# Overview

@sfoster1 noticed a bug where if you select the heater-shaker form timer, it does not `waitForTemperature` if a `setTemperature` is set.

Basically there are 3 options for a heater-shaker form:

1. you build a heater-shaker step with no timer and choose to not add a pause to wait for temperature: a `waitForTemperature`  **is not** created. this is correct
2. you build a heater-shaker step with no timer and choose to add a pause to wait for temperature: a `waitForTemperature` **is** created, this is correct
3. you build a heater-shaker step with a timer and you aren't prompted to add a pause because you already added a timer: this is where the bug is that this PR is addressing. It should emit a `waitForTemperature` followed by a `waitForDuration` but it currently only emits a `waitForDuration`. this is not correct

This bug most definitely exists in Prod and has existed in prod for awhile. since no one has complained, i think we can just release this in PD 8.5.0

## Test Plan and Hands on Testing

Upload the attached protocol and export and see that a `waitForTemperature` is emitted before the 1st `waitForDuration`

[eaf.json](https://github.com/user-attachments/files/20256839/eaf.json)

## Changelog

- fix logic and tests
- update announcement modal and release notes

## Risk assessment

medium
