### PR TITLE
feat(protocol-designer, step-generation): ensure moveLiquid path is valid before step generation

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -7,6 +7,7 @@ import {
   getAllLiquidClassDefs,
   getFlexNameConversion,
   linearInterpolate,
+  WATER_LIQUID_CLASS_NAME,
 } from '@opentrons/shared-data'
 import { getTransferPlanAndReferenceVolumes } from '@opentrons/step-generation'
 
@@ -51,7 +52,7 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassDef =
     allLiquidClassDefs[formData?.liquidClass ?? ''] ??
-    allLiquidClassDefs.waterV1
+    allLiquidClassDefs[WATER_LIQUID_CLASS_NAME]
   const convertedPipetteName =
     pipette != null ? getFlexNameConversion(pipette.spec) : null
   const liquidClassValuesForPipette = liquidClassDef.byPipette.find(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -8,14 +8,15 @@ import {
   getFlexNameConversion,
   linearInterpolate,
 } from '@opentrons/shared-data'
+import { getTransferPlanAndReferenceVolumes } from '@opentrons/step-generation'
 
 import { InputStepFormField } from '../../../../../components/molecules'
 import { getRobotType } from '../../../../../file-data/selectors'
 import { selectors as stepFormSelectors } from '../../../../../step-forms'
-import { getReferenceVolumesForByVolumeInterpolation } from '../../../../../steplist/formLevel/handleFormChange/utils'
 import { getMatchingTipLiquidSpecs } from '../../../../../utils'
 import { getMaxUiFlowRate } from './utils'
 
+import type { PathOption } from '@opentrons/step-generation'
 import type { FormData } from '../../../../../form-types'
 import type { FlowRateType } from '../../../../../resources/types'
 import type { FieldProps } from '../types'
@@ -68,17 +69,27 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
     Object.values(labwareEntities).find(
       ({ labwareDefURI }) => labwareDefURI === tiprack
     )?.def ?? null
+
+  // if form type is 'mix', we will use single path
   const referenceVolumesForByVolumeInterpolation =
     pipette != null && tiprackDef != null && formData != null
-      ? getReferenceVolumesForByVolumeInterpolation({
-          rawForm: formData,
+      ? getTransferPlanAndReferenceVolumes({
+          volume: Number(formData.volume),
+          path: (formData.path as PathOption) ?? 'single',
+          numDispenseWells:
+            formData.stepType === 'moveLiquid'
+              ? formData.dispense_wells.length
+              : 1,
           pipetteSpecs: pipette?.spec,
           tiprackDefinition: tiprackDef,
-          conditioningByVolume: (liquidClassValuesForTip?.multiDispense
-            ?.conditioningByVolume ?? []) as Array<[number, number]>,
-          disposalByVolume: (liquidClassValuesForTip?.multiDispense
-            ?.disposalByVolume ?? []) as Array<[number, number]>,
-        })
+          conditioningByVolume:
+            (liquidClassValuesForTip?.multiDispense
+              ?.conditioningByVolume as Array<[number, number]>) ?? null,
+          disposalByVolume:
+            (liquidClassValuesForTip?.multiDispense?.disposalByVolume as Array<
+              [number, number]
+            >) ?? null,
+        }).referenceVolumes
       : null
   const [referenceVolumeFlowRate, referenceVolumeCorrection] =
     flowRateType === 'aspirate'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/LiquidClassesStepTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/LiquidClassesStepTools.test.tsx
@@ -1,6 +1,8 @@
 import { screen } from '@testing-library/react'
 import { beforeEach, describe, it, vi } from 'vitest'
 
+import { WATER_LIQUID_CLASS_NAME } from '@opentrons/shared-data'
+
 import { renderWithProviders } from '../../../../../../../__testing-utils__'
 import { i18n } from '../../../../../../../assets/localization'
 import { getLiquidEntities } from '../../../../../../../step-forms/selectors'
@@ -34,7 +36,11 @@ describe('LiquidClassesStepMoveLiquidTools', () => {
       },
       formData: { liquidClass: 'none' } as any,
       orderedLiquidClassOptions: [
-        { name: 'mockname', value: 'waterV1', subButtonLabel: '' },
+        {
+          name: 'mockname',
+          value: WATER_LIQUID_CLASS_NAME,
+          subButtonLabel: '',
+        },
       ],
       type: 'transfer',
     }

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -905,7 +905,7 @@ export const getArgsAndErrorsByStepId: Selector<
         const errors = _formHasErrors(hydratedForm, contextualState)
         const nextStepData = !errors
           ? {
-              stepArgs: stepFormToArgs(hydratedForm),
+              stepArgs: stepFormToArgs(hydratedForm, contextualState),
             }
           : {
               errors,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -7,6 +7,7 @@ import {
   linearInterpolate,
   POSITION_REFERENCE_TOP,
 } from '@opentrons/shared-data'
+import { getTransferPlanAndReferenceVolumes } from '@opentrons/step-generation'
 
 import { getPipetteCapacity } from '../../../pipettes/pipetteData'
 import { canPipetteUseLabware, getWellSetForMultichannel } from '../../../utils'
@@ -720,13 +721,15 @@ const getLiquidClassValuesMoveLiquid = (args: {
     Object.values(labwareEntities).find(
       ({ labwareDefURI }) => labwareDefURI === tipRack
     )?.def ?? null
-  const byVolumeLookup = getReferenceVolumesForByVolumeInterpolation({
-    rawForm,
+  const byVolumeLookup = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
     tiprackDefinition,
     conditioningByVolume,
     disposalByVolume,
-  })
+    volume: Number(rawForm.volume),
+    path: rawForm.path as PathOption,
+    numDispenseWells: rawForm.dispense_wells.length,
+  }).referenceVolumes
   // top-level aspirate fields
   const aspiratePositionReferenceFields = getPositionReferenceFields(
     aspiratePositionReference,
@@ -764,7 +767,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
         })
       : {}
   const conditioningFields =
-    multiDispense != null
+    multiDispense != null && byVolumeLookup.conditioning != null
       ? getByVolumeField({
           volume: byVolumeLookup.conditioning,
           byVolume: conditioningByVolume,
@@ -772,7 +775,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
         })
       : {}
   const disposalFields =
-    multiDispense != null
+    multiDispense != null && byVolumeLookup.disposal != null
       ? getByVolumeField({
           volume: byVolumeLookup.disposal,
           byVolume: disposalByVolume,
@@ -953,134 +956,6 @@ const getLiquidClassValuesMix = (args: {
       : {}),
   }
   return values
-}
-
-export const getReferenceVolumesForByVolumeInterpolation = (args: {
-  rawForm: FormData
-  pipetteSpecs: PipetteV2Specs
-  tiprackDefinition: LabwareDefinition2 | null
-  conditioningByVolume: Array<[number, number]>
-  disposalByVolume: Array<[number, number]>
-}): {
-  airGap: number
-  correctionAspirate: number
-  correctionDispense: number
-  pushOut: number
-  flowRateAspirate: number
-  flowRateDispense: number
-  conditioning: number
-  disposal: number
-} => {
-  const {
-    rawForm,
-    pipetteSpecs,
-    tiprackDefinition,
-    conditioningByVolume,
-    disposalByVolume,
-  } = args
-  const { volume: rawVolume, path: rawPath, aspirate_wells } = rawForm
-  const volume = Number(rawVolume)
-  const path = rawPath as PathOption
-  const { liquids } = pipetteSpecs
-  const isInLowVolumeMode =
-    volume < liquids.default.minVolume && 'lowVolumeDefault' in liquids
-  const maxWorkingVolumePipette = isInLowVolumeMode
-    ? liquids.lowVolumeDefault.maxVolume
-    : liquids.default.maxVolume
-  const maxWorkingVolumeTip = tiprackDefinition?.wells.A1.totalLiquidVolume
-  const maxWorkingVolume =
-    maxWorkingVolumeTip == null
-      ? maxWorkingVolumePipette
-      : Math.min(maxWorkingVolumePipette, maxWorkingVolumeTip)
-  const numAspirations = Math.ceil(volume / maxWorkingVolume)
-  const minVolumeForMultiAspirateDispense = volume * 2
-  const isMultiDispenseAvailable =
-    minVolumeForMultiAspirateDispense >=
-    minVolumeForMultiAspirateDispense +
-      (linearInterpolate(
-        minVolumeForMultiAspirateDispense,
-        conditioningByVolume
-      ) ?? 0) +
-      (linearInterpolate(minVolumeForMultiAspirateDispense, disposalByVolume) ??
-        0)
-  const isMultiAspirateAvailable =
-    maxWorkingVolume > minVolumeForMultiAspirateDispense
-
-  const getTotalVolumeForMultiDispense = (
-    targetVol: number,
-    includeConditioning: boolean = true
-  ): number => {
-    const interpolatedConditioningVolume =
-      linearInterpolate(targetVol, conditioningByVolume) ?? 0
-    const interpolatedDisposalVolume =
-      linearInterpolate(targetVol, disposalByVolume) ?? 0
-    return (
-      targetVol +
-      (includeConditioning ? interpolatedConditioningVolume : 0) +
-      interpolatedDisposalVolume
-    )
-  }
-
-  // early return if multiAspirate/multiDispense cannot be accommodated
-  if (
-    path === 'single' ||
-    (path === 'multiDispense' && !isMultiDispenseAvailable) ||
-    (path === 'multiAspirate' && !isMultiAspirateAvailable)
-  ) {
-    const volumePerAspiration = volume / numAspirations
-    return {
-      airGap: volumePerAspiration,
-      correctionAspirate: volumePerAspiration,
-      correctionDispense: volumePerAspiration,
-      pushOut: volumePerAspiration,
-      flowRateAspirate: volumePerAspiration,
-      flowRateDispense: volumePerAspiration,
-      conditioning: 0,
-      disposal: 0,
-    }
-  }
-
-  if (path === 'multiDispense') {
-    let totalVolumeForMultiDispense: number = 0
-    for (let i = 0; i < aspirate_wells.length; i++) {
-      const next = getTotalVolumeForMultiDispense((i + 1) * volume)
-      if (next > maxWorkingVolume) {
-        break
-      } else {
-        totalVolumeForMultiDispense = (i + 1) * volume
-      }
-    }
-    return {
-      airGap: getTotalVolumeForMultiDispense(
-        totalVolumeForMultiDispense,
-        false
-      ),
-      correctionAspirate: getTotalVolumeForMultiDispense(
-        totalVolumeForMultiDispense
-      ),
-      correctionDispense: volume,
-      pushOut: volume,
-      conditioning: totalVolumeForMultiDispense,
-      disposal: totalVolumeForMultiDispense,
-      flowRateAspirate: getTotalVolumeForMultiDispense(
-        totalVolumeForMultiDispense
-      ),
-      flowRateDispense: volume,
-    }
-  }
-  // path is valid multiAspirate
-  const maxSourcesPerAspiration = Math.floor(maxWorkingVolume / volume)
-  const volumeTotalAspiration = maxSourcesPerAspiration * volume
-  return {
-    airGap: volumeTotalAspiration,
-    correctionAspirate: volumeTotalAspiration,
-    correctionDispense: volumeTotalAspiration,
-    pushOut: volumeTotalAspiration,
-    flowRateAspirate: volume,
-    flowRateDispense: volumeTotalAspiration,
-    conditioning: volumeTotalAspiration,
-    disposal: volumeTotalAspiration,
-  }
 }
 
 export const getLiquidClassesValues = (args: {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -6,6 +6,7 @@ import {
   getFlexNameConversion,
   linearInterpolate,
   POSITION_REFERENCE_TOP,
+  WATER_LIQUID_CLASS_NAME,
 } from '@opentrons/shared-data'
 import { getTransferPlanAndReferenceVolumes } from '@opentrons/step-generation'
 
@@ -480,7 +481,7 @@ const getNoLiquidClassValuesMoveLiquid = (
     return {}
   }
   const volume = Number(rawVolume)
-  const referenceLiquidClass = getAllLiquidClassDefs().waterV1
+  const referenceLiquidClass = getAllLiquidClassDefs()[WATER_LIQUID_CLASS_NAME]
   const liquidClassValuesForPipette = referenceLiquidClass.byPipette.find(
     ({ pipetteModel }) => convertedPipetteName === pipetteModel
   )
@@ -598,7 +599,7 @@ const getNoLiquidClassValuesMix = (
     return {}
   }
   const volume = Number(rawVolume)
-  const referenceLiquidClass = getAllLiquidClassDefs().waterV1
+  const referenceLiquidClass = getAllLiquidClassDefs()[WATER_LIQUID_CLASS_NAME]
   const liquidClassValuesForPipette = referenceLiquidClass.byPipette.find(
     ({ pipetteModel }) => convertedPipetteName === pipetteModel
   )

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
@@ -12,7 +12,10 @@ import { pauseFormToArgs } from './pauseFormToArgs'
 import { temperatureFormToArgs } from './temperatureFormToArgs'
 import { thermocyclerFormToArgs } from './thermocyclerFormToArgs'
 
-import type { CommandCreatorArgs } from '@opentrons/step-generation'
+import type {
+  CommandCreatorArgs,
+  InvariantContext,
+} from '@opentrons/step-generation'
 import type {
   HydratedAbsorbanceReaderFormData,
   HydratedCommentFormData,
@@ -34,11 +37,17 @@ type StepArgs = CommandCreatorArgs | null
 export const _castForm = (hydratedForm: HydratedFormData): any =>
   mapValues(hydratedForm, (value, name) => castField(name, value))
 
-export const stepFormToArgs = (hydratedForm: HydratedFormData): StepArgs => {
+export const stepFormToArgs = (
+  hydratedForm: HydratedFormData,
+  contextualState: InvariantContext
+): StepArgs => {
   const castForm = _castForm(hydratedForm)
   switch (castForm.stepType) {
     case 'moveLiquid': {
-      return moveLiquidFormToArgs(castForm as HydratedMoveLiquidFormData)
+      return moveLiquidFormToArgs(
+        castForm as HydratedMoveLiquidFormData,
+        contextualState
+      )
     }
 
     case 'pause':

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -1,4 +1,11 @@
-import { DEST_WELL_BLOWOUT_DESTINATION } from '@opentrons/step-generation'
+import {
+  getAllLiquidClassDefs,
+  getFlexNameConversion,
+} from '@opentrons/shared-data'
+import {
+  DEST_WELL_BLOWOUT_DESTINATION,
+  getTransferPlanAndReferenceVolumes,
+} from '@opentrons/step-generation'
 
 import {
   DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP,
@@ -14,6 +21,8 @@ import type {
   ConsolidateArgs,
   DistributeArgs,
   InnerMixArgs,
+  InvariantContext,
+  PathOption,
   TransferArgs,
 } from '@opentrons/step-generation'
 import type { HydratedMoveLiquidFormData } from '../../../form-types'
@@ -58,9 +67,83 @@ export function getMixData(
 
   return null
 }
+
+const getCheckedPath = (
+  hydratedFormData: HydratedMoveLiquidFormData,
+  contextualState: InvariantContext,
+  path: PathOption
+): PathOption => {
+  const { pipette, tipRack, volume } = hydratedFormData
+  const { spec: pipetteSpecs } = pipette
+  const tiprackEntity = Object.values(contextualState.labwareEntities).find(
+    lw => lw.labwareDefURI === tipRack
+  )
+  // should not hit
+  if (tiprackEntity == null) {
+    console.error('Tiprack for transfer has no associated labware entity.')
+    return path
+  }
+  const { labwareDefURI: tiprackDefUri, def: tiprackDef } = tiprackEntity
+  const allLiquidClassDefs = getAllLiquidClassDefs()
+  const liquidClassValuesForTip = allLiquidClassDefs[
+    hydratedFormData.liquidClass ?? 'waterV1'
+  ]?.byPipette
+    .find(
+      ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))
+    )
+    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)
+
+  // be permissive with path if no liquid class tip values found
+  if (liquidClassValuesForTip == null) {
+    return path
+  }
+  if (
+    path === 'single' ||
+    // if liquid class values are found and path is 'multiDispense', make sure multiDispense object is defined
+    // this should be enforced by UI in liquid class selection, but this is another safeguard
+    (path === 'multiDispense' && liquidClassValuesForTip.multiDispense == null)
+  ) {
+    return 'single'
+  }
+
+  const { multiWellHandling } =
+    path === 'multiAspirate'
+      ? getTransferPlanAndReferenceVolumes({
+          pipetteSpecs,
+          tiprackDefinition: tiprackDef,
+          volume,
+          path,
+          numDispenseWells: hydratedFormData.dispense_wells.length,
+          conditioningByVolume: null,
+          disposalByVolume: null,
+        })
+      : getTransferPlanAndReferenceVolumes({
+          pipetteSpecs,
+          tiprackDefinition: tiprackDef,
+          volume,
+          path,
+          numDispenseWells: hydratedFormData.dispense_wells.length,
+          conditioningByVolume:
+            (liquidClassValuesForTip.multiDispense
+              ?.conditioningByVolume as Array<[number, number]>) ?? null,
+          disposalByVolume:
+            (liquidClassValuesForTip.multiDispense?.disposalByVolume as Array<
+              [number, number]
+            >) ?? null,
+        })
+  if (
+    !multiWellHandling.isSupported ||
+    multiWellHandling.numWellsToFitInTip === 1
+  ) {
+    return 'single'
+  }
+  // checked multiAspirate/Dispense and is safe
+  return path
+}
 type MoveLiquidStepArgs = ConsolidateArgs | DistributeArgs | TransferArgs | null
 export const moveLiquidFormToArgs = (
-  hydratedFormData: HydratedMoveLiquidFormData
+  hydratedFormData: HydratedMoveLiquidFormData,
+  contextualState: InvariantContext
 ): MoveLiquidStepArgs => {
   console.assert(
     hydratedFormData.stepType === 'moveLiquid',
@@ -321,7 +404,9 @@ export const moveLiquidFormToArgs = (
     'cannot distribute when destWells is null'
   )
 
-  switch (path) {
+  const checkedPath = getCheckedPath(hydratedFormData, contextualState, path)
+
+  switch (checkedPath) {
     case 'single': {
       const transferStepArguments: TransferArgs = {
         ...commonFields,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -1,6 +1,7 @@
 import {
   getAllLiquidClassDefs,
   getFlexNameConversion,
+  WATER_LIQUID_CLASS_NAME,
 } from '@opentrons/shared-data'
 import {
   DEST_WELL_BLOWOUT_DESTINATION,
@@ -86,7 +87,7 @@ const getCheckedPath = (
   const { labwareDefURI: tiprackDefUri, def: tiprackDef } = tiprackEntity
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassValuesForTip = allLiquidClassDefs[
-    hydratedFormData.liquidClass ?? 'waterV1'
+    hydratedFormData.liquidClass ?? WATER_LIQUID_CLASS_NAME
   ]?.byPipette
     .find(
       ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
@@ -8,7 +8,10 @@ import {
   fixture_12_trough,
   fixture_96_plate,
 } from '@opentrons/shared-data/labware/fixtures/2'
-import { DEST_WELL_BLOWOUT_DESTINATION } from '@opentrons/step-generation'
+import {
+  DEST_WELL_BLOWOUT_DESTINATION,
+  makeContext,
+} from '@opentrons/step-generation'
 
 import { DEFAULT_MM_OFFSET_FROM_BOTTOM } from '../../../../constants'
 import { getOrderedWells } from '../../../utils'
@@ -29,6 +32,7 @@ vi.mock('assert')
 
 const ASPIRATE_WELL = 'A2' // default source is trough for these tests
 const DISPENSE_WELL = 'C3' // default dest in 96 flat for these tests
+const invariantContext = makeContext()
 
 describe('move liquid step form -> command creator args', () => {
   let hydratedForm: HydratedMoveLiquidFormData
@@ -69,7 +73,7 @@ describe('move liquid step form -> command creator args', () => {
         type: sourceLabwareType,
         def: sourceLabwareDef,
       },
-      tipRack: 'mockTiprack',
+      tipRack: 'tiprack1Id',
       aspirate_wells: [ASPIRATE_WELL],
       aspirate_wellOrder_first: 'l2r',
       aspirate_wellOrder_second: 't2b',
@@ -117,7 +121,7 @@ describe('move liquid step form -> command creator args', () => {
   })
 
   it('moveLiquidFormToArgs calls getOrderedWells correctly', () => {
-    moveLiquidFormToArgs(hydratedForm)
+    moveLiquidFormToArgs(hydratedForm, invariantContext)
 
     expect(vi.mocked(getOrderedWells)).toHaveBeenCalledTimes(2)
     expect(vi.mocked(getOrderedWells)).toHaveBeenCalledWith(
@@ -135,16 +139,19 @@ describe('move liquid step form -> command creator args', () => {
   })
 
   it('moveLiquidFormToArgs calls getOrderedWells only for aspirate when dispensing is into a waste chute', () => {
-    moveLiquidFormToArgs({
-      ...hydratedForm,
-      dispense_labware: {
-        id: 'destLabwareId',
-        name: 'wasteChute',
-        location: 'cutoutD3',
-        isTouchTipAllowed: false,
-        pythonName: 'mockPythonName',
+    moveLiquidFormToArgs(
+      {
+        ...hydratedForm,
+        dispense_labware: {
+          id: 'destLabwareId',
+          name: 'wasteChute',
+          location: 'cutoutD3',
+          isTouchTipAllowed: false,
+          pythonName: 'mockPythonName',
+        },
       },
-    })
+      invariantContext
+    )
 
     expect(vi.mocked(getOrderedWells)).toHaveBeenCalledTimes(1)
     expect(vi.mocked(getOrderedWells)).toHaveBeenCalledWith(
@@ -156,7 +163,7 @@ describe('move liquid step form -> command creator args', () => {
   })
 
   it('moveLiquid form with 1:1 single transfer translated to args', () => {
-    const result = moveLiquidFormToArgs(hydratedForm)
+    const result = moveLiquidFormToArgs(hydratedForm, invariantContext)
 
     expect(result).toMatchObject({
       pipette: 'pipetteId',
@@ -273,20 +280,26 @@ describe('move liquid step form -> command creator args', () => {
     }) => {
       it(`${checkboxField} toggles dependent fields`, () => {
         expect(
-          moveLiquidFormToArgs({
-            ...hydratedForm,
+          moveLiquidFormToArgs(
+            {
+              ...hydratedForm,
 
-            [checkboxField]: false,
-            ...formFields,
-          })
+              [checkboxField]: false,
+              ...formFields,
+            },
+            invariantContext
+          )
         ).toMatchObject(expectedArgsUnchecked)
 
         expect(
-          moveLiquidFormToArgs({
-            ...hydratedForm,
-            [checkboxField]: true,
-            ...formFields,
-          })
+          moveLiquidFormToArgs(
+            {
+              ...hydratedForm,
+              [checkboxField]: true,
+              ...formFields,
+            },
+            invariantContext
+          )
         ).toMatchObject(expectedArgsChecked)
       })
     }
@@ -303,12 +316,15 @@ describe('move liquid step form -> command creator args', () => {
     }
 
     it('disposal volume works when checkbox true', () => {
-      const result = moveLiquidFormToArgs({
-        ...hydratedForm,
+      const result = moveLiquidFormToArgs(
+        {
+          ...hydratedForm,
 
-        ...disposalVolumeFields,
-        disposalVolume_checkbox: true,
-      })
+          ...disposalVolumeFields,
+          disposalVolume_checkbox: true,
+        },
+        invariantContext
+      )
 
       expect(result).toMatchObject({
         disposalVolume: 123,
@@ -316,12 +332,15 @@ describe('move liquid step form -> command creator args', () => {
     })
 
     it('blowout location works when checkbox true', () => {
-      const result = moveLiquidFormToArgs({
-        ...hydratedForm,
+      const result = moveLiquidFormToArgs(
+        {
+          ...hydratedForm,
 
-        ...disposalVolumeFields,
-        blowout_checkbox: true,
-      })
+          ...disposalVolumeFields,
+          blowout_checkbox: true,
+        },
+        invariantContext
+      )
 
       expect(result).toMatchObject({
         blowoutLocation: blowoutLabwareId,
@@ -329,12 +348,15 @@ describe('move liquid step form -> command creator args', () => {
     })
 
     it('disposal volume fields ignored when checkbox false', () => {
-      const result = moveLiquidFormToArgs({
-        ...hydratedForm,
+      const result = moveLiquidFormToArgs(
+        {
+          ...hydratedForm,
 
-        ...disposalVolumeFields,
-        disposalVolume_checkbox: false,
-      })
+          ...disposalVolumeFields,
+          disposalVolume_checkbox: false,
+        },
+        invariantContext
+      )
 
       expect(result).toMatchObject({
         disposalVolume: null,
@@ -342,13 +364,16 @@ describe('move liquid step form -> command creator args', () => {
     })
 
     it('disposal volume overrides blowout', () => {
-      const result = moveLiquidFormToArgs({
-        ...hydratedForm,
+      const result = moveLiquidFormToArgs(
+        {
+          ...hydratedForm,
 
-        ...disposalVolumeFields,
-        disposalVolume_checkbox: true,
-        blowout_checkbox: true,
-      })
+          ...disposalVolumeFields,
+          disposalVolume_checkbox: true,
+          blowout_checkbox: true,
+        },
+        invariantContext
+      )
 
       expect(result).toMatchObject({
         disposalVolume: 123,
@@ -357,13 +382,16 @@ describe('move liquid step form -> command creator args', () => {
     })
 
     it('fallback to blowout when disposal volume unchecked', () => {
-      const result = moveLiquidFormToArgs({
-        ...hydratedForm,
+      const result = moveLiquidFormToArgs(
+        {
+          ...hydratedForm,
 
-        ...disposalVolumeFields,
-        disposalVolume_checkbox: false,
-        blowout_checkbox: true,
-      })
+          ...disposalVolumeFields,
+          disposalVolume_checkbox: false,
+          blowout_checkbox: true,
+        },
+        invariantContext
+      )
 
       expect(result).toMatchObject({
         disposalVolume: null,
@@ -372,13 +400,16 @@ describe('move liquid step form -> command creator args', () => {
     })
 
     it('should blow out into the destination when checkbox is true and blowout location is destination', () => {
-      const result = moveLiquidFormToArgs({
-        ...hydratedForm,
+      const result = moveLiquidFormToArgs(
+        {
+          ...hydratedForm,
 
-        ...disposalVolumeFields,
-        blowout_checkbox: true,
-        blowout_location: DEST_WELL_BLOWOUT_DESTINATION,
-      })
+          ...disposalVolumeFields,
+          blowout_checkbox: true,
+          blowout_location: DEST_WELL_BLOWOUT_DESTINATION,
+        },
+        invariantContext
+      )
 
       expect(result).toMatchObject({
         disposalVolume: null,

--- a/shared-data/js/liquidClasses.ts
+++ b/shared-data/js/liquidClasses.ts
@@ -8,6 +8,8 @@ const ethanol80V1 = ethanol80V1Uncasted as LiquidClass
 const glycerol50V1 = glycerol50V1Uncasted as LiquidClass
 const waterV1 = waterV1Uncasted as LiquidClass
 
+export const WATER_LIQUID_CLASS_NAME = 'waterV1'
+
 const defs = { waterV1, glycerol50V1, ethanol80V1 }
 
 export const getAllLiquidClassDefs = (): Record<string, LiquidClass> => defs

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -220,6 +220,8 @@ export type ChangeTipOptions =
   | 'perDest'
   | 'perSource'
 
+export type PathOption = 'single' | 'multiAspirate' | 'multiDispense'
+
 export interface InnerMixArgs {
   volume: number
   times: number

--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  fixtureTiprack10ul as _fixtureTiprack10ul,
+  fixtureTiprack300ul as _fixtureTiprack300ul,
+} from '@opentrons/shared-data'
+
+import { getTransferPlanAndReferenceVolumes } from '../misc'
+
+import type { LabwareDefinition2, PipetteV2Specs } from '@opentrons/shared-data'
+
+const fixtureTiprack10ul = _fixtureTiprack10ul as LabwareDefinition2
+const fixtureTiprack300ul = _fixtureTiprack300ul as LabwareDefinition2
+const MOCK_P10_SPECS: PipetteV2Specs = {
+  channels: 1,
+  defaultTipracks: [],
+  displayCategory: 'GEN2',
+  id: 'p10_single_gen2',
+  model: 'p10_single',
+  name: 'p10 Single GEN2',
+  nominalMaxVolumeUl: 10,
+  supportedTips: [],
+  tipLength: 50,
+  liquids: {
+    default: {
+      maxVolume: 10,
+      minVolume: 1,
+    },
+  },
+} as any
+
+const MOCK_P300_SPECS: PipetteV2Specs = {
+  channels: 8,
+  defaultTipracks: [],
+  displayCategory: 'GEN2',
+  id: 'p300_multi_gen2',
+  model: 'p300_multi',
+  name: 'p300 Multi GEN2',
+  nominalMaxVolumeUl: 300,
+  supportedTips: [],
+  tipLength: 50,
+  liquids: {
+    default: {
+      maxVolume: 300,
+      minVolume: 10,
+    },
+  },
+} as any
+
+describe('getTransferPlanAndReferenceVolumes', () => {
+  it('should return correct values for single path', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P10_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 5,
+      path: 'single',
+      numDispenseWells: 1,
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result).toEqual({
+      referenceVolumes: {
+        airGap: 5,
+        correctionAspirate: 5,
+        correctionDispense: 5,
+        pushOut: 5,
+        flowRateAspirate: 5,
+        flowRateDispense: 5,
+      },
+      multiWellHandling: {
+        isSupported: false,
+      },
+    })
+  })
+
+  it('should handle volumes exceeding pipette max volume for single path', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P10_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 15,
+      path: 'single',
+      numDispenseWells: 1,
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result.referenceVolumes.airGap).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.correctionAspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.correctionDispense).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.pushOut).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.flowRateAspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.flowRateDispense).toBeCloseTo(7.5)
+    expect(result.multiWellHandling.isSupported).toBe(false)
+  })
+
+  it('should handle volumes exceeding tiprack max volume for single path', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P300_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 15,
+      path: 'single',
+      numDispenseWells: 1,
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result.referenceVolumes.airGap).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.correctionAspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.correctionDispense).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.pushOut).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.flowRateAspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.flowRateDispense).toBeCloseTo(7.5)
+    expect(result.multiWellHandling.isSupported).toBe(false)
+  })
+
+  it('should return correct values for multiAspirate path', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P10_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 3,
+      path: 'multiAspirate',
+      numDispenseWells: 1,
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result).toEqual({
+      referenceVolumes: {
+        airGap: 9,
+        correctionAspirate: 9,
+        correctionDispense: 9,
+        pushOut: 9,
+        flowRateAspirate: 3,
+        flowRateDispense: 9,
+      },
+      multiWellHandling: {
+        isSupported: true,
+        numWellsToFitInTip: 3,
+      },
+    })
+  })
+
+  it('should limit multiAspirate by pipette max volume', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P10_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 4,
+      path: 'multiAspirate',
+      numDispenseWells: 1,
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result.referenceVolumes.airGap).toBe(8)
+    expect(result.multiWellHandling.numWellsToFitInTip).toBe(2)
+  })
+
+  it('should limit multiAspirate by tiprack max volume', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P300_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 4,
+      path: 'multiAspirate',
+      numDispenseWells: 1,
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result.referenceVolumes.airGap).toBe(8)
+    expect(result.multiWellHandling.numWellsToFitInTip).toBe(2)
+  })
+
+  it('should return correct values for multiDispense path', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P300_SPECS,
+      tiprackDefinition: fixtureTiprack300ul,
+      volume: 10,
+      path: 'multiDispense',
+      numDispenseWells: 3,
+      conditioningByVolume: [
+        [20, 5],
+        [40, 10],
+      ],
+      disposalByVolume: [
+        [20, 2],
+        [40, 4],
+      ],
+    })
+    expect(result.referenceVolumes.airGap).toBe(30 + 3)
+    expect(result.referenceVolumes.correctionAspirate).toBe(30 + 7.5 + 3)
+    expect(result.referenceVolumes.correctionDispense).toBe(10)
+    expect(result.referenceVolumes.pushOut).toBe(10)
+    expect(result.referenceVolumes.conditioning).toBe(30)
+    expect(result.referenceVolumes.disposal).toBe(30)
+    expect(result.referenceVolumes.flowRateAspirate).toBe(30 + 7.5 + 3)
+    expect(result.referenceVolumes.flowRateDispense).toBe(10)
+    expect(result.multiWellHandling.isSupported).toBe(true)
+    expect(result.multiWellHandling.numWellsToFitInTip).toBe(3)
+  })
+
+  it('should limit multiDispense by pipette max volume', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P10_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 3,
+      path: 'multiDispense',
+      numDispenseWells: 4,
+      conditioningByVolume: [
+        [5, 0],
+        [7, 2],
+      ],
+      disposalByVolume: [
+        [5, 1],
+        [7, 3],
+      ],
+    })
+    expect(result.referenceVolumes.airGap).toBe(6 + 2)
+    expect(result.referenceVolumes.correctionAspirate).toBe(6 + 1 + 2)
+    expect(result.referenceVolumes.correctionDispense).toBe(3)
+    expect(result.referenceVolumes.pushOut).toBe(3)
+    expect(result.referenceVolumes.conditioning).toBe(6)
+    expect(result.referenceVolumes.disposal).toBe(6)
+    expect(result.referenceVolumes.flowRateAspirate).toBe(6 + 1 + 2)
+    expect(result.referenceVolumes.flowRateDispense).toBe(3)
+    expect(result.multiWellHandling.isSupported).toBe(true)
+    expect(result.multiWellHandling.numWellsToFitInTip).toBe(2)
+  })
+
+  it('should limit multiDispense by tiprack max volume', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P300_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 3,
+      path: 'multiDispense',
+      numDispenseWells: 4,
+      conditioningByVolume: [
+        [5, 0],
+        [7, 2],
+      ],
+      disposalByVolume: [
+        [5, 1],
+        [7, 3],
+      ],
+    })
+    expect(result.referenceVolumes.airGap).toBe(6 + 2)
+    expect(result.referenceVolumes.correctionAspirate).toBe(6 + 1 + 2)
+    expect(result.referenceVolumes.correctionDispense).toBe(3)
+    expect(result.referenceVolumes.pushOut).toBe(3)
+    expect(result.referenceVolumes.conditioning).toBe(6)
+    expect(result.referenceVolumes.disposal).toBe(6)
+    expect(result.referenceVolumes.flowRateAspirate).toBe(6 + 1 + 2)
+    expect(result.referenceVolumes.flowRateDispense).toBe(3)
+    expect(result.multiWellHandling.isSupported).toBe(true)
+    expect(result.multiWellHandling.numWellsToFitInTip).toBe(2)
+  })
+
+  it('should return isSupported false for multiDispense if not enough volume', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P10_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 6,
+      path: 'multiDispense',
+      numDispenseWells: 2,
+      conditioningByVolume: [[10, 1]],
+      disposalByVolume: [[10, 0.5]],
+    })
+    expect(result.multiWellHandling.isSupported).toBe(false)
+  })
+
+  it('should handle low volume mode for single path', () => {
+    const mockLowVolumePipetteSpecs: PipetteV2Specs = {
+      ...MOCK_P10_SPECS,
+      liquids: {
+        default: {
+          maxVolume: 10,
+          minVolume: 2,
+        },
+        lowVolumeDefault: {
+          maxVolume: 2,
+          minVolume: 0.5,
+        },
+      },
+    } as any
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: mockLowVolumePipetteSpecs,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 1,
+      path: 'single',
+      numDispenseWells: 1,
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result.referenceVolumes.airGap).toBe(1)
+  })
+
+  it('should use default liquids if lowVolumeDefault is not defined', () => {
+    const mockNoLowVolumePipetteSpecs: PipetteV2Specs = {
+      ...MOCK_P10_SPECS,
+      liquids: {
+        default: {
+          maxVolume: 10,
+          minVolume: 1,
+        },
+      },
+    } as any
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: mockNoLowVolumePipetteSpecs,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 0.8,
+      path: 'single',
+      numDispenseWells: 1,
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result.referenceVolumes.airGap).toBe(0.8)
+  })
+})

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -10,6 +10,7 @@ import {
   getIsTiprack,
   getLabwareDefURI,
   getWellNamePerMultiTip,
+  linearInterpolate,
   NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   OT2_ROBOT_TYPE,
@@ -43,6 +44,7 @@ import type {
   LabwareDefinition2,
   NozzleConfigurationStyle,
   PipetteChannels,
+  PipetteV2Specs,
   RobotType,
 } from '@opentrons/shared-data'
 import type {
@@ -53,6 +55,7 @@ import type {
   LabwareEntity,
   LabwareTemporalProperties,
   LocationLiquidState,
+  PathOption,
   PipetteEntity,
   RobotState,
   SourceAndDest,
@@ -931,4 +934,170 @@ export const getTopmostLabwareOnModuleFromStackRobotState = (
   return Object.values(labware)
     .filter(lw => lw.stack.includes(moduleId)) // all stacks involving this module
     .sort((a, b) => b.stack.length - a.stack.length)[0]?.stack[0] // return topmost labware from largest stack
+}
+
+export const getTransferPlanAndReferenceVolumes = (args: {
+  pipetteSpecs: PipetteV2Specs
+  tiprackDefinition: LabwareDefinition2 | null
+  volume: number
+  path: PathOption
+  numDispenseWells: number
+  conditioningByVolume: Array<[number, number]> | null
+  disposalByVolume: Array<[number, number]> | null
+}): {
+  referenceVolumes: {
+    airGap: number
+    correctionAspirate: number
+    correctionDispense: number
+    pushOut: number
+    flowRateAspirate: number
+    flowRateDispense: number
+    conditioning?: number
+    disposal?: number
+  }
+  multiWellHandling: {
+    isSupported: boolean
+    numWellsToFitInTip?: number
+  }
+} => {
+  const {
+    path,
+    volume,
+    pipetteSpecs,
+    tiprackDefinition,
+    conditioningByVolume,
+    disposalByVolume,
+    numDispenseWells,
+  } = args
+  const { liquids } = pipetteSpecs
+  const isInLowVolumeMode =
+    volume < liquids.default.minVolume && 'lowVolumeDefault' in liquids
+  const maxWorkingVolumePipette = isInLowVolumeMode
+    ? liquids.lowVolumeDefault.maxVolume
+    : liquids.default.maxVolume
+  const maxWorkingVolumeTip = tiprackDefinition?.wells.A1.totalLiquidVolume
+  const maxWorkingVolume =
+    maxWorkingVolumeTip == null
+      ? maxWorkingVolumePipette
+      : Math.min(maxWorkingVolumePipette, maxWorkingVolumeTip)
+  const numAspirations = Math.ceil(volume / maxWorkingVolume)
+  const minVolumeForMultiAspirateDispense = volume * 2
+  const isMultiDispenseAvailable =
+    conditioningByVolume != null &&
+    disposalByVolume != null &&
+    maxWorkingVolume >=
+      minVolumeForMultiAspirateDispense +
+        (linearInterpolate(
+          minVolumeForMultiAspirateDispense,
+          conditioningByVolume
+        ) ?? 0) +
+        (linearInterpolate(
+          minVolumeForMultiAspirateDispense,
+          disposalByVolume
+        ) ?? 0)
+  const isMultiAspirateAvailable =
+    maxWorkingVolume > minVolumeForMultiAspirateDispense
+
+  const getTotalVolumeForMultiDispense = (
+    targetVol: number,
+    conditioningByVolume: Array<[number, number]>,
+    disposalByVolume: Array<[number, number]>,
+    includeConditioning: boolean = true
+  ): number => {
+    const interpolatedConditioningVolume =
+      linearInterpolate(targetVol, conditioningByVolume) ?? 0
+    const interpolatedDisposalVolume =
+      linearInterpolate(targetVol, disposalByVolume) ?? 0
+    return (
+      targetVol +
+      (includeConditioning ? interpolatedConditioningVolume : 0) +
+      interpolatedDisposalVolume
+    )
+  }
+
+  // early return if multiAspirate/multiDispense cannot be accommodated
+  if (
+    path === 'single' ||
+    (path === 'multiDispense' && !isMultiDispenseAvailable) ||
+    (path === 'multiAspirate' && !isMultiAspirateAvailable)
+  ) {
+    const volumePerAspiration = volume / numAspirations
+    return {
+      referenceVolumes: {
+        airGap: volumePerAspiration,
+        correctionAspirate: volumePerAspiration,
+        correctionDispense: volumePerAspiration,
+        pushOut: volumePerAspiration,
+        flowRateAspirate: volumePerAspiration,
+        flowRateDispense: volumePerAspiration,
+      },
+      multiWellHandling: {
+        isSupported: false,
+      },
+    }
+  }
+
+  if (path === 'multiDispense') {
+    let totalVolumeForMultiDispense: number = 0
+    let numDestinationsPerAspiration: number = 0
+    for (let i = 0; i < numDispenseWells; i++) {
+      const next = getTotalVolumeForMultiDispense(
+        (i + 1) * volume,
+        conditioningByVolume ?? [],
+        disposalByVolume ?? []
+      )
+      if (next > maxWorkingVolume) {
+        break
+      } else {
+        totalVolumeForMultiDispense = (i + 1) * volume
+        numDestinationsPerAspiration += 1
+      }
+    }
+    return {
+      referenceVolumes: {
+        airGap: getTotalVolumeForMultiDispense(
+          totalVolumeForMultiDispense,
+          conditioningByVolume ?? [],
+          disposalByVolume ?? [],
+          false
+        ),
+        correctionAspirate: getTotalVolumeForMultiDispense(
+          totalVolumeForMultiDispense,
+          conditioningByVolume ?? [],
+          disposalByVolume ?? []
+        ),
+        correctionDispense: volume,
+        pushOut: volume,
+        conditioning: totalVolumeForMultiDispense,
+        disposal: totalVolumeForMultiDispense,
+        flowRateAspirate: getTotalVolumeForMultiDispense(
+          totalVolumeForMultiDispense,
+          conditioningByVolume ?? [],
+          disposalByVolume ?? []
+        ),
+        flowRateDispense: volume,
+      },
+      multiWellHandling: {
+        isSupported: true,
+        numWellsToFitInTip: numDestinationsPerAspiration,
+      },
+    }
+  }
+  // path is valid multiAspirate
+  const maxSourcesPerAspiration = Math.floor(maxWorkingVolume / volume)
+  const volumeTotalAspiration = maxSourcesPerAspiration * volume
+  return {
+    referenceVolumes: {
+      airGap: volumeTotalAspiration,
+      correctionAspirate: volumeTotalAspiration,
+      correctionDispense: volumeTotalAspiration,
+      pushOut: volumeTotalAspiration,
+      flowRateAspirate: volume,
+      flowRateDispense: volumeTotalAspiration,
+    },
+    multiWellHandling: {
+      isSupported: true,
+      numWellsToFitInTip: maxSourcesPerAspiration,
+    },
+  }
 }

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -936,6 +936,23 @@ export const getTopmostLabwareOnModuleFromStackRobotState = (
     .sort((a, b) => b.stack.length - a.stack.length)[0]?.stack[0] // return topmost labware from largest stack
 }
 
+const _getTotalVolumeForMultiDispense = (
+  targetVol: number,
+  conditioningByVolume: Array<[number, number]>,
+  disposalByVolume: Array<[number, number]>,
+  includeConditioning: boolean = true
+): number => {
+  const interpolatedConditioningVolume =
+    linearInterpolate(targetVol, conditioningByVolume) ?? 0
+  const interpolatedDisposalVolume =
+    linearInterpolate(targetVol, disposalByVolume) ?? 0
+  return (
+    targetVol +
+    (includeConditioning ? interpolatedConditioningVolume : 0) +
+    interpolatedDisposalVolume
+  )
+}
+
 export const getTransferPlanAndReferenceVolumes = (args: {
   pipetteSpecs: PipetteV2Specs
   tiprackDefinition: LabwareDefinition2 | null
@@ -998,23 +1015,6 @@ export const getTransferPlanAndReferenceVolumes = (args: {
   const isMultiAspirateAvailable =
     maxWorkingVolume > minVolumeForMultiAspirateDispense
 
-  const getTotalVolumeForMultiDispense = (
-    targetVol: number,
-    conditioningByVolume: Array<[number, number]>,
-    disposalByVolume: Array<[number, number]>,
-    includeConditioning: boolean = true
-  ): number => {
-    const interpolatedConditioningVolume =
-      linearInterpolate(targetVol, conditioningByVolume) ?? 0
-    const interpolatedDisposalVolume =
-      linearInterpolate(targetVol, disposalByVolume) ?? 0
-    return (
-      targetVol +
-      (includeConditioning ? interpolatedConditioningVolume : 0) +
-      interpolatedDisposalVolume
-    )
-  }
-
   // early return if multiAspirate/multiDispense cannot be accommodated
   if (
     path === 'single' ||
@@ -1041,7 +1041,7 @@ export const getTransferPlanAndReferenceVolumes = (args: {
     let totalVolumeForMultiDispense: number = 0
     let numDestinationsPerAspiration: number = 0
     for (let i = 0; i < numDispenseWells; i++) {
-      const next = getTotalVolumeForMultiDispense(
+      const next = _getTotalVolumeForMultiDispense(
         (i + 1) * volume,
         conditioningByVolume ?? [],
         disposalByVolume ?? []
@@ -1055,13 +1055,13 @@ export const getTransferPlanAndReferenceVolumes = (args: {
     }
     return {
       referenceVolumes: {
-        airGap: getTotalVolumeForMultiDispense(
+        airGap: _getTotalVolumeForMultiDispense(
           totalVolumeForMultiDispense,
           conditioningByVolume ?? [],
           disposalByVolume ?? [],
           false
         ),
-        correctionAspirate: getTotalVolumeForMultiDispense(
+        correctionAspirate: _getTotalVolumeForMultiDispense(
           totalVolumeForMultiDispense,
           conditioningByVolume ?? [],
           disposalByVolume ?? []
@@ -1070,7 +1070,7 @@ export const getTransferPlanAndReferenceVolumes = (args: {
         pushOut: volume,
         conditioning: totalVolumeForMultiDispense,
         disposal: totalVolumeForMultiDispense,
-        flowRateAspirate: getTotalVolumeForMultiDispense(
+        flowRateAspirate: _getTotalVolumeForMultiDispense(
           totalVolumeForMultiDispense,
           conditioningByVolume ?? [],
           disposalByVolume ?? []


### PR DESCRIPTION
# Overview

This PR ensures that multiDispense/Aspirate paths are safe for moveLiquid forms before passing args to step generation. I also move `getTransferPlanAndReferenceVolumes` utility to step-generation for future use in `distribute` and `consolidate` command creators. Also, I pass invariant context to `stepFormToArgs` in order to access necessary tiprack definition info in `moveLiquidFormToArgs`.

TODO: implement same path-checking logic (with same utility) in UI

## Test Plan and Hands on Testing

Review logic and implementation in `moveLiquidStepFormToArgs`. Please let me know if you have any questions re: the `getTransferPlanAndReferenceVolumes` utility

## Changelog

- Move `getTransferPlanAndReferenceVolumes` utility to step generation
- Fix `FlowRateField` to accommodate mix or move liquid step
- Pass contextual state to `stepFormToArgs` > `moveLiquidFormToArgs`

## Review requests

see test plan

## Risk assessment

mediumish 