### PR TITLE
fix(api): preserve meniscus relative through move()

### DIFF
--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -199,7 +199,11 @@ class Location:
 
         """
 
-        return Location(point=self.point + point, labware=self._given_labware)
+        return Location(
+            point=self.point + point,
+            labware=self._given_labware,
+            _meniscus_tracking=self._meniscus_tracking,
+        )
 
     def __repr__(self) -> str:
         return f"Location(point={repr(self._point)}, labware={self._labware}, meniscus_tracking={self._meniscus_tracking})"

--- a/api/tests/opentrons/test_types.py
+++ b/api/tests/opentrons/test_types.py
@@ -1,5 +1,5 @@
 import pytest
-from opentrons.types import DeckSlotName, Point, Location
+from opentrons.types import DeckSlotName, Point, Location, MeniscusTrackingTarget
 from opentrons.protocol_api.labware import Labware
 
 
@@ -91,3 +91,18 @@ def test_deck_slot_name_equivalencies(
 )
 def test_deck_slot_name_as_int(input: DeckSlotName, expected_int: int) -> None:
     assert input.as_int() == expected_int
+
+
+def test_location_move_preseves_meniscus() -> None:
+    """Location.move() should preserve meniscus relativeness."""
+    loc = Location(
+        point=Point(x=1, y=2, z=3),
+        labware=None,
+        _meniscus_tracking=MeniscusTrackingTarget.START,
+    )
+    moved = loc.move(Point(x=1, y=2, z=3))
+    assert moved == Location(
+        point=Point(x=2, y=4, z=6),
+        labware=None,
+        _meniscus_tracking=MeniscusTrackingTarget.START,
+    )


### PR DESCRIPTION
When we call location.move(), we need to preserve a meniscus origin if we have one.

Closes RABR-774
