### PR TITLE
fix(protocol-designer): properly null heaterShakerTimer field and dep

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -37,6 +37,7 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 - No longer allow touch tip with incompatible labware. This changes the behavior of imported protocols that had touch tip on incompatible labware.
 - If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.
 - If a Heater-Shaker step is created with a a heater set and a timer, the protocol will now wait until the temperature is reached before counting down the timer.
+- If the timer of a Heater-Shaker step is toggled on and off, the timer input field no longer errors.
 
 Running a protocol created in Protocol Designer now requires Opentrons App version 8.5.0 or newer.
 

--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -94,8 +94,9 @@
       "body9": "No longer allow touch tip with incompatible labware. This changes the behavior of imported protocols that had touch tip on incompatible labware.",
       "body10": "If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.",
       "body11": "If a Heater-Shaker step is created with a a heater set and a timer, the protocol will now wait until the temperature is reached before counting down the timer.",
-      "body12": "All protocols now require Opentrons App version 8.5.0+ to run.",
-      "body13": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
+      "body12": "If the timer of a Heater-Shaker step is toggled on and off, the timer input field no longer errors.",
+      "body13": "All protocols now require Opentrons App version 8.5.0+ to run.",
+      "body14": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
     }
   },
   "labware_selection": {

--- a/protocol-designer/src/components/organisms/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/organisms/AnnouncementModal/announcements.tsx
@@ -70,6 +70,7 @@ const EIGHT_FIVE_ZERO_RELEASE_BULLET_POINTS = [
   '9',
   '10',
   '11',
+  '12',
 ]
 
 export const useAnnouncements = (): Announcement[] => {
@@ -611,7 +612,7 @@ export const useAnnouncements = (): Announcement[] => {
           </Flex>
           <Flex gridGap={SPACING.spacing4} flexDirection={DIRECTION_COLUMN}>
             <StyledText desktopStyle="bodyDefaultRegular">
-              {t('announcements.liquidClassAndPythonExport.body12')}
+              {t('announcements.liquidClassAndPythonExport.body13')}
             </StyledText>
             <StyledText desktopStyle="bodyDefaultRegular">
               <Trans
@@ -626,7 +627,7 @@ export const useAnnouncements = (): Announcement[] => {
                     />
                   ),
                 }}
-                i18nKey="announcements.liquidClassAndPythonExport.body13"
+                i18nKey="announcements.liquidClassAndPythonExport.body14"
               />
             </StyledText>
           </Flex>

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -1,5 +1,4 @@
 import {
-  MAX_HEATER_SHAKER_DURATION_SECONDS,
   MAX_HEATER_SHAKER_MODULE_RPM,
   MAX_HEATER_SHAKER_MODULE_TEMP,
   MAX_TC_BLOCK_TEMP,
@@ -7,7 +6,6 @@ import {
   MAX_TC_LID_TEMP,
   MAX_TC_PROFILE_VOLUME,
   MAX_TEMP_MODULE_TEMP,
-  MIN_HEATER_SHAKER_DURATION_SECONDS,
   MIN_HEATER_SHAKER_MODULE_RPM,
   MIN_HEATER_SHAKER_MODULE_TEMP,
   MIN_TC_BLOCK_TEMP,
@@ -298,15 +296,6 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
   dispense_retract_delay_seconds: {
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
   },
-  pauseHour: {
-    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
-  },
-  pauseMinute: {
-    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
-  },
-  pauseSecond: {
-    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
-  },
   pipette: {
     getErrors: composeErrors(requiredField),
     hydrate: getPipetteEntity,
@@ -361,18 +350,6 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
         MIN_HEATER_SHAKER_MODULE_RPM,
         MAX_HEATER_SHAKER_MODULE_RPM
       )
-    ),
-    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
-    castValue: Number,
-  },
-  heaterShakerTimerMinutes: {
-    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
-    castValue: Number,
-  },
-  heaterShakerTimerSeconds: {
-    getErrors: composeErrors(
-      minFieldValue(MIN_HEATER_SHAKER_DURATION_SECONDS),
-      maxFieldValue(MAX_HEATER_SHAKER_DURATION_SECONDS)
     ),
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,

--- a/protocol-designer/src/steplist/fieldLevel/processing.ts
+++ b/protocol-designer/src/steplist/fieldLevel/processing.ts
@@ -13,6 +13,9 @@ export const maskToInteger = (rawValue: unknown): string => {
   return rawNumericValue
 }
 export const maskToTime = (rawValue: unknown): string => {
+  if (rawValue == null) {
+    return ''
+  }
   const rawTimeValue =
     typeof rawValue === 'string'
       ? rawValue.replace(/[^-0-9:]/g, '')

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateHeaterShaker.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateHeaterShaker.ts
@@ -18,6 +18,21 @@ const updatePatchOnSetShakeChange = (
   return patch
 }
 
+const updatePatchOnTimer = (patch: FormPatch, rawForm: FormData): FormPatch => {
+  // when setShake is toggled to true, change latchOpen to false
+  if (
+    fieldHasChanged(rawForm, patch, 'heaterShakerSetTimer') &&
+    patch.heaterShakerSetTimer === false
+  ) {
+    return {
+      ...patch,
+      ...{ heaterShakerTimer: '' },
+    }
+  }
+
+  return patch
+}
+
 export function dependentFieldsUpdateHeaterShaker(
   originalPatch: FormPatch,
   rawForm: FormData // raw = NOT hydrated
@@ -25,5 +40,6 @@ export function dependentFieldsUpdateHeaterShaker(
   // sequentially modify parts of the patch until it's fully updated
   return chainPatchUpdaters(originalPatch, [
     chainPatch => updatePatchOnSetShakeChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnTimer(chainPatch, rawForm),
   ])
 }


### PR DESCRIPTION
…recate field from hydrating

closes AUTH-1837

# Overview

This bug exists in prod too. If you click and unclick and reclick the checkbox for the heater-shaker form timer, the input field errors with a "null" added. This PR fixes that by properly hydrating the field value as an empty string instead. And it adds to the dependent heater-shaker fields by emptying the timer field if you add something in but then unclick the checkbox.

Additionally, the old heater-shaker and pause timer fields in the hydration map are deprecated since they are no longer in use.

## Test Plan and Hands on Testing

Create a heater-shaker step and click, add a timer, unclick then click again for the timer checkbox and see that it properly empties and does not cause an error


## Changelog

- add to release notes and announcement modal
- deprecate old hydration fields that are no longer used (old timer fields)
- fix `mastToTime` to return an empty string
- add a patch to the HS timer

## Risk assessment

low
