### PR TITLE
fix(app): fix unhandled undefined selectedLabware when exiting LPC

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/steps/DetachProbe.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/DetachProbe.tsx
@@ -15,10 +15,6 @@ import {
 import { DescriptionContent, TwoColumn } from '/app/molecules/InterventionModal'
 
 import type { LoadedPipette } from '@opentrons/shared-data'
-import type {
-  OffsetLocationDetails,
-  SelectedLwOverview,
-} from '/app/redux/protocol-runs'
 import type { LPCWizardContentProps } from '/app/organisms/LabwarePositionCheck/types'
 
 import detachProbe1 from '/app/assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_1.webm'
@@ -37,20 +33,21 @@ export function DetachProbe(props: LPCWizardContentProps): JSX.Element {
   const currentSubstep = useSelector(selectCurrentSubstep(runId))
   const pipette = useSelector(selectActivePipette(runId)) as LoadedPipette
   const pipetteId = pipette.id
-  const selectedLwInfo = useSelector(
-    selectSelectedLwOverview(runId)
-  ) as SelectedLwOverview
+  const selectedLwInfo = useSelector(selectSelectedLwOverview(runId))
   const mostRecentVectorOffset = useSelector(
     selectSelectedLwWithOffsetDetailsMostRecentVectorOffset(runId)
   )
-  const offsetLocationDetails = selectedLwInfo.offsetLocationDetails as OffsetLocationDetails
+  const offsetLocationDetails = selectedLwInfo?.offsetLocationDetails
 
   const handleGoBack = (): void => {
     void toggleRobotMoving(true)
       .then(() => {
         // On the desktop app, ensure the robot returns to the initial offset position instead of the home position
         // when actively calibrating an offset.
-        if (currentSubstep === 'handle-lw/edit-offset/check-labware') {
+        if (
+          currentSubstep === 'handle-lw/edit-offset/check-labware' &&
+          offsetLocationDetails != null
+        ) {
           return home()
             .then(() =>
               handleMoveToInitialOffsetPosition(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes a whitescreen when exiting LPC on the desktop app from the "labware list" view.

https://github.com/Opentrons/opentrons/pull/18300 accounts for some specific gantry movement when exiting on the desktop app, but we should not type assert `selectedLabware` or `offsetLocationDetails` here: these can very much be undefined if the user clicks the exit button on the "labware list view". I don't know why I decided we needed to type assert here to begin with, whoops.

### Current Behavior

https://github.com/user-attachments/assets/6317910f-64ba-4a11-9db1-efd6d4beb16f

### Fixed Behavior

https://github.com/user-attachments/assets/41656ac5-79e1-4c43-b6c7-a7880e3eff3d

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See video.
- Verified that the behavior introduced in https://github.com/Opentrons/opentrons/pull/18300 is preserved.

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a whitescreen on the desktop app when performing LPC and clicking "exit" on the "labware list" screen.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
