### PR TITLE
fix(protocol-designer): add trash required snackbar too all components

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -40,6 +40,7 @@ import {
   ConfirmDeleteModal,
   getMainPagePortalEl,
 } from '../../../../components/organisms'
+import { useKitchen } from '../../../../components/organisms/Kitchen/hooks'
 import { OFFDECK } from '../../../../constants'
 import { getEnableComment } from '../../../../feature-flags/selectors'
 import {
@@ -55,7 +56,7 @@ import {
   getIsMultiSelectMode,
   actions as stepsActions,
 } from '../../../../ui/steps'
-import { getIsAdapterFromDef } from '../../../../utils'
+import { getHasTrash, getIsAdapterFromDef } from '../../../../utils'
 import { AddStepOverflowButton } from './AddStepOverflowButton'
 
 import type { ThunkDispatch } from 'redux-thunk'
@@ -68,8 +69,9 @@ interface AddStepButtonProps {
 }
 
 export function AddStepButton({ hasText }: AddStepButtonProps): JSX.Element {
-  const { t } = useTranslation(['tooltip', 'button'])
+  const { t } = useTranslation(['tooltip', 'button', 'starting_deck_state'])
   const enableComment = useSelector(getEnableComment)
+  const { makeSnackbar } = useKitchen()
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,
@@ -82,7 +84,10 @@ export function AddStepButton({ hasText }: AddStepButtonProps): JSX.Element {
     stepFormSelectors.getCurrentFormHasUnsavedChanges
   )
   const isStepCreationDisabled = useSelector(getIsMultiSelectMode)
-  const modules = useSelector(stepFormSelectors.getInitialDeckSetup).modules
+  const { modules, additionalEquipmentOnDeck } = useSelector(
+    stepFormSelectors.getInitialDeckSetup
+  )
+  const hasTrash = getHasTrash(additionalEquipmentOnDeck)
   const [showStepOverflowMenu, setShowStepOverflowMenu] = useState<boolean>(
     false
   )
@@ -163,9 +168,16 @@ export function AddStepButton({ hasText }: AddStepButtonProps): JSX.Element {
       />
     ))
 
+  const handleAddClick = (): void => {
+    if (hasTrash) {
+      setShowStepOverflowMenu(true)
+    } else {
+      makeSnackbar(t('starting_deck_state:trash_required') as string)
+    }
+  }
+
   return (
     <>
-      {/* TODO(ja): update this modal to match latest modal designs */}
       {enqueuedStepType !== null &&
         createPortal(
           <ConfirmDeleteModal
@@ -209,9 +221,7 @@ export function AddStepButton({ hasText }: AddStepButtonProps): JSX.Element {
         width="100%"
         {...targetProps}
         id="AddStepButton"
-        onClick={() => {
-          setShowStepOverflowMenu(true)
-        }}
+        onClick={handleAddClick}
         disabled={isStepCreationDisabled}
       >
         <Icon name="plus" size="1rem" />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -202,14 +202,14 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
   } = useConditionalConfirm(handleDelete, true)
 
   const handleOpenForm = (clickNum: number, e: ReactMouseEvent): void => {
-    if (hasTrash) {
-      if (clickNum === 1) {
-        onClick?.(e)
-      } else {
-        onDoubleClick?.(e)
-      }
-    } else {
+    if (!hasTrash) {
       makeSnackbar(t('trash_required') as string)
+    }
+
+    if (clickNum === 0) {
+      onClick?.(e)
+    } else {
+      onDoubleClick?.(e)
     }
   }
   return (
@@ -241,10 +241,10 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
           role="button"
           data-testid={`StepContainer_${stepId}`}
           onDoubleClick={(e: ReactMouseEvent) => {
-            handleOpenForm(2, e)
+            handleOpenForm(1, e)
           }}
           onClick={(e: ReactMouseEvent) => {
-            handleOpenForm(1, e)
+            handleOpenForm(0, e)
           }}
           padding={`${SPACING.spacing4} ${SPACING.spacing12}`}
           borderRadius={BORDERS.borderRadius8}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
@@ -29,12 +30,15 @@ import {
   DELETE_STEP_FORM,
   getMainPagePortalEl,
 } from '../../../../components/organisms'
+import { useKitchen } from '../../../../components/organisms/Kitchen/hooks'
 import { actions as steplistActions } from '../../../../steplist'
+import { getDeckSetupForActiveItem } from '../../../../top-selectors/labware-locations'
 import {
   deselectAllSteps,
   populateForm,
 } from '../../../../ui/steps/actions/actions'
 import { getMultiSelectItemIds } from '../../../../ui/steps/selectors'
+import { getHasTrash } from '../../../../utils'
 import { StepOverflowMenu } from './StepOverflowMenu'
 import { capitalizeFirstLetterAfterNumber } from './utils'
 
@@ -91,12 +95,16 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
     openedOverflowMenuId,
     sidebarWidth,
   } = props
+  const { t } = useTranslation('starting_deck_state')
+  const { makeSnackbar } = useKitchen()
   const [top, setTop] = useState<number>(0)
   const menuRootRef = useRef<HTMLDivElement | null>(null)
   const isStartingOrEndingState =
     title === STARTING_DECK_STATE || title === FINAL_DECK_STATE
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const multiSelectItemIds = useSelector(getMultiSelectItemIds)
+  const { additionalEquipmentOnDeck } = useSelector(getDeckSetupForActiveItem)
+  const hasTrash = getHasTrash(additionalEquipmentOnDeck)
 
   const hasText = sidebarWidth > PX_SIDEBAR_MIN_WIDTH_FOR_ICON
   let backgroundColor = isStartingOrEndingState ? COLORS.blue20 : COLORS.grey20
@@ -193,6 +201,17 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
     cancel: cancelDelete,
   } = useConditionalConfirm(handleDelete, true)
 
+  const handleOpenForm = (clickNum: number, e: ReactMouseEvent): void => {
+    if (hasTrash) {
+      if (clickNum === 1) {
+        onClick?.(e)
+      } else {
+        onDoubleClick?.(e)
+      }
+    } else {
+      makeSnackbar(t('trash_required') as string)
+    }
+  }
   return (
     <>
       {showDeleteConfirmation === true && (
@@ -221,8 +240,12 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
         <Box
           role="button"
           data-testid={`StepContainer_${stepId}`}
-          onDoubleClick={onDoubleClick}
-          onClick={onClick}
+          onDoubleClick={(e: ReactMouseEvent) => {
+            handleOpenForm(2, e)
+          }}
+          onClick={(e: ReactMouseEvent) => {
+            handleOpenForm(1, e)
+          }}
           padding={`${SPACING.spacing4} ${SPACING.spacing12}`}
           borderRadius={BORDERS.borderRadius8}
           width="100%"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -146,7 +146,9 @@ describe('AddStepButton', () => {
         },
       },
       labware: {},
-      additionalEquipmentOnDeck: {},
+      additionalEquipmentOnDeck: {
+        trash: { id: 'trash', location: 'cutoutA3', name: 'trashBin' },
+      },
       pipettes: {},
     })
     vi.mocked(getRobotStateTimeline).mockReturnValue({ timeline: [] })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/StepContainer.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/StepContainer.test.tsx
@@ -9,6 +9,7 @@ import { COLORS } from '@opentrons/components'
 import { renderWithProviders } from '../../../../../__testing-utils__'
 import { i18n } from '../../../../../assets/localization'
 import { getUnsavedForm } from '../../../../../step-forms/selectors'
+import { getDeckSetupForActiveItem } from '../../../../../top-selectors/labware-locations'
 import { StepContainer } from '../StepContainer'
 import { StepOverflowMenu } from '../StepOverflowMenu'
 
@@ -19,6 +20,7 @@ vi.mock('../../../../../step-forms/selectors')
 vi.mock('../../../../../ui/steps/actions/actions')
 vi.mock('../../../../../ui/steps/selectors')
 vi.mock('../StepOverflowMenu')
+vi.mock('../../../../../top-selectors/labware-locations')
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof OverflowBtn>()
   return {
@@ -52,6 +54,14 @@ describe('StepContainer', () => {
       <div>mock StepOverflowMenu</div>
     )
     vi.mocked(getUnsavedForm).mockReturnValue(null)
+    vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
+      labware: {},
+      modules: {},
+      additionalEquipmentOnDeck: {
+        trash: { id: 'trash', name: 'trashBin', location: 'cutoutA3' },
+      },
+      pipettes: {},
+    })
   })
 
   it('renders the starting deck state step', () => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/__tests__/ProtocolSteps.test.tsx
@@ -108,7 +108,9 @@ describe('ProtocolSteps', () => {
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
       modules: {},
       labware: {},
-      additionalEquipmentOnDeck: {},
+      additionalEquipmentOnDeck: {
+        trash: { id: 'trash', location: 'cutoutA3', name: 'trashBin' },
+      },
       pipettes: {},
     })
     vi.mocked(getAdditionalEquipmentEntities).mockReturnValue({})

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -31,6 +31,7 @@ import {
   StepSummary,
   TimelineAlerts,
 } from '../../../components/organisms'
+import { useKitchen } from '../../../components/organisms/Kitchen/hooks'
 import { DECK_SETUP_TOOLS_WIDTH_REM } from '../../../constants'
 import { getEnableHotKeysDisplay } from '../../../feature-flags/selectors'
 import {
@@ -56,6 +57,7 @@ import {
   getSelectedSubstep,
   getSelectedTerminalItemId,
 } from '../../../ui/steps/selectors'
+import { getHasTrash } from '../../../utils'
 import { LOAD_COMMANDS } from '../../ProtocolOverview'
 import {
   getUnusedEntities,
@@ -94,6 +96,7 @@ export function ProtocolSteps({
 }: ProtocolStepsProps): JSX.Element {
   const { i18n, t } = useTranslation('starting_deck_state')
   const formData = useSelector(getUnsavedForm)
+  const { makeSnackbar } = useKitchen()
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const selectedTerminalItemId = useSelector(getSelectedTerminalItemId)
   const hoveredTerminalItem = useSelector(getHoveredTerminalItemId)
@@ -108,6 +111,7 @@ export function ProtocolSteps({
   const [hoverSlot, setHoverSlot] = useState<DeckSlot | null>(null)
   const savedStepForms = useSelector(getSavedStepForms)
   const deckDef = useMemo(() => getDeckDefFromRobotType(robotType), [robotType])
+  const hasTrash = getHasTrash(additionalEquipmentOnDeck)
   const viewBoxX = deckDef.cornerOffsetFromOrigin[0]
   const windowInnerWidthRem = window.innerWidth / 16
   const deckMapRatio = round(
@@ -194,6 +198,14 @@ export function ProtocolSteps({
       dispatch(saveProtocolFile())
     },
   })
+
+  const handleExporting = (): void => {
+    if (hasTrash) {
+      handleExportClick()
+    } else {
+      makeSnackbar(t('trash_required') as string)
+    }
+  }
 
   let currentStep
   if (hoveredTerminalItem === HARDWARE_ID && selectedStepId != null) {
@@ -293,7 +305,7 @@ export function ProtocolSteps({
           >
             {isZoomedIn || formData != null ? null : (
               <Flex justifyContent={JUSTIFY_END}>
-                <ExportButton onClick={handleExportClick} />
+                <ExportButton onClick={handleExporting} />
               </Flex>
             )}
             <Flex

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -34,6 +34,7 @@ import type {
 } from '@opentrons/step-generation'
 import type { BoundingRect, GenericRect } from '../collision-types'
 import type {
+  AllTemporalPropertiesForTimelineFrame,
   InitialDeckSetup,
   LabwareOnDeck,
   ModuleEntities,
@@ -440,4 +441,12 @@ export const getLabwareIdAfterModuleIdInStack = (
   const indexAfter = index + 1
 
   return matchingLabware.stack[indexAfter] ?? null
+}
+
+export const getHasTrash = (
+  additionalEquipment: AllTemporalPropertiesForTimelineFrame['additionalEquipmentOnDeck']
+): boolean => {
+  return Object.values(additionalEquipment).some(
+    ae => ae.name === 'trashBin' || ae.name === 'wasteChute'
+  )
 }


### PR DESCRIPTION
closes RQA-4142

# Overview

More error handling for if you delete the trash bin or waste chute since PD does not support return tip

## Test Plan and Hands on Testing

Import a protocol and go to the hardware button of the timeine. Delete the trash bin or waste chute and try to press on:
1. export button
2. any button in the timeline besides the liquids button
3. go back button
4. new step button

See that they all render a snackbar

## Changelog

- make util
- add logic for the call to actions

## Risk assessment

low
