### PR TITLE
fix(protocol-desinger): error handling for adding modules when slot h…

### DIFF
--- a/protocol-designer/src/components/organisms/FlexHardware/util.ts
+++ b/protocol-designer/src/components/organisms/FlexHardware/util.ts
@@ -194,8 +194,7 @@ export const updateInitialDeckState = (
           ? getLabwareNotCompatibleWithModule(
               matchingModuleForAboveStaging.type,
               labwareOnDeck,
-              value.cutoutId,
-              'A1'
+              value.cutoutId
             )
           : null
       //  if deleting staging area where labware is in 4th column slot
@@ -347,8 +346,7 @@ export const updateInitialDeckState = (
         const labwareNotCompatible = getLabwareNotCompatibleWithModule(
           type,
           labwareOnDeck,
-          value.cutoutId,
-          'A1'
+          value.cutoutId
         )
         const slot = value.cutoutId.split('cutout')[1]
         //   creating module

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -20,20 +20,19 @@ import {
   getCutoutDisplayName,
   getFixtureDisplayName,
   getModuleType,
-  MAGNETIC_BLOCK_TYPE,
   MAGNETIC_BLOCK_V1,
   MODULE_MODELS,
   SINGLE_CENTER_CUTOUTS,
   THERMOCYCLER_MODULE_V2,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
-import { uuid } from '@opentrons/step-generation'
+import { getSlotInLocationStack, uuid } from '@opentrons/step-generation'
 
 import { editDeckConfiguration } from '../../../step-forms/actions'
 import { getInitialDeckSetup } from '../../../step-forms/selectors'
 import { useKitchen } from '../Kitchen/hooks'
 import { getMainPagePortalEl } from '../Portal'
-import { getLabwareNotCompatibleWithModule, getSlotHasLabware } from '../utils'
+import { getLabwareCompatibleForEditHardware } from '../utils'
 import { getAvailableOptions } from './useDeckConfigurationEditing'
 
 import type { UseFormSetValue } from 'react-hook-form'
@@ -190,13 +189,18 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
       makeSnackbar(t('add_gripper_for_plate') as string)
       //  block thermocycler from being added if there is something in slot A1
     } else if (
-      addedCutoutConfigs.some(
+      (addedCutoutConfigs.some(
         cutoutConfig => cutoutConfig.type === THERMOCYCLER_MODULE_V2
       ) &&
-      (Object.values(modules).some(module => module.cutoutId === 'cutoutA1') ||
-        Object.values(fixtures).some(
-          fixture => fixture.cutoutId === 'cutoutA1'
-        ))
+        (Object.values(modules).some(
+          module => module.cutoutId === 'cutoutA1'
+        ) ||
+          Object.values(fixtures).some(
+            fixture => fixture.cutoutId === 'cutoutA1'
+          ))) ||
+      Object.values(labware).some(
+        lw => getSlotInLocationStack(lw.stack) === 'A1'
+      )
     ) {
       makeSnackbar(t('thermocycler_blocked') as string)
     } else {
@@ -285,24 +289,13 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
         }
         setValue?.('fixtures', updatedFixtures)
       }
-      const labwareNotCompatible =
-        newModule != null
-          ? getLabwareNotCompatibleWithModule(
-              newModule.type === 'stagingAreaAndMagneticBlock'
-                ? MAGNETIC_BLOCK_TYPE
-                : getModuleType(newModule.type as ModuleModel),
-              labware,
-              newModule.cutoutId,
-              'B1'
-            )
-          : null
-      const hasLabware =
-        newFixture != null
-          ? (newFixture.type === 'wasteChute' ||
-              newFixture.type === 'trashBin') &&
-            getSlotHasLabware(labware, cutoutId)
-          : false
-      if (labwareNotCompatible == null && !hasLabware) {
+      const labwareCompatible = getLabwareCompatibleForEditHardware(
+        labware,
+        cutoutId,
+        newModule,
+        newFixture
+      )
+      if (labwareCompatible) {
         dispatch(editDeckConfiguration({ deckConfig: newDeckConfig }))
       }
       updateInitialDeckState?.(addedCutoutConfigs)

--- a/protocol-designer/src/components/organisms/__tests__/utils.test.tsx
+++ b/protocol-designer/src/components/organisms/__tests__/utils.test.tsx
@@ -31,6 +31,27 @@ describe('getLabwareCompatibleForEditHardware', () => {
       )
     ).toBe(false)
   })
+  it('returns false when there there is something in slot B1 for a TC', () => {
+    expect(
+      getLabwareCompatibleForEditHardware(
+        {
+          labware: {
+            id: 'labware',
+            labwareDefURI: 'mockURI',
+            def: fixture96Plate as LabwareDefinition2,
+            stack: ['labware', 'B1'],
+            pythonName: 'mockPythonName',
+          },
+        },
+        'cutoutA1',
+        {
+          cutoutId: 'cutoutA1',
+          cutoutFixtureId: 'thermocyclerModuleV2Front',
+          type: 'thermocyclerModuleV2',
+        }
+      )
+    ).toBe(false)
+  })
   it('returns false when labware is incompatible with module', () => {
     expect(
       getLabwareCompatibleForEditHardware(

--- a/protocol-designer/src/components/organisms/__tests__/utils.test.tsx
+++ b/protocol-designer/src/components/organisms/__tests__/utils.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { fixture96Plate } from '@opentrons/shared-data'
+
+import { getLabwareCompatibleForEditHardware } from '../utils'
+
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+
+describe('getLabwareCompatibleForEditHardware', () => {
+  it('return true when there is nothing on the slot', () => {
+    expect(getLabwareCompatibleForEditHardware({}, 'cutoutA1')).toBe(true)
+  })
+  it('returns false when there there is something in slot A1 for a TC', () => {
+    expect(
+      getLabwareCompatibleForEditHardware(
+        {
+          labware: {
+            id: 'labware',
+            labwareDefURI: 'mockURI',
+            def: fixture96Plate as LabwareDefinition2,
+            stack: ['labware', 'A1'],
+            pythonName: 'mockPythonName',
+          },
+        },
+        'cutoutB1',
+        {
+          cutoutId: 'cutoutB1',
+          cutoutFixtureId: 'thermocyclerModuleV2Front',
+          type: 'thermocyclerModuleV2',
+        }
+      )
+    ).toBe(false)
+  })
+  it('returns false when labware is incompatible with module', () => {
+    expect(
+      getLabwareCompatibleForEditHardware(
+        {
+          labware: {
+            id: 'labware',
+            labwareDefURI: 'mockURI',
+            def: fixture96Plate as LabwareDefinition2,
+            stack: ['labware', 'A3'],
+            pythonName: 'mockPythonName',
+          },
+        },
+        'cutoutA3',
+        {
+          cutoutId: 'cutoutA3',
+          cutoutFixtureId: 'heaterShakerModuleV1',
+          type: 'heaterShakerModuleV1',
+        }
+      )
+    ).toBe(false)
+  })
+  it('returns false when labware is on trash bin', () => {
+    expect(
+      getLabwareCompatibleForEditHardware(
+        {
+          labware: {
+            id: 'labware',
+            labwareDefURI: 'mockURI',
+            def: fixture96Plate as LabwareDefinition2,
+            stack: ['labware', 'A3'],
+            pythonName: 'mockPythonName',
+          },
+        },
+        'cutoutA3',
+        undefined,
+        {
+          type: 'trashBin',
+          cutoutId: 'cutoutA3',
+          cutoutFixtureId: 'trashBinAdapter',
+        }
+      )
+    ).toBe(false)
+  })
+  it('returns true when there is no labware on slot and adding a trash bin', () => {
+    expect(
+      getLabwareCompatibleForEditHardware({}, 'cutoutA3', undefined, {
+        type: 'trashBin',
+        cutoutId: 'cutoutA3',
+        cutoutFixtureId: 'trashBinAdapter',
+      })
+    ).toBe(true)
+  })
+})

--- a/protocol-designer/src/components/organisms/utils.ts
+++ b/protocol-designer/src/components/organisms/utils.ts
@@ -96,6 +96,7 @@ export const getLabwareCompatibleForEditHardware = (
   newFixture?: CutoutConfigExtended
 ): boolean => {
   const labwareDef = getLabwareOnSlot(labware, cutoutId)
+  const labwareDefB1 = getLabwareOnSlot(labware, 'cutoutB1')
   const moduleType =
     newModule != null
       ? newModule.type === 'stagingAreaAndMagneticBlock'
@@ -104,12 +105,14 @@ export const getLabwareCompatibleForEditHardware = (
       : null
 
   let labwareCompatible = true
-  if (
-    moduleType != null &&
-    moduleType === THERMOCYCLER_MODULE_TYPE &&
-    Object.values(labware).some(lw => lw.stack.includes('A1'))
-  ) {
-    labwareCompatible = false
+  if (moduleType != null && moduleType === THERMOCYCLER_MODULE_TYPE) {
+    if (Object.values(labware).some(lw => lw.stack.includes('A1'))) {
+      labwareCompatible = false
+    } else if (labwareDefB1 != null) {
+      labwareCompatible = getLabwareIsCompatible(labwareDefB1, moduleType)
+    } else {
+      labwareCompatible = false
+    }
   } else if (labwareDef != null && moduleType != null) {
     labwareCompatible = getLabwareIsCompatible(labwareDef, moduleType)
   } else if (

--- a/protocol-designer/src/components/organisms/utils.ts
+++ b/protocol-designer/src/components/organisms/utils.ts
@@ -1,6 +1,7 @@
 import {
   getAreSlotsVerticallyAdjacent,
   getModuleType,
+  MAGNETIC_BLOCK_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { AIR, MODULES_WITH_COLLISION_ISSUES } from '@opentrons/step-generation'
@@ -14,6 +15,7 @@ import type {
   AddressableAreaName,
   CutoutId,
   DeckDefinition,
+  LabwareDefinition2,
   ModuleModel,
   ModuleType,
 } from '@opentrons/shared-data'
@@ -23,6 +25,7 @@ import type {
   ModuleOnDeck,
 } from '../../step-forms'
 import type * as wellContentsSelectors from '../../top-selectors/well-contents'
+import type { CutoutConfigExtended } from './HardwareConfigurator/AddFixtureModal'
 import type { WellContentsByNumber } from './SlotDetailModal'
 
 export const getSlotsWithCollisions = (
@@ -53,8 +56,7 @@ export const getSlotsWithCollisions = (
 export const getLabwareNotCompatibleWithModule = (
   moduleType: ModuleType,
   labware: AllTemporalPropertiesForTimelineFrame['labware'],
-  cutoutId: CutoutId,
-  tcSlot: string
+  cutoutId: CutoutId
 ): string | null => {
   const slot = cutoutId.split('cutout')[1]
   const isThermocycler = moduleType === THERMOCYCLER_MODULE_TYPE
@@ -62,18 +64,13 @@ export const getLabwareNotCompatibleWithModule = (
     lw.stack.includes(slot)
   )
   const isLabwareOnOtherTCSlot = isThermocycler
-    ? Object.values(labware).some(({ stack }) => stack.includes(tcSlot))
+    ? Object.values(labware).some(({ stack }) => stack.includes('A1'))
     : false
-
-  if (isLabwareOnOtherTCSlot) {
-    return tcSlot
-  } else {
-    const isCompatible =
-      labwareOnSlot != null
-        ? getLabwareIsCompatible(labwareOnSlot.def, moduleType)
-        : true
-    return isCompatible ? null : slot
-  }
+  const isCompatible =
+    labwareOnSlot != null
+      ? getLabwareIsCompatible(labwareOnSlot.def, moduleType)
+      : true
+  return isCompatible && !isLabwareOnOtherTCSlot ? null : slot
 }
 
 export const getSlotHasLabware = (
@@ -82,6 +79,47 @@ export const getSlotHasLabware = (
 ): boolean => {
   const slot = cutoutId.split('cutout')[1]
   return Object.values(labware).some(lw => lw.stack.includes(slot))
+}
+
+export const getLabwareOnSlot = (
+  labware: AllTemporalPropertiesForTimelineFrame['labware'],
+  cutoutId: CutoutId
+): LabwareDefinition2 | null => {
+  const slot = cutoutId.split('cutout')[1]
+  return Object.values(labware).find(lw => lw.stack.includes(slot))?.def ?? null
+}
+
+export const getLabwareCompatibleForEditHardware = (
+  labware: AllTemporalPropertiesForTimelineFrame['labware'],
+  cutoutId: CutoutId,
+  newModule?: CutoutConfigExtended,
+  newFixture?: CutoutConfigExtended
+): boolean => {
+  const labwareDef = getLabwareOnSlot(labware, cutoutId)
+  const moduleType =
+    newModule != null
+      ? newModule.type === 'stagingAreaAndMagneticBlock'
+        ? MAGNETIC_BLOCK_TYPE
+        : getModuleType(newModule.type as ModuleModel)
+      : null
+
+  let labwareCompatible = true
+  if (
+    moduleType != null &&
+    moduleType === THERMOCYCLER_MODULE_TYPE &&
+    Object.values(labware).some(lw => lw.stack.includes('A1'))
+  ) {
+    labwareCompatible = false
+  } else if (labwareDef != null && moduleType != null) {
+    labwareCompatible = getLabwareIsCompatible(labwareDef, moduleType)
+  } else if (
+    newFixture != null &&
+    (newFixture.type === 'wasteChute' || newFixture.type === 'trashBin') &&
+    labwareDef != null
+  ) {
+    labwareCompatible = false
+  }
+  return labwareCompatible
 }
 
 //  NOTE: used to get the next available module slot for OT-2


### PR DESCRIPTION
…as labware

closes RQA-4140

# Overview

Fixes up some bugs when adding a labware then going to add a module to the slot when the labware is compatible or incompatible

## Test Plan and Hands on Testing

- Add a NEST 96 well plate to the deck to slot B1, add a thermocycler and see that it adds correctly.
- Delete the thermocycler, move the labware to slot A1. Add the thermocycler again and see that it errors
- Move the labware to a different slot that is not A1 or B1. Move the tiprack to slot B1, add the thermocycler, see that it errors
- Try other modules too and the trash bin/waste chute. see that it only successfully adds if there is no labware on the slot or the labware is compatible with the module.

## Changelog

- refactor logic
- make utils and test

## Risk assessment

low